### PR TITLE
manifests: switch demos to the off-GCP pause image (use community assets!)

### DIFF
--- a/manifests/agent-secret/agent-secret.yaml.tmpl
+++ b/manifests/agent-secret/agent-secret.yaml.tmpl
@@ -39,7 +39,7 @@ spec:
     arm64:
       url: "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"
       sha256Hash: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9"
-  pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
+  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
   containers:
   - name: agent-secret
     image: ko://github.com/agent-substrate/substrate/demos/agent-secret

--- a/manifests/claude-code-multiplex/claude-code-multiplex.yaml.tmpl
+++ b/manifests/claude-code-multiplex/claude-code-multiplex.yaml.tmpl
@@ -60,7 +60,7 @@ spec:
     arm64:
       url: "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"
       sha256Hash: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9"
-  pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
+  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
   containers:
   - name: claude
     image: ${WORKLOAD_IMAGE}
@@ -94,7 +94,7 @@ spec:
     arm64:
       url: "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"
       sha256Hash: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9"
-  pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
+  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
   containers:
   - name: claude
     image: ${WORKLOAD_IMAGE}
@@ -128,7 +128,7 @@ spec:
     arm64:
       url: "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"
       sha256Hash: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9"
-  pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
+  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
   containers:
   - name: claude
     image: ${WORKLOAD_IMAGE}

--- a/manifests/counter/counter.yaml.tmpl
+++ b/manifests/counter/counter.yaml.tmpl
@@ -43,7 +43,7 @@ spec:
     arm64:
       url: "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"
       sha256Hash: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9"
-  pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
+  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
   containers:
   - name: counter
     image: ko://github.com/agent-substrate/substrate/demos/counter

--- a/manifests/sandbox/sandbox.yaml.tmpl
+++ b/manifests/sandbox/sandbox.yaml.tmpl
@@ -42,7 +42,7 @@ spec:
     arm64:
       url: "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"
       sha256Hash: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9"
-  pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
+  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
   containers:
   - name: sandbox
     image: ko://github.com/agent-substrate/substrate/demos/sandbox


### PR DESCRIPTION
`api/v1alpha1/actortemplate_types.go:64-67` documents the GKE `pause` digest as the on-GCP choice and `registry.k8s.io/pause:3.10.2@…` as the off-GCP choice. All four demo templates currently pin the on-GCP digest, which puts the local kind quickstart on a Google-hosted registry by default.

The API doc comment keeps both references; on-GCP deployments can still pin the GKE digest explicitly.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
