### PR TITLE
Make agent-secret demo route correctly: inject session header + fix DNS suffix

### DIFF
--- a/cmd/servers/atenet/app/router/extproc.go
+++ b/cmd/servers/atenet/app/router/extproc.go
@@ -150,9 +150,11 @@ func (s *ExtProcServer) handleRequestHeaders(
 
 	slog.InfoContext(ctx, "Route ok", slog.String("actorID", actorID), slog.String("targetAddr", targetAddr))
 
-	// Route by rewriting the :authority header.
+	// Route by rewriting the :authority header, and inject the resolved actor
+	// ID so the workload can identify itself without inspecting :authority.
 	mutation := &extprocv3.HeaderMutation{}
 	addAuthorityMutation(targetAddr, mutation)
+	addSessionHeaderMutation(actorID, mutation)
 
 	return &extprocv3.HeadersResponse{
 		Response: &extprocv3.CommonResponse{

--- a/cmd/servers/atenet/app/router/extproc_out.go
+++ b/cmd/servers/atenet/app/router/extproc_out.go
@@ -43,6 +43,21 @@ func addAuthorityMutation(auth string, mut *extprocv3.HeaderMutation) {
 	)
 }
 
+// sessionHeader is set on every successfully-routed request so that the
+// workload can identify its own actor without parsing the rewritten :authority.
+const sessionHeader = "x-agentset-session"
+
+func addSessionHeaderMutation(actorID string, mut *extprocv3.HeaderMutation) {
+	mut.SetHeaders = append(mut.SetHeaders,
+		&corev3.HeaderValueOption{
+			Header: &corev3.HeaderValue{
+				Key:      sessionHeader,
+				RawValue: []byte(actorID),
+			},
+		},
+	)
+}
+
 func immediateResponse(statusCode envoy_type.StatusCode, message string) *extproc.ProcessingResponse {
 	return &extproc.ProcessingResponse{
 		Response: &extproc.ProcessingResponse_ImmediateResponse{

--- a/cmd/servers/atenet/app/router/extproc_test.go
+++ b/cmd/servers/atenet/app/router/extproc_test.go
@@ -131,17 +131,20 @@ func TestExtProcHeadersEvaluation(t *testing.T) {
 			}
 
 			mutation := res.Response.GetHeaderMutation()
-			if len(mutation.GetSetHeaders()) != 1 {
-				t.Fatalf("expected exactly one Header option set, found: %v", mutation.GetSetHeaders())
+			if len(mutation.GetSetHeaders()) != 2 {
+				t.Fatalf("expected exactly two Header options set, found: %v", mutation.GetSetHeaders())
 			}
 
-			headerOption := mutation.GetSetHeaders()[0]
-			if strings.ToLower(headerOption.Header.Key) != ":authority" {
-				t.Errorf("invalid resulting dynamic parameter key: %s", headerOption.Header.Key)
+			setHeaders := map[string]string{}
+			for _, h := range mutation.GetSetHeaders() {
+				setHeaders[strings.ToLower(h.Header.Key)] = string(h.Header.RawValue)
 			}
 
-			if string(headerOption.Header.RawValue) != tc.expectedTarget {
-				t.Errorf("invalid destination mapping found: %s, expected: %s", headerOption.Header.RawValue, tc.expectedTarget)
+			if got := setHeaders[":authority"]; got != tc.expectedTarget {
+				t.Errorf("invalid :authority mutation: got %q, want %q", got, tc.expectedTarget)
+			}
+			if got := setHeaders["x-agentset-session"]; got != testUUID {
+				t.Errorf("invalid x-agentset-session mutation: got %q, want %q", got, testUUID)
 			}
 
 			// Confirm that query logs recorded metric trace details

--- a/demos/agent-secret/README.md
+++ b/demos/agent-secret/README.md
@@ -40,7 +40,7 @@ Create a single actor and watch it automatically yield compute after use:
 ./kubectl-ate create actor my-agent --template ate-demo-secret-agent-v2/agent-secret
 
 # Send a request via the Substrate Router (Note the official DNS suffix)
-curl -H "Host: my-agent.actors.resources.substrate.k8s.io" http://localhost:8000
+curl -H "Host: my-agent.actors.resources.substrate.ate.dev" http://localhost:8000
 ```
 
 **What to observe:**
@@ -50,7 +50,7 @@ curl -H "Host: my-agent.actors.resources.substrate.k8s.io" http://localhost:8000
 ### 2. Verify Identity Persistence
 Send another request to the same actor:
 ```bash
-curl -H "Host: my-agent.actors.resources.substrate.k8s.io" http://localhost:8000
+curl -H "Host: my-agent.actors.resources.substrate.ate.dev" http://localhost:8000
 ```
 The "Identity" secret returned will be identical to the first response, even if the actor was resumed on a different physical pod. This proves the volatile RAM survived the hibernation cycle.
 
@@ -71,7 +71,7 @@ for wave in 0 1 2; do
   echo "Triggering Wave $((wave + 1))..."
   for i in {1..8}; do
     num=$(printf "%03d" $((wave * 8 + i)))
-    curl -s -H "Host: session-$num.actors.resources.substrate.k8s.io" http://localhost:8000 &
+    curl -s -H "Host: session-$num.actors.resources.substrate.ate.dev" http://localhost:8000 &
   done
   sleep 8 # 7s linger + 1s buffer
 done

--- a/demos/agent-secret/main.go
+++ b/demos/agent-secret/main.go
@@ -60,7 +60,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 	log.Printf("DEBUG: Request received. Path=%s Host=%s", r.URL.Path, r.Host)
 
 	// 1. Identify Actor (Robust extraction)
-	// New architecture uses Host: <actor-id>.actors.resources.substrate.k8s.io
+	// New architecture uses Host: <actor-id>.actors.resources.substrate.ate.dev
 	actorID := r.Header.Get("X-AgentSet-Session")
 	if actorID == "" {
 		actorID = r.Header.Get("x-agentset-session")
@@ -70,7 +70,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		if host == "" {
 			host = r.Header.Get("Host")
 		}
-		// Extract prefix from <id>.actors.resources.substrate.k8s.io
+		// Extract prefix from <id>.actors.resources.substrate.ate.dev
 		parts := strings.Split(host, ".")
 		if len(parts) > 1 {
 			actorID = parts[0]


### PR DESCRIPTION
Two compact changes that together make the `agent-secret` demo run as documented:

- **`feat(atenet/router)`** — inject the resolved actor ID as an `x-agentset-session` request header on every successful resume, so workloads can identify their own actor without parsing the rewritten `:authority`.
- **`fix(demos/agent-secret)`** — replace the stale `substrate.k8s.io` DNS suffix with `substrate.ate.dev` (the live router suffix per `internal/resources/actor.go:27`) in three curl examples and two source comments.

Running the demo's README verbatim today fails in two ways:

1. The `Host` header uses the legacy `substrate.k8s.io` suffix and is rejected by the router with a 404.
2. Even with the correct suffix, the router rewrites `:authority` to the worker pod IP before the workload sees it. The workload's fallback prefix-extraction then grabs the first octet of the IP (`10` for `10.244.0.30`), `SuspendActor(actor_id="10")` returns `NotFound`, and the actor never self-suspends.

The header-injection change is also useful beyond this demo: any future workload that needs its own actor identity now has a stable header to read it from, instead of either reverse-engineering `:authority` or relying on an environment-variable mount.

Testing:
```
go build -buildvcs=false ./cmd/servers/atenet/... ./demos/agent-secret/...    # exit 0
go vet                  ./cmd/servers/atenet/app/router/... ./demos/agent-secret/...   # exit 0
go test -count=1        ./cmd/servers/atenet/app/router/...                            # ok 0.787s
```

End-to-end on a local kind cluster:
- `curl -H "Host: my-agent.actors.resources.substrate.ate.dev" http://localhost:8000` (no other headers) — workload now logs `DEBUG: Identified ActorID: [my-agent]`, the response reads `Session: my-agent` (was `Session: 10`), and the actor flips to `STATUS_SUSPENDED` ~9 s after the response.
- RAM-state preservation (same `SECRET-NNNN` returned across resume cycles, including worker-pod migration) is unchanged.