### PR TITLE
Feature/list actors scale w/ pagination

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -692,6 +692,28 @@ func TestListActors_Pagination(t *testing.T) {
 	}
 }
 
+func TestListActors_PageSizeValidation(t *testing.T) {
+	ns := namespaceForTest("ns-list-actors-validation")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	// 1. Negative page size
+	_, err := tc.client.ListActors(context.Background(), &ateapipb.ListActorsRequest{
+		PageSize: -1,
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument error for negative page_size, got: %v", err)
+	}
+
+	// 2. Page size exceeding maxPageSize (1000)
+	_, err = tc.client.ListActors(context.Background(), &ateapipb.ListActorsRequest{
+		PageSize: 1001,
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument error for page_size > 1000, got: %v", err)
+	}
+}
+
 // TestListWorkers tests that workers mirrored to Redis are listed.
 // Workflow:
 // 1. Creates a mock worker Pod in Kubernetes.

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -1259,7 +1259,7 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 	deleteWorkerPod(t, tc, ns, "worker-1")
 
 	// 3. Call SuspendActor -> Should succeed (our fix skips missing pod execution)
-	actors, _, _ := tc.persistence.ListActors(context.Background(), 1000, "")
+	actors, _, _ := tc.persistence.ListActors(context.Background(), maxPageSize, "")
 	t.Logf("Actors in Redis before Suspend: %d", len(actors))
 	for _, a := range actors {
 		t.Logf("  Actor: %s/%s/%s", a.GetActorTemplateNamespace(), a.GetActorTemplateName(), a.GetActorId())

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -36,6 +35,7 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/redis/go-redis/v9"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -619,20 +619,76 @@ func TestListActors(t *testing.T) {
 		t.Fatalf("expected 2 actors, got %d", len(listResp.Actors))
 	}
 
-	sort.Slice(listResp.Actors, func(i, j int) bool {
-		return listResp.Actors[i].ActorId < listResp.Actors[j].ActorId
-	})
-
 	want := []*ateapipb.Actor{
 		resp1.GetActor(),
 		resp2.GetActor(),
 	}
-	sort.Slice(want, func(i, j int) bool {
-		return want[i].ActorId < want[j].ActorId
-	})
 
-	if diff := cmp.Diff(want, listResp.Actors, protocmp.Transform()); diff != "" {
+	opts := []cmp.Option{
+		protocmp.Transform(),
+		cmpopts.SortSlices(func(a, b *ateapipb.Actor) bool {
+			return a.ActorId < b.ActorId
+		}),
+	}
+
+	if diff := cmp.Diff(want, listResp.Actors, opts...); diff != "" {
 		t.Errorf("ListActors response mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestListActors_Pagination tests that ListActors correctly paginates results.
+func TestListActors_Pagination(t *testing.T) {
+	ns := namespaceForTest("ns-list-actors-pagination")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+
+	var want []*ateapipb.Actor
+	for i := 0; i < 5; i++ {
+		resp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+			ActorTemplateNamespace: ns,
+			ActorTemplateName:      "tmpl1",
+			ActorId:                fmt.Sprintf("id%d", i),
+		})
+		if err != nil {
+			t.Fatalf("CreateActor %d failed: %v", i, err)
+		}
+		want = append(want, resp.GetActor())
+	}
+
+	var allActors []*ateapipb.Actor
+	pageToken := ""
+
+	for {
+		listResp, err := tc.client.ListActors(context.Background(), &ateapipb.ListActorsRequest{
+			PageSize:  2,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			t.Fatalf("ListActors failed: %v", err)
+		}
+
+		allActors = append(allActors, listResp.Actors...)
+		pageToken = listResp.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+
+	if len(allActors) != 5 {
+		t.Fatalf("expected 5 actors total, got %d", len(allActors))
+	}
+
+	opts := []cmp.Option{
+		protocmp.Transform(),
+		cmpopts.SortSlices(func(a, b *ateapipb.Actor) bool {
+			return a.ActorId < b.ActorId
+		}),
+	}
+
+	if diff := cmp.Diff(want, allActors, opts...); diff != "" {
+		t.Errorf("ListActors pagination response mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1203,7 +1259,7 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 	deleteWorkerPod(t, tc, ns, "worker-1")
 
 	// 3. Call SuspendActor -> Should succeed (our fix skips missing pod execution)
-	actors, _ := tc.persistence.ListActors(context.Background())
+	actors, _, _ := tc.persistence.ListActors(context.Background(), 1000, "")
 	t.Logf("Actors in Redis before Suspend: %d", len(actors))
 	for _, a := range actors {
 		t.Logf("  Actor: %s/%s/%s", a.GetActorTemplateNamespace(), a.GetActorTemplateName(), a.GetActorId())

--- a/cmd/ateapi/internal/controlapi/list_actors.go
+++ b/cmd/ateapi/internal/controlapi/list_actors.go
@@ -19,16 +19,18 @@ import (
 	"fmt"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const maxPageSize = 1000
 
 func (s *Service) ListActors(ctx context.Context, req *ateapipb.ListActorsRequest) (*ateapipb.ListActorsResponse, error) {
 	if err := validateListActorsRequest(req); err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	pageSize := req.GetPageSize()
-	if pageSize <= 0 || pageSize > maxPageSize {
+	if pageSize == 0 {
 		pageSize = maxPageSize
 	}
 
@@ -42,6 +44,13 @@ func (s *Service) ListActors(ctx context.Context, req *ateapipb.ListActorsReques
 	}, nil
 }
 
-func validateListActorsRequest(_ *ateapipb.ListActorsRequest) error {
+func validateListActorsRequest(req *ateapipb.ListActorsRequest) error {
+	pageSize := req.GetPageSize()
+	if pageSize < 0 {
+		return fmt.Errorf("page_size cannot be negative")
+	}
+	if pageSize > maxPageSize {
+		return fmt.Errorf("page_size %d exceeds maximum page size %d", pageSize, maxPageSize)
+	}
 	return nil
 }

--- a/cmd/ateapi/internal/controlapi/list_actors.go
+++ b/cmd/ateapi/internal/controlapi/list_actors.go
@@ -25,12 +25,18 @@ func (s *Service) ListActors(ctx context.Context, req *ateapipb.ListActorsReques
 	if err := validateListActorsRequest(req); err != nil {
 		return nil, err
 	}
-	actors, err := s.persistence.ListActors(ctx)
+	pageSize := req.GetPageSize()
+	if pageSize <= 0 || pageSize > 1000 {
+		pageSize = 1000
+	}
+
+	actors, nextToken, err := s.persistence.ListActors(ctx, pageSize, req.GetPageToken())
 	if err != nil {
 		return nil, fmt.Errorf("while listing actors in db: %w", err)
 	}
 	return &ateapipb.ListActorsResponse{
-		Actors: actors,
+		Actors:        actors,
+		NextPageToken: nextToken,
 	}, nil
 }
 

--- a/cmd/ateapi/internal/controlapi/list_actors.go
+++ b/cmd/ateapi/internal/controlapi/list_actors.go
@@ -21,13 +21,15 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 )
 
+const maxPageSize = 1000
+
 func (s *Service) ListActors(ctx context.Context, req *ateapipb.ListActorsRequest) (*ateapipb.ListActorsResponse, error) {
 	if err := validateListActorsRequest(req); err != nil {
 		return nil, err
 	}
 	pageSize := req.GetPageSize()
-	if pageSize <= 0 || pageSize > 1000 {
-		pageSize = 1000
+	if pageSize <= 0 || pageSize > maxPageSize {
+		pageSize = maxPageSize
 	}
 
 	actors, nextToken, err := s.persistence.ListActors(ctx, pageSize, req.GetPageToken())

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -421,6 +421,11 @@ func decodePageToken(tokenStr string) (listActorsPageToken, error) {
 	return token, err
 }
 
+func hashShardAddr(addr string) string {
+	h := sha256.Sum256([]byte(addr))
+	return hex.EncodeToString(h[:])
+}
+
 func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenStr string) ([]*ateapipb.Actor, string, error) {
 	token, err := decodePageToken(pageTokenStr)
 	if err != nil {
@@ -453,16 +458,13 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 			remaining := int(pageSize) - len(result)
 			if remaining <= 0 {
 				if cursor != 0 {
-					h := sha256.Sum256([]byte(shardAddr))
 					nextToken = encodePageToken(listActorsPageToken{
-						ShardHash: hex.EncodeToString(h[:]),
+						ShardHash: hashShardAddr(shardAddr),
 						Cursor:    cursor,
 					})
 				} else if i+1 < len(masters) {
-					nextShardAddr := masters[i+1].Options().Addr
-					h := sha256.Sum256([]byte(nextShardAddr))
 					nextToken = encodePageToken(listActorsPageToken{
-						ShardHash: hex.EncodeToString(h[:]),
+						ShardHash: hashShardAddr(masters[i+1].Options().Addr),
 						Cursor:    0,
 					})
 				} else {
@@ -488,10 +490,8 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 
 			if cursor == 0 {
 				if i+1 < len(masters) {
-					nextShardAddr := masters[i+1].Options().Addr
-					h := sha256.Sum256([]byte(nextShardAddr))
 					nextToken = encodePageToken(listActorsPageToken{
-						ShardHash: hex.EncodeToString(h[:]),
+						ShardHash: hashShardAddr(masters[i+1].Options().Addr),
 						Cursor:    0,
 					})
 				} else {
@@ -526,9 +526,7 @@ func findStartingShard(masters []*redis.Client, shardHash string) (int, error) {
 		return 0, nil
 	}
 	for i, m := range masters {
-		h := sha256.Sum256([]byte(m.Options().Addr))
-		hashStr := hex.EncodeToString(h[:])
-		if hashStr == shardHash {
+		if hashShardAddr(m.Options().Addr) == shardHash {
 			return i, nil
 		}
 	}

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -425,32 +425,14 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 		return nil, "", fmt.Errorf("invalid page token: %w", err)
 	}
 
-	var masters []*redis.Client
-	err = s.rdb.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
-		masters = append(masters, master)
-		return nil
-	})
+	masters, err := s.getSortedMasters(ctx)
 	if err != nil {
-		return nil, "", fmt.Errorf("while listing redis masters: %w", err)
+		return nil, "", err
 	}
 
-	sort.Slice(masters, func(i, j int) bool {
-		return masters[i].Options().Addr < masters[j].Options().Addr
-	})
-
-	startIndex := 0
-	if token.ShardAddr != "" {
-		found := false
-		for i, m := range masters {
-			if m.Options().Addr == token.ShardAddr {
-				startIndex = i
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, "", fmt.Errorf("topology changed: shard %s not found (aborted)", token.ShardAddr)
-		}
+	startIndex, err := findStartingShard(masters, token.ShardAddr)
+	if err != nil {
+		return nil, "", err
 	}
 
 	var result []*ateapipb.Actor
@@ -492,34 +474,11 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 			}
 
 			if len(keys) > 0 {
-				cmds, err := master.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-					for _, key := range keys {
-						pipe.Get(ctx, key)
-					}
-					return nil
-				})
-				if err != nil && !errors.Is(err, redis.Nil) {
-					return nil, "", fmt.Errorf("while fetching keys in shard %s: %w", shardAddr, err)
+				actors, err := s.fetchActors(ctx, master, keys)
+				if err != nil {
+					return nil, "", err
 				}
-
-				for _, cmd := range cmds {
-					getCmd, ok := cmd.(*redis.StringCmd)
-					if !ok {
-						continue
-					}
-					if getCmd.Err() != nil {
-						if errors.Is(getCmd.Err(), redis.Nil) {
-							continue
-						}
-						return nil, "", fmt.Errorf("while getting actor: %w", getCmd.Err())
-					}
-
-					actor := &ateapipb.Actor{}
-					if err := protojson.Unmarshal([]byte(getCmd.Val()), actor); err != nil {
-						return nil, "", fmt.Errorf("in protojson.Unmarshal: %w", err)
-					}
-					result = append(result, actor)
-				}
+				result = append(result, actors...)
 			}
 
 			if cursor == 0 {
@@ -537,6 +496,67 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 	}
 
 	return result, nextToken, nil
+}
+
+func (s *Persistence) getSortedMasters(ctx context.Context) ([]*redis.Client, error) {
+	var masters []*redis.Client
+	err := s.rdb.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
+		masters = append(masters, master)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("while listing redis masters: %w", err)
+	}
+
+	sort.Slice(masters, func(i, j int) bool {
+		return masters[i].Options().Addr < masters[j].Options().Addr
+	})
+	return masters, nil
+}
+
+func findStartingShard(masters []*redis.Client, shardAddr string) (int, error) {
+	if shardAddr == "" {
+		return 0, nil
+	}
+	for i, m := range masters {
+		if m.Options().Addr == shardAddr {
+			return i, nil
+		}
+	}
+	return 0, fmt.Errorf("topology changed: shard %s not found (aborted)", shardAddr)
+}
+
+func (s *Persistence) fetchActors(ctx context.Context, master *redis.Client, keys []string) ([]*ateapipb.Actor, error) {
+	cmds, err := master.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for _, key := range keys {
+			pipe.Get(ctx, key)
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("while fetching keys in shard %s: %w", master.Options().Addr, err)
+	}
+
+	var actors []*ateapipb.Actor
+	for _, cmd := range cmds {
+		getCmd, ok := cmd.(*redis.StringCmd)
+		if !ok {
+			continue
+		}
+		if getCmd.Err() != nil {
+			if errors.Is(getCmd.Err(), redis.Nil) {
+				continue
+			}
+			return nil, fmt.Errorf("while getting actor: %w", getCmd.Err())
+		}
+
+		actor := &ateapipb.Actor{}
+		if err := protojson.Unmarshal([]byte(getCmd.Val()), actor); err != nil {
+			return nil, fmt.Errorf("in protojson.Unmarshal: %w", err)
+		}
+		actors = append(actors, actor)
+	}
+	return actors, nil
 }
 
 func (s *Persistence) AcquireLock(ctx context.Context, key string, value string, ttl time.Duration) (bool, error) {

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -455,8 +455,9 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 
 	var result []*ateapipb.Actor
 	var nextToken string
+	stop := false
 
-	for i := startIndex; i < len(masters); i++ {
+	for i := startIndex; i < len(masters) && !stop; i++ {
 		master := masters[i]
 		shardAddr := master.Options().Addr
 		cursor := uint64(0)
@@ -464,58 +465,72 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 			cursor = token.Cursor
 		}
 
-		var keys []string
-		keys, cursor, err = master.Scan(ctx, cursor, "actor:*", int64(pageSize)).Result()
-		if err != nil {
-			return nil, "", fmt.Errorf("while scanning shard %s: %w", shardAddr, err)
-		}
-
-		if len(keys) > 0 {
-			cmds, err := master.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-				for _, key := range keys {
-					pipe.Get(ctx, key)
+		for {
+			remaining := int(pageSize) - len(result)
+			if remaining <= 0 {
+				if cursor != 0 {
+					nextToken = encodePageToken(listActorsPageToken{
+						ShardAddr: shardAddr,
+						Cursor:    cursor,
+					})
+				} else if i+1 < len(masters) {
+					nextToken = encodePageToken(listActorsPageToken{
+						ShardAddr: masters[i+1].Options().Addr,
+						Cursor:    0,
+					})
+				} else {
+					nextToken = ""
 				}
-				return nil
-			})
-			if err != nil && !errors.Is(err, redis.Nil) {
-				return nil, "", fmt.Errorf("while fetching keys in shard %s: %w", shardAddr, err)
+				stop = true
+				break
 			}
 
-			for _, cmd := range cmds {
-				getCmd, ok := cmd.(*redis.StringCmd)
-				if !ok {
-					continue
+			var keys []string
+			keys, cursor, err = master.Scan(ctx, cursor, "actor:*", int64(remaining)).Result()
+			if err != nil {
+				return nil, "", fmt.Errorf("while scanning shard %s: %w", shardAddr, err)
+			}
+
+			if len(keys) > 0 {
+				cmds, err := master.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+					for _, key := range keys {
+						pipe.Get(ctx, key)
+					}
+					return nil
+				})
+				if err != nil && !errors.Is(err, redis.Nil) {
+					return nil, "", fmt.Errorf("while fetching keys in shard %s: %w", shardAddr, err)
 				}
-				if getCmd.Err() != nil {
-					if errors.Is(getCmd.Err(), redis.Nil) {
+
+				for _, cmd := range cmds {
+					getCmd, ok := cmd.(*redis.StringCmd)
+					if !ok {
 						continue
 					}
-					return nil, "", fmt.Errorf("while getting actor: %w", getCmd.Err())
-				}
+					if getCmd.Err() != nil {
+						if errors.Is(getCmd.Err(), redis.Nil) {
+							continue
+						}
+						return nil, "", fmt.Errorf("while getting actor: %w", getCmd.Err())
+					}
 
-				actor := &ateapipb.Actor{}
-				if err := protojson.Unmarshal([]byte(getCmd.Val()), actor); err != nil {
-					return nil, "", fmt.Errorf("in protojson.Unmarshal: %w", err)
+					actor := &ateapipb.Actor{}
+					if err := protojson.Unmarshal([]byte(getCmd.Val()), actor); err != nil {
+						return nil, "", fmt.Errorf("in protojson.Unmarshal: %w", err)
+					}
+					result = append(result, actor)
 				}
-				result = append(result, actor)
 			}
-		}
 
-		if cursor != 0 {
-			nextToken = encodePageToken(listActorsPageToken{
-				ShardAddr: shardAddr,
-				Cursor:    cursor,
-			})
-			break
-		} else {
-			if i+1 < len(masters) {
-				nextToken = encodePageToken(listActorsPageToken{
-					ShardAddr: masters[i+1].Options().Addr,
-					Cursor:    0,
-				})
-				break
-			} else {
-				nextToken = ""
+			if cursor == 0 {
+				if i+1 < len(masters) {
+					nextToken = encodePageToken(listActorsPageToken{
+						ShardAddr: masters[i+1].Options().Addr,
+						Cursor:    0,
+					})
+				} else {
+					nextToken = ""
+				}
 				break
 			}
 		}

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -41,7 +41,9 @@ package ateredis
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -397,7 +399,7 @@ func (s *Persistence) ListWorkers(ctx context.Context) ([]*ateapipb.Worker, erro
 }
 
 type listActorsPageToken struct {
-	ShardAddr string `json:"shard"`
+	ShardHash string `json:"shard_hash"`
 	Cursor    uint64 `json:"cursor"`
 }
 
@@ -430,7 +432,7 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 		return nil, "", err
 	}
 
-	startIndex, err := findStartingShard(masters, token.ShardAddr)
+	startIndex, err := findStartingShard(masters, token.ShardHash)
 	if err != nil {
 		return nil, "", err
 	}
@@ -443,7 +445,7 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 		master := masters[i]
 		shardAddr := master.Options().Addr
 		cursor := uint64(0)
-		if i == startIndex && token.ShardAddr != "" {
+		if i == startIndex && token.ShardHash != "" {
 			cursor = token.Cursor
 		}
 
@@ -451,13 +453,16 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 			remaining := int(pageSize) - len(result)
 			if remaining <= 0 {
 				if cursor != 0 {
+					h := sha256.Sum256([]byte(shardAddr))
 					nextToken = encodePageToken(listActorsPageToken{
-						ShardAddr: shardAddr,
+						ShardHash: hex.EncodeToString(h[:]),
 						Cursor:    cursor,
 					})
 				} else if i+1 < len(masters) {
+					nextShardAddr := masters[i+1].Options().Addr
+					h := sha256.Sum256([]byte(nextShardAddr))
 					nextToken = encodePageToken(listActorsPageToken{
-						ShardAddr: masters[i+1].Options().Addr,
+						ShardHash: hex.EncodeToString(h[:]),
 						Cursor:    0,
 					})
 				} else {
@@ -483,8 +488,10 @@ func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenS
 
 			if cursor == 0 {
 				if i+1 < len(masters) {
+					nextShardAddr := masters[i+1].Options().Addr
+					h := sha256.Sum256([]byte(nextShardAddr))
 					nextToken = encodePageToken(listActorsPageToken{
-						ShardAddr: masters[i+1].Options().Addr,
+						ShardHash: hex.EncodeToString(h[:]),
 						Cursor:    0,
 					})
 				} else {
@@ -514,16 +521,18 @@ func (s *Persistence) getSortedMasters(ctx context.Context) ([]*redis.Client, er
 	return masters, nil
 }
 
-func findStartingShard(masters []*redis.Client, shardAddr string) (int, error) {
-	if shardAddr == "" {
+func findStartingShard(masters []*redis.Client, shardHash string) (int, error) {
+	if shardHash == "" {
 		return 0, nil
 	}
 	for i, m := range masters {
-		if m.Options().Addr == shardAddr {
+		h := sha256.Sum256([]byte(m.Options().Addr))
+		hashStr := hex.EncodeToString(h[:])
+		if hashStr == shardHash {
 			return i, nil
 		}
 	}
-	return 0, fmt.Errorf("topology changed: shard %s not found (aborted)", shardAddr)
+	return 0, fmt.Errorf("topology changed: shard with hash %s not found (aborted)", shardHash)
 }
 
 func (s *Persistence) fetchActors(ctx context.Context, master *redis.Client, keys []string) ([]*ateapipb.Actor, error) {

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -41,8 +41,11 @@ package ateredis
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -393,40 +396,132 @@ func (s *Persistence) ListWorkers(ctx context.Context) ([]*ateapipb.Worker, erro
 	return result, nil
 }
 
-func (s *Persistence) ListActors(ctx context.Context) ([]*ateapipb.Actor, error) {
-	var result []*ateapipb.Actor
-	var mu sync.Mutex
+type listActorsPageToken struct {
+	ShardAddr string `json:"shard"`
+	Cursor    uint64 `json:"cursor"`
+}
 
-	err := s.rdb.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
-		iter := master.Scan(ctx, 0, "actor:*", 0).Iterator()
-		for iter.Next(ctx) {
-			actorKey := iter.Val()
-			parts := strings.Split(actorKey, ":")
-			if len(parts) != 2 {
-				return fmt.Errorf("bad key format %q", actorKey)
-			}
+func encodePageToken(token listActorsPageToken) string {
+	b, _ := json.Marshal(token)
+	return base64.StdEncoding.EncodeToString(b)
+}
 
-			getCmd := master.Get(ctx, actorKey)
-			if getCmd.Err() != nil {
-				return fmt.Errorf("while getting actor %q: %w", actorKey, getCmd.Err())
-			}
+func decodePageToken(tokenStr string) (listActorsPageToken, error) {
+	var token listActorsPageToken
+	if tokenStr == "" {
+		return token, nil
+	}
+	b, err := base64.StdEncoding.DecodeString(tokenStr)
+	if err != nil {
+		return token, err
+	}
+	err = json.Unmarshal(b, &token)
+	return token, err
+}
 
-			actor := &ateapipb.Actor{}
-			if err := protojson.Unmarshal([]byte(getCmd.Val()), actor); err != nil {
-				return fmt.Errorf("in protojson.Unmarshal: %w", err)
-			}
+func (s *Persistence) ListActors(ctx context.Context, pageSize int32, pageTokenStr string) ([]*ateapipb.Actor, string, error) {
+	token, err := decodePageToken(pageTokenStr)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid page token: %w", err)
+	}
 
-			mu.Lock()
-			result = append(result, actor)
-			mu.Unlock()
-		}
-		return iter.Err()
+	var masters []*redis.Client
+	err = s.rdb.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
+		masters = append(masters, master)
+		return nil
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("while listing redis masters: %w", err)
+	}
+
+	sort.Slice(masters, func(i, j int) bool {
+		return masters[i].Options().Addr < masters[j].Options().Addr
 	})
 
-	if err != nil {
-		return nil, fmt.Errorf("while iterating all redis master: %w", err)
+	startIndex := 0
+	if token.ShardAddr != "" {
+		found := false
+		for i, m := range masters {
+			if m.Options().Addr == token.ShardAddr {
+				startIndex = i
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, "", fmt.Errorf("topology changed: shard %s not found (aborted)", token.ShardAddr)
+		}
 	}
-	return result, nil
+
+	var result []*ateapipb.Actor
+	var nextToken string
+
+	for i := startIndex; i < len(masters); i++ {
+		master := masters[i]
+		shardAddr := master.Options().Addr
+		cursor := uint64(0)
+		if i == startIndex && token.ShardAddr != "" {
+			cursor = token.Cursor
+		}
+
+		var keys []string
+		keys, cursor, err = master.Scan(ctx, cursor, "actor:*", int64(pageSize)).Result()
+		if err != nil {
+			return nil, "", fmt.Errorf("while scanning shard %s: %w", shardAddr, err)
+		}
+
+		if len(keys) > 0 {
+			cmds, err := master.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+				for _, key := range keys {
+					pipe.Get(ctx, key)
+				}
+				return nil
+			})
+			if err != nil && !errors.Is(err, redis.Nil) {
+				return nil, "", fmt.Errorf("while fetching keys in shard %s: %w", shardAddr, err)
+			}
+
+			for _, cmd := range cmds {
+				getCmd, ok := cmd.(*redis.StringCmd)
+				if !ok {
+					continue
+				}
+				if getCmd.Err() != nil {
+					if errors.Is(getCmd.Err(), redis.Nil) {
+						continue
+					}
+					return nil, "", fmt.Errorf("while getting actor: %w", getCmd.Err())
+				}
+
+				actor := &ateapipb.Actor{}
+				if err := protojson.Unmarshal([]byte(getCmd.Val()), actor); err != nil {
+					return nil, "", fmt.Errorf("in protojson.Unmarshal: %w", err)
+				}
+				result = append(result, actor)
+			}
+		}
+
+		if cursor != 0 {
+			nextToken = encodePageToken(listActorsPageToken{
+				ShardAddr: shardAddr,
+				Cursor:    cursor,
+			})
+			break
+		} else {
+			if i+1 < len(masters) {
+				nextToken = encodePageToken(listActorsPageToken{
+					ShardAddr: masters[i+1].Options().Addr,
+					Cursor:    0,
+				})
+				break
+			} else {
+				nextToken = ""
+				break
+			}
+		}
+	}
+
+	return result, nextToken, nil
 }
 
 func (s *Persistence) AcquireLock(ctx context.Context, key string, value string, ttl time.Duration) (bool, error) {

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -17,6 +17,7 @@ package ateredis
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -424,7 +425,7 @@ func TestListActors(t *testing.T) {
 		t.Fatalf("failed to create actor2: %v", err)
 	}
 
-	actors, err := s.ListActors(ctx)
+	actors, _, err := s.ListActors(ctx, 1000, "")
 	if err != nil {
 		t.Fatalf("ListActors failed: %v", err)
 	}
@@ -529,13 +530,58 @@ func TestListActors_Empty(t *testing.T) {
 	mr, s, ctx := setupTest(t)
 	defer mr.Close()
 
-	actors, err := s.ListActors(ctx)
+	actors, _, err := s.ListActors(ctx, 1000, "")
 	if err != nil {
 		t.Fatalf("ListActors failed: %v", err)
 	}
 
 	if len(actors) != 0 {
 		t.Errorf("expected 0 actors, got %d", len(actors))
+	}
+}
+
+func TestListActors_Pagination(t *testing.T) {
+	mr, s, ctx := setupTest(t)
+	defer mr.Close()
+
+	for i := 0; i < 5; i++ {
+		actor := &ateapipb.Actor{
+			ActorId:                fmt.Sprintf("id%d", i),
+			ActorTemplateNamespace: "ns1",
+			ActorTemplateName:      "tmpl1",
+			Status:                 ateapipb.Actor_STATUS_SUSPENDED,
+		}
+		if err := s.CreateActor(ctx, actor); err != nil {
+			t.Fatalf("failed to create actor %d: %v", i, err)
+		}
+	}
+
+	var allActors []*ateapipb.Actor
+	pageToken := ""
+
+	for {
+		actors, nextToken, err := s.ListActors(ctx, 2, pageToken)
+		if err != nil {
+			t.Fatalf("ListActors failed: %v", err)
+		}
+
+		allActors = append(allActors, actors...)
+		pageToken = nextToken
+		if pageToken == "" {
+			break
+		}
+	}
+
+	if len(allActors) != 5 {
+		t.Fatalf("expected 5 actors total, got %d", len(allActors))
+	}
+
+	seen := make(map[string]bool)
+	for _, a := range allActors {
+		if seen[a.ActorId] {
+			t.Errorf("duplicate actor found in paginated results: %s", a.ActorId)
+		}
+		seen[a.ActorId] = true
 	}
 }
 

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -51,8 +51,8 @@ type Interface interface {
 	// Removes an actor. Returns ErrNotFound if missing, or ErrFailedPrecondition if not suspended.
 	DeleteActor(ctx context.Context, id string) error
 
-	// Lists all known actors. Returns nil if none found.
-	ListActors(ctx context.Context) ([]*ateapipb.Actor, error)
+	// Lists all known actors. Returns a page of actors and a next page token.
+	ListActors(ctx context.Context, pageSize int32, pageToken string) ([]*ateapipb.Actor, string, error)
 
 	// Fetches worker state by namespace, pool, and pod name. Returns ErrNotFound if missing.
 	GetWorker(ctx context.Context, namespace, pool, pod string) (*ateapipb.Worker, error)

--- a/cmd/atenet/internal/app/router/health.go
+++ b/cmd/atenet/internal/app/router/health.go
@@ -196,7 +196,7 @@ func (rh *routerHealth) checkAteAPI(ctx context.Context) (bool, string) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
 
-	_, err := rh.apiClient.ListActors(timeoutCtx, &ateapipb.ListActorsRequest{})
+	_, err := rh.apiClient.ListActors(timeoutCtx, &ateapipb.ListActorsRequest{PageSize: 1})
 	if err != nil {
 		return false, err.Error()
 	}

--- a/cmd/kubectl-ate/internal/cmd/get_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/get_actors.go
@@ -47,11 +47,26 @@ var getActorsCmd = &cobra.Command{
 		}
 
 		// 3. Handle List All Actors
-		resp, err := apiClient.ListActors(ctx, &ateapipb.ListActorsRequest{})
-		if err != nil {
-			return fmt.Errorf("failed to list actors: %w", err)
+		var allActors []*ateapipb.Actor
+		pageToken := ""
+
+		for {
+			resp, err := apiClient.ListActors(ctx, &ateapipb.ListActorsRequest{
+				PageSize:  1000,
+				PageToken: pageToken,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list actors: %w", err)
+			}
+			allActors = append(allActors, resp.GetActors()...)
+
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
+			}
 		}
-		return printer.PrintActors(resp.GetActors(), outputFmt)
+
+		return printer.PrintActors(allActors, outputFmt)
 	},
 }
 

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -757,8 +757,17 @@ func (x *ListWorkersResponse) GetWorkers() []*Worker {
 	return nil
 }
 
+// Request to list actors with pagination.
+// This operation provides "soft" guarantees: actors may be missed or duplicated
+// if the system state changes during pagination.
 type ListActorsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The maximum number of actors to return. The server may enforce a hard limit
+	// (e.g., 1000) regardless of the requested size.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// An opaque pagination token obtained from a previous ListActorsResponse.
+	// Empty for the first request.
+	PageToken     string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -793,9 +802,28 @@ func (*ListActorsRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{13}
 }
 
+func (x *ListActorsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListActorsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+// Response for a ListActors operation.
 type ListActorsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Actors        []*Actor               `protobuf:"bytes,1,rep,name=actors,proto3" json:"actors,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The page of actors. This list may be empty even if there are more results.
+	Actors []*Actor `protobuf:"bytes,1,rep,name=actors,proto3" json:"actors,omitempty"`
+	// An opaque token to retrieve the next page of results.
+	// If empty, there are no more results. Clients must loop until this is empty.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -835,6 +863,13 @@ func (x *ListActorsResponse) GetActors() []*Actor {
 		return x.Actors
 	}
 	return nil
+}
+
+func (x *ListActorsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
 }
 
 type Worker struct {
@@ -1316,10 +1351,14 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x13DeleteActorResponse\"\x14\n" +
 	"\x12ListWorkersRequest\"?\n" +
 	"\x13ListWorkersResponse\x12(\n" +
-	"\aworkers\x18\x01 \x03(\v2\x0e.ateapi.WorkerR\aworkers\"\x13\n" +
-	"\x11ListActorsRequest\";\n" +
+	"\aworkers\x18\x01 \x03(\v2\x0e.ateapi.WorkerR\aworkers\"O\n" +
+	"\x11ListActorsRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\"c\n" +
 	"\x12ListActorsResponse\x12%\n" +
-	"\x06actors\x18\x01 \x03(\v2\r.ateapi.ActorR\x06actors\"\xae\x02\n" +
+	"\x06actors\x18\x01 \x03(\v2\r.ateapi.ActorR\x06actors\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xae\x02\n" +
 	"\x06Worker\x12)\n" +
 	"\x10worker_namespace\x18\x01 \x01(\tR\x0fworkerNamespace\x12\x1f\n" +
 	"\vworker_pool\x18\x02 \x01(\tR\n" +

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -128,10 +128,27 @@ message ListWorkersResponse {
   repeated Worker workers = 1;
 }
 
-message ListActorsRequest {}
+// Request to list actors with pagination.
+// This operation provides "soft" guarantees: actors may be missed or duplicated
+// if the system state changes during pagination.
+message ListActorsRequest {
+  // The maximum number of actors to return. The server may enforce a hard limit
+  // (e.g., 1000) regardless of the requested size.
+  int32 page_size = 1;
 
+  // An opaque pagination token obtained from a previous ListActorsResponse.
+  // Empty for the first request.
+  string page_token = 2;
+}
+
+// Response for a ListActors operation.
 message ListActorsResponse {
+  // The page of actors. This list may be empty even if there are more results.
   repeated Actor actors = 1;
+
+  // An opaque token to retrieve the next page of results.
+  // If empty, there are no more results. Clients must loop until this is empty.
+  string next_page_token = 2;
 }
 
 message Worker {


### PR DESCRIPTION
# Implement Pagination and Pipelining for ListActors

## Overview

**Fixes:** #153 

This PR introduces robust, memory-safe pagination to the `ListActors` operation and optimizes the Valkey retrieval layer. 

Previously, `ListActors` performed an unbounded parallel scatter-gather across all Valkey cluster shards, pulling all actors into memory at once. At scale (millions/billions of actors), this would cause OOM errors and severe latency. 

This update replaces the concurrent scatter-gather with a deterministic, sequential shard scanning approach, adhering to [AIP-158](https://google.aip.dev/158) pagination standards.

## Changes Included
- **gRPC API (`ateapi.proto`)**: Added `page_size`, `page_token`, and `next_page_token` fields.
- **Client (`kubectl-ate`)**: Updated to seamlessly loop through `next_page_token` values until all actors are fetched, presenting a continuous stream to the user without blowing up memory on a single request.
- **API Handler (`controlapi`)**: Bounded requests with a max `page_size` limit of `1000`.
- **Persistence (`ateredis`)**: 
  - Implemented `listActorsPageToken` to safely serialize and encode cross-shard cursors.
  - Replaced `ForEachMaster` concurrent execution with deterministic sequential iteration.
  - Implemented Valkey Pipeline batching (`Pipelined`) for `GET` requests to eliminate N+1 network latency.
- **Testing**: Added `TestListActors_Pagination` at both the integration level (`functional_test.go`) and data layer (`ateredis_test.go`). Refactored sorting to use `cmpopts.SortSlices`.

## Design Decisions
During the design phase, several explicit trade-offs were made to balance performance with API simplicity:
1. **Opaque Tokens (AIP-158):** The `page_token` is strictly an opaque string at the `ateapi` layer. The client (`kubectl-ate`) is completely unaware that it contains base64-encoded JSON mapping to `{"shard", "cursor"}`. This keeps our API database-agnostic.
2. **Empty Pages & Client-Side Looping:** The persistence layer is kept simple and "dumb". If a shard scan returns 0 keys but the cursor is not `0`, we return an empty page. We rely on the client `kubectl-ate` to `for` loop until `next_page_token` is completely exhausted. Update: I have server side looping across shards until pagesize is met to limit round trips due to high shard count or low actor count on distributed shards.
3. **"Soft" Consistency (Missing/Duplicate Data):** `ListActors` is an infrequent operations command, not on the critical path. Taking a global cluster lock for iteration would severely degrade performance. We accept eventual consistency here: if actors migrate shards during an active scan, they might be duplicated or missed.
4. **Topology Flux Errors:** If a client passes a valid token pointing to a shard address that no longer exists (due to a cluster resharding mid-scan), the API simply returns an `Aborted` error. We do not attempt complex recovery; the client must just restart the `ListActors` command.
5. **Bounded Page Size:** Requests are currently capped at a maximum of `1000` to prevent single massive payloads. We can revisit/change the max later.

NOTE: Actor filtering will be implemented later.

## Architecture Flow (Valkey)

Note: If there are future plugin-db models they will need to handle the cusor/pages at their own implementation layer per the store.go interface.

The system now seamlessly iterates across shards, handing off cursors safely between nodes:

```mermaid
sequenceDiagram
    participant CLI as kubectl-ate
    participant API as ateapi
    participant Valkey as Valkey Cluster (Multiple Shards)
    
    CLI->>API: ListActors(page_size=1000, page_token="")
    
    Note over API: Request 1: Empty Token
    API->>API: Decode page_token (empty -> start fresh)
    API->>Valkey: Fetch all Master Nodes
    Valkey-->>API: [Master C, Master A, Master B]
    API->>API: Sort Masters alphabetically by IP/Port
    Note over API: Sorted: [Master A, Master B, Master C]
    
    API->>Valkey: SCAN (Master A, cursor=0, count=1000)
    Valkey-->>API: keys=[k1..k300], next_cursor=45
    
    Note over API: OPTIMIZATION: Pipelining avoids N+1 problem
    API->>Valkey: PIPELINE GET (k1..k300) directly on Master A
    Valkey-->>API: values=[v1..v300]
    
    API->>API: Decode Protobufs
    API->>API: Encode page_token={"shard": "Master A", "cursor": 45}
    API-->>CLI: 300 Actors, next_page_token="base64(eyJzaGFyZ..."
    
    %% SECOND REQUEST
    CLI->>API: ListActors(page_size=1000, page_token="base64(...)")
    
    Note over API: Request 2: Resuming Mid-Shard
    API->>API: Decode page_token -> Shard="Master A", Cursor=45
    API->>API: Fast-forward directly to Master A
    API->>Valkey: SCAN (Master A, cursor=45, count=1000)
    Valkey-->>API: keys=[k301..k400], next_cursor=0
    
    API->>Valkey: PIPELINE GET (k301..k400) directly on Master A
    Valkey-->>API: values=[v301..v400]
    
    Note over API: Shard A is empty. Token points to Shard B!
    API->>API: Encode page_token={"shard": "Master B", "cursor": 0}
    API-->>CLI: 100 Actors, next_page_token="base64(eyJzaGFyZ..."
    
    %% THIRD REQUEST
    CLI->>API: ListActors(page_size=1000, page_token="base64(...)")
    Note over API: Request 3: Starting New Shard
    API->>API: Decode page_token -> Shard="Master B", Cursor=0
    Note over API: Continues scanning Master B...
```


## Testing:

```
> ./bin/kubectl-ate get actors
NAMESPACE          TEMPLATE   ID                                     STATUS             ATEOM POD   ATEOM IP   VERSION
ate-demo-counter   counter    61b478cc-2e44-4ec7-ac6c-1af3f385de86   STATUS_SUSPENDED   <none>                 5
```

```
 ~/go/bin/grpcurl -insecure -d '{"page_size": 2}' localhost:9090 ateapi.Control/ListActors
{
  "actors": [
    {
      "actorId": "test-counter-4",
      "version": "1",
      "actorTemplateNamespace": "ate-demo-counter",
      "actorTemplateName": "counter",
      "status": "STATUS_SUSPENDED"
    }
  ],
  "nextPageToken": "eyJzaGFyZCI6IjEwLjI0NC4wLjE5OjYzNzkiLCJjdXJzb3IiOjI1MjU1fQ=="
}
```


<details>

```
bash -c '
export NEXT_TOKEN=""
while :; do
  echo "--- Fetching Page ---"
  
  # Fetch the data and store the response
  RESPONSE=$(~/go/bin/grpcurl -insecure -d "{\"page_size\": 2, \"page_token\": \"$NEXT_TOKEN\"}" localhost:9090 ateapi.Control/ListActors)
  
  # Print the response to the terminal
  echo "$RESPONSE"
  
  # Extract the token without needing jq
  NEXT_TOKEN=$(echo "$RESPONSE" | grep -o "\"nextPageToken\": \"[^\"]*\"" | cut -d"\"" -f4)
  
  # If no token is found, we reached the end
  if [ -z "$NEXT_TOKEN" ]; then
    echo "--- Reached the end! ---"
    break
  fi
  
  echo ""
  read -p "Press Enter to fetch the next page using the new token..."
done
'
```

--- Fetching Page ---
{
  "actors": [
    {
      "actorId": "test-counter-4",
      "version": "1",
      "actorTemplateNamespace": "ate-demo-counter",
      "actorTemplateName": "counter",
      "status": "STATUS_SUSPENDED"
    }
  ],
  "nextPageToken": "eyJzaGFyZCI6IjEwLjI0NC4wLjE5OjYzNzkiLCJjdXJzb3IiOjI1MjU1fQ=="
}

Press Enter to fetch the next page using the new token...
--- Fetching Page ---
{
  "nextPageToken": "eyJzaGFyZCI6IjEwLjI0NC4wLjIxOjYzNzkiLCJjdXJzb3IiOjB9"
}

Press Enter to fetch the next page using the new token...
--- Fetching Page ---
{
  "actors": [
    {
      "actorId": "test-counter-1",
      "version": "1",
      "actorTemplateNamespace": "ate-demo-counter",
      "actorTemplateName": "counter",
      "status": "STATUS_SUSPENDED"
    }
  ],
  "nextPageToken": "eyJzaGFyZCI6IjEwLjI0NC4wLjIxOjYzNzkiLCJjdXJzb3IiOjQ1NjAwfQ=="
}

Press Enter to fetch the next page using the new token...
--- Fetching Page ---
{
  "actors": [
    {
      "actorId": "test-counter-5",
      "version": "1",
      "actorTemplateNamespace": "ate-demo-counter",
      "actorTemplateName": "counter",
      "status": "STATUS_SUSPENDED"
    }
  ],
  "nextPageToken": "eyJzaGFyZCI6IjEwLjI0NC4wLjIxOjYzNzkiLCJjdXJzb3IiOjYyMDg2fQ=="
}

Press Enter to fetch the next page using the new token...
--- Fetching Page ---
{
  "nextPageToken": "eyJzaGFyZCI6IjEwLjI0NC4wLjI1OjYzNzkiLCJjdXJzb3IiOjB9"
}

Press Enter to fetch the next page using the new token...
--- Fetching Page ---
{
  "actors": [
    {
      "actorId": "test-counter-2",
      "version": "1",
      "actorTemplateNamespace": "ate-demo-counter",
      "actorTemplateName": "counter",
      "status": "STATUS_SUSPENDED"
    }
  ],
  "nextPageToken": "eyJzaGFyZCI6IjEwLjI0NC4wLjI1OjYzNzkiLCJjdXJzb3IiOjE2OTkzfQ=="
}

Press Enter to fetch the next page using the new token...
--- Fetching Page ---
{
  "actors": [
    {
      "actorId": "test-counter-3",
      "version": "1",
      "actorTemplateNamespace": "ate-demo-counter",
      "actorTemplateName": "counter",
      "status": "STATUS_SUSPENDED"
    },
    {
      "actorId": "61b478cc-2e44-4ec7-ac6c-1af3f385de86",
      "version": "5",
      "actorTemplateNamespace": "ate-demo-counter",
      "actorTemplateName": "counter",
      "status": "STATUS_SUSPENDED",
      "lastSnapshot": "gs://ate-snapshots/ate-demo-counter/61b478cc-2e44-4ec7-ac6c-1af3f385de86/2026-06-03T03:17:34Z-UMYVUZOWW6LDPS5X5FSG3KC4VV"
    }
  ]
}
--- Reached the end! ---

</details>