### PR TITLE
docs: add Agent Executor to Ecosystem & Examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Agent Substrate is designed to be **framework and agent harness agnostic**. Beca
 *   **Claude Code & CodeX:** Support for high-density, stateful coding environments that preserve terminal and filesystem state across sessions.
 *   **Model Context Protocol (MCP):** Deploy secure, sandboxed MCP servers as Substrate Actors to provide durable tools for any LLM.
 
+## Ecosystem & Examples
+
+*   **[Agent Executor](https://github.com/google/ax):** A distributed agent runtime that demonstrates building a secure, hyper-scalable agent harness on Agent Substrate (see the [announcement blog](https://cloud.google.com/blog/products/ai-machine-learning/agent-executor-googles-distributed-agent-runtime) and [integration guide](https://github.com/google/ax/blob/main/manifests/README.md)).
+
 ## Status and compatibility
 
 Agent Substrate is currently in VERY early development.  It is not ready for


### PR DESCRIPTION
Incorporate Agent Executor as a demonstrative example of a distributed agent runtime and harness built on Agent Substrate.

ISSUE=None

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
