### PR TITLE
ci: also run pr-workflow on push to main

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -15,6 +15,8 @@
 name: pr-workflow
 on:
   pull_request:
+  push:
+    branches: [main]
 jobs:
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The existing trigger is pull_request only, so when a PR merges no CI runs against the resulting main-branch commit. A bad squash, a post-rebase test failure, or a flake-masked regression isn't surfaced until the next PR opens, at which point bisecting "is it my change or main?" wastes contributor time.

Add a push trigger restricted to main so the same run-tests and e2e-test jobs run against the merged commit. No new jobs, no new permissions, no change to PR behavior.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
