### PR TITLE
fix(ategcs): stop calling CreateBucket on every PutObject

### DIFF
--- a/internal/ategcs/ategcs.go
+++ b/internal/ategcs/ategcs.go
@@ -75,11 +75,6 @@ func (s *s3Client) GetObject(ctx context.Context, bucket, object string) (io.Rea
 }
 
 func (s *s3Client) PutObject(ctx context.Context, bucket, object string, reader io.Reader) error {
-	// Try creating the bucket first (ignore if it already exists)
-	_, _ = s.client.CreateBucket(ctx, &s3.CreateBucketInput{
-		Bucket: aws.String(bucket),
-	})
-
 	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(object),

--- a/manifests/ate-install/kind/rustfs.yaml
+++ b/manifests/ate-install/kind/rustfs.yaml
@@ -102,7 +102,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: create-bucket
-        image: amazon/aws-cli:2.17.0
+        image: amazon/aws-cli:2.17.0@sha256:643507c10ada7964ca6157b3d799f030b90577643da9955d319a77399ed80d73
         env:
         - name: AWS_ACCESS_KEY_ID
           value: rustfsadmin

--- a/manifests/ate-install/kind/rustfs.yaml
+++ b/manifests/ate-install/kind/rustfs.yaml
@@ -89,3 +89,45 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: rustfs-data
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rustfs-bucket-init
+  namespace: ate-system
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: create-bucket
+        image: amazon/aws-cli:2.17.0
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          value: rustfsadmin
+        - name: AWS_SECRET_ACCESS_KEY
+          value: rustfsadmin
+        - name: AWS_REGION
+          value: us-east-1
+        - name: AWS_ENDPOINT_URL
+          value: http://rustfs.ate-system.svc:9000
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          for i in $(seq 1 60); do
+            if aws s3api head-bucket --bucket ate-snapshots 2>/dev/null; then
+              echo "bucket ate-snapshots already exists"
+              exit 0
+            fi
+            if aws s3api create-bucket --bucket ate-snapshots 2>/dev/null; then
+              echo "bucket ate-snapshots created"
+              exit 0
+            fi
+            echo "waiting for rustfs to become available... ($i/60)"
+            sleep 2
+          done
+          echo "timed out waiting for rustfs"
+          exit 1


### PR DESCRIPTION
## Summary

`s3Client.PutObject` called `CreateBucket` before every upload. Convenient against local dev backends like rustfs/minio where buckets may not pre-exist, but against managed S3-compatible backends the caller typically lacks `s3:CreateBucket`, so each snapshot upload paid for a 403 in added latency and audit-log noise.

For local kind dev, add a one-shot Job alongside the rustfs Deployment that creates the `ate-snapshots` bucket once at install time.

## Validation

Verified locally with a kind cluster:

- Applied namespace + `manifests/ate-install/kind/rustfs.yaml`
- `rustfs-bucket-init` Job retried once while rustfs came up, then created `ate-snapshots`
- `aws s3api list-buckets` against rustfs returns `ate-snapshots`