### PR TITLE
build tag linux-only code

### DIFF
--- a/cmd/ateom-gvisor/internal/ateom/logger.go
+++ b/cmd/ateom-gvisor/internal/ateom/logger.go
@@ -25,15 +25,22 @@ import (
 	"time"
 )
 
-type syncedWriter struct {
+// SyncedWriter wraps an io.Writer and synchronizes writes across goroutines.
+type SyncedWriter struct {
 	mu sync.Mutex
 	w  io.Writer
 }
 
-func (sw *syncedWriter) Write(p []byte) (n int, err error) {
+// Write writes the byte slice to the underlying writer, synchronized by a mutex.
+func (sw *SyncedWriter) Write(p []byte) (n int, err error) {
 	sw.mu.Lock()
 	defer sw.mu.Unlock()
 	return sw.w.Write(p)
+}
+
+// NewSyncedWriter returns a new SyncedWriter wrapping the given io.Writer.
+func NewSyncedWriter(w io.Writer) *SyncedWriter {
+	return &SyncedWriter{w: w}
 }
 
 // ActorLogger handles structured logging for actor sandboxes and lifecycle events.

--- a/cmd/ateom-gvisor/internal/ateom/logger.go
+++ b/cmd/ateom-gvisor/internal/ateom/logger.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package main
+package ateom
 
 import (
 	"bufio"

--- a/cmd/ateom-gvisor/internal/ateom/logger_test.go
+++ b/cmd/ateom-gvisor/internal/ateom/logger_test.go
@@ -116,7 +116,7 @@ func TestWrapContainerLogs_JSONInput(t *testing.T) {
 
 func TestSyncedWriter_Concurrency(t *testing.T) {
 	var buf bytes.Buffer
-	sw := &syncedWriter{w: &buf}
+	sw := NewSyncedWriter(&buf)
 
 	const numWorkers = 10
 	const writesPerWorker = 100

--- a/cmd/ateom-gvisor/internal/ateom/logger_test.go
+++ b/cmd/ateom-gvisor/internal/ateom/logger_test.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package main
+package ateom
 
 import (
 	"bytes"

--- a/cmd/ateom-gvisor/internal/ateom/stopwatch.go
+++ b/cmd/ateom-gvisor/internal/ateom/stopwatch.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package main
+package ateom
 
 import (
 	"log/slog"

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -64,7 +64,7 @@ func do(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	syncedWriter := &syncedWriter{w: os.Stdout}
+	syncedWriter := ateom.NewSyncedWriter(os.Stdout)
 	logger := slog.New(contextlogging.NewHandler(slog.NewJSONHandler(syncedWriter, nil)))
 	slog.SetDefault(logger)
 

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 //  Copyright 2026 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +28,7 @@ import (
 	"sync"
 
 	"cloud.google.com/go/compute/metadata"
+	"github.com/agent-substrate/substrate/cmd/ateom-gvisor/internal/ateom"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/contextlogging"
@@ -126,7 +129,7 @@ func do(ctx context.Context) error {
 		return fmt.Errorf("while creating ateom-interior netns: %w", err)
 	}
 
-	actorLogger := NewActorLogger(syncedWriter, metadata.OnGCE())
+	actorLogger := ateom.NewActorLogger(syncedWriter, metadata.OnGCE())
 	ateomService := NewService(interiorNetNS, eth0LinkInfo, actorLogger)
 
 	svr := grpc.NewServer(
@@ -154,13 +157,13 @@ type AteomService struct {
 
 	interiorNetNS netns.NsHandle
 	eth0LinkInfo  *SaveLinkInfo
-	actorLogger   *ActorLogger
+	actorLogger   *ateom.ActorLogger
 }
 
 var _ ateompb.AteomServer = (*AteomService)(nil)
 
 // NewService creates a new AteomService.
-func NewService(interiorNetNS netns.NsHandle, eth0LinkInfo *SaveLinkInfo, actorLogger *ActorLogger) *AteomService {
+func NewService(interiorNetNS netns.NsHandle, eth0LinkInfo *SaveLinkInfo, actorLogger *ateom.ActorLogger) *AteomService {
 	svc := &AteomService{
 		interiorNetNS: interiorNetNS,
 		eth0LinkInfo:  eth0LinkInfo,

--- a/cmd/ateom-gvisor/main_unsupported.go
+++ b/cmd/ateom-gvisor/main_unsupported.go
@@ -1,0 +1,27 @@
+//go:build !linux
+
+//  Copyright 2026 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "ateom-gvisor is only supported on Linux")
+	os.Exit(1)
+}

--- a/cmd/ateom-gvisor/runsc.go
+++ b/cmd/ateom-gvisor/runsc.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 //  Copyright 2026 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixes https://github.com/agent-substrate/substrate/issues/69

Most of the code is portable and can be tested on the host on any platform, but some of aetom-gvisor requires linux-only dependencies / integrations.

1. Split between the `main` code which is not portable, and internal package
2. Add build tags.

NOTE: To keep `ko` functional, we have to make sure the package resolves without build tags, so we add `main_unsupported.go` constrained to `!linux` which will error if you attempt to run it.

Now `go test ./...`, `go build ./...` work fine on mac (agents like to test this) while e2e etc behave as before.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
