### PR TITLE
add otel collector in kind

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -100,4 +100,27 @@ Distributed tracing tracks the end-to-end flow of requests as they pass through 
 
 Currently, Agent Substrate supports on-demand request tracing. When initiated by a client (e.g., via the `--trace` flag), Agent Substrate leverages OpenTelemetry (OTel) for context propagation across the call stack. Each traced request generates a unique trace hash/ID, which you can use to inspect the detailed request lifecycle and span hierarchy inside Google Cloud Trace or Jaeger.
 
+### Local Tracing with Jaeger (Kind Cluster)
+
+For local development inside a `kind` cluster, Agent Substrate automatically provisions a local OpenTelemetry Collector and Jaeger instance.
+
+To visualize traces locally:
+
+1. **Expose the Jaeger query UI** via port forwarding:
+   ```bash
+   kubectl port-forward -n otel-system svc/jaeger 16686:16686
+   ```
+
+2. **Open the Jaeger UI** in your web browser:
+   [http://localhost:16686](http://localhost:16686)
+
+3. **Generate Traces**: Run a CLI command or API call with the `--trace` flag, e.g.:
+   ```bash
+   kubectl ate get actor --trace
+   # or
+   kubectl ate suspend actor <actor-id> --trace
+   ```
+
+4. **Search and Inspect**: Copy the printed Trace ID from the CLI output and paste it into the Jaeger search box (top right), or select `ateapi` or `atelet` under the **Service** dropdown and click **Find Traces** to inspect detailed call stacks, DB transactions, state updates, and worker pod handoffs.
+
 > **Developer Guide:** For detailed instructions on configuring OpenTelemetry tracer providers, middleware, and exporters in your servers or clients, please refer to the [Tracing Best Practices](dev/best-practices/tracing.md) guide.

--- a/manifests/ate-install/kind/atelet/kustomization.yaml
+++ b/manifests/ate-install/kind/atelet/kustomization.yaml
@@ -34,6 +34,8 @@ patches:
               - --gcp-auth-for-image-pulls=false
               - --localhost-registry-replacement=kind-registry:5000
               env:
+              - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: http://opentelemetry-collector.otel-system.svc:4317
               - name: ATE_STORAGE_BACKEND
                 value: s3
               - name: AWS_REGION

--- a/manifests/ate-install/kind/kustomization.yaml
+++ b/manifests/ate-install/kind/kustomization.yaml
@@ -24,3 +24,21 @@ resources:
   - ../valkey.yaml
   - ../pod-certificate-controller.yaml
   - rustfs.yaml
+  - ./otel-collector.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ate-api-server-deployment
+        namespace: ate-system
+      spec:
+        template:
+          spec:
+            containers:
+            - name: ate-api-server
+              env:
+              - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: http://opentelemetry-collector.otel-system.svc:4317
+

--- a/manifests/ate-install/kind/otel-collector.yaml
+++ b/manifests/ate-install/kind/otel-collector.yaml
@@ -1,0 +1,151 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opentelemetry-collector-config
+  namespace: otel-system
+data:
+  otel-collector-config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      batch:
+    exporters:
+      otlp/jaeger:
+        endpoint: jaeger.otel-system.svc.cluster.local:4317
+        tls:
+          insecure: true
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp/jaeger, debug]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-collector
+  namespace: otel-system
+  labels:
+    app: opentelemetry-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opentelemetry-collector
+  template:
+    metadata:
+      labels:
+        app: opentelemetry-collector
+    spec:
+      containers:
+      - name: otel-collector
+        image: otel/opentelemetry-collector-contrib:0.95.0@sha256:66029b09f9046eebcbd58c9cfd5e094865d4f474ed071a5d7f0a3c1de9909993
+        args:
+        - --config=/conf/otel-collector-config.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /conf
+        ports:
+        - name: otlp-grpc
+          containerPort: 4317
+        - name: otlp-http
+          containerPort: 4318
+      volumes:
+      - name: config
+        configMap:
+          name: opentelemetry-collector-config
+          items:
+          - key: otel-collector-config.yaml
+            path: otel-collector-config.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-collector
+  namespace: otel-system
+spec:
+  type: ClusterIP
+  selector:
+    app: opentelemetry-collector
+  ports:
+  - name: otlp-grpc
+    port: 4317
+    targetPort: 4317
+  - name: otlp-http
+    port: 4318
+    targetPort: 4318
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: otel-system
+  labels:
+    app: jaeger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+    spec:
+      containers:
+      - name: jaeger
+        image: jaegertracing/all-in-one:1.55@sha256:f6b5d09073f14f76873d300f565a6691d815e81bea8e07e1dc3ff67e0596dd4e
+        ports:
+        - name: otlp-grpc
+          containerPort: 4317
+        - name: otlp-http
+          containerPort: 4318
+        - name: query
+          containerPort: 16686
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  namespace: otel-system
+spec:
+  type: ClusterIP
+  selector:
+    app: jaeger
+  ports:
+  - name: otlp-grpc
+    port: 4317
+    targetPort: 4317
+  - name: otlp-http
+    port: 4318
+    targetPort: 4318
+  - name: query
+    port: 16686
+    targetPort: 16686


### PR DESCRIPTION
1. Adds an opentelemetry tracing collector + jaeger UI to the kind install, cc @juli4n 
2. Updates observability docs with how to use the jaeger UI.
 

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

<img width="1932" height="696" alt="image" src="https://github.com/user-attachments/assets/6d97bc04-c795-4140-a0b7-b9eac3497404" />

