### PR TITLE
dedupe kind and go version from CI config, upgrade go to latest

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -39,8 +39,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 1.26
-    - name: Install kind
-      run: go install sigs.k8s.io/kind@v0.31.0
     - name: Create cluster
       run: hack/create-kind-cluster.sh
     - name: Install Agent Substrate

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.26
+        go-version-file: 'go.mod'
     - run: go test -v ./...
     - name: verify
       run: hack/verify-all.sh
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.26
+        go-version-file: 'go.mod'
     - name: Create cluster
       run: hack/create-kind-cluster.sh
     - name: Install Agent Substrate

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agent-substrate/substrate
 
-go 1.26.1
+go 1.26.3
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
In github actions:
- We manage kind with a script, no need to separately install at a possibly incorrect version
- Use go.mod to specify version, instead of repeating the version in actions config

In the code:
- Upgrade go.mod to use latest go release (which should be reflected in CI)


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
