### PR TITLE
hack: tear down the kind overlay symmetrically on --delete-all

### DIFF
--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -313,10 +313,12 @@ deploy_atenet() {
 
 delete_ate_system() {
   log_step "delete_ate_system"
-  if [[ "${ATE_INSTALL_RUSTFS:-false}" == "true" ]]; then
-    run_kubectl delete --ignore-not-found -f manifests/ate-install/kind/rustfs.yaml
+  if [[ "${ATE_INSTALL_KIND:-false}" == "true" ]]; then
+    kubectl kustomize manifests/ate-install/kind --load-restrictor LoadRestrictionsNone \
+      | run_kubectl delete --ignore-not-found -f -
+  else
+    run_kubectl delete --ignore-not-found -f manifests/ate-install
   fi
-  run_kubectl delete --ignore-not-found -f manifests/ate-install
   run_kubectl delete --ignore-not-found -f manifests/ate-install/generated
 }
 


### PR DESCRIPTION
`install-ate-kind.sh --deploy-ate-system` installs the kind overlay (rustfs and the `otel-system` namespace) via a kustomize build of `manifests/ate-install/kind`, but the matching teardown only removed `kind/rustfs.yaml`, and only when `ATE_INSTALL_RUSTFS=true` was set in the environment.

Teardown now deletes the same kustomize set whenever `ATE_INSTALL_KIND=true` (already exported by `install-ate-kind.sh`). The GKE path is unchanged; `ATE_INSTALL_RUSTFS` is unused after this change.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
