### PR TITLE
refactor: trim cmd/* boilerplate, extract internal/serverboot

### DIFF
--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"net/http"
 	"os"
 	"time"
 
@@ -30,23 +29,14 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/sessionidentity"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/ateredis"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
-	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/agent-substrate/substrate/internal/credbundle"
+	"github.com/agent-substrate/substrate/internal/serverboot"
 	"github.com/agent-substrate/substrate/pkg/client/clientset/versioned"
 	"github.com/agent-substrate/substrate/pkg/client/informers/externalversions"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/exporters/prometheus"
-	"go.opentelemetry.io/otel/propagation"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -77,185 +67,41 @@ var (
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-	slog.SetDefault(slog.New(contextlogging.NewHandler(slog.NewJSONHandler(os.Stdout, nil))))
+	serverboot.InitLogger()
 
-	tp, err := initTracing(ctx)
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to initialize tracing", slog.Any("err", err))
-		os.Exit(1)
-	}
-	defer func() {
-		if err := tp.Shutdown(context.Background()); err != nil {
-			slog.Error("Failed to shutdown TracerProvider", slog.Any("err", err))
-		}
-	}()
-
-	mp, err := initMetrics(ctx)
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to initialize metrics", slog.Any("err", err))
-		os.Exit(1)
-	}
-	defer func() {
-		if err := mp.Shutdown(context.Background()); err != nil {
-			slog.Error("Failed to shutdown MeterProvider", slog.Any("err", err))
-		}
-	}()
-
-	// For development, certain flags that are likely to be different for each
-	// developer can optionally be read from environment variables.  This is
-	// helpful because it lets us keep one set of constant Kubernetes manifests
-	// that source the environment variables from a ConfigMap.  Each developer
-	// can then adapt the deployment to their own GCP project and setup, without
-	// having to edit the manifests each time they start a new branch.
-	if *redisClusterAddress == "@env" {
-		*redisClusterAddress = os.Getenv("ATE_API_REDIS_ADDRESS")
-	}
-	if *clientJWTIssuer == "@env" {
-		*clientJWTIssuer = os.Getenv("ATE_API_K8SJWT_ISSUER")
-	}
-	if *redisUseIAMAuth == "@env" {
-		*redisUseIAMAuth = os.Getenv("ATE_API_REDIS_USE_IAM_AUTH")
-	}
-	if *redisTLSServerName == "@env" {
-		*redisTLSServerName = os.Getenv("ATE_API_REDIS_TLS_SERVER_NAME")
-	}
-	if *redisClientCert == "@env" {
-		*redisClientCert = os.Getenv("ATE_API_REDIS_CLIENT_CERT")
-	}
-
-	slog.InfoContext(ctx, "Final flag values",
-		slog.String("grpc-listen-addr", *listenAddr),
-		slog.String("grpc-server-cred-bundle", *grpcServerCredBundle),
-		slog.String("redis-cluster-address", *redisClusterAddress),
-		slog.String("redis-ca-certs", *redisCACerts),
-		slog.String("redis-use-iam-auth", *redisUseIAMAuth),
-		slog.String("redis-tls-server-name", *redisTLSServerName),
-		slog.String("redis-client-cert", *redisClientCert),
-		slog.String("client-jwt-issuer", *clientJWTIssuer),
-		slog.String("client-jwt-audience", *clientJWTAudience),
-		slog.String("session-id-jwt-pool", *sessionIDJWTPoolFile),
-		slog.String("session-id-ca-pool", *sessionIDCAPoolFile),
-		slog.String("workerpool-ca-certs", *workerpoolCACerts),
-	)
-
-	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
-	if *redisCACerts != "" {
-		ca, err := os.ReadFile(*redisCACerts)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to read Redis CA cert", slog.Any("err", err))
-			os.Exit(1)
-		}
-		caPool := x509.NewCertPool()
-		if !caPool.AppendCertsFromPEM(ca) {
-			slog.ErrorContext(ctx, "Failed to parse Redis CA cert")
-			os.Exit(1)
-		}
-		slog.InfoContext(ctx, "Using custom CA cert for Redis", slog.String("path", *redisCACerts))
-		tlsConfig.RootCAs = caPool
-	}
-
-	if *redisTLSServerName != "" {
-		tlsConfig.ServerName = *redisTLSServerName
-		slog.InfoContext(ctx, "Using custom ServerName for Redis TLS verification", slog.String("name", *redisTLSServerName))
-	}
-
-	if *redisClientCert != "" {
-		cert, err := credbundle.Parse(*redisClientCert)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to parse Redis client credential bundle", slog.Any("err", err))
-			os.Exit(1)
-		}
-		tlsConfig.Certificates = []tls.Certificate{*cert}
-		slog.InfoContext(ctx, "Using client TLS certificate for Redis/Valkey", slog.String("path", *redisClientCert))
-	}
-
-	clusterOpts := &redis.ClusterOptions{
-		Addrs:     []string{*redisClusterAddress},
-		TLSConfig: tlsConfig,
-	}
-
-	if *redisUseIAMAuth != "false" {
-		creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to find default credentials for Redis IAM auth", slog.Any("err", err))
-			os.Exit(1)
-		}
-		tokenSource := creds.TokenSource
-		clusterOpts.CredentialsProvider = func() (string, string) {
-			tok, err := tokenSource.Token()
-			if err != nil {
-				slog.ErrorContext(ctx, "Failed to fetch Redis IAM token", slog.Any("err", err))
-				return "default", ""
-			}
-			return "default", tok.AccessToken
-		}
-		slog.InfoContext(ctx, "Using Google IAM authentication for Redis connection")
-	} else {
-		slog.InfoContext(ctx, "Skipping Google IAM authentication for Redis connection")
-	}
-
-	redisClient := redis.NewClusterClient(clusterOpts)
-	// Verify connection with retries on startup
-	var pingErr error
-	for i := 0; i < 30; i++ {
-		pingErr = redisClient.Ping(ctx).Err()
-		if pingErr == nil {
-			break
-		}
-		slog.WarnContext(ctx, "Failed to connect to Redis/Valkey, retrying...", slog.Int("attempt", i+1), slog.Any("err", pingErr))
-		select {
-		case <-ctx.Done():
-			pingErr = ctx.Err()
-			break
-		case <-time.After(2 * time.Second):
-		}
-	}
-	if pingErr != nil {
-		slog.ErrorContext(ctx, "Failed to connect to Redis/Valkey after retries", slog.Any("err", pingErr))
-		os.Exit(1)
-	}
-
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to get cluster config", slog.Any("err", err))
-		os.Exit(1)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create clientset", slog.Any("err", err))
-		os.Exit(1)
-	}
-
-	ateClient, err := versioned.NewForConfig(config)
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create ate clientset", slog.Any("err", err))
-		os.Exit(1)
-	}
-
-	var clientCACertPool *x509.CertPool
-	if *workerpoolCACerts != "" {
-		// TODO: Periodically reload these to handle rotations. Consult with Tina to see how she did it for client-go.
-		ca, err := os.ReadFile(*workerpoolCACerts)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to read workerpool CA", slog.Any("err", err))
-			os.Exit(1)
-		}
-		clientCACertPool = x509.NewCertPool()
-		if !clientCACertPool.AppendCertsFromPEM(ca) {
-			slog.ErrorContext(ctx, "Failed to parse workerpool CA")
-			os.Exit(1)
-		}
-		slog.InfoContext(ctx, "Using custom CA for workerpool clients", slog.String("path", *workerpoolCACerts))
-	}
-
-	serverCreds := credentials.NewTLS(&tls.Config{
-		GetCertificate: credbundle.Loader(*grpcServerCredBundle),
-		ClientAuth:     tls.VerifyClientCertIfGiven,
-		ClientCAs:      clientCACertPool,
+	tp, err := serverboot.InitTracing(ctx, serverboot.TracingOptions{
+		ServiceName: "ateapi",
+		Sampler:     sdktrace.ParentBased(sdktrace.AlwaysSample()),
 	})
+	if err != nil {
+		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
+	}
+	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+
+	mp, err := serverboot.InitMetrics(ctx, "ateapi")
+	if err != nil {
+		serverboot.Fatal(ctx, "Failed to initialize metrics", err)
+	}
+	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
+
+	loadFlagsFromEnv()
+	logFlagValues(ctx)
+
+	redisClient, err := connectRedis(ctx)
+	if err != nil {
+		serverboot.Fatal(ctx, "Failed to set up Redis/Valkey", err)
+	}
+
+	clientset, ateClient, err := newKubeClients()
+	if err != nil {
+		serverboot.Fatal(ctx, "Failed to create Kubernetes clients", err)
+	}
+
+	serverCreds, err := buildServerCreds(ctx)
+	if err != nil {
+		serverboot.Fatal(ctx, "Failed to build server credentials", err)
+	}
+
 	redisPersistence := ateredis.NewPersistence(redisClient)
 
 	ateFactory := externalversions.NewSharedInformerFactory(ateClient, 0)
@@ -285,8 +131,7 @@ func main() {
 	lisCfg := &net.ListenConfig{}
 	lis, err := lisCfg.Listen(ctx, "tcp", *listenAddr)
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to start listener", slog.Any("err", err))
-		os.Exit(1)
+		serverboot.Fatal(ctx, "Failed to start listener", err)
 	}
 
 	mux := grpc.NewServer(
@@ -298,86 +143,178 @@ func main() {
 	ateapipb.RegisterControlServer(mux, sm)
 	ateapipb.RegisterSessionIdentityServer(mux, sessionIdentitySrv)
 
-	go func() {
-		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.Handler())
-		mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("ok"))
-		})
-		slog.InfoContext(ctx, fmt.Sprintf("Starting Prometheus metrics server on %s", *metricsListenAddr))
-		if err := http.ListenAndServe(*metricsListenAddr, mux); err != nil {
-			slog.Error("Failed to start prometheus metrics server", slog.Any("err", err))
-		}
-	}()
+	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{
+		Addr:         *metricsListenAddr,
+		EnableReadyz: true,
+	})
 
 	if err := mux.Serve(lis); err != nil {
-		slog.ErrorContext(ctx, "Failed to serve", slog.Any("err", err))
-		os.Exit(1)
+		serverboot.Fatal(ctx, "Failed to serve", err)
 	}
 }
 
-func initTracing(ctx context.Context) (*sdktrace.TracerProvider, error) {
-	exporter, err := otlptracegrpc.New(ctx,
-		// GKE managed traces doesn't support validating the TLS certs of the collector
-		otlptracegrpc.WithInsecure(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create OTLP exporter: %w", err)
+// loadFlagsFromEnv resolves any flag whose value is the sentinel `@env`
+// against a known environment variable. Lets one set of Kubernetes
+// manifests source per-developer config from a ConfigMap without
+// editing the manifests for each branch.
+func loadFlagsFromEnv() {
+	overrides := []struct {
+		flag *string
+		env  string
+	}{
+		{redisClusterAddress, "ATE_API_REDIS_ADDRESS"},
+		{clientJWTIssuer, "ATE_API_K8SJWT_ISSUER"},
+		{redisUseIAMAuth, "ATE_API_REDIS_USE_IAM_AUTH"},
+		{redisTLSServerName, "ATE_API_REDIS_TLS_SERVER_NAME"},
+		{redisClientCert, "ATE_API_REDIS_CLIENT_CERT"},
 	}
-
-	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName("ateapi"),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource: %w", err)
+	for _, o := range overrides {
+		if *o.flag == "@env" {
+			*o.flag = os.Getenv(o.env)
+		}
 	}
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(res),
-		// Only trace on-demand when signaled by the client (e.g. via --trace flag)
-		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.AlwaysSample())),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.TraceContext{})
-
-	return tp, nil
 }
 
-func initMetrics(ctx context.Context) (*sdkmetric.MeterProvider, error) {
-	// Prometheus Exporter
-	promExporter, err := prometheus.New()
+func logFlagValues(ctx context.Context) {
+	slog.InfoContext(ctx, "Final flag values",
+		slog.String("grpc-listen-addr", *listenAddr),
+		slog.String("grpc-server-cred-bundle", *grpcServerCredBundle),
+		slog.String("redis-cluster-address", *redisClusterAddress),
+		slog.String("redis-ca-certs", *redisCACerts),
+		slog.String("redis-use-iam-auth", *redisUseIAMAuth),
+		slog.String("redis-tls-server-name", *redisTLSServerName),
+		slog.String("redis-client-cert", *redisClientCert),
+		slog.String("client-jwt-issuer", *clientJWTIssuer),
+		slog.String("client-jwt-audience", *clientJWTAudience),
+		slog.String("session-id-jwt-pool", *sessionIDJWTPoolFile),
+		slog.String("session-id-ca-pool", *sessionIDCAPoolFile),
+		slog.String("workerpool-ca-certs", *workerpoolCACerts),
+	)
+}
+
+// connectRedis builds the Redis/Valkey TLS config, plumbs IAM auth if
+// requested, opens the cluster client, and pings with retries.
+func connectRedis(ctx context.Context) (*redis.ClusterClient, error) {
+	tlsConfig, err := buildRedisTLSConfig(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Prometheus metric exporter: %w", err)
+		return nil, err
 	}
 
-	// OTLP Exporter
-	otlpExporter, err := otlpmetricgrpc.New(ctx,
-		otlpmetricgrpc.WithInsecure(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create OTLP metric exporter: %w", err)
+	clusterOpts := &redis.ClusterOptions{
+		Addrs:     []string{*redisClusterAddress},
+		TLSConfig: tlsConfig,
 	}
 
-	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName("ateapi"),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource: %w", err)
+	if *redisUseIAMAuth != "false" {
+		creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+		if err != nil {
+			return nil, fmt.Errorf("find default credentials for Redis IAM auth: %w", err)
+		}
+		tokenSource := creds.TokenSource
+		clusterOpts.CredentialsProvider = func() (string, string) {
+			tok, err := tokenSource.Token()
+			if err != nil {
+				slog.Error("Failed to fetch Redis IAM token", slog.Any("err", err))
+				return "default", ""
+			}
+			return "default", tok.AccessToken
+		}
+		slog.InfoContext(ctx, "Using Google IAM authentication for Redis connection")
+	} else {
+		slog.InfoContext(ctx, "Skipping Google IAM authentication for Redis connection")
 	}
 
-	mp := sdkmetric.NewMeterProvider(
-		// Register both readers
-		sdkmetric.WithReader(promExporter),
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(otlpExporter)),
-		sdkmetric.WithResource(res),
-	)
-	otel.SetMeterProvider(mp)
+	client := redis.NewClusterClient(clusterOpts)
+	if err := pingRedisWithRetries(ctx, client); err != nil {
+		return nil, err
+	}
+	return client, nil
+}
 
-	return mp, nil
+func buildRedisTLSConfig(ctx context.Context) (*tls.Config, error) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	if *redisCACerts != "" {
+		ca, err := os.ReadFile(*redisCACerts)
+		if err != nil {
+			return nil, fmt.Errorf("read Redis CA cert: %w", err)
+		}
+		caPool := x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(ca) {
+			return nil, fmt.Errorf("parse Redis CA cert from %s", *redisCACerts)
+		}
+		tlsConfig.RootCAs = caPool
+		slog.InfoContext(ctx, "Using custom CA cert for Redis", slog.String("path", *redisCACerts))
+	}
+	if *redisTLSServerName != "" {
+		tlsConfig.ServerName = *redisTLSServerName
+		slog.InfoContext(ctx, "Using custom ServerName for Redis TLS verification", slog.String("name", *redisTLSServerName))
+	}
+	if *redisClientCert != "" {
+		cert, err := credbundle.Parse(*redisClientCert)
+		if err != nil {
+			return nil, fmt.Errorf("parse Redis client credential bundle: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{*cert}
+		slog.InfoContext(ctx, "Using client TLS certificate for Redis/Valkey", slog.String("path", *redisClientCert))
+	}
+	return tlsConfig, nil
+}
+
+func pingRedisWithRetries(ctx context.Context, client *redis.ClusterClient) error {
+	var pingErr error
+	for i := 0; i < 30; i++ {
+		pingErr = client.Ping(ctx).Err()
+		if pingErr == nil {
+			return nil
+		}
+		slog.WarnContext(ctx, "Failed to connect to Redis/Valkey, retrying...", slog.Int("attempt", i+1), slog.Any("err", pingErr))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+	return fmt.Errorf("ping Redis/Valkey after 30 retries: %w", pingErr)
+}
+
+// newKubeClients builds the standard Kubernetes clientset and the ate
+// (substrate CRD) clientset from in-cluster config.
+func newKubeClients() (*kubernetes.Clientset, versioned.Interface, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("get cluster config: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create clientset: %w", err)
+	}
+	ateClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create ate clientset: %w", err)
+	}
+	return clientset, ateClient, nil
+}
+
+// buildServerCreds loads the workerpool CA pool (if configured) and
+// composes gRPC TransportCredentials over the server bundle + optional
+// client-cert verification.
+func buildServerCreds(ctx context.Context) (credentials.TransportCredentials, error) {
+	var clientCAs *x509.CertPool
+	if *workerpoolCACerts != "" {
+		// TODO: Periodically reload these to handle rotations. Consult with Tina to see how she did it for client-go.
+		ca, err := os.ReadFile(*workerpoolCACerts)
+		if err != nil {
+			return nil, fmt.Errorf("read workerpool CA: %w", err)
+		}
+		clientCAs = x509.NewCertPool()
+		if !clientCAs.AppendCertsFromPEM(ca) {
+			return nil, fmt.Errorf("parse workerpool CA from %s", *workerpoolCACerts)
+		}
+		slog.InfoContext(ctx, "Using custom CA for workerpool clients", slog.String("path", *workerpoolCACerts))
+	}
+	return credentials.NewTLS(&tls.Config{
+		GetCertificate: credbundle.Loader(*grpcServerCredBundle),
+		ClientAuth:     tls.VerifyClientCertIfGiven,
+		ClientCAs:      clientCAs,
+	}), nil
 }

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -35,25 +34,16 @@ import (
 	"github.com/agent-substrate/substrate/internal/ategcs"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/ateompath"
-	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/agent-substrate/substrate/internal/memorypullcache"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/serverboot"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/go-containerregistry/pkg/authn"
 	googlecontainerauth "github.com/google/go-containerregistry/pkg/v1/google"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/exporters/prometheus"
-	"go.opentelemetry.io/otel/propagation"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -73,38 +63,24 @@ var (
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-	slog.SetDefault(slog.New(contextlogging.NewHandler(slog.NewJSONHandler(os.Stdout, nil))))
+	serverboot.InitLogger()
 
-	tp, err := initTracing(ctx)
+	tp, err := serverboot.InitTracing(ctx, serverboot.TracingOptions{
+		ServiceName: "atelet",
+		Sampler:     sdktrace.ParentBased(sdktrace.NeverSample()),
+	})
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to initialize tracing", slog.Any("err", err))
-		os.Exit(1)
+		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
 	}
-	defer func() {
-		if err := tp.Shutdown(context.Background()); err != nil {
-			slog.Error("Failed to shutdown TracerProvider", slog.Any("err", err))
-		}
-	}()
+	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
 
-	mp, err := initMetrics(ctx)
+	mp, err := serverboot.InitMetrics(ctx, "atelet")
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to initialize metrics", slog.Any("err", err))
-		os.Exit(1)
+		serverboot.Fatal(ctx, "Failed to initialize metrics", err)
 	}
-	defer func() {
-		if err := mp.Shutdown(context.Background()); err != nil {
-			slog.Error("Failed to shutdown MeterProvider", slog.Any("err", err))
-		}
-	}()
+	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
 
-	go func() {
-		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.Handler())
-		slog.InfoContext(ctx, fmt.Sprintf("Starting Prometheus metrics server on %s", *metricsListenAddr))
-		if err := http.ListenAndServe(*metricsListenAddr, mux); err != nil {
-			slog.Error("Failed to start prometheus metrics server", slog.Any("err", err))
-		}
-	}()
+	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{Addr: *metricsListenAddr})
 
 	ateomDialer := &AteomDialer{
 		conns: lru.New(256),
@@ -114,21 +90,18 @@ func main() {
 	if *gcpAuthForImagePulls {
 		gcpRegistryAuthn, err = googlecontainerauth.NewEnvAuthenticator(ctx)
 		if err != nil {
-			slog.ErrorContext(ctx, "Failed to create GCP registry authenticator", slog.Any("err", err))
-			os.Exit(1)
+			serverboot.Fatal(ctx, "Failed to create GCP registry authenticator", err)
 		}
 	}
 
 	pullCache, err := memorypullcache.NewMemoryPullCache(ctx, gcpRegistryAuthn, *localhostRegistryReplacement)
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create pull cache", slog.Any("err", err))
-		os.Exit(1)
+		serverboot.Fatal(ctx, "Failed to create pull cache", err)
 	}
 
 	anonGCSClient, err := storage.NewClient(ctx, option.WithoutAuthentication())
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create anonymous GCS client", slog.Any("err", err))
-		os.Exit(1)
+		serverboot.Fatal(ctx, "Failed to create anonymous GCS client", err)
 	}
 
 	var gcsClient *storage.Client
@@ -141,8 +114,7 @@ func main() {
 		// these will need to be set on the atelet pods
 		cfg, err := config.LoadDefaultConfig(ctx)
 		if err != nil {
-			slog.ErrorContext(ctx, "Failed to load S3 config", slog.Any("err", err))
-			os.Exit(1)
+			serverboot.Fatal(ctx, "Failed to load S3 config", err)
 		}
 		s3Client = s3.NewFromConfig(cfg, func(o *s3.Options) {
 			if usePathStyle := os.Getenv("AWS_S3_USE_PATH_STYLE"); usePathStyle == "true" {
@@ -153,8 +125,7 @@ func main() {
 	default:
 		gcsClient, err = storage.NewClient(ctx)
 		if err != nil {
-			slog.ErrorContext(ctx, "Failed to create GCS client", slog.Any("err", err))
-			os.Exit(1)
+			serverboot.Fatal(ctx, "Failed to create GCS client", err)
 		}
 	}
 
@@ -180,8 +151,7 @@ func main() {
 
 	lis, err := net.Listen("tcp", ":"+strconv.Itoa(*port))
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to listen", slog.Any("err", err))
-		os.Exit(1)
+		serverboot.Fatal(ctx, "Failed to listen", err)
 	}
 
 	svr := grpc.NewServer(grpc.StatsHandler(otelgrpc.NewServerHandler()), grpc.UnaryInterceptor(ateinterceptors.ServerUnaryInterceptor))
@@ -189,74 +159,8 @@ func main() {
 	reflection.Register(svr)
 	slog.InfoContext(ctx, "WorkersManagerService listening", slog.Any("address", lis.Addr()))
 	if err := svr.Serve(lis); err != nil {
-		slog.ErrorContext(ctx, "Failed to serve", slog.Any("err", err))
-		os.Exit(1)
+		serverboot.Fatal(ctx, "Failed to serve", err)
 	}
-}
-
-func initTracing(ctx context.Context) (*sdktrace.TracerProvider, error) {
-	exporter, err := otlptracegrpc.New(ctx,
-		// GKE managed traces doesn't support validating the TLS certs of the collector
-		otlptracegrpc.WithInsecure(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create OTLP exporter: %w", err)
-	}
-
-	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName("atelet"),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource: %w", err)
-	}
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(res),
-		// Only trace on-demand when signaled by the client (e.g. via --trace flag)
-		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.NeverSample())),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.TraceContext{})
-
-	return tp, nil
-}
-
-func initMetrics(ctx context.Context) (*sdkmetric.MeterProvider, error) {
-	// Prometheus Exporter
-	promExporter, err := prometheus.New()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Prometheus metric exporter: %w", err)
-	}
-
-	// OTLP Exporter
-	otlpExporter, err := otlpmetricgrpc.New(ctx,
-		otlpmetricgrpc.WithInsecure(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create OTLP metric exporter: %w", err)
-	}
-
-	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName("atelet"),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource: %w", err)
-	}
-
-	mp := sdkmetric.NewMeterProvider(
-		// Register both readers
-		sdkmetric.WithReader(promExporter),
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(otlpExporter)),
-		sdkmetric.WithResource(res),
-	)
-	otel.SetMeterProvider(mp)
-
-	return mp, nil
 }
 
 // AteomHerder is a service that allows controlling workloads on individual
@@ -358,109 +262,36 @@ func (s *AteomHerder) fetchRunsc(ctx context.Context, cfg *ateletpb.RunscConfig)
 }
 
 func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*ateletpb.RunResponse, error) {
-	// Create static files dir if it doesn't exist.
-	if err := os.MkdirAll(ateompath.StaticFilesDir, 0o700); err != nil {
-		return nil, fmt.Errorf("while creating static files dir: %w", err)
-	}
-
-	// Download correct runsc version if not already downloaded.
-	runscPath, err := s.fetchRunsc(ctx, req.GetRunsc())
+	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())
 	if err != nil {
-		return nil, fmt.Errorf("in fetchRunsc: %w", err)
+		return nil, err
 	}
 
-	// Clear actor state
 	if err := resetActorDirs(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
-	netnsPath := ateompath.AteomNetNSPath(req.GetTargetAteomNamespace(), req.GetTargetAteomName())
-
-	g, gCtx := errgroup.WithContext(ctx)
-
-	// Pull pause container and assemble OCI bundle
-	g.Go(func() error {
-		if err := prepareOCIDirectory(
-			gCtx,
-			s.pullCache,
-			req.GetActorTemplateNamespace(),
-			req.GetActorTemplateName(),
-			req.GetActorId(),
-			"pause",
-			req.GetSpec().GetPauseImage(),
-			[]string{"/pause"},
-			nil,
-			map[string]string{
-				"io.kubernetes.cri.container-type": "sandbox",
-				"io.kubernetes.cri.container-name": "pause",
-			},
-			netnsPath,
-		); err != nil {
-			return fmt.Errorf("while creating pause OCI bundle: %w", err)
-		}
-		return nil
-	})
-
-	// Pull each application container and assemble OCI bundle
-	for _, ctr := range req.GetSpec().GetContainers() {
-		ctr := ctr
-		var envs []string
-		for _, env := range ctr.GetEnv() {
-			envs = append(envs, fmt.Sprintf("%s=%s", env.GetName(), env.GetValue()))
-		}
-
-		g.Go(func() error {
-			if err := prepareOCIDirectory(
-				gCtx,
-				s.pullCache,
-				req.GetActorTemplateNamespace(),
-				req.GetActorTemplateName(),
-				req.GetActorId(),
-				ctr.GetName(),
-				ctr.GetImage(),
-				ctr.GetCommand(),
-				envs,
-				map[string]string{
-					"io.kubernetes.cri.container-type": "container",
-					"io.kubernetes.cri.sandbox-id":     "pause",
-					"io.kubernetes.cri.container-name": ctr.GetName(),
-				},
-				netnsPath,
-			); err != nil {
-				return fmt.Errorf("while creating %q OCI bundle: %w", ctr.GetName(), err)
-			}
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
+	if err := s.prepareOCIBundles(ctx,
+		req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(),
+		req.GetSpec(), req.GetTargetAteomNamespace(), req.GetTargetAteomName(),
+	); err != nil {
 		return nil, err
 	}
 
-	// Dial correct ateom over UDS.
-	ateomConn, err := s.ateomDialer.DialAteomPod(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
+	client, err := s.dialAteom(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
 	if err != nil {
-		return nil, fmt.Errorf("while getting ateom conn for %s/%s: %w", req.GetTargetAteomNamespace(), req.GetTargetAteomName(), err)
+		return nil, err
 	}
-	client := ateompb.NewAteomClient(ateomConn)
 
 	// Tell ateom to do runsc create + runsc start for pause container and
 	// all application containers.
-	ateomReq := &ateompb.RunWorkloadRequest{
+	if _, err := client.RunWorkload(ctx, &ateompb.RunWorkloadRequest{
 		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
 		ActorTemplateName:      req.GetActorTemplateName(),
 		ActorId:                req.GetActorId(),
 		RunscPath:              runscPath,
-		Spec:                   &ateompb.WorkloadSpec{},
-	}
-	for _, ctr := range req.GetSpec().GetContainers() {
-		ateomCtr := &ateompb.Container{
-			Name: ctr.GetName(),
-		}
-		ateomReq.GetSpec().Containers = append(ateomReq.GetSpec().Containers, ateomCtr)
-	}
-	_, err = client.RunWorkload(ctx, ateomReq)
-	if err != nil {
+		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
+	}); err != nil {
 		return nil, fmt.Errorf("while calling ateom.RunWorkload: %w", err)
 	}
 
@@ -468,25 +299,17 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 }
 
 func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRequest) (*ateletpb.CheckpointResponse, error) {
-	// Create static files dir if it doesn't exist.
-	if err := os.MkdirAll(ateompath.StaticFilesDir, 0o700); err != nil {
-		return nil, fmt.Errorf("while creating static files dir: %w", err)
-	}
-
-	// Download correct runsc version if not already downloaded.
-	runscPath, err := s.fetchRunsc(ctx, req.GetRunsc())
+	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())
 	if err != nil {
-		return nil, fmt.Errorf("in fetchRunsc: %w", err)
+		return nil, err
 	}
 
 	checkpointDir := ateompath.CheckpointDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
 
-	// Dial correct ateom over UDS.
-	ateomConn, err := s.ateomDialer.DialAteomPod(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
+	client, err := s.dialAteom(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
 	if err != nil {
-		return nil, fmt.Errorf("while getting ateom conn for %s/%s: %w", req.GetTargetAteomNamespace(), req.GetTargetAteomName(), err)
+		return nil, err
 	}
-	client := ateompb.NewAteomClient(ateomConn)
 
 	// TODO(ateom): Once we enable background restore, we need `runsc wait
 	// --restore pause` here, so that we know that gVisor is done with the
@@ -501,63 +324,41 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	}
 
 	// Tell ateom to take checkpoint and delete containers.
-	ateomReq := &ateompb.CheckpointWorkloadRequest{
+	if _, err := client.CheckpointWorkload(ctx, &ateompb.CheckpointWorkloadRequest{
 		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
 		ActorTemplateName:      req.GetActorTemplateName(),
 		ActorId:                req.GetActorId(),
 		RunscPath:              runscPath,
-		Spec:                   &ateompb.WorkloadSpec{},
-	}
-	for _, ctr := range req.GetSpec().GetContainers() {
-		ateomCtr := &ateompb.Container{
-			Name: ctr.GetName(),
-		}
-		ateomReq.GetSpec().Containers = append(ateomReq.GetSpec().Containers, ateomCtr)
-	}
-	_, err = client.CheckpointWorkload(ctx, ateomReq)
-	if err != nil {
+		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
+	}); err != nil {
 		return nil, fmt.Errorf("while calling ateom.CheckpointWorkload: %w", err)
 	}
 
+	prefix := strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")
+	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
+
 	// Upload checkpoint from local dir.
-	err = ategcs.SendLocalFileToGCSWithZstd(
-		ctx,
-		s.gcsClient,
-		strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")+"/checkpoint.img.zstd",
-		ateompath.CheckpointImgPath(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()),
-	)
-	if err != nil {
+	if err := ategcs.SendLocalFileToGCSWithZstd(ctx, s.gcsClient,
+		prefix+"/checkpoint.img.zstd",
+		ateompath.CheckpointImgPath(ns, tmpl, actorID),
+	); err != nil {
 		return nil, fmt.Errorf("while uploading checkpoint.img to GCS: %w", err)
 	}
 
-	pagesImgPath := ateompath.PagesImgPath(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
-	if _, err := os.Stat(pagesImgPath); err == nil { // EQUALS nil
-		err = ategcs.SendLocalFileToGCSWithZstd(
-			ctx,
-			s.gcsClient,
-			strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")+"/pages.img.zstd",
-			pagesImgPath,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("while uploading pages.img to GCS: %w", err)
-		}
+	if err := uploadIfExists(ctx, s.gcsClient,
+		prefix+"/pages.img.zstd",
+		ateompath.PagesImgPath(ns, tmpl, actorID),
+	); err != nil {
+		return nil, err
+	}
+	if err := uploadIfExists(ctx, s.gcsClient,
+		prefix+"/pages_meta.img.zstd",
+		ateompath.PagesMetaImgPath(ns, tmpl, actorID),
+	); err != nil {
+		return nil, err
 	}
 
-	pagesMetaImgPath := ateompath.PagesMetaImgPath(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
-	if _, err := os.Stat(pagesMetaImgPath); err == nil { // EQUALS nil
-		err = ategcs.SendLocalFileToGCSWithZstd(
-			ctx,
-			s.gcsClient,
-			strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")+"/pages_meta.img.zstd",
-			pagesMetaImgPath,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("while uploading pages_meta.img to GCS: %w", err)
-		}
-	}
-
-	// Clear actor state
-	if err := resetActorDirs(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()); err != nil {
+	if err := resetActorDirs(ns, tmpl, actorID); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
@@ -565,78 +366,96 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 }
 
 func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest) (*ateletpb.RestoreResponse, error) {
-	// Create static files dir if it doesn't exist.
-	if err := os.MkdirAll(ateompath.StaticFilesDir, 0o700); err != nil {
-		return nil, fmt.Errorf("while creating static files dir: %w", err)
-	}
-
-	// Download correct runsc version if not already downloaded.
-	runscPath, err := s.fetchRunsc(ctx, req.GetRunsc())
+	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())
 	if err != nil {
-		return nil, fmt.Errorf("in fetchRunsc: %w", err)
+		return nil, err
 	}
 
-	// Clear actor state
-	if err := resetActorDirs(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()); err != nil {
+	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
+
+	if err := resetActorDirs(ns, tmpl, actorID); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
+	prefix := strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")
 	g, gCtx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		if err := ategcs.FetchLocalFileFromGCSWithZstd(
-			gCtx,
-			s.gcsClient,
-			strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")+"/checkpoint.img.zstd",
-			ateompath.CheckpointImgPath(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()),
-		); err != nil {
-			return fmt.Errorf("while downloading checkpoint.img from GCS: %w", err)
-		}
-		return nil
-	})
-
-	g.Go(func() error {
-		if err := ategcs.FetchLocalFileFromGCSWithZstd(
-			gCtx,
-			s.gcsClient,
-			strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")+"/pages.img.zstd",
-			ateompath.PagesImgPath(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()),
-		); err != nil {
-			return fmt.Errorf("while downloading pages.img from GCS: %w", err)
-		}
-		return nil
-	})
-
-	g.Go(func() error {
-		if err := ategcs.FetchLocalFileFromGCSWithZstd(
-			gCtx,
-			s.gcsClient,
-			strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")+"/pages_meta.img.zstd",
-			ateompath.PagesMetaImgPath(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()),
-		); err != nil {
-			return fmt.Errorf("while downloading pages_meta.img from GCS: %w", err)
-		}
-		return nil
-	})
-
+	for _, dl := range []struct{ remote, local string }{
+		{prefix + "/checkpoint.img.zstd", ateompath.CheckpointImgPath(ns, tmpl, actorID)},
+		{prefix + "/pages.img.zstd", ateompath.PagesImgPath(ns, tmpl, actorID)},
+		{prefix + "/pages_meta.img.zstd", ateompath.PagesMetaImgPath(ns, tmpl, actorID)},
+	} {
+		dl := dl
+		g.Go(func() error {
+			if err := ategcs.FetchLocalFileFromGCSWithZstd(gCtx, s.gcsClient, dl.remote, dl.local); err != nil {
+				return fmt.Errorf("while downloading %s from GCS: %w", filepath.Base(dl.remote), err)
+			}
+			return nil
+		})
+	}
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 
-	netnsPath := ateompath.AteomNetNSPath(req.GetTargetAteomNamespace(), req.GetTargetAteomName())
+	if err := s.prepareOCIBundles(ctx, ns, tmpl, actorID,
+		req.GetSpec(), req.GetTargetAteomNamespace(), req.GetTargetAteomName(),
+	); err != nil {
+		return nil, err
+	}
 
-	g, gCtx = errgroup.WithContext(ctx)
+	client, err := s.dialAteom(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
+	if err != nil {
+		return nil, err
+	}
 
-	// Pull pause container and assemble OCI bundle
+	// Tell ateom to do runsc create + runsc restore for pause container and
+	// all application containers.
+	if _, err := client.RestoreWorkload(ctx, &ateompb.RestoreWorkloadRequest{
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      tmpl,
+		ActorId:                actorID,
+		RunscPath:              runscPath,
+		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
+	}); err != nil {
+		return nil, fmt.Errorf("while calling ateom.RestoreWorkload: %w", err)
+	}
+
+	return &ateletpb.RestoreResponse{}, nil
+}
+
+// fetchRunscAndPrep ensures the static files dir exists and downloads the
+// runsc binary at the version pinned by the request. Returns the local
+// runsc path.
+func (s *AteomHerder) fetchRunscAndPrep(ctx context.Context, runscCfg *ateletpb.RunscConfig) (string, error) {
+	if err := os.MkdirAll(ateompath.StaticFilesDir, 0o700); err != nil {
+		return "", fmt.Errorf("while creating static files dir: %w", err)
+	}
+	runscPath, err := s.fetchRunsc(ctx, runscCfg)
+	if err != nil {
+		return "", fmt.Errorf("in fetchRunsc: %w", err)
+	}
+	return runscPath, nil
+}
+
+// prepareOCIBundles pulls images and assembles OCI bundles for the pause
+// container and every application container in spec, in parallel.
+func (s *AteomHerder) prepareOCIBundles(
+	ctx context.Context,
+	actorTemplateNamespace, actorTemplateName, actorID string,
+	spec *ateletpb.WorkloadSpec,
+	targetAteomNamespace, targetAteomName string,
+) error {
+	netnsPath := ateompath.AteomNetNSPath(targetAteomNamespace, targetAteomName)
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	// Pause container.
 	g.Go(func() error {
 		if err := prepareOCIDirectory(
 			gCtx,
 			s.pullCache,
-			req.GetActorTemplateNamespace(),
-			req.GetActorTemplateName(),
-			req.GetActorId(),
+			actorTemplateNamespace, actorTemplateName, actorID,
 			"pause",
-			req.GetSpec().GetPauseImage(),
+			spec.GetPauseImage(),
 			[]string{"/pause"},
 			nil,
 			map[string]string{
@@ -650,21 +469,18 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		return nil
 	})
 
-	// Pull each application container and assemble OCI bundle
-	for _, ctr := range req.GetSpec().GetContainers() {
+	// Application containers.
+	for _, ctr := range spec.GetContainers() {
 		ctr := ctr
 		var envs []string
 		for _, env := range ctr.GetEnv() {
 			envs = append(envs, fmt.Sprintf("%s=%s", env.GetName(), env.GetValue()))
 		}
-
 		g.Go(func() error {
 			if err := prepareOCIDirectory(
 				gCtx,
 				s.pullCache,
-				req.GetActorTemplateNamespace(),
-				req.GetActorTemplateName(),
-				req.GetActorId(),
+				actorTemplateNamespace, actorTemplateName, actorID,
 				ctr.GetName(),
 				ctr.GetImage(),
 				ctr.GetCommand(),
@@ -682,38 +498,40 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
+	return g.Wait()
+}
 
-	// Dial correct ateom over UDS.
-	ateomConn, err := s.ateomDialer.DialAteomPod(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
+// dialAteom opens (or reuses) the gRPC connection to the target ateom
+// pod and returns an ateom client.
+func (s *AteomHerder) dialAteom(ctx context.Context, namespace, name string) (ateompb.AteomClient, error) {
+	conn, err := s.ateomDialer.DialAteomPod(ctx, namespace, name)
 	if err != nil {
-		return nil, fmt.Errorf("while getting ateom conn for %s/%s: %w", req.GetTargetAteomNamespace(), req.GetTargetAteomName(), err)
+		return nil, fmt.Errorf("while getting ateom conn for %s/%s: %w", namespace, name, err)
 	}
-	client := ateompb.NewAteomClient(ateomConn)
+	return ateompb.NewAteomClient(conn), nil
+}
 
-	// Tell ateom to do runsc create + runsc restore for pause container and
-	// all application containers.
-	ateomReq := &ateompb.RestoreWorkloadRequest{
-		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
-		ActorTemplateName:      req.GetActorTemplateName(),
-		ActorId:                req.GetActorId(),
-		RunscPath:              runscPath,
-		Spec:                   &ateompb.WorkloadSpec{},
+// buildAteomWorkloadSpec projects the atelet-facing workload spec onto
+// the ateom-facing one — currently just the container names.
+func buildAteomWorkloadSpec(spec *ateletpb.WorkloadSpec) *ateompb.WorkloadSpec {
+	out := &ateompb.WorkloadSpec{}
+	for _, ctr := range spec.GetContainers() {
+		out.Containers = append(out.Containers, &ateompb.Container{Name: ctr.GetName()})
 	}
-	for _, ctr := range req.GetSpec().GetContainers() {
-		ateomCtr := &ateompb.Container{
-			Name: ctr.GetName(),
-		}
-		ateomReq.GetSpec().Containers = append(ateomReq.GetSpec().Containers, ateomCtr)
-	}
-	_, err = client.RestoreWorkload(ctx, ateomReq)
-	if err != nil {
-		return nil, fmt.Errorf("while calling ateom.RestoreWorkload: %w", err)
-	}
+	return out
+}
 
-	return &ateletpb.RestoreResponse{}, nil
+// uploadIfExists uploads a local file to GCS (zstd-compressed) only if
+// the file is present. Missing files are silently skipped — used for
+// optional checkpoint side-files (pages.img, pages_meta.img).
+func uploadIfExists(ctx context.Context, gcs ategcs.ObjectStorage, remoteURI, localPath string) error {
+	if _, err := os.Stat(localPath); err != nil {
+		return nil
+	}
+	if err := ategcs.SendLocalFileToGCSWithZstd(ctx, gcs, remoteURI, localPath); err != nil {
+		return fmt.Errorf("while uploading %s to GCS: %w", filepath.Base(localPath), err)
+	}
+	return nil
 }
 
 type AteomDialer struct {

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -28,17 +28,13 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/ateompath"
-	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/serverboot"
 	"github.com/hashicorp/go-reap"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -64,21 +60,20 @@ func do(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	logger := slog.New(contextlogging.NewHandler(slog.NewJSONHandler(os.Stdout, nil)))
-	slog.SetDefault(logger)
+	serverboot.InitLogger()
 
 	slog.InfoContext(ctx, "ateom booting")
 
-	tp, err := initTracing(ctx)
+	tp, err := serverboot.InitTracing(ctx, serverboot.TracingOptions{
+		ServiceName: "ateom-gvisor",
+		Sampler:     sdktrace.ParentBased(sdktrace.NeverSample()),
+		// ateom has no network connectivity once eth0 moves into the gvisor netns.
+		NoExporter: true,
+	})
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to initialize tracing", slog.Any("err", err))
-		os.Exit(1)
+		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
 	}
-	defer func() {
-		if err := tp.Shutdown(context.Background()); err != nil {
-			slog.Error("Failed to shutdown TracerProvider", slog.Any("err", err))
-		}
-	}()
+	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
 
 	// Create ateom dir
 	ateomDir := ateompath.AteomPath(*podNamespace, *podName)
@@ -128,7 +123,7 @@ func do(ctx context.Context) error {
 		return fmt.Errorf("while creating ateom-interior netns: %w", err)
 	}
 
-	actorLogger := NewActorLogger(logger, metadata.OnGCE())
+	actorLogger := NewActorLogger(slog.Default(), metadata.OnGCE())
 	ateomService := NewService(interiorNetNS, eth0LinkInfo, actorLogger)
 
 	svr := grpc.NewServer(
@@ -144,30 +139,6 @@ func do(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func initTracing(ctx context.Context) (*sdktrace.TracerProvider, error) {
-	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName("ateom-gvisor"),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource: %w", err)
-	}
-
-	// No exporter, since ateom has no network connectivity once eth0 is sent
-	// into the gvisor netns.  Maybe we can eventually figure out export via
-	// UDS.
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithResource(res),
-		// Only trace on-demand when signaled by the client (e.g. via --trace flag)
-		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.NeverSample())),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.TraceContext{})
-
-	return tp, nil
 }
 
 // AteomService is a service for shepherding single microvm.

--- a/internal/serverboot/serverboot.go
+++ b/internal/serverboot/serverboot.go
@@ -1,0 +1,167 @@
+//  Copyright 2026 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package serverboot collects the startup boilerplate shared by the
+// long-running substrate server binaries (ateapi, atelet, ateom-gvisor):
+// slog wiring, OTel tracer + meter providers, a Prometheus + /readyz
+// HTTP surface, and a couple of small helpers for startup fail-fast.
+package serverboot
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/agent-substrate/substrate/internal/contextlogging"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+)
+
+// InitLogger sets the global slog logger to a JSON handler wrapped in
+// contextlogging.NewHandler. Call once at process start.
+func InitLogger() {
+	slog.SetDefault(slog.New(contextlogging.NewHandler(slog.NewJSONHandler(os.Stdout, nil))))
+}
+
+// TracingOptions configures InitTracing.
+type TracingOptions struct {
+	// ServiceName is required; populates resource.semconv ServiceName.
+	ServiceName string
+	// Sampler is required. ateapi typically uses ParentBased(AlwaysSample);
+	// atelet/ateom-gvisor use ParentBased(NeverSample).
+	Sampler sdktrace.Sampler
+	// NoExporter skips the OTLP exporter. Used by binaries with no
+	// network egress (ateom-gvisor, after eth0 moves into the gvisor
+	// netns).
+	NoExporter bool
+}
+
+// InitTracing registers a global TracerProvider with the given options
+// and the TraceContext text-map propagator.
+func InitTracing(ctx context.Context, opts TracingOptions) (*sdktrace.TracerProvider, error) {
+	if opts.ServiceName == "" {
+		return nil, fmt.Errorf("TracingOptions.ServiceName is required")
+	}
+	res, err := resource.New(ctx,
+		resource.WithAttributes(semconv.ServiceName(opts.ServiceName)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create tracer resource: %w", err)
+	}
+
+	tpOpts := []sdktrace.TracerProviderOption{
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(opts.Sampler),
+	}
+	if !opts.NoExporter {
+		exporter, err := otlptracegrpc.New(ctx,
+			// GKE managed traces doesn't support validating the TLS certs of the collector.
+			otlptracegrpc.WithInsecure(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create OTLP exporter: %w", err)
+		}
+		tpOpts = append(tpOpts, sdktrace.WithBatcher(exporter))
+	}
+
+	tp := sdktrace.NewTracerProvider(tpOpts...)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	return tp, nil
+}
+
+// InitMetrics registers a global MeterProvider with both a Prometheus
+// reader (exposed via StartMetricsServer's /metrics handler) and an
+// OTLP periodic reader.
+func InitMetrics(ctx context.Context, serviceName string) (*sdkmetric.MeterProvider, error) {
+	if serviceName == "" {
+		return nil, fmt.Errorf("serviceName is required")
+	}
+	promExporter, err := prometheus.New()
+	if err != nil {
+		return nil, fmt.Errorf("create Prometheus metric exporter: %w", err)
+	}
+	otlpExporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithInsecure())
+	if err != nil {
+		return nil, fmt.Errorf("create OTLP metric exporter: %w", err)
+	}
+	res, err := resource.New(ctx,
+		resource.WithAttributes(semconv.ServiceName(serviceName)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create metric resource: %w", err)
+	}
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(promExporter),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(otlpExporter)),
+		sdkmetric.WithResource(res),
+	)
+	otel.SetMeterProvider(mp)
+	return mp, nil
+}
+
+// Fatal logs msg + err and exits with status 1. For startup-time
+// fail-fast where there's no recovery path.
+func Fatal(ctx context.Context, msg string, err error) {
+	slog.ErrorContext(ctx, msg, slog.Any("err", err))
+	os.Exit(1)
+}
+
+// ShutdownProvider invokes the OTel provider's Shutdown and logs any
+// error. Designed to be deferred from main():
+//
+//	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+func ShutdownProvider(name string, shutdown func(context.Context) error) {
+	if err := shutdown(context.Background()); err != nil {
+		slog.Error("Failed to shutdown "+name, slog.Any("err", err))
+	}
+}
+
+// MetricsServerOptions configures StartMetricsServer.
+type MetricsServerOptions struct {
+	// Addr is the TCP listen address (e.g. ":9090").
+	Addr string
+	// EnableReadyz adds a /readyz handler that returns 200 OK. Some
+	// binaries (ateapi) want it for Kubernetes readiness probes; others
+	// (atelet) historically didn't surface one.
+	EnableReadyz bool
+}
+
+// StartMetricsServer runs an HTTP server exposing /metrics (Prometheus)
+// and optionally /readyz. Blocks until http.ListenAndServe returns;
+// designed to be `go`-launched.
+func StartMetricsServer(ctx context.Context, opts MetricsServerOptions) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	if opts.EnableReadyz {
+		mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		})
+	}
+	slog.InfoContext(ctx, fmt.Sprintf("Starting Prometheus metrics server on %s", opts.Addr))
+	if err := http.ListenAndServe(opts.Addr, mux); err != nil {
+		slog.Error("Failed to start prometheus metrics server", slog.Any("err", err))
+	}
+}


### PR DESCRIPTION
Three related cleanups in cmd/{ateapi,atelet,ateom-gvisor}/main.go:

1. atelet Run/Checkpoint/Restore handlers shared three blocks of cut-and-paste (fetchRunsc + MkdirAll, errgroup over pause + application containers calling prepareOCIDirectory, dial-ateom + NewAteomClient, the ateletpb -> ateompb WorkloadSpec projection). Factored into fetchRunscAndPrep, prepareOCIBundles, dialAteom, buildAteomWorkloadSpec, plus a uploadIfExists for the optional pages.img / pages_meta.img upload in Checkpoint.

2. ateapi main() was a 242-line wall of inlined startup steps; decomposed into named helpers (loadFlagsFromEnv, logFlagValues, connectRedis with buildRedisTLSConfig + pingRedisWithRetries, newKubeClients, buildServerCreds) so the top-level flow reads as orchestration.

3. ateapi, atelet, and ateom-gvisor each carried their own ~30-line initTracing + ~35-line initMetrics + slog/metrics-server boilerplate that differed only in ServiceName, sampler choice, and whether the OTLP exporter was wired. Lifted to a new internal/serverboot package exposing InitLogger, InitTracing (with TracingOptions.NoExporter for ateom-gvisor which loses egress once eth0 moves into the gvisor netns), InitMetrics, Fatal, ShutdownProvider, and StartMetricsServer.

No behaviour change. Verified with go vet, GOOS=linux go build, and go test ./cmd/ateapi/internal/...

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
