### PR TITLE
Gitignore __* for local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ __pycache__/
 # Local environment variables
 .ate-dev-env.sh
 
+# Developers can store local stuff in dirs named __something
+__*
+
 # OS artifacts
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
This is a small QOL thing from k8s -- keep local files like __kubeconfig
