### PR TITLE
docs: clarify kind prereqs and fix stale install-script references

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ goals in the near term.
 
 To quickly set up the complete environment:
 
-1. Make sure you have [Go](https://go.dev/doc/install), [`kubectl`](https://kubernetes.io/docs/tasks/tools/), and [`docker`](https://www.docker.com/) installed and configured on your dev machine. We will automatically manage other dependencies via Go, including [`kind`](https://kind.sigs.k8s.io/).
+1. Make sure you have [Go](https://go.dev/doc/install), [`kubectl`](https://kubernetes.io/docs/tasks/tools/), and [`docker`](https://www.docker.com/) installed and configured on your dev machine. We will automatically manage other dependencies via Go, including [`kind`](https://kind.sigs.k8s.io/). On Docker Desktop, allocate at least **12 GiB of memory** to the Docker VM (Settings → Resources → Memory) — the full bring-up otherwise OOMs.
 
 2. Run the following steps:
 ```shell

--- a/demos/counter/README.md
+++ b/demos/counter/README.md
@@ -6,9 +6,20 @@ It deploys a simple Go HTTP server (`counter.go`) that increments a counter on e
 
 ## Prerequisites
 
-- A k8s cluster with Agent Substrate installed (`./hack/install-ate.sh --deploy-ate-system`).
+- A Kubernetes cluster with Agent Substrate installed.
 - `ko` installed for building images.
-- A GCS bucket for storing snapshots (configured via `BUCKET_NAME` env var).
+- A snapshot store appropriate to the cluster:
+  - On GKE, a GCS bucket whose name is supplied via the `BUCKET_NAME` environment variable.
+  - On a local `kind` cluster, the in-cluster `rustfs` S3-compatible store provisioned by the kind overlay. `BUCKET_NAME` defaults to `ate-snapshots` and does not need to be set.
+
+Two install scripts are available and accept the same flag set:
+
+| Target | Script |
+|---|---|
+| GKE | `./hack/install-ate.sh` |
+| Local `kind` | `./hack/install-ate-kind.sh` |
+
+The remainder of this guide uses `./hack/install-ate.sh`. For a `kind` cluster, substitute `./hack/install-ate-kind.sh` in every command below. The end-to-end `kind` bring-up is described in the [Quickstart in the top-level README](../../README.md#quickstart-development).
 
 ## How to Run on Agent Substrate
 

--- a/internal/e2e/README.md
+++ b/internal/e2e/README.md
@@ -18,7 +18,10 @@ $ go test -v ./internal/e2e/suites/... -args -e2e
 
 ## Preconditions
 
-The e2e tests assume you have a cluster setup with `hack/install.sh`.
+The e2e tests assume a cluster has been provisioned with one of the install scripts:
+
+- `hack/install-ate.sh --deploy-ate-system` for a GKE-based environment (requires `.ate-dev-env.sh`; see the top-level [README](../../README.md#gke-quickstart-development)).
+- `hack/install-ate-kind.sh --deploy-ate-system` for a local `kind` cluster (see the top-level [README](../../README.md#quickstart-development)).
 
 ## Creating a new test suite
 


### PR DESCRIPTION
- README Quickstart now pins kind >= v0.31.0. Earlier releases ship a default Kubernetes node image without the PodCertificateRequest API the install scripts depend on, so kube-apiserver never reaches readiness on a fresh `brew install kind` machine.
- internal/e2e/readme.md referenced a `hack/install.sh` that does not exist. Point readers at the two real entry points instead (hack/install-ate.sh for GKE, hack/install-ate-kind.sh for kind).
- demos/counter/README.md claimed a GCS bucket was required, but the kind overlay provisions an in-cluster rustfs S3 store. Document both targets so the demo can run without provisioning GCP.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
