### PR TITLE
ActorTemplate: Enforce that all images must be pinned

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -343,11 +343,11 @@ func createTemplate(t *testing.T, tc *testContext, ns string) {
 					SHA256Hash: "a397be1abc2420d26bce6c70e6e2ff96c73aaaab929756c56f5e2089ea842b63",
 				},
 			},
-			PauseImage: "pause",
+			PauseImage: "pause@sha256:abc",
 			Containers: []atev1alpha1.Container{
 				{
 					Name:    "main",
-					Image:   "main",
+					Image:   "main@sha256:abc",
 					Command: []string{"/main"},
 				},
 			},

--- a/manifests/ate-install/generated/ate.dev_actortemplates.yaml
+++ b/manifests/ate-install/generated/ate.dev_actortemplates.yaml
@@ -227,6 +227,10 @@ spec:
                     image:
                       description: Image to use for the worker replicas.
                       type: string
+                      x-kubernetes-validations:
+                      - message: All images must be pinned (changing the image invalidates
+                          snapshots)
+                        rule: self.contains('@')
                     name:
                       description: Name of the container.
                       type: string
@@ -272,6 +276,7 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 10
                 type: array
               pauseImage:
                 description: |-
@@ -282,6 +287,10 @@ spec:
                     - [1] gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da
                     - [2] registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4
                 type: string
+                x-kubernetes-validations:
+                - message: All images must be pinned (changing the image invalidates
+                    snapshots)
+                  rule: self.contains('@')
               runsc:
                 description: Parameters for fetching the runsc binary to use.
                 properties:

--- a/pkg/api/v1alpha1/actortemplate_types.go
+++ b/pkg/api/v1alpha1/actortemplate_types.go
@@ -37,6 +37,8 @@ type Container struct {
 	Name string `json:"name"`
 
 	// Image to use for the worker replicas.
+	//
+	// +kubebuilder:validation:XValidation:rule="self.contains('@')",message="All images must be pinned (changing the image invalidates snapshots)"
 	Image string `json:"image,omitempty"`
 
 	// Entrypoint array. Not executed within a shell.
@@ -67,11 +69,13 @@ type ActorTemplateSpec struct {
 	//   - [2] registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4
 	//
 	// +required
+	// +kubebuilder:validation:XValidation:rule="self.contains('@')",message="All images must be pinned (changing the image invalidates snapshots)"
 	PauseImage string `json:"pauseImage,omitempty"`
 
 	// Containers is the workload definition.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxItems=10
 	Containers []Container `json:"containers,omitempty"`
 
 	// Snapshots configuration for the actor.


### PR DESCRIPTION
This commit adds a ValidatingAdmissionPolicy that checks that all images in an ActorTemplate must be pinned to a specific hash.

Fixes #10 
