### PR TITLE
fix(build): stamp ko images via .ko.yaml, drop unsupported ko --ldflags

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -18,6 +18,13 @@ defaultPlatforms:
   - linux/amd64
   - linux/arm64
 
+# ldflags for ko-built images ({{.Git.*}}/{{.Date}} templating). Version uses
+# ShortCommit, not {{.Git.Tag}}: no release tag is reachable from HEAD yet.
+defaultLdflags:
+  - -X github.com/agent-substrate/substrate/internal/version.Version={{.Git.ShortCommit}}
+  - -X github.com/agent-substrate/substrate/internal/version.Commit={{.Git.FullCommit}}
+  - -X github.com/agent-substrate/substrate/internal/version.BuildDate={{.Date}}
+
 baseImageOverrides:
   github.com/agent-substrate/substrate/demos/sandbox: alpine
   github.com/agent-substrate/substrate/demos/agent-secret: alpine

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ KO := hack/run-tool.sh ko
 BINDIR := bin/
 ATECTL := $(BINDIR)/kubectl-ate
 
-# Version stamping. Override on the make command line to pin
-# (e.g. `make VERSION=v0.5.0 build`).
+# Version stamping for the go-built binaries (kubectl-ate, atenet). ko images
+# are stamped via .ko.yaml instead (`ko build` has no --ldflags flag).
+# Override VERSION on the make line to pin (e.g. `make VERSION=v0.5.0 build`).
 VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT     ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -44,10 +45,10 @@ build: build-images build-atectl
 
 .PHONY: build-images
 build-images:
-	$(KO) build --ldflags "$(LDFLAGS)" ./cmd/ateapi
-	$(KO) build --ldflags "$(LDFLAGS)" ./cmd/atelet
-	$(KO) build --ldflags "$(LDFLAGS)" ./cmd/podcertcontroller
-	$(KO) build --ldflags "$(LDFLAGS)" ./cmd/atenet
+	$(KO) build ./cmd/ateapi
+	$(KO) build ./cmd/atelet
+	$(KO) build ./cmd/podcertcontroller
+	$(KO) build ./cmd/atenet
 
 .PHONY: build-atectl
 build-atectl:
@@ -59,7 +60,7 @@ build-atenet:
 
 .PHONY: build-demos
 build-demos:
-	$(KO) build --ldflags "$(LDFLAGS)" ./demos/counter
+	$(KO) build ./demos/counter
 
 .PHONY: test
 test:


### PR DESCRIPTION
UGH! i made a mistake..  ko build has no --ldflags flag (only ko run/delete tolerate unknown flags), so `make build-images` and `make build-demos` aborted with "unknown flag: --ldflags". It went unnoticed because no CI workflow runs `make build*`: e2e installs via hack/install-ate.sh, which builds images with `ko apply`/`ko resolve`. Only the plain go-build targets (kubectl-ate, atenet) actually stamped anything.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
