### PR TITLE
Update the variable name used in logging to be actual Actor Template Namespace

### DIFF
--- a/cmd/ateom-gvisor/internal/ateom/logger.go
+++ b/cmd/ateom-gvisor/internal/ateom/logger.go
@@ -62,14 +62,14 @@ func NewActorLogger(w io.Writer, isOnGCE bool) *ActorLogger {
 }
 
 // EmitLifecycleLog logs a synthetic actor lifecycle event.
-func (al *ActorLogger) EmitLifecycleLog(msg, actorID, actorTemplate, actorNamespace string) {
+func (al *ActorLogger) EmitLifecycleLog(msg, actorID, actorTemplateName, actorTemplateNamespace string) {
 	envelope := map[string]any{
 		"time":    time.Now().Format(time.RFC3339Nano),
 		"message": msg,
 		al.labelsKey: map[string]string{
-			"ate.dev/actor_id":        actorID,
-			"ate.dev/actor_template":  actorTemplate,
-			"ate.dev/actor_namespace": actorNamespace,
+			"ate.dev/actor_id":                 actorID,
+			"ate.dev/actor_template_name":      actorTemplateName,
+			"ate.dev/actor_template_namespace": actorTemplateNamespace,
 		},
 	}
 	if envBytes, err := json.Marshal(envelope); err == nil {
@@ -79,20 +79,20 @@ func (al *ActorLogger) EmitLifecycleLog(msg, actorID, actorTemplate, actorNamesp
 }
 
 // StartJSONLogPipe intercepts container raw stdout/stderr streams and pipes them through the logger.
-func (al *ActorLogger) StartJSONLogPipe(actorID, actorTemplate, actorNamespace string) (io.WriteCloser, error) {
+func (al *ActorLogger) StartJSONLogPipe(actorID, actorTemplateName, actorTemplateNamespace string) (io.WriteCloser, error) {
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
 	go func() {
-		al.WrapContainerLogs(pr, actorID, actorTemplate, actorNamespace)
+		al.WrapContainerLogs(pr, actorID, actorTemplateName, actorTemplateNamespace)
 		pr.Close()
 	}()
 	return pw, nil
 }
 
 // WrapContainerLogs reads log lines from r, parses them, and logs them in a unified structured format.
-func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplate, actorNamespace string) {
+func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplateName, actorTemplateNamespace string) {
 	rdr := bufio.NewReader(r)
 	for {
 		lineBytes, err := rdr.ReadBytes('\n')
@@ -122,9 +122,9 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplate, ac
 					"time":    time.Now().Format(time.RFC3339Nano),
 					"message": string(lineBytes),
 					al.labelsKey: map[string]string{
-						"ate.dev/actor_id":        actorID,
-						"ate.dev/actor_template":  actorTemplate,
-						"ate.dev/actor_namespace": actorNamespace,
+						"ate.dev/actor_id":                 actorID,
+						"ate.dev/actor_template_name":      actorTemplateName,
+						"ate.dev/actor_template_namespace": actorTemplateNamespace,
 					},
 				}
 			} else {
@@ -137,8 +137,8 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplate, ac
 					m[al.labelsKey] = labels
 				}
 				labels["ate.dev/actor_id"] = actorID
-				labels["ate.dev/actor_template"] = actorTemplate
-				labels["ate.dev/actor_namespace"] = actorNamespace
+				labels["ate.dev/actor_template_name"] = actorTemplateName
+				labels["ate.dev/actor_template_namespace"] = actorTemplateNamespace
 				envelope = m
 			}
 

--- a/cmd/ateom-gvisor/internal/ateom/logger_test.go
+++ b/cmd/ateom-gvisor/internal/ateom/logger_test.go
@@ -57,11 +57,11 @@ func TestWrapContainerLogs(t *testing.T) {
 	if labels["ate.dev/actor_id"] != "act-1" {
 		t.Errorf("got actor_id = %v, want 'act-1'", labels["ate.dev/actor_id"])
 	}
-	if labels["ate.dev/actor_template"] != "tmpl-1" {
-		t.Errorf("got actor_template = %v, want 'tmpl-1'", labels["ate.dev/actor_template"])
+	if labels["ate.dev/actor_template_name"] != "tmpl-1" {
+		t.Errorf("got actor_template_name = %v, want 'tmpl-1'", labels["ate.dev/actor_template_name"])
 	}
-	if labels["ate.dev/actor_namespace"] != "default" {
-		t.Errorf("got actor_namespace = %v, want 'default'", labels["ate.dev/actor_namespace"])
+	if labels["ate.dev/actor_template_namespace"] != "default" {
+		t.Errorf("got actor_template_namespace = %v, want 'default'", labels["ate.dev/actor_template_namespace"])
 	}
 }
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -8,8 +8,8 @@ This guide explains how Agent Substrate achieves observability across these susp
 
 To make underlying infrastructure transitions transparent, Agent Substrate establishes a standardized metadata model to identify actors across worker pods:
 * `ate.dev/actor_id`: The unique identifier of the actor (e.g., `my-counter-1` or `test`).
-* `ate.dev/actor_template`: The template used to create the actor (e.g., `counter`).
-* `ate.dev/actor_namespace`: The Kubernetes namespace of the actor (e.g., `ate-demo-counter`).
+* `ate.dev/actor_template_name`: The name of the actor's ActorTemplate (e.g., `counter`).
+* `ate.dev/actor_template_namespace`: The Kubernetes namespace of the actor's ActorTemplate (e.g., `ate-demo-counter`).
 
 Currently, Agent Substrate automatically wraps container output and injects these metadata labels into **container logs**. For metrics and distributed tracing, Agent Substrate provides foundational system telemetry and on-demand request tracing, with roadmap plans to fully integrate actor-level correlation.
 


### PR DESCRIPTION
It was using a wrong name `Actor Namespace` before, which doesn't exist yet.


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
