### PR TITLE
Adopt the Kubernetes AI contribution policy

### DIFF
--- a/COLLABORATING.md
+++ b/COLLABORATING.md
@@ -48,13 +48,30 @@ PRs should be merged by the reviewer of a PR, not the author.
 
 ### Using AI
 
-Using AI tools to assist with coding is allowed, but please be transparent
-about it. Regardless of how a PR was created, the _human_ who is offering the
-PR is responsible for the content of the PR, and they should be able to explain
-the code and answer questions about it.  Please be respectful of your
-reviewers' time and do not offer PRs that you cannot explain or defend. If you
-use an AI tool to generate a significant fraction of a PR, please note that in
-the PR comment.
+For the time being, the Substrate project uses the same AI contribution policy
+as [the Kubernetes
+project](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance):
+
+> Using AI tools to help write your PR is acceptable, but as the author, you are
+> responsible for understanding every change. If you used AI tools in preparing
+> your PR, you must disclose this in the description of your PR. Listing AI
+> tooling as a co-author, co-signing commits using an AI tool, or using the
+> assisted-by, co-developed or similar commit trailer is not allowed.
+
+> All contributions must follow the contributions policies and use commit
+> messages that align with the policy.
+
+> Large AI generated PRs and AI generated commit messages are not allowed.
+
+> Do not leave the first review of AI generated changes to the reviewers. Verify
+> the changes (code review, testing, etc.) before submitting your PR. Reviewers
+> may ask questions about your AI-assisted code, and if you cannot explain why a
+> change was made, the PR will be closed.
+
+> When responding to review comments, you must do so without relying on AI
+> tools. Reviewers want to engage directly with you, not with generated
+> responses. If you do not engage directly with reviewers, the PR will be
+> closed.
 
 ## Code reviews
 


### PR DESCRIPTION
The policy is quoted inline for easy reference.
