### PR TITLE
fix(hack): only pass --context to kubectl-delegating ko subcommands

### DIFF
--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -104,9 +104,17 @@ run_kubectl_ate() {
 }
 
 run_ko() {
-  ./hack/run-tool.sh ko \
-    "$@" \
-    -- ${KUBECTL_CONTEXT:+--context=${KUBECTL_CONTEXT}}
+  # Only ko subcommands that delegate to kubectl (apply, create, delete, run)
+  # accept args after `--`. ko build, resolve, deps, login etc. reject
+  # `--context=...` as an unknown subcommand and abort the install.
+  case "${1:-}" in
+    apply|create|delete|run)
+      ./hack/run-tool.sh ko "$@" ${KUBECTL_CONTEXT:+-- --context="${KUBECTL_CONTEXT}"}
+      ;;
+    *)
+      ./hack/run-tool.sh ko "$@"
+      ;;
+  esac
 }
 
 create_valkey_ca_certs_secret() {


### PR DESCRIPTION
## Symptom

With `KUBECTL_CONTEXT` set in `.ate-dev-env.sh`, `./hack/install-ate.sh --deploy-ate-system` aborts mid-deploy at the first `ko resolve`:

    Error: unknown command "--context=..." for "ko resolve"

CRDs, the ate-system namespace, and podcertificate-controller have already been applied by then, leaving the cluster half-installed.

## Cause

`run_ko` unconditionally appends `-- --context=$KUBECTL_CONTEXT` to every ko invocation. Only `ko apply`, `ko create`, `ko delete`, `ko run` have a kubectl phase that consumes args after `--`. Other subcommands (`resolve`, `build`, `deps`, `login`, ...) parse it as a flag and reject it.

## Fix

Only forward `--context` for the ko subcommands that actually delegate to kubectl. `run_kubectl` already passes the context to direct kubectl invocations, so the chained `ko resolve | run_kubectl apply -f -` flow still targets the right cluster.