### PR TITLE
Atelet runs only on nodes hosting ateoms (#9)

### DIFF
--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -88,6 +88,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.AteletNodeReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "AteletNode")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/internal/controllers/ateletnode_controller.go
+++ b/internal/controllers/ateletnode_controller.go
@@ -33,28 +33,22 @@ import (
 )
 
 const (
-	// AteletNodeLabel is the substrate-owned label that gates atelet DS
-	// scheduling. Present on a Node iff at least one ateom pod is
-	// currently scheduled to that Node.
 	AteletNodeLabel      = "ate.dev/atelet"
 	AteletNodeLabelValue = "true"
 
-	// AteletNodeClaimAnnoPrefix is the prefix for per-pool claim
-	// annotations on Nodes. Full key: ate.dev/claim.<workerpool-uid>.
+	// Per-pool claim annotation. Full key: ate.dev/claim.<workerpool-uid>.
 	AteletNodeClaimAnnoPrefix = "ate.dev/claim."
 
-	// AteletNodeFieldOwner is the SSA field owner for substrate-managed
-	// Node fields (the label and claim annotations).
 	AteletNodeFieldOwner = "atelet-node-controller"
-
-	// PodNodeNameIndex is the field-indexer key for Pod.Spec.NodeName.
-	// Required for List(client.MatchingFields{PodNodeNameIndex: ...}).
-	PodNodeNameIndex = "spec.nodeName"
+	PodNodeNameIndex     = "spec.nodeName"
 )
 
-// AteletNodeReconciler reconciles ateom Pod events into Node labels and
-// claim annotations so the atelet DaemonSet schedules only on Nodes
-// currently hosting ateom workloads.
+// claimAnnotationKey is the shared claim-annotation format: written by this
+// reconciler, read by the WorkerPool finalizer.
+func claimAnnotationKey(workerPoolUID string) string {
+	return AteletNodeClaimAnnoPrefix + workerPoolUID
+}
+
 type AteletNodeReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -63,10 +57,6 @@ type AteletNodeReconciler struct {
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 
-// Reconcile is keyed by Node name (we map Pod events to Node names in
-// SetupWithManager). It converges the Node's substrate-owned label and
-// claim annotations to match the set of WorkerPool UIDs currently
-// scheduled to it.
 func (r *AteletNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileNode(ctx, req.Name)
 }
@@ -74,18 +64,16 @@ func (r *AteletNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *AteletNodeReconciler) reconcileNode(ctx context.Context, nodeName string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("node", nodeName)
 
-	node := &corev1.Node{}
-	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+	// Existence check only — don't let the SSA apply below recreate a deleted Node.
+	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, &corev1.Node{}); err != nil {
 		if k8errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("get node %q: %w", nodeName, err)
 	}
 
-	// A pod that is Terminating still has spec.nodeName set and appears
-	// here until its object is actually deleted. That is intentional: the
-	// claim (and thus atelet) must outlive a draining ateom pod, so the
-	// claim is released only once the pod object is gone.
+	// Terminating pods still appear here; intentional, so atelet outlives a
+	// draining ateom (the claim drops only once the pod object is gone).
 	podList := &corev1.PodList{}
 	if err := r.List(ctx, podList, client.MatchingFields{PodNodeNameIndex: nodeName}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("list pods on node %q: %w", nodeName, err)
@@ -94,14 +82,10 @@ func (r *AteletNodeReconciler) reconcileNode(ctx context.Context, nodeName strin
 	poolUIDs := map[string]struct{}{}
 	for i := range podList.Items {
 		pod := &podList.Items[i]
-		// Defensive: the spec.nodeName field index already filters to this
-		// node, so this should always be true.
 		if pod.Spec.NodeName != nodeName {
 			continue
 		}
-		// Skip pods without a worker-pool UID label (e.g. atelet's own DS
-		// pods). The field index is not label-filtered, so non-ateom pods
-		// on this node can appear here.
+		// Skip non-ateom pods; the field index is not label-filtered.
 		uid, ok := pod.Labels[WorkerPoolUIDLabelKey]
 		if !ok || uid == "" {
 			continue
@@ -113,10 +97,8 @@ func (r *AteletNodeReconciler) reconcileNode(ctx context.Context, nodeName strin
 	return ctrl.Result{}, r.applyNodeClaims(ctx, nodeName, poolUIDs)
 }
 
-// applyNodeClaims SSA-patches the Node so substrate-owned fields (the
-// ate.dev/atelet label and ate.dev/claim.<uid> annotations) match the
-// given set of WorkerPool UIDs. Previously-owned fields not in the set
-// are removed via SSA field-ownership semantics.
+// applyNodeClaims SSA-applies the label + per-pool claims; keys absent from
+// the apply are pruned by field-ownership (last claim gone -> label removed).
 func (r *AteletNodeReconciler) applyNodeClaims(ctx context.Context, nodeName string, poolUIDs map[string]struct{}) error {
 	nodeAC := corev1ac.Node(nodeName)
 
@@ -128,7 +110,7 @@ func (r *AteletNodeReconciler) applyNodeClaims(ctx context.Context, nodeName str
 
 	annotations := map[string]string{}
 	for uid := range poolUIDs {
-		annotations[AteletNodeClaimAnnoPrefix+uid] = ""
+		annotations[claimAnnotationKey(uid)] = ""
 	}
 	nodeAC.Annotations = annotations
 
@@ -138,8 +120,7 @@ func (r *AteletNodeReconciler) applyNodeClaims(ctx context.Context, nodeName str
 	return nil
 }
 
-// podToNode maps a Pod event to a reconcile request for the Pod's
-// assigned Node. Returns no requests for unscheduled Pods.
+// podToNode maps a Pod event to its assigned Node (none if unscheduled).
 func (r *AteletNodeReconciler) podToNode(_ context.Context, obj client.Object) []reconcile.Request {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
@@ -151,23 +132,20 @@ func (r *AteletNodeReconciler) podToNode(_ context.Context, obj client.Object) [
 	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: pod.Spec.NodeName}}}
 }
 
-// ateomPodPredicate returns true for pods that look like ateom workloads
-// (those carrying the WorkerPoolLabelKey). Atelet's own DS pods and other
-// system pods are filtered out.
+// ateomPodPredicate admits ateom pods by the UID label — the key reconcileNode
+// consumes — so the watch only fires for pods we can actually refcount.
 func ateomPodPredicate() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		labels := obj.GetLabels()
 		if labels == nil {
 			return false
 		}
-		_, ok := labels[WorkerPoolLabelKey]
+		_, ok := labels[WorkerPoolUIDLabelKey]
 		return ok
 	})
 }
 
-// SetupWithManager registers the reconciler with the manager and adds
-// a field indexer on Pod.Spec.NodeName so reconcileNode can List pods
-// efficiently.
+// SetupWithManager indexes Pod.Spec.NodeName so reconcileNode can list by node.
 func (r *AteletNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, PodNodeNameIndex, func(o client.Object) []string {
 		p := o.(*corev1.Pod)

--- a/internal/controllers/ateletnode_controller.go
+++ b/internal/controllers/ateletnode_controller.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// AteletNodeLabel is the substrate-owned label that gates atelet DS
+	// scheduling. Present on a Node iff at least one ateom pod is
+	// currently scheduled to that Node.
+	AteletNodeLabel      = "ate.dev/atelet"
+	AteletNodeLabelValue = "true"
+
+	// AteletNodeClaimAnnoPrefix is the prefix for per-pool claim
+	// annotations on Nodes. Full key: ate.dev/claim.<workerpool-uid>.
+	AteletNodeClaimAnnoPrefix = "ate.dev/claim."
+
+	// AteletNodeFieldOwner is the SSA field owner for substrate-managed
+	// Node fields (the label and claim annotations).
+	AteletNodeFieldOwner = "atelet-node-controller"
+
+	// PodNodeNameIndex is the field-indexer key for Pod.Spec.NodeName.
+	// Required for List(client.MatchingFields{PodNodeNameIndex: ...}).
+	PodNodeNameIndex = "spec.nodeName"
+)
+
+// AteletNodeReconciler reconciles ateom Pod events into Node labels and
+// claim annotations so the atelet DaemonSet schedules only on Nodes
+// currently hosting ateom workloads.
+type AteletNodeReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;patch
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
+// Reconcile is keyed by Node name (we map Pod events to Node names in
+// SetupWithManager). It converges the Node's substrate-owned label and
+// claim annotations to match the set of WorkerPool UIDs currently
+// scheduled to it.
+func (r *AteletNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return r.reconcileNode(ctx, req.Name)
+}
+
+func (r *AteletNodeReconciler) reconcileNode(_ context.Context, _ string) (ctrl.Result, error) {
+	// Implementation deferred to Task 5.
+	return ctrl.Result{}, nil
+}
+
+// podToNode maps a Pod event to a reconcile request for the Pod's
+// assigned Node. Returns no requests for unscheduled Pods.
+func (r *AteletNodeReconciler) podToNode(_ context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+	if pod.Spec.NodeName == "" {
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: pod.Spec.NodeName}}}
+}
+
+// ateomPodPredicate returns true for pods that look like ateom workloads
+// (those carrying the WorkerPoolLabelKey). Atelet's own DS pods and other
+// system pods are filtered out.
+func ateomPodPredicate() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		labels := obj.GetLabels()
+		if labels == nil {
+			return false
+		}
+		_, ok := labels[WorkerPoolLabelKey]
+		return ok
+	})
+}
+
+// SetupWithManager registers the reconciler with the manager and adds
+// a field indexer on Pod.Spec.NodeName so reconcileNode can List pods
+// efficiently.
+func (r *AteletNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, PodNodeNameIndex, func(o client.Object) []string {
+		p := o.(*corev1.Pod)
+		if p.Spec.NodeName == "" {
+			return nil
+		}
+		return []string{p.Spec.NodeName}
+	}); err != nil {
+		return err
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("atelet-node").
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.podToNode),
+			builder.WithPredicates(ateomPodPredicate()),
+		).
+		Complete(r)
+}

--- a/internal/controllers/ateletnode_controller.go
+++ b/internal/controllers/ateletnode_controller.go
@@ -16,14 +16,18 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -67,9 +71,71 @@ func (r *AteletNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return r.reconcileNode(ctx, req.Name)
 }
 
-func (r *AteletNodeReconciler) reconcileNode(_ context.Context, _ string) (ctrl.Result, error) {
-	// Implementation deferred to Task 5.
-	return ctrl.Result{}, nil
+func (r *AteletNodeReconciler) reconcileNode(ctx context.Context, nodeName string) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("node", nodeName)
+
+	node := &corev1.Node{}
+	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		if k8errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get node %q: %w", nodeName, err)
+	}
+
+	// A pod that is Terminating still has spec.nodeName set and appears
+	// here until its object is actually deleted. That is intentional: the
+	// claim (and thus atelet) must outlive a draining ateom pod, so the
+	// claim is released only once the pod object is gone.
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList, client.MatchingFields{PodNodeNameIndex: nodeName}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("list pods on node %q: %w", nodeName, err)
+	}
+
+	poolUIDs := map[string]struct{}{}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		// Defensive: the spec.nodeName field index already filters to this
+		// node, so this should always be true.
+		if pod.Spec.NodeName != nodeName {
+			continue
+		}
+		// Skip pods without a worker-pool UID label (e.g. atelet's own DS
+		// pods). The field index is not label-filtered, so non-ateom pods
+		// on this node can appear here.
+		uid, ok := pod.Labels[WorkerPoolUIDLabelKey]
+		if !ok || uid == "" {
+			continue
+		}
+		poolUIDs[uid] = struct{}{}
+	}
+
+	logger.V(1).Info("reconciling node claims", "pool_count", len(poolUIDs))
+	return ctrl.Result{}, r.applyNodeClaims(ctx, nodeName, poolUIDs)
+}
+
+// applyNodeClaims SSA-patches the Node so substrate-owned fields (the
+// ate.dev/atelet label and ate.dev/claim.<uid> annotations) match the
+// given set of WorkerPool UIDs. Previously-owned fields not in the set
+// are removed via SSA field-ownership semantics.
+func (r *AteletNodeReconciler) applyNodeClaims(ctx context.Context, nodeName string, poolUIDs map[string]struct{}) error {
+	nodeAC := corev1ac.Node(nodeName)
+
+	labels := map[string]string{}
+	if len(poolUIDs) > 0 {
+		labels[AteletNodeLabel] = AteletNodeLabelValue
+	}
+	nodeAC.Labels = labels
+
+	annotations := map[string]string{}
+	for uid := range poolUIDs {
+		annotations[AteletNodeClaimAnnoPrefix+uid] = ""
+	}
+	nodeAC.Annotations = annotations
+
+	if err := r.Apply(ctx, nodeAC, client.FieldOwner(AteletNodeFieldOwner), client.ForceOwnership); err != nil {
+		return fmt.Errorf("apply node %q: %w", nodeName, err)
+	}
+	return nil
 }
 
 // podToNode maps a Pod event to a reconcile request for the Pod's

--- a/internal/controllers/ateletnode_controller_test.go
+++ b/internal/controllers/ateletnode_controller_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func eventForObject(obj client.Object) event.TypedCreateEvent[client.Object] {
+	return event.TypedCreateEvent[client.Object]{Object: obj}
+}
+
+func updateEventForObject(oldObj, newObj client.Object) event.TypedUpdateEvent[client.Object] {
+	return event.TypedUpdateEvent[client.Object]{ObjectOld: oldObj, ObjectNew: newObj}
+}
+
+func TestAteomPodPredicate(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{
+			name:   "ateom pod with worker-pool label is admitted",
+			labels: map[string]string{WorkerPoolLabelKey: "pool-a", WorkerPoolUIDLabelKey: "uid-a"},
+			want:   true,
+		},
+		{
+			name:   "atelet pod (no worker-pool label) is rejected",
+			labels: map[string]string{"app": "atelet"},
+			want:   false,
+		},
+		{
+			name:   "pod with empty labels is rejected",
+			labels: map[string]string{},
+			want:   false,
+		},
+		{
+			name:   "pod with nil labels is rejected",
+			labels: nil,
+			want:   false,
+		},
+	}
+	pred := ateomPodPredicate()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: tc.labels}}
+			got := pred.Create(eventForObject(pod))
+			if got != tc.want {
+				t.Errorf("Create event: got %v, want %v", got, tc.want)
+			}
+			got = pred.Update(updateEventForObject(pod, pod))
+			if got != tc.want {
+				t.Errorf("Update event: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPodToNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeName string
+		want     int // number of reconcile requests expected
+	}{
+		{name: "scheduled pod returns one request", nodeName: "node-1", want: 1},
+		{name: "unscheduled pod returns zero requests", nodeName: "", want: 0},
+	}
+	r := &AteletNodeReconciler{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels:    map[string]string{WorkerPoolLabelKey: "pool-a"},
+				},
+				Spec: corev1.PodSpec{NodeName: tc.nodeName},
+			}
+			got := r.podToNode(testCtx, pod)
+			if len(got) != tc.want {
+				t.Errorf("got %d requests, want %d", len(got), tc.want)
+			}
+			if len(got) == 1 && got[0].Name != tc.nodeName {
+				t.Errorf("got request for %q, want %q", got[0].Name, tc.nodeName)
+			}
+		})
+	}
+}

--- a/internal/controllers/ateletnode_controller_test.go
+++ b/internal/controllers/ateletnode_controller_test.go
@@ -181,3 +181,148 @@ func bindPodToNode(t *testing.T, pod *corev1.Pod, nodeName string) {
 		t.Fatalf("bind pod to node: %v", err)
 	}
 }
+
+// TestTwoPoolsOnSameNode verifies that two ateom pods from different
+// WorkerPools, both scheduled to the same node, result in two claim
+// annotations and a single label.
+func TestTwoPoolsOnSameNode(t *testing.T) {
+	const nodeName = "test-node-two-pools"
+	const poolA = "uid-pool-a"
+	const poolB = "uid-pool-b"
+
+	node := makeNode(nodeName)
+	if err := k8sClient.Create(testCtx, node); err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, node) }) //nolint:errcheck
+
+	podA := makeAteomPod("pod-two-pools-a", "default", "pool-a", poolA)
+	podB := makeAteomPod("pod-two-pools-b", "default", "pool-b", poolB)
+	for _, p := range []*corev1.Pod{podA, podB} {
+		if err := k8sClient.Create(testCtx, p); err != nil {
+			t.Fatalf("create pod %s: %v", p.Name, err)
+		}
+		t.Cleanup(func(pod *corev1.Pod) func() {
+			return func() { k8sClient.Delete(testCtx, pod, client.GracePeriodSeconds(0)) } //nolint:errcheck
+		}(p))
+		bindPodToNode(t, p, nodeName)
+	}
+
+	eventually(t, func(ctx context.Context) (bool, error) {
+		n := &corev1.Node{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
+			return false, nil
+		}
+		if n.Labels[AteletNodeLabel] != AteletNodeLabelValue {
+			return false, nil
+		}
+		_, okA := n.Annotations[AteletNodeClaimAnnoPrefix+poolA]
+		_, okB := n.Annotations[AteletNodeClaimAnnoPrefix+poolB]
+		return okA && okB, nil
+	})
+}
+
+// TestPodDeletionRemovesOneClaim verifies that deleting one pod when
+// another pool's pod still shares the node removes only that pool's
+// claim and keeps the label.
+func TestPodDeletionRemovesOneClaim(t *testing.T) {
+	const nodeName = "test-node-pod-delete"
+	const poolA = "uid-delete-a"
+	const poolB = "uid-delete-b"
+
+	node := makeNode(nodeName)
+	if err := k8sClient.Create(testCtx, node); err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, node) }) //nolint:errcheck
+
+	podA := makeAteomPod("pod-delete-a", "default", "pool-a", poolA)
+	podB := makeAteomPod("pod-delete-b", "default", "pool-b", poolB)
+	for _, p := range []*corev1.Pod{podA, podB} {
+		if err := k8sClient.Create(testCtx, p); err != nil {
+			t.Fatalf("create pod %s: %v", p.Name, err)
+		}
+		bindPodToNode(t, p, nodeName)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, podA, client.GracePeriodSeconds(0)) }) //nolint:errcheck
+	t.Cleanup(func() { k8sClient.Delete(testCtx, podB, client.GracePeriodSeconds(0)) }) //nolint:errcheck
+
+	// Wait until both claims appear.
+	eventually(t, func(ctx context.Context) (bool, error) {
+		n := &corev1.Node{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
+			return false, nil
+		}
+		_, okA := n.Annotations[AteletNodeClaimAnnoPrefix+poolA]
+		_, okB := n.Annotations[AteletNodeClaimAnnoPrefix+poolB]
+		return okA && okB, nil
+	})
+
+	// Delete pod A; pod B remains. Use GracePeriodSeconds(0) so the pod
+	// object is removed immediately in envtest (no kubelet to honour
+	// graceful-termination, so the object would otherwise linger with a
+	// DeletionTimestamp and the reconciler would keep the claim alive).
+	if err := k8sClient.Delete(testCtx, podA, client.GracePeriodSeconds(0)); err != nil {
+		t.Fatalf("delete pod A: %v", err)
+	}
+
+	eventually(t, func(ctx context.Context) (bool, error) {
+		n := &corev1.Node{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
+			return false, nil
+		}
+		_, hasA := n.Annotations[AteletNodeClaimAnnoPrefix+poolA]
+		_, hasB := n.Annotations[AteletNodeClaimAnnoPrefix+poolB]
+		hasLabel := n.Labels[AteletNodeLabel] == AteletNodeLabelValue
+		return !hasA && hasB && hasLabel, nil
+	})
+}
+
+// TestLastPodDeletionRemovesLabel verifies that when the last ateom
+// pod on a node is deleted, both its claim annotation AND the label
+// are removed.
+func TestLastPodDeletionRemovesLabel(t *testing.T) {
+	const nodeName = "test-node-last-delete"
+	const poolUID = "uid-last"
+
+	node := makeNode(nodeName)
+	if err := k8sClient.Create(testCtx, node); err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, node) }) //nolint:errcheck
+
+	pod := makeAteomPod("pod-last", "default", "pool-last", poolUID)
+	if err := k8sClient.Create(testCtx, pod); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, pod, client.GracePeriodSeconds(0)) }) //nolint:errcheck
+	bindPodToNode(t, pod, nodeName)
+
+	// Wait for label + claim to appear.
+	eventually(t, func(ctx context.Context) (bool, error) {
+		n := &corev1.Node{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
+			return false, nil
+		}
+		_, hasClaim := n.Annotations[AteletNodeClaimAnnoPrefix+poolUID]
+		return n.Labels[AteletNodeLabel] == AteletNodeLabelValue && hasClaim, nil
+	})
+
+	// Delete the pod. Use GracePeriodSeconds(0) so the pod object is
+	// removed immediately in envtest (no kubelet to honour graceful
+	// termination, so the object would otherwise linger with a
+	// DeletionTimestamp and the reconciler would keep the claim alive).
+	if err := k8sClient.Delete(testCtx, pod, client.GracePeriodSeconds(0)); err != nil {
+		t.Fatalf("delete pod: %v", err)
+	}
+
+	eventually(t, func(ctx context.Context) (bool, error) {
+		n := &corev1.Node{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
+			return false, nil
+		}
+		_, hasClaim := n.Annotations[AteletNodeClaimAnnoPrefix+poolUID]
+		_, hasLabel := n.Labels[AteletNodeLabel]
+		return !hasClaim && !hasLabel, nil
+	})
+}

--- a/internal/controllers/ateletnode_controller_test.go
+++ b/internal/controllers/ateletnode_controller_test.go
@@ -15,10 +15,12 @@
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
@@ -102,5 +104,80 @@ func TestPodToNode(t *testing.T) {
 				t.Errorf("got request for %q, want %q", got[0].Name, tc.nodeName)
 			}
 		})
+	}
+}
+
+// TestSinglePodAddsClaimAndLabel verifies that scheduling a single
+// ateom pod to a node causes the reconciler to label the node and
+// add a single claim annotation.
+func TestSinglePodAddsClaimAndLabel(t *testing.T) {
+	const nodeName = "test-node-single"
+	const poolUID = "uid-single"
+
+	node := makeNode(nodeName)
+	if err := k8sClient.Create(testCtx, node); err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, node) }) //nolint:errcheck
+
+	pod := makeAteomPod("pod-single", "default", "pool-single", poolUID)
+	if err := k8sClient.Create(testCtx, pod); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, pod) }) //nolint:errcheck
+
+	// Bind the pod to the node (envtest doesn't schedule; we set nodeName via Binding).
+	bindPodToNode(t, pod, nodeName)
+
+	eventually(t, func(ctx context.Context) (bool, error) {
+		n := &corev1.Node{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
+			return false, nil
+		}
+		if n.Labels[AteletNodeLabel] != AteletNodeLabelValue {
+			return false, nil
+		}
+		_, ok := n.Annotations[AteletNodeClaimAnnoPrefix+poolUID]
+		return ok, nil
+	})
+}
+
+// --- helpers ---
+
+func makeNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+func makeAteomPod(name, namespace, poolName, poolUID string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				WorkerPoolLabelKey:    poolName,
+				WorkerPoolUIDLabelKey: poolUID,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "ateom",
+				Image: "ateom:test",
+			}},
+		},
+	}
+}
+
+// bindPodToNode sets Pod.Spec.NodeName via the Binding subresource,
+// which is the canonical "schedule a pod" operation in envtest.
+func bindPodToNode(t *testing.T, pod *corev1.Pod, nodeName string) {
+	t.Helper()
+	binding := &corev1.Binding{
+		ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
+		Target:     corev1.ObjectReference{Kind: "Node", Name: nodeName},
+	}
+	if err := k8sClient.SubResource("binding").Create(testCtx, pod, binding); err != nil {
+		t.Fatalf("bind pod to node: %v", err)
 	}
 }

--- a/internal/controllers/ateletnode_controller_test.go
+++ b/internal/controllers/ateletnode_controller_test.go
@@ -107,9 +107,6 @@ func TestPodToNode(t *testing.T) {
 	}
 }
 
-// TestSinglePodAddsClaimAndLabel verifies that scheduling a single
-// ateom pod to a node causes the reconciler to label the node and
-// add a single claim annotation.
 func TestSinglePodAddsClaimAndLabel(t *testing.T) {
 	const nodeName = "test-node-single"
 	const poolUID = "uid-single"
@@ -126,7 +123,6 @@ func TestSinglePodAddsClaimAndLabel(t *testing.T) {
 	}
 	t.Cleanup(func() { k8sClient.Delete(testCtx, pod) }) //nolint:errcheck
 
-	// Bind the pod to the node (envtest doesn't schedule; we set nodeName via Binding).
 	bindPodToNode(t, pod, nodeName)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
@@ -169,8 +165,7 @@ func makeAteomPod(name, namespace, poolName, poolUID string) *corev1.Pod {
 	}
 }
 
-// bindPodToNode sets Pod.Spec.NodeName via the Binding subresource,
-// which is the canonical "schedule a pod" operation in envtest.
+// bindPodToNode schedules a pod via the Binding subresource (envtest has no scheduler).
 func bindPodToNode(t *testing.T, pod *corev1.Pod, nodeName string) {
 	t.Helper()
 	binding := &corev1.Binding{
@@ -182,9 +177,6 @@ func bindPodToNode(t *testing.T, pod *corev1.Pod, nodeName string) {
 	}
 }
 
-// TestTwoPoolsOnSameNode verifies that two ateom pods from different
-// WorkerPools, both scheduled to the same node, result in two claim
-// annotations and a single label.
 func TestTwoPoolsOnSameNode(t *testing.T) {
 	const nodeName = "test-node-two-pools"
 	const poolA = "uid-pool-a"
@@ -222,9 +214,6 @@ func TestTwoPoolsOnSameNode(t *testing.T) {
 	})
 }
 
-// TestPodDeletionRemovesOneClaim verifies that deleting one pod when
-// another pool's pod still shares the node removes only that pool's
-// claim and keeps the label.
 func TestPodDeletionRemovesOneClaim(t *testing.T) {
 	const nodeName = "test-node-pod-delete"
 	const poolA = "uid-delete-a"
@@ -244,10 +233,11 @@ func TestPodDeletionRemovesOneClaim(t *testing.T) {
 		}
 		bindPodToNode(t, p, nodeName)
 	}
+	// GracePeriodSeconds(0): envtest has no kubelet, so a normal delete would
+	// leave the pod lingering with a DeletionTimestamp and keep the claim alive.
 	t.Cleanup(func() { k8sClient.Delete(testCtx, podA, client.GracePeriodSeconds(0)) }) //nolint:errcheck
 	t.Cleanup(func() { k8sClient.Delete(testCtx, podB, client.GracePeriodSeconds(0)) }) //nolint:errcheck
 
-	// Wait until both claims appear.
 	eventually(t, func(ctx context.Context) (bool, error) {
 		n := &corev1.Node{}
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
@@ -258,10 +248,6 @@ func TestPodDeletionRemovesOneClaim(t *testing.T) {
 		return okA && okB, nil
 	})
 
-	// Delete pod A; pod B remains. Use GracePeriodSeconds(0) so the pod
-	// object is removed immediately in envtest (no kubelet to honour
-	// graceful-termination, so the object would otherwise linger with a
-	// DeletionTimestamp and the reconciler would keep the claim alive).
 	if err := k8sClient.Delete(testCtx, podA, client.GracePeriodSeconds(0)); err != nil {
 		t.Fatalf("delete pod A: %v", err)
 	}
@@ -278,9 +264,6 @@ func TestPodDeletionRemovesOneClaim(t *testing.T) {
 	})
 }
 
-// TestLastPodDeletionRemovesLabel verifies that when the last ateom
-// pod on a node is deleted, both its claim annotation AND the label
-// are removed.
 func TestLastPodDeletionRemovesLabel(t *testing.T) {
 	const nodeName = "test-node-last-delete"
 	const poolUID = "uid-last"
@@ -295,10 +278,10 @@ func TestLastPodDeletionRemovesLabel(t *testing.T) {
 	if err := k8sClient.Create(testCtx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
+	// GracePeriodSeconds(0): envtest has no kubelet (see TestPodDeletionRemovesOneClaim).
 	t.Cleanup(func() { k8sClient.Delete(testCtx, pod, client.GracePeriodSeconds(0)) }) //nolint:errcheck
 	bindPodToNode(t, pod, nodeName)
 
-	// Wait for label + claim to appear.
 	eventually(t, func(ctx context.Context) (bool, error) {
 		n := &corev1.Node{}
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
@@ -308,10 +291,6 @@ func TestLastPodDeletionRemovesLabel(t *testing.T) {
 		return n.Labels[AteletNodeLabel] == AteletNodeLabelValue && hasClaim, nil
 	})
 
-	// Delete the pod. Use GracePeriodSeconds(0) so the pod object is
-	// removed immediately in envtest (no kubelet to honour graceful
-	// termination, so the object would otherwise linger with a
-	// DeletionTimestamp and the reconciler would keep the claim alive).
 	if err := k8sClient.Delete(testCtx, pod, client.GracePeriodSeconds(0)); err != nil {
 		t.Fatalf("delete pod: %v", err)
 	}

--- a/internal/controllers/workerpool_controller.go
+++ b/internal/controllers/workerpool_controller.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,7 @@ import (
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
@@ -43,6 +45,11 @@ const (
 	// Used by the AteletNodeReconciler for per-pool refcounting; survives
 	// WorkerPool rename / namespace move.
 	WorkerPoolUIDLabelKey = "ate.dev/worker-pool-uid"
+
+	// ReleaseClaimsFinalizer ensures atelet node claims tracked under
+	// ate.dev/claim.<workerpool-uid> are released when the WorkerPool
+	// is deleted.
+	ReleaseClaimsFinalizer = "ate.dev/release-node-claims"
 )
 
 type WorkerPoolReconciler struct {
@@ -71,7 +78,15 @@ func (r *WorkerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Handle deletion
 	if !wp.GetDeletionTimestamp().IsZero() {
-		log.Info("WorkerPool is being deleted")
+		return r.handleDeletion(ctx, wp)
+	}
+
+	if !controllerutil.ContainsFinalizer(wp, ReleaseClaimsFinalizer) {
+		controllerutil.AddFinalizer(wp, ReleaseClaimsFinalizer)
+		if err := r.Update(ctx, wp); err != nil {
+			return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
+		}
+		// Subsequent reconcile continues with the normal flow.
 		return ctrl.Result{}, nil
 	}
 
@@ -80,6 +95,48 @@ func (r *WorkerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	return ctrl.Result{}, nil
+}
+
+// handleDeletion is invoked when DeletionTimestamp is set. It waits until
+// all of this WorkerPool's claim annotations have been released from Nodes
+// (which happens as the Deployment cascade deletes ateom pods and the
+// AteletNodeReconciler observes the deletions), then removes the finalizer.
+// Note: this gate is best-effort against claims that have already been
+// applied. A WorkerPool created and deleted before AteletNodeReconciler
+// applies any claim may have its finalizer removed first; the Deployment
+// cascade still drives claim cleanup via pod deletion, so no claim leaks.
+func (r *WorkerPoolReconciler) handleDeletion(ctx context.Context, wp *atev1alpha1.WorkerPool) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(wp, ReleaseClaimsFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	claimKey := AteletNodeClaimAnnoPrefix + string(wp.UID)
+	nodes := &corev1.NodeList{}
+	// Claim state lives in Node annotations, which are not server-side
+	// selectable, so we list all Nodes and scan. This runs only while a
+	// WorkerPool is deleting and is bounded by the requeue interval below.
+	if err := r.List(ctx, nodes); err != nil {
+		return ctrl.Result{}, fmt.Errorf("list nodes: %w", err)
+	}
+
+	for i := range nodes.Items {
+		if _, ok := nodes.Items[i].Annotations[claimKey]; ok {
+			// At least one claim remains; the Deployment cascade is still
+			// deleting ateom pods. This controller does not watch Nodes, so
+			// we poll via RequeueAfter rather than waking on Node events
+			// cluster-wide. Log so a wedged deletion (claim never clears) is
+			// diagnosable.
+			log.FromContext(ctx).Info("waiting for atelet node claims to be released before deleting WorkerPool",
+				"node", nodes.Items[i].Name, "claimKey", claimKey)
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+	}
+
+	controllerutil.RemoveFinalizer(wp, ReleaseClaimsFinalizer)
+	if err := r.Update(ctx, wp); err != nil {
+		return ctrl.Result{}, fmt.Errorf("remove finalizer: %w", err)
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controllers/workerpool_controller.go
+++ b/internal/controllers/workerpool_controller.go
@@ -39,16 +39,10 @@ import (
 const (
 	workerPoolFieldOwner = "workerpool-controller"
 
-	// WorkerPoolLabelKey identifies an ateom pod's owning WorkerPool by name.
 	WorkerPoolLabelKey = "ate.dev/worker-pool"
-	// WorkerPoolUIDLabelKey identifies an ateom pod's owning WorkerPool by UID.
-	// Used by the AteletNodeReconciler for per-pool refcounting; survives
-	// WorkerPool rename / namespace move.
+	// UID is stable across WorkerPool rename / namespace move; used for claim refcounting.
 	WorkerPoolUIDLabelKey = "ate.dev/worker-pool-uid"
 
-	// ReleaseClaimsFinalizer ensures atelet node claims tracked under
-	// ate.dev/claim.<workerpool-uid> are released when the WorkerPool
-	// is deleted.
 	ReleaseClaimsFinalizer = "ate.dev/release-node-claims"
 )
 
@@ -86,7 +80,6 @@ func (r *WorkerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err := r.Update(ctx, wp); err != nil {
 			return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
 		}
-		// Subsequent reconcile continues with the normal flow.
 		return ctrl.Result{}, nil
 	}
 
@@ -98,35 +91,24 @@ func (r *WorkerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{}, nil
 }
 
-// handleDeletion is invoked when DeletionTimestamp is set. It waits until
-// all of this WorkerPool's claim annotations have been released from Nodes
-// (which happens as the Deployment cascade deletes ateom pods and the
-// AteletNodeReconciler observes the deletions), then removes the finalizer.
-// Note: this gate is best-effort against claims that have already been
-// applied. A WorkerPool created and deleted before AteletNodeReconciler
-// applies any claim may have its finalizer removed first; the Deployment
-// cascade still drives claim cleanup via pod deletion, so no claim leaks.
+// handleDeletion blocks deletion until this pool's node claims are released,
+// then drops the finalizer. Best-effort: a pool deleted before any claim is
+// applied may finalize early, but the Deployment cascade still cleans up pods.
 func (r *WorkerPoolReconciler) handleDeletion(ctx context.Context, wp *atev1alpha1.WorkerPool) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(wp, ReleaseClaimsFinalizer) {
 		return ctrl.Result{}, nil
 	}
 
-	claimKey := AteletNodeClaimAnnoPrefix + string(wp.UID)
+	claimKey := claimAnnotationKey(string(wp.UID))
 	nodes := &corev1.NodeList{}
-	// Claim state lives in Node annotations, which are not server-side
-	// selectable, so we list all Nodes and scan. This runs only while a
-	// WorkerPool is deleting and is bounded by the requeue interval below.
+	// Annotations aren't server-side selectable, so scan all nodes (deletion-only).
 	if err := r.List(ctx, nodes); err != nil {
 		return ctrl.Result{}, fmt.Errorf("list nodes: %w", err)
 	}
 
 	for i := range nodes.Items {
 		if _, ok := nodes.Items[i].Annotations[claimKey]; ok {
-			// At least one claim remains; the Deployment cascade is still
-			// deleting ateom pods. This controller does not watch Nodes, so
-			// we poll via RequeueAfter rather than waking on Node events
-			// cluster-wide. Log so a wedged deletion (claim never clears) is
-			// diagnosable.
+			// Claim still present; poll (we don't watch Nodes). Log so a wedged deletion is visible.
 			log.FromContext(ctx).Info("waiting for atelet node claims to be released before deleting WorkerPool",
 				"node", nodes.Items[i].Name, "claimKey", claimKey)
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil

--- a/internal/controllers/workerpool_controller.go
+++ b/internal/controllers/workerpool_controller.go
@@ -34,7 +34,16 @@ import (
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 )
 
-const workerPoolFieldOwner = "workerpool-controller"
+const (
+	workerPoolFieldOwner = "workerpool-controller"
+
+	// WorkerPoolLabelKey identifies an ateom pod's owning WorkerPool by name.
+	WorkerPoolLabelKey = "ate.dev/worker-pool"
+	// WorkerPoolUIDLabelKey identifies an ateom pod's owning WorkerPool by UID.
+	// Used by the AteletNodeReconciler for per-pool refcounting; survives
+	// WorkerPool rename / namespace move.
+	WorkerPoolUIDLabelKey = "ate.dev/worker-pool-uid"
+)
 
 type WorkerPoolReconciler struct {
 	client.Client
@@ -134,7 +143,8 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.Deployment
 			WithTemplate(corev1ac.PodTemplateSpec().
 				WithLabels(map[string]string{
 					"app":                 wp.Name,
-					"ate.dev/worker-pool": wp.Name,
+					WorkerPoolLabelKey:    wp.Name,
+					WorkerPoolUIDLabelKey: string(wp.UID),
 				}).
 				WithSpec(corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().

--- a/internal/controllers/workerpool_controller.go
+++ b/internal/controllers/workerpool_controller.go
@@ -147,6 +147,18 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.Deployment
 					WorkerPoolUIDLabelKey: string(wp.UID),
 				}).
 				WithSpec(corev1ac.PodSpec().
+					WithInitContainers(corev1ac.Container().
+						WithName("wait-for-atelet").
+						WithImage("busybox:1.36").
+						// Intentionally loops until atelet is reachable: the pod stays in
+						// Init until then, rather than crashlooping. Kubernetes does not
+						// restart an init container that is still running.
+						WithCommand("sh", "-c", `until nc -z "$HOST_IP" 8085; do sleep 1; done`).
+						WithEnv(corev1ac.EnvVar().
+							WithName("HOST_IP").
+							WithValueFrom(corev1ac.EnvVarSource().
+								WithFieldRef(corev1ac.ObjectFieldSelector().
+									WithFieldPath("status.hostIP"))))).
 					WithContainers(corev1ac.Container().
 						WithName("ateom").
 						WithImage(wp.Spec.AteomImage).

--- a/internal/controllers/workerpool_controller_test.go
+++ b/internal/controllers/workerpool_controller_test.go
@@ -97,6 +97,14 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	if err := (&AteletNodeReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		fmt.Fprintf(os.Stderr, "atelet-node controller setup failed: %v\n", err)
+		os.Exit(1)
+	}
+
 	testCtx, testCancel = context.WithCancel(context.Background())
 	go func() {
 		_ = mgr.Start(testCtx)

--- a/internal/controllers/workerpool_controller_test.go
+++ b/internal/controllers/workerpool_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -429,6 +430,91 @@ func TestWorkerPoolHasFinalizer(t *testing.T) {
 		}
 		return false, nil
 	})
+}
+
+// TestWorkerPoolDeletionReleasesClaims is an end-to-end check that
+// deleting a WorkerPool eventually clears its claim annotation off
+// every Node that hosted its pods, and removes the finalizer so the
+// WorkerPool itself is fully deleted.
+func TestWorkerPoolDeletionReleasesClaims(t *testing.T) {
+	const nodeName = "test-node-deletion"
+
+	// Pre-create a node so the test isn't dependent on Pod scheduling.
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+	if err := k8sClient.Create(testCtx, node); err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, node) }) //nolint:errcheck
+
+	wp := makeWorkerPool("test-deletion", "default", 1, "ateom:v1")
+	if err := k8sClient.Create(testCtx, wp); err != nil {
+		t.Fatalf("create WorkerPool: %v", err)
+	}
+	// Re-fetch to get the UID assigned by the API server.
+	if err := k8sClient.Get(testCtx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, wp); err != nil {
+		t.Fatalf("re-fetch WorkerPool: %v", err)
+	}
+
+	// Wait until the controller has added the finalizer.
+	eventually(t, func(ctx context.Context) (bool, error) {
+		current := &atev1alpha1.WorkerPool{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, current); err != nil {
+			return false, nil
+		}
+		for _, f := range current.Finalizers {
+			if f == ReleaseClaimsFinalizer {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+
+	// Simulate a pod from this WorkerPool landing on the node.
+	pod := makeAteomPod("pod-deletion", "default", wp.Name, string(wp.UID))
+	if err := k8sClient.Create(testCtx, pod); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+	bindPodToNode(t, pod, nodeName)
+
+	// Wait for the claim to appear on the node.
+	eventually(t, func(ctx context.Context) (bool, error) {
+		n := &corev1.Node{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
+			return false, nil
+		}
+		_, ok := n.Annotations[AteletNodeClaimAnnoPrefix+string(wp.UID)]
+		return ok, nil
+	})
+
+	// Delete the pod first to simulate the Deployment cascade. (envtest does
+	// not run kube-controller-manager, so the cascade does not happen
+	// automatically.) GracePeriodSeconds(0) forces immediate object removal
+	// (no kubelet to finalize graceful termination in envtest).
+	if err := k8sClient.Delete(testCtx, pod, client.GracePeriodSeconds(0)); err != nil {
+		t.Fatalf("delete pod: %v", err)
+	}
+
+	// Delete the WorkerPool. The finalizer should hold deletion until the
+	// claim is gone, then release.
+	if err := k8sClient.Delete(testCtx, wp); err != nil {
+		t.Fatalf("delete WorkerPool: %v", err)
+	}
+
+	eventually(t, func(ctx context.Context) (bool, error) {
+		current := &atev1alpha1.WorkerPool{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, current)
+		// Success: 404 (gone)
+		return k8errors.IsNotFound(err), nil
+	})
+
+	// And confirm the claim is gone.
+	n := &corev1.Node{}
+	if err := k8sClient.Get(testCtx, types.NamespacedName{Name: nodeName}, n); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if _, ok := n.Annotations[AteletNodeClaimAnnoPrefix+string(wp.UID)]; ok {
+		t.Fatalf("claim annotation still present after WorkerPool deletion: %v", n.Annotations)
+	}
 }
 
 // --- helpers ---

--- a/internal/controllers/workerpool_controller_test.go
+++ b/internal/controllers/workerpool_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -353,6 +354,50 @@ func TestReplicasValidationRejectsNegative(t *testing.T) {
 	if !k8errors.IsInvalid(err) {
 		t.Fatalf("expected Invalid error, got: %v", err)
 	}
+}
+
+// TestAteomDeploymentHasInitContainer verifies that the controller adds an
+// init container that waits for the local atelet's gRPC port before the main
+// ateom container starts.
+func TestAteomDeploymentHasInitContainer(t *testing.T) {
+	wp := makeWorkerPool("test-init-container", "default", 1, "ateom:v1")
+	if err := k8sClient.Create(testCtx, wp); err != nil {
+		t.Fatalf("create WorkerPool: %v", err)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+
+	eventually(t, func(ctx context.Context) (bool, error) {
+		dep, err := getDeployment(ctx, wp)
+		if err != nil {
+			return false, nil
+		}
+		inits := dep.Spec.Template.Spec.InitContainers
+		if len(inits) != 1 {
+			return false, nil
+		}
+		ic := inits[0]
+		if ic.Name != "wait-for-atelet" {
+			return false, nil
+		}
+		if ic.Image != "busybox:1.36" {
+			return false, nil
+		}
+		wantCmd := []string{"sh", "-c", `until nc -z "$HOST_IP" 8085; do sleep 1; done`}
+		if !reflect.DeepEqual(ic.Command, wantCmd) {
+			return false, nil
+		}
+		// Must reference HOST_IP via downward API.
+		hasHostIP := false
+		for _, e := range ic.Env {
+			if e.Name == "HOST_IP" && e.ValueFrom != nil &&
+				e.ValueFrom.FieldRef != nil &&
+				e.ValueFrom.FieldRef.FieldPath == "status.hostIP" {
+				hasHostIP = true
+				break
+			}
+		}
+		return hasHostIP, nil
+	})
 }
 
 // --- helpers ---

--- a/internal/controllers/workerpool_controller_test.go
+++ b/internal/controllers/workerpool_controller_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -365,9 +366,6 @@ func TestReplicasValidationRejectsNegative(t *testing.T) {
 	}
 }
 
-// TestAteomDeploymentHasInitContainer verifies that the controller adds an
-// init container that waits for the local atelet's gRPC port before the main
-// ateom container starts.
 func TestAteomDeploymentHasInitContainer(t *testing.T) {
 	wp := makeWorkerPool("test-init-container", "default", 1, "ateom:v1")
 	if err := k8sClient.Create(testCtx, wp); err != nil {
@@ -395,7 +393,6 @@ func TestAteomDeploymentHasInitContainer(t *testing.T) {
 		if !reflect.DeepEqual(ic.Command, wantCmd) {
 			return false, nil
 		}
-		// Must reference HOST_IP via downward API.
 		hasHostIP := false
 		for _, e := range ic.Env {
 			if e.Name == "HOST_IP" && e.ValueFrom != nil &&
@@ -409,8 +406,6 @@ func TestAteomDeploymentHasInitContainer(t *testing.T) {
 	})
 }
 
-// TestWorkerPoolHasFinalizer verifies that the controller adds the
-// node-claims finalizer to every WorkerPool on first reconcile.
 func TestWorkerPoolHasFinalizer(t *testing.T) {
 	wp := makeWorkerPool("test-finalizer", "default", 1, "ateom:v1")
 	if err := k8sClient.Create(testCtx, wp); err != nil {
@@ -423,24 +418,14 @@ func TestWorkerPoolHasFinalizer(t *testing.T) {
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, current); err != nil {
 			return false, nil
 		}
-		for _, f := range current.Finalizers {
-			if f == ReleaseClaimsFinalizer {
-				return true, nil
-			}
-		}
-		return false, nil
+		return controllerutil.ContainsFinalizer(current, ReleaseClaimsFinalizer), nil
 	})
 }
 
-// TestWorkerPoolDeletionReleasesClaims is an end-to-end check that
-// deleting a WorkerPool eventually clears its claim annotation off
-// every Node that hosted its pods, and removes the finalizer so the
-// WorkerPool itself is fully deleted.
 func TestWorkerPoolDeletionReleasesClaims(t *testing.T) {
 	const nodeName = "test-node-deletion"
 
-	// Pre-create a node so the test isn't dependent on Pod scheduling.
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+	node := makeNode(nodeName)
 	if err := k8sClient.Create(testCtx, node); err != nil {
 		t.Fatalf("create node: %v", err)
 	}
@@ -450,33 +435,25 @@ func TestWorkerPoolDeletionReleasesClaims(t *testing.T) {
 	if err := k8sClient.Create(testCtx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	// Re-fetch to get the UID assigned by the API server.
+	// Re-fetch for the API-assigned UID (used as the claim key).
 	if err := k8sClient.Get(testCtx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, wp); err != nil {
 		t.Fatalf("re-fetch WorkerPool: %v", err)
 	}
 
-	// Wait until the controller has added the finalizer.
 	eventually(t, func(ctx context.Context) (bool, error) {
 		current := &atev1alpha1.WorkerPool{}
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, current); err != nil {
 			return false, nil
 		}
-		for _, f := range current.Finalizers {
-			if f == ReleaseClaimsFinalizer {
-				return true, nil
-			}
-		}
-		return false, nil
+		return controllerutil.ContainsFinalizer(current, ReleaseClaimsFinalizer), nil
 	})
 
-	// Simulate a pod from this WorkerPool landing on the node.
 	pod := makeAteomPod("pod-deletion", "default", wp.Name, string(wp.UID))
 	if err := k8sClient.Create(testCtx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
 	bindPodToNode(t, pod, nodeName)
 
-	// Wait for the claim to appear on the node.
 	eventually(t, func(ctx context.Context) (bool, error) {
 		n := &corev1.Node{}
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, n); err != nil {
@@ -486,28 +463,23 @@ func TestWorkerPoolDeletionReleasesClaims(t *testing.T) {
 		return ok, nil
 	})
 
-	// Delete the pod first to simulate the Deployment cascade. (envtest does
-	// not run kube-controller-manager, so the cascade does not happen
-	// automatically.) GracePeriodSeconds(0) forces immediate object removal
-	// (no kubelet to finalize graceful termination in envtest).
+	// Delete the pod (stands in for the Deployment cascade); GracePeriodSeconds(0)
+	// removes the object immediately since envtest has no kubelet.
 	if err := k8sClient.Delete(testCtx, pod, client.GracePeriodSeconds(0)); err != nil {
 		t.Fatalf("delete pod: %v", err)
 	}
 
-	// Delete the WorkerPool. The finalizer should hold deletion until the
-	// claim is gone, then release.
 	if err := k8sClient.Delete(testCtx, wp); err != nil {
 		t.Fatalf("delete WorkerPool: %v", err)
 	}
 
+	// 404 == finalizer was released.
 	eventually(t, func(ctx context.Context) (bool, error) {
 		current := &atev1alpha1.WorkerPool{}
 		err := k8sClient.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, current)
-		// Success: 404 (gone)
 		return k8errors.IsNotFound(err), nil
 	})
 
-	// And confirm the claim is gone.
 	n := &corev1.Node{}
 	if err := k8sClient.Get(testCtx, types.NamespacedName{Name: nodeName}, n); err != nil {
 		t.Fatalf("get node: %v", err)

--- a/internal/controllers/workerpool_controller_test.go
+++ b/internal/controllers/workerpool_controller_test.go
@@ -408,6 +408,29 @@ func TestAteomDeploymentHasInitContainer(t *testing.T) {
 	})
 }
 
+// TestWorkerPoolHasFinalizer verifies that the controller adds the
+// node-claims finalizer to every WorkerPool on first reconcile.
+func TestWorkerPoolHasFinalizer(t *testing.T) {
+	wp := makeWorkerPool("test-finalizer", "default", 1, "ateom:v1")
+	if err := k8sClient.Create(testCtx, wp); err != nil {
+		t.Fatalf("create WorkerPool: %v", err)
+	}
+	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+
+	eventually(t, func(ctx context.Context) (bool, error) {
+		current := &atev1alpha1.WorkerPool{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, current); err != nil {
+			return false, nil
+		}
+		for _, f := range current.Finalizers {
+			if f == ReleaseClaimsFinalizer {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
 // --- helpers ---
 
 func makeWorkerPool(name, ns string, replicas int32, image string) *atev1alpha1.WorkerPool {

--- a/manifests/ate-install/atelet.yaml
+++ b/manifests/ate-install/atelet.yaml
@@ -64,6 +64,8 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: atelet
+      nodeSelector:
+        ate.dev/atelet: "true"
       containers:
       - name: atelet
         image: ko://github.com/agent-substrate/substrate/cmd/atelet

--- a/manifests/ate-install/generated/role.yaml
+++ b/manifests/ate-install/generated/role.yaml
@@ -30,6 +30,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create


### PR DESCRIPTION
## Summary

Closes #9. Atelet currently runs on every node as a DaemonSet. This makes it run **only on nodes that currently host ateom pods**.

A new `AteletNodeReconciler` (Pod-keyed) watches ateom pods and maintains a substrate-owned `ate.dev/atelet=true` label on each Node currently hosting an ateom. The atelet DaemonSet now carries `nodeSelector: ate.dev/atelet=true`, so its footprint follows ateom placement.

### Mechanism

- **Reactive labeling.** On each ateom-pod event, the reconciler lists pods on the affected node (via a cached `spec.nodeName` field index) and SSA-applies the desired node state.
- **Per-pool refcounting via annotations.** Each node carries one `ate.dev/claim.<workerpool-uid>` annotation per WorkerPool occupying it. The label is present iff at least one claim exists; SSA's field-ownership prunes claims/label as pods leave. Multiple WorkerPools can safely share a node.
- **Init container.** Every ateom pod gets a `wait-for-atelet` init container that TCP-probes `$HOST_IP:8085` until the local atelet is serving. This absorbs the scheduling→atelet-ready gap and makes ateoms robust to atelet restarts/upgrades mid-life.
- **Finalizer.** A `ate.dev/release-node-claims` finalizer on WorkerPool holds deletion until its claims are released, so claims can't leak.
- **RBAC.** Adds `nodes: get;list;watch;patch` and `pods: get;list;watch` to the controller ClusterRole (regenerated from kubebuilder markers).

### Why reactive (not a placement policy)

Substrate doesn't decide *which* nodes ateoms run on — the kube-scheduler does, freely. The reconciler just records that choice as a label. This keeps the change small and avoids inventing a node-selection policy; richer schemes (worker classes, capacity reservations) can layer on later.

## Test plan

- [x] envtest: single pod → node gets label + claim
- [x] envtest: two pools on one node → two claims, one label
- [x] envtest: delete one pool's pod with another present → only its claim removed, label stays
- [x] envtest: delete last pod → claim and label both removed (SSA prune)
- [x] envtest: WorkerPool deletion held by finalizer until claim released, then completes
- [x] envtest: ateom Deployment carries the `wait-for-atelet` init container
- [x] `make verify` (tests, gofmt, lint, codegen, licenses, go-mod-tidy, boilerplate)

## Migration / rollout

This replaces the atelet DS's "run on all nodes" behavior with "run on labeled nodes only." Recommended two-phase rollout for existing clusters:

1. Deploy the new controller image + RBAC first. It observes existing ateom pods and labels their nodes.
2. Apply the atelet DS manifest change. The rolling update drops atelet from unlabeled nodes (no ateoms there) and keeps it on labeled ones (no disruption).

On a **fresh** cluster the atelet DaemonSet runs zero pods until the first WorkerPool's ateoms are scheduled — expected, not a broken install (`kubectl rollout status` on a 0-desired DaemonSet returns success immediately). The init container means even a single-shot `kubectl apply -k` is safe: ateoms wait rather than crash.