### PR TITLE
fix(ateom): move actor working dir off tmpfs (#30)

### DIFF
--- a/internal/controllers/workerpool_controller.go
+++ b/internal/controllers/workerpool_controller.go
@@ -169,7 +169,10 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.Deployment
 					WithVolumes(corev1ac.Volume().
 						WithName("run-ateom").
 						WithHostPath(corev1ac.HostPathVolumeSource().
-							WithPath("/run/ateom-gvisor").
+							// Disk-backed path; /run is tmpfs on COS/GKE and caps
+							// actor working sets at ~700 MB (#30). Must match the
+							// atelet DaemonSet's hostPath.
+							WithPath("/var/lib/agent-substrate/ateom-gvisor").
 							WithType(corev1.HostPathDirectoryOrCreate))))))
 }
 

--- a/manifests/ate-install/atelet.yaml
+++ b/manifests/ate-install/atelet.yaml
@@ -94,5 +94,7 @@ spec:
       volumes:
       - name: run-ateom
         hostPath:
-          path: /run/ateom-gvisor
+          # Use a disk-backed path on the host; /run is tmpfs on COS/GKE
+          # nodes and caps actor working sets at ~700 MB (#30).
+          path: /var/lib/agent-substrate/ateom-gvisor
           type: DirectoryOrCreate


### PR DESCRIPTION
Closes #30.

## Symptom

Any sandbox image larger than ~700 MB fails to start on GKE with:

    while writing contents of "/nix/store/.../<file>" from tar stream:
    write /run/ateom-gvisor/actors/.../bundles/sandbox/rootfs/...:
    no space left on device

…even on nodes with plenty of disk and memory.

## Cause

Both the `atelet` DaemonSet and the `ateom-gvisor` worker pods (created by `WorkerPoolReconciler`) mount the host's `/run/ateom-gvisor` via `hostPath`. On GKE Container-Optimised OS, `/run` is tmpfs and defaults to ~700 MB. OCI bundle unpack writes the full rootfs there.

## Fix

Switch the `hostPath` to `/var/lib/agent-substrate/ateom-gvisor`. The in-pod `mountPath` stays `/run/ateom-gvisor`, so `ateompath.BasePath` and every path helper still work without touching Go code beyond the controller's one-line spec edit.

## Performance note

Restore now reads `pages.img` from disk on cold start instead of RAM. gVisor `mmap`s `pages.img`, so faulting is lazy and the kernel page cache hides repeat restores. Operators with cold-start SLOs may want to mount Local SSD at this `hostPath`; making the path configurable through the `WorkerPool` spec is a natural follow-up.

## Verification

- `go build ./...` and `go test ./internal/controllers/...` pass.
- `DirectoryOrCreate` lets kubelet create the host dir on first use; no node prep required.