### PR TITLE
Propagate ctx into memorypullcache image pulls

### DIFF
--- a/internal/memorypullcache/memorypullcache.go
+++ b/internal/memorypullcache/memorypullcache.go
@@ -121,10 +121,17 @@ func (c *MemoryPullCache) Fetch(ctx context.Context, ref string) (io.ReadCloser,
 	// trips to the registry.
 
 	var remoteOptions []remote.Option
-	remoteOptions = append(remoteOptions, remote.WithPlatform(v1.Platform{
-		Architecture: runtime.GOARCH,
-		OS:           "linux",
-	}))
+	remoteOptions = append(remoteOptions,
+		// Propagate caller ctx into go-containerregistry so cancellation tears
+		// down in-flight layer-blob HTTP requests instead of letting them run
+		// to completion in background goroutines (which retain partial-blob
+		// buffers and amplify atelet RSS during ResumeActor death loops).
+		remote.WithContext(ctx),
+		remote.WithPlatform(v1.Platform{
+			Architecture: runtime.GOARCH,
+			OS:           "linux",
+		}),
+	)
 
 	registry := parsedRef.Context().Registry.RegistryStr()
 	if registry == "gcr.io" || strings.HasSuffix(registry, ".gcr.io") || registry == "pkg.dev" || strings.HasSuffix(registry, ".pkg.dev") {


### PR DESCRIPTION
Fixes #230.

## Summary

`remote.Image` in `internal/memorypullcache/memorypullcache.go` was being called without `remote.WithContext`, so cancellation of the caller's ctx (e.g. when `ActorWorkflow.ResumeActor` hits its 28s deadline at `cmd/ateapi/internal/controlapi/workflow.go:145`) did not stop the in-flight layer-blob HTTP requests. The goroutines kept running until the TCP connection was torn down, retaining partial-blob buffers in the meantime.

On a death loop of `ResumeActor` retries against a large image, this amplifies atelet RSS proportionally to the loop duration — observed peaking at ~9.4GB on a kind node where baseline atelet was ~2.4GB, enough to OOM atelet on tight production workers and take every other actor on that worker down with it.

This PR only addresses the leak (Bug B in #230). The 28s workflow-deadline bug (Bug A) — which is what produces the death loops in the first place — is a separate, larger change and will land in a follow-up PR.

## Test plan

- [x] `go test ./internal/memorypullcache/... -count=1` — 29 passed
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [ ] Manual repro from `bin/repro.md` shows atelet RSS no longer climbs during the death loop (TODO: rerun on this branch and attach a before/after RSS chart in a follow-up comment)