### PR TITLE
feat(serverboot): set service.instance.id on the telemetry resource

### DIFF
--- a/internal/serverboot/serverboot.go
+++ b/internal/serverboot/serverboot.go
@@ -20,12 +20,14 @@ package serverboot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 
 	"github.com/agent-substrate/substrate/internal/contextlogging"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -42,6 +44,28 @@ import (
 // contextlogging.NewHandler. Call once at process start.
 func InitLogger() {
 	slog.SetDefault(slog.New(contextlogging.NewHandler(slog.NewJSONHandler(os.Stdout, nil))))
+}
+
+// serviceInstanceID is generated once so the tracer and meter resources share it.
+var serviceInstanceID = uuid.NewString()
+
+// newResource builds the resource shared by the tracer and meter providers.
+// WithFromEnv is last so OTEL_* env vars override the defaults.
+func newResource(ctx context.Context, serviceName string) (*resource.Resource, error) {
+	res, err := resource.New(ctx,
+		resource.WithTelemetrySDK(),
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+			semconv.ServiceInstanceID(serviceInstanceID),
+		),
+		resource.WithFromEnv(),
+	)
+	if errors.Is(err, resource.ErrPartialResource) || errors.Is(err, resource.ErrSchemaURLConflict) {
+		slog.WarnContext(ctx, "partial telemetry resource", slog.Any("err", err))
+	} else if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // TracingOptions configures InitTracing.
@@ -63,9 +87,7 @@ func InitTracing(ctx context.Context, opts TracingOptions) (*sdktrace.TracerProv
 	if opts.ServiceName == "" {
 		return nil, fmt.Errorf("TracingOptions.ServiceName is required")
 	}
-	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceName(opts.ServiceName)),
-	)
+	res, err := newResource(ctx, opts.ServiceName)
 	if err != nil {
 		return nil, fmt.Errorf("create tracer resource: %w", err)
 	}
@@ -106,9 +128,7 @@ func InitMetrics(ctx context.Context, serviceName string) (*sdkmetric.MeterProvi
 	if err != nil {
 		return nil, fmt.Errorf("create OTLP metric exporter: %w", err)
 	}
-	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceName(serviceName)),
-	)
+	res, err := newResource(ctx, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("create metric resource: %w", err)
 	}

--- a/internal/serverboot/serverboot_test.go
+++ b/internal/serverboot/serverboot_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serverboot
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+)
+
+func resourceAttrs(res *resource.Resource) map[string]string {
+	m := make(map[string]string)
+	for _, kv := range res.Attributes() {
+		m[string(kv.Key)] = kv.Value.Emit()
+	}
+	return m
+}
+
+func TestNewResourceDefaults(t *testing.T) {
+	res, err := newResource(context.Background(), "ateapi")
+	if err != nil {
+		t.Fatalf("newResource: %v", err)
+	}
+	attrs := resourceAttrs(res)
+	if got := attrs[string(semconv.ServiceNameKey)]; got != "ateapi" {
+		t.Errorf("service.name = %q, want ateapi", got)
+	}
+	if attrs[string(semconv.ServiceInstanceIDKey)] == "" {
+		t.Error("service.instance.id must be set")
+	}
+}
+
+func TestNewResourceEnvWins(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "from-env")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.instance.id=fixed-id")
+	res, err := newResource(context.Background(), "ateapi")
+	if err != nil {
+		t.Fatalf("newResource: %v", err)
+	}
+	attrs := resourceAttrs(res)
+	if got := attrs[string(semconv.ServiceNameKey)]; got != "from-env" {
+		t.Errorf("service.name = %q, want from-env (OTEL_SERVICE_NAME must win)", got)
+	}
+	if got := attrs[string(semconv.ServiceInstanceIDKey)]; got != "fixed-id" {
+		t.Errorf("service.instance.id = %q, want fixed-id (OTEL_RESOURCE_ATTRIBUTES must win)", got)
+	}
+}

--- a/manifests/ate-install/ate-api-server.yaml
+++ b/manifests/ate-install/ate-api-server.yaml
@@ -84,6 +84,20 @@ spec:
           - --session-id-ca-pool=/run/session-id-ca-pool/pool.json
           - --workerpool-ca-certs=/run/workerpool-ca-certs/trust-bundle.pem
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),service.instance.id=$(POD_UID)
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
         # Inject env vars from a ConfigMap created by each developer.  This lets

--- a/manifests/ate-install/atelet.yaml
+++ b/manifests/ate-install/atelet.yaml
@@ -76,6 +76,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),service.instance.id=$(POD_UID)
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
         - name: ATE_STORAGE_BACKEND


### PR DESCRIPTION
Fixes #154

Give `serverboot`'s OTel resource a per-instance identity so multi-instance components (e.g. the `atelet` DaemonSet) don't collide in the backend, and honor `OTEL_RESOURCE_ATTRIBUTES`. The shared tracer/meter resource now carries `service.instance.id` (UUID fallback) with `WithFromEnv` last so env overrides defaults (`ErrPartialResource`/`ErrSchemaURLConflict` are non-fatal), and the `ate-api-server` Deployment / `atelet` DaemonSet inject pod identity via the Downward API (`service.instance.id=$(POD_UID)`, `k8s.namespace.name/pod.name/pod.uid`).

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR