### PR TITLE
cmd/podcertcontroller,hack: graceful skip when certificates.k8s.io/v1beta1 absent

### DIFF
--- a/cmd/podcertcontroller/main.go
+++ b/cmd/podcertcontroller/main.go
@@ -102,6 +102,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	// The signers below depend on certificates.k8s.io/v1beta1 (ClusterTrustBundle,
+	// ClusterTrustBundleProjection, PodCertificateRequest). On managed Kubernetes
+	// surfaces that don't expose the v1beta1 group — e.g. GKE alpha clusters, which
+	// enable AllAlpha but not AllBeta — the signers crashloop with "the server could
+	// not find the requested resource". Probe discovery once at startup and exit 0
+	// if absent, so install scripts can detect the no-op cluster shape instead of
+	// hanging on bundle-ready waits. See agent-substrate/substrate#104.
+	hasV1Beta1, err := hasCertsV1Beta1(kc)
+	if err != nil {
+		slog.ErrorContext(ctx, "Error querying certificates.k8s.io discovery", slog.Any("err", err))
+		os.Exit(1)
+	}
+	if !hasV1Beta1 {
+		slog.InfoContext(ctx, "certificates.k8s.io/v1beta1 is not exposed by this cluster; podcertcontroller has nothing to do. Enable BETA-stage feature gates (ClusterTrustBundle, ClusterTrustBundleProjection, PodCertificateRequest) to run signers.")
+		return
+	}
+
 	hasher := rendezvous.New(
 		kc,
 		*shardingNamespace,
@@ -146,4 +163,27 @@ func main() {
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
 
 	<-signalCh
+}
+
+// hasCertsV1Beta1 returns true iff the cluster's discovery API exposes the
+// certificates.k8s.io/v1beta1 group-version. This is the group that contains
+// ClusterTrustBundle, ClusterTrustBundleProjection, and PodCertificateRequest
+// in K8s 1.31+ (BETA). Managed clusters that enable AllAlpha but not AllBeta
+// (e.g. GKE alpha clusters) will return false here.
+func hasCertsV1Beta1(kc kubernetes.Interface) (bool, error) {
+	groups, err := kc.Discovery().ServerGroups()
+	if err != nil {
+		return false, err
+	}
+	for _, g := range groups.Groups {
+		if g.Name != "certificates.k8s.io" {
+			continue
+		}
+		for _, v := range g.Versions {
+			if v.Version == "v1beta1" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -217,6 +217,27 @@ deploy_crds() {
 
 deploy_ate_system() {
   log_step "deploy_ate_system"
+
+  # Probe for certificates.k8s.io/v1beta1. ate-system's signers depend on the
+  # BETA-stage ClusterTrustBundle, ClusterTrustBundleProjection, and
+  # PodCertificateRequest APIs in this group. Managed Kubernetes surfaces that
+  # enable AllAlpha but not AllBeta (e.g. GKE alpha clusters) do not expose
+  # v1beta1, in which case the ClusterTrustBundle wait below would hang
+  # indefinitely. Detect once and bail with a clear message so the operator
+  # can re-target a cluster with the BETA gates enabled. The regex tolerates
+  # optional whitespace after the JSON colon in case a future kubectl pretty-
+  # prints discovery responses. 2>/dev/null intentionally collapses kubectl/
+  # auth/connectivity errors into the same "skipping" exit — operator-friendly
+  # for an install script (the Go controller's discovery probe keeps the two
+  # failure modes distinct). See agent-substrate/substrate#104.
+  if ! run_kubectl get --raw /apis/certificates.k8s.io 2>/dev/null \
+       | grep -qE '"version":[[:space:]]*"v1beta1"'; then
+    echo "certificates.k8s.io/v1beta1 is not exposed by this cluster — skipping ate-system install." >&2
+    echo "Enable the BETA-stage feature gates ClusterTrustBundle, ClusterTrustBundleProjection," >&2
+    echo "and PodCertificateRequest (e.g. via kube-apiserver --feature-gates) to proceed." >&2
+    return 0
+  fi
+
   ensure_crds
 
   # Ensure namespace exists


### PR DESCRIPTION
Fixes #104.

> Supersedes #105 — same diff, opened under matching alex identity end-to-end (branch + commit both authored by @AlexBulankou). The original was opened by a local CLI shim that intercepted the API call with a bot token even though the commit was correct.

ate-system signers depend on the BETA-stage `ClusterTrustBundle`, `ClusterTrustBundleProjection`, and `PodCertificateRequest` APIs in `certificates.k8s.io/v1beta1`. Managed Kubernetes surfaces that enable `AllAlpha` but not `AllBeta` — e.g. GKE alpha clusters — do not expose `v1beta1`, in which case:

- `podcertcontroller` crashloops with `"Failed to watch *v1beta1.PodCertificateRequest: the server could not find the requested resource"`.
- `hack/install-ate.sh --deploy-ate-system` hangs at the `Waiting for podcertificate ClusterTrustBundles to be ready...` loop, because the controller never creates the bundles.

This PR implements shape (a) from issue #104 — startup discovery + graceful skip — chosen for smallest diff (57 lines, additive only, no new imports):

### `cmd/podcertcontroller/main.go`

After the kubernetes client is created and before the rendezvous hasher / signer controllers are wired up, probe `kc.Discovery().ServerGroups()` for `certificates.k8s.io/v1beta1`. If absent:

- Log an informational message naming the missing group and the BETA gates that need to be enabled.
- `return` from `main` — clean exit 0.

The probe runs once at startup, so the hot-path cost is one extra discovery API call per pod lifetime; on clusters where v1beta1 IS present (the existing supported surface) behavior is unchanged.

### `hack/install-ate.sh`

Mirror the same check at the top of `deploy_ate_system()`. If `kubectl get --raw /apis/certificates.k8s.io` doesn't include `v1beta1`, print a clear "skipping" message to stderr and `return 0`, short-circuiting the function before any namespace / CRD / controller work begins. This lets `--deploy-ate-system` complete cleanly on a cluster that fundamentally can't run ate-system, instead of hanging on the wait-for-bundles loop.

### Verification

I cannot exercise the GKE-alpha path end-to-end as part of this PR (substrate-demo-cluster lacks v1beta1 and that's what surfaced the original bug — see #104). Sanity-check ideas a maintainer might want to run:

- **Negative path** (cluster lacks v1beta1): `podcertcontroller` logs the "nothing to do" message and exits 0; `install-ate.sh --deploy-ate-system` prints the "skipping" message and exits 0 instead of hanging.
- **Positive path** (cluster has v1beta1): no observable change — discovery probe returns true, control flow proceeds into the existing rendezvous/signer setup unchanged.

### Notes for maintainer

- The Go side uses `kubernetes.Interface` (not `*kubernetes.Clientset`) in the helper's signature so it can be exercised with a fake clientset. Happy to add `main_test.go` in a follow-up — kept out of this PR to keep the first-touch surface at 57 additive lines.
- The shell-side probe uses `grep -qE '"version":[[:space:]]*"v1beta1"'` on the raw `/apis/certificates.k8s.io` JSON to avoid a `jq` dependency (regex tolerates optional whitespace after the JSON colon in case a future kubectl pretty-prints discovery responses). If `jq` is available elsewhere in `install-ate.sh`'s expected environment, happy to switch to `jq -e '.versions[]? | select(.version == "v1beta1")'`.
- The shell probe's `2>/dev/null` intentionally collapses two failure modes — v1beta1 genuinely absent vs kubectl/auth/connectivity broken — into the same "skipping" exit. The Go controller's discovery probe keeps these distinct (returns err → exit 1). Asymmetric on purpose: operator-friendliness wins for an install script (run it on a half-broken cluster and the script tells you to fix the cluster, not crashloops the install); strict failure-mode separation wins for a long-running controller.
- The `slog.InfoContext` message + script stderr message are both written to surface as a clear "you need to enable BETA gates" pointer for operators hitting this for the first time — same shape as the diagnosis #104 walks through.
