### PR TITLE
ateom: avoid unix socket path length limits

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -671,7 +671,7 @@ func TestListWorkers(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(want, filteredWorkers, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(want, filteredWorkers, protocmp.Transform(), protocmp.IgnoreFields(&ateapipb.Worker{}, "worker_pod_uid")); diff != "" {
 		t.Errorf("ListWorkers response mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -733,7 +733,7 @@ func TestResumeActor(t *testing.T) {
 			AteomPodIp:             "127.0.0.1",
 		},
 	}
-	if diff := cmp.Diff(want, getResp, protocmp.Transform(), protocmp.IgnoreFields(&ateapipb.Actor{}, "version")); diff != "" {
+	if diff := cmp.Diff(want, getResp, protocmp.Transform(), protocmp.IgnoreFields(&ateapipb.Actor{}, "version"), protocmp.IgnoreFields(&ateapipb.Actor{}, "ateom_pod_uid")); diff != "" {
 		t.Errorf("GetActor response mismatch (-want +got):\n%s", diff)
 	}
 
@@ -763,7 +763,7 @@ func TestResumeActor(t *testing.T) {
 		Ip:              "127.0.0.1",
 	}
 
-	if diff := cmp.Diff(wantWorker, actorWorker, protocmp.Transform(), protocmp.IgnoreFields(&ateapipb.Worker{}, "version")); diff != "" {
+	if diff := cmp.Diff(wantWorker, actorWorker, protocmp.Transform(), protocmp.IgnoreFields(&ateapipb.Worker{}, "version"), protocmp.IgnoreFields(&ateapipb.Worker{}, "worker_pod_uid")); diff != "" {
 		t.Errorf("Worker state mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -943,7 +943,7 @@ func TestSuspendActor(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(want, getResp, protocmp.Transform(), protocmp.IgnoreFields(&ateapipb.Actor{}, "version"), protocmp.IgnoreFields(&ateapipb.Actor{}, "last_snapshot")); diff != "" {
+	if diff := cmp.Diff(want, getResp, protocmp.Transform(), protocmp.IgnoreFields(&ateapipb.Actor{}, "version"), protocmp.IgnoreFields(&ateapipb.Actor{}, "last_snapshot"), protocmp.IgnoreFields(&ateapipb.Actor{}, "ateom_pod_uid")); diff != "" {
 		t.Errorf("GetActor response mismatch (-want +got):\n%s", diff)
 	}
 

--- a/cmd/ateapi/internal/controlapi/syncer.go
+++ b/cmd/ateapi/internal/controlapi/syncer.go
@@ -119,6 +119,7 @@ func (s *WorkerPoolSyncer) syncWorkerToStore(ctx context.Context, pod *corev1.Po
 				WorkerPool:      pod.Labels[workerPodLabel],
 				WorkerPod:       pod.Name,
 				Ip:              pod.Status.PodIP,
+				WorkerPodUid:    string(pod.UID),
 			})
 			if err != nil && !errors.Is(err, store.ErrAlreadyExists) {
 				slog.ErrorContext(ctx, "Failed to create worker in store", slog.Any("err", err))

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -123,6 +123,7 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 	state.Actor.AteomPodNamespace = assignedWorker.GetWorkerNamespace()
 	state.Actor.AteomPodName = assignedWorker.GetWorkerPod()
 	state.Actor.AteomPodIp = assignedWorker.GetIp()
+	state.Actor.AteomPodUid = assignedWorker.GetWorkerPodUid()
 
 	if err := s.store.UpdateActor(ctx, state.Actor, state.Actor.GetVersion()); err != nil {
 		return err
@@ -213,8 +214,7 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 		slog.InfoContext(ctx, "Actor has snapshot; Restoring from snapshot")
 
 		req := &ateletpb.RestoreRequest{
-			TargetAteomNamespace:   state.Actor.GetAteomPodNamespace(),
-			TargetAteomName:        state.Actor.GetAteomPodName(),
+			TargetAteomUid:         state.Actor.GetAteomPodUid(),
 			ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
 			ActorTemplateName:      state.Actor.GetActorTemplateName(),
 			ActorId:                state.Actor.GetActorId(),
@@ -233,8 +233,7 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 		snapshot := state.ActorTemplate.Status.GoldenSnapshot
 
 		req := &ateletpb.RestoreRequest{
-			TargetAteomNamespace:   state.Actor.GetAteomPodNamespace(),
-			TargetAteomName:        state.Actor.GetAteomPodName(),
+			TargetAteomUid:         state.Actor.GetAteomPodUid(),
 			ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
 			ActorTemplateName:      state.Actor.GetActorTemplateName(),
 			ActorId:                state.Actor.GetActorId(),
@@ -250,8 +249,7 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 	} else {
 		slog.InfoContext(ctx, "Actor has no snapshot; ActorTemplate has no golden snapshot; Booting from ActorTemplate spec")
 		req := &ateletpb.RunRequest{
-			TargetAteomNamespace:   state.Actor.GetAteomPodNamespace(),
-			TargetAteomName:        state.Actor.GetAteomPodName(),
+			TargetAteomUid:         state.Actor.GetAteomPodUid(),
 			ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
 			ActorTemplateName:      state.Actor.GetActorTemplateName(),
 			ActorId:                state.Actor.GetActorId(),

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -136,8 +136,7 @@ func (s *CallAteletSuspendStep) Execute(ctx context.Context, input *SuspendInput
 	}
 
 	req := &ateletpb.CheckpointRequest{
-		TargetAteomNamespace:   state.Actor.GetAteomPodNamespace(),
-		TargetAteomName:        state.Actor.GetAteomPodName(),
+		TargetAteomUid:         state.Actor.GetAteomPodUid(),
 		ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
 		ActorTemplateName:      state.Actor.GetActorTemplateName(),
 		ActorId:                state.Actor.GetActorId(),

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -273,12 +273,12 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 
 	if err := s.prepareOCIBundles(ctx,
 		req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(),
-		req.GetSpec(), req.GetTargetAteomNamespace(), req.GetTargetAteomName(),
+		req.GetSpec(), req.GetTargetAteomUid(),
 	); err != nil {
 		return nil, err
 	}
 
-	client, err := s.dialAteom(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
+	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 
 	checkpointDir := ateompath.CheckpointDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
 
-	client, err := s.dialAteom(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
+	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
 	if err != nil {
 		return nil, err
 	}
@@ -397,12 +397,12 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	}
 
 	if err := s.prepareOCIBundles(ctx, ns, tmpl, actorID,
-		req.GetSpec(), req.GetTargetAteomNamespace(), req.GetTargetAteomName(),
+		req.GetSpec(), req.GetTargetAteomUid(),
 	); err != nil {
 		return nil, err
 	}
 
-	client, err := s.dialAteom(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
+	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
 	if err != nil {
 		return nil, err
 	}
@@ -442,9 +442,9 @@ func (s *AteomHerder) prepareOCIBundles(
 	ctx context.Context,
 	actorTemplateNamespace, actorTemplateName, actorID string,
 	spec *ateletpb.WorkloadSpec,
-	targetAteomNamespace, targetAteomName string,
+	targetAteomUid string,
 ) error {
-	netnsPath := ateompath.AteomNetNSPath(targetAteomNamespace, targetAteomName)
+	netnsPath := ateompath.AteomNetNSPath(targetAteomUid)
 
 	g, gCtx := errgroup.WithContext(ctx)
 
@@ -503,10 +503,10 @@ func (s *AteomHerder) prepareOCIBundles(
 
 // dialAteom opens (or reuses) the gRPC connection to the target ateom
 // pod and returns an ateom client.
-func (s *AteomHerder) dialAteom(ctx context.Context, namespace, name string) (ateompb.AteomClient, error) {
-	conn, err := s.ateomDialer.DialAteomPod(ctx, namespace, name)
+func (s *AteomHerder) dialAteom(ctx context.Context, targetAteomUid string) (ateompb.AteomClient, error) {
+	conn, err := s.ateomDialer.DialAteomPod(ctx, targetAteomUid)
 	if err != nil {
-		return nil, fmt.Errorf("while getting ateom conn for %s/%s: %w", namespace, name, err)
+		return nil, fmt.Errorf("while getting ateom conn for %s: %w", targetAteomUid, err)
 	}
 	return ateompb.NewAteomClient(conn), nil
 }
@@ -538,8 +538,8 @@ type AteomDialer struct {
 	conns *lru.Cache
 }
 
-func (d *AteomDialer) DialAteomPod(ctx context.Context, namespace, name string) (*grpc.ClientConn, error) {
-	key := namespace + "/" + name
+func (d *AteomDialer) DialAteomPod(ctx context.Context, podUID string) (*grpc.ClientConn, error) {
+	key := podUID
 
 	connAny, ok := d.conns.Get(key)
 	if ok {
@@ -547,7 +547,7 @@ func (d *AteomDialer) DialAteomPod(ctx context.Context, namespace, name string) 
 	}
 
 	conn, err := grpc.NewClient(
-		"unix://"+ateompath.AteomSocketPath(namespace, name),
+		"unix://"+ateompath.AteomSocketPath(podUID),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	)

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -44,8 +44,7 @@ import (
 )
 
 var (
-	podNamespace = flag.String("pod-namespace", "", "The namespace of the current pod")
-	podName      = flag.String("pod-name", "", "The name of the current pod")
+	podUID = flag.String("pod-uid", "", "The UID of the current pod")
 
 	reapLock sync.RWMutex
 )
@@ -82,7 +81,7 @@ func do(ctx context.Context) error {
 	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
 
 	// Create ateom dir
-	ateomDir := ateompath.AteomPath(*podNamespace, *podName)
+	ateomDir := ateompath.AteomPath(*podUID)
 	if err := os.MkdirAll(ateomDir, 0o700); err != nil {
 		return fmt.Errorf("in os.MkdirAll(%q): %w", ateomDir, err)
 	}
@@ -94,14 +93,8 @@ func do(ctx context.Context) error {
 	go reap.ReapChildren(nil, nil, nil, &reapLock)
 	slog.InfoContext(ctx, "Child process reaper launched")
 
-	// Validate before opening the socket so the operator sees a clear
-	// message rather than the kernel's cryptic "bind: invalid argument".
-	if err := ateompath.ValidateAteomSocketPath(*podNamespace, *podName); err != nil {
-		return err
-	}
-
 	// Clean up any old socket.
-	sockPath := ateompath.AteomSocketPath(*podNamespace, *podName)
+	sockPath := ateompath.AteomSocketPath(*podUID)
 	if err := os.RemoveAll(sockPath); err != nil {
 		return fmt.Errorf("while removing %q: %w", sockPath, err)
 	}
@@ -130,7 +123,7 @@ func do(ctx context.Context) error {
 	// read the addresses and routes off of every link in the namespace, then
 	// remove all the addresses and handle injecting packets into the interfaces
 	// using AF_PACKET.
-	interiorNetNS, err := createNetNSWithoutSwitching(ctx, ateompath.AteomNetNSName(*podNamespace, *podName))
+	interiorNetNS, err := createNetNSWithoutSwitching(ctx, ateompath.AteomNetNSName(*podUID))
 	if err != nil {
 		return fmt.Errorf("while creating ateom-interior netns: %w", err)
 	}

--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -16,14 +16,8 @@
 package ateompath
 
 import (
-	"fmt"
 	"path/filepath"
 )
-
-// MaxUnixSocketPathLen is the practical Linux limit for unix-domain socket
-// paths. The kernel's sockaddr_un.sun_path is 108 bytes including the trailing
-// NUL, leaving 107 usable bytes. Bind fails with EINVAL above this.
-const MaxUnixSocketPathLen = 107
 
 const (
 	// The base path.  This is both the path of the root shared folder on the
@@ -40,45 +34,29 @@ func RunSCBinaryPath(sha256 string) string {
 	return filepath.Join(StaticFilesDir, "runsc-"+sha256)
 }
 
-func AteomPath(ateomNamespace, ateomName string) string {
+func AteomPath(podUID string) string {
 	return filepath.Join(
 		BasePath,
 		"ateoms",
-		ateomNamespace+":"+ateomName,
+		podUID,
 	)
 }
 
-func AteomSocketPath(ateomNamespace, ateomName string) string {
+func AteomSocketPath(podUID string) string {
 	return filepath.Join(
-		AteomPath(ateomNamespace, ateomName),
+		AteomPath(podUID),
 		"ateom.sock",
 	)
 }
 
-// ValidateAteomSocketPath returns a descriptive error when the socket path
-// derived from ateomNamespace and ateomName would exceed Linux's unix-socket
-// limit. Calling net.Listen("unix", ...) with an over-limit path otherwise
-// fails with the cryptic "bind: invalid argument".
-func ValidateAteomSocketPath(ateomNamespace, ateomName string) error {
-	p := AteomSocketPath(ateomNamespace, ateomName)
-	if len(p) > MaxUnixSocketPathLen {
-		return fmt.Errorf(
-			"ateom socket path %q is %d bytes, exceeds Linux unix-socket limit of %d: shorten the namespace or pod name (%d + %d = %d chars used for namespace + name)",
-			p, len(p), MaxUnixSocketPathLen,
-			len(ateomNamespace), len(ateomName), len(ateomNamespace)+len(ateomName),
-		)
-	}
-	return nil
+func AteomNetNSName(podUID string) string {
+	return "ateom:" + podUID
 }
 
-func AteomNetNSName(ateomNamespace, ateomName string) string {
-	return "ateom:" + ateomNamespace + ":" + ateomName
-}
-
-func AteomNetNSPath(ateomNamespace, ateomName string) string {
+func AteomNetNSPath(podUID string) string {
 	return filepath.Join(
 		"/run/netns",
-		AteomNetNSName(ateomNamespace, ateomName),
+		AteomNetNSName(podUID),
 	)
 }
 

--- a/internal/ateompath/ateompath_test.go
+++ b/internal/ateompath/ateompath_test.go
@@ -19,53 +19,42 @@ import (
 	"testing"
 )
 
-func TestValidateAteomSocketPath(t *testing.T) {
-	tests := []struct {
-		name      string
-		namespace string
-		podName   string
-		wantErr   bool
-	}{
-		{
-			name:      "short names well under the limit",
-			namespace: "ate-demo-counter",
-			podName:   "counter-deployment-abcd1234-xyzw1",
-			wantErr:   false,
-		},
-		{
-			name:      "exactly at the limit",
-			namespace: strings.Repeat("a", 25),
-			podName:   strings.Repeat("b", 45),
-			wantErr:   false,
-		},
-		{
-			name:      "one byte over the limit",
-			namespace: strings.Repeat("a", 25),
-			podName:   strings.Repeat("b", 46),
-			wantErr:   true,
-		},
-		{
-			name:      "the reproducer from the original bug report",
-			namespace: "ate-demo-lovable-sandbox",
-			podName:   "lovable-sandbox-pool-deployment-5797879cd7-2n7wb",
-			wantErr:   true,
-		},
+func TestAteomPath(t *testing.T) {
+	podUID := "123e4567-e89b-12d3-a456-426614174000"
+
+	path := AteomPath(podUID)
+	expectedSuffix := "/ateoms/" + podUID
+	if !strings.HasSuffix(path, expectedSuffix) {
+		t.Errorf("expected path to end with %s, got %s", expectedSuffix, path)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateAteomSocketPath(tt.namespace, tt.podName)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateAteomSocketPath(%q, %q) err=%v, wantErr=%v",
-					tt.namespace, tt.podName, err, tt.wantErr)
-			}
-			if tt.wantErr && err != nil {
-				// Error message should mention the limit so an operator can
-				// figure out by how much to shorten.
-				msg := err.Error()
-				if !strings.Contains(msg, "107") {
-					t.Errorf("error message %q does not reference the limit (107)", msg)
-				}
-			}
-		})
+}
+
+func TestAteomSocketPathLimits(t *testing.T) {
+	podUID := "123e4567-e89b-12d3-a456-426614174000"
+
+	sockPath := AteomSocketPath(podUID)
+
+	// Unix domain socket path limit is 107 bytes (108 with NUL terminator)
+	const maxUnixSocketLen = 107
+	if len(sockPath) > maxUnixSocketLen {
+		t.Errorf("socket path length %d exceeds max allowed length %d: %q", len(sockPath), maxUnixSocketLen, sockPath)
+	}
+
+	// Verify it is deterministic
+	sockPath2 := AteomSocketPath(podUID)
+	if sockPath != sockPath2 {
+		t.Errorf("expected deterministic socket paths, got %q and %q", sockPath, sockPath2)
+	}
+}
+
+func TestAteomPathUniqueness(t *testing.T) {
+	uid1 := "123e4567-e89b-12d3-a456-426614174000"
+	uid2 := "987f6543-e21b-32d1-b654-246614174111"
+
+	path1 := AteomPath(uid1)
+	path2 := AteomPath(uid2)
+
+	if path1 == path2 {
+		t.Errorf("expected different paths for different pod UIDs, got %q", path1)
 	}
 }

--- a/internal/controllers/workerpool_controller.go
+++ b/internal/controllers/workerpool_controller.go
@@ -141,8 +141,7 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.Deployment
 						WithName("ateom").
 						WithImage(wp.Spec.AteomImage).
 						WithArgs(
-							"-pod-namespace=$(POD_NAMESPACE)",
-							"-pod-name=$(POD_NAME)",
+							"-pod-uid=$(POD_UID)",
 						).
 						WithSecurityContext(corev1ac.SecurityContext().
 							WithPrivileged(true).
@@ -150,15 +149,10 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.Deployment
 							WithRunAsGroup(0)).
 						WithEnv(
 							corev1ac.EnvVar().
-								WithName("POD_NAMESPACE").
+								WithName("POD_UID").
 								WithValueFrom(corev1ac.EnvVarSource().
 									WithFieldRef(corev1ac.ObjectFieldSelector().
-										WithFieldPath("metadata.namespace"))),
-							corev1ac.EnvVar().
-								WithName("POD_NAME").
-								WithValueFrom(corev1ac.EnvVarSource().
-									WithFieldRef(corev1ac.ObjectFieldSelector().
-										WithFieldPath("metadata.name"))),
+										WithFieldPath("metadata.uid"))),
 						).
 						WithVolumeMounts(corev1ac.VolumeMount().
 							WithName("run-ateom").

--- a/internal/proto/ateletpb/atelet.pb.go
+++ b/internal/proto/ateletpb/atelet.pb.go
@@ -37,8 +37,7 @@ const (
 
 type RunRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
-	TargetAteomNamespace   string                 `protobuf:"bytes,1,opt,name=target_ateom_namespace,json=targetAteomNamespace,proto3" json:"target_ateom_namespace,omitempty"`
-	TargetAteomName        string                 `protobuf:"bytes,2,opt,name=target_ateom_name,json=targetAteomName,proto3" json:"target_ateom_name,omitempty"`
+	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
 	ActorTemplateNamespace string                 `protobuf:"bytes,3,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
 	ActorTemplateName      string                 `protobuf:"bytes,4,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
 	ActorId                string                 `protobuf:"bytes,5,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
@@ -78,16 +77,9 @@ func (*RunRequest) Descriptor() ([]byte, []int) {
 	return file_atelet_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *RunRequest) GetTargetAteomNamespace() string {
+func (x *RunRequest) GetTargetAteomUid() string {
 	if x != nil {
-		return x.TargetAteomNamespace
-	}
-	return ""
-}
-
-func (x *RunRequest) GetTargetAteomName() string {
-	if x != nil {
-		return x.TargetAteomName
+		return x.TargetAteomUid
 	}
 	return ""
 }
@@ -542,8 +534,7 @@ func (*RunResponse) Descriptor() ([]byte, []int) {
 
 type CheckpointRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
-	TargetAteomNamespace   string                 `protobuf:"bytes,1,opt,name=target_ateom_namespace,json=targetAteomNamespace,proto3" json:"target_ateom_namespace,omitempty"`
-	TargetAteomName        string                 `protobuf:"bytes,2,opt,name=target_ateom_name,json=targetAteomName,proto3" json:"target_ateom_name,omitempty"`
+	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
 	ActorTemplateNamespace string                 `protobuf:"bytes,3,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
 	ActorTemplateName      string                 `protobuf:"bytes,4,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
 	ActorId                string                 `protobuf:"bytes,5,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
@@ -594,16 +585,9 @@ func (*CheckpointRequest) Descriptor() ([]byte, []int) {
 	return file_atelet_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *CheckpointRequest) GetTargetAteomNamespace() string {
+func (x *CheckpointRequest) GetTargetAteomUid() string {
 	if x != nil {
-		return x.TargetAteomNamespace
-	}
-	return ""
-}
-
-func (x *CheckpointRequest) GetTargetAteomName() string {
-	if x != nil {
-		return x.TargetAteomName
+		return x.TargetAteomUid
 	}
 	return ""
 }
@@ -688,8 +672,7 @@ func (*CheckpointResponse) Descriptor() ([]byte, []int) {
 
 type RestoreRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
-	TargetAteomNamespace   string                 `protobuf:"bytes,1,opt,name=target_ateom_namespace,json=targetAteomNamespace,proto3" json:"target_ateom_namespace,omitempty"`
-	TargetAteomName        string                 `protobuf:"bytes,2,opt,name=target_ateom_name,json=targetAteomName,proto3" json:"target_ateom_name,omitempty"`
+	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
 	ActorTemplateNamespace string                 `protobuf:"bytes,3,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
 	ActorTemplateName      string                 `protobuf:"bytes,4,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
 	ActorId                string                 `protobuf:"bytes,5,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
@@ -731,16 +714,9 @@ func (*RestoreRequest) Descriptor() ([]byte, []int) {
 	return file_atelet_proto_rawDescGZIP(), []int{11}
 }
 
-func (x *RestoreRequest) GetTargetAteomNamespace() string {
+func (x *RestoreRequest) GetTargetAteomUid() string {
 	if x != nil {
-		return x.TargetAteomNamespace
-	}
-	return ""
-}
-
-func (x *RestoreRequest) GetTargetAteomName() string {
-	if x != nil {
-		return x.TargetAteomName
+		return x.TargetAteomUid
 	}
 	return ""
 }
@@ -827,11 +803,10 @@ var File_atelet_proto protoreflect.FileDescriptor
 
 const file_atelet_proto_rawDesc = "" +
 	"\n" +
-	"\fatelet.proto\x12\x06atelet\"\xc8\x02\n" +
+	"\fatelet.proto\x12\x06atelet\"\x90\x02\n" +
 	"\n" +
-	"RunRequest\x124\n" +
-	"\x16target_ateom_namespace\x18\x01 \x01(\tR\x14targetAteomNamespace\x12*\n" +
-	"\x11target_ateom_name\x18\x02 \x01(\tR\x0ftargetAteomName\x128\n" +
+	"RunRequest\x12(\n" +
+	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x128\n" +
 	"\x18actor_template_namespace\x18\x03 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
 	"\x13actor_template_name\x18\x04 \x01(\tR\x11actorTemplateName\x12\x19\n" +
 	"\bactor_id\x18\x05 \x01(\tR\aactorId\x12)\n" +
@@ -863,20 +838,18 @@ const file_atelet_proto_rawDesc = "" +
 	"\bEnvEntry\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\"\r\n" +
-	"\vRunResponse\"\xff\x02\n" +
-	"\x11CheckpointRequest\x124\n" +
-	"\x16target_ateom_namespace\x18\x01 \x01(\tR\x14targetAteomNamespace\x12*\n" +
-	"\x11target_ateom_name\x18\x02 \x01(\tR\x0ftargetAteomName\x128\n" +
+	"\vRunResponse\"\xc7\x02\n" +
+	"\x11CheckpointRequest\x12(\n" +
+	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x128\n" +
 	"\x18actor_template_namespace\x18\x03 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
 	"\x13actor_template_name\x18\x04 \x01(\tR\x11actorTemplateName\x12\x19\n" +
 	"\bactor_id\x18\x05 \x01(\tR\aactorId\x12)\n" +
 	"\x05runsc\x18\x06 \x01(\v2\x13.atelet.RunscConfigR\x05runsc\x12(\n" +
 	"\x04spec\x18\a \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12.\n" +
 	"\x13snapshot_uri_prefix\x18\b \x01(\tR\x11snapshotUriPrefix\"\x14\n" +
-	"\x12CheckpointResponse\"\xfc\x02\n" +
-	"\x0eRestoreRequest\x124\n" +
-	"\x16target_ateom_namespace\x18\x01 \x01(\tR\x14targetAteomNamespace\x12*\n" +
-	"\x11target_ateom_name\x18\x02 \x01(\tR\x0ftargetAteomName\x128\n" +
+	"\x12CheckpointResponse\"\xc4\x02\n" +
+	"\x0eRestoreRequest\x12(\n" +
+	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x128\n" +
 	"\x18actor_template_namespace\x18\x03 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
 	"\x13actor_template_name\x18\x04 \x01(\tR\x11actorTemplateName\x12\x19\n" +
 	"\bactor_id\x18\x05 \x01(\tR\aactorId\x12)\n" +

--- a/internal/proto/ateletpb/atelet.proto
+++ b/internal/proto/ateletpb/atelet.proto
@@ -33,8 +33,7 @@ service AteomHerder {
 }
 
 message RunRequest {
-  string target_ateom_namespace = 1;
-  string target_ateom_name      = 2;
+  string target_ateom_uid = 1;
 
   string actor_template_namespace = 3;
   string actor_template_name      = 4;
@@ -92,8 +91,7 @@ message RunResponse {
 }
 
 message CheckpointRequest {
-  string target_ateom_namespace = 1;
-  string target_ateom_name      = 2;
+  string target_ateom_uid = 1;
 
   string actor_template_namespace = 3;
   string actor_template_name      = 4;
@@ -121,8 +119,7 @@ message CheckpointResponse {
 }
 
 message RestoreRequest {
-  string target_ateom_namespace = 1;
-  string target_ateom_name      = 2;
+  string target_ateom_uid = 1;
 
   string actor_template_namespace = 3;
   string actor_template_name      = 4;

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -104,6 +104,7 @@ type Actor struct {
 	AteomPodIp             string                 `protobuf:"bytes,8,opt,name=ateom_pod_ip,json=ateomPodIp,proto3" json:"ateom_pod_ip,omitempty"`
 	LastSnapshot           string                 `protobuf:"bytes,9,opt,name=last_snapshot,json=lastSnapshot,proto3" json:"last_snapshot,omitempty"`
 	InProgressSnapshot     string                 `protobuf:"bytes,10,opt,name=in_progress_snapshot,json=inProgressSnapshot,proto3" json:"in_progress_snapshot,omitempty"`
+	AteomPodUid            string                 `protobuf:"bytes,11,opt,name=ateom_pod_uid,json=ateomPodUid,proto3" json:"ateom_pod_uid,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -204,6 +205,13 @@ func (x *Actor) GetLastSnapshot() string {
 func (x *Actor) GetInProgressSnapshot() string {
 	if x != nil {
 		return x.InProgressSnapshot
+	}
+	return ""
+}
+
+func (x *Actor) GetAteomPodUid() string {
+	if x != nil {
+		return x.AteomPodUid
 	}
 	return ""
 }
@@ -839,6 +847,7 @@ type Worker struct {
 	ActorId         string                 `protobuf:"bytes,6,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
 	Ip              string                 `protobuf:"bytes,7,opt,name=ip,proto3" json:"ip,omitempty"`
 	Version         int64                  `protobuf:"varint,8,opt,name=version,proto3" json:"version,omitempty"`
+	WorkerPodUid    string                 `protobuf:"bytes,9,opt,name=worker_pod_uid,json=workerPodUid,proto3" json:"worker_pod_uid,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -927,6 +936,13 @@ func (x *Worker) GetVersion() int64 {
 		return x.Version
 	}
 	return 0
+}
+
+func (x *Worker) GetWorkerPodUid() string {
+	if x != nil {
+		return x.WorkerPodUid
+	}
+	return ""
 }
 
 type DebugClearRequest struct {
@@ -1255,7 +1271,7 @@ var File_ateapi_proto protoreflect.FileDescriptor
 
 const file_ateapi_proto_rawDesc = "" +
 	"\n" +
-	"\fateapi.proto\x12\x06ateapi\"\x9b\x04\n" +
+	"\fateapi.proto\x12\x06ateapi\"\xbf\x04\n" +
 	"\x05Actor\x12\x19\n" +
 	"\bactor_id\x18\x01 \x01(\tR\aactorId\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\x03R\aversion\x128\n" +
@@ -1268,7 +1284,8 @@ const file_ateapi_proto_rawDesc = "" +
 	"ateomPodIp\x12#\n" +
 	"\rlast_snapshot\x18\t \x01(\tR\flastSnapshot\x120\n" +
 	"\x14in_progress_snapshot\x18\n" +
-	" \x01(\tR\x12inProgressSnapshot\"v\n" +
+	" \x01(\tR\x12inProgressSnapshot\x12\"\n" +
+	"\rateom_pod_uid\x18\v \x01(\tR\vateomPodUid\"v\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fSTATUS_RESUMING\x10\x01\x12\x12\n" +
@@ -1302,7 +1319,7 @@ const file_ateapi_proto_rawDesc = "" +
 	"\aworkers\x18\x01 \x03(\v2\x0e.ateapi.WorkerR\aworkers\"\x13\n" +
 	"\x11ListActorsRequest\";\n" +
 	"\x12ListActorsResponse\x12%\n" +
-	"\x06actors\x18\x01 \x03(\v2\r.ateapi.ActorR\x06actors\"\x88\x02\n" +
+	"\x06actors\x18\x01 \x03(\v2\r.ateapi.ActorR\x06actors\"\xae\x02\n" +
 	"\x06Worker\x12)\n" +
 	"\x10worker_namespace\x18\x01 \x01(\tR\x0fworkerNamespace\x12\x1f\n" +
 	"\vworker_pool\x18\x02 \x01(\tR\n" +
@@ -1313,7 +1330,8 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x0eactor_template\x18\x05 \x01(\tR\ractorTemplate\x12\x19\n" +
 	"\bactor_id\x18\x06 \x01(\tR\aactorId\x12\x0e\n" +
 	"\x02ip\x18\a \x01(\tR\x02ip\x12\x18\n" +
-	"\aversion\x18\b \x01(\x03R\aversion\"\x13\n" +
+	"\aversion\x18\b \x01(\x03R\aversion\x12$\n" +
+	"\x0eworker_pod_uid\x18\t \x01(\tR\fworkerPodUid\"\x13\n" +
 	"\x11DebugClearRequest\"\x14\n" +
 	"\x12DebugClearResponse\"{\n" +
 	"\x0eMintJWTRequest\x12\x1a\n" +

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -70,6 +70,7 @@ message Actor {
 
   string last_snapshot        = 9;
   string in_progress_snapshot = 10;
+  string ateom_pod_uid        = 11;
 }
 
 message GetActorRequest {
@@ -143,6 +144,7 @@ message Worker {
   string actor_id        = 6;
   string ip              = 7;
   int64  version         = 8;
+  string worker_pod_uid  = 9;
 }
 
 message DebugClearRequest {}


### PR DESCRIPTION
Pod names alone can easily exceed the max length (253 > 107).

Add a symlink with the full pod name for debugging.

Follow-up #92 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

---

TODO: I'm not sure about the symlink. It's annoying mapping pod => hash(pod) otherwise though. We could put a file inside the directory with the pod name instead, but I think we should probably put the full pod name _somewhere_ in the structure so it's easier to inspect these.