### PR TITLE
ci: bump actions/checkout from v3 to v5

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
v3 is EOL — GitHub Actions runners flag it as too old to run. v5 is the current stable major (latest release v5.0.1 as of 2026-05). Two callsites (run-tests and e2e-test jobs), no behavioural change.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
