### PR TITLE
add auto pr size labeler (k8s style)

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,34 @@
+name: PR Size Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: size-label
+        id: size
+        uses: pascalgn/size-label-action@v0.5.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IGNORED: |
+            go.sum
+            go.mod
+            *.generated.go
+            vendor/**
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "10": "S",
+              "30": "M",
+              "100": "L",
+              "500": "XL",
+              "1000": "XXL"
+            }


### PR DESCRIPTION
PR to add auto PR size labeler like in k8s repos. 
in order for this workflow to work, a pre-req is to create the relevant labels (need to be done by a repo maintainer). 

the commands to create them through cli are:
```
  gh label create "size/XS"  --color "009900" --description "Denotes a PR that changes 0-9 lines, ignoring generated files."
  gh label create "size/S"   --color "77bb00" --description "Denotes a PR that changes 10-29 lines, ignoring generated files."
  gh label create "size/M"   --color "eebb00" --description "Denotes a PR that changes 30-99 lines, ignoring generated files."
  gh label create "size/L"   --color "ee9900" --description "Denotes a PR that changes 100-499 lines, ignoring generated files."
  gh label create "size/XL"  --color "ee5500" --description "Denotes a PR that changes 500-999 lines, ignoring generated files."
  gh label create "size/XXL" --color "ee0000" --description "Denotes a PR that changes 1000+ lines, ignoring generated files."
```