### PR TITLE
feat(install): build + push ateom-gvisor image during kind bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ Thumbs.db
 
 # Local worktrees
 /.worktrees/
+
+# Local install state (digests of locally-published images, etc.)
+.ate-kind/

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -68,6 +68,7 @@ function usage() {
   echo "  --deploy-atelet                        Deploy atelet only"
   echo "  --deploy-ate-apiserver                 Deploy ate-api-server only"
   echo "  --deploy-atenet                        Deploy atenet only"
+  echo "  --publish-ateom-image                  Build + push ateom-gvisor (kind only); writes digest to .ate-kind/ateom-image"
   echo ""
   echo "To create individual resources used by ate-system (Note: These are"
   echo "called automatically by --deploy-ate-system):"
@@ -252,6 +253,32 @@ deploy_ate_system() {
   run_kubectl rollout status deployment/atenet-router -n ate-system --timeout=120s
   run_kubectl rollout status statefulset/valkey-cluster -n ate-system --timeout=120s
   run_kubectl rollout status daemonset/atelet -n ate-system --timeout=120s
+
+  publish_ateom_image
+}
+
+# Build + push the ateom-gvisor image and persist its digest under
+# .ate-kind/ateom-image. ateom-gvisor is the per-worker-pod sidecar
+# referenced via WorkerPool.spec.ateomImage; it has no Deployment
+# manifest under manifests/ate-install/, so the ko-resolve pipeline that
+# builds every other binary never touches it. Without this step,
+# operators creating a WorkerPool after a fresh --deploy-ate-system have
+# to invoke ko publish by hand.
+#
+# Only runs in kind mode; non-kind installs continue to manage their own
+# image-publishing flow against the cluster's registry.
+publish_ateom_image() {
+  if [[ "${ATE_INSTALL_KIND:-false}" != "true" ]]; then
+    return 0
+  fi
+  log_step "publish_ateom_image"
+  local out_dir="${ROOT}/.ate-kind"
+  mkdir -p "${out_dir}"
+  local image
+  image=$("${ROOT}/hack/run-tool.sh" ko publish --base-import-paths ./cmd/ateom-gvisor)
+  echo "${image}" > "${out_dir}/ateom-image"
+  echo "  image:  ${image}"
+  echo "  digest: ${out_dir}/ateom-image"
 }
 
 # Ensure secrets and configmaps required by ate-apiserver
@@ -382,6 +409,8 @@ while [[ "$#" -gt 0 ]]; do
 
     --deploy-atenet) deploy_atenet ;;
     --delete-atenet) delete_atenet ;;
+
+    --publish-ateom-image) publish_ateom_image ;;
 
     --create-jwt-authority-pool-secret) create_jwt_authority_pool_secret ;;
     --create-session-id-ca-pool-secret) create_session_id_ca_pool_secret ;;


### PR DESCRIPTION
`ateom-gvisor` is the per-worker-pod sidecar referenced via `WorkerPool.spec.ateomImage`.

Its source lives under `cmd/ateom-gvisor`, but no `Deployment` or `DaemonSet` manifest under `manifests/ate-install/` references it. The `ko resolve` pipeline that builds every other binary therefore never builds `ateom-gvisor`.

After a fresh `hack/install-ate-kind.sh --deploy-ate-system`, operators creating a `WorkerPool` have to either:

- run a packaged demo (whose template's `ko://` reference side-effects the build), or
- invoke `ko publish ./cmd/ateom-gvisor` by hand and substitute the resulting digest into their manifest.

Add `publish_ateom_image` to `hack/install-ate.sh`. It runs:

```
ko publish --base-import-paths ./cmd/ateom-gvisor
```

and writes the resulting `<repo>@sha256:<digest>` to `.ate-kind/ateom-image`.

Wiring:

- Called from the end of `deploy_ate_system` when `ATE_INSTALL_KIND=true`.
- Also exposed as `--publish-ateom-image` for standalone rebuilds.
- `.ate-kind/` added to `.gitignore`.