### PR TITLE
ignore codeowners files in boilerplate check

### DIFF
--- a/hack/util/verify-boilerplate.py
+++ b/hack/util/verify-boilerplate.py
@@ -105,7 +105,7 @@ def main():
         # Skip non-source-code files
         if ext in ['.md', '.txt', '.png', '.jpg', '.jpeg', '.gif', '.mp4', '.json', '.pdf', '.ico', '.woff', '.woff2', '.ttf', '.otf']:
             continue
-        if filename in ['LICENSE', 'NOTICE', '.gitignore', 'go.mod', 'go.sum']:
+        if filename in ['LICENSE', 'NOTICE', 'CODEOWNERS', '.gitignore', 'go.mod', 'go.sum']:
             continue
         
         # exclude third_party files, which should have their OWN LICENSE


### PR DESCRIPTION
We're planning to add these later, noticed this failing on @dims's PR.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
