### PR TITLE
sort actors/workers alphabetically

### DIFF
--- a/cmd/kubectl-ate/pkg/printer/printer.go
+++ b/cmd/kubectl-ate/pkg/printer/printer.go
@@ -15,10 +15,12 @@
 package printer
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"text/tabwriter"
 
 	"github.com/agent-substrate/substrate/proto/ateapipb"
@@ -32,8 +34,21 @@ func PrintActors(actors []*ateapipb.Actor, format string) error {
 	return PrintActorsTo(os.Stdout, actors, format)
 }
 
+func sortActors(actors []*ateapipb.Actor) {
+	slices.SortFunc(actors, func(a, b *ateapipb.Actor) int {
+		if c := cmp.Compare(a.GetActorTemplateNamespace(), b.GetActorTemplateNamespace()); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.GetActorTemplateName(), b.GetActorTemplateName()); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.GetActorId(), b.GetActorId())
+	})
+}
+
 // PrintActorsTo prints a slice of actors to the provided writer.
 func PrintActorsTo(out io.Writer, actors []*ateapipb.Actor, format string) error {
+	sortActors(actors)
 	switch format {
 	case "json", "yaml":
 		return printProto(out, &ateapipb.ListActorsResponse{Actors: actors}, format)
@@ -65,8 +80,21 @@ func PrintWorkers(workers []*ateapipb.Worker, format string) error {
 	return PrintWorkersTo(os.Stdout, workers, format)
 }
 
+func sortWorkers(workers []*ateapipb.Worker) {
+	slices.SortFunc(workers, func(a, b *ateapipb.Worker) int {
+		if c := cmp.Compare(a.GetWorkerNamespace(), b.GetWorkerNamespace()); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.GetWorkerPool(), b.GetWorkerPool()); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.GetWorkerPod(), b.GetWorkerPod())
+	})
+}
+
 // PrintWorkersTo prints a slice of workers to the provided writer.
 func PrintWorkersTo(out io.Writer, workers []*ateapipb.Worker, format string) error {
+	sortWorkers(workers)
 	switch format {
 	case "json", "yaml":
 		return printProto(out, &ateapipb.ListWorkersResponse{Workers: workers}, format)

--- a/cmd/kubectl-ate/pkg/printer/printer_test.go
+++ b/cmd/kubectl-ate/pkg/printer/printer_test.go
@@ -101,6 +101,43 @@ func TestPrintActorsTo_YAML(t *testing.T) {
 	}
 }
 
+func TestPrintActorsTo_Table_Sorted(t *testing.T) {
+	var buf bytes.Buffer
+	actors := []*ateapipb.Actor{
+		{
+			ActorId:                "zebra",
+			ActorTemplateNamespace: "default",
+			ActorTemplateName:      "template-1",
+			Status:                 ateapipb.Actor_STATUS_SUSPENDED,
+		},
+		{
+			ActorId:                "alpha",
+			ActorTemplateNamespace: "default",
+			ActorTemplateName:      "template-1",
+			Status:                 ateapipb.Actor_STATUS_RUNNING,
+		},
+		{
+			ActorId:                "beta",
+			ActorTemplateNamespace: "other",
+			ActorTemplateName:      "template-2",
+			Status:                 ateapipb.Actor_STATUS_SUSPENDED,
+		},
+	}
+
+	if err := PrintActorsTo(&buf, actors, "table"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `NAMESPACE   TEMPLATE     ID      STATUS             ATEOM POD   ATEOM IP   VERSION
+default     template-1   alpha   STATUS_RUNNING     <none>                 0
+default     template-1   zebra   STATUS_SUSPENDED   <none>                 0
+other       template-2   beta    STATUS_SUSPENDED   <none>                 0
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestPrintActorsTo_Invalid(t *testing.T) {
 	var buf bytes.Buffer
 	err := PrintActorsTo(&buf, nil, "xml")
@@ -154,6 +191,40 @@ func TestPrintWorkersTo_Table_Free(t *testing.T) {
 default     pool-1   pod-1   FREE     <none>
 `
 	if diff := cmp.Diff(expected, output); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintWorkersTo_Table_Sorted(t *testing.T) {
+	var buf bytes.Buffer
+	workers := []*ateapipb.Worker{
+		{
+			WorkerNamespace: "default",
+			WorkerPool:      "pool-1",
+			WorkerPod:       "pod-z",
+		},
+		{
+			WorkerNamespace: "default",
+			WorkerPool:      "pool-1",
+			WorkerPod:       "pod-a",
+		},
+		{
+			WorkerNamespace: "other",
+			WorkerPool:      "pool-2",
+			WorkerPod:       "pod-1",
+		},
+	}
+
+	if err := PrintWorkersTo(&buf, workers, "table"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `NAMESPACE   POOL     POD     STATUS   ASSIGNED ACTOR
+default     pool-1   pod-a   FREE     <none>
+default     pool-1   pod-z   FREE     <none>
+other       pool-2   pod-1   FREE     <none>
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Sort the output of `get actor/workers` alphabetically.

- [x] Tests pass
- [n/a] Appropriate changes to documentation are included in the PR
