### PR TITLE
Add trace ID to all log entries

### DIFF
--- a/cmd/servers/ateapi/ateapi.go
+++ b/cmd/servers/ateapi/ateapi.go
@@ -29,6 +29,8 @@ import (
 	"github.com/agent-substrate/substrate/cmd/servers/ateapi/controlapi"
 	"github.com/agent-substrate/substrate/cmd/servers/ateapi/sessionidentity"
 	"github.com/agent-substrate/substrate/cmd/servers/ateapi/store/ateredis"
+	"github.com/agent-substrate/substrate/internal/ateinterceptors"
+	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/agent-substrate/substrate/internal/credbundle"
 	"github.com/agent-substrate/substrate/pkg/client/clientset/versioned"
 	"github.com/agent-substrate/substrate/pkg/client/informers/externalversions"
@@ -75,7 +77,7 @@ var (
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+	slog.SetDefault(slog.New(contextlogging.NewHandler(slog.NewJSONHandler(os.Stdout, nil))))
 
 	tp, err := initTracing(ctx)
 	if err != nil {
@@ -299,7 +301,7 @@ func main() {
 	mux := grpc.NewServer(
 		grpc.Creds(serverCreds),
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
-		grpc.UnaryInterceptor(controlapi.StatusErrorInterceptor),
+		grpc.UnaryInterceptor(ateinterceptors.ServerUnaryInterceptor),
 	)
 	reflection.Register(mux)
 	ateapipb.RegisterControlServer(mux, sm)

--- a/cmd/servers/ateapi/controlapi/functional_test.go
+++ b/cmd/servers/ateapi/controlapi/functional_test.go
@@ -28,6 +28,7 @@ import (
 
 	atev1alpha1 "github.com/agent-substrate/substrate/api/v1alpha1"
 	"github.com/agent-substrate/substrate/cmd/servers/ateapi/store/ateredis"
+	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/pkg/client/clientset/versioned"
 	"github.com/agent-substrate/substrate/pkg/client/informers/externalversions"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
@@ -263,7 +264,7 @@ func setupTest(t *testing.T, ns string) *testContext {
 	service := NewService(persistence, actorTemplateLister, dialer)
 
 	// 5. Start REAL gRPC Server for ATE API
-	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(StatusErrorInterceptor))
+	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(ateinterceptors.ServerUnaryInterceptor))
 	ateapipb.RegisterControlServer(grpcServer, service)
 
 	lis, err := net.Listen("tcp", "localhost:0")

--- a/cmd/servers/ateapi/controlapi/service.go
+++ b/cmd/servers/ateapi/controlapi/service.go
@@ -15,17 +15,10 @@
 package controlapi
 
 import (
-	"context"
-	"errors"
-	"log/slog"
-
 	"github.com/agent-substrate/substrate/cmd/servers/ateapi/store"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 
 	"github.com/agent-substrate/substrate/proto/ateapipb"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Service implements ateapipb.Control
@@ -49,26 +42,4 @@ func NewService(persistence store.Interface, actorTemplateLister listersv1alpha1
 	}
 
 	return s
-}
-
-// StatusErrorInterceptor searches the error chain for a gRPC status error.
-// If found, it extracts the code and message to send to the client, ignoring
-// any outer wrapping, while logging the full error chain internally.
-func StatusErrorInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	resp, err := handler(ctx, req)
-	if err != nil {
-		var statusErr interface {
-			GRPCStatus() *status.Status
-		}
-
-		if errors.As(err, &statusErr) {
-			st := statusErr.GRPCStatus()
-			slog.ErrorContext(ctx, "gRPC Error", slog.String("method", info.FullMethod), slog.Any("err", err))
-			return nil, status.Error(st.Code(), st.Message())
-		}
-
-		slog.ErrorContext(ctx, "Unexpected error", slog.String("method", info.FullMethod), slog.Any("err", err))
-		return nil, status.Error(codes.Internal, "internal server error")
-	}
-	return resp, nil
 }

--- a/cmd/servers/atelet/atelet.go
+++ b/cmd/servers/atelet/atelet.go
@@ -30,11 +30,12 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/agent-substrate/substrate/internal/ategcs"
+	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/ateompath"
+	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/agent-substrate/substrate/internal/memorypullcache"
 	"github.com/agent-substrate/substrate/proto/ateletpb"
 	"github.com/agent-substrate/substrate/proto/ateompb"
@@ -72,7 +73,7 @@ var (
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+	slog.SetDefault(slog.New(contextlogging.NewHandler(slog.NewJSONHandler(os.Stdout, nil))))
 
 	tp, err := initTracing(ctx)
 	if err != nil {
@@ -183,7 +184,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	svr := grpc.NewServer(grpc.StatsHandler(otelgrpc.NewServerHandler()), grpc.UnaryInterceptor(unaryInterceptor))
+	svr := grpc.NewServer(grpc.StatsHandler(otelgrpc.NewServerHandler()), grpc.UnaryInterceptor(ateinterceptors.ServerUnaryInterceptor))
 	ateletpb.RegisterAteomHerderServer(svr, wmService)
 	reflection.Register(svr)
 	slog.InfoContext(ctx, "WorkersManagerService listening", slog.Any("address", lis.Addr()))
@@ -191,22 +192,6 @@ func main() {
 		slog.ErrorContext(ctx, "Failed to serve", slog.Any("err", err))
 		os.Exit(1)
 	}
-}
-
-func unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-	startTime := time.Now()
-
-	resp, err := handler(ctx, req)
-
-	slog.InfoContext(ctx, "Handle RPC",
-		slog.String("method", info.FullMethod),
-		slog.Any("req", req),
-		slog.Any("resp", resp),
-		slog.Any("err", err),
-		slog.String("elapsed-time", time.Since(startTime).String()),
-	)
-
-	return resp, err
 }
 
 func initTracing(ctx context.Context) (*sdktrace.TracerProvider, error) {

--- a/cmd/servers/ateom-gvisor/ateom-gvisor.go
+++ b/cmd/servers/ateom-gvisor/ateom-gvisor.go
@@ -23,14 +23,21 @@ import (
 	"os"
 	"runtime"
 	"sync"
-	"time"
 
 	"cloud.google.com/go/compute/metadata"
+	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/ateompath"
+	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/agent-substrate/substrate/proto/ateompb"
 	"github.com/hashicorp/go-reap"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -45,7 +52,6 @@ var (
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 
 	if err := do(ctx); err != nil {
 		slog.ErrorContext(ctx, "Error while executing", slog.Any("err", err))
@@ -57,7 +63,21 @@ func do(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	logger := slog.New(contextlogging.NewHandler(slog.NewJSONHandler(os.Stdout, nil)))
+	slog.SetDefault(logger)
+
 	slog.InfoContext(ctx, "ateom booting")
+
+	tp, err := initTracing(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to initialize tracing", slog.Any("err", err))
+		os.Exit(1)
+	}
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			slog.Error("Failed to shutdown TracerProvider", slog.Any("err", err))
+		}
+	}()
 
 	// Create ateom dir
 	ateomDir := ateompath.AteomPath(*podNamespace, *podName)
@@ -107,10 +127,13 @@ func do(ctx context.Context) error {
 		return fmt.Errorf("while creating ateom-interior netns: %w", err)
 	}
 
-	actorLogger := NewActorLogger(os.Stdout, metadata.OnGCE())
+	actorLogger := NewActorLogger(logger, metadata.OnGCE())
 	ateomService := NewService(interiorNetNS, eth0LinkInfo, actorLogger)
 
-	svr := grpc.NewServer(grpc.UnaryInterceptor(unaryInterceptor))
+	svr := grpc.NewServer(
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.UnaryInterceptor(ateinterceptors.ServerUnaryInterceptor),
+	)
 	ateompb.RegisterAteomServer(svr, ateomService)
 	reflection.Register(svr)
 
@@ -122,20 +145,28 @@ func do(ctx context.Context) error {
 	return nil
 }
 
-func unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-	startTime := time.Now()
-
-	resp, err := handler(ctx, req)
-
-	slog.InfoContext(ctx, "Handle RPC",
-		slog.String("method", info.FullMethod),
-		slog.Any("req", req),
-		slog.Any("resp", resp),
-		slog.Any("err", err),
-		slog.String("elapsed-time", time.Since(startTime).String()),
+func initTracing(ctx context.Context) (*sdktrace.TracerProvider, error) {
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName("ateom-gvisor"),
+		),
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
 
-	return resp, err
+	// No exporter, since ateom has no network connectivity once eth0 is sent
+	// into the gvisor netns.  Maybe we can eventually figure out export via
+	// UDS.
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithResource(res),
+		// Only trace on-demand when signaled by the client (e.g. via --trace flag)
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.NeverSample())),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	return tp, nil
 }
 
 // AteomService is a service for shepherding single microvm.

--- a/cmd/servers/ateom-gvisor/logger.go
+++ b/cmd/servers/ateom-gvisor/logger.go
@@ -26,27 +26,25 @@ import (
 
 // ActorLogger handles structured logging for actor sandboxes and lifecycle events.
 type ActorLogger struct {
-	logger    *slog.Logger
 	labelsKey string
-	writer    io.Writer
+	logger    *slog.Logger
 }
 
 // NewActorLogger creates a new ActorLogger wrapping the provided destination writer.
-func NewActorLogger(w io.Writer, isOnGCE bool) *ActorLogger {
+func NewActorLogger(logger *slog.Logger, isOnGCE bool) *ActorLogger {
 	labelsKey := "labels"
 	if isOnGCE {
 		labelsKey = "logging.googleapis.com/labels"
 	}
 	return &ActorLogger{
-		logger:    slog.New(slog.NewJSONHandler(w, nil)),
 		labelsKey: labelsKey,
-		writer:    w,
+		logger:    logger,
 	}
 }
 
 // EmitLifecycleLog logs a synthetic actor lifecycle event.
 func (al *ActorLogger) EmitLifecycleLog(msg, actorID, actorTemplate, actorNamespace string) {
-	al.logger.LogAttrs(context.Background(), slog.LevelInfo, msg,
+	slog.LogAttrs(context.Background(), slog.LevelInfo, msg,
 		slog.Group(al.labelsKey,
 			slog.String("ate.dev/actor_id", actorID),
 			slog.String("ate.dev/actor_template", actorTemplate),

--- a/cmd/servers/ateom-gvisor/logger_test.go
+++ b/cmd/servers/ateom-gvisor/logger_test.go
@@ -17,16 +17,21 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"log/slog"
 	"strings"
 	"testing"
+
+	"github.com/agent-substrate/substrate/internal/contextlogging"
 )
 
 func TestWrapContainerLogs(t *testing.T) {
 	input := "Test application log output\n"
 	rdr := strings.NewReader(input)
-	var buf bytes.Buffer
 
-	al := NewActorLogger(&buf, false)
+	var buf bytes.Buffer
+	logger := slog.New(contextlogging.NewHandler(slog.NewJSONHandler(&buf, nil)))
+
+	al := NewActorLogger(logger, false)
 	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default")
 
 	var m map[string]any
@@ -64,9 +69,11 @@ func TestWrapContainerLogs(t *testing.T) {
 func TestWrapContainerLogs_JSONInput(t *testing.T) {
 	input := `{"level":"info","msg":"Started container","custom_attr":"value"}` + "\n"
 	rdr := strings.NewReader(input)
-	var buf bytes.Buffer
 
-	al := NewActorLogger(&buf, false)
+	var buf bytes.Buffer
+	logger := slog.New(contextlogging.NewHandler(slog.NewJSONHandler(&buf, nil)))
+
+	al := NewActorLogger(logger, false)
 	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default")
 
 	var m map[string]any

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
@@ -143,7 +144,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/internal/ateinterceptors/ateinterceptors.go
+++ b/internal/ateinterceptors/ateinterceptors.go
@@ -1,0 +1,56 @@
+//  Copyright 2026 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ateinterceptors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func ServerUnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	startTime := time.Now()
+
+	resp, err := handler(ctx, req)
+
+	slog.InfoContext(ctx, "Handle RPC",
+		slog.String("method", info.FullMethod),
+		slog.Any("req", req),
+		slog.Any("resp", resp),
+		slog.Any("err", err),
+		slog.String("elapsed-time", time.Since(startTime).String()),
+	)
+
+	if err != nil {
+		var statusErr interface {
+			GRPCStatus() *status.Status
+		}
+
+		if errors.As(err, &statusErr) {
+			st := statusErr.GRPCStatus()
+			return nil, status.Error(st.Code(), st.Message())
+		}
+
+		// No status error found in chain.
+		return nil, status.Error(codes.Internal, "internal server error")
+	}
+
+	return resp, err
+}

--- a/internal/ateinterceptors/ateinterceptors_test.go
+++ b/internal/ateinterceptors/ateinterceptors_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package controlapi
+package ateinterceptors
 
 import (
 	"context"
@@ -57,7 +57,7 @@ func TestStatusErrorInterceptor(t *testing.T) {
 				return "response", tt.handlerErr
 			}
 
-			resp, err := StatusErrorInterceptor(context.Background(), "request", &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, handler)
+			resp, err := ServerUnaryInterceptor(context.Background(), "request", &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, handler)
 
 			if tt.expectResponse {
 				if err != nil {

--- a/internal/contextlogging/contextlogging.go
+++ b/internal/contextlogging/contextlogging.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contextlogging
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+type ContextHandler struct {
+	internal slog.Handler
+}
+
+func NewHandler(internal slog.Handler) *ContextHandler {
+	return &ContextHandler{
+		internal: internal,
+	}
+}
+
+func (h *ContextHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
+	return h.internal.Enabled(ctx, lvl)
+}
+
+func (h *ContextHandler) Handle(ctx context.Context, rec slog.Record) error {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if spanContext.HasTraceID() {
+		traceID := spanContext.TraceID()
+		rec.AddAttrs(slog.String("ate.dev/trace-id", traceID.String()))
+	}
+
+	return h.internal.Handle(ctx, rec)
+}
+
+func (h *ContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &ContextHandler{internal: h.internal.WithAttrs(attrs)}
+}
+
+func (h *ContextHandler) WithGroup(name string) slog.Handler {
+	return &ContextHandler{internal: h.internal.WithGroup(name)}
+}


### PR DESCRIPTION
This commit adds a small log handler that reads the trace id out of the context, if present, and includes it as a log attribute.  Additionally, ateom is integrated with tracing (although it has no exporter because it has no network connectivity).

This allows easy correlation of logs from a single parent request across ate-api-server, atelet, and ateom.

I have also fixed the potential for log tearing from the ateom runsc log exporter by having it reuse the same slog.Handler as the main program.

