### PR TITLE
Add Substrate Snapshot size metric and dashboard

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -44,6 +44,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	googlecontainerauth "github.com/google/go-containerregistry/pkg/v1/google"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/option"
@@ -86,6 +89,10 @@ func main() {
 		serverboot.Fatal(ctx, "Failed to initialize metrics", err)
 	}
 	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
+
+	if err := initSnapshotSizeMetric(); err != nil {
+		serverboot.Fatal(ctx, "Failed to create snapshot size metric", err)
+	}
 
 	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{Addr: *metricsListenAddr})
 
@@ -305,6 +312,42 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 	return &ateletpb.RunResponse{}, nil
 }
 
+var snapshotSizeBytes metric.Int64Histogram
+
+func initSnapshotSizeMetric() error {
+	var err error
+	snapshotSizeBytes, err = otel.Meter("atelet").Int64Histogram(
+		"atelet.snapshot.size",
+		metric.WithUnit("By"),
+		metric.WithDescription("Uncompressed size in bytes of each gVisor snapshot image written during checkpoint."),
+
+		metric.WithExplicitBucketBoundaries(
+			1e6, 5e6, 1e7, 2.5e7, 5e7, 1e8, 2.5e8, 5e8, 1e9, 2e9, 5e9, 1e10,
+		),
+	)
+	return err
+}
+
+func recordSnapshotSize(ctx context.Context, kind, path, atNamespace, atName string) {
+	if snapshotSizeBytes == nil {
+		return
+	}
+	fi, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to stat snapshot image for size metric",
+			slog.String("kind", kind), slog.String("path", path), slog.Any("err", err))
+		return
+	}
+	snapshotSizeBytes.Record(ctx, fi.Size(), metric.WithAttributes(
+		attribute.String("kind", kind),
+		attribute.String("actor_template_namespace", atNamespace),
+		attribute.String("actor_template_name", atName),
+	))
+}
+
 func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRequest) (*ateletpb.CheckpointResponse, error) {
 	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())
 	if err != nil {
@@ -336,6 +379,8 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	pagesImgPath := filepath.Join(checkpointDir, "pages.img")
 	pagesMetaImgPath := filepath.Join(checkpointDir, "pages_meta.img")
 
+	recordSnapshotSize(ctx, "checkpoint", checkpointImgPath, ns, tmpl)
+
 	// Upload checkpoint from local dir.
 	if err := ategcs.SendLocalFileToGCSWithZstd(ctx, s.gcsClient,
 		prefix+"/checkpoint.img.zstd",
@@ -344,12 +389,14 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, fmt.Errorf("while uploading checkpoint.img to GCS: %w", err)
 	}
 
+	recordSnapshotSize(ctx, "pages", pagesImgPath, ns, tmpl)
 	if err := uploadIfExists(ctx, s.gcsClient,
 		prefix+"/pages.img.zstd",
 		pagesImgPath,
 	); err != nil {
 		return nil, err
 	}
+	recordSnapshotSize(ctx, "pages_meta", pagesMetaImgPath, ns, tmpl)
 	if err := uploadIfExists(ctx, s.gcsClient,
 		prefix+"/pages_meta.img.zstd",
 		pagesMetaImgPath,

--- a/monitoring/dashboards/README.md
+++ b/monitoring/dashboards/README.md
@@ -8,6 +8,7 @@ per-method / per-stage latency / throughput / error views.
 |------|-------|
 | `ate-grpc-dashboard.json` | ateapi & atelet gRPC latency (p50/p95/p99), request rate, and error rate, by method |
 | `ate-e2e-latency-dashboard.json` | "Substrate Routing & E2E Latency". Substrate routing P50/P95/P99, routing P99 by stage (routing / ateapi ResumeActor / atelet Restore), routing P99 by ActorTemplate, routing QPS by status, plus the E2E full round-trip from Envoy (ms — includes actor compute + response, so it's context, not our overhead): P99 and QPS by response class. Needs the `atenet-router-envoy` PodMonitoring for the round-trip lines. |
+| `ate-snapshot-dashboard.json` | Substrate snapshot image size and throughput ("Substrate Snapshot Size & QPS"): snapshot (`pages`) image size P99 by ActorTemplate, P50/P95/P99 by image kind, and snapshot QPS. Checkpoint/Restore *latency* is not here — it's the atelet gRPC `Checkpoint`/`Restore` methods in `ate-grpc-dashboard.json`. |
 
 ## Applying
 

--- a/monitoring/dashboards/ate-snapshot-dashboard.json
+++ b/monitoring/dashboards/ate-snapshot-dashboard.json
@@ -1,0 +1,136 @@
+{
+  "displayName": "Substrate Snapshot Size & QPS",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "xPos": 0,
+        "yPos": 0,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Substrate — snapshot image size P99 by ActorTemplate",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le, actor_template_name) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=\"atelet\", kind=\"pages\"}[1h])))",
+                  "unitOverride": "By"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": {
+              "label": "bytes",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 0,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Substrate — snapshot image size P50/P95/P99",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.50, sum by (le) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=\"atelet\"}[1h])))",
+                  "unitOverride": "By"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "P50"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.95, sum by (le) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=\"atelet\"}[1h])))",
+                  "unitOverride": "By"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "P95"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=\"atelet\"}[1h])))",
+                  "unitOverride": "By"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "legendTemplate": "P99"
+              }
+            ],
+            "yAxis": {
+              "label": "bytes",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 4,
+        "width": 12,
+        "height": 4,
+        "widget": {
+          "title": "Substrate — Snapshot QPS",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "sum by (actor_template_name) (rate({\"atelet.snapshot.size_count\", top_level_controller_name=\"atelet\", kind=\"pages\"}[1h]))",
+                  "unitOverride": "1/s"
+                },
+                "plotType": "LINE",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": {
+              "label": "snapshots/s",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 8,
+        "width": 12,
+        "height": 4,
+        "widget": {
+          "title": "Substrate — snapshot (pages) size distribution (heatmap)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "metric.type=\"prometheus.googleapis.com/atelet.snapshot.size/histogram\" resource.type=\"prometheus_target\" metric.labels.kind=\"pages\"",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_SUM"
+                    }
+                  }
+                },
+                "plotType": "HEATMAP",
+                "targetAxis": "Y1"
+              }
+            ],
+            "yAxis": {
+              "label": "bytes",
+              "scale": "LINEAR"
+            },
+            "chartOptions": {
+              "mode": "COLOR"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tools/setup-gcp/cmd/dashboards.go
+++ b/tools/setup-gcp/cmd/dashboards.go
@@ -32,6 +32,7 @@ import (
 var dashboardsToApply = []string{
 	"monitoring/dashboards/ate-grpc-dashboard.json",
 	"monitoring/dashboards/ate-e2e-latency-dashboard.json",
+	"monitoring/dashboards/ate-snapshot-dashboard.json",
 }
 
 // createMonitoringDashboards creates or updates each dashboard in


### PR DESCRIPTION
This PR introduces a new OpenTelemetry histogram `"atelet.snapshot.size"` from `atelet` over the existing
OTLP path. It records the uncompressed size in bytes of each gVisor snapshot image written during checkpoint -- `checkpoint.img` , `pages.img`  and `pages_meta.img`  -- tagged by image `kind` and `ActorTemplate`. This surfaces how large actor snapshots are and which `ActorTemplate`s are expensive to checkpoint/restore.

Add a well-defined dashboard for snapshot metrics that contains 3 charts.
- snapshot image size p99 by `ActorTemplate`
- snapshot image size p50/p95/p99 (all kinds)
- snapshot QPS by `ActorTemplate`

<img width="996" height="717" alt="image" src="https://github.com/user-attachments/assets/99bbab46-37dc-476e-bfd9-cdffeb174b4b" />


> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
