### PR TITLE
Register /readyz in ate-api and wait for components to be ready

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -44,8 +44,6 @@ jobs:
       run: hack/create-kind-cluster.sh
     - name: Install Agent Substrate
       run: hack/install-ate-kind.sh --deploy-ate-system
-    - name: Wait For Ready
-      run: kubectl wait pod --all --for=condition=Ready --namespace=ate-system --timeout=300s
     - name: Deploy Counter Demo
       run: hack/install-ate-kind.sh --deploy-demo-counter
     - name: Run E2E tests

--- a/cmd/servers/ateapi/ateapi.go
+++ b/cmd/servers/ateapi/ateapi.go
@@ -99,15 +99,6 @@ func main() {
 		}
 	}()
 
-	go func() {
-		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.Handler())
-		slog.InfoContext(ctx, fmt.Sprintf("Starting Prometheus metrics server on %s", *metricsListenAddr))
-		if err := http.ListenAndServe(*metricsListenAddr, mux); err != nil {
-			slog.Error("Failed to start prometheus metrics server", slog.Any("err", err))
-		}
-	}()
-
 	// For development, certain flags that are likely to be different for each
 	// developer can optionally be read from environment variables.  This is
 	// helpful because it lets us keep one set of constant Kubernetes manifests
@@ -304,6 +295,19 @@ func main() {
 	reflection.Register(mux)
 	ateapipb.RegisterControlServer(mux, sm)
 	ateapipb.RegisterSessionIdentityServer(mux, sessionIdentitySrv)
+
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("ok"))
+		})
+		slog.InfoContext(ctx, fmt.Sprintf("Starting Prometheus metrics server on %s", *metricsListenAddr))
+		if err := http.ListenAndServe(*metricsListenAddr, mux); err != nil {
+			slog.Error("Failed to start prometheus metrics server", slog.Any("err", err))
+		}
+	}()
 
 	if err := mux.Serve(lis); err != nil {
 		slog.ErrorContext(ctx, "Failed to serve", slog.Any("err", err))

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -238,6 +238,13 @@ deploy_ate_system() {
     manifests=$(run_ko resolve -f manifests/ate-install)
   fi
   echo "${manifests}" | run_kubectl apply -f -
+
+  log_step "Waiting for ATE system components to be ready..."
+  run_kubectl rollout status deployment/ate-api-server-deployment -n ate-system --timeout=120s
+  run_kubectl rollout status deployment/ate-controller -n ate-system --timeout=120s
+  run_kubectl rollout status deployment/atenet-router -n ate-system --timeout=120s
+  run_kubectl rollout status statefulset/valkey-cluster -n ate-system --timeout=120s
+  run_kubectl rollout status daemonset/atelet -n ate-system --timeout=120s
 }
 
 # Ensure secrets and configmaps required by ate-apiserver
@@ -267,6 +274,7 @@ deploy_ate_apiserver() {
   ensure_apiserver_prerequisites
 
   run_ko apply -f manifests/ate-install/ate-api-server.yaml
+  run_kubectl rollout status deployment/ate-api-server-deployment -n ate-system --timeout=120s
 }
 
 deploy_atelet() {
@@ -286,6 +294,7 @@ deploy_atelet() {
     manifest=$(run_ko resolve -f manifests/ate-install/atelet.yaml)
   fi
   echo "${manifest}" | run_kubectl apply -f -
+  run_kubectl rollout status daemonset/atelet -n ate-system --timeout=120s
 }
 
 deploy_atenet() {
@@ -298,6 +307,8 @@ deploy_atenet() {
 
   run_ko apply -f manifests/ate-install/atenet-router.yaml
   run_ko apply -f manifests/ate-install/atenet-dns.yaml
+  run_kubectl rollout status deployment/atenet-router -n ate-system --timeout=120s
+  run_kubectl rollout status deployment/atenet-dns -n ate-system --timeout=120s
 }
 
 delete_ate_system() {

--- a/manifests/ate-install/ate-api-server.yaml
+++ b/manifests/ate-install/ate-api-server.yaml
@@ -113,6 +113,12 @@ spec:
         - containerPort: 443
         - name: prometheus
           containerPort: 9090
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9090
+          initialDelaySeconds: 5
+          periodSeconds: 2
       volumes:
       - name: "servicedns"
         projected:


### PR DESCRIPTION
- Add a trivial /readyz handler (which will only be served once we finish initializing)
   - We use the metrics handler because we already expose an HTTP port there and there should be no conflict
- Add a readiness probe to the install manifest
- Update install script to wait for readiness on core components

Improves reliability for the demo flow, including the test flake seen in #2 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
