### PR TITLE
Reenable the "-direct" and "-background" runsc flags

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -304,23 +304,11 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, err
 	}
 
-	checkpointDir := ateompath.CheckpointDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	checkpointDir := ateompath.CheckpointStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
 
 	client, err := s.dialAteom(ctx, req.GetTargetAteomNamespace(), req.GetTargetAteomName())
 	if err != nil {
 		return nil, err
-	}
-
-	// TODO(ateom): Once we enable background restore, we need `runsc wait
-	// --restore pause` here, so that we know that gVisor is done with the
-	// restore checkpoint file.
-
-	// Delete any existing checkpoint file left over from restore.
-	if err := os.RemoveAll(checkpointDir); err != nil {
-		return nil, fmt.Errorf("while deleting checkpoint: %w", err)
-	}
-	if err := os.MkdirAll(checkpointDir, 0o700); err != nil {
-		return nil, fmt.Errorf("while creating checkpoint dir: %w", err)
 	}
 
 	// Tell ateom to take checkpoint and delete containers.
@@ -337,23 +325,27 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	prefix := strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")
 	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
 
+	checkpointImgPath := filepath.Join(checkpointDir, "checkpoint.img")
+	pagesImgPath := filepath.Join(checkpointDir, "pages.img")
+	pagesMetaImgPath := filepath.Join(checkpointDir, "pages_meta.img")
+
 	// Upload checkpoint from local dir.
 	if err := ategcs.SendLocalFileToGCSWithZstd(ctx, s.gcsClient,
 		prefix+"/checkpoint.img.zstd",
-		ateompath.CheckpointImgPath(ns, tmpl, actorID),
+		checkpointImgPath,
 	); err != nil {
 		return nil, fmt.Errorf("while uploading checkpoint.img to GCS: %w", err)
 	}
 
 	if err := uploadIfExists(ctx, s.gcsClient,
 		prefix+"/pages.img.zstd",
-		ateompath.PagesImgPath(ns, tmpl, actorID),
+		pagesImgPath,
 	); err != nil {
 		return nil, err
 	}
 	if err := uploadIfExists(ctx, s.gcsClient,
 		prefix+"/pages_meta.img.zstd",
-		ateompath.PagesMetaImgPath(ns, tmpl, actorID),
+		pagesMetaImgPath,
 	); err != nil {
 		return nil, err
 	}
@@ -377,12 +369,17 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
+	checkpointDir := ateompath.RestoreStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	checkpointImgPath := filepath.Join(checkpointDir, "checkpoint.img")
+	pagesImgPath := filepath.Join(checkpointDir, "pages.img")
+	pagesMetaImgPath := filepath.Join(checkpointDir, "pages_meta.img")
+
 	prefix := strings.TrimSuffix(req.GetSnapshotUriPrefix(), "/")
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, dl := range []struct{ remote, local string }{
-		{prefix + "/checkpoint.img.zstd", ateompath.CheckpointImgPath(ns, tmpl, actorID)},
-		{prefix + "/pages.img.zstd", ateompath.PagesImgPath(ns, tmpl, actorID)},
-		{prefix + "/pages_meta.img.zstd", ateompath.PagesMetaImgPath(ns, tmpl, actorID)},
+		{prefix + "/checkpoint.img.zstd", checkpointImgPath},
+		{prefix + "/pages.img.zstd", pagesImgPath},
+		{prefix + "/pages_meta.img.zstd", pagesMetaImgPath},
 	} {
 		dl := dl
 		g.Go(func() error {
@@ -587,12 +584,20 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating PID file dir: %w", err)
 	}
 
-	checkpointDir := ateompath.CheckpointDir(actorTemplateNamespace, actorTemplateName, actorID)
+	checkpointDir := ateompath.CheckpointStateDir(actorTemplateNamespace, actorTemplateName, actorID)
 	if err := os.RemoveAll(checkpointDir); err != nil {
-		return fmt.Errorf("while deleting checkpoint dir: %w", err)
+		return fmt.Errorf("while deleting checkpoint-state dir: %w", err)
 	}
 	if err := os.MkdirAll(checkpointDir, 0o700); err != nil {
-		return fmt.Errorf("while creating checkpoint dir: %w", err)
+		return fmt.Errorf("while creating checkpoint-state dir: %w", err)
+	}
+
+	restoreStateDir := ateompath.RestoreStateDir(actorTemplateNamespace, actorTemplateName, actorID)
+	if err := os.RemoveAll(restoreStateDir); err != nil {
+		return fmt.Errorf("while deleting restore-state dir: %w", err)
+	}
+	if err := os.MkdirAll(restoreStateDir, 0o700); err != nil {
+		return fmt.Errorf("while creating restore-state dir: %w", err)
 	}
 
 	return nil

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -323,7 +323,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		actorID:                req.GetActorId(),
 	}
 
-	checkpointPath := ateompath.CheckpointDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	checkpointPath := ateompath.CheckpointStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
 	if err := os.MkdirAll(checkpointPath, 0o700); err != nil {
 		return nil, fmt.Errorf("while creating checkpoint directory: %w", err)
 	}
@@ -454,7 +454,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		actorID:                req.GetActorId(),
 	}
 
-	checkpointDir := ateompath.CheckpointDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	checkpointDir := ateompath.RestoreStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
 
 	// Create and restore pause container
 	if err := rcmd.cmdCreate(ctx, os.Stdout, "pause"); err != nil {

--- a/cmd/ateom-gvisor/runsc.go
+++ b/cmd/ateom-gvisor/runsc.go
@@ -152,8 +152,8 @@ func (r *runsc) cmdRestore(ctx context.Context, out io.Writer, containerName, ch
 		"-bundle", ateompath.OCIBundlePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
 		"-image-path", checkpointPath,
 		"-pid-file", ateompath.PIDFilePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
-		//"-background",
-		//"-direct", // TODO(ateom): Reenable direct
+		"-background",
+		"-direct",
 		"-detach",
 		containerName,
 	)

--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -119,31 +119,28 @@ func RunscDebugLogDir(actorTemplateNamespace, actorTemplateName, actorID, contai
 	)
 }
 
-func CheckpointDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func CheckpointStateDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
 	return filepath.Join(
 		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
-		"checkpoint",
+		"checkpoint-state",
 	)
 }
 
-func CheckpointImgPath(actorTemplateNamespace, actorTemplateName, actorID string) string {
+// RestoreStateDir is the local directory to use to restore an actor from a
+// checkpoint downloaded from GCS.
+//
+// We need to use a different path from CheckpointStateDir, because using `runsc
+// restore -direct -background` means that runsc starts executing first, then
+// demand-pages in parts of the checkpoint file as they are needed.  To know
+// when the background reading is finished, we would need to run `runsc wait
+// -checkpoint`, which will block until the read is done.  Alternatively, we can
+// make sure we write the suspension checkpoint to a different location.  This
+// will work properly, with `runsc checkpoint` paging in any data that hasn't
+// yet been loaded.
+func RestoreStateDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
 	return filepath.Join(
-		CheckpointDir(actorTemplateNamespace, actorTemplateName, actorID),
-		"checkpoint.img", // gvisor implementation detail, technically.
-	)
-}
-
-func PagesImgPath(actorTemplateNamespace, actorTemplateName, actorID string) string {
-	return filepath.Join(
-		CheckpointDir(actorTemplateNamespace, actorTemplateName, actorID),
-		"pages.img", // gvisor implementation detail, technically.
-	)
-}
-
-func PagesMetaImgPath(actorTemplateNamespace, actorTemplateName, actorID string) string {
-	return filepath.Join(
-		CheckpointDir(actorTemplateNamespace, actorTemplateName, actorID),
-		"pages_meta.img", // gvisor implementation detail, technically.
+		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		"restore-state",
 	)
 }
 


### PR DESCRIPTION
These flags allow the guest workload to begin executing sooner during restore, because gVisor loads only the necessary memory pages.  Other pages are lazily loaded in the background or as they are referenced.

This mode slightly complicates our state management, because it's more difficult to tell when gVisor is done with the checkpoint files passed to `runsc restore`.

We can work around this by ensuring that we always pass different directories to `runsc checkpoint` and `runsc restore`.

`runsc checkpoint` properly handles the case where the gVisor sentry has not finished background loading of pages from a previous `runsc restore`.

