### PR TITLE
lint: enable more golangci-lint plugins

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,8 @@ linters:
     - contextcheck
     # High-signal bug-pattern checks without enabling style-only churn.
     - gocritic
+    # CRD phase/state-machine switches should handle every declared state.
+    - exhaustive
 
   settings:
     errcheck:
@@ -89,6 +91,19 @@ linters:
         - truncateCmp
         - uncheckedInlineErr
 
+    exhaustive:
+      # Controller phase/state-machine switches should handle every declared
+      # state explicitly; a bare default hides the gap.
+      check:
+        - switch
+        - map
+      default-signifies-exhaustive: false
+      package-scope-only: true
+      # Map literals are opt-in (annotate with //exhaustive:enforce). Most maps
+      # here are k8s corev1.ResourceList values, which are partial by design;
+      # requiring every ResourceName key would be noise, not a bug check.
+      explicit-exhaustive-map: true
+
   exclusions:
     # Built-in presets that suppress the most common idiomatic false
     # positives across the standard linters.
@@ -105,14 +120,14 @@ linters:
     rules:
       # Generated code: ignore findings entirely.
       - path: '\.pb\.go$'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic, exhaustive]
       - path: '\.pb\.gw\.go$'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic, exhaustive]
       - path: 'zz_generated.*\.go$'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic, exhaustive]
       # Kubernetes client-gen / informer-gen / lister-gen output.
       - path: '^pkg/client/'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic, exhaustive]
       # Tests routinely discard error returns from setup helpers.
       - path: '_test\.go'
         linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,8 @@ linters:
     - misspell
     # Reconciliation and RPC calls should inherit the caller's context.
     - contextcheck
+    # High-signal bug-pattern checks without enabling style-only churn.
+    - gocritic
 
   settings:
     errcheck:
@@ -57,6 +59,36 @@ linters:
     misspell:
       mode: default
 
+    gocritic:
+      # Opt in explicitly rather than inheriting gocritic's default set, which
+      # includes opinionated style checks. We only want the bug-pattern checks.
+      disable-all: true
+      enabled-checks:
+        - appendAssign
+        - argOrder
+        - badCall
+        - badCond
+        - badLock
+        - badRegexp
+        - badSorting
+        - badSyncOnceFunc
+        - caseOrder
+        - dupArg
+        - dupBranchBody
+        - dupCase
+        - dupSubExpr
+        - dynamicFmtString
+        - exitAfterDefer
+        - mapKey
+        - nilValReturn
+        - offBy1
+        - regexpMust
+        - sloppyLen
+        - sloppyReassign
+        - sloppyTypeAssert
+        - truncateCmp
+        - uncheckedInlineErr
+
   exclusions:
     # Built-in presets that suppress the most common idiomatic false
     # positives across the standard linters.
@@ -73,14 +105,14 @@ linters:
     rules:
       # Generated code: ignore findings entirely.
       - path: '\.pb\.go$'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic]
       - path: '\.pb\.gw\.go$'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic]
       - path: 'zz_generated.*\.go$'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic]
       # Kubernetes client-gen / informer-gen / lister-gen output.
       - path: '^pkg/client/'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck, gocritic]
       # Tests routinely discard error returns from setup helpers.
       - path: '_test\.go'
         linters:
@@ -88,7 +120,7 @@ linters:
       # Demo binaries intentionally favor concise examples over production
       # control-flow discipline.
       - path: '^demos/'
-        linters: [contextcheck]
+        linters: [gocritic, contextcheck]
       # Suppress staticcheck QF* (quickfix) recommendations. They are
       # stylistic rewrites rather than bug detectors and would generate a
       # large amount of churn if applied indiscriminately.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,6 +29,8 @@ linters:
   enable:
     # Spelling errors in comments, strings, and identifiers.
     - misspell
+    # Reconciliation and RPC calls should inherit the caller's context.
+    - contextcheck
 
   settings:
     errcheck:
@@ -71,18 +73,22 @@ linters:
     rules:
       # Generated code: ignore findings entirely.
       - path: '\.pb\.go$'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck]
       - path: '\.pb\.gw\.go$'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck]
       - path: 'zz_generated.*\.go$'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck]
       # Kubernetes client-gen / informer-gen / lister-gen output.
       - path: '^pkg/client/'
-        linters: [errcheck, govet, ineffassign, staticcheck, unused]
+        linters: [errcheck, govet, ineffassign, staticcheck, unused, contextcheck]
       # Tests routinely discard error returns from setup helpers.
       - path: '_test\.go'
         linters:
           - errcheck
+      # Demo binaries intentionally favor concise examples over production
+      # control-flow discipline.
+      - path: '^demos/'
+        linters: [contextcheck]
       # Suppress staticcheck QF* (quickfix) recommendations. They are
       # stylistic rewrites rather than bug detectors and would generate a
       # large amount of churn if applied indiscriminately.

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -284,6 +284,8 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 				},
 			}
 			req.Scope = toAteletSnapshotScope(state.ActorTemplate.Spec.SnapshotsConfig.OnCommit)
+		case ateapipb.SnapshotType_SNAPSHOT_TYPE_UNSPECIFIED:
+			fallthrough
 		default:
 			return fmt.Errorf("unsupported snapshot type: %v", state.Actor.GetLatestSnapshotInfo().GetType())
 		}

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -84,13 +84,13 @@ func main() {
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
 	}
-	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "TracerProvider", tp.Shutdown)
 
 	mp, err := serverboot.InitMetrics(ctx, "ateapi")
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize metrics", err)
 	}
-	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "MeterProvider", mp.Shutdown)
 
 	loadFlagsFromEnv()
 	logFlagValues(ctx)

--- a/cmd/atecontroller/internal/controllers/actortemplate_controller.go
+++ b/cmd/atecontroller/internal/controllers/actortemplate_controller.go
@@ -162,6 +162,9 @@ func (r *ActorTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	case atev1alpha1.PhaseReady:
 		return ctrl.Result{}, nil
+	case atev1alpha1.PhaseFailed:
+		// Terminal state; nothing left to reconcile.
+		return ctrl.Result{}, nil
 	default:
 		return ctrl.Result{}, fmt.Errorf("unrecognized phase %q", at.Status.Phase)
 	}

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -84,13 +84,13 @@ func main() {
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
 	}
-	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "TracerProvider", tp.Shutdown)
 
 	mp, err := serverboot.InitMetrics(ctx, "atelet")
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize metrics", err)
 	}
-	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "MeterProvider", mp.Shutdown)
 
 	if err := initSnapshotSizeMetric(); err != nil {
 		serverboot.Fatal(ctx, "Failed to create snapshot size metric", err)

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -357,6 +357,8 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		if err := s.moveLocalCheckpoint(ctx, req, checkpointDir, sandboxRec); err != nil {
 			return nil, err
 		}
+	case ateletpb.CheckpointType_CHECKPOINT_TYPE_UNSPECIFIED:
+		fallthrough
 	default:
 		return nil, fmt.Errorf("unexpected checkpoint type: %v", req.GetType())
 	}
@@ -373,6 +375,8 @@ func toAteomSnapshotScope(scope ateletpb.SnapshotScope) ateompb.SnapshotScope {
 	switch scope {
 	case ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA:
 		return ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA
+	case ateletpb.SnapshotScope_SNAPSHOT_SCOPE_UNSPECIFIED, ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL:
+		return ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL
 	default:
 		return ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL
 	}
@@ -489,6 +493,8 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		if sandboxRec, err = unmarshalSandboxRecord(manifest); err != nil {
 			return nil, err
 		}
+	case ateletpb.CheckpointType_CHECKPOINT_TYPE_UNSPECIFIED:
+		fallthrough
 	default:
 		return nil, fmt.Errorf("unexpected checkpoint type: %v", req.GetType())
 	}
@@ -513,6 +519,8 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			if err := s.copyLocalCheckpoint(gctx, req.GetLocalConfig().GetSnapshotPrefix(), ateompath.LocalCheckpointsDir(ns, tmpl, actorID), checkpointDir, sandboxRec.SnapshotFiles); err != nil {
 				return err
 			}
+		case ateletpb.CheckpointType_CHECKPOINT_TYPE_UNSPECIFIED:
+			// Rejected by validateRestoreRequest before we get here; nothing to fetch.
 		}
 		dDownload = time.Since(t)
 		return nil
@@ -847,6 +855,8 @@ func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
 		if req.GetLocalConfig().GetSnapshotPrefix() == "" {
 			return fmt.Errorf("snapshot prefix must be non-empty for type %s", req.GetType().String())
 		}
+	case ateletpb.CheckpointType_CHECKPOINT_TYPE_UNSPECIFIED:
+		fallthrough
 	default:
 		return fmt.Errorf("invalid checkpoint type: %v", req.GetType())
 	}
@@ -871,6 +881,8 @@ func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
 		if req.GetLocalConfig().GetSnapshotPrefix() == "" {
 			return fmt.Errorf("snapshot prefix must be non-empty for type %s", req.GetType().String())
 		}
+	case ateletpb.CheckpointType_CHECKPOINT_TYPE_UNSPECIFIED:
+		fallthrough
 	default:
 		return fmt.Errorf("invalid checkpoint type: %v", req.GetType())
 	}

--- a/cmd/atenet/internal/router/controller.go
+++ b/cmd/atenet/internal/router/controller.go
@@ -92,7 +92,7 @@ func (c *Controller) reconcile(ctx context.Context) error {
 		return err
 	}
 
-	if err := c.xdsSrv.UpdateSnapshot(); err != nil {
+	if err := c.xdsSrv.UpdateSnapshot(ctx); err != nil {
 		slog.ErrorContext(ctx, "xDS Configuration generation problem", slog.String("err", err.Error()))
 		return err
 	}

--- a/cmd/atenet/internal/router/errors.go
+++ b/cmd/atenet/internal/router/errors.go
@@ -84,7 +84,7 @@ func mapResumeError(actorID string, err error) error {
 	case codes.ResourceExhausted:
 		re.statusCode = int(envoy_type.StatusCode_TooManyRequests)
 		re.msg = fmt.Sprintf("actor %q rate limited", actorID)
-	default:
+	case codes.OK, codes.Canceled, codes.Unknown, codes.InvalidArgument, codes.AlreadyExists, codes.Aborted, codes.OutOfRange, codes.Unimplemented, codes.Internal, codes.DataLoss:
 		re.statusCode = int(envoy_type.StatusCode_InternalServerError)
 		re.msg = fmt.Sprintf("error resuming actor %q", actorID)
 	}

--- a/cmd/atenet/internal/router/resumer.go
+++ b/cmd/atenet/internal/router/resumer.go
@@ -47,7 +47,7 @@ func (r *ActorResumer) ResumeActor(ctx context.Context, actorID string) (*ateapi
 		trace.WithAttributes(attribute.String("actor_id", actorID)))
 	defer span.End()
 
-	ch := r.flight.DoChan(actorID, func() (interface{}, error) {
+	ch := r.flight.DoChan(actorID, func() (interface{}, error) { //nolint:contextcheck // Shared resume work must outlive the first caller's cancellation.
 		// We detach the context from the first caller using a fixed background timeout.
 		// This guarantees that if Caller 1 disconnects or times out, the underlying
 		// resume operation continues running for Caller 2 and Caller 3 without failing.

--- a/cmd/atenet/internal/router/router.go
+++ b/cmd/atenet/internal/router/router.go
@@ -179,13 +179,13 @@ func (s *RouterServer) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize tracing: %w", err)
 	}
-	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "TracerProvider", tp.Shutdown)
 
 	mp, err := serverboot.InitMetrics(ctx, routerServiceName)
 	if err != nil {
 		return fmt.Errorf("failed to initialize metrics: %w", err)
 	}
-	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "MeterProvider", mp.Shutdown)
 
 	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{Addr: s.cfg.MetricsAddr})
 
@@ -204,7 +204,7 @@ func (s *RouterServer) Run(ctx context.Context) error {
 
 	g, ctx := errgroup.WithContext(ctx)
 
-	xdsSrv := NewXdsServer(s.cfg.XdsPort)
+	xdsSrv := NewXdsServer(ctx, s.cfg.XdsPort)
 	xdsSrv.SetConfig(s.cfg.HttpPort, s.cfg.ExtprocPort, s.cfg.ExtprocAddr)
 	if err := xdsSrv.SetOtlpCollector(s.cfg.OtlpCollectorAddress); err != nil {
 		return fmt.Errorf("configure OTLP collector: %w", err)

--- a/cmd/atenet/internal/router/xds.go
+++ b/cmd/atenet/internal/router/xds.go
@@ -89,9 +89,9 @@ type XdsServer struct {
 	otlpPort uint32
 }
 
-func NewXdsServer(xdsPort int) *XdsServer {
+func NewXdsServer(ctx context.Context, xdsPort int) *XdsServer {
 	cache := cachev3.NewSnapshotCache(true, cachev3.IDHash{}, nil)
-	srv := serverv3.NewServer(context.Background(), cache, nil)
+	srv := serverv3.NewServer(ctx, cache, nil)
 
 	return &XdsServer{
 		xdsPort:     xdsPort,
@@ -145,7 +145,7 @@ func (x *XdsServer) SetOtlpCollector(addr string) error {
 	return nil
 }
 
-func (x *XdsServer) UpdateSnapshot() error {
+func (x *XdsServer) UpdateSnapshot(ctx context.Context) error {
 	x.mu.Lock()
 	defer x.mu.Unlock()
 
@@ -190,12 +190,12 @@ func (x *XdsServer) UpdateSnapshot() error {
 	}
 
 	slog.Info("Deploying updated xDS configuration snapshot", slog.String("version", ver))
-	return x.snapshot.SetSnapshot(context.Background(), NodeID, snapshot)
+	return x.snapshot.SetSnapshot(ctx, NodeID, snapshot)
 }
 
 func (x *XdsServer) Serve(ctx context.Context, lis net.Listener) error {
 	// Ensure a first snapshot is deployed
-	if err := x.UpdateSnapshot(); err != nil {
+	if err := x.UpdateSnapshot(ctx); err != nil {
 		slog.ErrorContext(ctx, "Warning - initial xDS setup update failed", slog.String("err", err.Error()))
 	}
 

--- a/cmd/atenet/internal/router/xds_test.go
+++ b/cmd/atenet/internal/router/xds_test.go
@@ -29,10 +29,10 @@ import (
 )
 
 func TestXdsServer_UpdateSnapshot(t *testing.T) {
-	server := NewXdsServer(18000)
+	server := NewXdsServer(context.Background(), 18000)
 	server.SetConfig(8081, 50052, "10.0.0.1")
 
-	err := server.UpdateSnapshot()
+	err := server.UpdateSnapshot(context.Background())
 	if err != nil {
 		t.Fatalf("UpdateSnapshot failed: %v", err)
 	}
@@ -139,11 +139,11 @@ func TestXdsServer_UpdateSnapshot(t *testing.T) {
 }
 
 func TestXdsServer_UpdateSnapshot_WithHttps(t *testing.T) {
-	server := NewXdsServer(18000)
+	server := NewXdsServer(context.Background(), 18000)
 	server.SetConfig(8085, 50053, "127.0.0.1")
 	server.SetTlsConfig(8443, "", "dummy-cert", "dummy-key")
 
-	err := server.UpdateSnapshot()
+	err := server.UpdateSnapshot(context.Background())
 	if err != nil {
 		t.Fatalf("UpdateSnapshot failed: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestXdsServer_UpdateSnapshot_WithHttps(t *testing.T) {
 }
 
 func TestXdsServer_Serve_Shutdown(t *testing.T) {
-	server := NewXdsServer(18000)
+	server := NewXdsServer(context.Background(), 18000)
 	server.SetConfig(8085, 50053, "127.0.0.1")
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -101,7 +101,7 @@ func do(ctx context.Context) error {
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
 	}
-	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "TracerProvider", tp.Shutdown)
 
 	// Create ateom dir
 	ateomDir := ateompath.AteomPath(*podUID)

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -147,8 +147,7 @@ func do(ctx context.Context) error {
 	reflection.Register(svr)
 
 	if err := svr.Serve(lis); err != nil {
-		slog.ErrorContext(ctx, "Failed to serve", slog.Any("err", err))
-		os.Exit(1)
+		return fmt.Errorf("failed to serve: %w", err)
 	}
 
 	return nil

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -279,6 +279,8 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		if err := rcmd.cmdCheckpoint(ctx, "pause", checkpointPath); err != nil {
 			return nil, fmt.Errorf("while checkpointing pause: %w", err)
 		}
+	case ateompb.SnapshotScope_SNAPSHOT_SCOPE_UNSPECIFIED:
+		fallthrough
 	default:
 		return nil, fmt.Errorf("unsupported snapshot scope: %v", req.GetScope())
 	}
@@ -399,6 +401,8 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		if err := rcmd.cmdRestore(ctx, os.Stdout, "pause", checkpointDir); err != nil {
 			return nil, fmt.Errorf("while starting pause container: %w", err)
 		}
+	case ateompb.SnapshotScope_SNAPSHOT_SCOPE_UNSPECIFIED:
+		fallthrough
 	default:
 		return nil, fmt.Errorf("unexpected snapshot scope: %v", req.GetScope())
 	}
@@ -426,6 +430,8 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 			if err := rcmd.cmdRestore(ctx, pw, ac.GetName(), checkpointDir); err != nil {
 				return nil, fmt.Errorf("while starting %q application container: %w", ac.GetName(), err)
 			}
+		case ateompb.SnapshotScope_SNAPSHOT_SCOPE_UNSPECIFIED:
+			fallthrough
 		default:
 			return nil, fmt.Errorf("unexpected snapshot scope: %v", req.GetScope())
 		}

--- a/cmd/ateom-microvm/internal/kata/specconv.go
+++ b/cmd/ateom-microvm/internal/kata/specconv.go
@@ -103,6 +103,8 @@ func SpecToAgentPB(s *specs.Spec) *agentpb.Spec {
 			switch ns.Type {
 			case specs.NetworkNamespace, specs.CgroupNamespace, specs.TimeNamespace:
 				continue
+			case specs.PIDNamespace, specs.MountNamespace, specs.IPCNamespace, specs.UTSNamespace, specs.UserNamespace:
+				// Kept: appended below with an emptied host Path.
 			}
 			l.Namespaces = append(l.Namespaces, &agentpb.LinuxNamespace{Type: string(ns.Type)})
 		}

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -92,7 +92,7 @@ func do(ctx context.Context) error {
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
 	}
-	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "TracerProvider", tp.Shutdown)
 
 	// Create ateom dir.
 	ateomDir := ateompath.AteomPath(*podUID)

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -193,7 +193,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	} else {
 		ra.logAgent = logAC
 		for _, c := range containers {
-			s.startActorLogForwarding(logAC, id, overlayWorkloadID(c.GetName()), c.GetName(), name, ns)
+			s.startActorLogForwarding(logAC, id, overlayWorkloadID(c.GetName()), c.GetName(), name, ns) //nolint:contextcheck // Log forwarders run for the actor's lifetime, not the RPC's: they detach to a background context and exit when teardownActor closes the agent client.
 		}
 	}
 

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -357,7 +357,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	// that and tag with the display container name. The goroutines read over ac for the
 	// actor's lifetime and exit (io.EOF) when teardownActor closes ac.
 	for _, c := range ctrs {
-		s.startActorLogForwarding(ac, id, overlayWorkloadID(c.name), c.name, name, ns)
+		s.startActorLogForwarding(ac, id, overlayWorkloadID(c.name), c.name, name, ns) //nolint:contextcheck // Log forwarders run for the actor's lifetime, not the RPC's: they detach to a background context and exit when teardownActor closes the agent client.
 	}
 
 	s.actorLogger.EmitLifecycleLog("Actor started", id, name, ns)

--- a/cmd/podcertcontroller/internal/servicednssigner/servicednssigner.go
+++ b/cmd/podcertcontroller/internal/servicednssigner/servicednssigner.go
@@ -108,7 +108,7 @@ func (h *Impl) MakeCert(ctx context.Context, pcr *certsv1beta1.PodCertificateReq
 		switch svc.Spec.Type {
 		case corev1.ServiceTypeClusterIP, corev1.ServiceTypeNodePort, corev1.ServiceTypeLoadBalancer:
 			// ok
-		default:
+		case corev1.ServiceTypeExternalName:
 			// This service type doesn't select pods using a label selector.
 			continue
 		}

--- a/cmd/testing/glutton/main.go
+++ b/cmd/testing/glutton/main.go
@@ -80,13 +80,13 @@ func main() {
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
 	}
-	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "TracerProvider", tp.Shutdown)
 
 	mp, err := serverboot.InitMetrics(ctx, "glutton")
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize metrics", err)
 	}
-	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
+	defer serverboot.ShutdownProvider(ctx, "MeterProvider", mp.Shutdown)
 
 	if err := os.MkdirAll(*dataDir, 0o700); err != nil {
 		serverboot.Fatal(ctx, "Failed to create data directory", fmt.Errorf("%s: %w", *dataDir, err))
@@ -408,7 +408,7 @@ func (s *gluttonService) Gossip(_ context.Context, req *glutton.GossipRequest) (
 		s.mu.Lock()
 		s.peers[w.GetHost()] = pg
 		s.mu.Unlock()
-		go s.runGossip(gctx, pg)
+		go s.runGossip(gctx, pg) //nolint:contextcheck // Each peer-gossip worker has its own lifecycle (cancelled via pg.cancel) and must outlive the StartGossip RPC.
 	}
 
 	return &glutton.GossipResponse{}, nil

--- a/demos/claude-code-multiplex/ui/server.go
+++ b/demos/claude-code-multiplex/ui/server.go
@@ -206,6 +206,8 @@ func newKubeClient() (*kubernetes.Clientset, error) {
 // / etc).
 func actorStatusString(s ateapipb.Actor_Status) string {
 	switch s {
+	case ateapipb.Actor_STATUS_UNSPECIFIED:
+		return "?"
 	case ateapipb.Actor_STATUS_RESUMING:
 		return "Resuming"
 	case ateapipb.Actor_STATUS_RUNNING:
@@ -214,6 +216,10 @@ func actorStatusString(s ateapipb.Actor_Status) string {
 		return "Suspending"
 	case ateapipb.Actor_STATUS_SUSPENDED:
 		return "Suspended"
+	case ateapipb.Actor_STATUS_PAUSING:
+		return "Pausing"
+	case ateapipb.Actor_STATUS_PAUSED:
+		return "Paused"
 	default:
 		return "?"
 	}

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -171,7 +171,7 @@ func TestDurableDirLifecycle(t *testing.T) {
 			}
 			waitForActorStatus(ctx, t, clients, actorID, ateapipb.Actor_STATUS_RUNNING)
 
-			resp, err := callActor(t, actorID)
+			resp, err := callActor(ctx, t, actorID)
 			if err != nil {
 				t.Fatalf("failed to call actor: %v", err)
 			}
@@ -197,7 +197,7 @@ func TestDurableDirLifecycle(t *testing.T) {
 			}
 			waitForActorStatus(ctx, t, clients, actorID, ateapipb.Actor_STATUS_RUNNING)
 
-			resp, err = callActor(t, actorID)
+			resp, err = callActor(ctx, t, actorID)
 			if err != nil {
 				t.Fatalf("failed to call actor again: %v", err)
 			}
@@ -223,7 +223,7 @@ func TestDurableDirLifecycle(t *testing.T) {
 			}
 			waitForActorStatus(ctx, t, clients, actorID, ateapipb.Actor_STATUS_RUNNING)
 
-			resp, err = callActor(t, actorID)
+			resp, err = callActor(ctx, t, actorID)
 			if err != nil {
 				t.Fatalf("failed to call actor again: %v", err)
 			}
@@ -321,7 +321,7 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 	}
 	waitForActorStatus(ctx, t, clients, actorID, ateapipb.Actor_STATUS_RUNNING)
 
-	resp, err := callActor(t, actorID)
+	resp, err := callActor(ctx, t, actorID)
 	if err != nil {
 		t.Fatalf("failed to call actor: %v", err)
 	}
@@ -350,7 +350,7 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 	}
 	waitForActorStatus(ctx, t, clients, actorID, ateapipb.Actor_STATUS_RUNNING)
 
-	resp, err = callActor(t, actorID)
+	resp, err = callActor(ctx, t, actorID)
 	if err != nil {
 		t.Fatalf("failed to call actor again: %v", err)
 	}
@@ -409,7 +409,7 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 	}
 	waitForActorStatus(ctx, t, clients, actorID, ateapipb.Actor_STATUS_RUNNING)
 
-	resp, err := callActor(t, actorID)
+	resp, err := callActor(ctx, t, actorID)
 	if err != nil {
 		t.Fatalf("failed to call actor: %v", err)
 	}
@@ -437,7 +437,7 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 	}
 	waitForActorStatus(ctx, t, clients, actorID, ateapipb.Actor_STATUS_RUNNING)
 
-	resp, err = callActor(t, actorID)
+	resp, err = callActor(ctx, t, actorID)
 	if err != nil {
 		t.Fatalf("failed to call actor again: %v", err)
 	}
@@ -610,17 +610,17 @@ func waitForActorStatus(ctx context.Context, t *testing.T, clients *e2e.Clients,
 	t.Fatalf("timed out waiting for actor %q to reach status %v", actorID, expectedStatus)
 }
 
-func callActor(t *testing.T, actorID string) (string, error) {
+func callActor(ctx context.Context, t *testing.T, actorID string) (string, error) {
 	t.Helper()
 	clients := e2e.GetClients()
 
-	svc, err := clients.K8s.CoreV1().Services("ate-system").Get(context.Background(), "atenet-router", metav1.GetOptions{})
+	svc, err := clients.K8s.CoreV1().Services("ate-system").Get(ctx, "atenet-router", metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get atenet-router service: %w", err)
 	}
 
 	selector := labels.SelectorFromSet(svc.Spec.Selector).String()
-	pods, err := clients.K8s.CoreV1().Pods("ate-system").List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+	pods, err := clients.K8s.CoreV1().Pods("ate-system").List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return "", fmt.Errorf("failed to list atenet-router pods: %w", err)
 	}

--- a/internal/e2e/suites/identity/identity_test.go
+++ b/internal/e2e/suites/identity/identity_test.go
@@ -149,6 +149,8 @@ func waitForGolden(t *testing.T, ctx context.Context, clients *e2e.Clients) stri
 				return at.Status.GoldenActorID
 			case v1alpha1.PhaseFailed:
 				t.Fatalf("probe ActorTemplate entered PhaseFailed")
+			case v1alpha1.PhaseInitial, v1alpha1.PhaseResumeGoldenActor, v1alpha1.PhaseWaitGoldenActor:
+				// Still provisioning the golden actor; keep polling.
 			}
 		}
 		time.Sleep(2 * time.Second)

--- a/internal/serverboot/serverboot.go
+++ b/internal/serverboot/serverboot.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/google/uuid"
@@ -153,9 +154,15 @@ func Fatal(ctx context.Context, msg string, err error) {
 // ShutdownProvider invokes the OTel provider's Shutdown and logs any
 // error. Designed to be deferred from main():
 //
-//	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
-func ShutdownProvider(name string, shutdown func(context.Context) error) {
-	if err := shutdown(context.Background()); err != nil {
+//	defer serverboot.ShutdownProvider(ctx, "TracerProvider", tp.Shutdown)
+func ShutdownProvider(ctx context.Context, name string, shutdown func(context.Context) error) {
+	// Detach from the caller's cancellation (main's ctx is usually already
+	// cancelled by the time these deferred shutdowns run) but keep a bound so
+	// a wedged exporter can't hang process exit.
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+
+	if err := shutdown(shutdownCtx); err != nil {
 		slog.Error("Failed to shutdown "+name, slog.Any("err", err))
 	}
 }


### PR DESCRIPTION
Enable contextcheck, gocritic, and exhaustive to catch detached contexts, bug patterns, and incomplete controller state-machine switches.

Assisted by GPT 5.5

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
