### PR TITLE
fix(atelet): set OCI CgroupsPath so each actor gets its own cgroup

### DIFF
--- a/cmd/atelet/oci.go
+++ b/cmd/atelet/oci.go
@@ -67,7 +67,21 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 	}
 	envVars = append(envVars, env...)
 
-	ociSpec := &specs.Spec{
+	ociSpec := buildSpec(args, envVars, annotations, netns, actorTemplateNamespace, actorTemplateName, actorID, containerName)
+	ociSpecBytes, err := json.MarshalIndent(ociSpec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("while marshaling OCI spec: %w", err)
+	}
+	specPath := path.Join(bundlePath, "config.json")
+	if err := os.WriteFile(specPath, ociSpecBytes, 0o600); err != nil {
+		return fmt.Errorf("while writing OCI spec: %w", err)
+	}
+
+	return nil
+}
+
+func buildSpec(args, envVars []string, annotations map[string]string, netns, actorTemplateNamespace, actorTemplateName, actorID, containerName string) *specs.Spec {
+	return &specs.Spec{
 		Process: &specs.Process{
 			User: specs.User{
 				UID: 0,
@@ -142,6 +156,7 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 			},
 		},
 		Linux: &specs.Linux{
+			CgroupsPath: path.Join("actors", actorTemplateNamespace, actorTemplateName, actorID, containerName),
 			Namespaces: []specs.LinuxNamespace{
 				{
 					Type: "pid",
@@ -163,16 +178,6 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 		},
 		Annotations: annotations,
 	}
-	ociSpecBytes, err := json.MarshalIndent(ociSpec, "", "  ")
-	if err != nil {
-		return fmt.Errorf("while marshaling OCI spec: %w", err)
-	}
-	specPath := path.Join(bundlePath, "config.json")
-	if err := os.WriteFile(specPath, ociSpecBytes, 0o600); err != nil {
-		return fmt.Errorf("while writing OCI spec: %w", err)
-	}
-
-	return nil
 }
 
 func validateTarName(name string) (cleaned string, skip bool, err error) {

--- a/cmd/atelet/oci_test.go
+++ b/cmd/atelet/oci_test.go
@@ -450,3 +450,21 @@ func TestUntar_TruncatedArchive(t *testing.T) {
 		t.Errorf("error = %v, want it to surface the underlying tar/copy error", err)
 	}
 }
+
+func TestBuildSpec(t *testing.T) {
+	spec := buildSpec(
+		[]string{"/bin/sh"},
+		[]string{"PATH=/usr/bin"},
+		map[string]string{"k": "v"},
+		"/var/run/netns/foo",
+		"actorTemplateNamespace",
+		"actorTemplateName",
+		"actorID",
+		"123",
+	)
+
+	wantCgroups := "actors/actorTemplateNamespace/actorTemplateName/actorID/123"
+	if got := spec.Linux.CgroupsPath; got != wantCgroups {
+		t.Errorf("Linux.CgroupsPath = %q, want %q", got, wantCgroups)
+	}
+}


### PR DESCRIPTION
Fixes #50

## Issue

When the OCI spec leaves `Linux.CgroupsPath` empty, runsc uses whatever cgroup it inherited from its parent process and does **not** record it as one it owns. At teardown, runsc only attempts `Rmdir` on paths it owns:

```go
// runsc/cgroup/cgroup_v2.go — Uninstall
for i := len(c.Own) - 1; i >= 0; i-- {
    current := c.Own[i]
    // unix.Rmdir(current) with backoff on EBUSY
}
```

That makes the failure mode **asymmetric** and that is why it is hard to spot:

- **Non-owner actors** hit `Uninstall` with an empty `c.Own`, the loop body never runs, the function returns nil — **no log, no error**.
- **The owner actor** actually calls `Rmdir` on the shared cgroup, and gets `EBUSY` because the non-owners' processes are still in `cgroup.procs`. This is the *only* log line you ever see.

From logs alone it looks like one specific actor is broken — when in reality the bug is shared-cgroup ownership across actors.

## How to reproduce

1. Start actor **A** with no `Linux.CgroupsPath`. runsc creates the pause cgroup; A owns it.
2. Start actor **B** in the same sandbox; B attaches processes to A's pause cgroup.
3. Suspend or delete **A**. runsc calls `Rmdir` on the pause path.
4. `Rmdir` returns `EBUSY` (B is still in `cgroup.procs`), surfacing `removing cgroup path "/sys/fs/cgroup/pause": device or resource busy` and leaving stale state — matching the failure in #50.

## Solution

Set a relative, per-actor path:

```go
CgroupsPath: path.Join("actors", actorTemplateNamespace, actorTemplateName, actorID, containerName),
```

- **Relative** → runsc resolves it under its own current cgroup (the sandbox pod's cgroup), so per-actor usage rolls up into the pod's kubelet/cAdvisor accounting.
- **Unique per actor** → each container lives in its own directory, ends up in `c.Own`, and is created/cleaned up cleanly with no cross-actor `EBUSY`.
- **Layout** follows the kubectl `<namespace>/<name>` convention (`actors/<ns>/<template>/<actor>/<container>`), so per-namespace and per-template totals are queryable at each level.

Spec construction is extracted into `buildSpec` so the new behavior is unit-testable.
