### PR TITLE
feat(atelet): inject ATE_ACTOR_ID into actor process env

### DIFF
--- a/cmd/atelet/oci.go
+++ b/cmd/atelet/oci.go
@@ -62,10 +62,7 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 		return fmt.Errorf("in untar: %w", err)
 	}
 
-	envVars := []string{
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-	}
-	envVars = append(envVars, env...)
+	envVars := buildActorEnv(actorID, env)
 
 	ociSpec := &specs.Spec{
 		Process: &specs.Process{
@@ -173,6 +170,35 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 	}
 
 	return nil
+}
+
+// buildActorEnv builds the environment for an actor container's process:
+// a default PATH, the template-supplied env, and finally substrate-managed
+// identity variables. Any template-supplied entry that collides with a
+// substrate-managed name is dropped, so substrate's identity values are
+// authoritative and cannot be overridden by the ActorTemplate.
+//
+// Dropping the collision (rather than appending after it) is a security
+// requirement, not a cosmetic one: getenv(3) returns the first match, so a
+// surviving template-supplied ATE_ACTOR_ID would win at runtime and let a
+// template spoof its actor ID and impersonate another actor.
+func buildActorEnv(actorID string, env []string) []string {
+	reserved := map[string]struct{}{
+		"ATE_ACTOR_ID": {},
+	}
+
+	envVars := []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	}
+	for _, e := range env {
+		name, _, _ := strings.Cut(e, "=")
+		if _, ok := reserved[name]; ok {
+			continue
+		}
+		envVars = append(envVars, e)
+	}
+	envVars = append(envVars, "ATE_ACTOR_ID="+actorID)
+	return envVars
 }
 
 func validateTarName(name string) (cleaned string, skip bool, err error) {

--- a/cmd/atelet/oci_test.go
+++ b/cmd/atelet/oci_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -78,6 +79,38 @@ func runUntar(t *testing.T, entries []tarEntry) (string, error) {
 	t.Helper()
 	dir := t.TempDir()
 	return dir, untar(context.Background(), bytes.NewReader(buildTar(t, entries)), dir)
+}
+
+func TestBuildActorEnv(t *testing.T) {
+	got := buildActorEnv("counter-1", []string{"FOO=bar", "ATE_ACTOR_ID=spoofed"})
+
+	if got[0] != "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" {
+		t.Errorf("PATH should be first, got %q", got[0])
+	}
+	// The template-supplied env is preserved.
+	if !slices.Contains(got, "FOO=bar") {
+		t.Errorf("template env FOO=bar missing from %v", got)
+	}
+	// Security: the template's attempt to set the reserved identity var must
+	// be dropped entirely, not merely shadowed. getenv(3) returns the first
+	// match, so a surviving duplicate would let an ActorTemplate spoof its
+	// actor ID and impersonate another actor at runtime.
+	if slices.Contains(got, "ATE_ACTOR_ID=spoofed") {
+		t.Errorf("spoofed ATE_ACTOR_ID should be dropped, got %v", got)
+	}
+	var count int
+	for _, e := range got {
+		if name, _, _ := strings.Cut(e, "="); name == "ATE_ACTOR_ID" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one ATE_ACTOR_ID entry, got %d in %v", count, got)
+	}
+	// substrate's identity value is authoritative.
+	if !slices.Contains(got, "ATE_ACTOR_ID=counter-1") {
+		t.Errorf("ATE_ACTOR_ID=counter-1 should be present and authoritative, got %v", got)
+	}
 }
 
 func TestValidateTarName(t *testing.T) {

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -47,6 +47,11 @@ Substrate has standardized on a **Uniform DNS Mesh**. You no longer need to defi
 
 **Format:** `<actor-id>.actors.resources.substrate.ate.dev`
 
+### Actor Identity (`ATE_ACTOR_ID`)
+Every actor process is started with a `ATE_ACTOR_ID` environment variable set to its own actor ID. Read this when your workload needs to know which actor it is (for logging, keying external state, etc.) instead of parsing the `Host` header off incoming requests.
+
+This value is set by Substrate and is authoritative: if your `ActorTemplate` defines an env var named `ATE_ACTOR_ID`, it is ignored in favor of the real ID.
+
 ### Example
 
 ```yaml


### PR DESCRIPTION
Fixes #178

Exposes an actor's own ID to its workload via an `ATE_ACTOR_ID`
environment variable, so actors no longer need to strip the incoming
atenet request and parse the `Host` header to learn their identity.

### What changed
- `cmd/atelet/oci.go`: new `buildActorEnv` helper assembles the actor
  container's OCI process env (default `PATH` → template-supplied env →
  substrate-managed identity vars). `prepareOCIDirectory` now uses it.
- The injected value is **authoritative**: any template-supplied entry
  whose name collides with the reserved `ATE_ACTOR_ID` is dropped before
  substrate's value is appended. This is a security requirement, not
  cosmetic — `getenv(3)` returns the *first* match in glibc/most runtimes,
  so a surviving template-supplied duplicate would win at runtime and let
  a template spoof its actor ID and impersonate another actor.
- `cmd/atelet/oci_test.go`: `TestBuildActorEnv` covers PATH-first,
  template env preserved, the spoofed duplicate dropped, exactly one
  `ATE_ACTOR_ID`, and the authoritative value present.
- `docs/api-guide.md`: documents the variable for actor authors, next to
  the Uniform DNS / `Host`-header section.

### Naming
- Uses the repo's `ATE_*` prefix (`ATE_STORAGE_BACKEND`,
  `ATE_API_REDIS_*`) for consistency.

### Notes / follow-ups
- The rootfs-file variant mentioned in #178 (e.g. `/run/ate/actor-id`)
  is deliberately deferred; the env var resolves the core need.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)