### PR TITLE
controllers/actortemplate: add deletion finalizer to clean up golden actor

### DIFF
--- a/internal/controllers/actortemplate_controller.go
+++ b/internal/controllers/actortemplate_controller.go
@@ -22,16 +22,24 @@ import (
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
 	GoldenSnapshotCreationReason = "GoldenSnapshotCreation"
+
+	// ActorTemplateFinalizer ensures the golden actor is suspended and deleted
+	// from the ateom before the ActorTemplate resource is garbage-collected.
+	ActorTemplateFinalizer = "ate.dev/actortemplate-finalizer"
 )
 
 type ActorTemplateReconciler struct {
@@ -62,8 +70,21 @@ func (r *ActorTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to get actor template %q: %w", req.NamespacedName, err)
 	}
 
-	// Handle deletion
+	// Handle deletion before any other work — once a DeletionTimestamp is
+	// set, we must drive cleanup and remove the finalizer; the phase switch
+	// would otherwise keep creating or driving the golden actor.
 	if !at.GetDeletionTimestamp().IsZero() {
+		return r.reconcileDelete(ctx, at)
+	}
+
+	// Ensure the finalizer is present before the phase switch creates a
+	// golden actor. If we crashed between CreateActor and the finalizer add,
+	// a kubectl delete would orphan the actor on the ateom.
+	if !controllerutil.ContainsFinalizer(at, ActorTemplateFinalizer) {
+		controllerutil.AddFinalizer(at, ActorTemplateFinalizer)
+		if err := r.Update(ctx, at); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -153,6 +174,51 @@ func (r *ActorTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	default:
 		return ctrl.Result{}, fmt.Errorf("unrecognized phase %q", at.Status.Phase)
 	}
+}
+
+// reconcileDelete drains the golden actor from the ateom and removes the
+// finalizer. Suspend + Delete are both idempotent (workflow-level guards on
+// IsComplete) and NotFound is treated as success so a retry after partial
+// progress converges.
+func (r *ActorTemplateReconciler) reconcileDelete(ctx context.Context, at *atev1alpha1.ActorTemplate) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	if !controllerutil.ContainsFinalizer(at, ActorTemplateFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	actorID := at.Status.GoldenActorID
+	if actorID != "" {
+		if _, err := r.AteClient.SuspendActor(ctx, &ateapipb.SuspendActorRequest{ActorId: actorID}); err != nil {
+			if !isNotFound(err) {
+				log.Error(err, "failed to suspend golden actor on deletion", "actorID", actorID)
+				return ctrl.Result{}, fmt.Errorf("suspend before delete: %w", err)
+			}
+			log.Info("golden actor already absent on suspend", "actorID", actorID)
+		}
+		if _, err := r.AteClient.DeleteActor(ctx, &ateapipb.DeleteActorRequest{ActorId: actorID}); err != nil {
+			if !isNotFound(err) {
+				log.Error(err, "failed to delete golden actor", "actorID", actorID)
+				return ctrl.Result{}, fmt.Errorf("delete golden actor: %w", err)
+			}
+			log.Info("golden actor already absent on delete", "actorID", actorID)
+		}
+	} else {
+		log.Info("no golden actor ID recorded; removing finalizer without RPC calls")
+	}
+
+	controllerutil.RemoveFinalizer(at, ActorTemplateFinalizer)
+	if err := r.Update(ctx, at); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// isNotFound reports whether the gRPC error carries codes.NotFound, so the
+// caller can treat the ateom-side resource as already gone.
+func isNotFound(err error) bool {
+	s, ok := status.FromError(err)
+	return ok && s.Code() == codes.NotFound
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
## Context

This is the second of three pieces of substrate-charter #5 work being landed from the AlexBulankou/a4 team. The first (WorkerPool 3-in-1: image-set + RBAC + status-conditions, PR #114 — supersedes #105) is live and in review. This change addresses the orphan-actor leak on ActorTemplate deletion. A sibling envtest PR will follow once this one lands.

> Supersedes #109 — same diff, opened under matching alex identity end-to-end (branch + commit both authored by @AlexBulankou). The original was opened by a local CLI shim that intercepted the API call with a bot token even though the commit was correct.

## Problem

`ActorTemplate` has no finalizer, so `kubectl delete at <name>` (or owner-ref cascade from a parent resource) garbage-collects the K8s object immediately and the reconciler never gets a chance to drive cleanup. The golden actor that `Reconcile` provisioned via `CreateActor` is left stranded on the ateom — there is no GC sweep that reaps it later. Repeated recreate cycles accumulate orphans. It's most visible when WorkerPool tests churn through ActorTemplates, but it's a real leak any user can hit.

The existing `// Handle deletion` block in `Reconcile` was a no-op early-return — placeholder for exactly this work.

## Fix

Add the finalizer `ate.dev/actortemplate-finalizer` and wire it into the Reconcile loop:

1. **Deletion check moved BEFORE the phase switch.** Once `DeletionTimestamp` is set we must drive cleanup; the phase switch would otherwise keep creating or driving the golden actor.
2. **AddFinalizer happens BEFORE the phase switch creates the actor.** If the controller crashes between `CreateActor` and the finalizer add, a `kubectl delete` could otherwise orphan the actor. The finalizer-first ordering closes that window.
3. **`reconcileDelete` helper** suspends then deletes the golden actor and removes the finalizer. Both RPCs treat `codes.NotFound` as already-done so a retry after partial progress converges:
   - `SuspendActor` is idempotent via the workflow_suspend.go `IsComplete` guards at L78-80 and L100-103.
   - `DeleteActor` is idempotent via the workflow.go:160 already-deleted short-circuit.
4. **`isNotFound()` helper** unwraps a grpc status — kept local to this file because it's the only call site; promote if a second package picks it up.

## RBAC

`actortemplates/finalizers` verb=update is already granted on the controller at `actortemplate_controller.go:46` via the kubebuilder-default scaffolding. No manifest change needed.

## Test plan

- [x] `go vet ./internal/controllers/...` clean locally
- [ ] Manual smoke: kubectl-apply an ActorTemplate, wait for Ready, `kubectl delete at` — observe the golden actor is gone from the ateom before the K8s object is GC'd
- [ ] Manual smoke: kill the controller mid-Reconcile (between CreateActor and the finalizer add path is the tightest window, but observably stable since finalizer-add precedes phase switch) — restart and confirm AddFinalizer + RemoveFinalizer paths converge

## Follow-ups (separate PRs)

- **envtest coverage** for the finalizer life-cycle: AddFinalizer / suspend-failure / delete-failure / NotFound paths. Test design at https://github.com/AlexBulankou/a/issues/371 — sibling PR opens once this lands.
- **Event recording** on suspend/delete branches once envtest is in place — small surface, defer until the test scaffold is ready to assert on emitted events.

Refs https://github.com/AlexBulankou/a/issues/139
