### PR TITLE
manifests: add metrics pipeline to the kind otel-collector

### DIFF
--- a/manifests/ate-install/kind/otel-collector.yaml
+++ b/manifests/ate-install/kind/otel-collector.yaml
@@ -38,6 +38,8 @@ data:
         endpoint: jaeger.otel-system.svc.cluster.local:4317
         tls:
           insecure: true
+      prometheus:
+        endpoint: 0.0.0.0:8889
       debug:
         verbosity: detailed
     service:
@@ -46,6 +48,10 @@ data:
           receivers: [otlp]
           processors: [batch]
           exporters: [otlp/jaeger, debug]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [prometheus, debug]
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -77,6 +83,8 @@ spec:
           containerPort: 4317
         - name: otlp-http
           containerPort: 4318
+        - name: prom
+          containerPort: 8889
       volumes:
       - name: config
         configMap:
@@ -101,6 +109,9 @@ spec:
   - name: otlp-http
     port: 4318
     targetPort: 4318
+  - name: prom
+    port: 8889
+    targetPort: 8889
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
atelet and ate-api-server push traces and metrics via OTLP. The kind collector declared only a `traces:` pipeline, so each metric push returned `Unimplemented`; the GKE managed collector accepts both.

Add a matching `metrics:` pipeline, re-exported via a Prometheus endpoint on `:8889`. Server-side configuration is unchanged.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
