### PR TITLE
Fix atelet otel kustomize

### DIFF
--- a/manifests/ate-install/kind/kustomization.yaml
+++ b/manifests/ate-install/kind/kustomization.yaml
@@ -41,4 +41,18 @@ patches:
               env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
+  - patch: |-
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: atelet
+        namespace: ate-system
+      spec:
+        template:
+          spec:
+            containers:
+            - name: atelet
+              env:
+              - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: http://opentelemetry-collector.otel-system.svc:4317
 


### PR DESCRIPTION
We were doing it for `ate-apiserver`, but not `atelet`. This results in `atelet` failing to ingest its own metrics.

Fixes https://github.com/agent-substrate/substrate/issues/38