### PR TITLE
fix(make): correct build-demos target path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build-atenet:
 
 .PHONY: build-demos
 build-demos:
-	$(KO) build ./cmd/demos/counter
+	$(KO) build ./demos/counter
 
 .PHONY: test
 test:


### PR DESCRIPTION
`make build-demos` invoked `ko build ./cmd/demos/counter`, but the demo sources live at `./demos/counter`. The target failed loudly when run, but nothing in CI exercises it — `hack/install-ate-kind.sh --deploy-demo-counter` (the path CI actually uses) goes through `hack/install-demo-counter.sh` and doesn't touch the Makefile, so the breakage went unnoticed.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
