### PR TITLE
Allow tag-based ActorTemplate images

### DIFF
--- a/cmd/atelet/internal/ategcs/gcs.go
+++ b/cmd/atelet/internal/ategcs/gcs.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 
 	"cloud.google.com/go/storage"
 )
@@ -32,7 +33,14 @@ func NewGCSClient(client *storage.Client) ObjectStorage {
 }
 
 func (g *gcsClient) GetObject(ctx context.Context, bucket, object string) (io.ReadCloser, error) {
-	return g.client.Bucket(bucket).Object(object).NewReader(ctx)
+	rc, err := g.client.Bucket(bucket).Object(object).NewReader(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return nil, fmt.Errorf("%w: %w", fs.ErrNotExist, err)
+		}
+		return nil, err
+	}
+	return rc, nil
 }
 
 func (g *gcsClient) PutObject(ctx context.Context, bucket, object string, reader io.Reader) error {

--- a/cmd/atelet/internal/ategcs/objects.go
+++ b/cmd/atelet/internal/ategcs/objects.go
@@ -15,6 +15,7 @@
 package ategcs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -55,6 +56,17 @@ func FetchFromGCS(ctx context.Context, client ObjectStorage, gsURL string) ([]by
 	}
 
 	return content, nil
+}
+
+func SendBytesToGCS(ctx context.Context, client ObjectStorage, gsURL string, content []byte) error {
+	bucket, object, err := parseGCSURL(gsURL)
+	if err != nil {
+		return fmt.Errorf("while parsing URL: %w", err)
+	}
+	if err := client.PutObject(ctx, bucket, object, bytes.NewReader(content)); err != nil {
+		return fmt.Errorf("while putting object: %w", err)
+	}
+	return nil
 }
 
 func SendLocalFileToGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL string, localFilePath string) (err error) {

--- a/cmd/atelet/internal/ategcs/s3.go
+++ b/cmd/atelet/internal/ategcs/s3.go
@@ -16,10 +16,14 @@ package ategcs
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 )
 
 type s3Client struct {
@@ -36,6 +40,10 @@ func (s *s3Client) GetObject(ctx context.Context, bucket, object string) (io.Rea
 		Key:    aws.String(object),
 	})
 	if err != nil {
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchKey" {
+			return nil, fmt.Errorf("%w: %w", fs.ErrNotExist, err)
+		}
 		return nil, err
 	}
 	return output.Body, nil

--- a/cmd/atelet/internal/memorypullcache/memorypullcache.go
+++ b/cmd/atelet/internal/memorypullcache/memorypullcache.go
@@ -42,6 +42,11 @@ type MemoryPullCache struct {
 	cache *lru.Cache
 }
 
+type PullResult struct {
+	RootFSTar   io.ReadCloser
+	ResolvedRef string
+}
+
 func NewMemoryPullCache(ctx context.Context, gcpAuthenticator authn.Authenticator, localhostRegistryReplacement string) (*MemoryPullCache, error) {
 	c := &MemoryPullCache{
 		// TODO: Need a smarter cache with bounds on total consumed size, not
@@ -65,10 +70,11 @@ func NewMemoryPullCache(ctx context.Context, gcpAuthenticator authn.Authenticato
 	return c, nil
 }
 
-func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (io.ReadCloser, error) {
+func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (*PullResult, error) {
 	// when running in kind we need to rewrite the registry endpoint similar to the
 	// containerd mirror config used in https://kind.sigs.k8s.io/docs/user/local-registry/
 	// for now we have simple opt-in support to rewrite local registries
+	originalRef := ref
 	rewritten := false
 	if c.localhostRegistryReplacement != "" {
 		newRef := c.rewriteLocalRegistry(ref)
@@ -82,6 +88,11 @@ func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (io.ReadCloser,
 	// this avoids needing to distribute TLS certs all around for local development
 	if rewritten || isLocalRegistry(ref) {
 		nameOpts = append(nameOpts, name.Insecure)
+	}
+
+	originalParsedRef, err := name.ParseReference(originalRef, nameOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("while parsing original reference: %w", err)
 	}
 
 	parsedRef, err := name.ParseReference(ref, nameOpts...)
@@ -106,7 +117,10 @@ func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (io.ReadCloser,
 				slog.String("ref", ref),
 				slog.String("digest", requestedDigest.DigestStr()),
 			)
-			return io.NopCloser(bytes.NewReader(vAny.([]byte))), nil
+			return &PullResult{
+				RootFSTar:   io.NopCloser(bytes.NewReader(vAny.([]byte))),
+				ResolvedRef: originalParsedRef.String(),
+			}, nil
 		}
 	}
 
@@ -144,6 +158,10 @@ func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (io.ReadCloser,
 	if err != nil {
 		return nil, fmt.Errorf("in remote.Image: %w", err)
 	}
+	resolvedRef, resolvedDigest, err := resolvedImageRef(originalParsedRef, img, digestWasIncluded)
+	if err != nil {
+		return nil, err
+	}
 
 	size, err := img.Size()
 	if err != nil {
@@ -155,7 +173,7 @@ func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (io.ReadCloser,
 			slog.String("ref", ref),
 			slog.Int64("size", size),
 		)
-		return mutate.Extract(img), err
+		return &PullResult{RootFSTar: mutate.Extract(img), ResolvedRef: resolvedRef}, err
 	}
 
 	tarData := mutate.Extract(img)
@@ -178,9 +196,31 @@ func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (io.ReadCloser,
 			slog.String("ref", ref),
 			slog.String("digest", requestedDigest.DigestStr()),
 		)
+	} else if resolvedDigest != "" {
+		c.cache.Add(resolvedDigest, memData)
+		slog.InfoContext(
+			ctx,
+			"Populated image cache",
+			slog.String("ref", ref),
+			slog.String("digest", resolvedDigest),
+		)
 	}
 
-	return io.NopCloser(bytes.NewReader(memData)), nil
+	return &PullResult{
+		RootFSTar:   io.NopCloser(bytes.NewReader(memData)),
+		ResolvedRef: resolvedRef,
+	}, nil
+}
+
+func resolvedImageRef(parsedRef name.Reference, img v1.Image, digestWasIncluded bool) (string, string, error) {
+	if digestWasIncluded {
+		return parsedRef.String(), "", nil
+	}
+	digest, err := img.Digest()
+	if err != nil {
+		return "", "", fmt.Errorf("in img.Digest(): %w", err)
+	}
+	return parsedRef.Context().Digest(digest.String()).String(), digest.String(), nil
 }
 
 func registryHost(ref string) string {

--- a/cmd/atelet/internal/memorypullcache/memorypullcache_test.go
+++ b/cmd/atelet/internal/memorypullcache/memorypullcache_test.go
@@ -16,6 +16,9 @@ package memorypullcache
 
 import (
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 )
 
 func TestIsLocalRegistry(t *testing.T) {
@@ -46,6 +49,62 @@ func TestIsLocalRegistry(t *testing.T) {
 				t.Errorf("isLocalRegistry(%q) = %v; want %v", tt.ref, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolvedImageRef(t *testing.T) {
+	tagRef, err := name.ParseReference("example.com/repo/app:latest")
+	if err != nil {
+		t.Fatalf("ParseReference(tag): %v", err)
+	}
+	gotRef, gotDigest, err := resolvedImageRef(tagRef, empty.Image, false)
+	if err != nil {
+		t.Fatalf("resolvedImageRef(tag): %v", err)
+	}
+	wantDigest, err := empty.Image.Digest()
+	if err != nil {
+		t.Fatalf("empty.Image.Digest: %v", err)
+	}
+	if gotDigest != wantDigest.String() {
+		t.Errorf("digest = %q, want %q", gotDigest, wantDigest.String())
+	}
+	if gotRef != "example.com/repo/app@"+wantDigest.String() {
+		t.Errorf("resolved ref = %q, want %q", gotRef, "example.com/repo/app@"+wantDigest.String())
+	}
+
+	digestRef, err := name.ParseReference("example.com/repo/app@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("ParseReference(digest): %v", err)
+	}
+	gotRef, gotDigest, err = resolvedImageRef(digestRef, empty.Image, true)
+	if err != nil {
+		t.Fatalf("resolvedImageRef(digest): %v", err)
+	}
+	if gotRef != digestRef.String() {
+		t.Errorf("resolved pinned ref = %q, want %q", gotRef, digestRef.String())
+	}
+	if gotDigest != "" {
+		t.Errorf("resolved pinned digest cache key = %q, want empty", gotDigest)
+	}
+}
+
+func TestResolvedImageRefUsesOriginalRepositoryAfterLocalRewrite(t *testing.T) {
+	originalRef, err := name.ParseReference("localhost:5001/repo/app:latest", name.Insecure)
+	if err != nil {
+		t.Fatalf("ParseReference(original): %v", err)
+	}
+
+	gotRef, _, err := resolvedImageRef(originalRef, empty.Image, false)
+	if err != nil {
+		t.Fatalf("resolvedImageRef: %v", err)
+	}
+	wantDigest, err := empty.Image.Digest()
+	if err != nil {
+		t.Fatalf("empty.Image.Digest: %v", err)
+	}
+	wantRef := "localhost:5001/repo/app@" + wantDigest.String()
+	if gotRef != wantRef {
+		t.Errorf("resolved ref = %q, want %q", gotRef, wantRef)
 	}
 }
 

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -29,6 +29,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"cloud.google.com/go/storage"
 	"github.com/agent-substrate/substrate/cmd/atelet/internal/ategcs"
@@ -300,10 +301,14 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
-	if err := s.prepareOCIBundles(ctx,
+	manifest, err := s.prepareOCIBundles(ctx,
 		req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(),
 		req.GetSpec(), req.GetTargetAteomUid(),
-	); err != nil {
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeActorSnapshotManifest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), manifest); err != nil {
 		return nil, err
 	}
 
@@ -373,7 +378,21 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, err
 	}
 
-	checkpointDir := ateompath.CheckpointStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
+	checkpointDir := ateompath.CheckpointStateDir(ns, tmpl, actorID)
+
+	manifest, err := readActorSnapshotManifest(ns, tmpl, actorID)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		if !workloadSpecImagesPinned(req.GetSpec()) {
+			return nil, fmt.Errorf("snapshot manifest is missing for %s/%s actor %s, and the checkpoint request contains unpinned image refs", ns, tmpl, actorID)
+		}
+		// Legacy actor fallback: before snapshot manifests existed, pinned
+		// image refs were the only supported restore contract.
+		manifest = manifestFromPinnedWorkloadSpec(req.GetSpec())
+	}
 
 	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
 	if err != nil {
@@ -391,15 +410,13 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, fmt.Errorf("while calling ateom.CheckpointWorkload: %w", err)
 	}
 
-	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
-
 	switch req.GetType() {
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL:
-		if err := s.uploadExternalCheckpoint(ctx, req, checkpointDir); err != nil {
+		if err := s.uploadExternalCheckpoint(ctx, req, checkpointDir, manifest); err != nil {
 			return nil, err
 		}
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-		if err := s.moveLocalCheckpoint(ctx, req, checkpointDir); err != nil {
+		if err := s.moveLocalCheckpoint(ctx, req, checkpointDir, manifest); err != nil {
 			return nil, err
 		}
 	default:
@@ -413,7 +430,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	return &ateletpb.CheckpointResponse{}, nil
 }
 
-func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string) error {
+func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string, manifest *snapshotManifest) error {
 	localCheckpointPath := filepath.Join(ateompath.LocalCheckpointsDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()), req.GetLocalConfig().GetSnapshotPrefix())
 	if err := os.MkdirAll(localCheckpointPath, 0o700); err != nil {
 		return fmt.Errorf("while creating local checkpoint directory: %w", err)
@@ -431,10 +448,14 @@ func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.Che
 		}
 	}
 
+	if err := writeSnapshotManifestFile(filepath.Join(localCheckpointPath, snapshotManifestFile), manifest); err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string) error {
+func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string, manifest *snapshotManifest) error {
 	ns, tmpl := req.GetActorTemplateNamespace(), req.GetActorTemplateName()
 	prefix := strings.TrimSuffix(req.GetExternalConfig().GetSnapshotUriPrefix(), "/")
 
@@ -466,6 +487,10 @@ func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletp
 	); err != nil {
 		return err
 	}
+
+	if err := uploadSnapshotManifest(ctx, s.gcsClient, prefix, manifest); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -486,24 +511,59 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	}
 
 	checkpointDir := ateompath.RestoreStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	var (
+		manifest         *snapshotManifest
+		manifestFound    bool
+		manifestLocation string
+	)
 	switch req.GetType() {
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL:
-		if err := s.downloadExternalCheckpoint(ctx, req.GetExternalConfig().GetSnapshotUriPrefix(), checkpointDir); err != nil {
+		prefix := strings.TrimSuffix(req.GetExternalConfig().GetSnapshotUriPrefix(), "/")
+		if err := s.downloadExternalCheckpoint(ctx, prefix, checkpointDir); err != nil {
+			return nil, err
+		}
+		manifestLocation = prefix + "/" + snapshotManifestFile
+		manifest, manifestFound, err = fetchSnapshotManifest(ctx, s.gcsClient, prefix)
+		if err != nil {
 			return nil, err
 		}
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
 		// TODO(dberkov): the old pause checkpoint files are not deleted after they are copied to checkpointDir. This needs to be fixed in following PR.
 		localCheckpointDir := ateompath.LocalCheckpointsDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
-		if err := s.copyLocalCheckpoint(ctx, req.GetLocalConfig().GetSnapshotPrefix(), localCheckpointDir, checkpointDir); err != nil {
+		snapshotPrefix := req.GetLocalConfig().GetSnapshotPrefix()
+		if err := s.copyLocalCheckpoint(ctx, snapshotPrefix, localCheckpointDir, checkpointDir); err != nil {
 			return nil, err
+		}
+		manifestLocation = filepath.Join(localCheckpointDir, snapshotPrefix, snapshotManifestFile)
+		manifest, err = readSnapshotManifestFile(manifestLocation)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, err
+			}
+		} else {
+			manifestFound = true
 		}
 	default:
 		return nil, fmt.Errorf("unexpected checkpoint type: %v", req.GetType())
 	}
 
-	if err := s.prepareOCIBundles(ctx, ns, tmpl, actorID,
-		req.GetSpec(), req.GetTargetAteomUid(),
-	); err != nil {
+	restoreSpec := req.GetSpec()
+	if manifestFound {
+		restoreSpec, err = applySnapshotManifest(req.GetSpec(), manifest)
+		if err != nil {
+			return nil, err
+		}
+	} else if !workloadSpecImagesPinned(req.GetSpec()) {
+		return nil, fmt.Errorf("snapshot manifest is missing at %s, and the restore request contains unpinned image refs", manifestLocation)
+	}
+
+	manifest, err = s.prepareOCIBundles(ctx, ns, tmpl, actorID,
+		restoreSpec, req.GetTargetAteomUid(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeActorSnapshotManifest(ns, tmpl, actorID, manifest); err != nil {
 		return nil, err
 	}
 
@@ -519,7 +579,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		ActorTemplateName:      tmpl,
 		ActorId:                actorID,
 		RunscPath:              runscPath,
-		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
+		Spec:                   buildAteomWorkloadSpec(restoreSpec),
 	}); err != nil {
 		return nil, fmt.Errorf("while calling ateom.RestoreWorkload: %w", err)
 	}
@@ -615,7 +675,7 @@ func (s *AteomHerder) prepareOCIBundles(
 	actorTemplateNamespace, actorTemplateName, actorID string,
 	spec *ateletpb.WorkloadSpec,
 	targetAteomUid string,
-) error {
+) (*snapshotManifest, error) {
 	netnsPath := ateompath.AteomNetNSPath(targetAteomUid)
 
 	// Populate the per-actor identity directory that gets bind-mounted into
@@ -623,17 +683,29 @@ func (s *AteomHerder) prepareOCIBundles(
 	// the correct per-actor ID even when restoring from the golden snapshot.
 	identityDir := ateompath.ActorIdentityDirPath(actorTemplateNamespace, actorTemplateName, actorID)
 	if err := os.MkdirAll(identityDir, 0o755); err != nil {
-		return fmt.Errorf("while creating actor identity dir: %w", err)
+		return nil, fmt.Errorf("while creating actor identity dir: %w", err)
 	}
 	if err := writeFileAtomic(filepath.Join(identityDir, ActorIDFileName), []byte(actorID), 0o644); err != nil {
-		return fmt.Errorf("while writing actor identity file: %w", err)
+		return nil, fmt.Errorf("while writing actor identity file: %w", err)
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)
+	manifest := &snapshotManifest{Version: snapshotManifestVersion}
+	var manifestMu sync.Mutex
+
+	addImage := func(name, originalRef, resolvedRef string) {
+		manifestMu.Lock()
+		defer manifestMu.Unlock()
+		manifest.Images = append(manifest.Images, snapshotManifestImage{
+			Name:        name,
+			OriginalRef: originalRef,
+			ResolvedRef: resolvedRef,
+		})
+	}
 
 	// Pause container.
 	g.Go(func() error {
-		if err := prepareOCIDirectory(
+		resolvedRef, err := prepareOCIDirectory(
 			gCtx,
 			s.pullCache,
 			actorTemplateNamespace, actorTemplateName, actorID,
@@ -647,9 +719,11 @@ func (s *AteomHerder) prepareOCIBundles(
 			},
 			netnsPath,
 			"", // pause is sandbox infra; it gets no actor identity mount.
-		); err != nil {
+		)
+		if err != nil {
 			return fmt.Errorf("while creating pause OCI bundle: %w", err)
 		}
+		addImage("pause", spec.GetPauseImage(), resolvedRef)
 		return nil
 	})
 
@@ -661,7 +735,7 @@ func (s *AteomHerder) prepareOCIBundles(
 			envs = append(envs, fmt.Sprintf("%s=%s", env.GetName(), env.GetValue()))
 		}
 		g.Go(func() error {
-			if err := prepareOCIDirectory(
+			resolvedRef, err := prepareOCIDirectory(
 				gCtx,
 				s.pullCache,
 				actorTemplateNamespace, actorTemplateName, actorID,
@@ -676,14 +750,19 @@ func (s *AteomHerder) prepareOCIBundles(
 				},
 				netnsPath,
 				identityDir,
-			); err != nil {
+			)
+			if err != nil {
 				return fmt.Errorf("while creating %q OCI bundle: %w", ctr.GetName(), err)
 			}
+			addImage(ctr.GetName(), ctr.GetImage(), resolvedRef)
 			return nil
 		})
 	}
 
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return manifest, nil
 }
 
 // dialAteom opens (or reuses) the gRPC connection to the target ateom

--- a/cmd/atelet/oci.go
+++ b/cmd/atelet/oci.go
@@ -51,7 +51,7 @@ const (
 	ActorIDFileName = "actor-id"
 )
 
-func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryPullCache, actorTemplateNamespace, actorTemplateName, actorID, containerName, ref string, args []string, env []string, annotations map[string]string, netns string, identityDir string) error {
+func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryPullCache, actorTemplateNamespace, actorTemplateName, actorID, containerName, ref string, args []string, env []string, annotations map[string]string, netns string, identityDir string) (string, error) {
 	tracer := otel.Tracer("prepareOCIDirectory")
 
 	ctx, span := tracer.Start(ctx, "prepareOCIDirectory")
@@ -62,21 +62,22 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 	rootPath := path.Join(bundlePath, "rootfs")
 
 	if err := os.RemoveAll(rootPath); err != nil {
-		return fmt.Errorf("while clearing rootfs %q: %w", rootPath, err)
+		return "", fmt.Errorf("while clearing rootfs %q: %w", rootPath, err)
 	}
 
 	if err := os.MkdirAll(rootPath, 0o700); err != nil {
-		return fmt.Errorf("in os.MkdirAll for container bundle dir: %w", err)
+		return "", fmt.Errorf("in os.MkdirAll for container bundle dir: %w", err)
 	}
 
-	tarData, err := pullCache.Fetch(ctx, ref)
+	pullResult, err := pullCache.Fetch(ctx, ref)
 	if err != nil {
-		return fmt.Errorf("in pullCache.Fetch: %w", err)
+		return "", fmt.Errorf("in pullCache.Fetch: %w", err)
 	}
+	tarData := pullResult.RootFSTar
 	defer tarData.Close()
 
 	if err := untar(ctx, tarData, rootPath); err != nil {
-		return fmt.Errorf("in untar: %w", err)
+		return "", fmt.Errorf("in untar: %w", err)
 	}
 
 	// Bind-mount the per-actor identity directory so the workload can read its
@@ -84,21 +85,21 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 	// in the rootfs for the mount to attach.
 	if identityDir != "" {
 		if err := createMountPoint(rootPath, IdentityMountPath); err != nil {
-			return fmt.Errorf("while creating identity mount point: %w", err)
+			return "", fmt.Errorf("while creating identity mount point: %w", err)
 		}
 	}
 
 	ociSpec := buildActorOCISpec(args, env, annotations, netns, identityDir)
 	ociSpecBytes, err := json.MarshalIndent(ociSpec, "", "  ")
 	if err != nil {
-		return fmt.Errorf("while marshaling OCI spec: %w", err)
+		return "", fmt.Errorf("while marshaling OCI spec: %w", err)
 	}
 	specPath := path.Join(bundlePath, "config.json")
 	if err := os.WriteFile(specPath, ociSpecBytes, 0o600); err != nil {
-		return fmt.Errorf("while writing OCI spec: %w", err)
+		return "", fmt.Errorf("while writing OCI spec: %w", err)
 	}
 
-	return nil
+	return pullResult.ResolvedRef, nil
 }
 
 // buildActorOCISpec assembles the OCI runtime spec for an actor container.

--- a/cmd/atelet/snapshot_manifest.go
+++ b/cmd/atelet/snapshot_manifest.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/agent-substrate/substrate/cmd/atelet/internal/ategcs"
+	"github.com/agent-substrate/substrate/internal/ateompath"
+	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	snapshotManifestFile    = "snapshot-manifest.json"
+	snapshotManifestVersion = 1
+)
+
+type snapshotManifest struct {
+	Version int                     `json:"version"`
+	Images  []snapshotManifestImage `json:"images"`
+}
+
+type snapshotManifestImage struct {
+	Name        string `json:"name"`
+	OriginalRef string `json:"originalRef"`
+	ResolvedRef string `json:"resolvedRef"`
+}
+
+func actorSnapshotManifestPath(actorTemplateNamespace, actorTemplateName, actorID string) string {
+	return filepath.Join(ateompath.ActorPath(actorTemplateNamespace, actorTemplateName, actorID), snapshotManifestFile)
+}
+
+func writeActorSnapshotManifest(actorTemplateNamespace, actorTemplateName, actorID string, manifest *snapshotManifest) error {
+	return writeSnapshotManifestFile(actorSnapshotManifestPath(actorTemplateNamespace, actorTemplateName, actorID), manifest)
+}
+
+func readActorSnapshotManifest(actorTemplateNamespace, actorTemplateName, actorID string) (*snapshotManifest, error) {
+	return readSnapshotManifestFile(actorSnapshotManifestPath(actorTemplateNamespace, actorTemplateName, actorID))
+}
+
+func writeSnapshotManifestFile(path string, manifest *snapshotManifest) error {
+	if manifest == nil {
+		return nil
+	}
+	manifestBytes, err := marshalSnapshotManifest(manifest)
+	if err != nil {
+		return fmt.Errorf("while marshaling snapshot manifest: %w", err)
+	}
+	if err := os.WriteFile(path, manifestBytes, 0o600); err != nil {
+		return fmt.Errorf("while writing snapshot manifest: %w", err)
+	}
+	return nil
+}
+
+func readSnapshotManifestFile(path string) (*snapshotManifest, error) {
+	manifestBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return parseSnapshotManifest(manifestBytes)
+}
+
+func uploadSnapshotManifest(ctx context.Context, client ategcs.ObjectStorage, prefix string, manifest *snapshotManifest) error {
+	manifestBytes, err := marshalSnapshotManifest(manifest)
+	if err != nil {
+		return fmt.Errorf("while marshaling snapshot manifest: %w", err)
+	}
+	if err := ategcs.SendBytesToGCS(ctx, client, strings.TrimSuffix(prefix, "/")+"/"+snapshotManifestFile, manifestBytes); err != nil {
+		return fmt.Errorf("while uploading snapshot manifest: %w", err)
+	}
+	return nil
+}
+
+func fetchSnapshotManifest(ctx context.Context, client ategcs.ObjectStorage, prefix string) (*snapshotManifest, bool, error) {
+	manifestBytes, err := ategcs.FetchFromGCS(ctx, client, strings.TrimSuffix(prefix, "/")+"/"+snapshotManifestFile)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("while fetching snapshot manifest: %w", err)
+	}
+	manifest, err := parseSnapshotManifest(manifestBytes)
+	if err != nil {
+		return nil, false, err
+	}
+	return manifest, true, nil
+}
+
+func marshalSnapshotManifest(manifest *snapshotManifest) ([]byte, error) {
+	manifestCopy := *manifest
+	manifestCopy.Images = append([]snapshotManifestImage(nil), manifest.Images...)
+	sort.Slice(manifestCopy.Images, func(i, j int) bool {
+		return manifestCopy.Images[i].Name < manifestCopy.Images[j].Name
+	})
+	return json.MarshalIndent(&manifestCopy, "", "  ")
+}
+
+func parseSnapshotManifest(manifestBytes []byte) (*snapshotManifest, error) {
+	var manifest snapshotManifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, fmt.Errorf("while parsing snapshot manifest: %w", err)
+	}
+	if manifest.Version != snapshotManifestVersion {
+		return nil, fmt.Errorf("unsupported snapshot manifest version %d", manifest.Version)
+	}
+	for _, image := range manifest.Images {
+		if image.Name == "" {
+			return nil, fmt.Errorf("snapshot manifest contains image with empty name")
+		}
+		if image.ResolvedRef == "" {
+			return nil, fmt.Errorf("snapshot manifest image %q has empty resolvedRef", image.Name)
+		}
+	}
+	return &manifest, nil
+}
+
+func manifestFromPinnedWorkloadSpec(spec *ateletpb.WorkloadSpec) *snapshotManifest {
+	manifest := &snapshotManifest{
+		Version: snapshotManifestVersion,
+		Images: []snapshotManifestImage{{
+			Name:        "pause",
+			OriginalRef: spec.GetPauseImage(),
+			ResolvedRef: spec.GetPauseImage(),
+		}},
+	}
+	for _, ctr := range spec.GetContainers() {
+		manifest.Images = append(manifest.Images, snapshotManifestImage{
+			Name:        ctr.GetName(),
+			OriginalRef: ctr.GetImage(),
+			ResolvedRef: ctr.GetImage(),
+		})
+	}
+	return manifest
+}
+
+func applySnapshotManifest(spec *ateletpb.WorkloadSpec, manifest *snapshotManifest) (*ateletpb.WorkloadSpec, error) {
+	if manifest == nil {
+		return spec, nil
+	}
+	byName := make(map[string]snapshotManifestImage, len(manifest.Images))
+	for _, image := range manifest.Images {
+		byName[image.Name] = image
+	}
+
+	out := cloneWorkloadSpec(spec)
+	pause, ok := byName["pause"]
+	if !ok {
+		return nil, fmt.Errorf("snapshot manifest is missing pause image")
+	}
+	out.PauseImage = pause.ResolvedRef
+
+	for _, ctr := range out.Containers {
+		image, ok := byName[ctr.GetName()]
+		if !ok {
+			return nil, fmt.Errorf("snapshot manifest is missing container image %q", ctr.GetName())
+		}
+		ctr.Image = image.ResolvedRef
+	}
+	return out, nil
+}
+
+func cloneWorkloadSpec(spec *ateletpb.WorkloadSpec) *ateletpb.WorkloadSpec {
+	return proto.Clone(spec).(*ateletpb.WorkloadSpec)
+}
+
+func workloadSpecImagesPinned(spec *ateletpb.WorkloadSpec) bool {
+	if !strings.Contains(spec.GetPauseImage(), "@") {
+		return false
+	}
+	for _, ctr := range spec.GetContainers() {
+		if !strings.Contains(ctr.GetImage(), "@") {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/atelet/snapshot_manifest_test.go
+++ b/cmd/atelet/snapshot_manifest_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
+)
+
+func TestApplySnapshotManifest(t *testing.T) {
+	spec := &ateletpb.WorkloadSpec{
+		PauseImage: "registry.k8s.io/pause:3.10.2",
+		Containers: []*ateletpb.Container{{
+			Name:    "main",
+			Image:   "busybox:latest",
+			Command: []string{"sleep", "1"},
+			Env: []*ateletpb.EnvEntry{{
+				Name:  "A",
+				Value: "B",
+			}},
+		}},
+	}
+	manifest := &snapshotManifest{
+		Version: snapshotManifestVersion,
+		Images: []snapshotManifestImage{{
+			Name:        "pause",
+			OriginalRef: "registry.k8s.io/pause:3.10.2",
+			ResolvedRef: "registry.k8s.io/pause@sha256:pause",
+		}, {
+			Name:        "main",
+			OriginalRef: "busybox:latest",
+			ResolvedRef: "index.docker.io/library/busybox@sha256:main",
+		}},
+	}
+
+	got, err := applySnapshotManifest(spec, manifest)
+	if err != nil {
+		t.Fatalf("applySnapshotManifest: %v", err)
+	}
+	if got.GetPauseImage() != "registry.k8s.io/pause@sha256:pause" {
+		t.Errorf("pause image = %q", got.GetPauseImage())
+	}
+	if got.GetContainers()[0].GetImage() != "index.docker.io/library/busybox@sha256:main" {
+		t.Errorf("container image = %q", got.GetContainers()[0].GetImage())
+	}
+	if spec.GetContainers()[0].GetImage() != "busybox:latest" {
+		t.Errorf("applySnapshotManifest mutated input spec image to %q", spec.GetContainers()[0].GetImage())
+	}
+	if got.GetContainers()[0].GetCommand()[0] != "sleep" || got.GetContainers()[0].GetEnv()[0].GetValue() != "B" {
+		t.Errorf("applySnapshotManifest did not preserve non-image fields: %+v", got.GetContainers()[0])
+	}
+}
+
+func TestApplySnapshotManifestRequiresEveryImage(t *testing.T) {
+	spec := &ateletpb.WorkloadSpec{
+		PauseImage: "pause:latest",
+		Containers: []*ateletpb.Container{{Name: "main", Image: "busybox:latest"}},
+	}
+	manifest := &snapshotManifest{
+		Version: snapshotManifestVersion,
+		Images: []snapshotManifestImage{{
+			Name:        "pause",
+			OriginalRef: "pause:latest",
+			ResolvedRef: "pause@sha256:pause",
+		}},
+	}
+
+	if _, err := applySnapshotManifest(spec, manifest); err == nil {
+		t.Fatalf("applySnapshotManifest succeeded with missing container image")
+	}
+}
+
+func TestWorkloadSpecImagesPinned(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *ateletpb.WorkloadSpec
+		want bool
+	}{{
+		name: "all pinned",
+		spec: &ateletpb.WorkloadSpec{
+			PauseImage: "pause@sha256:pause",
+			Containers: []*ateletpb.Container{{Name: "main", Image: "busybox@sha256:main"}},
+		},
+		want: true,
+	}, {
+		name: "tagged pause",
+		spec: &ateletpb.WorkloadSpec{
+			PauseImage: "pause:latest",
+			Containers: []*ateletpb.Container{{Name: "main", Image: "busybox@sha256:main"}},
+		},
+		want: false,
+	}, {
+		name: "tagged container",
+		spec: &ateletpb.WorkloadSpec{
+			PauseImage: "pause@sha256:pause",
+			Containers: []*ateletpb.Container{{Name: "main", Image: "busybox:latest"}},
+		},
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workloadSpecImagesPinned(tt.spec); got != tt.want {
+				t.Errorf("workloadSpecImagesPinned() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSnapshotManifestRoundTripSortsImages(t *testing.T) {
+	manifest := &snapshotManifest{
+		Version: snapshotManifestVersion,
+		Images: []snapshotManifestImage{{
+			Name:        "z",
+			OriginalRef: "z:latest",
+			ResolvedRef: "z@sha256:z",
+		}, {
+			Name:        "pause",
+			OriginalRef: "pause:latest",
+			ResolvedRef: "pause@sha256:pause",
+		}, {
+			Name:        "a",
+			OriginalRef: "a:latest",
+			ResolvedRef: "a@sha256:a",
+		}},
+	}
+
+	manifestBytes, err := marshalSnapshotManifest(manifest)
+	if err != nil {
+		t.Fatalf("marshalSnapshotManifest: %v", err)
+	}
+	gotJSON := string(manifestBytes)
+	if !(strings.Index(gotJSON, `"name": "a"`) < strings.Index(gotJSON, `"name": "pause"`) &&
+		strings.Index(gotJSON, `"name": "pause"`) < strings.Index(gotJSON, `"name": "z"`)) {
+		t.Fatalf("manifest images were not sorted by name:\n%s", gotJSON)
+	}
+
+	got, err := parseSnapshotManifest(manifestBytes)
+	if err != nil {
+		t.Fatalf("parseSnapshotManifest: %v", err)
+	}
+	if len(got.Images) != 3 || got.Images[0].Name != "a" || got.Images[1].Name != "pause" || got.Images[2].Name != "z" {
+		t.Fatalf("round-tripped images = %+v", got.Images)
+	}
+}
+
+func TestParseSnapshotManifestValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{{
+		name: "unsupported version",
+		json: `{"version":2,"images":[]}`,
+	}, {
+		name: "empty image name",
+		json: `{"version":1,"images":[{"name":"","resolvedRef":"busybox@sha256:abc"}]}`,
+	}, {
+		name: "empty resolved ref",
+		json: `{"version":1,"images":[{"name":"main","resolvedRef":""}]}`,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseSnapshotManifest([]byte(tt.json)); err == nil {
+				t.Fatalf("parseSnapshotManifest succeeded")
+			}
+		})
+	}
+}
+
+type missingObjectStorage struct{}
+
+func (missingObjectStorage) GetObject(ctx context.Context, bucket, object string) (io.ReadCloser, error) {
+	return nil, fs.ErrNotExist
+}
+
+func (missingObjectStorage) PutObject(ctx context.Context, bucket, object string, reader io.Reader) error {
+	return nil
+}
+
+type brokenObjectStorage struct{}
+
+func (brokenObjectStorage) GetObject(ctx context.Context, bucket, object string) (io.ReadCloser, error) {
+	return nil, errors.New("permission denied")
+}
+
+func (brokenObjectStorage) PutObject(ctx context.Context, bucket, object string, reader io.Reader) error {
+	return nil
+}
+
+func TestFetchSnapshotManifestNotFound(t *testing.T) {
+	manifest, found, err := fetchSnapshotManifest(context.Background(), missingObjectStorage{}, "gs://bucket/snapshot")
+	if err != nil {
+		t.Fatalf("fetchSnapshotManifest: %v", err)
+	}
+	if found || manifest != nil {
+		t.Fatalf("fetchSnapshotManifest found = %v, manifest = %+v; want missing", found, manifest)
+	}
+}
+
+func TestFetchSnapshotManifestPropagatesRealErrors(t *testing.T) {
+	if _, _, err := fetchSnapshotManifest(context.Background(), brokenObjectStorage{}, "gs://bucket/snapshot"); err == nil {
+		t.Fatalf("fetchSnapshotManifest succeeded on non-not-found error")
+	}
+}

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -80,6 +80,10 @@ The `ActorTemplate` defines the code, environment, and state-management policies
 | `pauseImage` | `string` | **Required.** The image used for the sandbox root (e.g. `gcr.io/gke-release/pause`). |
 | `runsc` | `RunscConfig` | **Required.** Multi-platform configuration for fetching the gVisor binary. |
 
+ActorTemplate images may be tag-based or digest-pinned. When atelet pulls an
+image to create or restore a workload, it records the resolved digest reference
+with the snapshot and uses that resolved reference for later restores.
+
 Container environment variables support literal `value` entries and `valueFrom.secretKeyRef`. Secret references are resolved by `ate-api-server` from the `ActorTemplate` namespace when a workload spec is materialized. For the golden actor, the resolved values are captured in the golden snapshot and future actors inherit those values until the golden snapshot is recreated. For an actor that bypasses the golden snapshot and boots from the current template spec, the resolved values are sent to atelet but are not serialized into the public Actor API. Other Kubernetes `valueFrom` sources are not supported yet. Secret changes do not automatically restart actors or invalidate snapshots; rotating a Secret requires an explicit actor or template lifecycle action.
 
 ### Workload Connectivity (Uniform DNS)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
+	github.com/aws/smithy-go v1.25.1
 	github.com/envoyproxy/go-control-plane v0.14.0
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
 	github.com/google/go-cmp v0.7.0
@@ -76,7 +77,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
-	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/manifests/ate-install/generated/ate.dev_actortemplates.yaml
+++ b/manifests/ate-install/generated/ate.dev_actortemplates.yaml
@@ -137,10 +137,6 @@ spec:
                     image:
                       description: Image to use for the worker replicas.
                       type: string
-                      x-kubernetes-validations:
-                      - message: All images must be pinned (changing the image invalidates
-                          snapshots)
-                        rule: self.contains('@')
                     name:
                       description: Name of the container.
                       maxLength: 63
@@ -148,6 +144,8 @@ spec:
                       x-kubernetes-validations:
                       - message: Name must be a valid DNS label
                         rule: '!format.dns1123Label().validate(self).hasValue()'
+                      - message: Name 'pause' is reserved for sandbox infrastructure
+                        rule: self != 'pause'
                   required:
                   - image
                   - name
@@ -163,10 +161,6 @@ spec:
                     - [1] gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da
                     - [2] registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4
                 type: string
-                x-kubernetes-validations:
-                - message: All images must be pinned (changing the image invalidates
-                    snapshots)
-                  rule: self.contains('@')
               runsc:
                 description: Parameters for fetching the runsc binary to use.
                 properties:

--- a/pkg/api/v1alpha1/actortemplate_types.go
+++ b/pkg/api/v1alpha1/actortemplate_types.go
@@ -37,12 +37,12 @@ type Container struct {
 	// +required
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:XValidation:rule="!format.dns1123Label().validate(self).hasValue()",message="Name must be a valid DNS label"
+	// +kubebuilder:validation:XValidation:rule="self != 'pause'",message="Name 'pause' is reserved for sandbox infrastructure"
 	Name string `json:"name"`
 
 	// Image to use for the worker replicas.
 	//
 	// +required
-	// +kubebuilder:validation:XValidation:rule="self.contains('@')",message="All images must be pinned (changing the image invalidates snapshots)"
 	Image string `json:"image,omitempty"`
 
 	// Entrypoint array. Not executed within a shell.
@@ -144,7 +144,6 @@ type ActorTemplateSpec struct {
 	//   - [2] registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4
 	//
 	// +required
-	// +kubebuilder:validation:XValidation:rule="self.contains('@')",message="All images must be pinned (changing the image invalidates snapshots)"
 	PauseImage string `json:"pauseImage,omitempty"`
 
 	// Containers is the workload definition.

--- a/pkg/api/v1alpha1/actortemplate_validation_test.go
+++ b/pkg/api/v1alpha1/actortemplate_validation_test.go
@@ -124,12 +124,11 @@ func TestActorTemplateValidation(t *testing.T) {
 		wantErr: true,
 		errMsg:  "Required value",
 	}, {
-		name: "unpinned PauseImage",
+		name: "tagged PauseImage",
 		mutate: func(at *ActorTemplate) {
-			at.Spec.PauseImage = "pause"
+			at.Spec.PauseImage = "pause:latest"
 		},
-		wantErr: true,
-		errMsg:  "All images must be pinned",
+		wantErr: false,
 	}, {
 		name: "missing SnapshotsConfig.Location",
 		mutate: func(at *ActorTemplate) {
@@ -183,6 +182,13 @@ func TestActorTemplateValidation(t *testing.T) {
 		wantErr: true,
 		errMsg:  "must be a valid DNS label",
 	}, {
+		name: "reserved container name pause",
+		mutate: func(at *ActorTemplate) {
+			at.Spec.Containers[0].Name = "pause"
+		},
+		wantErr: true,
+		errMsg:  "reserved for sandbox infrastructure",
+	}, {
 		name: "empty container Image",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.Containers[0].Image = ""
@@ -190,12 +196,11 @@ func TestActorTemplateValidation(t *testing.T) {
 		wantErr: true,
 		errMsg:  "Required value",
 	}, {
-		name: "unpinned container Image",
+		name: "tagged container Image",
 		mutate: func(at *ActorTemplate) {
-			at.Spec.Containers[0].Image = "busybox"
+			at.Spec.Containers[0].Image = "busybox:latest"
 		},
-		wantErr: true,
-		errMsg:  "All images must be pinned",
+		wantErr: false,
 	}, {
 		name: "valid container Command",
 		mutate: func(at *ActorTemplate) {


### PR DESCRIPTION
## Summary

Fixes #223.

- relax ActorTemplate image validation so tags are accepted
- persist resolved digest image refs in a versioned `snapshot-manifest.json`
- restore snapshots using manifest-pinned image refs instead of re-resolving current tags
- normalize object-storage missing-object errors for manifest fallback handling
- reserve workload container name `pause` at the API level because atelet uses it for sandbox infrastructure

## Testing

- `go test ./cmd/atelet ./internal/memorypullcache ./pkg/api/v1alpha1`
- `GOCACHE=$PWD/.cache/gocache hack/update/go-generate.sh`
- `hack/verify/crd-chart.sh`
- `git diff --check`

Full `go test ./...` was not clean in this sandbox: default run hit `NO_COLOR`-sensitive color tests; rerun with `NO_COLOR` unset and `GOCACHE=/tmp/substrate-go-cache` then failed on sandbox-restricted local TCP listeners (`socket: operation not permitted`) and `setup-envtest`.