### PR TITLE
remove go vet, which is redundant to golangci-lint

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -27,7 +27,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 1.26
-    - run: go vet -v ./...
     - run: go test -v ./...
     - name: verify
       run: hack/verify-all.sh

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ lint:
 
 .PHONY: verify
 verify: test
-	$(GO) vet ./...
 	bash hack/verify-all.sh
 
 .PHONY: clean


### PR DESCRIPTION
save some time in CI

follow-up https://github.com/agent-substrate/substrate/pull/63

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
