### PR TITLE
fix(atelet): validate RPC inputs that become host filesystem paths

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -645,14 +645,20 @@ func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
 	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
 		return err
 	}
-	return validateSnapshotURIPrefix(req.GetSnapshotUriPrefix())
+	if err := validateSnapshotURIPrefix(req.GetSnapshotUriPrefix()); err != nil {
+		return err
+	}
+	return nil
 }
 
 func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
 	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
 		return err
 	}
-	return validateSnapshotURIPrefix(req.GetSnapshotUriPrefix())
+	if err := validateSnapshotURIPrefix(req.GetSnapshotUriPrefix()); err != nil {
+		return err
+	}
+	return nil
 }
 
 // validateActorRequest is the shared core for the fields common to all three

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -282,7 +283,7 @@ func (s *AteomHerder) fetchRunsc(ctx context.Context, cfg *ateletpb.RunscConfig)
 }
 
 func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*ateletpb.RunResponse, error) {
-	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+	if err := validateRunRequest(req); err != nil {
 		return nil, err
 	}
 
@@ -359,7 +360,7 @@ func recordSnapshotSize(ctx context.Context, kind, path, atNamespace, atName str
 }
 
 func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRequest) (*ateletpb.CheckpointResponse, error) {
-	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+	if err := validateCheckpointRequest(req); err != nil {
 		return nil, err
 	}
 
@@ -426,7 +427,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 }
 
 func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest) (*ateletpb.RestoreResponse, error) {
-	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+	if err := validateRestoreRequest(req); err != nil {
 		return nil, err
 	}
 
@@ -629,11 +630,33 @@ func (d *AteomDialer) DialAteomPod(ctx context.Context, podUID string) (*grpc.Cl
 	return conn, nil
 }
 
-// validateActorRequest validates the request fields that atelet turns into host
-// filesystem paths. atelet listens on an insecure hostPort, so any reachable
-// caller could otherwise smuggle a path separator or ".." through them and make
-// atelet read/RemoveAll/write outside the intended directory tree, or collide
-// bundles. Validate at the RPC boundary, before any path is built.
+// validateRunRequest, validateCheckpointRequest, and validateRestoreRequest
+// validate everything in their request that atelet turns into host filesystem
+// paths, plus the request-specific fields. atelet listens on an insecure
+// hostPort, so any reachable caller could otherwise smuggle a path separator
+// or ".." through these fields and make atelet read/RemoveAll/write outside
+// the intended directory tree, or collide bundles. Each RPC validates at its
+// boundary, before any path is built.
+func validateRunRequest(req *ateletpb.RunRequest) error {
+	return validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec())
+}
+
+func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
+	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+		return err
+	}
+	return validateSnapshotURIPrefix(req.GetSnapshotUriPrefix())
+}
+
+func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
+	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+		return err
+	}
+	return validateSnapshotURIPrefix(req.GetSnapshotUriPrefix())
+}
+
+// validateActorRequest is the shared core for the fields common to all three
+// RPCs.
 func validateActorRequest(namespace, template, actorID, targetAteomUID string, spec *ateletpb.WorkloadSpec) error {
 	if err := validateActorRef(namespace, template, actorID); err != nil {
 		return err
@@ -642,6 +665,26 @@ func validateActorRequest(namespace, template, actorID, targetAteomUID string, s
 		return err
 	}
 	return validateContainers(spec)
+}
+
+// validateSnapshotURIPrefix ensures the checkpoint/restore snapshot location
+// is a well-formed URI with a bucket, so a bad prefix fails fast at the RPC
+// boundary instead of deep inside an object-storage call. It deliberately
+// does not restrict the scheme: the storage layer (ategcs.parseGCSURL) only
+// uses the host (bucket) and path, and which schemes are acceptable is a
+// storage-backend policy, not a per-RPC one. The local paths used for
+// snapshot upload/download are derived from the separately validated actor
+// ref, not from this URI, so this is a sanity check rather than a
+// path-traversal guard.
+func validateSnapshotURIPrefix(prefix string) error {
+	u, err := url.Parse(prefix)
+	if err != nil {
+		return fmt.Errorf("invalid snapshot URI prefix %q: %v", prefix, err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid snapshot URI prefix %q: missing bucket", prefix)
+	}
+	return nil
 }
 
 // validateActorRef ensures every component of the per-actor directory tree is a

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -52,8 +52,10 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 	"k8s.io/utils/lru"
 )
 
@@ -219,7 +221,7 @@ func (s *AteomHerder) fetchRunsc(ctx context.Context, cfg *ateletpb.RunscConfig)
 
 	sha256Hash := platCfg.GetSha256Hash()
 	if err := resources.ValidateRunscHash(sha256Hash); err != nil {
-		return "", err
+		return "", status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	localPath := ateompath.RunSCBinaryPath(sha256Hash)
@@ -283,7 +285,9 @@ func (s *AteomHerder) fetchRunsc(ctx context.Context, cfg *ateletpb.RunscConfig)
 
 func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*ateletpb.RunResponse, error) {
 	if err := validateRunRequest(req); err != nil {
-		return nil, err
+		// status.Error so the interceptor surfaces InvalidArgument and the
+		// message instead of masking both as Internal.
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())
@@ -360,7 +364,7 @@ func recordSnapshotSize(ctx context.Context, kind, path, atNamespace, atName str
 
 func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRequest) (*ateletpb.CheckpointResponse, error) {
 	if err := validateCheckpointRequest(req); err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())
@@ -427,7 +431,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 
 func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest) (*ateletpb.RestoreResponse, error) {
 	if err := validateRestoreRequest(req); err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -651,17 +651,14 @@ func validateActorRequest(namespace, template, actorID, targetAteomUID string, s
 // leave a traversal window via the others. Template names are DNS-1123
 // subdomains (dots allowed); namespaces and actor IDs are labels.
 func validateActorRef(namespace, template, actorID string) error {
-	for _, f := range []struct {
-		kind, value string
-		errs        []string
-	}{
-		{"namespace", namespace, validation.IsDNS1123Label(namespace)},
-		{"template", template, validation.IsDNS1123Subdomain(template)},
-		{"actor ID", actorID, validation.IsDNS1123Label(actorID)},
-	} {
-		if len(f.errs) > 0 {
-			return fmt.Errorf("invalid %s %q: %s", f.kind, f.value, strings.Join(f.errs, "; "))
-		}
+	if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
+		return fmt.Errorf("invalid namespace %q: %s", namespace, strings.Join(errs, "; "))
+	}
+	if errs := validation.IsDNS1123Subdomain(template); len(errs) > 0 {
+		return fmt.Errorf("invalid template %q: %s", template, strings.Join(errs, "; "))
+	}
+	if errs := validation.IsDNS1123Label(actorID); len(errs) > 0 {
+		return fmt.Errorf("invalid actor ID %q: %s", actorID, strings.Join(errs, "; "))
 	}
 	return nil
 }
@@ -710,11 +707,9 @@ func validateRunscHash(sha256Hash string) error {
 	if len(sha256Hash) != 64 {
 		return fmt.Errorf("invalid runsc sha256 hash: want 64 hex chars, got %d", len(sha256Hash))
 	}
-	for _, r := range sha256Hash {
-		isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
-		if !isHex {
-			return fmt.Errorf("invalid runsc sha256 hash %q: must be hex", sha256Hash)
-		}
+	// Same decoder the digest comparison in fetchRunsc uses.
+	if _, err := hex.DecodeString(sha256Hash); err != nil {
+		return fmt.Errorf("invalid runsc sha256 hash %q: must be hex", sha256Hash)
 	}
 	return nil
 }

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -38,6 +37,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/memorypullcache"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/internal/serverboot"
 	"github.com/agent-substrate/substrate/internal/version"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -54,7 +54,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/lru"
 )
 
@@ -219,7 +218,7 @@ func (s *AteomHerder) fetchRunsc(ctx context.Context, cfg *ateletpb.RunscConfig)
 	}
 
 	sha256Hash := platCfg.GetSha256Hash()
-	if err := validateRunscHash(sha256Hash); err != nil {
+	if err := resources.ValidateRunscHash(sha256Hash); err != nil {
 		return "", err
 	}
 
@@ -636,7 +635,8 @@ func (d *AteomDialer) DialAteomPod(ctx context.Context, podUID string) (*grpc.Cl
 // hostPort, so any reachable caller could otherwise smuggle a path separator
 // or ".." through these fields and make atelet read/RemoveAll/write outside
 // the intended directory tree, or collide bundles. Each RPC validates at its
-// boundary, before any path is built.
+// boundary, before any path is built. The field rules live in
+// internal/resources so other components can apply them at their boundaries.
 func validateRunRequest(req *ateletpb.RunRequest) error {
 	return validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec())
 }
@@ -645,7 +645,7 @@ func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
 	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
 		return err
 	}
-	if err := validateSnapshotURIPrefix(req.GetSnapshotUriPrefix()); err != nil {
+	if err := resources.ValidateSnapshotURIPrefix(req.GetSnapshotUriPrefix()); err != nil {
 		return err
 	}
 	return nil
@@ -655,7 +655,7 @@ func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
 	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
 		return err
 	}
-	if err := validateSnapshotURIPrefix(req.GetSnapshotUriPrefix()); err != nil {
+	if err := resources.ValidateSnapshotURIPrefix(req.GetSnapshotUriPrefix()); err != nil {
 		return err
 	}
 	return nil
@@ -664,103 +664,17 @@ func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
 // validateActorRequest is the shared core for the fields common to all three
 // RPCs.
 func validateActorRequest(namespace, template, actorID, targetAteomUID string, spec *ateletpb.WorkloadSpec) error {
-	if err := validateActorRef(namespace, template, actorID); err != nil {
+	if err := resources.ValidateActorRef(namespace, template, actorID); err != nil {
 		return err
 	}
-	if err := validateAteomUID(targetAteomUID); err != nil {
+	if err := resources.ValidateAteomUID(targetAteomUID); err != nil {
 		return err
 	}
-	return validateContainers(spec)
-}
-
-// validateSnapshotURIPrefix ensures the checkpoint/restore snapshot location
-// is a well-formed URI with a bucket, so a bad prefix fails fast at the RPC
-// boundary instead of deep inside an object-storage call. It deliberately
-// does not restrict the scheme: the storage layer (ategcs.parseGCSURL) only
-// uses the host (bucket) and path, and which schemes are acceptable is a
-// storage-backend policy, not a per-RPC one. The local paths used for
-// snapshot upload/download are derived from the separately validated actor
-// ref, not from this URI, so this is a sanity check rather than a
-// path-traversal guard.
-func validateSnapshotURIPrefix(prefix string) error {
-	u, err := url.Parse(prefix)
-	if err != nil {
-		return fmt.Errorf("invalid snapshot URI prefix %q: %v", prefix, err)
-	}
-	if u.Host == "" {
-		return fmt.Errorf("invalid snapshot URI prefix %q: missing bucket", prefix)
-	}
-	return nil
-}
-
-// validateActorRef ensures every component of the per-actor directory tree is a
-// valid DNS-1123 name. namespace+template+actorID are concatenated by
-// ateompath.ActorPath into a host path on which atelet runs os.RemoveAll and
-// os.MkdirAll, so all three must be validated. Checking only one would still
-// leave a traversal window via the others. Template names are DNS-1123
-// subdomains (dots allowed); namespaces and actor IDs are labels.
-func validateActorRef(namespace, template, actorID string) error {
-	if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
-		return fmt.Errorf("invalid namespace %q: %s", namespace, strings.Join(errs, "; "))
-	}
-	if errs := validation.IsDNS1123Subdomain(template); len(errs) > 0 {
-		return fmt.Errorf("invalid template %q: %s", template, strings.Join(errs, "; "))
-	}
-	if errs := validation.IsDNS1123Label(actorID); len(errs) > 0 {
-		return fmt.Errorf("invalid actor ID %q: %s", actorID, strings.Join(errs, "; "))
-	}
-	return nil
-}
-
-// validateAteomUID rejects a target ateom pod UID that could escape the host
-// paths built from it: the netns path (/run/netns/ateom:<uid>) and the ateom
-// control socket (.../ateoms/<uid>/ateom.sock). Kubernetes pod UIDs are UUIDs,
-// which are valid DNS-1123 labels, so a label check accepts every legitimate
-// value while rejecting separators and "..".
-func validateAteomUID(targetAteomUID string) error {
-	if errs := validation.IsDNS1123Label(targetAteomUID); len(errs) > 0 {
-		return fmt.Errorf("invalid target ateom UID %q: %s", targetAteomUID, strings.Join(errs, "; "))
-	}
-	return nil
-}
-
-// validateContainers ensures every application container name is safe to use as
-// an OCI bundle path component. Each must be a DNS-1123 label (no separator or
-// ".."), must not be the reserved "pause" name (which would collide with the
-// sandbox-infra bundle and race its concurrent writer), and must be unique
-// (duplicates map to the same bundle path and corrupt each other).
-func validateContainers(spec *ateletpb.WorkloadSpec) error {
-	seen := make(map[string]struct{})
+	names := make([]string, 0, len(spec.GetContainers()))
 	for _, ctr := range spec.GetContainers() {
-		name := ctr.GetName()
-		if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
-			return fmt.Errorf("invalid container name %q: %s", name, strings.Join(errs, "; "))
-		}
-		if name == "pause" {
-			return fmt.Errorf("invalid container name %q: reserved for sandbox infrastructure", name)
-		}
-		if _, dup := seen[name]; dup {
-			return fmt.Errorf("duplicate container name %q", name)
-		}
-		seen[name] = struct{}{}
+		names = append(names, ctr.GetName())
 	}
-	return nil
-}
-
-// validateRunscHash ensures the runsc SHA-256 hash is exactly 64 hex characters
-// before it is used to build the on-disk binary path (static-files/runsc-<hash>)
-// and, on a cache hit, returned for ateom to execute. Without this, a hash
-// containing path separators or ".." could point the cache-hit early return
-// (and the download target) at an arbitrary binary outside the static-files dir.
-func validateRunscHash(sha256Hash string) error {
-	if len(sha256Hash) != 64 {
-		return fmt.Errorf("invalid runsc sha256 hash: want 64 hex chars, got %d", len(sha256Hash))
-	}
-	// Same decoder the digest comparison in fetchRunsc uses.
-	if _, err := hex.DecodeString(sha256Hash); err != nil {
-		return fmt.Errorf("invalid runsc sha256 hash %q: must be hex", sha256Hash)
-	}
-	return nil
+	return resources.ValidateContainerNames(names)
 }
 
 func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) error {

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -53,6 +53,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/lru"
 )
 
@@ -216,7 +217,12 @@ func (s *AteomHerder) fetchRunsc(ctx context.Context, cfg *ateletpb.RunscConfig)
 		platCfg = cfg.GetArm64()
 	}
 
-	localPath := ateompath.RunSCBinaryPath(platCfg.GetSha256Hash())
+	sha256Hash := platCfg.GetSha256Hash()
+	if err := validateRunscHash(sha256Hash); err != nil {
+		return "", err
+	}
+
+	localPath := ateompath.RunSCBinaryPath(sha256Hash)
 	_, err := os.Stat(localPath)
 	if err == nil { // EQUALS nil
 		return localPath, nil
@@ -276,6 +282,10 @@ func (s *AteomHerder) fetchRunsc(ctx context.Context, cfg *ateletpb.RunscConfig)
 }
 
 func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*ateletpb.RunResponse, error) {
+	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+		return nil, err
+	}
+
 	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())
 	if err != nil {
 		return nil, err
@@ -349,6 +359,10 @@ func recordSnapshotSize(ctx context.Context, kind, path, atNamespace, atName str
 }
 
 func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRequest) (*ateletpb.CheckpointResponse, error) {
+	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+		return nil, err
+	}
+
 	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())
 	if err != nil {
 		return nil, err
@@ -412,6 +426,10 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 }
 
 func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest) (*ateletpb.RestoreResponse, error) {
+	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+		return nil, err
+	}
+
 	runscPath, err := s.fetchRunscAndPrep(ctx, req.GetRunsc())
 	if err != nil {
 		return nil, err
@@ -609,6 +627,96 @@ func (d *AteomDialer) DialAteomPod(ctx context.Context, podUID string) (*grpc.Cl
 	d.conns.Add(key, conn)
 
 	return conn, nil
+}
+
+// validateActorRequest validates the request fields that atelet turns into host
+// filesystem paths. atelet listens on an insecure hostPort, so any reachable
+// caller could otherwise smuggle a path separator or ".." through them and make
+// atelet read/RemoveAll/write outside the intended directory tree, or collide
+// bundles. Validate at the RPC boundary, before any path is built.
+func validateActorRequest(namespace, template, actorID, targetAteomUID string, spec *ateletpb.WorkloadSpec) error {
+	if err := validateActorRef(namespace, template, actorID); err != nil {
+		return err
+	}
+	if err := validateAteomUID(targetAteomUID); err != nil {
+		return err
+	}
+	return validateContainers(spec)
+}
+
+// validateActorRef ensures every component of the per-actor directory tree is a
+// valid DNS-1123 name. namespace+template+actorID are concatenated by
+// ateompath.ActorPath into a host path on which atelet runs os.RemoveAll and
+// os.MkdirAll, so all three must be validated. Checking only one would still
+// leave a traversal window via the others. Template names are DNS-1123
+// subdomains (dots allowed); namespaces and actor IDs are labels.
+func validateActorRef(namespace, template, actorID string) error {
+	for _, f := range []struct {
+		kind, value string
+		errs        []string
+	}{
+		{"namespace", namespace, validation.IsDNS1123Label(namespace)},
+		{"template", template, validation.IsDNS1123Subdomain(template)},
+		{"actor ID", actorID, validation.IsDNS1123Label(actorID)},
+	} {
+		if len(f.errs) > 0 {
+			return fmt.Errorf("invalid %s %q: %s", f.kind, f.value, strings.Join(f.errs, "; "))
+		}
+	}
+	return nil
+}
+
+// validateAteomUID rejects a target ateom pod UID that could escape the host
+// paths built from it: the netns path (/run/netns/ateom:<uid>) and the ateom
+// control socket (.../ateoms/<uid>/ateom.sock). Kubernetes pod UIDs are UUIDs,
+// which are valid DNS-1123 labels, so a label check accepts every legitimate
+// value while rejecting separators and "..".
+func validateAteomUID(targetAteomUID string) error {
+	if errs := validation.IsDNS1123Label(targetAteomUID); len(errs) > 0 {
+		return fmt.Errorf("invalid target ateom UID %q: %s", targetAteomUID, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// validateContainers ensures every application container name is safe to use as
+// an OCI bundle path component. Each must be a DNS-1123 label (no separator or
+// ".."), must not be the reserved "pause" name (which would collide with the
+// sandbox-infra bundle and race its concurrent writer), and must be unique
+// (duplicates map to the same bundle path and corrupt each other).
+func validateContainers(spec *ateletpb.WorkloadSpec) error {
+	seen := make(map[string]struct{})
+	for _, ctr := range spec.GetContainers() {
+		name := ctr.GetName()
+		if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
+			return fmt.Errorf("invalid container name %q: %s", name, strings.Join(errs, "; "))
+		}
+		if name == "pause" {
+			return fmt.Errorf("invalid container name %q: reserved for sandbox infrastructure", name)
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("duplicate container name %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+// validateRunscHash ensures the runsc SHA-256 hash is exactly 64 hex characters
+// before it is used to build the on-disk binary path (static-files/runsc-<hash>)
+// and, on a cache hit, returned for ateom to execute. Without this, a hash
+// containing path separators or ".." could point the cache-hit early return
+// (and the download target) at an arbitrary binary outside the static-files dir.
+func validateRunscHash(sha256Hash string) error {
+	if len(sha256Hash) != 64 {
+		return fmt.Errorf("invalid runsc sha256 hash: want 64 hex chars, got %d", len(sha256Hash))
+	}
+	for _, r := range sha256Hash {
+		isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+		if !isHex {
+			return fmt.Errorf("invalid runsc sha256 hash %q: must be hex", sha256Hash)
+		}
+	}
+	return nil
 }
 
 func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) error {

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -193,48 +193,105 @@ func TestValidateSnapshotURIPrefix(t *testing.T) {
 	}
 }
 
-// TestPerRequestValidators pins the request-specific rules: Checkpoint and
-// Restore must reject a bad snapshot URI prefix even when every common field
-// is valid, and Run (which has no URI field) must accept the same common
-// fields.
-func TestPerRequestValidators(t *testing.T) {
-	const okNS, okTmpl, okID, okUID = "ate-demo", "counter", "counter-1", "422938ba-8860-4983-a25d-d6bcb0a69d4e"
-	okSpec := &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}}
+// validRunRequest, validCheckpointRequest, and validRestoreRequest build
+// requests whose every field passes validation; the per-request tests below
+// break one field per case.
+func validRunRequest() *ateletpb.RunRequest {
+	return &ateletpb.RunRequest{
+		ActorTemplateNamespace: "ate-demo",
+		ActorTemplateName:      "counter",
+		ActorId:                "counter-1",
+		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
+		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
+	}
+}
 
-	if err := validateRunRequest(&ateletpb.RunRequest{
-		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
-		TargetAteomUid: okUID, Spec: okSpec,
-	}); err != nil {
-		t.Errorf("validateRunRequest with valid fields: %v", err)
+func validCheckpointRequest() *ateletpb.CheckpointRequest {
+	return &ateletpb.CheckpointRequest{
+		ActorTemplateNamespace: "ate-demo",
+		ActorTemplateName:      "counter",
+		ActorId:                "counter-1",
+		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
+		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
+		SnapshotUriPrefix:      "gs://bucket/actors/1/snapshots/2/",
 	}
+}
 
-	if err := validateCheckpointRequest(&ateletpb.CheckpointRequest{
-		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
-		TargetAteomUid: okUID, Spec: okSpec,
-		SnapshotUriPrefix: "gs://bucket/actors/1/snapshots/2/",
-	}); err != nil {
-		t.Errorf("validateCheckpointRequest with valid fields: %v", err)
+func validRestoreRequest() *ateletpb.RestoreRequest {
+	return &ateletpb.RestoreRequest{
+		ActorTemplateNamespace: "ate-demo",
+		ActorTemplateName:      "counter",
+		ActorId:                "counter-1",
+		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
+		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
+		SnapshotUriPrefix:      "gs://bucket/actors/1/snapshots/2/",
 	}
-	if err := validateCheckpointRequest(&ateletpb.CheckpointRequest{
-		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
-		TargetAteomUid: okUID, Spec: okSpec,
-		SnapshotUriPrefix: "relative/path",
-	}); err == nil {
-		t.Error("validateCheckpointRequest accepted a bucketless snapshot URI prefix")
-	}
+}
 
-	if err := validateRestoreRequest(&ateletpb.RestoreRequest{
-		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
-		TargetAteomUid: okUID, Spec: okSpec,
-		SnapshotUriPrefix: "gs://bucket/actors/1/snapshots/2/",
-	}); err != nil {
-		t.Errorf("validateRestoreRequest with valid fields: %v", err)
+func TestValidateRunRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ateletpb.RunRequest)
+		wantErr bool
+	}{
+		{"valid", func(*ateletpb.RunRequest) {}, false},
+		{"invalid ateom uid", func(r *ateletpb.RunRequest) { r.TargetAteomUid = "../escape" }, true},
+		{"invalid actor id", func(r *ateletpb.RunRequest) { r.ActorId = "../escape" }, true},
 	}
-	if err := validateRestoreRequest(&ateletpb.RestoreRequest{
-		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
-		TargetAteomUid: okUID, Spec: okSpec,
-	}); err == nil {
-		t.Error("validateRestoreRequest accepted an empty snapshot URI prefix")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validRunRequest()
+			tc.mutate(req)
+			if err := validateRunRequest(req); (err != nil) != tc.wantErr {
+				t.Errorf("validateRunRequest err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// Checkpoint and Restore must reject a bad snapshot URI prefix even when
+// every common field is valid.
+func TestValidateCheckpointRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ateletpb.CheckpointRequest)
+		wantErr bool
+	}{
+		{"valid", func(*ateletpb.CheckpointRequest) {}, false},
+		{"empty snapshot uri", func(r *ateletpb.CheckpointRequest) { r.SnapshotUriPrefix = "" }, true},
+		{"bucketless snapshot uri", func(r *ateletpb.CheckpointRequest) { r.SnapshotUriPrefix = "relative/path" }, true},
+		{"invalid ateom uid", func(r *ateletpb.CheckpointRequest) { r.TargetAteomUid = "../escape" }, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validCheckpointRequest()
+			tc.mutate(req)
+			if err := validateCheckpointRequest(req); (err != nil) != tc.wantErr {
+				t.Errorf("validateCheckpointRequest err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRestoreRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ateletpb.RestoreRequest)
+		wantErr bool
+	}{
+		{"valid", func(*ateletpb.RestoreRequest) {}, false},
+		{"empty snapshot uri", func(r *ateletpb.RestoreRequest) { r.SnapshotUriPrefix = "" }, true},
+		{"bucketless snapshot uri", func(r *ateletpb.RestoreRequest) { r.SnapshotUriPrefix = "relative/path" }, true},
+		{"invalid ateom uid", func(r *ateletpb.RestoreRequest) { r.TargetAteomUid = "../escape" }, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validRestoreRequest()
+			tc.mutate(req)
+			if err := validateRestoreRequest(req); (err != nil) != tc.wantErr {
+				t.Errorf("validateRestoreRequest err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestValidateActorRequest(t *testing.T) {
@@ -181,8 +183,9 @@ func TestFetchRunscRejectsBadHash(t *testing.T) {
 
 // TestRPCBoundariesReject confirms each of the three RPCs validates path inputs
 // before touching its (here nil) dependencies. A traversal value must be
-// rejected with an error rather than panicking. Guards against a future
-// removal or reordering of the validation call at any boundary.
+// rejected as InvalidArgument rather than panicking or surfacing as
+// Internal. Guards against a future removal or reordering of the validation
+// call at any boundary.
 func TestRPCBoundariesReject(t *testing.T) {
 	s := &AteomHerder{}
 	ctx := context.Background()
@@ -190,28 +193,36 @@ func TestRPCBoundariesReject(t *testing.T) {
 	const okNS, okTmpl, okID = "ate-demo", "counter", "counter-1"
 	okSpec := &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}}
 
+	wantInvalidArgument := func(t *testing.T, rpc string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Errorf("%s accepted an invalid target ateom UID", rpc)
+			return
+		}
+		if code := status.Code(err); code != codes.InvalidArgument {
+			t.Errorf("%s returned code %v, want InvalidArgument", rpc, code)
+		}
+	}
+
 	t.Run("Run", func(t *testing.T) {
-		if _, err := s.Run(ctx, &ateletpb.RunRequest{
+		_, err := s.Run(ctx, &ateletpb.RunRequest{
 			ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
 			TargetAteomUid: badUID, Spec: okSpec,
-		}); err == nil {
-			t.Error("Run accepted an invalid target ateom UID")
-		}
+		})
+		wantInvalidArgument(t, "Run", err)
 	})
 	t.Run("Checkpoint", func(t *testing.T) {
-		if _, err := s.Checkpoint(ctx, &ateletpb.CheckpointRequest{
+		_, err := s.Checkpoint(ctx, &ateletpb.CheckpointRequest{
 			ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
 			TargetAteomUid: badUID, Spec: okSpec,
-		}); err == nil {
-			t.Error("Checkpoint accepted an invalid target ateom UID")
-		}
+		})
+		wantInvalidArgument(t, "Checkpoint", err)
 	})
 	t.Run("Restore", func(t *testing.T) {
-		if _, err := s.Restore(ctx, &ateletpb.RestoreRequest{
+		_, err := s.Restore(ctx, &ateletpb.RestoreRequest{
 			ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
 			TargetAteomUid: badUID, Spec: okSpec,
-		}); err == nil {
-			t.Error("Restore accepted an invalid target ateom UID")
-		}
+		})
+		wantInvalidArgument(t, "Restore", err)
 	})
 }

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -169,6 +169,75 @@ func TestValidateActorRequest(t *testing.T) {
 	}
 }
 
+func TestValidateSnapshotURIPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{"valid with trailing slash", "gs://bucket/actors/1234/snapshots/5678/", false},
+		{"valid without path", "gs://bucket", false},
+		// Scheme is storage-backend policy, not validated here.
+		{"valid alternate scheme", "s3://bucket/path", false},
+		{"empty", "", true},
+		{"missing bucket", "gs://", true},
+		{"no scheme or bucket", "bucket/path", true},
+		{"unparseable", "://bucket", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateSnapshotURIPrefix(tc.prefix); (err != nil) != tc.wantErr {
+				t.Errorf("validateSnapshotURIPrefix(%q) err = %v, wantErr %v", tc.prefix, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestPerRequestValidators pins the request-specific rules: Checkpoint and
+// Restore must reject a bad snapshot URI prefix even when every common field
+// is valid, and Run (which has no URI field) must accept the same common
+// fields.
+func TestPerRequestValidators(t *testing.T) {
+	const okNS, okTmpl, okID, okUID = "ate-demo", "counter", "counter-1", "422938ba-8860-4983-a25d-d6bcb0a69d4e"
+	okSpec := &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}}
+
+	if err := validateRunRequest(&ateletpb.RunRequest{
+		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+		TargetAteomUid: okUID, Spec: okSpec,
+	}); err != nil {
+		t.Errorf("validateRunRequest with valid fields: %v", err)
+	}
+
+	if err := validateCheckpointRequest(&ateletpb.CheckpointRequest{
+		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+		TargetAteomUid: okUID, Spec: okSpec,
+		SnapshotUriPrefix: "gs://bucket/actors/1/snapshots/2/",
+	}); err != nil {
+		t.Errorf("validateCheckpointRequest with valid fields: %v", err)
+	}
+	if err := validateCheckpointRequest(&ateletpb.CheckpointRequest{
+		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+		TargetAteomUid: okUID, Spec: okSpec,
+		SnapshotUriPrefix: "relative/path",
+	}); err == nil {
+		t.Error("validateCheckpointRequest accepted a bucketless snapshot URI prefix")
+	}
+
+	if err := validateRestoreRequest(&ateletpb.RestoreRequest{
+		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+		TargetAteomUid: okUID, Spec: okSpec,
+		SnapshotUriPrefix: "gs://bucket/actors/1/snapshots/2/",
+	}); err != nil {
+		t.Errorf("validateRestoreRequest with valid fields: %v", err)
+	}
+	if err := validateRestoreRequest(&ateletpb.RestoreRequest{
+		ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+		TargetAteomUid: okUID, Spec: okSpec,
+	}); err == nil {
+		t.Error("validateRestoreRequest accepted an empty snapshot URI prefix")
+	}
+}
+
 // TestFetchRunscRejectsBadHash confirms fetchRunsc validates the runsc hash
 // before the cache-hit os.Stat/early-return, not merely "at some point". To
 // prove the ordering, it plants a real file at the exact path an invalid hash

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/agent-substrate/substrate/internal/ateompath"
+	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
+)
+
+func TestValidateActorRef(t *testing.T) {
+	const okNS, okTmpl, okID = "ate-demo", "counter", "counter-1"
+
+	tests := []struct {
+		name         string
+		ns, tmpl, id string
+		wantErr      bool
+	}{
+		{"all valid", okNS, okTmpl, okID, false},
+		{"uuid id valid", okNS, okTmpl, "422938ba-8860-4983-a25d-d6bcb0a69d4e", false},
+
+		// Label vs subdomain distinction: template names are DNS-1123
+		// subdomains (dots allowed); namespaces and actor IDs are labels.
+		{"dotted template valid (subdomain)", okNS, "probe.v1", okID, false},
+		{"dotted namespace invalid (label)", "ate.demo", okTmpl, okID, true},
+		{"dotted id invalid (label)", okNS, okTmpl, "probe.alpha", true},
+
+		{"id traversal", okNS, okTmpl, "..", true},
+		{"id separator", okNS, okTmpl, "a/b", true},
+		{"id empty", okNS, okTmpl, "", true},
+		{"id uppercase", okNS, okTmpl, "Counter", true},
+		{"id too long", okNS, okTmpl, strings.Repeat("a", 64), true},
+
+		{"namespace separator", "a/b", okTmpl, okID, true},
+		{"namespace traversal", "..", okTmpl, okID, true},
+		{"namespace empty", "", okTmpl, okID, true},
+		{"template separator", okNS, "a/b", okID, true},
+		{"template traversal", okNS, "..", okID, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateActorRef(tc.ns, tc.tmpl, tc.id)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateActorRef(%q, %q, %q) err = %v, wantErr %v", tc.ns, tc.tmpl, tc.id, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAteomUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		uid     string
+		wantErr bool
+	}{
+		{"uuid valid", "422938ba-8860-4983-a25d-d6bcb0a69d4e", false},
+		{"separator", "a/b", true},
+		{"traversal", "..", true},
+		{"empty", "", true},
+		{"uppercase", "Pod-UID", true},
+		{"too long", strings.Repeat("a", 64), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateAteomUID(tc.uid); (err != nil) != tc.wantErr {
+				t.Errorf("validateAteomUID(%q) err = %v, wantErr %v", tc.uid, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateContainers(t *testing.T) {
+	spec := func(names ...string) *ateletpb.WorkloadSpec {
+		s := &ateletpb.WorkloadSpec{}
+		for _, n := range names {
+			s.Containers = append(s.Containers, &ateletpb.Container{Name: n})
+		}
+		return s
+	}
+
+	tests := []struct {
+		name    string
+		spec    *ateletpb.WorkloadSpec
+		wantErr bool
+	}{
+		{"no containers", spec(), false},
+		{"single valid", spec("worker"), false},
+		{"multiple valid", spec("worker", "sidecar"), false},
+		{"separator", spec("a/b"), true},
+		{"traversal", spec(".."), true},
+		{"empty name", spec(""), true},
+		{"uppercase", spec("Worker"), true},
+		{"reserved pause", spec("pause"), true},
+		{"reserved pause among valid", spec("worker", "pause"), true},
+		{"duplicate", spec("worker", "worker"), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateContainers(tc.spec); (err != nil) != tc.wantErr {
+				t.Errorf("validateContainers(%v) err = %v, wantErr %v", tc.spec, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRunscHash(t *testing.T) {
+	const valid = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	tests := []struct {
+		name    string
+		hash    string
+		wantErr bool
+	}{
+		{"valid lowercase", valid, false},
+		{"valid uppercase", strings.ToUpper(valid), false},
+		{"empty", "", true},
+		{"too short", "abc123", true},
+		{"too long", valid + "00", true},
+		{"separator", strings.Repeat("a", 60) + "/../", true},
+		{"non-hex", strings.Repeat("g", 64), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateRunscHash(tc.hash); (err != nil) != tc.wantErr {
+				t.Errorf("validateRunscHash(%q) err = %v, wantErr %v", tc.hash, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateActorRequest(t *testing.T) {
+	const okNS, okTmpl, okID, okUID = "ate-demo", "counter", "counter-1", "422938ba-8860-4983-a25d-d6bcb0a69d4e"
+	okSpec := &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}}
+
+	tests := []struct {
+		name              string
+		ns, tmpl, id, uid string
+		spec              *ateletpb.WorkloadSpec
+		wantErr           bool
+	}{
+		{"all valid", okNS, okTmpl, okID, okUID, okSpec, false},
+		{"bad namespace", "../x", okTmpl, okID, okUID, okSpec, true},
+		{"bad actor id", okNS, okTmpl, "../x", okUID, okSpec, true},
+		{"bad uid", okNS, okTmpl, okID, "../x", okSpec, true},
+		{"bad container", okNS, okTmpl, okID, okUID, &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "../x"}}}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateActorRequest(tc.ns, tc.tmpl, tc.id, tc.uid, tc.spec); (err != nil) != tc.wantErr {
+				t.Errorf("validateActorRequest err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestFetchRunscRejectsBadHash confirms fetchRunsc validates the runsc hash
+// before the cache-hit os.Stat/early-return, not merely "at some point". To
+// prove the ordering, it plants a real file at the exact path an invalid hash
+// resolves to: a correctly-ordered fetchRunsc validates first and returns an
+// error, while a regression that stats first would find this file and return it
+// with a nil error, failing the test. StaticFilesDir is redirected to a temp
+// dir so the planted path is writable and isolated. Both arch fields are set so
+// the test is independent of the host GOARCH.
+func TestFetchRunscRejectsBadHash(t *testing.T) {
+	orig := ateompath.StaticFilesDir
+	ateompath.StaticFilesDir = t.TempDir()
+	t.Cleanup(func() { ateompath.StaticFilesDir = orig })
+
+	// Invalid (8 chars, not 64) but separator-free, so it resolves to a normal
+	// filename inside the temp StaticFilesDir.
+	const badHash = "deadbeef"
+	if err := os.WriteFile(ateompath.RunSCBinaryPath(badHash), []byte("planted"), 0o755); err != nil {
+		t.Fatalf("planting cache file: %v", err)
+	}
+
+	s := &AteomHerder{}
+	bad := &ateletpb.RunscPlatformConfig{Sha256Hash: badHash}
+	cfg := &ateletpb.RunscConfig{Amd64: bad, Arm64: bad}
+
+	if _, err := s.fetchRunsc(context.Background(), cfg); err == nil {
+		t.Error("fetchRunsc returned a cache hit for an invalid hash; validation must run before the os.Stat early return")
+	}
+}
+
+// TestRPCBoundariesReject confirms each of the three RPCs validates path inputs
+// before touching its (here nil) dependencies. A traversal value must be
+// rejected with an error rather than panicking. Guards against a future
+// removal or reordering of the validation call at any boundary.
+func TestRPCBoundariesReject(t *testing.T) {
+	s := &AteomHerder{}
+	ctx := context.Background()
+	badUID := "../escape" // valid actor ref, invalid ateom UID
+	const okNS, okTmpl, okID = "ate-demo", "counter", "counter-1"
+	okSpec := &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}}
+
+	t.Run("Run", func(t *testing.T) {
+		if _, err := s.Run(ctx, &ateletpb.RunRequest{
+			ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+			TargetAteomUid: badUID, Spec: okSpec,
+		}); err == nil {
+			t.Error("Run accepted an invalid target ateom UID")
+		}
+	})
+	t.Run("Checkpoint", func(t *testing.T) {
+		if _, err := s.Checkpoint(ctx, &ateletpb.CheckpointRequest{
+			ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+			TargetAteomUid: badUID, Spec: okSpec,
+		}); err == nil {
+			t.Error("Checkpoint accepted an invalid target ateom UID")
+		}
+	})
+	t.Run("Restore", func(t *testing.T) {
+		if _, err := s.Restore(ctx, &ateletpb.RestoreRequest{
+			ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+			TargetAteomUid: badUID, Spec: okSpec,
+		}); err == nil {
+			t.Error("Restore accepted an invalid target ateom UID")
+		}
+	})
+}

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -17,132 +17,11 @@ package main
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 )
-
-func TestValidateActorRef(t *testing.T) {
-	const okNS, okTmpl, okID = "ate-demo", "counter", "counter-1"
-
-	tests := []struct {
-		name         string
-		ns, tmpl, id string
-		wantErr      bool
-	}{
-		{"all valid", okNS, okTmpl, okID, false},
-		{"uuid id valid", okNS, okTmpl, "422938ba-8860-4983-a25d-d6bcb0a69d4e", false},
-
-		// Label vs subdomain distinction: template names are DNS-1123
-		// subdomains (dots allowed); namespaces and actor IDs are labels.
-		{"dotted template valid (subdomain)", okNS, "probe.v1", okID, false},
-		{"dotted namespace invalid (label)", "ate.demo", okTmpl, okID, true},
-		{"dotted id invalid (label)", okNS, okTmpl, "probe.alpha", true},
-
-		{"id traversal", okNS, okTmpl, "..", true},
-		{"id separator", okNS, okTmpl, "a/b", true},
-		{"id empty", okNS, okTmpl, "", true},
-		{"id uppercase", okNS, okTmpl, "Counter", true},
-		{"id too long", okNS, okTmpl, strings.Repeat("a", 64), true},
-
-		{"namespace separator", "a/b", okTmpl, okID, true},
-		{"namespace traversal", "..", okTmpl, okID, true},
-		{"namespace empty", "", okTmpl, okID, true},
-		{"template separator", okNS, "a/b", okID, true},
-		{"template traversal", okNS, "..", okID, true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validateActorRef(tc.ns, tc.tmpl, tc.id)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("validateActorRef(%q, %q, %q) err = %v, wantErr %v", tc.ns, tc.tmpl, tc.id, err, tc.wantErr)
-			}
-		})
-	}
-}
-
-func TestValidateAteomUID(t *testing.T) {
-	tests := []struct {
-		name    string
-		uid     string
-		wantErr bool
-	}{
-		{"uuid valid", "422938ba-8860-4983-a25d-d6bcb0a69d4e", false},
-		{"separator", "a/b", true},
-		{"traversal", "..", true},
-		{"empty", "", true},
-		{"uppercase", "Pod-UID", true},
-		{"too long", strings.Repeat("a", 64), true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := validateAteomUID(tc.uid); (err != nil) != tc.wantErr {
-				t.Errorf("validateAteomUID(%q) err = %v, wantErr %v", tc.uid, err, tc.wantErr)
-			}
-		})
-	}
-}
-
-func TestValidateContainers(t *testing.T) {
-	spec := func(names ...string) *ateletpb.WorkloadSpec {
-		s := &ateletpb.WorkloadSpec{}
-		for _, n := range names {
-			s.Containers = append(s.Containers, &ateletpb.Container{Name: n})
-		}
-		return s
-	}
-
-	tests := []struct {
-		name    string
-		spec    *ateletpb.WorkloadSpec
-		wantErr bool
-	}{
-		{"no containers", spec(), false},
-		{"single valid", spec("worker"), false},
-		{"multiple valid", spec("worker", "sidecar"), false},
-		{"separator", spec("a/b"), true},
-		{"traversal", spec(".."), true},
-		{"empty name", spec(""), true},
-		{"uppercase", spec("Worker"), true},
-		{"reserved pause", spec("pause"), true},
-		{"reserved pause among valid", spec("worker", "pause"), true},
-		{"duplicate", spec("worker", "worker"), true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := validateContainers(tc.spec); (err != nil) != tc.wantErr {
-				t.Errorf("validateContainers(%v) err = %v, wantErr %v", tc.spec, err, tc.wantErr)
-			}
-		})
-	}
-}
-
-func TestValidateRunscHash(t *testing.T) {
-	const valid = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-
-	tests := []struct {
-		name    string
-		hash    string
-		wantErr bool
-	}{
-		{"valid lowercase", valid, false},
-		{"valid uppercase", strings.ToUpper(valid), false},
-		{"empty", "", true},
-		{"too short", "abc123", true},
-		{"too long", valid + "00", true},
-		{"separator", strings.Repeat("a", 60) + "/../", true},
-		{"non-hex", strings.Repeat("g", 64), true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := validateRunscHash(tc.hash); (err != nil) != tc.wantErr {
-				t.Errorf("validateRunscHash(%q) err = %v, wantErr %v", tc.hash, err, tc.wantErr)
-			}
-		})
-	}
-}
 
 func TestValidateActorRequest(t *testing.T) {
 	const okNS, okTmpl, okID, okUID = "ate-demo", "counter", "counter-1", "422938ba-8860-4983-a25d-d6bcb0a69d4e"
@@ -164,30 +43,6 @@ func TestValidateActorRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := validateActorRequest(tc.ns, tc.tmpl, tc.id, tc.uid, tc.spec); (err != nil) != tc.wantErr {
 				t.Errorf("validateActorRequest err = %v, wantErr %v", err, tc.wantErr)
-			}
-		})
-	}
-}
-
-func TestValidateSnapshotURIPrefix(t *testing.T) {
-	tests := []struct {
-		name    string
-		prefix  string
-		wantErr bool
-	}{
-		{"valid with trailing slash", "gs://bucket/actors/1234/snapshots/5678/", false},
-		{"valid without path", "gs://bucket", false},
-		// Scheme is storage-backend policy, not validated here.
-		{"valid alternate scheme", "s3://bucket/path", false},
-		{"empty", "", true},
-		{"missing bucket", "gs://", true},
-		{"no scheme or bucket", "bucket/path", true},
-		{"unparseable", "://bucket", true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := validateSnapshotURIPrefix(tc.prefix); (err != nil) != tc.wantErr {
-				t.Errorf("validateSnapshotURIPrefix(%q) err = %v, wantErr %v", tc.prefix, err, tc.wantErr)
 			}
 		})
 	}

--- a/internal/resources/validate.go
+++ b/internal/resources/validate.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// The validators in this file guard inputs that atelet turns into host
+// filesystem paths. atelet listens on an insecure hostPort, so any reachable
+// caller could otherwise smuggle a path separator or ".." through these
+// fields and make atelet read/RemoveAll/write outside the intended directory
+// tree, or collide OCI bundles. They are exported so the API server and
+// controller can apply the same rules at their own boundaries.
+
+// ValidateActorRef ensures every component of the per-actor directory tree is
+// a valid DNS-1123 name. namespace+template+actorID are concatenated by
+// ateompath.ActorPath into a host path on which atelet runs os.RemoveAll and
+// os.MkdirAll, so all three must be validated. Checking only one would still
+// leave a traversal window via the others. Template names are DNS-1123
+// subdomains (dots allowed); namespaces and actor IDs are labels.
+//
+// The actor ID rule here is DNS-1123 label, which matches ValidateActorID;
+// unifying the two implementations is tracked separately.
+func ValidateActorRef(namespace, template, actorID string) error {
+	if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
+		return fmt.Errorf("invalid namespace %q: %s", namespace, strings.Join(errs, "; "))
+	}
+	if errs := validation.IsDNS1123Subdomain(template); len(errs) > 0 {
+		return fmt.Errorf("invalid template %q: %s", template, strings.Join(errs, "; "))
+	}
+	if errs := validation.IsDNS1123Label(actorID); len(errs) > 0 {
+		return fmt.Errorf("invalid actor ID %q: %s", actorID, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// ValidateAteomUID rejects a target ateom pod UID that could escape the host
+// paths built from it: the netns path (/run/netns/ateom:<uid>) and the ateom
+// control socket (.../ateoms/<uid>/ateom.sock). Kubernetes pod UIDs are UUIDs,
+// which are valid DNS-1123 labels, so a label check accepts every legitimate
+// value while rejecting separators and "..".
+func ValidateAteomUID(targetAteomUID string) error {
+	if errs := validation.IsDNS1123Label(targetAteomUID); len(errs) > 0 {
+		return fmt.Errorf("invalid target ateom UID %q: %s", targetAteomUID, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// ValidateContainerNames ensures every application container name is safe to
+// use as an OCI bundle path component. Each must be a DNS-1123 label (no
+// separator or ".."), must not be the reserved "pause" name (which would
+// collide with the sandbox-infra bundle and race its concurrent writer), and
+// must be unique (duplicates map to the same bundle path and corrupt each
+// other).
+func ValidateContainerNames(names []string) error {
+	seen := make(map[string]struct{})
+	for _, name := range names {
+		if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
+			return fmt.Errorf("invalid container name %q: %s", name, strings.Join(errs, "; "))
+		}
+		if name == "pause" {
+			return fmt.Errorf("invalid container name %q: reserved for sandbox infrastructure", name)
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("duplicate container name %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+// ValidateRunscHash ensures the runsc SHA-256 hash is exactly 64 hex
+// characters before it is used to build the on-disk binary path
+// (static-files/runsc-<hash>) and, on a cache hit, returned for ateom to
+// execute. Without this, a hash containing path separators or ".." could
+// point the cache-hit early return (and the download target) at an arbitrary
+// binary outside the static-files dir.
+func ValidateRunscHash(sha256Hash string) error {
+	if len(sha256Hash) != 64 {
+		return fmt.Errorf("invalid runsc sha256 hash: want 64 hex chars, got %d", len(sha256Hash))
+	}
+	// Same decoder atelet's digest comparison uses.
+	if _, err := hex.DecodeString(sha256Hash); err != nil {
+		return fmt.Errorf("invalid runsc sha256 hash %q: must be hex", sha256Hash)
+	}
+	return nil
+}
+
+// ValidateSnapshotURIPrefix ensures a checkpoint/restore snapshot location is
+// a well-formed URI with a bucket, so a bad prefix fails fast at the RPC
+// boundary instead of deep inside an object-storage call. It deliberately
+// does not restrict the scheme: the storage layer only uses the host (bucket)
+// and path, and which schemes are acceptable is a storage-backend policy, not
+// a per-RPC one. The local paths used for snapshot upload/download are
+// derived from the separately validated actor ref, not from this URI, so this
+// is a sanity check rather than a path-traversal guard.
+func ValidateSnapshotURIPrefix(prefix string) error {
+	u, err := url.Parse(prefix)
+	if err != nil {
+		return fmt.Errorf("invalid snapshot URI prefix %q: %v", prefix, err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid snapshot URI prefix %q: missing bucket", prefix)
+	}
+	return nil
+}

--- a/internal/resources/validate.go
+++ b/internal/resources/validate.go
@@ -49,6 +49,13 @@ func ValidateActorRef(namespace, template, actorID string) error {
 	if errs := validation.IsDNS1123Label(actorID); len(errs) > 0 {
 		return fmt.Errorf("invalid actor ID %q: %s", actorID, strings.Join(errs, "; "))
 	}
+	// The three names are joined into a single path component
+	// (<namespace>:<template>:<actorID>, see ateompath.ActorPath), which must
+	// fit the 255-byte filename limit of common filesystems. Individually
+	// valid DNS names can exceed it: 63 + 253 + 63 plus separators is 381.
+	if n := len(namespace) + 1 + len(template) + 1 + len(actorID); n > 255 {
+		return fmt.Errorf("actor ref %s:%s:%s is %d bytes; the combined path component must be at most 255", namespace, template, actorID, n)
+	}
 	return nil
 }
 
@@ -119,6 +126,13 @@ func ValidateSnapshotURIPrefix(prefix string) error {
 	}
 	if u.Host == "" {
 		return fmt.Errorf("invalid snapshot URI prefix %q: missing bucket", prefix)
+	}
+	// Object names are appended to the prefix by string concatenation. A
+	// query, fragment, or userinfo component would swallow the appended name
+	// when the result is re-parsed (the storage layer uses only host and
+	// path), silently redirecting the upload/download to a different object.
+	if u.Opaque != "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("invalid snapshot URI prefix %q: must contain only a scheme, bucket, and path", prefix)
 	}
 	return nil
 }

--- a/internal/resources/validate_test.go
+++ b/internal/resources/validate_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateActorRef(t *testing.T) {
+	const okNS, okTmpl, okID = "ate-demo", "counter", "counter-1"
+
+	tests := []struct {
+		name         string
+		ns, tmpl, id string
+		wantErr      bool
+	}{
+		{"all valid", okNS, okTmpl, okID, false},
+		{"uuid id valid", okNS, okTmpl, "422938ba-8860-4983-a25d-d6bcb0a69d4e", false},
+
+		// Label vs subdomain distinction: template names are DNS-1123
+		// subdomains (dots allowed); namespaces and actor IDs are labels.
+		{"dotted template valid (subdomain)", okNS, "probe.v1", okID, false},
+		{"dotted namespace invalid (label)", "ate.demo", okTmpl, okID, true},
+		{"dotted id invalid (label)", okNS, okTmpl, "probe.alpha", true},
+
+		{"id traversal", okNS, okTmpl, "..", true},
+		{"id separator", okNS, okTmpl, "a/b", true},
+		{"id empty", okNS, okTmpl, "", true},
+		{"id uppercase", okNS, okTmpl, "Counter", true},
+		{"id too long", okNS, okTmpl, strings.Repeat("a", 64), true},
+
+		{"namespace separator", "a/b", okTmpl, okID, true},
+		{"namespace traversal", "..", okTmpl, okID, true},
+		{"namespace empty", "", okTmpl, okID, true},
+		{"template separator", okNS, "a/b", okID, true},
+		{"template traversal", okNS, "..", okID, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateActorRef(tt.ns, tt.tmpl, tt.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateActorRef(%q, %q, %q) err = %v, wantErr %v", tt.ns, tt.tmpl, tt.id, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAteomUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		uid     string
+		wantErr bool
+	}{
+		{"uuid valid", "422938ba-8860-4983-a25d-d6bcb0a69d4e", false},
+		{"separator", "a/b", true},
+		{"traversal", "..", true},
+		{"empty", "", true},
+		{"uppercase", "Pod-UID", true},
+		{"too long", strings.Repeat("a", 64), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateAteomUID(tt.uid); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAteomUID(%q) err = %v, wantErr %v", tt.uid, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateContainerNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		names   []string
+		wantErr bool
+	}{
+		{"no containers", nil, false},
+		{"single valid", []string{"worker"}, false},
+		{"multiple valid", []string{"worker", "sidecar"}, false},
+		{"separator", []string{"a/b"}, true},
+		{"traversal", []string{".."}, true},
+		{"empty name", []string{""}, true},
+		{"uppercase", []string{"Worker"}, true},
+		{"reserved pause", []string{"pause"}, true},
+		{"reserved pause among valid", []string{"worker", "pause"}, true},
+		{"duplicate", []string{"worker", "worker"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateContainerNames(tt.names); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateContainerNames(%v) err = %v, wantErr %v", tt.names, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRunscHash(t *testing.T) {
+	const valid = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	tests := []struct {
+		name    string
+		hash    string
+		wantErr bool
+	}{
+		{"valid lowercase", valid, false},
+		{"valid uppercase", strings.ToUpper(valid), false},
+		{"empty", "", true},
+		{"too short", "abc123", true},
+		{"too long", valid + "00", true},
+		{"separator", strings.Repeat("a", 60) + "/../", true},
+		{"non-hex", strings.Repeat("g", 64), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateRunscHash(tt.hash); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRunscHash(%q) err = %v, wantErr %v", tt.hash, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateSnapshotURIPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{"valid with trailing slash", "gs://bucket/actors/1234/snapshots/5678/", false},
+		{"valid without path", "gs://bucket", false},
+		// Scheme is storage-backend policy, not validated here.
+		{"valid alternate scheme", "s3://bucket/path", false},
+		{"empty", "", true},
+		{"missing bucket", "gs://", true},
+		{"no scheme or bucket", "bucket/path", true},
+		{"unparseable", "://bucket", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateSnapshotURIPrefix(tt.prefix); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSnapshotURIPrefix(%q) err = %v, wantErr %v", tt.prefix, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/resources/validate_test.go
+++ b/internal/resources/validate_test.go
@@ -47,6 +47,11 @@ func TestValidateActorRef(t *testing.T) {
 		{"namespace empty", "", okTmpl, okID, true},
 		{"template separator", okNS, "a/b", okID, true},
 		{"template traversal", okNS, "..", okID, true},
+
+		// The names join into one <ns>:<tmpl>:<id> path component, capped at
+		// 255 bytes even when each name is individually valid.
+		{"combined fits filename limit", strings.Repeat("a", 63), strings.Repeat("b", 120), strings.Repeat("c", 63), false},
+		{"combined exceeds filename limit", strings.Repeat("a", 63), strings.Repeat("b", 253), strings.Repeat("c", 63), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -145,6 +150,13 @@ func TestValidateSnapshotURIPrefix(t *testing.T) {
 		{"missing bucket", "gs://", true},
 		{"no scheme or bucket", "bucket/path", true},
 		{"unparseable", "://bucket", true},
+		// Appended object names must not be swallowed by URL components.
+		{"query", "gs://bucket/path?x=1", true},
+		{"fragment", "gs://bucket/path#frag", true},
+		{"userinfo", "gs://user@bucket/path", true},
+		// Opaque form (no //) parses with an empty host, so it is rejected
+		// on either the bucket or the opaque check.
+		{"opaque", "gs:bucket/path", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #202

atelet's gRPC server runs on an unauthenticated hostPort
(`manifests/ate-install/atelet.yaml`), so its `Run`/`Restore`/`Checkpoint`
RPCs must treat every request field as untrusted. Several of those fields
are turned into host filesystem paths and then deleted, created, written,
or executed, none of them validated first. A caller that can reach the
port can smuggle a path separator or `..` through them and make atelet
operate outside the intended actor tree.

### Unvalidated inputs (each an independent escape route)
- **`actor_template_namespace` / `name` / `id`** are concatenated by
  `ateompath.ActorPath` into the per-actor dir that `resetActorDirs` runs
  `os.RemoveAll` / `os.MkdirAll` on.
- **`target_ateom_uid`** builds the netns path (`/run/netns/ateom:<uid>`)
  and the ateom control socket (`.../ateoms/<uid>/ateom.sock`).
- **`spec.containers[].name`** becomes an OCI bundle path component
  (`os.RemoveAll` / `MkdirAll` / `config.json` write).
- **`runsc.sha256_hash`** builds `static-files/runsc-<hash>`. The cache-hit
  `os.Stat` early return hands that path to ateom to **execute** before the
  existing hex check runs, so an escaped path could execute an arbitrary
  on-disk binary as the sandbox runtime.

### Where the validators live
The field rules are exported from **`internal/resources`**
(`ValidateActorRef`, `ValidateAteomUID`, `ValidateContainerNames`,
`ValidateRunscHash`, `ValidateSnapshotURIPrefix`), alongside the existing
`ValidateActorID`. Every one of these values originates upstream in
user-supplied API/CRD data (the runsc hash and snapshot location come from
the `ActorTemplate` spec), so the API server and controller can apply the
same rules at admission time instead of failing at actor-activation time.
`ValidateContainerNames` takes names rather than the atelet proto so
`resources` stays proto-free. Unifying `ValidateActorID` with
`ValidateActorRef` is deferred: it changes ate-api-server's client-facing
error responses.

The per-RPC glue stays in `cmd/atelet`: each of `Run`/`Checkpoint`/`Restore`
calls its own typed validator (`validateRunRequest` etc.) as the first
statement at the boundary, before any path is constructed.

### What is validated
- namespace and actor ID as DNS-1123 labels, template as a DNS-1123
  subdomain, matching how these are named; additionally the combined
  `<ns>:<tmpl>:<id>` path component is capped at 255 bytes, since
  individually valid DNS names can join to 381 bytes, over common
  filesystems' filename limit;
- `target_ateom_uid` as a DNS-1123 label (pod UIDs are UUIDs, which
  qualify);
- each container name as a DNS-1123 label, additionally rejecting the
  reserved name `pause` (collides with the sandbox-infra bundle and races
  its concurrent writer) and duplicate names (same bundle path, mutual
  corruption);
- `runsc.sha256_hash` as exactly 64 hex chars, checked in `fetchRunsc`
  before the path is built and before the cache-hit early return;
- `snapshot_uri_prefix` (Checkpoint/Restore) as a parseable URI naming a
  bucket, with query/fragment/userinfo rejected: object names are appended
  by concatenation and the storage layer re-parses using only host and
  path, so those components would silently redirect the upload/download to
  a different object. The scheme is deliberately not restricted; that is
  storage-backend policy.

Validation failures return `codes.InvalidArgument` with the reason.
Previously the interceptor surfaced them as `codes.Internal` with the
message masked as "internal server error".

DNS-1123 is a deliberate fit. These values already *are* Kubernetes names,
so every legitimate value passes, while the charset forbids `/`, `.` (for
labels), and `..`, which is exactly what enables traversal. For a
cooperating caller the change is behavior-neutral: inputs newly rejected
previously failed later or misbehaved silently.

### Testing
- Table tests for each validator in `internal/resources`, targeting the
  exported functions (valid values, separators, `..`, empty, case, length,
  the label-vs-subdomain distinction, the combined-length cap, the
  `pause`/duplicate rules, and the URI component rejections).
- Per-request validator tests in `cmd/atelet` pin which rules each RPC
  enforces, one table per validator.
- `TestRPCBoundariesReject` exercises `Run`/`Checkpoint`/`Restore` directly
  and asserts a traversal value is rejected with `InvalidArgument`, which
  guards against future removal or reordering of the validation call.
- `TestFetchRunscRejectsBadHash` plants a real cache file at the path an
  invalid hash resolves to and asserts `fetchRunsc` still errors. It passes
  with the current code and fails if validation is moved after the
  `os.Stat` early return, so it proves the ordering rather than just that
  validation runs.

- [x] Tests pass
- [x] No documentation changes needed
