### PR TITLE
chore(benchmarking): remove deprecated sessionDiscovery from workload manifests

### DIFF
--- a/benchmarking/workloads/manifests/full_workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/full_workloads.yaml.tmpl
@@ -57,13 +57,6 @@ spec:
   - name: sleep
     image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
     command: ["/bin/sleep", "1000000"]
-  sessionDiscovery:
-    mapping:
-      pathPrefix: "/v1/sleep"
-    protocol:
-      strategy: CEL
-      actorIdentity:
-        cel: "request.host.split('.')[0]"
   workerPoolRef:
     namespace: benchmark-workloads
     name: benchmark-ateom
@@ -90,13 +83,6 @@ spec:
   - name: usermem
     image: containerstack/alpine-stress:latest
     command: ["stress", "--vm", "1", "--vm-bytes", "1G", "--vm-keep", "--vm-hang", "0"]
-  sessionDiscovery:
-    mapping:
-      pathPrefix: "/v1/usermem"
-    protocol:
-      strategy: CEL
-      actorIdentity:
-        cel: "request.host.split('.')[0]"
   workerPoolRef:
     namespace: benchmark-workloads
     name: benchmark-ateom
@@ -123,13 +109,6 @@ spec:
   - name: kernelmem
     image: containerstack/alpine-stress:latest
     command: ["sh", "-c", "find /; for i in $(seq 50000); do sleep 10000 & done; sleep 10000"]
-  sessionDiscovery:
-    mapping:
-      pathPrefix: "/v1/kernelmem"
-    protocol:
-      strategy: CEL
-      actorIdentity:
-        cel: "request.host.split('.')[0]"
   workerPoolRef:
     namespace: benchmark-workloads
     name: benchmark-ateom

--- a/benchmarking/workloads/manifests/workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/workloads.yaml.tmpl
@@ -48,13 +48,6 @@ spec:
   - name: sleep
     image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
     command: ["/bin/sleep", "1000000"]
-  sessionDiscovery:
-    mapping:
-      pathPrefix: "/v1/sleep"
-    protocol:
-      strategy: CEL
-      actorIdentity:
-        cel: "request.host.split('.')[0]"
   workerPoolRef:
     namespace: benchmark-workloads
     name: benchmark-ateom


### PR DESCRIPTION
`sessionDiscovery` was removed from the `ActorTemplate` CRD when Substrate adopted the Uniform DNS Mesh (`docs/api-guide.md` §Workload Connectivity). Four references in `benchmarking/workloads/manifests/{workloads,full_workloads}.yaml.tmpl` were missed in that cleanup — strict Kubernetes API servers reject the rendered manifests via `benchmarking/workloads/deploy.sh`.

Pure deletion; no functional change to the rendered ActorTemplates.