### PR TITLE
fix(memorypullcache): surface pull failures with the image ref

### DIFF
--- a/internal/memorypullcache/memorypullcache.go
+++ b/internal/memorypullcache/memorypullcache.go
@@ -135,12 +135,14 @@ func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (io.ReadCloser,
 
 	img, err := remote.Image(parsedRef, remoteOptions...)
 	if err != nil {
-		return nil, fmt.Errorf("in remote.Image: %w", err)
+		slog.WarnContext(ctx, "Image pull failed", slog.String("ref", ref), slog.Any("error", err))
+		return nil, fmt.Errorf("while pulling image %q: %w", ref, err)
 	}
 
 	size, err := img.Size()
 	if err != nil {
-		return nil, fmt.Errorf("in img.Size(): %w", err)
+		slog.WarnContext(ctx, "Image size lookup failed", slog.String("ref", ref), slog.Any("error", err))
+		return nil, fmt.Errorf("while reading size of image %q: %w", ref, err)
 	}
 	if size > 100*1024*1024 {
 		slog.InfoContext(ctx,
@@ -156,7 +158,8 @@ func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (io.ReadCloser,
 
 	memData, err := io.ReadAll(tarData)
 	if err != nil {
-		return nil, fmt.Errorf("while reading image: %w", err)
+		slog.WarnContext(ctx, "Image read failed", slog.String("ref", ref), slog.Any("error", err))
+		return nil, fmt.Errorf("while reading image %q: %w", ref, err)
 	}
 
 	if digestWasIncluded {

--- a/internal/memorypullcache/memorypullcache_test.go
+++ b/internal/memorypullcache/memorypullcache_test.go
@@ -15,6 +15,8 @@
 package memorypullcache
 
 import (
+	"context"
+	"strings"
 	"testing"
 )
 
@@ -80,5 +82,24 @@ func TestRewriteLocalRegistry(t *testing.T) {
 				t.Errorf("rewriteLocalRegistry(%q) = %q; want %q", tt.ref, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestFetchErrorIncludesRef checks that pull failures wrap the error with the
+// requested image ref, so operators can identify which image failed from the
+// error chain alone (without having to correlate trace IDs across systems).
+func TestFetchErrorIncludesRef(t *testing.T) {
+	// A registry that refuses connection so remote.Image returns an error.
+	const ref = "127.0.0.1:1/missing/image:nope"
+	c, err := NewMemoryPullCache(context.Background(), nil, "")
+	if err != nil {
+		t.Fatalf("NewMemoryPullCache: %v", err)
+	}
+	_, err = c.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch on an unreachable registry returned nil error")
+	}
+	if !strings.Contains(err.Error(), ref) {
+		t.Errorf("Fetch error %q does not contain ref %q", err, ref)
 	}
 }


### PR DESCRIPTION
## Symptom

When `memorypullcache.Fetch` fails (network, auth, 404, ...), the log shows `Cache miss ref=...` followed by silence. The eventual user-visible error comes from a higher layer with no ref attached, so the actual offending image is invisible in operator logs.

## Cause

`remote.Image`, `img.Size`, and `io.ReadAll` errors were wrapped as `in remote.Image: %w` (etc.) and returned without ever being logged or naming the ref.

## Fix

Wrap each error with the ref and log it at WARN. Same shape as the existing surfacing in #40.