### PR TITLE
internal/dns/readme: refresh stale regex example and terminology

### DIFF
--- a/internal/dns/readme.md
+++ b/internal/dns/readme.md
@@ -2,9 +2,9 @@
 
 The DNS Controller orchsterates the configuration needed to setup the ATE routing.
 
-We want to resolve requests for <actor UUID>.actors.resources.substrate.ate.dev to the router service address.
+We want to resolve requests for <actor id>.actors.resources.substrate.ate.dev to the router service address.
 
-* Stub resolver mode: orchestrate running a CoreDNS instance with the UUID mapped to the router service address.
+* Stub resolver mode: orchestrate running a CoreDNS instance with the actor id mapped to the router service address.
 
 Cluster resources:
 
@@ -23,9 +23,9 @@ These are defined in manifests/ate-install/atenet-dns.yaml.
 ConfigMap `ate-system:dns`:
 
 ```
-# Match any 'A' query for a UUID pattern under actors.resources.substrate.ate.dev
+# Match any 'A' query for an actor id pattern under actors.resources.substrate.ate.dev
     template IN A actors.resources.substrate.ate.dev {
-        match "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\.actors\\.resources\\.substrate\\.k8s\\.io\\.$"
+        match "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.actors\\.resources\\.substrate\\.ate\\.dev\\.$"
         answer "{{ .Name }} 60 IN A <router service address>"
     }
 ```


### PR DESCRIPTION
The example CoreDNS regex in `internal/dns/readme.md` was last updated before two renames: the actor DNS suffix changed from `substrate.k8s.io` to `substrate.ate.dev`, and the actor id format changed from UUID to a generic DNS label. The authoritative source (`internal/resources/actor.go` — `ActorIDRegexPattern` + `ActorDNSSuffix`) and the corefile test (`internal/dns/corefile_test.go`) both reflect the current shape; only the readme drifted.

Pure documentation change; no code or test changes.

Reopening manually under my credentials, with the commit authored by me. The original PR was drafted by an a4 fleet bot and tracked as #99 (closed because the bot account is not CLA-signed). It was reviewed and **approved by @bowei** on commit f92de4d before being closed — linking that PR for review continuity: https://github.com/agent-substrate/substrate/pull/99

(First re-open attempt landed as #112 with a bot author because the local CLI shim swapped my OAuth token for the bot's installation token on the API call — closed and re-opened here under the correct identity. Same branch, same single commit `1df9895a` authored as me.)
