### PR TITLE
fix: Allow large image pulls to succeed by decoupling workflow deadline from lock TTL via heartbeat

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -310,7 +310,7 @@ func setupTest(t *testing.T, ns string) *testContext {
 	}
 
 	dialer := NewAteletDialer(workerInformer.GetIndexer(), ateletInformer.GetIndexer())
-	service := NewService(persistence, wc, actorTemplateLister, workerPoolLister, sandboxConfigLister, dialer, k8sClient)
+	service := NewService(persistence, wc, actorTemplateLister, workerPoolLister, sandboxConfigLister, dialer, k8sClient, 30*time.Second)
 
 	// 5. Start REAL gRPC Server for ATE API
 	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(ateinterceptors.ServerUnaryInterceptor))

--- a/cmd/ateapi/internal/controlapi/service.go
+++ b/cmd/ateapi/internal/controlapi/service.go
@@ -15,6 +15,8 @@
 package controlapi
 
 import (
+	"time"
+
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
@@ -34,7 +36,8 @@ type Service struct {
 
 var _ ateapipb.ControlServer = (*Service)(nil)
 
-// NewService creates a service.
+// NewService creates a service. actorWorkflowDeadline bounds how long a single
+// Resume/Suspend workflow can run end-to-end.
 func NewService(
 	persistence store.Interface,
 	workerCache *workercache.Cache,
@@ -43,13 +46,14 @@ func NewService(
 	sandboxConfigLister listersv1alpha1.SandboxConfigLister,
 	dialer *AteletDialer,
 	kubeClient kubernetes.Interface,
+	actorWorkflowDeadline time.Duration,
 ) *Service {
 	s := &Service{
 		persistence:         persistence,
 		actorTemplateLister: actorTemplateLister,
 		workerPoolLister:    workerPoolLister,
 		dialer:              dialer,
-		actorWorkflow:       NewActorWorkflow(persistence, workerCache, dialer, actorTemplateLister, workerPoolLister, sandboxConfigLister, kubeClient),
+		actorWorkflow:       NewActorWorkflow(persistence, workerCache, dialer, actorTemplateLister, workerPoolLister, sandboxConfigLister, kubeClient, actorWorkflowDeadline),
 	}
 
 	return s

--- a/cmd/ateapi/internal/controlapi/workflow.go
+++ b/cmd/ateapi/internal/controlapi/workflow.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
@@ -32,6 +33,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
+
+// actorLockTTL is the Redis TTL on the per-actor workflow lock. It bounds how
+// long a peer must wait to retry an actor after this process crashes mid-workflow.
+const actorLockTTL = 30 * time.Second
+
+// actorLockHeartbeatInterval is how often the heartbeat refreshes the lock.
+// Chosen so we get ~3 attempts before the TTL would otherwise lapse.
+const actorLockHeartbeatInterval = actorLockTTL / 3
+
+// errLostActorLock is the context cause set when the heartbeat can no longer
+// keep the actor lock alive (peer stole it, or Redis returned an error).
+var errLostActorLock = errors.New("lost actor lock during workflow")
 
 // WorkflowStep represents a single, idempotent operation in a workflow graph.
 // Params is the immutable parameters used to start the workflow.
@@ -123,9 +136,14 @@ type ActorWorkflow struct {
 	sandboxConfigLister listersv1alpha1.SandboxConfigLister
 	kubeClient          kubernetes.Interface
 	secretCache         *envSecretCache
+	// workflowDeadline is the maximum duration of a single Resume/Suspend
+	// workflow. The lock is kept alive across this duration by a heartbeat,
+	// independent of actorLockTTL.
+	workflowDeadline time.Duration
 }
 
-// NewActorWorkflow creates a new ActorWorkflow.
+// NewActorWorkflow creates a new ActorWorkflow. workflowDeadline bounds how
+// long a single Resume/Suspend can run end-to-end.
 func NewActorWorkflow(
 	store store.Interface,
 	workerCache *workercache.Cache,
@@ -134,6 +152,7 @@ func NewActorWorkflow(
 	workerPoolLister listersv1alpha1.WorkerPoolLister,
 	sandboxConfigLister listersv1alpha1.SandboxConfigLister,
 	kubeClient kubernetes.Interface,
+	workflowDeadline time.Duration,
 ) *ActorWorkflow {
 	return &ActorWorkflow{
 		store:               store,
@@ -144,6 +163,7 @@ func NewActorWorkflow(
 		sandboxConfigLister: sandboxConfigLister,
 		kubeClient:          kubeClient,
 		secretCache:         newEnvSecretCache(envSecretCacheTTL),
+		workflowDeadline:    workflowDeadline,
 	}
 }
 
@@ -156,9 +176,7 @@ func (w *ActorWorkflow) ResumeActor(ctx context.Context, atespace, name string, 
 	}
 	state := &ResumeState{}
 
-	// Acquire lock and get the timeout context for the workflow
-	// Lock TTL is 30 seconds, with 2 seconds padding for workflow timeout
-	ctx, releaseLock, err := w.acquireActorLock(ctx, atespace, name, 30*time.Second, 2*time.Second)
+	ctx, releaseLock, err := w.acquireActorLock(ctx, atespace, name, actorLockTTL, actorLockHeartbeatInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -186,9 +204,7 @@ func (w *ActorWorkflow) SuspendActor(ctx context.Context, atespace, name string)
 	}
 	state := &SuspendState{}
 
-	// Acquire lock and get the timeout context for the workflow
-	// Lock TTL is 30 seconds, with 2 seconds padding for workflow timeout
-	ctx, releaseLock, err := w.acquireActorLock(ctx, atespace, name, 30*time.Second, 2*time.Second)
+	ctx, releaseLock, err := w.acquireActorLock(ctx, atespace, name, actorLockTTL, actorLockHeartbeatInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -216,9 +232,7 @@ func (w *ActorWorkflow) PauseActor(ctx context.Context, atespace, name string) (
 	}
 	state := &PauseState{}
 
-	// Acquire lock and get the timeout context for the workflow
-	// Lock TTL is 30 seconds, with 2 seconds padding for workflow timeout
-	ctx, releaseLock, err := w.acquireActorLock(ctx, atespace, name, 30*time.Second, 2*time.Second)
+	ctx, releaseLock, err := w.acquireActorLock(ctx, atespace, name, actorLockTTL, actorLockHeartbeatInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -238,27 +252,72 @@ func (w *ActorWorkflow) PauseActor(ctx context.Context, atespace, name string) (
 	return state.Actor, nil
 }
 
-func (w *ActorWorkflow) acquireActorLock(ctx context.Context, atespace, name string, ttl time.Duration, padding time.Duration) (context.Context, func(), error) {
-	lockKey := "lock:actor:" + atespace + ":" + name
+// acquireActorLock takes the per-actor workflow lock and returns a workflow
+// context bounded by w.workflowDeadline. A background heartbeat keeps the lock
+// alive — independent of lockTTL — for as long as the workflow runs. If the
+// heartbeat fails (Redis error or another peer stole the lock) the returned
+// context is cancelled with errLostActorLock as the cause, and in-flight steps
+// will see ctx.Err() and unwind. The returned release function stops the
+// heartbeat, waits for it to exit, then best-effort releases the lock.
+func (w *ActorWorkflow) acquireActorLock(ctx context.Context, atespace, name string, lockTTL, heartbeatInterval time.Duration) (context.Context, func(), error) {
+	actorID := atespace + ":" + name
+	lockKey := "lock:actor:" + actorID
 	lockValue := uuid.New().String()
 
-	// Create a child context for the workflow that expires BEFORE the lock
-	workflowTimeout := ttl - padding
-	workflowCtx, cancel := context.WithTimeout(ctx, workflowTimeout)
-
-	acquired, err := w.store.AcquireLock(workflowCtx, lockKey, lockValue, ttl)
+	acquired, err := w.store.AcquireLock(ctx, lockKey, lockValue, lockTTL)
 	if err != nil {
-		cancel()
 		return nil, nil, fmt.Errorf("while acquiring lock: %w", err)
 	}
 	if !acquired {
-		cancel()
 		return nil, nil, status.Error(grpcCodes.Aborted, "another operation is in progress for this actor")
 	}
 
-	return workflowCtx, func() {
-		cancel()
+	cancellableCtx, cancelCause := context.WithCancelCause(ctx)
+	workflowCtx, cancelDeadline := context.WithTimeout(cancellableCtx, w.workflowDeadline)
+
+	heartbeatDone := make(chan struct{})
+	go w.runLockHeartbeat(workflowCtx, lockKey, lockValue, actorID, lockTTL, heartbeatInterval, cancelCause, heartbeatDone)
+
+	release := func() {
+		cancelDeadline()
+		cancelCause(context.Canceled)
+		<-heartbeatDone
 		// Use context.Background() to ensure the lock is released even if the workflow context was canceled.
 		w.store.ReleaseLock(context.Background(), lockKey, lockValue) //nolint:errcheck // best-effort release; the lock TTL is the safety net.
-	}, nil
+	}
+	return workflowCtx, release, nil
+}
+
+// runLockHeartbeat refreshes the actor lock on a ticker until ctx is done. If
+// a refresh fails or returns false (we no longer own the lock), it cancels the
+// workflow context with errLostActorLock so workflow steps tear down promptly.
+func (w *ActorWorkflow) runLockHeartbeat(ctx context.Context, lockKey, lockValue, actorID string, lockTTL, heartbeatInterval time.Duration, cancelCause context.CancelCauseFunc, done chan<- struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ok, err := w.store.RefreshLock(ctx, lockKey, lockValue, lockTTL)
+			if err != nil {
+				// If ctx was cancelled out from under us we're already tearing
+				// down — no need to set a misleading cause.
+				if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+					slog.WarnContext(ctx, "Lock heartbeat failed; cancelling workflow",
+						slog.String("actor_id", actorID),
+						slog.String("err", err.Error()))
+					cancelCause(fmt.Errorf("%w: %w", errLostActorLock, err))
+				}
+				return
+			}
+			if !ok {
+				slog.WarnContext(ctx, "Actor lock no longer owned; cancelling workflow",
+					slog.String("actor_id", actorID))
+				cancelCause(errLostActorLock)
+				return
+			}
+		}
+	}
 }

--- a/cmd/ateapi/internal/controlapi/workflow_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/ateredis"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newLockTestWorkflow(t *testing.T) (*miniredis.Miniredis, *ActorWorkflow) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rdb := redis.NewClusterClient(&redis.ClusterOptions{Addrs: []string{mr.Addr()}})
+	return mr, &ActorWorkflow{
+		store:            ateredis.NewPersistence(rdb),
+		workflowDeadline: 30 * time.Second,
+	}
+}
+
+func TestAcquireActorLock_HeartbeatKeepsLockAlivePastTTL(t *testing.T) {
+	mr, w := newLockTestWorkflow(t)
+
+	lockTTL := 150 * time.Millisecond
+	heartbeat := 40 * time.Millisecond
+
+	ctx, release, err := w.acquireActorLock(context.Background(), "ns", "actor-1", lockTTL, heartbeat)
+	if err != nil {
+		t.Fatalf("acquireActorLock: %v", err)
+	}
+	defer release()
+
+	// Wait through multiple TTLs. If the heartbeat is working the lock key
+	// must still be in Redis — its TTL is being PEXPIRE'd back to `lockTTL`
+	// every `heartbeat`.
+	time.Sleep(4 * lockTTL)
+
+	if !mr.Exists("lock:actor:ns:actor-1") {
+		t.Fatalf("lock key disappeared from Redis despite heartbeat; ctx err=%v cause=%v", ctx.Err(), context.Cause(ctx))
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("workflow ctx cancelled while heartbeat was healthy: err=%v cause=%v", ctx.Err(), context.Cause(ctx))
+	}
+}
+
+func TestAcquireActorLock_LostLockCancelsWorkflow(t *testing.T) {
+	mr, w := newLockTestWorkflow(t)
+
+	lockTTL := 200 * time.Millisecond
+	heartbeat := 30 * time.Millisecond
+
+	ctx, release, err := w.acquireActorLock(context.Background(), "ns", "actor-2", lockTTL, heartbeat)
+	if err != nil {
+		t.Fatalf("acquireActorLock: %v", err)
+	}
+	defer release()
+
+	// Simulate a peer stealing the lock (or the TTL lapsing and someone else
+	// re-acquiring): wipe our key so the next heartbeat refresh's CAS fails.
+	mr.Del("lock:actor:ns:actor-2")
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatalf("workflow ctx was not cancelled after lock was lost")
+	}
+
+	if cause := context.Cause(ctx); !errors.Is(cause, errLostActorLock) {
+		t.Errorf("context.Cause = %v, want errLostActorLock", cause)
+	}
+}
+
+func TestAcquireActorLock_ReleaseRemovesLock(t *testing.T) {
+	mr, w := newLockTestWorkflow(t)
+
+	_, release, err := w.acquireActorLock(context.Background(), "ns", "actor-3", 200*time.Millisecond, 60*time.Millisecond)
+	if err != nil {
+		t.Fatalf("acquireActorLock: %v", err)
+	}
+
+	if !mr.Exists("lock:actor:ns:actor-3") {
+		t.Fatalf("lock key not in Redis after acquire")
+	}
+	release()
+	if mr.Exists("lock:actor:ns:actor-3") {
+		t.Errorf("lock key still in Redis after release")
+	}
+}
+
+func TestAcquireActorLock_ConflictReturnsAborted(t *testing.T) {
+	_, w := newLockTestWorkflow(t)
+
+	_, release, err := w.acquireActorLock(context.Background(), "ns", "actor-4", 5*time.Second, 1*time.Second)
+	if err != nil {
+		t.Fatalf("first acquireActorLock: %v", err)
+	}
+	defer release()
+
+	_, _, err = w.acquireActorLock(context.Background(), "ns", "actor-4", 5*time.Second, 1*time.Second)
+	if err == nil {
+		t.Fatalf("expected second acquireActorLock to fail")
+	}
+}

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -838,6 +838,26 @@ func (s *Persistence) ReleaseLock(ctx context.Context, key string, value string)
 	return nil
 }
 
+func (s *Persistence) RefreshLock(ctx context.Context, key string, value string, ttl time.Duration) (bool, error) {
+	var luaRefresh = redis.NewScript(`
+		if redis.call("get", KEYS[1]) == ARGV[1] then
+			return redis.call("pexpire", KEYS[1], ARGV[2])
+		else
+			return 0
+		end
+	`)
+
+	res, err := luaRefresh.Run(ctx, s.rdb, []string{key}, value, ttl.Milliseconds()).Result()
+	if err != nil {
+		return false, fmt.Errorf("while refreshing lock for %q with value %q: %w", key, value, err)
+	}
+	n, ok := res.(int64)
+	if !ok {
+		return false, fmt.Errorf("while refreshing lock for %q: unexpected result type %T", key, res)
+	}
+	return n == 1, nil
+}
+
 func newCreateMetadata(atespace, name string) *ateapipb.ResourceMetadata {
 	now := timestamppb.Now()
 	return &ateapipb.ResourceMetadata{

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -860,6 +860,97 @@ func receiveEvent(t *testing.T, ch <-chan store.WorkerEvent) store.WorkerEvent {
 	}
 }
 
+func TestRefreshLock_ExtendsTTL(t *testing.T) {
+	mr, s, ctx := setupTest(t)
+	defer mr.Close()
+
+	key := "test-lock"
+	value := "token-1"
+	otherValue := "token-2"
+	ttl := 10 * time.Second
+
+	acquired, err := s.AcquireLock(ctx, key, value, ttl)
+	if err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("expected lock to be acquired")
+	}
+
+	// Advance to just before expiry, refresh, and verify another holder still
+	// can't acquire after the original TTL would have elapsed.
+	mr.FastForward(8 * time.Second)
+	refreshed, err := s.RefreshLock(ctx, key, value, ttl)
+	if err != nil {
+		t.Fatalf("RefreshLock failed: %v", err)
+	}
+	if !refreshed {
+		t.Fatalf("expected lock to be refreshed")
+	}
+
+	mr.FastForward(5 * time.Second)
+	stolen, err := s.AcquireLock(ctx, key, otherValue, ttl)
+	if err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+	if stolen {
+		t.Errorf("expected refreshed lock to still be held, but it was stolen")
+	}
+}
+
+func TestRefreshLock_WrongValueReturnsFalse(t *testing.T) {
+	mr, s, ctx := setupTest(t)
+	defer mr.Close()
+
+	key := "test-lock"
+	value := "token-1"
+	otherValue := "token-2"
+	ttl := 10 * time.Second
+
+	acquired, err := s.AcquireLock(ctx, key, value, ttl)
+	if err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("expected lock to be acquired")
+	}
+
+	refreshed, err := s.RefreshLock(ctx, key, otherValue, ttl)
+	if err != nil {
+		t.Fatalf("RefreshLock failed: %v", err)
+	}
+	if refreshed {
+		t.Errorf("expected RefreshLock with wrong value to return false")
+	}
+}
+
+func TestRefreshLock_AfterExpirationReturnsFalse(t *testing.T) {
+	mr, s, ctx := setupTest(t)
+	defer mr.Close()
+
+	key := "test-lock"
+	value := "token-1"
+	ttl := 5 * time.Second
+
+	acquired, err := s.AcquireLock(ctx, key, value, ttl)
+	if err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("expected lock to be acquired")
+	}
+
+	mr.FastForward(6 * time.Second)
+
+	refreshed, err := s.RefreshLock(ctx, key, value, ttl)
+	if err != nil {
+		t.Fatalf("RefreshLock failed: %v", err)
+	}
+	if refreshed {
+		t.Errorf("expected RefreshLock after expiration to return false")
+	}
+}
+
 func TestAcquireLock_NonReentry(t *testing.T) {
 	mr, s, ctx := setupTest(t)
 	defer mr.Close()

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -113,6 +113,12 @@ type Interface interface {
 	// Returns an error only on database failure.
 	ReleaseLock(ctx context.Context, key string, value string) error
 
+	// RefreshLock extends the TTL on a distributed lock iff the stored value still matches.
+	// Returns true if the TTL was extended.
+	// Returns false if we no longer own the lock (either expired and reclaimed, or never held).
+	// Returns an error only on database failure.
+	RefreshLock(ctx context.Context, key string, value string, ttl time.Duration) (bool, error)
+
 	// DebugClearAll drop all data from the database. Useful for debugging / local testing/
 	DebugClearAll(ctx context.Context) error
 }

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -70,6 +70,8 @@ var (
 	sessionIDCAPoolFile = pflag.String("session-id-ca-pool", "", "The file that contains the CA pool for signing session JWTs")
 	workerpoolCACerts   = pflag.String("workerpool-ca-certs", "", "The file that contains the CA for verifying workerpool client certificates.")
 
+	actorWorkflowDeadline = pflag.Duration("actor-workflow-deadline", 5*time.Minute, "Maximum wall-clock duration of a single Resume/Suspend workflow. A heartbeat keeps the per-actor lock alive across this duration; raise it for slow image registries.")
+
 	showVersion     = pflag.Bool("version", false, "Print version and exit.")
 	authMode        = pflag.String("auth-mode", "mtls", "Auth mode for incoming gRPC: mtls|jwt. 'mtls' (default) relies on transport-level mTLS for client identity. 'jwt' additionally requires a Kubernetes ServiceAccount Bearer token on every RPC. Substrate will drop support for JWT auth mode once the Pod Certificates feature is enabled by default in the minimum supported Kubernetes version.")
 	clientJWTCAFile = pflag.String("client-jwt-ca-cert", ateapiauth.DefaultServiceAccountCAFile, "CA cert file used to verify TLS when fetching the OIDC discovery document and JWKS for JWT authentication. Defaults to the in-cluster service account CA.")
@@ -151,7 +153,7 @@ func main() {
 	ateFactory.WaitForCacheSync(stopCh)
 
 	dialer := controlapi.NewAteletDialer(workerPodInformer.GetIndexer(), ateletPodInformer.GetIndexer())
-	sm := controlapi.NewService(redisPersistence, workerCache, actorTemplateLister, workerPoolLister, sandboxConfigLister, dialer, clientset)
+	sm := controlapi.NewService(redisPersistence, workerCache, actorTemplateLister, workerPoolLister, sandboxConfigLister, dialer, clientset, *actorWorkflowDeadline)
 
 	jwtIssuerDiscoveryClient := buildK8sServiceAccountIssuerDiscoveryClient(ctx, *clientJWTCAFile, *clientJWTIssuer)
 	if authModeParsed == ateapiauth.ModeJWT && jwtIssuerDiscoveryClient == nil {
@@ -239,6 +241,7 @@ func logFlagValues(ctx context.Context) {
 		slog.String("session-id-ca-pool", *sessionIDCAPoolFile),
 		slog.String("workerpool-ca-certs", *workerpoolCACerts),
 		slog.String("auth-mode", *authMode),
+		slog.Duration("actor-workflow-deadline", *actorWorkflowDeadline),
 	)
 }
 


### PR DESCRIPTION
Fixes #233.

Customer Impact: Prior to #230, large images (specifically our test image) would eventually finish pulling in ~20 min, at the cost of RSS increasing in atelet i.e. worker successfully has actor scheduled to it at the cost of overall system stability. This wasn't an acceptable tradeoff. Orphaned image pulls resulted in atelet consuming almost 10 GiB of memory before being garbage collected.

Now, long running image pulls have a process of reacquiring a lock, preventing it from expiring before the image pull has completed. Introduced a high level, user configurable timeout ensuring that there is a window in which the lock can be lost and be lost in the event of image pull hanging (instead of a similar bug where a process is left hanging despite the caller having abandoned it.)

## Summary

Decouples the per-actor workflow deadline from the Redis lock TTL via a heartbeat, so large image pulls can finish without raising the lock TTL (which also bounds peer failover after a crashed `ateapi`).

**Lock TTL** (~30s) bounds *failover latency* — how long a peer `ateapi` waits to retry an actor if the original instance crashes mid-workflow. **Workflow deadline** (~5min) bounds *legitimate work* — how long a single Resume/Suspend/Pause is allowed to run end-to-end before we give up. The **lock refresh** (heartbeat goroutine, PEXPIREs every TTL/3) is the bridge: it keeps the lock alive across the long workflow window without raising the TTL itself, so we get both fast failover AND room for slow legitimate operations.

**Lifecycle RPCs** (Resume/Suspend/Pause) all go through `acquireActorLock` on entry. That call (a) grabs the Redis lock with the short TTL, (b) returns a workflow-bounded ctx via `WithTimeout(workflowDeadline)`, and (c) spawns the heartbeat. While the RPC runs, the lock stays held; if the heartbeat ever fails or returns "you no longer own this lock," it cancels the workflow ctx so steps tear down promptly. On normal return, release stops the heartbeat and frees the lock. Mutual exclusion per actor holds throughout — exactly one workflow per actor at any instant, just like before, but no longer pinned to a 28-second ceiling.

## Why a server-side deadline at all (not just heartbeat)

Considered keeping only the heartbeat and letting the workflow ctx inherit from the caller. Rejected on defense-in-depth grounds:

- Substrate does not configure gRPC keepalive, so a network partition or a hung-but-not-killed caller would leave the workflow running indefinitely on `ateapi`.
- A workflow step that forgets to propagate ctx would have no upstream timeout to fall back on.

The 5-minute server-side cap covers both cases at the cost of one config knob. Operators can raise it for slow registries; the lock TTL is independent so peer failover stays bounded at ≤30s regardless.

## Test plan

Automated:

- [x] `go test ./cmd/ateapi/internal/store/ateredis/... -run 'TestRefreshLock|TestAcquireLock'` — 7 lock tests pass (3 new + 4 existing).
- [x] `go test ./cmd/ateapi/internal/controlapi/ -run TestAcquireActorLock` — 4 new heartbeat tests pass:
  - Heartbeat keeps lock alive past TTL.
  - Lost lock cancels workflow ctx with `errLostActorLock` cause.
  - Release callback removes the lock.
  - Second concurrent acquire returns `codes.Aborted`.
- [x] `go test ./... -count=1` — full repo suite green (419 tests / 65 packages).
- [x] `go vet ./...` — clean.

Manual:

```aiignore
# Setup cluster
./hack/create-kind-cluster.sh && ./hack/install-ate-kind.sh --deploy-ate-system
export KO_DOCKER_REPO=localhost:5001
export KO_DEFAULTPLATFORMS=linux/$(go env GOARCH)
./hack/run-tool.sh ko build -B ./cmd/ateom-gvisor

# Install metrics server to keep tabs on memory
kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/high-availability-1.21+.yaml
# Tweak values for cluster
kubectl patch -n kube-system deploy metrics-server --type=json -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
kubectl scale -n kube-system deploy/metrics-server --replicas=1
kubectl rollout status deploy/metrics-server -n kube-system

# Watch memory consumption
while true; do date; kubectl top pod -n ate-system -l app=atelet --containers >> bin/output-fix.log; sleep 5; done

# Check atelet, image pull starts and eventually completes in a reasonable amount of time
kubectl logs daemonset/atelet -n ate-system --follow
{"time":"2026-06-12T17:33:16.609666504Z","level":"INFO","msg":"Using S3 storage backend"}
{"time":"2026-06-12T17:33:16.61079017Z","level":"INFO","msg":"Starting Prometheus metrics server on :9090"}
{"time":"2026-06-12T17:33:16.626096171Z","level":"INFO","msg":"WorkersManagerService listening","address":{"IP":"::","Port":8085,"Zone":""}}
{"time":"2026-06-12T17:36:40.508440418Z","level":"INFO","msg":"Ref includes digest, checking for cache hit","ref":"ghcr.io/kagent-dev/nemoclaw/sandbox-base@sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4","digest":"sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4","ate.dev/trace-id":"f2bd930bd82771821f8d5fcabcb895a0"}
{"time":"2026-06-12T17:36:40.508567918Z","level":"INFO","msg":"Ref includes digest, checking for cache hit","ref":"registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4","digest":"sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4","ate.dev/trace-id":"f2bd930bd82771821f8d5fcabcb895a0"}
{"time":"2026-06-12T17:36:40.508644543Z","level":"INFO","msg":"Cache miss","ref":"registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4","ate.dev/trace-id":"f2bd930bd82771821f8d5fcabcb895a0"}
{"time":"2026-06-12T17:36:40.508595126Z","level":"INFO","msg":"Cache miss","ref":"ghcr.io/kagent-dev/nemoclaw/sandbox-base@sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4","ate.dev/trace-id":"f2bd930bd82771821f8d5fcabcb895a0"}
{"time":"2026-06-12T17:38:35.082124179Z","level":"INFO","msg":"Handle RPC","method":"/atelet.AteomHerder/Run","req":{"target_ateom_uid":"739d5e60-905f-4681-bac4-171190ab7cba","actor_template_namespace":"ate-repro","actor_template_name":"repro-fat-image","actor_id":"69bcf578-73af-48da-8cb8-c73f4b09622b","runsc":{"amd64":{"sha256_hash":"a397be1abc2420d26bce6c70e6e2ff96c73aaaab929756c56f5e2089ea842b63","url":"gs://gvisor/releases/nightly/2026-05-19/x86_64/runsc"},"arm64":{"sha256_hash":"1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9","url":"gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"}},"spec":{"containers":[{"name":"fat","image":"ghcr.io/kagent-dev/nemoclaw/sandbox-base@sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4","command":["/bin/sh","-c","sleep 3600"]}],"pause_image":"registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"}},"resp":{},"err":null,"elapsed-time":"2m0.322655054s","ate.dev/trace-id":"f2bd930bd82771821f8d5fcabcb895a0"}
{"time":"2026-06-12T17:38:55.689723883Z","level":"INFO","msg":"Handle RPC","method":"/atelet.AteomHerder/Checkpoint","req":{"target_ateom_uid":"739d5e60-905f-4681-bac4-171190ab7cba","actor_template_namespace":"ate-repro","actor_template_name":"repro-fat-image","actor_id":"69bcf578-73af-48da-8cb8-c73f4b09622b","runsc":{"amd64":{"sha256_hash":"a397be1abc2420d26bce6c70e6e2ff96c73aaaab929756c56f5e2089ea842b63","url":"gs://gvisor/releases/nightly/2026-05-19/x86_64/runsc"},"arm64":{"sha256_hash":"1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9","url":"gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"}},"spec":{"containers":[{"name":"fat","image":"ghcr.io/kagent-dev/nemoclaw/sandbox-base@sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4","command":["/bin/sh","-c","sleep 3600"]}],"pause_image":"registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"},"snapshot_uri_prefix":"gs://ate-snapshots/repro/69bcf578-73af-48da-8cb8-c73f4b09622b/2026-06-12T17:38:55Z-XHXXXIU65H5YZCKRHLGC3XH6F4"},"resp":{},"err":null,"elapsed-time":"685.691709ms","ate.dev/trace-id":"41774e0b1b60502ad62d6351bafd4a1b"}
```

## Out of scope / follow-ups

- Moving image pulls off the workflow path entirely (background pull worker + status-polling RPC) is the long-term fix per `internal/memorypullcache/memorypullcache.go:47-58`. Should follow the on-disk / shared layer cache work via `ategcs.ObjectStorage`. The heartbeat shape introduced here does not preclude that redesign.
- gRPC keepalive on `ateapi` server + client sides would tighten the partition-detection story. Left as a separate change.
