### PR TITLE
fix(router): stop logging secrets in ext_proc request logs

### DIFF
--- a/cmd/atenet/internal/router/extproc.go
+++ b/cmd/atenet/internal/router/extproc.go
@@ -108,7 +108,7 @@ func (s *ExtProcServer) Process(stream extprocv3.ExternalProcessor_ProcessServer
 		default:
 			// No modification for other processing states, but log because this should
 			// not be called.
-			slog.Error("Unexpected request type", slog.Any("reqType", reqType))
+			slog.Error("Unexpected request type", slog.String("reqType", fmt.Sprintf("%T", reqType)))
 			resp.Response = &extprocv3.ProcessingResponse_RequestHeaders{
 				RequestHeaders: &extprocv3.HeadersResponse{
 					Response: &extprocv3.CommonResponse{},
@@ -127,7 +127,7 @@ func (s *ExtProcServer) handleRequestHeaders(
 	reqHeaders *extprocv3.HttpHeaders,
 ) (*extprocv3.HeadersResponse, *requestMetadata, string, string, string, error) {
 	metadata := newRequestMetadata(reqHeaders.Headers.GetHeaders())
-	slog.InfoContext(ctx, "Request", slog.String("metadata", metadata.String()))
+	slog.InfoContext(ctx, "Request", slog.String("host", metadata.host))
 
 	actorID, err := parseActorID(metadata.host)
 	if err != nil {
@@ -137,12 +137,6 @@ func (s *ExtProcServer) handleRequestHeaders(
 
 	slog.InfoContext(ctx, "ResumeActor", slog.String("actorID", actorID))
 	actor, err := s.resumer.ResumeActor(ctx, actorID)
-
-	slog.InfoContext(ctx, "ResumeActor result",
-		slog.String("actor", fmt.Sprintf("%+v", actor)),
-		slog.String("worker_ip", actor.GetAteomPodIp()),
-		slog.Any("err", err))
-
 	if err != nil {
 		return nil, metadata, "", "", "", mapResumeError(actorID, err)
 	}
@@ -153,6 +147,11 @@ func (s *ExtProcServer) handleRequestHeaders(
 	tmplName := actor.GetActorTemplateName()
 
 	workerIP := actor.GetAteomPodIp()
+	slog.InfoContext(ctx, "ResumeActor result",
+		slog.String("actorID", actorID),
+		slog.String("status", actor.GetStatus().String()),
+		slog.String("workerIP", workerIP))
+
 	if ip := net.ParseIP(workerIP); ip == nil {
 		return nil, metadata, "", tmplNs, tmplName, newReqError(envoy_type.StatusCode_InternalServerError,
 			"actor %q routing failed", actorID)

--- a/cmd/atenet/internal/router/extproc_in.go
+++ b/cmd/atenet/internal/router/extproc_in.go
@@ -29,10 +29,6 @@ type requestMetadata struct {
 	host    string
 }
 
-func (m *requestMetadata) String() string {
-	return fmt.Sprintf("host=%s path=%s", m.host, m.path)
-}
-
 func newRequestMetadata(headers []*corev3.HeaderValue) *requestMetadata {
 	headersMap := make(map[string]string)
 	var path string
@@ -47,7 +43,7 @@ func newRequestMetadata(headers []*corev3.HeaderValue) *requestMetadata {
 
 		headersMap[k] = val
 		if k == ":path" {
-			path, _, _ = strings.Cut(val, "?")
+			path = val
 		}
 		if k == ":authority" || k == "host" {
 			host = val

--- a/cmd/atenet/internal/router/extproc_in.go
+++ b/cmd/atenet/internal/router/extproc_in.go
@@ -30,7 +30,7 @@ type requestMetadata struct {
 }
 
 func (m *requestMetadata) String() string {
-	return fmt.Sprintf("%+v", *m)
+	return fmt.Sprintf("host=%s path=%s", m.host, m.path)
 }
 
 func newRequestMetadata(headers []*corev3.HeaderValue) *requestMetadata {
@@ -47,7 +47,7 @@ func newRequestMetadata(headers []*corev3.HeaderValue) *requestMetadata {
 
 		headersMap[k] = val
 		if k == ":path" {
-			path = val
+			path, _, _ = strings.Cut(val, "?")
 		}
 		if k == ":authority" || k == "host" {
 			host = val

--- a/cmd/atenet/internal/router/extproc_in_test.go
+++ b/cmd/atenet/internal/router/extproc_in_test.go
@@ -16,7 +16,6 @@ package router
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -117,21 +116,6 @@ func TestExtractMetadata(t *testing.T) {
 				t.Errorf("extractMetadata() host = %v, want %v", got.host, tc.wantHost)
 			}
 		})
-	}
-}
-
-func TestRequestMetadata_String(t *testing.T) {
-	m := newRequestMetadata([]*corev3.HeaderValue{
-		{Key: ":path", Value: "/api/v1/test"},
-		{Key: ":authority", Value: "example.com"},
-		{Key: "authorization", Value: "Bearer do-not-log-me"},
-	})
-	got := m.String()
-	if want := "host=example.com path=/api/v1/test"; got != want {
-		t.Errorf("String() = %q, want %q", got, want)
-	}
-	if strings.Contains(got, "do-not-log-me") {
-		t.Errorf("String() leaked header value: %q", got)
 	}
 }
 

--- a/cmd/atenet/internal/router/extproc_in_test.go
+++ b/cmd/atenet/internal/router/extproc_in_test.go
@@ -15,8 +15,8 @@
 package router
 
 import (
-	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -121,17 +121,17 @@ func TestExtractMetadata(t *testing.T) {
 }
 
 func TestRequestMetadata_String(t *testing.T) {
-	headers := []*corev3.HeaderValue{
+	m := newRequestMetadata([]*corev3.HeaderValue{
 		{Key: ":path", Value: "/api/v1/test"},
 		{Key: ":authority", Value: "example.com"},
+		{Key: "authorization", Value: "Bearer do-not-log-me"},
+	})
+	got := m.String()
+	if want := "host=example.com path=/api/v1/test"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
 	}
-	m := newRequestMetadata(headers)
-	str := m.String()
-	if str == "" {
-		t.Errorf("expected non-empty string from String()")
-	}
-	if !reflect.DeepEqual(str, fmt.Sprintf("%+v", *m)) {
-		t.Errorf("String() = %q, want %q", str, fmt.Sprintf("%+v", *m))
+	if strings.Contains(got, "do-not-log-me") {
+		t.Errorf("String() leaked header value: %q", got)
 	}
 }
 

--- a/cmd/atenet/internal/router/extproc_test.go
+++ b/cmd/atenet/internal/router/extproc_test.go
@@ -15,8 +15,11 @@
 package router
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +40,54 @@ type mockClient struct {
 
 func (m *mockClient) ResumeActor(ctx context.Context, in *ateapipb.ResumeActorRequest, opts ...grpc.CallOption) (*ateapipb.ResumeActorResponse, error) {
 	return m.resumeFn(ctx, in, opts...)
+}
+
+func TestHandleRequestHeadersDoesNotLogSensitiveData(t *testing.T) {
+	const testUUID = "123e4567-e89b-12d3-a456-426614174000"
+	const secret = "do-not-log-me"
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	s := NewExtProcServer(50051, &mockClient{
+		resumeFn: func(ctx context.Context, in *ateapipb.ResumeActorRequest, opts ...grpc.CallOption) (*ateapipb.ResumeActorResponse, error) {
+			return &ateapipb.ResumeActorResponse{Actor: &ateapipb.Actor{AteomPodIp: "10.0.0.52"}}, nil
+		},
+	}, nil)
+
+	reqHeaders := &extprocv3.HttpHeaders{
+		Headers: &corev3.HeaderMap{
+			Headers: []*corev3.HeaderValue{
+				{Key: ":path", Value: "/api/v1/reset?token=" + secret},
+				{Key: ":authority", Value: testUUID + ".actors.resources.substrate.ate.dev"},
+				{Key: ":method", Value: "POST"},
+				{Key: "authorization", Value: "Bearer " + secret},
+				{Key: "cookie", Value: "session=" + secret},
+			},
+		},
+	}
+
+	_, metadata, target, _, _, err := s.handleRequestHeaders(context.Background(), reqHeaders)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, secret) {
+		t.Errorf("router log leaked sensitive value: %s", out)
+	}
+	if !strings.Contains(out, testUUID) {
+		t.Errorf("router log missing actor/host routing context: %s", out)
+	}
+
+	s.recorder.AddRouterRequest(time.Now(), time.Millisecond, "Route ok", target, metadata)
+	for _, q := range s.recorder.Get() {
+		if blob, _ := json.Marshal(q); strings.Contains(string(blob), secret) {
+			t.Errorf("recorder/statusz retained sensitive value: %s", blob)
+		}
+	}
 }
 
 func TestExtProcHeadersEvaluation(t *testing.T) {

--- a/cmd/atenet/internal/router/status.go
+++ b/cmd/atenet/internal/router/status.go
@@ -103,6 +103,12 @@ func (qr *QueryRecorder) Get() []RecordedQuery {
 	return res
 }
 
+// redactPath drops the query string, which may carry credentials (CWE-598).
+func redactPath(path string) string {
+	p, _, _ := strings.Cut(path, "?")
+	return p
+}
+
 func (qr *QueryRecorder) AddRouterRequest(
 	start time.Time,
 	duration time.Duration,
@@ -114,7 +120,7 @@ func (qr *QueryRecorder) AddRouterRequest(
 		Timestamp: start,
 		Client:    m.headers[":authority"],
 		Host:      m.host,
-		Path:      m.path,
+		Path:      redactPath(m.path),
 		Method:    m.headers[":method"],
 		Action:    action,
 		Target:    target,


### PR DESCRIPTION
Part of #103.

Stops the router (ext_proc) request path from writing secrets to logs.

This PR was prepared in part with the assistance of generative AI.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
