### PR TITLE
Switch ateom gVisor state path

### DIFF
--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -22,7 +22,7 @@ import (
 const (
 	// The base path.  This is both the path of the root shared folder on the
 	// host filesystem, and when it is mounted into ateom and atelet containers.
-	BasePath = "/run/ateom-gvisor"
+	BasePath = "/var/lib/ateom-gvisor"
 )
 
 var (

--- a/internal/controllers/workerpool_controller.go
+++ b/internal/controllers/workerpool_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/agent-substrate/substrate/internal/ateompath"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 )
 
@@ -155,14 +156,14 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.Deployment
 						).
 						WithVolumeMounts(corev1ac.VolumeMount().
 							WithName("run-ateom").
-							WithMountPath("/run/ateom-gvisor"))).
+							WithMountPath(ateompath.BasePath))).
 					WithSecurityContext(corev1ac.PodSecurityContext().
 						WithRunAsUser(0).
 						WithRunAsGroup(0)).
 					WithVolumes(corev1ac.Volume().
 						WithName("run-ateom").
 						WithHostPath(corev1ac.HostPathVolumeSource().
-							WithPath("/run/ateom-gvisor").
+							WithPath(ateompath.BasePath).
 							WithType(corev1.HostPathDirectoryOrCreate))))))
 }
 

--- a/manifests/ate-install/atelet.yaml
+++ b/manifests/ate-install/atelet.yaml
@@ -90,9 +90,9 @@ spec:
           protocol: TCP
         volumeMounts:
         - name: run-ateom
-          mountPath: /run/ateom-gvisor
+          mountPath: /var/lib/ateom-gvisor
       volumes:
       - name: run-ateom
         hostPath:
-          path: /run/ateom-gvisor
+          path: /var/lib/ateom-gvisor
           type: DirectoryOrCreate


### PR DESCRIPTION
## Summary

  Switch the shared atelet/ateom gVisor state directory from `/run/ateom-gvisor` to `/var/lib/ateom-
  gvisor`.

  ## Why

  This path is not just a transient socket location. It is the shared host/container state root for
  downloaded `runsc` binaries, per-ateom sockets, OCI bundles, runsc state, pidfiles, checkpoint state,
  and restore state.

  `/run` is normally volatile runtime storage and may be tmpfs-backed, which makes it a poor fit for
  large or service-owned local state. Moving this under `/var/lib` better matches Linux filesystem
  conventions and avoids treating gVisor runtime/checkpoint artifacts as ephemeral runtime-only files.

Additionally I was running into many permissions issues with apps trying to use various folders mounted under `/root` before this change.

  ## Changes

  - Update `ateompath.BasePath` to `/var/lib/ateom-gvisor`.
  - Update the WorkerPool controller to use `ateompath.BasePath` instead of hard-coding the mount path.
  - Update the atelet install manifest to mount the new hostPath.

  ## Impact

  This keeps `atelet`, `ateom-gvisor`, and dynamically created WorkerPool Deployments aligned on the
  same shared state path. Without that alignment, the system can fail to find sockets, bundles, runsc
  state, or checkpoint/restore files.