### PR TITLE
Add Substrate routing-latency metric and Cloud Monitoring dashboard

### DIFF
--- a/cmd/atenet/internal/app/router/extproc.go
+++ b/cmd/atenet/internal/app/router/extproc.go
@@ -25,6 +25,8 @@ import (
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
@@ -33,18 +35,20 @@ import (
 // ExtProcServer implements the Envoy external processing gRPC server
 // to dynamically manage actor activations based on request traffic.
 type ExtProcServer struct {
-	port      int
-	apiClient ateapipb.ControlClient
-	recorder  *QueryRecorder
-	resumer   *ActorResumer
+	port          int
+	apiClient     ateapipb.ControlClient
+	recorder      *QueryRecorder
+	resumer       *ActorResumer
+	routeDuration metric.Float64Histogram
 }
 
-func NewExtProcServer(port int, apiClient ateapipb.ControlClient) *ExtProcServer {
+func NewExtProcServer(port int, apiClient ateapipb.ControlClient, routeDuration metric.Float64Histogram) *ExtProcServer {
 	return &ExtProcServer{
-		port:      port,
-		apiClient: apiClient,
-		recorder:  NewQueryRecorder(100),
-		resumer:   NewActorResumer(apiClient),
+		port:          port,
+		apiClient:     apiClient,
+		recorder:      NewQueryRecorder(100),
+		resumer:       NewActorResumer(apiClient),
+		routeDuration: routeDuration,
 	}
 }
 
@@ -83,7 +87,8 @@ func (s *ExtProcServer) Process(stream extprocv3.ExternalProcessor_ProcessServer
 		switch reqType := req.Request.(type) {
 		case *extprocv3.ProcessingRequest_RequestHeaders:
 			start := time.Now()
-			hResponse, rqm, target, err := s.handleRequestHeaders(stream.Context(), reqType.RequestHeaders)
+			hResponse, rqm, target, tmplNs, tmplName, err := s.handleRequestHeaders(stream.Context(), reqType.RequestHeaders)
+			elapsed := time.Since(start)
 			if err != nil {
 				slog.ErrorContext(stream.Context(), "Error during ext_proc RequestHeaders processing", slog.String("err", err.Error()))
 				var reqErr *reqError
@@ -92,10 +97,12 @@ func (s *ExtProcServer) Process(stream extprocv3.ExternalProcessor_ProcessServer
 				} else {
 					resp = immediateResponse(envoy_type.StatusCode_InternalServerError, err.Error())
 				}
-				s.recorder.AddRouterRequest(start, time.Since(start), "Error", "-", rqm)
+				s.recordRouteDuration(stream.Context(), elapsed, tmplNs, tmplName, classifyOutcome(err))
+				s.recorder.AddRouterRequest(start, elapsed, "Error", "-", rqm)
 			} else {
 				resp.Response = &extprocv3.ProcessingResponse_RequestHeaders{RequestHeaders: hResponse}
-				s.recorder.AddRouterRequest(start, time.Since(start), "Route ok", target, rqm)
+				s.recordRouteDuration(stream.Context(), elapsed, tmplNs, tmplName, "ok")
+				s.recorder.AddRouterRequest(start, elapsed, "Route ok", target, rqm)
 			}
 
 		default:
@@ -118,13 +125,14 @@ func (s *ExtProcServer) Process(stream extprocv3.ExternalProcessor_ProcessServer
 func (s *ExtProcServer) handleRequestHeaders(
 	ctx context.Context,
 	reqHeaders *extprocv3.HttpHeaders,
-) (*extprocv3.HeadersResponse, *requestMetadata, string, error) {
+) (*extprocv3.HeadersResponse, *requestMetadata, string, string, string, error) {
 	metadata := newRequestMetadata(reqHeaders.Headers.GetHeaders())
 	slog.InfoContext(ctx, "Request", slog.String("metadata", metadata.String()))
 
 	actorID, err := parseActorID(metadata.host)
 	if err != nil {
-		return nil, metadata, "", invalidHostErr(metadata.host, err)
+		// Host is invalid, respond with 404.
+		return nil, metadata, "", "", "", invalidHostErr(metadata.host, err)
 	}
 
 	slog.InfoContext(ctx, "ResumeActor", slog.String("actorID", actorID))
@@ -136,12 +144,17 @@ func (s *ExtProcServer) handleRequestHeaders(
 		slog.Any("err", err))
 
 	if err != nil {
-		return nil, metadata, "", mapResumeError(actorID, err)
+		return nil, metadata, "", "", "", mapResumeError(actorID, err)
 	}
+
+	// Actor template identity, used as low-cardinality route-latency metric
+	// attributes (see recordRouteDuration).
+	tmplNs := actor.GetActorTemplateNamespace()
+	tmplName := actor.GetActorTemplateName()
 
 	workerIP := actor.GetAteomPodIp()
 	if ip := net.ParseIP(workerIP); ip == nil {
-		return nil, metadata, "", newReqError(envoy_type.StatusCode_InternalServerError,
+		return nil, metadata, "", tmplNs, tmplName, newReqError(envoy_type.StatusCode_InternalServerError,
 			"actor %q routing failed", actorID)
 	}
 
@@ -158,5 +171,29 @@ func (s *ExtProcServer) handleRequestHeaders(
 		Response: &extprocv3.CommonResponse{
 			HeaderMutation: mutation,
 		},
-	}, metadata, targetAddr, nil
+	}, metadata, targetAddr, tmplNs, tmplName, nil
+}
+
+func (s *ExtProcServer) recordRouteDuration(ctx context.Context, d time.Duration, tmplNs, tmplName, outcome string) {
+	if s.routeDuration == nil {
+		return
+	}
+	s.routeDuration.Record(ctx, d.Seconds(), metric.WithAttributes(
+		attribute.String("actor_template_namespace", tmplNs),
+		attribute.String("actor_template_name", tmplName),
+		attribute.String("outcome", outcome),
+	))
+}
+
+func classifyOutcome(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return "cancelled"
+	default:
+		var re *reqError
+		if errors.As(err, &re) && re.statusCode == int(envoy_type.StatusCode_NotFound) {
+			return "not_found"
+		}
+		return "error"
+	}
 }

--- a/cmd/atenet/internal/app/router/extproc_test.go
+++ b/cmd/atenet/internal/app/router/extproc_test.go
@@ -138,7 +138,7 @@ func TestExtProcHeadersEvaluation(t *testing.T) {
 				},
 			}
 
-			s := NewExtProcServer(50051, clientMock)
+			s := NewExtProcServer(50051, clientMock, nil)
 
 			reqHeaders := &extprocv3.HttpHeaders{
 				Headers: &corev3.HeaderMap{
@@ -150,7 +150,7 @@ func TestExtProcHeadersEvaluation(t *testing.T) {
 				},
 			}
 
-			res, metadata, target, err := s.handleRequestHeaders(context.Background(), reqHeaders)
+			res, metadata, target, _, _, err := s.handleRequestHeaders(context.Background(), reqHeaders)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("expected error but got nil")

--- a/cmd/atenet/internal/app/router/metrics.go
+++ b/cmd/atenet/internal/app/router/metrics.go
@@ -1,0 +1,51 @@
+//  Copyright 2026 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package router
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	routerServiceName = "atenet-router"
+
+	// atenet.router.route.duration measures the latency from when the ext_proc handler receives a request
+	// (Envoy -> EPP) until the target worker endpoint is resolved
+	routeDurationMetricName = "atenet.router.route.duration"
+)
+
+// newRouteDurationHistogram creates the atenet.router.route.duration histogram from
+// the global MeterProvider.
+func newRouteDurationHistogram() (metric.Float64Histogram, error) {
+	h, err := otel.Meter(routerServiceName).Float64Histogram(
+		routeDurationMetricName,
+		metric.WithUnit("s"),
+		metric.WithDescription(
+			"latency between Substrate router receiving a request and resolving "+
+				"the target worker endpoint, excluding actor execution and response",
+		),
+		metric.WithExplicitBucketBoundaries(
+			0.001, 0.0025, 0.005, 0.01, 0.025, 0.05,
+			0.075, 0.1, 0.15, 0.2, 0.25, 0.5, 1, 2.5, 5, 10, 15, 30,
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s histogram: %w", routeDurationMetricName, err)
+	}
+	return h, nil
+}

--- a/cmd/atenet/internal/app/router/router.go
+++ b/cmd/atenet/internal/app/router/router.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	"github.com/agent-substrate/substrate/internal/serverboot"
 	v1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 )
@@ -76,6 +77,7 @@ type RouterConfig struct {
 	HttpsPort      int
 	EnvoyCertPath  string
 	LogLevel       string
+	MetricsAddr    string
 }
 
 // RouterServer instantiates and coordinates runtime threads executing system modules.
@@ -114,6 +116,14 @@ func NewCmd() *cobra.Command {
 			}
 			slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
 
+			mp, err := serverboot.InitMetrics(ctx, routerServiceName)
+			if err != nil {
+				return fmt.Errorf("failed to initialize metrics: %w", err)
+			}
+			defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
+
+			go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{Addr: cfg.MetricsAddr})
+
 			sigChan := make(chan os.Signal, 1)
 			signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 			go func() {
@@ -132,6 +142,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&cfg.LogLevel, "log-level", "info", "Log level: debug, info, warn, error")
+	cmd.Flags().StringVar(&cfg.MetricsAddr, "metrics-listen-addr", ":9090", "Address and port the prometheus metrics server should listen on.")
 	cmd.Flags().BoolVar(&cfg.Standalone, "standalone", false, "Run in standalone mode, bypassing creation of managed deployment and services in Kubernetes cluster")
 	cmd.Flags().StringVar(&cfg.Namespace, "namespace", "default", "Target operations namespace")
 	cmd.Flags().StringVar(&cfg.Kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig configuration file")
@@ -226,7 +237,11 @@ func (s *RouterServer) Run(ctx context.Context) error {
 
 	xdsSrv.SetTlsConfig(s.cfg.HttpsPort, s.cfg.EnvoyCertPath, certContent, keyContent)
 	if s.extprocSrv == nil {
-		s.extprocSrv = NewExtProcServer(s.cfg.ExtprocPort, s.apiClient)
+		routeDuration, err := newRouteDurationHistogram()
+		if err != nil {
+			return fmt.Errorf("failed to create route-duration histogram: %w", err)
+		}
+		s.extprocSrv = NewExtProcServer(s.cfg.ExtprocPort, s.apiClient, routeDuration)
 	}
 	ctrl := NewController(s.k8sClient, s.clientset, s.cfg, xdsSrv, s.extprocSrv)
 

--- a/cmd/atenet/internal/app/router/status_test.go
+++ b/cmd/atenet/internal/app/router/status_test.go
@@ -62,7 +62,7 @@ func TestStatuszEndpoint(t *testing.T) {
 		t.Fatalf("Failed generating router server: %v", err)
 	}
 
-	srv.extprocSrv = NewExtProcServer(cfg.ExtprocPort, &mockClient{})
+	srv.extprocSrv = NewExtProcServer(cfg.ExtprocPort, &mockClient{}, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
@@ -140,7 +141,6 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.42.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/manifests/ate-install/atenet-router-monitoring.yaml
+++ b/manifests/ate-install/atenet-router-monitoring.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Scrape the Envoy sidecar's admin /stats/prometheus endpoint so its end-to-end
+# request-latency histogram (envoy_http_downstream_rq_time, milliseconds) reaches
+# Google Managed Prometheus. This is E2E *context* for the per-stage latency
+# dashboard, not an SLI we own (the SLI is the OTLP atenet.router.route.duration
+# histogram). Envoy only speaks Prometheus, so it needs an explicit scrape; the
+# admin port (9901) is already exposed by the envoy container above.
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: atenet-router-envoy
+  namespace: ate-system
+  labels:
+    app: atenet-router
+spec:
+  selector:
+    matchLabels:
+      app: atenet-router
+  endpoints:
+  - port: admin
+    path: /stats/prometheus
+    interval: 30s

--- a/manifests/ate-install/atenet-router.yaml
+++ b/manifests/ate-install/atenet-router.yaml
@@ -115,6 +115,9 @@ spec:
     metadata:
       labels:
         app: atenet-router
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
     spec:
       serviceAccountName: atenet-router
       containers:
@@ -132,6 +135,23 @@ spec:
         - "--status-port=4040"
         - "--port-https=8443"
         - "--envoy-cert-path=/run/servicedns.podcert.ate.dev/credential-bundle.pem"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),service.instance.id=$(POD_UID)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
         ports:
         - name: xds
           containerPort: 18000
@@ -139,6 +159,8 @@ spec:
           containerPort: 50051
         - name: status
           containerPort: 4040
+        - name: metrics
+          containerPort: 9090
       - name: envoy
         image: envoyproxy/envoy:v1.30-latest
         command:

--- a/monitoring/dashboards/README.md
+++ b/monitoring/dashboards/README.md
@@ -2,11 +2,12 @@
 
 Google Cloud Monitoring dashboard definitions for ATE. They turn the raw
 `prometheus.googleapis.com/...` metrics that ATE emits into readable
-per-method latency / throughput / error views.
+per-method / per-stage latency / throughput / error views.
 
 | File | Shows |
 |------|-------|
 | `ate-grpc-dashboard.json` | ateapi & atelet gRPC latency (p50/p95/p99), request rate, and error rate, by method |
+| `ate-e2e-latency-dashboard.json` | "Substrate Routing & E2E Latency". Substrate routing P50/P95/P99, routing P99 by stage (routing / ateapi ResumeActor / atelet Restore), routing P99 by ActorTemplate, routing QPS by status, plus the E2E full round-trip from Envoy (ms — includes actor compute + response, so it's context, not our overhead): P99 and QPS by response class. Needs the `atenet-router-envoy` PodMonitoring for the round-trip lines. |
 
 ## Applying
 

--- a/monitoring/dashboards/ate-e2e-latency-dashboard.json
+++ b/monitoring/dashboards/ate-e2e-latency-dashboard.json
@@ -1,0 +1,216 @@
+{
+  "displayName": "Substrate Routing & E2E Latency",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "xPos": 0,
+        "yPos": 0,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Substrate routing latency — P50/P95/P99",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.50, sum by (le) (rate({\"atenet.router.route.duration_bucket\", top_level_controller_name=\"atenet-router\"}[5m])))",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "P50"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.95, sum by (le) (rate({\"atenet.router.route.duration_bucket\", top_level_controller_name=\"atenet-router\"}[5m])))",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "P95"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"atenet.router.route.duration_bucket\", top_level_controller_name=\"atenet-router\"}[5m])))",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "P99"
+              }
+            ],
+            "yAxis": {
+              "label": "seconds",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 0,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Substrate routing latency P99 - by stages",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"atenet.router.route.duration_bucket\", top_level_controller_name=\"atenet-router\"}[5m])))",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "substrate routing P99"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=\"ate-api-server-deployment\", \"rpc.method\"=\"ateapi.Control/ResumeActor\"}[5m])))",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "ateapi ResumeActor P99"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=\"atelet\", \"rpc.method\"=\"atelet.AteomHerder/Restore\"}[5m])))",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "atelet Restore P99"
+              }
+            ],
+            "yAxis": {
+              "label": "seconds",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 4,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Substrate routing latency P99 — by ActorTemplate",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le, actor_template_name) (rate({\"atenet.router.route.duration_bucket\", top_level_controller_name=\"atenet-router\", outcome=\"ok\"}[5m])))",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": {
+              "label": "seconds",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 4,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Substrate routing QPS - by Status",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "sum by (outcome) (rate({\"atenet.router.route.duration_count\", top_level_controller_name=\"atenet-router\"}[5m]))",
+                  "unitOverride": "1/s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": {
+              "label": "requests/s",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 8,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Substrate E2E (full round-trip) Latency — P50/P95/P99",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.50, sum by (le) (rate(envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix=~\"ingress_.*\"}[5m])))",
+                  "unitOverride": "ms"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "P50 (all ingress)"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.95, sum by (le) (rate(envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix=~\"ingress_.*\"}[5m])))",
+                  "unitOverride": "ms"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "P95 (all ingress)"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate(envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix=~\"ingress_.*\"}[5m])))",
+                  "unitOverride": "ms"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "P99 (all ingress)"
+              }
+            ],
+            "yAxis": {
+              "label": "milliseconds",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 8,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Substrate E2E (full round-trip) QPS — by Response Code",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "sum by (envoy_response_code_class) (rate(envoy_http_downstream_rq_xx{envoy_http_conn_manager_prefix=~\"ingress_.*\"}[5m]))",
+                  "unitOverride": "1/s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "${metric.labels.envoy_response_code_class}xx"
+              }
+            ],
+            "yAxis": {
+              "label": "requests/s",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/monitoring/dashboards/ate-grpc-dashboard.json
+++ b/monitoring/dashboards/ate-grpc-dashboard.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "ATE gRPC Server — latency / QPS / errors",
+  "displayName": "Substrate gRPC Server — latency / QPS / errors",
   "mosaicLayout": {
     "columns": 12,
     "tiles": [

--- a/tools/setup-gcp/cmd/dashboards.go
+++ b/tools/setup-gcp/cmd/dashboards.go
@@ -31,6 +31,7 @@ import (
 // the repo root, so run setup from the repo root) that setup creates or updates.
 var dashboardsToApply = []string{
 	"monitoring/dashboards/ate-grpc-dashboard.json",
+	"monitoring/dashboards/ate-e2e-latency-dashboard.json",
 }
 
 // createMonitoringDashboards creates or updates each dashboard in


### PR DESCRIPTION
This PR introduces a new OpenTelemetry histogram `"atenet.router.route.duration"` from `atenet-router` over the existing
OTLP path. It measures substrate overhead -- from envoy receiving a request to envoy sending the request to the the resolved worker endpoint, excluding actor compute and the response. This is the `Substrate E2E latency` that under our control.

Add a well-defined dashboard for E2E metrics that contains 6 charts.
- Substrate routing latency — P50/P95/P99
- Substrate routing latency P99 - by stages
- Substrate routing latency P99 — by ActorTemplate
- Substrate routing QPS - by Status
- Substrate E2E (full round-trip) Latency — P50/P95/P99
- Substrate E2E (full round-trip) QPS — by Response Code

<img width="1601" height="894" alt="image" src="https://github.com/user-attachments/assets/be6fc572-dfd8-4ef0-a0a9-a77f85f2ecf8" />


Fixes b/508613998

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [x] Appropriate changes to documentation are included in the PR
