### PR TITLE
Add Valkey operations handbook

### DIFF
--- a/docs/valkey/README.md
+++ b/docs/valkey/README.md
@@ -1,0 +1,125 @@
+# Valkey Operations Handbook
+
+This handbook documents how Agent Substrate's Valkey deployment behaves under
+normal conditions, how it fails, and how to recover it. It is written for
+operators, on-call engineers, and future maintainers who need to reason about
+the storage tier without first reading the application code.
+
+## Scope
+
+The handbook is intentionally **API-agnostic**. The Substrate API surface will
+change; the operational properties of a six-node Valkey Cluster — hash-slot
+ownership, asynchronous replication, AOF durability windows, failover
+behavior, cluster coverage rules — will not. Sections that touch the Substrate
+API at all do so only to ground a failure mode in a concrete code path; the
+recovery guidance should remain valid as the API evolves.
+
+In scope:
+
+- Topology and configuration of the current Valkey deployment.
+- Critical read/write paths through the storage tier.
+- Every failure mode we have identified, with detection signals and recovery
+  procedures.
+- Risk register: known sharp edges, missing safeguards, and the tradeoffs of
+  the levers available to tighten them.
+
+Out of scope:
+
+- Tutorials on Valkey itself. Link to upstream docs rather than restate them.
+- Application-level behavior that does not interact with the storage tier.
+- Alternative storage backends. The evaluation in
+  [issue #12](https://github.com/agent-substrate/substrate/issues/12) is a
+  separate document.
+
+## How to read this handbook
+
+The handbook is organized so that each page stands alone. There is no
+required reading order. During an incident, jump straight to the failure mode
+page that matches the symptom. Outside an incident, the topology and critical
+paths pages are the most useful starting points for building a mental model.
+
+## Contributing
+
+**Update this handbook whenever you learn something new about how Valkey
+behaves in this deployment.** That includes:
+
+- New failure modes observed in development, staging, or production.
+- Recovery steps that worked (or did not) during a real incident.
+- Configuration changes to `manifests/ate-install/valkey.yaml` or the
+  cluster-client wiring in `cmd/ateapi/main.go`.
+- Surprising behavior from Valkey upgrades, client-library upgrades, or
+  Kubernetes platform changes.
+
+Prefer a dedicated handbook PR over folding a substantive update into a
+feature PR — it keeps reviews focused and gives the handbook change its own
+review attention. Trivial touch-ups (a renamed flag, an updated path) can
+ride with the code change that prompted them.
+
+When in doubt, write it down. A page that captures the *why* of a past
+decision is more valuable than a page that perfectly describes the current
+code, because the code is already self-describing.
+
+## Future direction: agent-assisted drift detection
+
+The cost of a living handbook is drift: code changes, the page does not, and
+trust in the document erodes. The temptation is to close that gap with
+automation — webhooks that fire on push, agents that regenerate the handbook
+from the current source of truth. We do not intend to take that path.
+
+The value of this handbook is not the factual description of what the code
+does — that is derivable from the code itself and can be regenerated on
+demand. The value is the synthesized judgment about failure modes, recovery
+tradeoffs, and the institutional memory of what has bitten us before.
+Autonomous agent-authored commits to operational documentation are a poor
+fit for that work: agents are bad at distinguishing "I am confident about
+this operational claim" from "this sentence reads plausibly," and a single
+wrong-but-confident handbook entry quietly poisons reviewer trust in every
+other entry.
+
+The shape we do intend to pursue:
+
+- A scheduled or webhook-triggered job that diffs recently touched code
+  paths against the handbook sections that reference them, and opens an
+  **issue** (not a PR) flagging sections that may be stale, optionally with
+  a suggested draft for a human to curate.
+- Agent-assisted *drafting* of new sections, where a human prompts the agent
+  with the relevant context and reviews the output before it lands.
+- No autonomous commits to anything under `docs/valkey/`.
+
+This direction is recorded here so that future contributors do not have to
+re-litigate the decision when the temptation to "just hook up an agent"
+returns.
+
+## Planned subdocuments
+
+The following pages will be added under this directory as the handbook is
+built out. This list is the working table of contents; update it as pages
+land or as new topics surface.
+
+- [`topology.md`](./topology.md) — current deployment shape, scaling
+  projection to target scale, sharding model, TLS / identity wiring, and
+  the explicit go/no-go verdict for MVP and target scale.
+- [`actor-lifecycle.md`](./actor-lifecycle.md) — actor state machine,
+  per-transition sequence diagrams with Valkey round-trip counts, locking
+  model, stranded-state recovery, and a lifecycle-specific risk register.
+- [`admin-operations.md`](./admin-operations.md) — non-critical-path
+  operations (`ListActors`, `ListWorkers`, syncer-driven worker
+  bookkeeping, lock primitives, debug utilities) with special attention
+  to where they cross into the critical path.
+- [`critical-questions.md`](./critical-questions.md) — open
+  architectural questions specific to the storage tier, each tracked
+  with its design space, constraints, and the handbook pages that
+  would change once decided.
+- [`failure-modes.md`](./failure-modes.md) — catalog of Valkey-deployment
+  failure modes (pod, data, network, security, and Kubernetes-level)
+  with detection signals, blast radius, recovery semantics, and a
+  cross-cutting table mapping each failure to its actor-lifecycle
+  impact.
+- [`recovery-procedures.md`](./recovery-procedures.md) — runbook-style
+  procedures (R-1 through R-14) keyed to the failure modes above, with
+  trigger / goal / commands / verification / postmortem capture for
+  each. Written for the on-call engineer at 3 am.
+- [`risk-register.md`](./risk-register.md) — consolidated catalogue of
+  every sharp edge surfaced across the handbook (R-1 through R-23),
+  each with severity, status, MVP / target-scale impact, mitigation
+  levers and their costs, and recommended action.

--- a/docs/valkey/actor-lifecycle.md
+++ b/docs/valkey/actor-lifecycle.md
@@ -1,0 +1,456 @@
+# Actor Lifecycle: Critical Path
+
+This page documents the actor state machine, the Valkey operations each
+state transition performs, the locking model that serializes concurrent
+operations on the same actor, and the failure / recovery modes for every
+edge.
+
+The framing target is the **<10 ms whole-path budget** for scheduling and
+state-machine operations. Where a transition does not fit that budget
+today, it is called out explicitly.
+
+## State machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> SUSPENDED: CreateActor
+
+  SUSPENDED --> RESUMING: ResumeActor (1)
+  RESUMING --> RUNNING: ResumeActor (2-4)
+
+  RUNNING --> SUSPENDING: SuspendActor (1-2)
+  SUSPENDING --> SUSPENDED: SuspendActor (3-4)
+
+  RUNNING --> SUSPENDED: syncer · worker pod deleted
+  RESUMING --> SUSPENDED: syncer · worker pod deleted
+
+  SUSPENDED --> [*]: DeleteActor
+
+  note right of RUNNING
+    actor.AteomPod* fields point
+    at the assigned worker pod
+  end note
+  note right of SUSPENDED
+    actor.AteomPod* fields cleared
+    actor.LastSnapshot retained
+  end note
+```
+
+Statuses are defined by the `Actor.Status` enum in
+`pkg/proto/ateapipb/ateapi.proto`. Every transition that mutates state
+goes through `store.Interface.UpdateActor` with optimistic concurrency
+(version-check CAS). The implicit transition driven by the
+`WorkerPoolSyncer` (worker pod deletion → actor reset) is the only edge
+that is *not* triggered by a client API call.
+
+## Locking model
+
+`ResumeActor` and `SuspendActor` both serialize per-actor via a distributed
+lock at key `lock:actor:<id>`:
+
+- **Acquire**: `SET NX EX` with a UUID token, **TTL 30 s**.
+- **Release**: Lua CAS (read token, compare, delete) — safe even if the
+  lock has already expired and been re-acquired by someone else.
+- **Workflow timeout**: lock TTL minus 2 s padding (28 s). The workflow
+  context is cancelled before the lock TTL fires, so the workflow stops
+  acting before another caller can validly grab the lock.
+- **Fallback safety net**: the lock TTL itself. If the API server crashes
+  mid-workflow without releasing, the lock auto-expires in ≤ 30 s and
+  another caller can proceed.
+
+`CreateActor` and `DeleteActor` do **not** acquire the actor lock. They
+rely on the storage-level CAS in `CreateActor` (atomic `SET NX`) and the
+status-precondition CAS in `DeleteActor` (`WATCH`/`GET`/check
+`STATUS_SUSPENDED`/`DEL`).
+
+## Transition 1: `CreateActor` (∅ → SUSPENDED)
+
+The simplest transition. See `cmd/ateapi/internal/controlapi/create_actor.go`.
+
+```mermaid
+sequenceDiagram
+  participant C as client
+  participant API as ate-api-server
+  participant K as K8s lister (in-memory)
+  participant V as Valkey
+
+  C->>API: CreateActor(id, template)
+  API->>K: Get ActorTemplate
+  K-->>API: template
+  API->>V: SET NX actor:id (status=SUSPENDED, version=1)
+  V-->>API: ok
+  API->>V: GET actor:id
+  V-->>API: actor bytes
+  API-->>C: Actor{status=SUSPENDED, version=1}
+```
+
+**Valkey ops**: 2 (one `SET NX`, one `GET`). Single key, single shard.
+
+**Failure modes**:
+
+| Failure | Detection | Effect | Recovery |
+|---|---|---|---|
+| Actor already exists | `SET NX` returns false → `store.ErrAlreadyExists` | gRPC `AlreadyExists` to client | client picks new id |
+| ActorTemplate missing | K8s lister returns `IsNotFound` | gRPC `FailedPrecondition` | create template first |
+| Valkey unreachable | `SET NX` network error | gRPC `Internal` (wrapped error) | client retries |
+| Crash after `SET NX`, before `GET` | client sees timeout / disconnect | actor IS created in DB | retry returns `AlreadyExists`; client treats as success and calls `GetActor` |
+
+The post-create `GET` is a wasted round trip — `CreateActor` could
+return the locally-constructed actor and avoid it. Not a critical-path
+operation, but it doubles the round trips for this transition.
+
+## Transition 2: `ResumeActor` (SUSPENDED → RUNNING)
+
+The most expensive transition in the system. The workflow runs four
+steps under the actor lock. See
+`cmd/ateapi/internal/controlapi/workflow_resume.go`.
+
+```mermaid
+sequenceDiagram
+  participant C as client
+  participant API as ate-api-server
+  participant V as Valkey
+  participant K as K8s lister
+  participant T as atelet (target pod)
+
+  C->>API: ResumeActor(id, boot)
+  API->>V: SET NX lock:actor:id (ttl=30s)
+  V-->>API: acquired
+
+  Note over API: Step LoadActorForResume
+  API->>V: GET actor:id
+  V-->>API: actor (SUSPENDED)
+  API->>K: Get ActorTemplate
+  K-->>API: template
+
+  Note over API: Step AssignWorker (retry: 5×, 10ms base, jitter)
+  API->>V: ListWorkers (SCAN+GET across ALL primaries)
+  V-->>API: ALL workers in cluster
+  Note over API: find existing assignment OR shuffle-pick free worker
+  API->>V: WATCH/GET/check/MULTI/SET worker:ns:pool:pod
+  V-->>API: ok (worker claimed)
+  API->>V: WATCH/GET/check/MULTI/SET actor:id (status=RESUMING, pod info)
+  V-->>API: ok
+
+  Note over API: Step CallAteletRestore (NO retry)
+  API->>T: Restore(or Run) via gRPC
+  T-->>API: ok
+
+  Note over API: Step FinalizeRunning (NO retry)
+  API->>V: GET actor:id
+  V-->>API: actor (still RESUMING)
+  API->>V: WATCH/GET/check/MULTI/SET actor:id (status=RUNNING)
+  V-->>API: ok
+
+  API->>V: ReleaseLock (Lua CAS)
+  V-->>API: ok
+  API-->>C: Actor{status=RUNNING}
+```
+
+**Valkey ops (happy path, no contention)**:
+
+| Step | Ops | Notes |
+|---|---|---|
+| AcquireLock | 1 (`SET NX`) | |
+| LoadActor | 1 (`GET`) | |
+| AssignWorker — ListWorkers | **1 SCAN + N GET** | **N = total worker count cluster-wide, fans out to every primary** |
+| AssignWorker — UpdateWorker | 2 (`WATCH/GET`, `MULTI/SET/EXEC`) | |
+| AssignWorker — UpdateActor | 2 (`WATCH/GET`, `MULTI/SET/EXEC`) | |
+| FinalizeRunning — GetActor | 1 (`GET`) | |
+| FinalizeRunning — UpdateActor | 2 (`WATCH/GET`, `MULTI/SET/EXEC`) | |
+| ReleaseLock | 1 (Lua EVAL) | |
+| **Total** | **10 + N** | |
+
+At 1 ms per round trip (intra-cluster mTLS), the base cost is **~10 ms**
+*before* `ListWorkers` fan-out. At 10 k workers, the `ListWorkers` fan-out
+adds another 10 k+ round trips and bulk data transfer; at 100 k workers,
+the fan-out alone is multiple seconds. **`ResumeActor` does not fit the
+<10 ms budget at any non-trivial worker count today** — the binding
+constraint is the `ListWorkers` call inside `AssignWorkerStep`. See
+[`admin-operations.md`](./admin-operations.md) for details.
+
+The atelet `Restore` / `Run` gRPC call is the actual work (image pull,
+sandbox bring-up, snapshot restore). Its latency is unrelated to Valkey
+but the storage tier consumes its budget before atelet is even contacted.
+
+**Failure modes**:
+
+| Failure | Step | Effect | Recovery |
+|---|---|---|---|
+| Lock already held | AcquireLock | gRPC `Aborted` ("another operation in progress") | client retries after delay |
+| Valkey unreachable mid-workflow | any | step error bubbles up | lock auto-expires after 30 s; client retries; idempotent fast-forward |
+| `UpdateWorker` conflict (concurrent claim) | AssignWorker | retry up to 5× with exponential backoff + jitter | usually resolves; if exhausted, surface `Aborted` |
+| `UpdateActor` conflict on transition to RESUMING | AssignWorker | retry up to 5× | usually resolves |
+| No free workers in pool | AssignWorker | gRPC `FailedPrecondition` ("no free workers available") | requires worker pool scale-up |
+| atelet pod unreachable | CallAteletRestore | error bubbles up; **NO retry** | client retries entire workflow |
+| atelet `Restore` partial success / crash | CallAteletRestore | error bubbles, actor stuck RESUMING (see "stranded states") | next `ResumeActor` re-runs Restore (idempotency assumed atelet-side) |
+| Crash after `Restore` succeeded, before `FinalizeRunning` | FinalizeRunning | actor stuck RESUMING; lock expires; workload is actually running | next `ResumeActor` re-loads, sees status RESUMING, fast-forwards through AssignWorker (existing assignment), **re-invokes atelet `Restore`** (relies on atelet idempotency), then finalizes |
+| `UpdateActor` conflict on transition to RUNNING | FinalizeRunning | step error bubbles up; **NO retry** | next `ResumeActor` re-finalizes |
+
+The **NO retry** annotations are load-bearing. `FinalizeRunning` has no
+`RetryBackoff()`, so a single `ErrPersistenceRetry` (from a concurrent
+mutation by `releaseActorOnDeadWorker` or a racing operation) strands
+the actor in RESUMING and requires an external retry to reach RUNNING.
+
+## Transition 3: `SuspendActor` (RUNNING → SUSPENDED)
+
+Four steps under the actor lock. See
+`cmd/ateapi/internal/controlapi/workflow_suspend.go`.
+
+```mermaid
+sequenceDiagram
+  participant C as client
+  participant API as ate-api-server
+  participant V as Valkey
+  participant K as K8s lister
+  participant T as atelet (target pod)
+
+  C->>API: SuspendActor(id)
+  API->>V: SET NX lock:actor:id (ttl=30s)
+  V-->>API: acquired
+
+  Note over API: Step LoadActorForSuspend
+  API->>V: GET actor:id
+  V-->>API: actor (RUNNING)
+  API->>K: Get ActorTemplate
+  K-->>API: template
+
+  Note over API: Step MarkSuspending (NO retry)
+  Note over API: generate snapshot URI = base + actor_id + timestamp-rand
+  API->>V: WATCH/GET/check/MULTI/SET actor:id (status=SUSPENDING, InProgressSnapshot)
+  V-->>API: ok
+
+  Note over API: Step CallAteletSuspend (NO retry)
+  API->>T: Checkpoint via gRPC
+  T-->>API: ok (snapshot written to URI)
+
+  Note over API: Step FinalizeSuspended (NO retry)
+  API->>V: GET actor:id
+  V-->>API: actor (SUSPENDING)
+  API->>V: GET worker:ns:pool:pod
+  V-->>API: worker (claimed by this actor)
+  API->>V: WATCH/GET/check/MULTI/SET worker:ns:pool:pod (clear actor_id)
+  V-->>API: ok
+  API->>V: GET actor:id
+  V-->>API: actor (SUSPENDING)
+  API->>V: WATCH/GET/check/MULTI/SET actor:id (status=SUSPENDED, swap snapshots, clear pod)
+  V-->>API: ok
+
+  API->>V: ReleaseLock (Lua CAS)
+  V-->>API: ok
+  API-->>C: Actor{status=SUSPENDED}
+```
+
+**Valkey ops (happy path)**:
+
+| Step | Ops |
+|---|---|
+| AcquireLock | 1 |
+| LoadActor | 1 |
+| MarkSuspending — UpdateActor | 2 |
+| FinalizeSuspended — GetActor | 1 |
+| FinalizeSuspended — GetWorker | 1 |
+| FinalizeSuspended — UpdateWorker | 2 |
+| FinalizeSuspended — GetActor (again) | 1 |
+| FinalizeSuspended — UpdateActor | 2 |
+| ReleaseLock | 1 |
+| **Total** | **12** |
+
+Twelve round trips on the happy path. No cluster-wide fan-out (unlike
+`ResumeActor`), so this is closer to fitting the budget — at 1 ms per
+trip it lands around 12 ms in the storage tier, plus the atelet
+`Checkpoint` call. The two redundant `GetActor` calls in
+`FinalizeSuspended` (lines `s.store.GetActor` called twice with no
+intervening mutation by us) look like defensive re-reads that could be
+folded.
+
+**Failure modes**:
+
+| Failure | Step | Effect | Recovery |
+|---|---|---|---|
+| Lock held | AcquireLock | gRPC `Aborted` | client retries |
+| Actor already SUSPENDING / SUSPENDED | MarkSuspending | step IsComplete fast-forwards | proceeds idempotently |
+| Worker pod unreachable | CallAteletSuspend | if `ErrWorkerPodNotFound`, **skipped** (warn-logged); else error bubbles | dangling-pod path handled; other errors require retry |
+| atelet `Checkpoint` partial success | CallAteletSuspend | error bubbles, actor stuck SUSPENDING | next call re-Checkpoints to same URI (atelet must overwrite or dedup) |
+| Crash after Checkpoint, before FinalizeSuspended | FinalizeSuspended | actor stuck SUSPENDING, snapshot on object storage at `InProgressSnapshot`, worker still claimed | next `SuspendActor` fast-forwards MarkSuspending, re-Checkpoints (idempotency assumed), then finalizes; **resume in this state is blocked** until a suspend retry completes |
+| `UpdateWorker` conflict freeing worker | FinalizeSuspended | step error bubbles up; **NO retry** | actor stays SUSPENDING; next call retries cleanup |
+| `UpdateActor` conflict on transition to SUSPENDED | FinalizeSuspended | step error bubbles up; **NO retry** | actor stays SUSPENDING; snapshot remains on `InProgressSnapshot`; LastSnapshot not promoted |
+
+## Transition 4: `DeleteActor` (SUSPENDED → ∅)
+
+```mermaid
+sequenceDiagram
+  participant C as client
+  participant API as ate-api-server
+  participant V as Valkey
+
+  C->>API: DeleteActor(id)
+  API->>V: WATCH/GET/check status=SUSPENDED/MULTI/DEL actor:id
+  V-->>API: ok or ErrFailedPrecondition
+  alt FailedPrecondition
+    API->>V: GET actor:id (for error detail)
+    V-->>API: actor
+  end
+  API-->>C: ok / FailedPrecondition / NotFound
+```
+
+**Valkey ops**: 2 on happy path (the `WATCH/GET/check/MULTI/DEL` dance);
+one additional `GET` on the precondition-failure path for the error
+message.
+
+**No actor lock acquired.** The status-precondition CAS in the storage
+layer is the only safety. This is fine for SUSPENDED → DELETED (an
+already-deleted actor returns `NotFound`), but it does mean a
+`DeleteActor` racing with a `ResumeActor` will either:
+
+- See SUSPENDED at WATCH time, then EXEC fails because ResumeActor
+  changed the version → `ErrPersistenceRetry` → gRPC `Aborted`; or
+- See RESUMING/RUNNING/SUSPENDING at the precondition check →
+  `ErrFailedPrecondition` → gRPC `FailedPrecondition` with status detail.
+
+Either way the client gets a clean error.
+
+**Snapshot leak.** `DeleteActor` removes the actor record only; the
+snapshot URIs stored in `LastSnapshot` (and any `InProgressSnapshot`)
+point at object storage that is **not cleaned up**. This is a known
+operational issue, not a Valkey concern — flagging here because the
+state machine's terminal transition is the right place to surface it.
+
+## Implicit transition: syncer-driven RESET (RUNNING/RESUMING → SUSPENDED)
+
+When a worker pod is deleted in Kubernetes, the `WorkerPoolSyncer`
+(see `cmd/ateapi/internal/controlapi/syncer.go`,
+`releaseActorOnDeadWorker`) attempts to reset any actor currently bound
+to that worker:
+
+1. `GetWorker` to find the bound actor id.
+2. `GetActor` to confirm it still points at the dead pod (skip if a
+   concurrent SuspendActor already moved it).
+3. `UpdateActor` with version CAS to set status=SUSPENDED, clear pod
+   fields, clear InProgressSnapshot.
+
+**Critical property**: the syncer does **not** acquire `lock:actor:<id>`.
+It relies entirely on optimistic CAS on the actor's version.
+
+**Concurrent-with-SuspendActor analysis**:
+
+- If SuspendActor has bumped the version (any step that did `UpdateActor`),
+  syncer's `UpdateActor` gets `ErrPersistenceRetry` and **silently drops**
+  the error. SuspendActor completes; status ends up SUSPENDED via the
+  intended path; snapshot is preserved.
+- If syncer wins the race (runs before SuspendActor's first
+  `UpdateActor`), the actor is reset to SUSPENDED with **no snapshot
+  promoted** (any in-progress snapshot is cleared). SuspendActor then
+  loads, sees SUSPENDED, fast-forwards through everything, and returns
+  success — but the user's intent ("checkpoint before suspending") is
+  silently lost. The workload was never checkpointed because the worker
+  was already gone.
+
+**Concurrent-with-ResumeActor analysis**:
+
+- If ResumeActor is mid-AssignWorker and the chosen worker dies, syncer's
+  `releaseActorOnDeadWorker` either races with ResumeActor's
+  `UpdateActor` (one wins, the other gets `ErrPersistenceRetry`) or
+  observes the actor still pointing at the now-dead pod.
+- If syncer wins: actor reset to SUSPENDED, ResumeActor's UpdateActor
+  fails with `ErrPersistenceRetry`, AssignWorker retries (it has
+  backoff), re-loads actor (SUSPENDED again), reassigns to a different
+  free worker, proceeds.
+- If ResumeActor wins: actor is now RESUMING pointing at a worker whose
+  pod is being deleted. ResumeActor proceeds to CallAteletRestore,
+  fails (pod gone), returns error. Actor is **stranded RESUMING pointing
+  at a deleted worker**. Recovery requires another `ResumeActor` call,
+  which will re-AssignWorker — but the existing-assignment check finds
+  worker X (now deleted from DB by syncer) → falls through to "find free
+  worker" → picks new worker. Old workload (if any) is leaked.
+
+These race outcomes are not failures in isolation, but the system has
+no observability into them today. A counter on
+`releaseActorOnDeadWorker` outcomes (won race / lost race / no actor
+bound) would surface how often these paths fire in production.
+
+## Stranded states
+
+| Status | How we got here | What the next `ResumeActor` does | What the next `SuspendActor` does | Notes |
+|---|---|---|---|---|
+| RESUMING (with pod ptr) | Crash after AssignWorker, before FinalizeRunning | Re-assigns same worker, **re-invokes atelet Restore**, finalizes | Marks SUSPENDING, re-Checkpoints (workload may not exist yet on atelet → unclear) | Atelet-side idempotency assumption is load-bearing |
+| RESUMING (pod deleted) | Worker died mid-resume, syncer raced and lost | Re-assigns to a **different** worker, old workload leaks | Loaded actor still RESUMING, MarkSuspending advances to SUSPENDING with a *new* InProgressSnapshot, Checkpoint to a dead pod fails | Operator should `SuspendActor` first to reach a clean SUSPENDED |
+| SUSPENDING | Crash after Checkpoint, before FinalizeSuspended | Aborted: lock acquired by SuspendActor retry would conflict; if no concurrent suspend, ResumeActor proceeds to AssignWorker on a still-claimed worker → conflict | Fast-forwards MarkSuspending, re-Checkpoints to same URI, finalizes | Snapshot URI is stable across retries; relies on atelet to overwrite or dedup |
+
+There is no background reconciler that drives stranded actors to a
+clean state. Recovery is **client-driven retry** in all cases. A
+reconciler that periodically scans for actors stuck in transitional
+states longer than some threshold and re-issues the appropriate
+workflow is a known gap; the current design assumes clients (or
+controllers) will retry on their own behalf.
+
+## Risk register (lifecycle-specific)
+
+The risks below are specific to the actor state machine. Topology /
+scaling risks live in [`topology.md`](./topology.md).
+
+1. **`ListWorkers` fan-out inside `ResumeActor`.** Every actor resume
+   reads every worker in the cluster. This is the single most
+   load-bearing scaling concern in the critical path. Mitigations
+   exist (per-pool index, scoped scan, in-memory worker cache) but
+   none are implemented today. Detail in
+   [`admin-operations.md`](./admin-operations.md).
+
+2. **No retry on `FinalizeRunning` / `FinalizeSuspended`.** These steps
+   write the terminal status of the workflow but have no
+   `RetryBackoff()`. A single CAS conflict (which can be caused by an
+   informer-driven `UpdateActor` from `releaseActorOnDeadWorker` or any
+   other writer) strands the actor in a transitional state until an
+   external retry. Adding backoff to these steps is mechanically a
+   one-line change; understanding the contention model first is the
+   precondition.
+
+3. **Atelet-side idempotency assumed but undocumented.** The workflow
+   assumes `Restore` and `Checkpoint` can be safely re-invoked with the
+   same arguments. If atelet does not enforce idempotency, retries
+   double-resume (two workloads booting against the same actor id) or
+   double-checkpoint (racing writers to the same snapshot URI). This is
+   a contract that needs to be made explicit in the atelet protobuf
+   docs, and verified.
+
+4. **Syncer bypasses the actor lock.** `releaseActorOnDeadWorker`
+   operates with optimistic CAS only. The interleaving with a racing
+   `SuspendActor` can silently drop the user's snapshot intent (worker
+   dies during suspend → syncer resets actor first → SuspendActor
+   fast-forwards and reports success without checkpointing). Either
+   acquire the lock (with a short timeout to keep the syncer
+   responsive) or add explicit metrics so the path is observable.
+
+5. **Snapshot URI stability under retry.** The snapshot URI is set
+   atomically with status=SUSPENDING and stable across retries.
+   However, if a SuspendActor is retried *after* the actor reaches
+   SUSPENDED (i.e. lock released, status finalized), then a *new*
+   SuspendActor races a stale retry, the stable-URI assumption no
+   longer holds. The actor lock prevents this in practice; documenting
+   it ensures any future locking change does not regress.
+
+6. **Snapshot leak on delete.** `DeleteActor` removes the actor record
+   but not the snapshot blob. Operationally, an actor that is
+   resume-suspend-resume-suspend-...-delete leaves N snapshot URIs in
+   object storage with no Substrate-side cleanup. Not a Valkey
+   concern; flagged here as the natural place to track the lifecycle
+   gap.
+
+7. **No bounded retry budget on client-driven retries.** API errors
+   like `Aborted` ("concurrent update conflict, please retry") have no
+   server-side guidance about when to retry, and no per-actor circuit
+   breaker. A pathological caller can hot-loop the same actor and
+   starve other operations on the same shard.
+
+## Open questions for the design eval
+
+- What is the realistic ceiling on per-actor lifecycle QPS today? Without
+  measurement, the 10 ms-budget conversation is theoretical.
+- Should `AssignWorker` move to a pool-indexed scan (worker keys carry
+  the pool in the key, but the scan still reads all of them)?
+- Is the workflow framework (`WorkflowStep[Params, Context]`,
+  `RunWorkflow`) the right place to add a global step-level retry policy
+  for terminal steps, or should each step opt-in explicitly?
+- Should the syncer take the actor lock?
+- Is there an audit log of state-machine transitions? If not, debugging
+  a stranded actor relies on log greps across the API server.

--- a/docs/valkey/admin-operations.md
+++ b/docs/valkey/admin-operations.md
@@ -1,0 +1,263 @@
+# Admin & List Operations
+
+This page covers the storage operations that are **not** on the actor
+lifecycle critical path: bulk listing, debug utilities, and the
+implicit worker-record bookkeeping driven by the Kubernetes informer.
+
+They are labelled "non-critical" because they do not directly drive an
+actor's state machine. However, one of them — `ListWorkers` — is
+**called on the critical path** of every `ResumeActor`, and that
+crossing is the most important thing this document exists to surface.
+
+See [`actor-lifecycle.md`](./actor-lifecycle.md) for the operations that
+*are* on the critical path.
+
+## The cluster-mode SCAN constraint
+
+Every list operation in Valkey Cluster has the same shape: a key range
+cannot be scanned cluster-wide in one command. You have to ask each
+primary separately and merge results client-side. The codebase uses
+`s.rdb.ForEachMaster(ctx, fn)` to fan out, then runs `SCAN` against
+each primary's connection. Three implications colour every list
+operation:
+
+- Per-shard `SCAN` is non-atomic and may return duplicates or miss
+  recently-modified keys. The proto comments on `ListActorsRequest`
+  acknowledge this explicitly: *"actors may be missed or duplicated if
+  the system state changes during pagination."*
+- Cross-shard ordering is undefined. Callers that need a stable order
+  must impose it themselves.
+- Adding a primary mid-list invalidates any in-flight cursor — the new
+  primary will not be visited, its keys will not appear in this call.
+
+These constraints fall out of Valkey Cluster's design and are not
+solvable in the application layer. They drive the soft-semantics
+contract on every list method.
+
+## `ListActors` — paginated, well-formed
+
+<details>
+<summary><em>Expand</em></summary>
+
+See `cmd/ateapi/internal/store/ateredis/ateredis.go`, function
+`ListActors`.
+
+The implementation does the right things:
+
+- Sorts primaries by a stable address hash so pagination order is
+  deterministic across calls.
+- Walks one primary at a time, advancing per-shard `SCAN` cursor until
+  exhausted, then moves to the next primary.
+- Encodes `(shard_hash, cursor)` into an opaque page token so the next
+  call resumes exactly where the previous one stopped.
+- Honours `pageSize` as a target ceiling per call (Valkey's `SCAN COUNT`
+  is a hint, not a hard cap, so the actual page can drift slightly over).
+- Issues a `GET` per key after the `SCAN` returns the keys for a page.
+
+**Cost per page**: 1 `SCAN` call + `pageSize` `GET` calls (serial) on a
+single shard's connection. At a `pageSize` of 100, that's roughly 100 ms
+of round-trip-bound latency per page on intra-cluster mTLS — fine for a
+UI-style listing.
+
+**Risks**:
+
+- The per-key `GET` is serial. A pipelined or `MGET`-equivalent could
+  cut the wall-clock by an order of magnitude. Worth it if list pages
+  ever become user-facing critical-path.
+- Soft semantics: a user paginating through 1 M actors will *miss*
+  actors that are deleted during the pagination and may *see twice*
+  actors whose keys are touched during pagination. This is documented
+  on the request proto but worth surfacing in operator-facing tooling.
+- A primary failover mid-pagination invalidates the cursor (cursors
+  are per-connection in Valkey). The next page request will get an
+  error from the affected shard's cursor and start that shard from
+  the beginning, double-returning keys at the head.
+
+</details>
+
+## `ListWorkers` — unbounded, and on the critical path
+
+<details>
+<summary><em>Expand</em></summary>
+
+See `cmd/ateapi/internal/store/ateredis/ateredis.go`, function
+`ListWorkers`.
+
+**This is the most operationally significant function in the storage
+layer.** It is invoked by `AssignWorkerStep` inside every `ResumeActor`
+workflow (see [`actor-lifecycle.md`](./actor-lifecycle.md) — Transition
+2). Its cost directly determines the floor on actor-resume latency.
+
+Implementation properties:
+
+- **No pagination.** Reads every worker key in the cluster on every call.
+- **Fans out to every primary** via `ForEachMaster`. The fan-out is
+  sequential, not parallel (one primary at a time inside the callback).
+- **Serial `GET` per key** with the default `SCAN COUNT` (10). At
+  N workers, this is roughly N/10 `SCAN` calls + N `GET` calls per
+  invocation.
+- Returns the full list as one slice in memory. At 100 k workers and
+  ~200 bytes per Worker proto serialized, that is ~20 MB transferred,
+  parsed, and held per call.
+
+**Cost model**:
+
+| Workers | SCAN ops | GET ops | Round trips | Approx wall-clock (1ms/op) |
+|---|---|---|---|---|
+| 100   | ~10    | 100     | ~110    | ~110 ms |
+| 1 000 | ~100   | 1 000   | ~1 100  | ~1.1 s |
+| 10 000 | ~1 000 | 10 000 | ~11 000 | ~11 s |
+| 100 000 | ~10 000 | 100 000 | ~110 000 | **~110 s** |
+
+These numbers are storage-tier latency floors. They are **paid on every
+`ResumeActor` call**, before atelet is even contacted. The <10 ms
+whole-path budget for the state machine is unreachable at any
+non-trivial worker count under the current implementation.
+
+**Mitigation options**, in roughly increasing order of effort:
+
+1. **Pipeline the per-key `GET`s.** Single most impactful per-line-of-code
+   change. Cuts wall-clock by 5–10× by amortizing TLS round-trips
+   without touching the API or the SCAN strategy.
+2. **`MGET` per shard.** Even better — collapses N `GET`s into one
+   `MGET` per shard chunk. Works because the keys returned by a single
+   shard's `SCAN` are by definition co-located on that shard.
+3. **Pool-scoped secondary index.** Each worker has a known `WorkerPool`.
+   Maintain a Valkey set per pool (`pool:<ns>:<name>` → set of worker
+   keys); `AssignWorkerStep` reads only the set for the relevant pool.
+   Cuts read volume from "all workers" to "workers in the target pool"
+   — typically 1–2 orders of magnitude smaller. Costs a write
+   amplification (every CreateWorker / DeleteWorker also touches the
+   set) and the set must hash to the same slot as the workers (hash
+   tags required).
+4. **In-process worker cache fed by the K8s informer.** The
+   `WorkerPoolSyncer` already watches worker pods via the Kubernetes
+   informer. The same data could be cached in the API server process,
+   serving `AssignWorkerStep` from memory in microseconds, with the
+   informer keeping the cache fresh. Removes `ListWorkers` from the
+   critical path entirely. Cost: an extra source of truth to keep
+   consistent with the Valkey worker records.
+5. **Reverse the read direction.** Today, `AssignWorker` reads all
+   workers and filters for free ones in the right pool. A
+   `freeWorkers` set per pool (workers self-add when they become free,
+   actors atomically `SPOP` to claim one) collapses worker assignment
+   to two `O(1)` operations. Requires reworking the worker-claim
+   protocol significantly.
+
+Recommended near-term path: (1) + (2) for immediate relief, then (4)
+for the structural fix when scale demands it. (3) and (5) are larger
+designs that should be evaluated together.
+
+</details>
+
+## `GetActor`, `GetWorker` — point reads
+
+<details>
+<summary><em>Expand</em></summary>
+
+Single key `GET` per call, single shard, no fan-out. These are the
+cheapest operations in the storage tier: roughly 0.5–1 ms each on
+intra-cluster mTLS. They are used liberally throughout the lifecycle
+workflows (see the per-transition round-trip tables in
+`actor-lifecycle.md`).
+
+No risks beyond the standard cluster-mode failure modes (primary loss
+→ shard unavailable for a few seconds; whole-shard loss →
+cluster-wide stop with `cluster-require-full-coverage yes`). Covered
+in `topology.md` / forthcoming `failure-modes.md`.
+
+</details>
+
+## `CreateWorker`, `UpdateWorker`, `DeleteWorker` — informer-driven
+
+<details>
+<summary><em>Expand</em></summary>
+
+The `WorkerPoolSyncer` (see
+`cmd/ateapi/internal/controlapi/syncer.go`) watches the pod informer
+in Kubernetes and reconciles the Valkey worker records:
+
+- `CreateWorker` on first sight of an eligible pod (`SET NX`-style).
+- `UpdateWorker` on IP change (CAS-protected; the in-code comment
+  notes this path is not believed to be reachable in practice).
+- `DeleteWorker` on pod deletion or `DeletionTimestamp` set.
+
+These are **not** triggered by client API calls; they fire whenever the
+informer surfaces a pod event. At 100k workers, pod churn during
+deploys, autoscaler activity, and node maintenance can produce
+sustained CreateWorker/DeleteWorker traffic. The dominant cost is the
+storage CAS for `UpdateWorker` (rare) and the `DEL` for `DeleteWorker`
+(cheap).
+
+**Concurrency note**: `DeleteWorker` is paired with
+`releaseActorOnDeadWorker`, which mutates the actor record bound to
+the dying worker. The race analysis for that pairing is in
+[`actor-lifecycle.md`](./actor-lifecycle.md) under "Implicit
+transition: syncer-driven RESET".
+
+</details>
+
+## `DebugClearAll` — test fixture, not production
+
+<details>
+<summary><em>Expand</em></summary>
+
+`DebugClearAll` (in
+`cmd/ateapi/internal/store/ateredis/ateredis.go`) calls
+`FlushAllAsync` on every primary via `ForEachMaster`. It exists for
+test setup and is referenced by the storetest harness. There is no
+runtime guard against calling it in production; if exposed via an API
+surface it would be catastrophic.
+
+The function is package-public and reachable from any code that holds
+a `*Persistence`. The handbook recommendation is to either rename it
+to make the production-danger explicit (`DebugClearAll_TESTONLY`) or
+to add a build-tag guard. Until then, treat the symbol's reachability
+as a known sharp edge.
+
+</details>
+
+## `AcquireLock` / `ReleaseLock` — primitive, used by the lifecycle
+
+<details>
+<summary><em>Expand</em></summary>
+
+Implementation summary:
+
+- `AcquireLock` is `SET NX EX` with a caller-supplied token.
+- `ReleaseLock` is a Lua CAS script (read token, compare, conditional
+  delete). Safe under the "lock expired and was re-acquired by another
+  caller" scenario — the script will not delete a lock held by a
+  different token.
+- Single key, single shard per lock. No cluster-wide coordination.
+
+These are primitives consumed by the actor lifecycle (lock key
+`lock:actor:<id>`). They are not directly exposed to API clients but
+are recorded here because they are part of the storage-tier surface
+area.
+
+**Risk**: there is no fencing token. A caller that holds the lock,
+stalls long enough for the TTL to expire, then attempts a state
+mutation will have its mutation rejected by the version-CAS on the
+actor record — but only if the actor's version has advanced. In the
+narrow window where the lock has expired but no one else has claimed
+it (and no one else has updated the actor), a stalled caller can
+write through. The actor's version-CAS catches the common case; a
+true fencing-token discipline would close the remaining gap. Worth
+revisiting if the lock is ever extended to longer-running operations.
+
+</details>
+
+## Summary: which admin operations touch the critical path
+
+| Operation | On critical path | Cost (current impl) | Recommended action |
+|---|---|---|---|
+| `GetActor`, `GetWorker` | yes (many places) | ~1 ms | nothing |
+| `CreateActor` | yes (creation) | ~2 ms (one extra GET) | could drop the post-create GET |
+| `UpdateActor`, `UpdateWorker` | yes (every transition) | ~2 ms uncontended | see contention notes in lifecycle |
+| `DeleteActor` | yes (deletion) | ~2 ms | nothing |
+| `ListActors` | no (user-facing UI) | ~100 ms / page of 100 | pipeline / MGET if it ever moves to critical path |
+| `ListWorkers` | **yes** (every ResumeActor) | **O(N) round trips** | **fix this before scaling — pool index or in-process cache** |
+| `CreateWorker`, `DeleteWorker`, `UpdateWorker` (syncer) | no (informer-driven) | ~1–2 ms | nothing |
+| `DebugClearAll` | no (test only) | catastrophic if called | rename or guard |
+| `AcquireLock`, `ReleaseLock` | yes (Resume / Suspend) | ~1 ms each | add fencing if locks ever extend |

--- a/docs/valkey/critical-questions.md
+++ b/docs/valkey/critical-questions.md
@@ -1,0 +1,777 @@
+# Critical Questions
+
+This page tracks **open architectural decisions** specific to the storage
+tier — questions where the team knows a choice will need to be made, but
+the decision is not yet final. It is deliberately distinct from two
+nearby concepts:
+
+- The **risk register** (in [`topology.md`](./topology.md) and
+  [`actor-lifecycle.md`](./actor-lifecycle.md)) catalogs operational
+  hazards in the *current* design — things that are already true and
+  may bite us. Critical questions are about decisions we have not
+  made yet.
+- **Upstream RFCs** (GitHub issues tagged RFC, e.g. issue #12, #135)
+  are heavyweight design proposals with broad scope. A critical
+  question entry is lighter weight: it names a choice, sketches the
+  design space, and points at the constraints. Once a question grows
+  large enough to warrant a real proposal, the entry's resolution
+  links to the RFC.
+
+## Entry lifecycle
+
+Each entry below carries a **Status**:
+
+- **OPEN** — under consideration. Design space is described; no
+  binding choice has been made.
+- **DECIDED** — a choice has been made. The entry retains its
+  history but is annotated with the date, the deciding artifact
+  (PR / issue / handbook page), and which design-space option was
+  selected. Kept on the page so the reasoning is discoverable from
+  the storage handbook, not buried in commit history.
+- **DEFERRED** — explicitly punted, with a brief note on the trigger
+  that would re-open it (e.g. "revisit if per-resume p99 exceeds
+  20 ms").
+
+## When to add an entry
+
+Add a new entry when both are true:
+
+1. The decision has more than one defensible answer.
+2. The choice will affect more than one handbook page (topology,
+   lifecycle, admin-operations, or a future failure-modes /
+   latency-budget page).
+
+If neither is true, the right home is probably an inline TODO in the
+relevant handbook page or an upstream issue. If only condition 2 is
+true (one obvious answer, multi-page consequence), capture the
+guidance directly in the affected pages.
+
+---
+
+## Q-1: Can Valkey cluster mode support locality-aware scheduling?
+
+<details>
+<summary><em>Expand entry</em></summary>
+
+- **Status:** OPEN
+- **Tags:** scheduling, locality, sharding, cluster-mode, fallback
+- **Related:** upstream issues
+  [#119](https://github.com/agent-substrate/substrate/issues/119),
+  [#52](https://github.com/agent-substrate/substrate/issues/52),
+  [#44](https://github.com/agent-substrate/substrate/issues/44),
+  [#47](https://github.com/agent-substrate/substrate/issues/47),
+  [#198](https://github.com/agent-substrate/substrate/issues/198),
+  [#212](https://github.com/agent-substrate/substrate/issues/212);
+  [`topology.md`](./topology.md) — cluster-mode constraints and sizing;
+  `docs/architecture.md` (data-locality section);
+  `docs/roadmap.md` (data locality in scheduling);
+  [Q-2](#q-2-can-valkey-cluster-mode-tolerate-hot-partitions-and-serve-flat-keyspace-queries)
+  — secondary-indexing substrate (any locality index inherits Q-2's
+  hot-shard and cross-key consistency concerns);
+  [Q-3](#q-3-can-valkey-cluster-mode-support-label-based-worker-matching)
+  — locality is a special case of label-based matching, so a Q-3
+  answer may subsume this one.
+
+> *Assume the current O(N) worker-listing pattern is fixed by the time
+> this question matters; that fix is a tactical concern, not an
+> architectural one. The question this entry exists to answer is whether
+> distributed-Valkey-cluster-mode is a viable substrate for the
+> scheduling model we ultimately want.*
+
+### Why this matters
+
+The proposed state model (upstream issue #119) introduces a `PAUSED`
+state whose entire purpose is **locality**: keep snapshots on the node
+where the actor was running so that resume is fast and the cluster's
+NIC budget is not saturated re-uploading hot snapshots. Cache-aware
+routing (originally discussed in upstream issue #52, since merged into
+#119) is the read-side companion: route an actor's resume to a worker
+on a node that already holds its snapshot.
+
+Cluster-mode Valkey imposes structural constraints — hash-slot
+partitioning, no cross-slot atomicity, shard-local availability
+semantics — that may or may not support a locality-aware scheduler at
+1B-actor / 100k-worker scale (see [`topology.md`](./topology.md)). The
+question is **architectural, not implementation-level**: does cluster
+mode have the data-model and consistency primitives we need, and what
+does the fallback path look like when the primary mechanism misses or
+is unavailable?
+
+Answering this is a precondition for committing to either the PAUSED
+state or cache-aware routing. If cluster-mode Valkey cannot reasonably
+hold the snapshot-locality index, the locality story belongs on a
+different substrate (in-process cache, separate service, or a
+different persistence backend entirely). If it can, but with caveats,
+the caveats become hard design constraints on every other piece of
+the scheduler.
+
+<details>
+<summary><strong>What we know</strong></summary>
+
+**About cluster mode** (from [`topology.md`](./topology.md)):
+
+- 16,384 hash slots are partitioned across primaries. A key's home
+  slot is `CRC16(key) mod 16384`.
+- **Cross-slot atomicity is forbidden.** A single Valkey operation
+  (multi-key command, transaction, Lua script) cannot touch keys in
+  different slots. Hash tags (`{tag}` substring of a key) override
+  the slot calculation and force co-location, at the cost of skewing
+  distribution toward whichever shard owns the tag's slot.
+- **`cluster-require-full-coverage yes`** (currently set) means
+  losing any single shard takes down the entire cluster's writes.
+  Flipping to `no` lets surviving shards keep serving their slot
+  ranges at the cost of per-slot availability instead of all-or-nothing.
+- Replica failover takes seconds (`cluster-node-timeout` 5 s plus
+  election plus client slot-map refresh), during which the affected
+  slot range is unavailable.
+- Cluster-bus gossip cost grows roughly O(N²) in primary count; the
+  practical comfort ceiling is widely cited at ~500 primaries.
+
+**About the locality model:**
+
+- A snapshot lives in object storage indefinitely (no Substrate-side
+  cleanup today). When materialized for use, it is also cached on
+  the node where the actor is running.
+- The mapping `snapshot_id → {nodes currently caching it}` is the
+  data the scheduler needs. Nothing in the current data model
+  stores this; it would be net new.
+- That mapping changes whenever a snapshot is created on a node,
+  evicted from a node cache, or moved between nodes. Eviction is
+  driven by node-local pressure (storage, memory, restart) and is
+  not centrally coordinated today.
+- Worker pods can be rescheduled by Kubernetes; the node a worker
+  pod runs on is not stable over the pod's lifetime.
+
+**About scale:**
+
+- At target scale (1 B actors, see [`topology.md`](./topology.md)),
+  even a modest 10–20 % of actors carrying a recently-cached
+  on-node snapshot puts the index at **100 M – 200 M entries**. The
+  Valkey keyspace handles that easily across 50–200 primaries; the
+  question is what *kinds* of access patterns those keys see.
+- A "popular" snapshot — e.g. the golden snapshot for an
+  ActorTemplate used by many actors — could be cached on hundreds
+  or thousands of nodes simultaneously. A single set-of-nodes
+  member can be effectively unbounded.
+
+</details>
+
+<details>
+<summary><strong>Design space</strong></summary>
+
+Two intertwined sub-questions: **(L)** where does the locality
+mapping live, and **(R)** what's the fallback when locality misses or
+is unavailable. The answer is almost certainly an L + R pair.
+
+**L: where does the locality data live**
+
+- **L-A. Cluster-stored, sharded by snapshot ID.** `loc:<snapshot_id>`
+  is a set of node IDs currently caching that snapshot. Scheduler
+  does an O(1) `SRANDMEMBER loc:<snapshot_id>` to find a candidate
+  node, then picks a free worker on that node. Property bought:
+  cluster-wide consistent view of locality, accessible from any API
+  server. Cost: every snapshot cache event (create / evict / move)
+  is a write to a *different* shard than the actor record — so the
+  actor-state and index-state writes cannot be made atomic, and we
+  accept some best-effort window of disagreement.
+- **L-B. Cluster-stored, sharded by node.** `nodecache:<node_id>`
+  is a set of snapshot IDs cached on that node. To find candidate
+  nodes for a snapshot, the scheduler would have to scan every
+  `nodecache:*` set — O(nodes) reads per scheduling decision. Worse
+  on the read side, simpler on the write side. Probably not viable
+  at target scale; included for completeness.
+- **L-C. Cluster-stored, co-located via hash tags.** Force the
+  index and the relevant actor record onto the same shard by hash
+  tag (`actor:{<snapshot_id>}:<actor_id>` and `loc:{<snapshot_id>}`).
+  Allows atomic actor + index updates and removes cross-key
+  consistency from the table. Cost: distribution skew — popular
+  snapshots hot-spot the shard their tag hashes to, and the snapshot
+  ID becomes a load-balancing dimension whether we want it to or
+  not.
+- **L-D. No separate index — hint in the actor record itself.**
+  The actor's existing `AteomPod*` fields are retained across
+  SUSPEND/RESUME as a *preference* rather than cleared. Resume
+  reads the actor, attempts the hinted pod, falls back on miss.
+  Property bought: zero new index, zero cross-key writes, fits in
+  the existing actor GET. Cost: the hint is only as fresh as the
+  last assignment — no awareness of snapshot eviction or node
+  rescheduling between then and now.
+- **L-E. Index lives outside Valkey.** API-server in-process cache
+  fed by atelet heartbeats, or a separate locality service.
+  Decouples the locality data path from Valkey entirely. Cost: a
+  second source of truth to keep consistent; in-process variants
+  lose state on API-server restart unless persisted somewhere.
+
+**R: random-fallback path when L misses or is unavailable**
+
+- **R-A. Random shard, random worker.** Pick a random shard from
+  the slot map, then pick a random free worker on that shard.
+  Requires that workers expose themselves shard-locally (e.g. a
+  per-shard `workers` set written by the syncer, or an external
+  registry). O(1), zero locality. Reasonable as a fallback; not
+  reasonable as a primary mechanism unless locality is genuinely
+  unwanted.
+- **R-B. Pool-aware random.** Random *within the target pool* only.
+  Same mechanics as R-A but restricted to the relevant worker pool.
+  Required as soon as pools have different shapes (CPU class,
+  image, runtime), which they will.
+- **R-C. Park-and-retry** (per upstream issue #52, step 3). When
+  locality misses, *hold* the request rather than falling back to
+  random, betting that a locality-matching worker will free up soon.
+  Trades availability for locality preservation. Probably useful as
+  a top-up policy layered on R-B, not as a primary fallback.
+
+</details>
+
+<details>
+<summary><strong>Open subquestions</strong></summary>
+
+1. **Cross-key consistency.** Under L-A, snapshot cache updates and
+   actor-state updates touch different shards and cannot be made
+   atomic. Can the system tolerate brief windows where the actor is
+   RUNNING but the index does not yet reflect the assignment, or
+   vice versa? If yes, the simpler design works. If no, the answer
+   forces L-C (hash-tag co-location, accepting skew) or a
+   reconciliation protocol.
+2. **Availability under shard loss.** If the shard holding the
+   locality index (under L-A or L-C) or the shard holding a
+   per-shard worker registry (under R-A) has a failover or total
+   loss, what happens? Under `cluster-require-full-coverage yes`
+   (current), all scheduling stops cluster-wide. Under `no`,
+   scheduling continues with degraded behavior for the affected
+   slot range. Which mode are we committing to, and what's the
+   user-visible contract during a shard outage?
+3. **Popular-snapshot hot keys.** A golden snapshot cached on
+   hundreds of nodes is a single set with hundreds of members.
+   `SRANDMEMBER` is O(1) per pick, but every node-cache update is a
+   write to that same set. Does the hot-key write rate survive
+   cluster mode's single-threaded primary execution? At what fan-in
+   does it stop?
+4. **Eviction staleness.** When a node evicts a snapshot from its
+   cache, what is the acceptable lag before the index reflects that
+   eviction? Stale entries cause sniper-shot misses (acceptable —
+   fallback covers them), but at some rate they degrade
+   scheduling quality enough to be measurable. What's the budget?
+5. **K8s pod rescheduling.** Worker pods can be moved between nodes
+   by Kubernetes (eviction, node failure, deploys). When a pod
+   moves nodes, the on-node snapshot cache does *not* follow.
+   Does the locality index key on node ID (cache survives pod
+   reschedule, pod-to-node mapping must be looked up) or on pod ID
+   (cache invalidated on pod reschedule, no extra lookup)? Each
+   choice has materially different invalidation semantics.
+6. **Index size at scale.** 100–200 M entries spread across 50–200
+   primaries works for the keyspace. But does it survive
+   `BGSAVE` / `BGREWRITEAOF` fork latency and full-resync time
+   bounds on individual primaries as per-shard memory grows? This
+   feeds back into [`topology.md`](./topology.md)'s primary-count
+   sizing.
+7. **Fallback observability.** Without a metric for "fraction of
+   scheduling decisions that hit the fallback path," locality
+   regressions are invisible. What metric primitives need to be in
+   place before any L-A / L-C design ships?
+8. **Whether Valkey is the right substrate at all.** If the answers
+   to (1)–(7) push us toward L-E (index outside Valkey), the
+   locality story decouples from the persistence-backend decision.
+   Valkey may still be fine for actor records but not for the
+   locality index. That changes the broader storage evaluation.
+
+</details>
+
+<details>
+<summary><strong>What would change in the handbook</strong></summary>
+
+- [`topology.md`](./topology.md) — sizing math grows by the index
+  size and access pattern if the answer is L-A / L-B / L-C. If the
+  answer is L-D or L-E, sizing is unaffected.
+- [`actor-lifecycle.md`](./actor-lifecycle.md) — Transition 2
+  (Resume) gains an explicit locality-lookup step and an explicit
+  random-fallback step, each with its own latency budget and
+  failure mode.
+- [`admin-operations.md`](./admin-operations.md) — locality-index
+  inspection, repair, and reconciliation become admin operations in
+  their own right under any L-A / L-B / L-C answer.
+- Future `failure-modes.md` — index inconsistency (entries pointing
+  at nodes that have evicted the snapshot) and index unavailability
+  (the locality shard is failing over) need their own failure-mode
+  entries with detection signals and recovery procedures.
+
+</details>
+
+</details>
+
+## Q-2: Can Valkey cluster mode tolerate hot partitions and serve flat-keyspace queries?
+
+<details>
+<summary><em>Expand entry</em></summary>
+
+- **Status:** OPEN
+- **Tags:** hot-keys, sharding, indexing, cluster-mode, queryability
+- **Related:** [`topology.md`](./topology.md) — cluster-mode
+  constraints and sharding model;
+  [`admin-operations.md`](./admin-operations.md) — `ListWorkers` /
+  `ListActors` cluster-wide scan patterns;
+  [`failure-modes.md`](./failure-modes.md) — primary-loss / shard-loss
+  blast radius; [Q-1](#q-1-can-valkey-cluster-mode-support-locality-aware-scheduling)
+  — same write-amplification and consistency concerns apply to any
+  secondary index;
+  [Q-3](#q-3-can-valkey-cluster-mode-support-label-based-worker-matching)
+  — label-based scheduling is the most likely first need for real
+  secondary indexes.
+
+> *Two distinct concerns travel together here: **hot partitions**
+> (one shard receives disproportionate load — usually because of a
+> hot key or a slot range that happens to hold popular data) and
+> **flat keyspace** (no native way to ask "all actors matching X"
+> without a cluster-wide scan). They share a substrate — cluster
+> mode's hash-slot model — and the available mitigations overlap.*
+
+### Why this matters
+
+Cluster mode assumes keys are uniformly distributed across the
+16,384 slots. Real access patterns are not uniform. Two concrete
+failure shapes:
+
+- **A single hot actor.** Some actors get hammered far harder than
+  others — a debugging target, a misbehaving client in a retry
+  loop, a popular template's instance. That actor's key lives on
+  one slot, on one primary. That primary's single-threaded command
+  execution becomes the cluster-wide bottleneck for any traffic
+  involving that actor — and, under
+  `cluster-require-full-coverage yes`, any spillover impacts the
+  whole cluster.
+- **Implicit hot prefix.** If business logic ever creates keys that
+  cluster on certain slots (e.g. tenant-scoped hash tags that
+  concentrate a big tenant onto one shard), the same single-primary
+  bottleneck applies but is harder to detect because the keys look
+  different.
+
+The flat-keyspace problem is the other half of the same model. The
+current key scheme (`actor:<id>`, `worker:<ns>:<pool>:<pod>`) gives
+us point lookup by full key and SCAN-based enumeration — nothing
+else. Any "find actors matching X" query either reduces to "iterate
+everything" (the [`admin-operations.md`](./admin-operations.md)
+`ListWorkers` problem, generalized) or requires explicit secondary
+indexes that the application maintains by hand.
+
+Both failure shapes worsen with scale. A 6-pod MVP cluster rarely
+notices a hot key — there's enough headroom on each primary's core.
+A 200-primary target-scale cluster, with finer slot partitioning
+and tighter per-shard QPS ceilings, is much more sensitive. The
+flat-keyspace problem similarly: it's an annoyance at MVP, a
+correctness/SLO concern at target scale.
+
+<details>
+<summary><strong>What we know</strong></summary>
+
+**About hot keys under cluster mode:**
+
+- Valkey's primary is single-threaded for command execution. One
+  hot key saturates one CPU core. Adding cluster nodes does not
+  help — the hot key still lives on one primary.
+- Replicas can serve reads if the client opts in
+  (`ReadOnly` / `RouteByLatency` / `RouteRandomly` in go-redis).
+  Currently the API server does **not** opt in
+  (see [`topology.md`](./topology.md)) — all reads route to primaries.
+- Resharding (moving slots between primaries) is supported but
+  manual and disruptive. There is no automatic hot-slot rebalancing.
+- Valkey's `--hotkeys` mode for `valkey-cli` can sample hot keys,
+  but it's expensive to run and not suitable for continuous
+  monitoring.
+
+**About flat keyspace:**
+
+- Current key scheme is intentionally flat. No hash tags.
+- The only enumeration primitives are `SCAN` (per-shard, fan-out
+  via `ForEachMaster`) — both are O(N) over the relevant key set.
+- `ateredis`'s denormalization (worker status inline in actor
+  records) was specifically designed to avoid the cross-key
+  problem this question asks about: it sidesteps the need for
+  secondary indexes by duplicating data. That works at small scale
+  but creates write amplification and consistency risk as data
+  grows.
+- The Worker proto has no labels / metadata beyond pool / pod
+  identity. Any future label-based scheduling (Q-3) needs either a
+  proto extension or an external label index.
+
+**About scale interaction:**
+
+- At MVP (3 primaries, low QPS), one core per shard is plenty;
+  hot keys are unlikely to bind.
+- At target (50–200 primaries, 100k workers' worth of traffic),
+  per-shard QPS ceilings tighten and hot-key risk grows.
+- Flat-keyspace `SCAN` operations that are tolerable at 10k actors
+  become unusable at 1B. The
+  [`admin-operations.md`](./admin-operations.md) numbers for
+  `ListWorkers` are the worked example.
+
+</details>
+
+<details>
+<summary><strong>Design space</strong></summary>
+
+Two intertwined sub-questions: **(H)** how do we tolerate hot
+partitions, and **(I)** how do we serve queries that the flat
+keyspace doesn't natively support.
+
+**H: hot-partition mitigations**
+
+- **H-A. Read-side replica routing.** Configure the cluster client
+  to send reads to replicas (`ReadOnly`, optionally with
+  `RouteByLatency` / `RouteRandomly`). Buys read scale-out at the
+  cost of read-after-write consistency (replicas lag the primary).
+  Cheap to enable; well-suited to read-heavy hot keys.
+- **H-B. API-server local cache with short TTL.** Cache hot reads
+  in the API server process with a few-second TTL. Effectively
+  another form of read-side scaling without touching Valkey
+  config. Cost: cache invalidation discipline, slightly stale data.
+- **H-C. Application-level key sharding.** Split a logically-single
+  hot key into N sub-keys distributed by request-id hash. The
+  application reassembles or routes per-request. Only useful for
+  certain access patterns (counters, queues, aggregations).
+  Inappropriate for entity records like `actor:<id>` where the key
+  represents a single logical thing.
+- **H-D. Manual slot rebalancing.** When a hot slot is identified
+  via monitoring, manually move it to a less-loaded primary using
+  `CLUSTER SETSLOT`. Disruptive and labor-intensive; treats the
+  symptom, not the cause.
+- **H-E. Redesign to eliminate the hot key.** Often the real fix —
+  if a key is hot because the workload has a bottleneck on it, the
+  bottleneck may be removable at the application level.
+- **H-F. Move to a multi-threaded primary.** Garnet or KeyDB
+  removes the single-core-per-shard ceiling. This is a backend
+  swap, not a configuration knob — covered separately in the
+  backend-selection conversation.
+
+**I: secondary-index / non-flat-query strategies**
+
+- **I-A. In-Valkey secondary index, hash-tagged.** Maintain
+  explicit index keys (e.g. `idx:pool:{<pool>}` is a SET of worker
+  IDs in that pool). Hash tags co-locate the index with its
+  members, enabling atomic membership updates via single-key sets.
+  Buys: O(1) lookup; structured queries inside cluster mode.
+  Costs: write amplification on every entity create / delete /
+  update (touch the entity record AND every index it belongs to);
+  the hash-tag concentration means the index's host shard sees all
+  traffic for that index — a new hot-shard risk.
+- **I-B. In-Valkey secondary index, separately sharded.** Don't
+  hash-tag; let the index spread by its own key's hash. Costs:
+  index updates are cross-shard (no atomicity with the entity
+  update); requires reconciliation discipline.
+- **I-C. In-process index in the API server, fed by informer or by
+  storage writes.** Build the index in memory in each API server,
+  served from RAM in microseconds. Costs: an additional source of
+  truth to keep consistent; rebuilds on API-server restart;
+  per-server memory cost.
+- **I-D. External index.** Drop indexing into a system designed
+  for it (Elasticsearch, a custom service). Costs: a new
+  operational dependency; new failure modes; no shared
+  consistency story with Valkey.
+- **I-E. Accept O(N) scans for admin queries; design the hot path
+  never to need them.** The current state with discipline added.
+  Works if every critical-path query has a known key.
+
+The composition matters. Most realistic answers combine an `H`
+choice for the hot-key direction and an `I` choice for the
+queryability direction. A common shape: H-A + H-B + I-C — read
+replicas + local cache + in-process index. That keeps the hot path
+off the cluster entirely for both load-balancing and queryability.
+
+</details>
+
+<details>
+<summary><strong>Open subquestions</strong></summary>
+
+1. **What is the actual hot-key risk at our access pattern?** Most
+   actors are touched by one or a few actors at a time — write
+   patterns are write-heavy but not bursty per key. The real
+   hot-key risk likely comes from accidental shared state (a hot
+   counter, a popular template's reads, a registry key). Need
+   monitoring to know.
+2. **How do we monitor for hot keys continuously?** `--hotkeys`
+   sampling is too expensive for production. Likely answer: track
+   per-shard QPS imbalance as a leading indicator; sample only
+   when imbalance is detected.
+3. **Do we want a general secondary-indexing strategy, or do we
+   solve each indexing need bespoke?** A general framework (in-
+   process index pattern, informer-fed, generic) is reusable for
+   pool indexing, label indexing (Q-3), locality indexing (Q-1).
+   Without a framework, each new need invents its own pattern.
+4. **How does an in-Valkey index (I-A / I-B) interact with
+   `cluster-require-full-coverage`?** If the index's host shard
+   has a failover or loss, all queries against that index fail.
+   Same answer applies as Q-1 sub-question 2: pick a stance on
+   coverage mode first.
+5. **What's the cost ceiling on read replicas (H-A) before they
+   become the new bottleneck?** Replica resync overhead, network
+   amplification — each read-routed-to-replica is still a network
+   request. At a high enough read rate the replicas saturate too.
+6. **Should the in-process cache (H-B / I-C) be a project-wide
+   primitive?** A general informer-fed cache layer in the API
+   server (one source of truth, multiple indexed views) would
+   solve hot-keys, flat-keyspace queries, and the worker-selection
+   problem from Q-1 in one shape.
+
+</details>
+
+<details>
+<summary><strong>What would change in the handbook</strong></summary>
+
+- [`topology.md`](./topology.md) — if the answer is I-A / I-B (any
+  Valkey-side secondary index), sizing grows by the index size and
+  the index shard's QPS becomes a load-bearing capacity figure.
+- [`actor-lifecycle.md`](./actor-lifecycle.md) — any write that
+  must also touch an index becomes a cross-key operation, which
+  needs new round-trip accounting on the relevant transitions.
+- [`admin-operations.md`](./admin-operations.md) — index inspection
+  and reconciliation become admin operations in their own right
+  under any in-Valkey indexing answer.
+- [`failure-modes.md`](./failure-modes.md) — new entries for index
+  inconsistency (entity exists but not in its expected index, or
+  index points to non-existent entity) and index unavailability
+  (the index shard is down).
+- [`risk-register.md`](./risk-register.md) — R-10
+  (`ListWorkers` O(N)) and R-22 (popular-snapshot hot keys)
+  collapse into or expand from this entry depending on which
+  design is chosen.
+
+</details>
+
+</details>
+
+## Q-3: Can Valkey cluster mode support label-based worker matching?
+
+<details>
+<summary><em>Expand entry</em></summary>
+
+- **Status:** OPEN
+- **Tags:** scheduling, labels, indexing, cluster-mode, k8s
+- **Related:** [Q-1](#q-1-can-valkey-cluster-mode-support-locality-aware-scheduling)
+  — locality scheduling is a special case of label-based matching
+  ("has snapshot X cached" is one specific label);
+  [Q-2](#q-2-can-valkey-cluster-mode-tolerate-hot-partitions-and-serve-flat-keyspace-queries)
+  — label indexing is the most likely first concrete need for the
+  secondary-indexing decision; upstream issues
+  [#47](https://github.com/agent-substrate/substrate/issues/47),
+  [#212](https://github.com/agent-substrate/substrate/issues/212);
+  [`actor-lifecycle.md`](./actor-lifecycle.md) — `AssignWorkerStep`
+  is where label filtering would land;
+  [`admin-operations.md`](./admin-operations.md) — current scheduler
+  filters by pool only.
+
+> *Today, worker selection filters by pool name only. The natural
+> next ask is multi-dimensional matching — "find a free worker with
+> H100 AND in pool foo AND has snapshot xyz cached." That is a set
+> intersection over arbitrary label dimensions, and the data model
+> for it doesn't exist in the current Worker proto. This question
+> exists to decide the shape of the answer before that ask becomes
+> urgent.*
+
+### Why this matters
+
+Real scheduling requirements are not single-dimension. A few
+plausible near-term examples:
+
+- **Hardware affinity.** A workload needs an H100 GPU; the worker
+  pod has the H100 label (it's running on a node with the GPU);
+  the scheduler should only match those.
+- **Snapshot locality** (Q-1, generalized). A worker that has the
+  actor's snapshot cached is preferred. The "has snapshot X" is
+  effectively a dynamic label that comes and goes as the cache
+  changes.
+- **Workload affinity / tenancy.** A worker tagged for a specific
+  customer, or restricted to certain workload types, or running
+  a specific runtime version.
+- **Temporary draining state.** A worker marked "draining" should
+  not receive new assignments. This is a single negative label,
+  but it's the same primitive.
+
+Each of these reduces to the same operation: **given a set of
+required labels, find a free worker that has all of them.**
+
+The current scheduler in `AssignWorkerStep` (see
+[`actor-lifecycle.md`](./actor-lifecycle.md) Transition 2) does
+this in the simplest possible way: read every worker, filter
+in-process. That doesn't scale — the
+[`admin-operations.md`](./admin-operations.md) cost table for
+`ListWorkers` already shows it's O(N) round trips per scheduling
+decision, and label filtering doesn't change that.
+
+The deeper question is what shape worker labels take and where
+they're stored. K8s pods already have labels — the informer already
+sees them. So the answer might not involve Valkey at all (the
+labels live in K8s, the scheduler reads from an informer-fed
+in-process index). Or it might involve Valkey holding a label
+index for cross-API-server consistency. The choice has cascading
+consequences for the rest of the storage tier.
+
+<details>
+<summary><strong>What we know</strong></summary>
+
+**About the current scheduler:**
+
+- `AssignWorkerStep` filters by pool name and namespace only.
+- The Worker proto carries `worker_namespace`, `worker_pool`,
+  `worker_pod`, `actor_*` assignment fields, and `ip` / `uid` —
+  **no label dimension**.
+- The filter step happens after reading every worker in the cluster
+  (the Q-1 / R-10 problem).
+- `findFreeWorker` shuffles candidates randomly to spread load.
+
+**About K8s labels:**
+
+- Worker pods already carry K8s labels. `WorkerPoolSyncer` uses
+  one of them (`workerPodLabel`) to identify the pool.
+- The informer surfaces the full label set on every pod event.
+- K8s label selectors support equality (`key=value`),
+  set-membership (`key in (a, b)`), and exists/not-exists. They do
+  not natively support range queries.
+- At 100k worker pods, the informer cache holds a large amount of
+  pod data in API-server memory — already a real cost.
+
+**About cluster-mode constraints (re-stated):**
+
+- Cross-slot atomicity is forbidden.
+- Multi-key set intersection (`SINTER`) requires all keys to hash
+  to the same slot. Forcing co-location via hash tags concentrates
+  a whole index family on one shard — hot-shard risk per Q-2.
+- Single-key operations (one set per label, queried independently)
+  scale naturally but require the application to do the
+  intersection client-side.
+
+**About label cardinality (assumptions, not measurements):**
+
+- Pool: low cardinality (tens, maybe hundreds).
+- Hardware class (H100, A100, CPU-only): low cardinality (tens).
+- Snapshot-cached labels (Q-1 locality): high cardinality and
+  dynamic — one label per cached snapshot, set of nodes per label.
+- Per-tenant / per-customer labels: potentially very high
+  cardinality at multi-tenant scale.
+
+The right data structure depends heavily on which of these regimes
+the labels live in.
+
+</details>
+
+<details>
+<summary><strong>Design space</strong></summary>
+
+Six candidate shapes, in roughly increasing decoupling from
+Valkey:
+
+- **L-A. Brute-force scan with label filter.** Current pattern,
+  extended to filter on label fields in the Worker proto. Requires
+  proto extension; doesn't fix scaling. Useful only as the most
+  minimal change to get *correct* label behavior; doesn't fix
+  *fast* label behavior.
+- **L-B. Per-label SET in Valkey, hash-tagged to one slot.**
+  `label:{schedulingdomain}:H100` is a SET of worker IDs.
+  Scheduling: `SINTER label:{schedulingdomain}:H100
+  label:{schedulingdomain}:pool-foo` returns matching workers.
+  Hash tag forces co-location so SINTER works in cluster mode.
+  Costs: every label key shares one shard → hot-shard concern
+  (Q-2); every worker update writes to many SETs.
+- **L-C. Per-label SET in Valkey, sharded by label name.** No
+  hash tag; each label's SET lives on whichever shard its key
+  hashes to. Cross-shard intersection cannot be done with SINTER
+  — the application must read each SET separately and intersect
+  client-side. Costs: more round trips per scheduling decision;
+  no atomicity between label updates.
+- **L-D. In-process inverted index in the API server, fed by the
+  K8s informer.** Each API server maintains
+  `map[label] → set[worker_id]` in memory; intersections are
+  microseconds. The informer already has the label data. Costs:
+  per-server memory cost (significant at 100k workers with many
+  labels); rebuild on API-server restart.
+- **L-E. K8s label selectors via the informer.** Skip the
+  inverted index entirely. The informer maintains its own indexed
+  view; the scheduler queries it with a label selector and gets
+  back the matching pods. Costs: tightly couples the scheduler to
+  the K8s informer's query capabilities (no range queries, no
+  fancy predicates); informer query rate at 100k workers needs
+  measurement.
+- **L-F. External label-search system.** Index workers in
+  Elasticsearch / OpenSearch / similar. Schedule by querying the
+  search system, then reading matching workers from Valkey
+  (or the in-process cache). Costs: new operational dependency;
+  new failure mode; consistency story between the index and the
+  workers.
+
+**Cross-cutting with Q-1.** Locality scheduling is L-D or L-E
+applied to one specific label dimension ("has snapshot X cached").
+A solution to Q-3 that handles dynamic high-cardinality labels
+likely *subsumes* Q-1 — locality becomes one row in the label
+matrix, not a separate system. Conversely, a Q-3 answer that only
+handles low-cardinality static labels (L-B / L-C) leaves Q-1
+unsolved.
+
+**Cross-cutting with Q-2.** L-B and L-C are both instances of the
+in-Valkey secondary-index pattern Q-2 addresses. The answer to
+Q-2's I-A vs I-B vs I-C choice directly determines which Q-3
+candidate is feasible.
+
+</details>
+
+<details>
+<summary><strong>Open subquestions</strong></summary>
+
+1. **Where do labels live — on the Worker proto, on K8s pod
+   labels, or both?** If K8s-only, L-D / L-E / L-F are natural and
+   the storage tier doesn't change. If Worker-proto-only, the
+   index must be maintained by the API server's storage writes.
+   If both, consistency between the two becomes an operational
+   problem.
+2. **What's the expected label cardinality?** Low-cardinality
+   static labels (hardware class, pool) are easy under any scheme.
+   Dynamic high-cardinality labels (snapshot-cached, per-tenant)
+   force harder choices. Without numbers, the design picks the
+   wrong tradeoffs.
+3. **Are scheduling queries always conjunctions (AND)?** If yes,
+   simple set intersection works. If we need OR / NOT / range,
+   we likely need a real query layer (L-F).
+4. **What is the consistency contract on label updates?** A
+   worker re-tagged for a new GPU model needs to start receiving
+   matching work; how stale can the index be? Q-1 has the same
+   question for locality, with the same answer space.
+5. **Does this interact with worker autoscaling (upstream issue
+   #198)?** Yes — pods come and go, labels come and go with them.
+   The index must tolerate the autoscaler's pace.
+6. **Should this be in scope for MVP?** Probably not for the first
+   alpha — the current pool-only filter covers the obvious
+   workloads. Becomes urgent the first time a customer asks for
+   hardware affinity or any cross-pool dimension. Worth deciding
+   the shape now so the eventual implementation isn't
+   pattern-incompatible with the existing scheduler.
+7. **Should the answer collapse Q-1 and Q-3 into one decision?**
+   If yes (label-based scheduling generalizes locality), the
+   handbook benefits from one mechanism rather than two. If no
+   (locality is dynamic enough to deserve special treatment),
+   keep them separate.
+
+</details>
+
+<details>
+<summary><strong>What would change in the handbook</strong></summary>
+
+- [`actor-lifecycle.md`](./actor-lifecycle.md) — `AssignWorkerStep`
+  in Transition 2 gains a label-filter step. Latency depends
+  entirely on which design is chosen (L-D is microseconds; L-B is
+  a SINTER round trip; L-F is an external HTTP hop).
+- [`admin-operations.md`](./admin-operations.md) — label-index
+  inspection becomes an admin operation under L-B / L-C / L-F.
+  Under L-D / L-E, the inspection is in-process and surfaces via
+  metrics rather than admin commands.
+- [`topology.md`](./topology.md) — under any in-Valkey label-index
+  answer, sizing math grows by the label-index data. Under L-D,
+  per-API-server memory grows with label cardinality.
+- [`failure-modes.md`](./failure-modes.md) — label-index
+  inconsistency (worker matches the label predicate but isn't
+  picked up, or is picked up but doesn't actually have the
+  capability) becomes a failure-mode category.
+- [Q-1](#q-1-can-valkey-cluster-mode-support-locality-aware-scheduling)
+  — if Q-3 resolves first with L-D / L-E / L-F, the locality
+  question may be answered as a special case rather than a
+  separate mechanism.
+
+</details>
+
+</details>

--- a/docs/valkey/failure-modes.md
+++ b/docs/valkey/failure-modes.md
@@ -1,0 +1,672 @@
+# Failure Modes
+
+This page catalogs the ways the Valkey deployment can fail, what each
+failure looks like from outside, how much of the system it takes down,
+and what auto-recovery does (or doesn't do) for you. It is written for
+the on-call engineer reading this at 3am with a paging alert open.
+
+The framing scope is **the storage tier itself**. Failures that
+originate in the actor lifecycle (stranded RESUMING, syncer races, etc.)
+live in [`actor-lifecycle.md`](./actor-lifecycle.md). Failures that
+originate in admin paths live in
+[`admin-operations.md`](./admin-operations.md). Where a Valkey failure
+*causes* a lifecycle failure, this page links across — but the
+authoritative description of the lifecycle effect stays in the
+lifecycle doc.
+
+Two cross-cutting tables at the end summarize:
+1. Which Valkey failures affect which actor operations.
+2. Per-failure detection signal + first response (the cheatsheet).
+
+## Detection model
+
+Failure signals come from four places, in roughly increasing
+specificity:
+
+- **Client-side errors** in `ate-api-server` logs and metrics — usually
+  the first thing on-call sees. Patterns: `MOVED` / `ASK` (slot-map
+  staleness), `CLUSTERDOWN` (no full coverage), `MASTERDOWN`
+  (replication issue), TLS handshake failures, context-deadline
+  errors.
+- **Kubernetes events and pod status** — pod restarts, OOMKilled,
+  Pending state, PVC binding failures. Surfaced by `kubectl events`
+  and the cluster's K8s event monitoring.
+- **Valkey `INFO` and cluster commands** — `INFO replication`,
+  `INFO persistence`, `CLUSTER INFO`, `CLUSTER NODES`. These give
+  authoritative state but require shelling into a pod.
+- **Prometheus / metric exporters** — replication lag, memory usage,
+  ops/sec, fsync latency. These are the leading indicators that fire
+  *before* the user-visible failure.
+
+The handbook recommendation is to wire all four into a single
+incident runbook so the on-call doesn't have to chase signals across
+multiple consoles during an active page.
+
+## Pod & process failures
+
+> **Interaction with `cluster-require-full-coverage`.** All three
+> pod-level failure modes below are amplified by the current
+> `cluster-require-full-coverage yes` setting (see
+> [`topology.md`](./topology.md)). Under that setting, **any** shard
+> whose slot range is briefly uncovered — including during a normal
+> primary failover, not just under whole-shard loss — flips
+> `cluster_state` to `fail` and pauses **all** writes cluster-wide
+> until coverage is restored. The blast-radius descriptions below
+> assume the current config; flipping to `no` would localize each
+> failure to its own slot range.
+
+### Single replica loss
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** One replica pod dies — OOM kill, node failure,
+manual delete, image-pull failure on restart. The StatefulSet will
+recreate it with the same PVC, so on-disk state survives.
+
+**Blast radius.** None for clients. The primary continues serving;
+no data is lost; no slot range goes unavailable. The affected shard
+runs *degraded* (no HA copy) until the replica is back and resynced.
+
+**Detection.** K8s pod restart event for `valkey-cluster-<N>`. From
+inside the cluster, `INFO replication` on the primary shows
+`connected_slaves` decremented. Replica catch-up state visible via
+`slave_repl_offset` lag.
+
+**Recovery.** Automatic. StatefulSet recreates the pod; the new pod
+starts with the existing PVC; Valkey performs a partial resync if
+the replication backlog still covers the missed window, or a full
+resync if not. Partial resync is near-instant; full resync of a
+populated shard can take minutes (see "Replication lag / resync
+storm" below).
+
+**During the recovery window.** Writes succeed at the primary but
+are not protected by a replica — a primary failure during this
+window is a whole-shard loss with respect to recently-acked writes.
+This is the single most important framing for incident handling: a
+"benign" replica restart elevates risk on its shard until resync
+completes.
+
+**Mitigations to consider.** Pod Disruption Budget on the
+StatefulSet to limit replica restart concurrency during voluntary
+disruptions. Anti-affinity so a replica and its primary don't land
+on the same node (so a node failure doesn't take both). Neither is
+configured today — see [`topology.md`](./topology.md).
+
+</details>
+
+### Primary loss & automatic failover
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** A primary pod dies. The replica detects the loss via
+cluster-bus gossip and, after a quorum-based election, gets promoted
+to primary. The cluster slot map updates; clients eventually see
+`MOVED` or `CLUSTERDOWN` errors and refresh their slot maps.
+
+**Blast radius.** Under the current `cluster-require-full-coverage yes`
+setting (see [`topology.md`](./topology.md)), a primary loss causes a
+**cluster-wide pause** for the duration of the failover window. *Any*
+shard whose slot range is briefly uncovered — between the primary
+being declared dead and the replica being promoted — flips
+`cluster_state` to `fail`, and all writes refuse across every shard,
+not just the affected one. The window is roughly `cluster-node-timeout`
+(5 s today) plus election delay (~500 ms) plus client slot-map refresh
+(50–200 ms): call it **~5–10 s of cluster-wide unavailability**, then
+automatic recovery once the replica is promoted. With
+`cluster-require-full-coverage no`, the same event would limit
+unavailability to ~1/N of the keyspace; that is not how the cluster is
+configured today.
+
+**Data loss window.** Async replication means any write the old
+primary acked but had not yet shipped to the replica is **lost** on
+promotion. Under light load this is sub-millisecond; under burst
+write load or network blips, it can be hundreds of milliseconds to
+seconds of writes.
+
+**Lifecycle impact.** Calls to `GetActor` / `UpdateActor` for keys
+on the affected slot range fail during the window. go-redis defaults
+of 3 retries + 3 redirect hops will transparently cover a fast
+failover for in-flight calls; slower failovers surface as gRPC
+errors to the API client. See
+[`actor-lifecycle.md`](./actor-lifecycle.md) for which lifecycle
+steps have retry budgets and which strand on a single failure.
+
+**Detection.** K8s pod restart on the primary. `MOVED` /
+`CLUSTERDOWN` spike in `ate-api-server` logs. Cluster-state metrics
+flip degraded. Once the new primary is up, `INFO replication` on it
+reports `role:master`.
+
+**Recovery.** Automatic. After the failover, the old primary
+(recreated by the StatefulSet) joins back as a *replica* of the new
+primary and begins resync. The shard runs without HA until that
+resync completes — same elevated-risk window as a plain replica
+loss.
+
+**Mitigations to consider.** `min-replicas-to-write 1` +
+`min-replicas-max-lag 10` to refuse writes when no replica is in
+sync (closes the async-replication data-loss window at the cost of
+write availability). Lower `cluster-node-timeout` (with spurious-
+failover risk on cloud networks). Neither is configured today.
+
+</details>
+
+### Whole-shard loss (primary + replica both gone)
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** Both the primary and its replica for a single shard
+are down simultaneously. Most common cause: a shared-infrastructure
+failure (both pods on the same K8s node; both nodes in the same
+rack; same AZ outage). Without anti-affinity — which isn't
+configured today (see [`topology.md`](./topology.md)) — primary and
+replica can absolutely land on the same node.
+
+**Blast radius.** With **`cluster-require-full-coverage yes`** (the
+current default), losing any single shard takes down **the entire
+cluster's writes** — surviving shards refuse to serve until coverage
+is restored. With `no`, surviving shards keep serving their slot
+ranges; the lost shard's ~1/N of the keyspace is unavailable.
+
+**Data loss window.** Recovery is from disk via AOF replay. With
+the default `appendfsync everysec`, up to ~1 s of acked writes can
+be lost. If the underlying PVCs are also lost (node disk failure,
+PVC deleted), **all data on that shard is gone** — the only
+recovery is from off-cluster backups (which are not configured
+today).
+
+**Lifecycle impact.** Severe. Under current config, *all* lifecycle
+operations fail cluster-wide until the shard is back. Even with
+`cluster-require-full-coverage no`, every actor and worker keyed
+into the lost shard's slot range is inaccessible — those actors
+look NOT-FOUND, workers similarly, and `releaseActorOnDeadWorker`
+mutations targeting them fail silently. See
+[`actor-lifecycle.md`](./actor-lifecycle.md) for the stranded-state
+analysis.
+
+**Detection.** Multiple K8s pod restarts in the same shard within
+seconds. `CLUSTERDOWN` errors across all `ate-api-server` pods.
+`CLUSTER INFO` reports `cluster_state:fail`.
+
+**Recovery.** StatefulSet recreates both pods. Each loads its AOF
+from PVC. Cluster reconverges when at least one of the shard's pods
+finishes loading. Manual: if PVCs are lost, the shard cannot be
+recovered without external backups; the operator must decide
+between accepting the data loss (re-bootstrap the shard) and pulling
+from a backup.
+
+**Mitigations to consider.** Pod anti-affinity / topology spread
+constraints to keep primary and replica on different nodes (and
+ideally different AZs). `cluster-require-full-coverage no` so a
+single-shard outage doesn't take down the cluster. Off-cluster
+backups so PVC loss is recoverable. None of these are configured
+today.
+
+</details>
+
+## Data & storage failures
+
+### AOF corruption / partial write
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** The append-only file on disk gets corrupted — most
+commonly a torn final write from a power-loss-style crash, less
+commonly a real disk error. Valkey refuses to start a primary
+whose AOF won't parse cleanly.
+
+**Blast radius.** The affected pod fails to start, looking like a
+pod crash loop. If the corrupted pod is a *replica*, no client
+impact — the primary keeps serving. If it's the *primary*, the
+event becomes a primary-loss / failover (see above), inheriting
+the same **~5–10 s cluster-wide pause** under the current
+`cluster-require-full-coverage yes` setting; the corrupted pod
+then comes up as the new replica and stays in crash-loop until
+manually repaired.
+
+**Detection.** Pod in `CrashLoopBackOff`. Valkey logs show
+`Bad file format reading the append only file` or similar AOF
+parse error. K8s pod restart count climbing.
+
+**Recovery.** Not automatic for a fully-corrupted AOF. Manual
+recovery: shell into the pod (or attach a debug container with the
+PVC mounted), run `valkey-check-aof --fix /data/appendonly.aof` to
+truncate to the last valid command, restart. Modern Valkey defaults
+include `aof-load-truncated yes` which auto-handles cleanly
+truncated tails (e.g. a single torn final write), but anything
+deeper still needs the manual fix.
+
+**Lifecycle impact.** If the corrupted pod is a replica, none —
+the primary keeps serving. If it's the primary, it's a primary loss
+event; the replica is promoted, and the corrupted pod becomes the
+new replica after the AOF fix. Writes that were in the corrupted
+tail of the AOF are lost.
+
+**Mitigations to consider.** Storage with stronger crash semantics
+(e.g. PD-SSD with journaling; avoid local SSD on non-replicated
+hosts). Monitoring for pod-restart loops as an early signal.
+Periodic `BGREWRITEAOF` to keep AOF size bounded so a corruption
+event loses less data on truncation.
+
+</details>
+
+### Disk full / IOPS exhaustion
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** AOF and `nodes.conf` grow on disk. If the PVC fills,
+writes start failing. Separately, if the storage tier's IOPS quota
+is exceeded (PD-SSD throttling, EBS burst credits exhausted), every
+`fsync(2)` stalls and the single-threaded Valkey main thread blocks
+on it — *all* operations on that primary back up behind the stall.
+
+**Blast radius.** A full disk takes the affected pod down (writes
+fail, AOF can't be rewritten). IOPS exhaustion is more insidious —
+the primary appears up but its p99 latency spikes 10–100×, often
+without an obvious error in logs.
+
+**Detection.** Disk-usage metrics (the PVC is currently provisioned
+at **1 Gi** — see [`topology.md`](./topology.md) — which is fine
+for MVP but will need monitoring as data grows). fsync latency
+metrics. Client-side latency p99 spikes without a corresponding
+spike in QPS. Cloud-provider IOPS metrics if available.
+
+**Recovery.** Disk full: expand the PVC (if the storage class
+supports it) or migrate the shard. IOPS exhaustion: usually
+transient — the storage class refills credits. Sustained
+exhaustion requires provisioning a higher-IOPS tier.
+
+**Lifecycle impact.** Latency spikes blow the <10 ms whole-path
+budget on the affected shard, surfacing as user-visible slowness
+for any operation touching keys in that slot range. See
+[`topology.md`](./topology.md) for the budget analysis.
+
+**Mitigations to consider.** Bigger PVCs (1 Gi is barely enough for
+the AOF of a moderately busy shard). Alerts at 50% / 70% / 90%
+disk usage. Higher-IOPS storage class for production. `auto-aof-
+rewrite-percentage` and `auto-aof-rewrite-min-size` tuning to keep
+AOF size from drifting unbounded.
+
+</details>
+
+### Memory pressure & OOM
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** Valkey is an in-memory store. If the working set
+grows past available memory, behavior depends on `maxmemory` and
+`maxmemory-policy`. The current `valkey.yaml` sets *neither* — there
+is no explicit `maxmemory`, so Valkey grows until the K8s pod hits
+its memory limit and gets OOMKilled.
+
+**Blast radius.** OOMKill = pod restart = same effect as primary
+loss (failover + replication tail loss) or replica loss, depending
+on which pod died. If both primary and replica are under the same
+memory pressure (likely — same workload, same data), an OOM on the
+primary can quickly cascade into an OOM on the replica too.
+
+**Detection.** K8s `OOMKilled` events. Memory-usage metrics
+trending toward the pod limit. Replication lag growing if the
+replica is also under pressure (fork-based BGSAVE doubles
+memory transiently).
+
+**Recovery.** Pod restarts, AOF replay restores state. Same
+caveats as primary loss for the data-loss window.
+
+**Lifecycle impact.** During the restart, the shard is unavailable
+or degraded. If memory pressure recurs, the shard cycles —
+catastrophic for the SLO.
+
+**Mitigations to consider.** Set `maxmemory` explicitly, *below*
+the K8s pod limit, with `maxmemory-policy noeviction` so writes
+fail with a clear OOM error instead of triggering an opaque
+OOMKill. Monitor memory headroom proactively. Plan shard splits
+before memory hits 50–70 % of the pod limit (see scaling math in
+[`topology.md`](./topology.md)).
+
+</details>
+
+### Replication lag / resync storm
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** Async replication is normally microseconds of lag.
+Under sustained write load or network issues, lag can grow past
+the replication backlog (`repl-backlog-size`, default ~1 MB). When
+that happens, the replica must perform a **full resync**: the
+primary forks for `BGSAVE`, transfers the entire RDB snapshot,
+the replica loads it.
+
+A **resync storm** happens when multiple replicas restart together
+(rolling upgrade, node maintenance, autoscaler scale-down) and
+each triggers a full resync against its primary in parallel.
+
+**Blast radius.** During a full resync: primary memory usage spikes
+(copy-on-write fork), network is saturated transferring the
+snapshot, primary CPU is partially consumed by the BGSAVE. For
+small shards (~100 MB) this is a sub-second event. For large
+shards (~10 GB) it's tens of seconds during which the primary is
+serving normally but resource-pressured.
+
+**Detection.** `INFO replication` shows replica state transitions
+(`send_bulk` is full-resync in progress). Network and disk-read
+metrics on the primary spike during BGSAVE. K8s pod-restart events
+correlated across multiple replicas in the same time window =
+storm signal.
+
+**Recovery.** Automatic when individual; storms self-resolve but
+can take much longer than serial recovery.
+
+**Lifecycle impact.** Generally none for correctness; latency on
+the affected shard may briefly increase. If a primary failover
+happens during a storm, the new primary may have a backlog of
+catch-up work and serve degraded.
+
+**Mitigations to consider.** Larger `repl-backlog-size` so brief
+lag spikes don't escalate to full resync. Stagger replica
+restarts during maintenance (don't restart all replicas of all
+shards at once). Pod Disruption Budgets to enforce the staggering
+automatically.
+
+</details>
+
+## Network & cluster topology failures
+
+### Network partition / split-brain
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** A network partition cuts some pods off from others.
+Could be a K8s network plugin failure, a node-level NIC issue, or
+an AZ-to-AZ link issue (if Valkey is deployed multi-AZ).
+
+**Blast radius.** Valkey Cluster uses majority-quorum elections, so
+a *strict* split-brain (two primaries serving the same slot range
+with both accepting writes) is avoided by design — a replica only
+promotes if it can reach a majority of *other* primaries. The
+practical failure modes are:
+
+- **Symmetric partition** (~50/50): both sides lack majority,
+  cluster enters a degraded state, neither side can promote
+  replicas. Writes on both sides may continue against existing
+  primaries until cluster timeouts fire.
+- **Asymmetric partition** (minority cut off): the minority side
+  loses access to majority-quorum services; its primaries
+  eventually fail health checks; its writes stop succeeding.
+
+**Detection.** `MASTERDOWN` / `CLUSTERDOWN` errors from clients
+on the cut-off side. Cluster-state metrics divergence between
+sides. K8s NetworkPolicy or CNI alerts if the partition is
+configuration-level.
+
+**Recovery.** Heals automatically when the network heals. Some
+data loss is possible for writes that were acked on the minority
+side but never replicated to majority replicas.
+
+**Lifecycle impact.** Lifecycle operations on the affected side
+fail or hang until the partition resolves. Lock TTLs (30 s for
+the actor lock — see [`actor-lifecycle.md`](./actor-lifecycle.md))
+will expire during a partition longer than that, releasing locks
+on the still-healthy side; this can cause workflow interleavings
+that wouldn't normally happen.
+
+**Mitigations to consider.** Single-AZ deployment trades network
+resilience for fewer partition modes; multi-AZ trades latency for
+resilience. Today the cluster is single-cluster, single-namespace —
+partition risk is dominated by K8s network plugin reliability.
+
+</details>
+
+### Cluster bus / gossip storm
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** Every pair of primaries exchanges cluster-bus
+messages (port 16379) periodically. Message volume scales O(N²) in
+primary count. At small N (3–10) this is invisible; at N=100+ it
+starts to consume meaningful CPU and bandwidth on each primary.
+
+**Blast radius.** Sustained high gossip overhead manifests as
+elevated CPU on every primary in the cluster, with reduced headroom
+for actual command processing. At extreme scales (~500+ primaries),
+gossip can become the dominant cost.
+
+**Detection.** CPU usage on primaries elevated and roughly equal
+across all of them. Cluster-bus metrics if exported.
+
+**Recovery.** Not really a "failure" — more of a scaling ceiling.
+Mitigation is shard count discipline.
+
+**Lifecycle impact.** Latency creep across all lifecycle operations
+proportional to gossip overhead.
+
+**Mitigations to consider.** Cap primary count. If target scale
+requires more than ~500 primaries, consider sharding across
+multiple Valkey clusters (each with its own slot map) rather than
+growing a single cluster. See [`topology.md`](./topology.md) for
+scaling-projection caveats.
+
+</details>
+
+### Client slot-map staleness
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** Each `ate-api-server` pod's `redis.ClusterClient`
+caches the slot map. When a slot moves (failover, manual reshard),
+the cached map is stale until the client refreshes it on the next
+`MOVED` / `ASK` response.
+
+**Blast radius.** Per-client transient: a small burst of redirected
+requests after each topology change, then the client re-stabilizes.
+go-redis handles this transparently with `MaxRedirects=3` (default).
+
+**Detection.** Spike in redirect-retry metrics (if exported).
+Brief latency bumps after failover events.
+
+**Recovery.** Automatic. Each client converges within a few
+operations after the topology change.
+
+**Lifecycle impact.** Minor latency tax during the convergence
+window. Can cumulatively widen the failover unavailability window
+by a few hundred milliseconds.
+
+**Mitigations to consider.** None typically needed — go-redis
+defaults are fine. If the team observes pathological redirect
+storms during failover, increasing `MaxRedirects` is the lever.
+
+</details>
+
+## Identity & security failures
+
+### Pod certificate expiry / rotation failure
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** Per-pod server certs come from a `podCertificate`
+projected volume signed by `servicedns.podcert.ate.dev/identity`
+(see [`topology.md`](./topology.md)). If the signing controller
+fails to rotate before the current cert expires, TLS handshakes
+start failing.
+
+**Blast radius.** Every client of the affected pod sees TLS
+handshake errors. Cluster-internal traffic (replication, cluster
+bus) is also mTLS, so a cert failure can also break replication
+and gossip — potentially escalating a "TLS issue" into a primary-
+loss event from the cluster's perspective.
+
+**Detection.** TLS handshake error rate in `ate-api-server` logs
+and Valkey logs. Cert-expiry metrics from the pod-certificate
+controller if exported.
+
+**Recovery.** Rotate the cert (forces a pod restart if the volume
+projection doesn't pick up the new cert dynamically). If the
+controller itself is unhealthy, fix the controller first.
+
+**Lifecycle impact.** Cluster-wide if the certs across all Valkey
+pods are expiring (same controller, same CA). Otherwise per-shard
+depending on which pods have valid certs.
+
+**Mitigations to consider.** Monitoring on cert TTL — alert at
+50 % of TTL remaining. Monitoring on the pod-certificate
+controller's own health. Rotate the CA bundle (`valkey-ca-certs`
+secret) on a known schedule, before client-side `ca.crt`
+expiration.
+
+</details>
+
+### CA bundle rotation
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** The `valkey-ca-certs` secret holds the CA cert
+that all Valkey pods (and the API server) use to verify each
+other's pod certs. Rotating it requires both sides to load the new
+bundle before either side starts issuing certs signed only by the
+new CA.
+
+**Blast radius.** A botched rotation breaks every mTLS handshake
+in the cluster — effectively a whole-cluster TLS outage.
+
+**Detection.** TLS verification failures everywhere immediately
+after a CA bundle change.
+
+**Recovery.** Roll back the CA bundle (re-apply the previous
+secret), then plan the rotation more carefully (typically: ship a
+*bundle* containing both old and new CA certs, wait for all pods
+to be re-rolled with the bundle, then narrow to new-CA-only).
+
+**Lifecycle impact.** Cluster-wide unavailability until rotation
+is fixed.
+
+**Mitigations to consider.** Bundle-overlap rotation procedure
+documented and rehearsed. CA rotation should be a planned
+maintenance event, not an ad-hoc secret update.
+
+</details>
+
+## Kubernetes-level failures
+
+### StatefulSet pod stuck pending
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** A pod can't schedule (node pressure, image-pull
+failure, PVC binding failure, taints/tolerations mismatch). The
+StatefulSet doesn't proceed; the affected ordinal stays Pending.
+
+**Blast radius.** Depends on the ordinal. With
+`podManagementPolicy: Parallel` (the current setting — see
+[`topology.md`](./topology.md)), other ordinals come up in parallel,
+so a single stuck pod is "just" one missing shard member. Under
+the default `OrderedReady` policy, a stuck pod would block all
+higher ordinals — but we don't use that policy.
+
+**Detection.** Pod status `Pending` for extended time. K8s events
+explaining the scheduling failure.
+
+**Recovery.** Manual — fix the underlying scheduling issue.
+
+**Lifecycle impact.** Same as replica loss (if stuck pod is a
+replica) or primary loss (if primary) until resolved.
+
+**Mitigations to consider.** Alerts on pods Pending > N minutes.
+Pre-provisioned node capacity. Image-pull pre-warm via DaemonSet if
+image-pull failures are common.
+
+</details>
+
+### PVC / PV failures
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** A PersistentVolume becomes unavailable — node
+disk failure, PV provisioner outage, accidentally-deleted PVC. The
+bound pod can't start (or can't write).
+
+**Blast radius.** Loses the data on the affected PVC. If the
+shard's other pod (primary or replica) is healthy, data is
+recoverable via replication; if both PVCs are lost, the shard's
+data is gone permanently (no off-cluster backups configured today).
+
+**Detection.** Pod status Pending with PVC-related events. PV
+state `Failed`.
+
+**Recovery.** Depends on the cause. Recoverable: restore the PV
+from the storage backend. Unrecoverable: provision a new PVC,
+accept data loss for that shard, rely on replication or rebootstrap.
+
+**Lifecycle impact.** If single-PVC loss with healthy peer:
+replica loss equivalent. If both PVCs of a shard lost: whole-shard
+loss + data loss (see "Whole-shard loss" above).
+
+**Mitigations to consider.** Storage class with resilient PVs
+(replicated block storage, e.g. PD-SSD with regional replication).
+Periodic backups to off-cluster storage. Anti-affinity so primary
+and replica PVCs don't sit on the same physical disk.
+
+</details>
+
+### Multi-pod node loss
+<details>
+<summary><em>Expand</em></summary>
+
+**What it is.** A K8s node dies and takes every Valkey pod
+scheduled on it with it. Without pod anti-affinity, primary and
+replica for the same shard can be on the same node — a single
+node failure becomes a whole-shard loss.
+
+**Blast radius.** N pods (where N = pods scheduled to that node).
+If those N include both members of any shard, that shard is
+whole-shard-lost. With 6 pods spread across an undetermined number
+of nodes today, the probability of this co-location depends on the
+node pool size and scheduler choices.
+
+**Detection.** Node `NotReady`. Multiple Valkey pod restarts
+correlated to the node loss.
+
+**Recovery.** K8s reschedules the pods (eventually) onto other
+nodes. PVCs follow if the storage class supports it; otherwise
+the data is lost.
+
+**Lifecycle impact.** Same as whole-shard loss for any shards
+that had both pods on the lost node. Cluster-wide outage under
+current `cluster-require-full-coverage yes` if any shard is lost.
+
+**Mitigations to consider.** **Pod anti-affinity is the
+single most impactful mitigation** — it ensures primary and replica
+of the same shard cannot co-locate. Topology-spread constraints
+across AZs harden further. Neither is configured today — see
+[`topology.md`](./topology.md).
+
+</details>
+
+## Cross-cutting: which Valkey failures affect which actor operations
+
+| Valkey failure | `CreateActor` | `GetActor` | `ResumeActor` | `SuspendActor` | `DeleteActor` | `ListActors` | Syncer reconciliation |
+|---|---|---|---|---|---|---|---|
+| Replica loss (one shard) | unaffected | unaffected | unaffected | unaffected | unaffected | unaffected | unaffected |
+| Primary loss (any shard, failover ~5–10 s; current config) | **fails cluster-wide briefly** | **fails cluster-wide briefly** | **fails cluster-wide briefly** | **fails cluster-wide briefly** | **fails cluster-wide briefly** | **fails cluster-wide briefly** | reconciliation paused |
+| Whole-shard loss (current config) | **all writes fail cluster-wide** | **fails cluster-wide** | **fails** | **fails** | **fails** | **fails** | **all reconciliation halts** |
+| Whole-shard loss (`require-full-coverage no`) | fails only for that slot | fails only for that slot | fails for actors on that slot | fails for actors on that slot | fails for actors on that slot | partial results | partial reconciliation |
+| AOF corruption (one pod) | unaffected if other pod healthy | unaffected | unaffected | unaffected | unaffected | unaffected | unaffected |
+| Network partition | per-side: like multiple primary losses | per-side | per-side | per-side | per-side | per-side | per-side |
+| Cert expiry (one pod) | TLS errors for that pod | TLS errors | workflow may fail mid-step | workflow may fail mid-step | TLS errors | TLS errors | reconciler errors |
+| Cert expiry (cluster-wide) | **all operations fail** | **all** | **all** | **all** | **all** | **all** | **halts** |
+
+## Detection cheatsheet
+
+| Failure | First signal | First action |
+|---|---|---|
+| Single replica loss | K8s pod restart event for `valkey-cluster-<N>` | Confirm primary still healthy; watch resync progress; do not panic. |
+| Primary loss / failover | Spike in `MOVED` / `CLUSTERDOWN` errors in `ate-api-server` logs | Confirm failover completed (`CLUSTER INFO`); check for stranded RESUMING/SUSPENDING actors per [`actor-lifecycle.md`](./actor-lifecycle.md). |
+| Whole-shard loss | Multiple shard pods restarting + `CLUSTERDOWN` | Determine if PVCs survived; if yes, wait for AOF replay; if no, escalate to data-recovery procedure. |
+| AOF corruption | Pod in `CrashLoopBackOff` with AOF parse error in logs | Run `valkey-check-aof --fix` on the PVC; restart pod. |
+| Disk full | PVC usage approaching cap; write errors | Expand PVC if storage class allows; otherwise migrate shard. |
+| IOPS exhaustion | Client p99 spike without QPS spike | Check cloud-provider IOPS / burst-credit metrics; provision higher tier. |
+| OOMKilled | K8s `OOMKilled` event | Check working-set growth trend; plan shard split or memory increase. |
+| Resync storm | Multiple replica restarts correlated; primary CPU + network spike | Stagger remaining restarts; do not restart more replicas until storm subsides. |
+| Network partition | `MASTERDOWN` from one subset of pods | Identify cut-off side; do not promote manually unless prepared for split-brain risk. |
+| Cert expiry | TLS handshake errors | Check pod-certificate controller; force rotation; verify CA bundle freshness. |
+| Pod stuck Pending | Pod in `Pending` > N minutes | Read K8s events to find scheduling cause (PVC, image-pull, resources). |
+| PV failure | PVC events show `Failed` | Determine recoverability; restore PV or accept data loss + rebuild shard. |
+| Multi-pod node loss | Node `NotReady` + cascading pod restarts | Treat as whole-shard loss for any co-located primary+replica pairs; same response. |

--- a/docs/valkey/recovery-procedures.md
+++ b/docs/valkey/recovery-procedures.md
@@ -1,0 +1,1008 @@
+# Recovery Procedures
+
+This page is the runbook companion to
+[`failure-modes.md`](./failure-modes.md). For each failure mode that
+needs operator action (or operator-verified automatic recovery), it
+gives a concrete procedure: what symptom brings you here, what state
+you are trying to reach, the commands to run, and how to confirm
+recovery.
+
+These procedures are written for the engineer reading this with a
+paging alert open. They assume working knowledge of `kubectl` and
+shell, basic familiarity with Valkey / Redis cluster commands, and
+the ability to `exec` into pods in the `ate-system` namespace. They
+do not re-explain what each failure means — go read the matching
+entry in [`failure-modes.md`](./failure-modes.md) first if you are
+unfamiliar with the failure mode.
+
+## How to use this page
+
+1. **Identify the failure mode** from the detection signals in
+   [`failure-modes.md`](./failure-modes.md). The detection cheatsheet
+   at the end of that page is the fastest entry point.
+2. **Find the matching procedure (R-N)** below. Each procedure names
+   the failure modes it covers in its trigger section.
+3. **Run universal preflight** before any destructive action — see
+   the section immediately below.
+4. **Work the procedure** top to bottom. Do not skip verification
+   steps; "looks better" is not "recovered."
+5. **Capture artifacts** for the postmortem as you go. Each procedure
+   names what to capture before moving past each branch point.
+
+> **Do not make it worse.** Several procedures below have steps that
+> can permanently lose data or escalate the failure if performed at
+> the wrong time. Where this is true, the procedure says so
+> explicitly with a warning callout. If you are unsure, **stop and
+> escalate** rather than proceeding.
+
+## Universal preflight
+
+Run these before any non-trivial recovery action. They serve two
+purposes: confirming the scope of the incident, and preserving
+evidence for the postmortem.
+
+```bash
+# 1. Snapshot the K8s state of the Valkey StatefulSet
+kubectl -n ate-system get pods -l app=valkey-cluster -o wide > /tmp/incident-pods-$(date +%s).txt
+kubectl -n ate-system describe statefulset valkey-cluster > /tmp/incident-sts-$(date +%s).txt
+kubectl -n ate-system get events --sort-by=.lastTimestamp | tail -100 > /tmp/incident-events-$(date +%s).txt
+
+# 2. Snapshot the cluster's own view of itself
+kubectl -n ate-system exec valkey-cluster-0 -- \
+  valkey-cli --tls \
+    --cacert /etc/valkey-ca/ca.crt \
+    --cert /run/servicedns.podcert.ate.dev/credential-bundle.pem \
+    --key /run/servicedns.podcert.ate.dev/credential-bundle.pem \
+    cluster info > /tmp/incident-cluster-info-$(date +%s).txt
+
+kubectl -n ate-system exec valkey-cluster-0 -- \
+  valkey-cli --tls \
+    --cacert /etc/valkey-ca/ca.crt \
+    --cert /run/servicedns.podcert.ate.dev/credential-bundle.pem \
+    --key /run/servicedns.podcert.ate.dev/credential-bundle.pem \
+    cluster nodes > /tmp/incident-cluster-nodes-$(date +%s).txt
+```
+
+The long TLS flag set is identical to the init Job; see
+[`topology.md`](./topology.md). All `valkey-cli` invocations below
+elide the TLS flags for readability — substitute the full set when
+running.
+
+A useful shorthand if you'll be running many commands:
+
+```bash
+alias vcli='valkey-cli --tls --cacert /etc/valkey-ca/ca.crt --cert /run/servicedns.podcert.ate.dev/credential-bundle.pem --key /run/servicedns.podcert.ate.dev/credential-bundle.pem'
+```
+
+## Pod & process recovery
+
+### R-1: Verify automatic failover after primary loss
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** Primary loss & automatic failover
+([`failure-modes.md`](./failure-modes.md)). Symptoms: K8s pod restart
+on a Valkey pod, spike of `MOVED` / `CLUSTERDOWN` errors in
+`ate-api-server` logs, cluster-wide write pause for ~5–10 s.
+
+**Goal.** Confirm the failover completed cleanly, the new topology
+is stable, and no actor was left in a stranded transitional state.
+
+**Procedure.**
+
+1. Run universal preflight.
+
+2. Identify which shard's primary died. From `cluster-nodes` output:
+   ```
+   <node-id> <ip>:6379 master fail - <ping-sent> <pong-recv> <epoch> disconnected <slots>
+   <other-id> <ip>:6379 master - <ping-sent> <pong-recv> <epoch> connected <slots>
+   ```
+   The `master fail` line is the lost primary. The slot range on that
+   line is what was unavailable during the failover window.
+
+3. Confirm a new primary has been elected for that slot range:
+   ```bash
+   kubectl -n ate-system exec valkey-cluster-0 -- vcli cluster info
+   ```
+   Expect `cluster_state:ok`. If it still shows `cluster_state:fail`
+   minutes after the original event, jump to **R-3** (whole-shard
+   recovery) — failover did not complete.
+
+4. Identify the recreated pod and verify it has come back as a
+   replica:
+   ```bash
+   kubectl -n ate-system get pods -l app=valkey-cluster
+   kubectl -n ate-system exec <recreated-pod> -- vcli info replication
+   ```
+   Expect `role:slave`, `master_link_status:up`, and
+   `slave_repl_offset` advancing toward the new primary's
+   `master_repl_offset`.
+
+5. Watch resync complete. For a small data set (~100 MB) this is
+   seconds; for ~10 GB it can be tens of seconds. The shard is
+   single-pod (no HA) for the duration of the resync — flag this
+   as elevated risk in the incident channel.
+
+6. Check for stranded actors. Per
+   [`actor-lifecycle.md`](./actor-lifecycle.md), an actor's
+   workflow can strand in RESUMING or SUSPENDING if a CAS-write
+   landed on the wrong side of the failover. Spot-check by running:
+   ```bash
+   # From a pod with API-server access
+   ate actors list --status RESUMING,SUSPENDING --older-than 1m
+   ```
+   Any actor that has been transitional for more than ~1 minute is
+   stranded and needs a manual `ate actor suspend` (then a
+   subsequent resume) to reach a clean state.
+
+**Verification.** All four conditions hold:
+- `cluster_state:ok`
+- All 6 pods Running and Ready
+- All replicas show `master_link_status:up` with bounded
+  `slave_repl_offset` lag
+- No actors stranded transitional for > 1 minute
+
+**Postmortem capture.** Note the failover trigger (was it
+OOMKilled? node lost? voluntary disruption?), the failover
+duration measured from first `CLUSTERDOWN` to first successful
+write, and any data-loss tail (writes acked before the failure
+that did not survive — usually only visible via application
+log correlation).
+
+</details>
+
+### R-2: Verify replica resync after replica restart
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** Single replica loss
+([`failure-modes.md`](./failure-modes.md)). Symptoms: a single
+non-primary Valkey pod restarted; no client-visible errors.
+
+**Goal.** Confirm the replica is fully resynced and the shard is
+back to HA.
+
+**Procedure.**
+
+1. Run universal preflight (lightweight version — pod state +
+   cluster nodes is sufficient).
+
+2. Identify the restarted pod:
+   ```bash
+   kubectl -n ate-system get pods -l app=valkey-cluster \
+     --sort-by=.status.startTime
+   ```
+   Most-recently-started is at the bottom.
+
+3. From the restarted pod, check replication state:
+   ```bash
+   kubectl -n ate-system exec <pod> -- vcli info replication
+   ```
+   Expect `role:slave`, `master_link_status:up`. If
+   `master_link_status:down`, the replica cannot reach its primary
+   (TLS issue, network, primary unhealthy) — escalate to investigate
+   the primary side.
+
+4. Confirm resync is bounded:
+   ```bash
+   # On the replica
+   kubectl -n ate-system exec <pod> -- vcli info replication | \
+     grep -E "(master_repl_offset|slave_repl_offset|master_sync_in_progress)"
+   ```
+   `master_sync_in_progress:0` means partial-resync (instant) or
+   already-caught-up. `master_sync_in_progress:1` means full resync
+   in flight — let it complete.
+
+5. While resync runs, do **not** restart any other pod. Resync
+   storms (see [`failure-modes.md`](./failure-modes.md)) are caused
+   by parallel full resyncs against the same primary. If a deploy
+   or rolling restart is in flight, pause it.
+
+**Verification.** Replica reaches
+`master_link_status:up`, `master_sync_in_progress:0`,
+`slave_repl_offset` within a few hundred KB of
+`master_repl_offset`. Shard is back to HA.
+
+**Postmortem capture.** Note the restart cause (OOMKilled?
+manual? deploy?). Note resync type (partial vs full). If full,
+note the duration — this informs `repl-backlog-size` tuning.
+
+</details>
+
+### R-3: Recover from whole-shard loss
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** Whole-shard loss
+([`failure-modes.md`](./failure-modes.md)). Symptoms: both pods of
+a shard restarting; cluster-wide writes failing with `CLUSTERDOWN`
+(under current `cluster-require-full-coverage yes` setting);
+`cluster_state:fail` persists past ~30 s.
+
+**Goal.** Restore at least one pod of the affected shard to a
+serving state. Accept the data-loss window if PVCs survived; if
+not, decide between accepting full shard data loss and restoring
+from off-cluster backup (note: no backups are configured today —
+see [`failure-modes.md`](./failure-modes.md)).
+
+**Procedure.**
+
+> **WARNING.** Several branches below involve discarding data.
+> Capture all PVC contents and pod logs *before* any destructive
+> action. If you are unsure which branch applies, stop and
+> escalate.
+
+1. Run universal preflight in full.
+
+2. Identify the affected shard's pods (e.g. `valkey-cluster-1` and
+   `valkey-cluster-4` if shard B is down):
+   ```bash
+   kubectl -n ate-system get pods -l app=valkey-cluster -o wide
+   ```
+
+3. Check PVC status for both affected pods:
+   ```bash
+   kubectl -n ate-system get pvc -l app=valkey-cluster
+   kubectl -n ate-system describe pvc data-valkey-cluster-1 data-valkey-cluster-4
+   ```
+   PVC `Bound` to a `Available` PV → data survives. PVC `Lost`
+   or PV missing → data is gone for that pod.
+
+4. Branch on PVC state:
+
+   **Branch A — both PVCs survived.** Wait for AOF replay. Each
+   pod will come up and load its AOF; this takes time proportional
+   to data size. Up to ~1 s of acked writes may be lost (default
+   `appendfsync everysec`). Skip to step 6.
+
+   **Branch B — one PVC survived, one lost.** The surviving pod
+   will load its AOF and serve. The other pod will start with an
+   empty data dir; the cluster will treat it as a fresh replica
+   and full-resync from the surviving pod. No additional data loss
+   beyond Branch A. Skip to step 6.
+
+   **Branch C — both PVCs lost.** Shard data is permanently lost
+   unless an off-cluster backup exists. Confirm with leadership
+   before proceeding. If no backup exists or accepting loss is
+   approved:
+   - The shard must be re-added to the cluster with an empty data
+     dir.
+   - This requires explicit `CLUSTER RESET` + re-bootstrap of just
+     the affected pods. Procedure is **escalation-only** — do not
+     attempt without engaging a senior on-call. Risk: a botched
+     re-bootstrap can corrupt the whole cluster's slot map.
+
+5. (Branch C continuation, escalation-only) Coordinate with senior
+   on-call to:
+   - Verify the slot range that needs reassignment.
+   - Bring up the affected pods with empty PVCs.
+   - Manually rebuild the cluster topology including the new
+     pods.
+   - Confirm `cluster_state:ok` and all 16,384 slots covered.
+
+6. Once both pods are up: verify the cluster state:
+   ```bash
+   kubectl -n ate-system exec valkey-cluster-0 -- vcli cluster info
+   ```
+   Expect `cluster_state:ok`, `cluster_known_nodes:6`,
+   `cluster_size:3`, `cluster_slots_assigned:16384`,
+   `cluster_slots_ok:16384`.
+
+7. Run **R-1** to verify the recovered shard is HA-healthy.
+
+8. Sweep for stranded actors. Per
+   [`actor-lifecycle.md`](./actor-lifecycle.md), every actor whose
+   keys hashed into the lost shard's slot range was unavailable
+   during the outage; some workflows likely stranded.
+
+**Verification.** `cluster_state:ok`, both pods Running, replication
+healthy, no stranded actors.
+
+**Postmortem capture.** Critical:
+- Cause of the simultaneous double pod loss (same node? same AZ?
+  application-driven OOM cascade?).
+- PVC state and any data lost.
+- Whether `cluster-require-full-coverage yes` was the right call
+  for this scale — see [`topology.md`](./topology.md) and
+  [`failure-modes.md`](./failure-modes.md).
+- Whether anti-affinity / topology spread should be configured
+  *before* the next deployment to prevent recurrence.
+
+</details>
+
+## Data & storage recovery
+
+### R-4: Recover from AOF corruption
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** AOF corruption / partial write
+([`failure-modes.md`](./failure-modes.md)). Symptoms: pod in
+`CrashLoopBackOff`; pod logs contain
+`Bad file format reading the append only file`,
+`Unexpected EOF`, or similar AOF parse error.
+
+**Goal.** Restore the pod to a serving state with a truncated AOF.
+Some tail writes will be lost; this is unavoidable.
+
+**Procedure.**
+
+> **WARNING.** `valkey-check-aof --fix` is destructive — it
+> truncates the AOF in place. Snapshot the file first.
+
+1. Run universal preflight.
+
+2. Identify the crash-looping pod and capture its logs and AOF:
+   ```bash
+   kubectl -n ate-system logs <pod> --previous > /tmp/incident-pod-logs-$(date +%s).txt
+
+   # Copy the AOF off the PVC for postmortem
+   kubectl -n ate-system cp <pod>:/data/appendonly.aof \
+     /tmp/incident-aof-$(date +%s).aof
+   ```
+   If the pod is in `CrashLoopBackOff`, `kubectl cp` may need a
+   timing window between restarts; alternatively, attach a
+   debug container.
+
+3. Stop the StatefulSet-managed restart cycle for the affected
+   pod by scaling down its specific behavior is not directly
+   possible. Instead, run the fix via a one-shot debug pod that
+   mounts the same PVC:
+   ```yaml
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: valkey-aof-fix
+     namespace: ate-system
+   spec:
+     restartPolicy: Never
+     containers:
+     - name: fix
+       image: valkey/valkey:8.0
+       command: ["sh", "-c", "sleep 3600"]
+       volumeMounts:
+       - name: data
+         mountPath: /data
+     volumes:
+     - name: data
+       persistentVolumeClaim:
+         claimName: data-<affected-pod-name>
+   ```
+   Apply, then exec in:
+   ```bash
+   kubectl -n ate-system exec -it valkey-aof-fix -- \
+     valkey-check-aof --fix /data/appendonly.aof
+   ```
+   The tool reports the offset of the first corruption and the
+   amount of data that will be truncated. Confirm acceptable
+   loss; type `y` to proceed.
+
+4. Delete the debug pod and let the StatefulSet's failed pod
+   restart naturally:
+   ```bash
+   kubectl -n ate-system delete pod valkey-aof-fix
+   kubectl -n ate-system delete pod <affected-pod>
+   ```
+
+5. Watch the pod come up. Expect normal startup logs (no AOF
+   error), then `Ready to accept connections`.
+
+**Verification.** Pod Running and Ready. If the pod was a primary,
+run **R-1** to confirm failover/recovery story. If it was a
+replica, run **R-2**.
+
+**Postmortem capture.** Cause of the original crash (was the AOF
+corrupted by a power loss? K8s evict? OOM?). Amount of data
+truncated. Whether `aof-load-truncated yes` (which auto-handles
+cleanly truncated tails) was already in effect — if not, enabling
+it pre-empts this class of incident for clean truncations.
+
+</details>
+
+### R-5: Expand a full PVC
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** Disk full
+([`failure-modes.md`](./failure-modes.md)). Symptoms: writes failing
+with `MISCONF` or `OOM` errors mentioning disk; PVC usage at or
+near 100%; AOF rewrite failures in Valkey logs.
+
+**Goal.** Increase available disk on the affected PVC.
+
+**Procedure.**
+
+1. Run universal preflight.
+
+2. Confirm disk full on the affected pod:
+   ```bash
+   kubectl -n ate-system exec <pod> -- df -h /data
+   ```
+
+3. Confirm the storage class supports online PVC expansion:
+   ```bash
+   kubectl get storageclass <class-name> -o yaml | grep allowVolumeExpansion
+   ```
+   If `false` or missing → expansion is not possible online;
+   escalate to consider migrating the shard.
+
+4. Patch the PVC to a larger size:
+   ```bash
+   kubectl -n ate-system patch pvc data-<affected-pod> \
+     -p '{"spec":{"resources":{"requests":{"storage":"5Gi"}}}}'
+   ```
+   (Choose a size that gives meaningful headroom; doubling the
+   current size is a reasonable default.)
+
+5. Watch the expansion proceed:
+   ```bash
+   kubectl -n ate-system describe pvc data-<affected-pod>
+   ```
+   Look for `FileSystemResizePending` then `FileSystemResizeSuccessful`.
+
+6. If the filesystem resize requires a pod restart (depends on CSI
+   driver), restart the pod:
+   ```bash
+   kubectl -n ate-system delete pod <affected-pod>
+   ```
+
+7. Confirm the new size is visible inside the pod:
+   ```bash
+   kubectl -n ate-system exec <affected-pod> -- df -h /data
+   ```
+
+**Verification.** New size reflected; writes succeeding; no
+disk-related errors in logs.
+
+**Postmortem capture.** What drove the disk usage growth (data
+growth? AOF rewrite never completing? oversized backlog?). Whether
+the 1 Gi default in [`topology.md`](./topology.md) should be
+updated for future deployments.
+
+</details>
+
+### R-6: Respond to IOPS exhaustion
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** IOPS exhaustion
+([`failure-modes.md`](./failure-modes.md)). Symptoms: client p99
+latency spike with no corresponding QPS spike; fsync latency
+metrics elevated; cloud-provider IOPS / burst-credit metrics
+showing exhaustion.
+
+**Goal.** Restore expected latency. Usually self-resolves; the
+operator's job is to confirm it's transient or escalate to
+provisioning if it's not.
+
+**Procedure.**
+
+1. Run universal preflight.
+
+2. Confirm the symptom is IOPS-bound, not something else:
+   - QPS roughly flat or declining (rules out load spike)
+   - Memory and CPU not pressured (rules out OOM / CPU starvation)
+   - One or a few pods affected (rules out network)
+
+3. Check cloud-provider IOPS metrics for the affected PVC's
+   underlying disk. For GCP PD-SSD: `disk/operation_time` and
+   `disk/throttled_operations`. For AWS gp3: `VolumeIOPSExceededCheck`
+   or burst-balance metrics.
+
+4. Branch:
+
+   **Transient (burst credits exhausted).** Confirm the storage
+   class is burst-credit-based, and that credits will replenish.
+   The system will recover on its own as credits return. Monitor;
+   do not act unless the latency persists beyond expected
+   replenishment time.
+
+   **Sustained.** The provisioned IOPS is insufficient for the
+   workload. Plan a migration to a higher-IOPS storage class or
+   provision explicit IOPS (GCP PD-Extreme, AWS gp3 with
+   provisioned IOPS). This is a planned change, not an
+   in-incident action — surface the recommendation and exit the
+   incident.
+
+**Verification.** p99 latency returns to baseline. IOPS metrics
+back below throttling thresholds.
+
+**Postmortem capture.** Whether the storage class choice matches
+the workload's actual demand. Whether monitoring should fire
+*before* the latency hit (on credit-balance trend, not just on
+latency).
+
+</details>
+
+### R-7: Recover from OOM kill / set `maxmemory`
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** Memory pressure & OOM
+([`failure-modes.md`](./failure-modes.md)). Symptoms: K8s
+`OOMKilled` event on a Valkey pod; pod restart with empty in-memory
+state, AOF replay on restart.
+
+**Goal.** Get the pod back up and prevent recurrence. The pod
+restart itself is automatic; the operator's job is the
+prevention work.
+
+**Procedure.**
+
+1. Run universal preflight.
+
+2. Identify the OOMKilled pod and confirm:
+   ```bash
+   kubectl -n ate-system describe pod <pod> | grep -A5 "Last State"
+   ```
+   Expect `Reason: OOMKilled`.
+
+3. If the killed pod was a primary, expect a failover; run **R-1**
+   to verify it completed cleanly. If a replica, run **R-2**.
+
+4. Identify the working-set growth that caused the OOM:
+   ```bash
+   kubectl -n ate-system exec <any-healthy-pod> -- vcli info memory | \
+     grep -E "(used_memory_human|used_memory_peak_human|maxmemory_human)"
+   ```
+   If `maxmemory` is `0`, no limit is set — the pod can grow until
+   the K8s pod limit triggers OOMKill.
+
+5. Set `maxmemory` explicitly. The right value is roughly 75% of
+   the K8s pod memory limit (leaves headroom for fork-on-BGSAVE,
+   client buffers, replication backlog). For a 4 Gi pod limit,
+   set 3 Gi:
+   ```bash
+   kubectl -n ate-system exec <pod> -- vcli \
+     config set maxmemory 3gb
+   kubectl -n ate-system exec <pod> -- vcli \
+     config set maxmemory-policy noeviction
+   ```
+   `noeviction` is the correct policy for a persistence store —
+   it makes writes fail with a clear OOM error instead of silently
+   deleting actor records. **Persist** the config change into
+   `valkey.yaml` so it survives pod restarts; the `config set` above
+   is in-memory only.
+
+6. Monitor memory trend. If `used_memory` is still growing toward
+   the new ceiling, the underlying issue (actor / worker count
+   growth) needs structural resolution — see scaling math in
+   [`topology.md`](./topology.md).
+
+**Verification.** Pod Running, `maxmemory` set, eviction policy
+`noeviction`. No further OOMKilled events.
+
+**Postmortem capture.** Working-set growth rate. Whether the pod
+memory limit needs raising or the shard needs splitting. Whether
+`valkey.yaml` should be updated to set `maxmemory` and
+`maxmemory-policy` for every pod by default.
+
+</details>
+
+### R-8: Stop and contain a resync storm
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** Replication lag / resync storm
+([`failure-modes.md`](./failure-modes.md)). Symptoms: multiple
+replicas in full-resync simultaneously; primary CPU and network
+elevated; latency spiking on affected shards.
+
+**Goal.** Prevent additional replicas from starting concurrent
+full resyncs. Let existing resyncs complete serially.
+
+**Procedure.**
+
+> **WARNING.** Restarting any replica during this incident risks
+> escalating the storm. Pause all voluntary pod restarts
+> (deploys, autoscaler scale-downs) immediately.
+
+1. Run universal preflight.
+
+2. Pause anything that could trigger more pod restarts:
+   ```bash
+   # Pause any in-flight deploy
+   kubectl -n ate-system rollout pause statefulset valkey-cluster
+
+   # Pause autoscaler if applicable
+   # (depends on autoscaler setup; consult your platform)
+   ```
+
+3. Identify replicas currently in full resync:
+   ```bash
+   for pod in $(kubectl -n ate-system get pods -l app=valkey-cluster \
+                  -o jsonpath='{.items[*].metadata.name}'); do
+     echo "== $pod =="
+     kubectl -n ate-system exec $pod -- vcli info replication | \
+       grep -E "(role|master_sync_in_progress|master_link_status)"
+   done
+   ```
+   Replicas with `master_sync_in_progress:1` are mid-resync.
+
+4. Wait. Resyncs proceed; do not intervene unless a primary is in
+   distress (high CPU or memory pressure spilling toward OOM).
+
+5. If a primary IS in distress and might OOM:
+   - Confirm `maxmemory` is set with `noeviction` (R-7).
+   - Consider temporarily blocking new client writes to give the
+     primary headroom — there is no clean knob for this, so it's
+     escalation-only.
+
+6. Once all replicas show `master_sync_in_progress:0` and
+   replication lag is bounded, resume normal operations:
+   ```bash
+   kubectl -n ate-system rollout resume statefulset valkey-cluster
+   ```
+
+**Verification.** All replicas
+`master_sync_in_progress:0`, lag within `repl-backlog-size`. No
+more concurrent full resyncs.
+
+**Postmortem capture.** What triggered the storm (rolling deploy?
+node maintenance? autoscaler?). Whether a Pod Disruption Budget
+on the StatefulSet would prevent recurrence by enforcing serial
+restart.
+
+</details>
+
+## Network recovery
+
+### R-9: Recover from network partition
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** Network partition / split-brain
+([`failure-modes.md`](./failure-modes.md)). Symptoms:
+`MASTERDOWN` / `CLUSTERDOWN` from a subset of pods or clients;
+cluster-state divergence between subsets.
+
+**Goal.** Let the partition heal on its own. Do **not** intervene
+manually unless you have explicit confirmation that one side is
+permanently lost.
+
+**Procedure.**
+
+> **WARNING.** Manual promotion (`CLUSTER FAILOVER FORCE`) of a
+> replica during a network partition can create split-brain if
+> the partition heals. **Do not perform manual failover during a
+> live partition.**
+
+1. Run universal preflight from a vantage point that can reach
+   the majority side. If your `kubectl` is on the minority side,
+   you may not be able to.
+
+2. Identify the partition boundary:
+   - Which pods can reach which (gossip state via `CLUSTER NODES`
+     on both sides will diverge).
+   - Whether the partition is K8s-internal (CNI, NetworkPolicy)
+     or external (AZ link, regional).
+
+3. Engage networking / platform on-call. Recovery is not a Valkey
+   operation; it's a network operation.
+
+4. Once network is restored, the cluster heals automatically.
+   Some writes that succeeded on the minority side and were
+   never replicated to majority may be lost on heal.
+
+5. Run **R-1** for any shard whose primary was on the minority
+   side (it may or may not still be primary post-heal).
+
+**Verification.** `cluster_state:ok` from any pod. `CLUSTER NODES`
+identical from all pods. No `MASTERDOWN` / `CLUSTERDOWN` errors.
+
+**Postmortem capture.** Cause of the partition. Duration. Any
+data lost on heal. Whether multi-AZ or single-AZ deployment is
+the right tradeoff for the failure rate observed.
+
+</details>
+
+## Security recovery
+
+### R-10: Recover from cert expiry
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** Pod certificate expiry
+([`failure-modes.md`](./failure-modes.md)). Symptoms: TLS handshake
+errors in `ate-api-server` and / or Valkey logs; cert-expiry
+monitoring alert fired.
+
+**Goal.** Get fresh certs onto the affected pods and verify mTLS
+is restored cluster-wide.
+
+**Procedure.**
+
+1. Run universal preflight.
+
+2. Confirm the issue is cert expiry and not something else:
+   ```bash
+   kubectl -n ate-system logs <pod> --tail=200 | grep -i "tls\|certificate\|expired"
+   ```
+
+3. Check the pod-certificate controller is healthy:
+   ```bash
+   kubectl -n <controller-namespace> get pods -l app=pod-certificate-controller
+   kubectl -n <controller-namespace> logs <controller-pod> --tail=200
+   ```
+   If the controller itself is unhealthy, **fix the controller
+   first** — restarting pods without a working signer will not
+   help, and may make things worse.
+
+4. Force cert rotation on affected pods. The `podCertificate`
+   projected volume re-fetches on pod restart, so:
+   ```bash
+   kubectl -n ate-system delete pod <affected-pod>
+   ```
+   The StatefulSet will recreate with fresh certs.
+
+5. If all Valkey pods have expired certs, restart them with
+   staggering to avoid simultaneous failover:
+   ```bash
+   for pod in valkey-cluster-{3,4,5}; do
+     kubectl -n ate-system delete pod $pod
+     # Wait for the pod to be Ready before continuing
+     kubectl -n ate-system wait pod/$pod --for=condition=Ready --timeout=120s
+   done
+   # Then primaries:
+   for pod in valkey-cluster-{0,1,2}; do
+     kubectl -n ate-system delete pod $pod
+     kubectl -n ate-system wait pod/$pod --for=condition=Ready --timeout=120s
+   done
+   ```
+   Restart replicas first so each primary still has its replica
+   when it eventually restarts.
+
+**Verification.** No TLS errors in logs for 5+ minutes after the
+last pod restart. `cluster_state:ok`.
+
+**Postmortem capture.** Why monitoring didn't fire earlier
+(monitor TTL at 50% remaining, not 10%). Whether the controller's
+rotation cadence matches the cert TTL safely.
+
+</details>
+
+### R-11: Recover from a botched CA bundle rotation
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** CA bundle rotation
+([`failure-modes.md`](./failure-modes.md)). Symptoms: TLS
+verification failures everywhere immediately after a
+`valkey-ca-certs` secret change. Effectively a whole-cluster
+TLS outage.
+
+**Goal.** Restore TLS by reverting to the previous CA bundle,
+then plan a proper bundle-overlap rotation as a separate change.
+
+**Procedure.**
+
+> **WARNING.** Time-critical. Every minute of cert mismatch is a
+> minute of cluster outage.
+
+1. Identify the previous-known-good `valkey-ca-certs` secret
+   contents. Sources: secret history (if your platform retains
+   it), git config repo, or a fresh export from before the
+   rotation.
+
+2. Re-apply the previous secret:
+   ```bash
+   kubectl -n ate-system apply -f /path/to/known-good-valkey-ca-certs.yaml
+   ```
+
+3. The `valkey-ca-certs` secret is mounted as a projected volume.
+   Most projection types pick up secret changes within ~60 s
+   without a pod restart. If pods do not recover within 2 minutes,
+   force restart in the same staggered order as R-10.
+
+4. Verify TLS recovery (R-10 step 5 verification).
+
+5. **Stop**. Do not retry the CA rotation in-incident. Plan a
+   bundle-overlap rotation as a separate, scheduled change:
+   - Build a CA bundle containing **both** old and new CA certs.
+   - Apply the bundle to `valkey-ca-certs`.
+   - Wait for all pods to pick up the bundle.
+   - Issue new client / pod certs signed by the new CA.
+   - Once all certs are new-CA-signed, narrow the bundle to
+     new-CA-only.
+
+**Verification.** TLS errors clear. `cluster_state:ok`.
+
+**Postmortem capture.** Why the rotation procedure missed the
+bundle-overlap discipline. Whether to enforce a check in the
+rotation tooling.
+
+</details>
+
+## Kubernetes-level recovery
+
+### R-12: Unstick a Pending pod
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** StatefulSet pod stuck Pending
+([`failure-modes.md`](./failure-modes.md)). Symptoms: a Valkey pod
+in `Pending` state for more than a few minutes.
+
+**Goal.** Identify the scheduling block and clear it.
+
+**Procedure.**
+
+1. Run universal preflight.
+
+2. Read the K8s events for the stuck pod:
+   ```bash
+   kubectl -n ate-system describe pod <pending-pod>
+   ```
+   The `Events` section at the bottom names the scheduling
+   failure: insufficient resources, PVC binding failure, image
+   pull failure, taint mismatch, etc.
+
+3. Branch on the cause:
+
+   **Insufficient resources.** Verify node pool capacity; scale
+   the node pool up if applicable.
+
+   **PVC binding failure.** Run **R-13**.
+
+   **Image pull failure.** Check image registry access from the
+   target node; verify image pull secret if needed.
+
+   **Taints / tolerations.** Verify the StatefulSet's tolerations
+   match the available nodes' taints.
+
+4. Once the underlying cause is resolved, the pod schedules
+   automatically. No manual intervention needed beyond fixing the
+   block.
+
+**Verification.** Pod Running and Ready. Run **R-1** or **R-2**
+depending on whether it was a primary or replica.
+
+**Postmortem capture.** Why the resource / image / taint state
+was off. Whether monitoring should fire when a pod is Pending
+for > N minutes.
+
+</details>
+
+### R-13: Recover from PVC / PV failure
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** PVC / PV failures
+([`failure-modes.md`](./failure-modes.md)). Symptoms: PVC stuck in
+`Pending`, PV in `Failed`, pod can't start because volume can't
+mount.
+
+**Goal.** Restore the PV (preserving data) or replace the PVC
+(accepting data loss for that pod).
+
+**Procedure.**
+
+> **WARNING.** PVC deletion is permanent unless retained by a
+> reclaim policy. **Confirm the PV reclaim policy before any
+> destructive action.**
+
+1. Run universal preflight.
+
+2. Diagnose the PV state:
+   ```bash
+   kubectl get pv | grep ate-system
+   kubectl describe pv <pv-name>
+   ```
+
+3. Branch on the cause:
+
+   **Underlying storage transient failure.** Wait or retry. Some
+   CSI drivers self-heal.
+
+   **Underlying storage permanently lost (node disk failure on a
+   non-replicated PV).** The data on that PV is gone. Options:
+   - If the affected pod is a replica and the primary is healthy:
+     delete the PVC, let the StatefulSet create a fresh one, the
+     new pod will full-resync from the primary (no cluster-wide
+     data loss).
+   - If the affected pod is a primary AND the replica is healthy:
+     promote the replica first (cluster will failover automatically
+     when this pod is unreachable long enough), then handle as
+     above on the new replica side.
+   - If both pods of the shard are affected: this is whole-shard
+     data loss; run **R-3** Branch C.
+
+   **PV provisioner outage.** Engage platform on-call; not a
+   Valkey-side fix.
+
+4. To delete a PVC and force a fresh one (only when accepting
+   data loss for that pod):
+   ```bash
+   # Confirm reclaim policy first
+   kubectl get pv <pv-name> -o jsonpath='{.spec.persistentVolumeReclaimPolicy}'
+   # If Delete: the PV will be cleaned up when PVC is removed
+   # If Retain: the PV survives PVC removal; you must clean up separately
+
+   kubectl -n ate-system delete pvc data-<affected-pod>
+   kubectl -n ate-system delete pod <affected-pod>
+   ```
+   The StatefulSet recreates both PVC and pod. The new pod
+   full-resyncs from its primary.
+
+**Verification.** PVC `Bound`, pod Running, replication healthy.
+
+**Postmortem capture.** Whether the storage class survives the
+failure mode observed. Whether resilient storage (regional
+PD-SSD, EBS with cross-AZ) should be the default.
+
+</details>
+
+### R-14: Recover from multi-pod node loss
+<details>
+<summary><em>Expand</em></summary>
+
+**Triggers.** Multi-pod node loss
+([`failure-modes.md`](./failure-modes.md)). Symptoms: K8s node
+`NotReady`; multiple Valkey pods restarting / Pending; potentially
+a whole-shard loss if a shard's two pods co-located on the lost
+node.
+
+**Goal.** Reschedule the affected pods onto healthy nodes;
+recover any shard that lost both members.
+
+**Procedure.**
+
+1. Run universal preflight.
+
+2. Identify the lost node and the pods that were on it:
+   ```bash
+   kubectl get nodes
+   kubectl -n ate-system get pods -l app=valkey-cluster -o wide
+   ```
+
+3. For each affected pod, determine if its PVC follows or is
+   stranded on the dead node:
+   - With cloud-provider block storage (PD-SSD, EBS): PVC follows
+     to a new node when the pod is rescheduled.
+   - With local-PV: PVC is stranded; the pod can't reschedule
+     without losing data on that PV.
+
+4. Per-shard branch:
+
+   **A shard with both pods on the lost node.** This is
+   whole-shard loss. Run **R-3**.
+
+   **A shard with one pod on the lost node.** Replica- or
+   primary-loss event. Run **R-2** or **R-1**.
+
+5. If the node will not return (hardware failure, decommission),
+   cordon and drain to prevent further scheduling and let pods
+   reschedule onto other nodes:
+   ```bash
+   kubectl cordon <dead-node>
+   kubectl drain <dead-node> --ignore-daemonsets --delete-emptydir-data
+   ```
+
+**Verification.** All pods Running on healthy nodes;
+`cluster_state:ok`.
+
+**Postmortem capture.** **Critical**: how many shards lost both
+pods to the same node. If any, this is direct evidence that
+anti-affinity / topology spread is mandatory for the current
+shard count. Update [`topology.md`](./topology.md) and the
+StatefulSet manifest before the next deployment.
+
+</details>
+
+## Post-incident artifacts
+
+For every incident handled with a procedure above, capture the
+following before closing the ticket:
+
+- All `/tmp/incident-*` files generated by universal preflight.
+- Pod logs from before and after recovery (`kubectl logs --previous`
+  for the failed pods).
+- Timeline: first detection signal, each operator action, recovery
+  confirmed.
+- Data loss accounting if any.
+- Whether the recovery procedure as written worked, was incomplete,
+  or was wrong — and what to change in this doc for next time.
+
+The handbook gets better only if every incident updates it. A
+procedure that didn't quite work is a higher-priority improvement
+than a missing procedure for a not-yet-seen failure.

--- a/docs/valkey/risk-register.md
+++ b/docs/valkey/risk-register.md
@@ -1,0 +1,1022 @@
+# Risk Register
+
+This page is the consolidated catalogue of **known sharp edges** in
+the current Valkey deployment and the configuration levers available
+to mitigate each one. Every risk listed here is also discussed
+contextually in another handbook page (topology, lifecycle, admin-ops,
+failure-modes); the register's job is to give a single place to scan,
+compare severities, and decide what to fix before MVP, before target
+scale, or never.
+
+This is **not** a list of every imaginable failure — that lives in
+[`failure-modes.md`](./failure-modes.md). It is a list of things we
+know we are deliberately leaving on, or have not yet decided about,
+that an honest reader of the handbook should see surfaced and
+prioritized in one place.
+
+## How to read this register
+
+Each risk carries five pieces of information:
+
+- **Severity** — the worst-case impact category (see definitions
+  below).
+- **Status** — `ACCEPTED` (known and deliberately tolerated for
+  now), `ACTIVE` (needs attention before some milestone), or
+  `MITIGATED` (closed, with link to the resolution).
+- **MVP / Target** — whether this is a risk at MVP scale (≤ 10 M
+  actors, ≤ a few thousand workers) and / or at target scale (1 B
+  actors, 100k+ workers). A risk can be safe at one and blocking at
+  the other.
+- **What it costs to mitigate** — the trade-off each lever forces.
+  Most levers are not free; the handbook's job is to make the
+  cost explicit.
+- **Cross-references** — the handbook pages that cover this risk in
+  context.
+
+### Severity definitions
+
+- **Data loss** — acked writes can be permanently lost. Highest
+  severity; always merits explicit acceptance.
+- **Availability** — operations can fail (refuse, error, time out)
+  for some non-trivial window. Cluster-wide and per-shard
+  availability are tracked separately.
+- **Latency** — operations succeed but exceed the <10 ms whole-path
+  budget.
+- **Operational hazard** — sharp edge in code or process that can
+  be triggered accidentally, with disproportionate consequences.
+- **Scaling** — does not bite at MVP; will bite at target scale.
+
+## Summary table
+
+| ID | Risk | Severity | Status | MVP | Target |
+|---|---|---|---|---|---|
+| [R-1](#r-1-no-off-cluster-backups) | No off-cluster backups | Data loss | ACTIVE | Tolerable | **Blocking** |
+| [R-2](#r-2-appendfsync-everysec-aof-default) | `appendfsync everysec` default | Data loss (≤1 s) | ACCEPTED | OK | Revisit |
+| [R-3](#r-3-async-replication-tail) | Async-replication tail on failover | Data loss (variable) | ACCEPTED | OK | **Blocking** |
+| [R-4](#r-4-no-anti-affinity-or-topology-spread) | No anti-affinity / topology spread | Data loss + Availability | ACTIVE | Tolerable | **Blocking** |
+| [R-5](#r-5-cluster-require-full-coverage-yes) | `cluster-require-full-coverage yes` | Cluster-wide availability | ACCEPTED | OK | **Blocking** |
+| [R-6](#r-6-ca-bundle-rotation-hazard) | CA bundle rotation hazard | Cluster-wide availability | ACTIVE | At risk | At risk |
+| [R-7](#r-7-no-pod-certificate-monitoring) | No pod-cert expiry monitoring | Cluster-wide availability | ACTIVE | At risk | At risk |
+| [R-8](#r-8-cluster-node-timeout-5-s) | `cluster-node-timeout 5000` | Availability (5–10 s) | ACCEPTED | OK | Revisit |
+| [R-9](#r-9-no-pod-disruption-budget) | No Pod Disruption Budget | Availability | ACTIVE | Tolerable | **Blocking** |
+| [R-10](#r-10-listworkers-on-critical-path) | `ListWorkers` O(N) on critical path | Latency | ACTIVE | At risk | **Blocking** |
+| [R-11](#r-11-no-retry-on-terminal-lifecycle-steps) | No retry on `FinalizeRunning` / `FinalizeSuspended` | Operational | ACTIVE | At risk | At risk |
+| [R-12](#r-12-1-gi-pvc-default) | 1 Gi PVC default | Latency / Operational | ACTIVE | At risk | **Blocking** |
+| [R-13](#r-13-no-maxmemory-set) | No `maxmemory` set | Data loss + Availability | ACTIVE | At risk | **Blocking** |
+| [R-14](#r-14-debugclearall-package-public) | `DebugClearAll` package-public | Operational hazard | ACTIVE | At risk | At risk |
+| [R-15](#r-15-syncer-bypasses-actor-lock) | Syncer bypasses actor lock | Operational | ACCEPTED | Tolerable | Revisit |
+| [R-16](#r-16-atelet-idempotency-undocumented) | Atelet-side idempotency assumed | Operational | ACTIVE | At risk | At risk |
+| [R-17](#r-17-no-client-retry-budget) | No bounded retry budget on client errors | Operational | ACTIVE | Tolerable | At risk |
+| [R-18](#r-18-acquirelock-no-fencing-token) | `AcquireLock` has no fencing token | Operational | ACCEPTED | OK | Revisit |
+| [R-19](#r-19-snapshot-leak-on-delete) | Snapshot leak on `DeleteActor` | Operational | ACTIVE | At risk | At risk |
+| [R-20](#r-20-cluster-bus-on2-gossip) | Cluster-bus O(N²) gossip at high primary count | Scaling | ACCEPTED | OK | At risk |
+| [R-21](#r-21-bgsave-bgrewriteaof-fork-latency) | `BGSAVE` / `BGREWRITEAOF` fork latency at scale | Scaling | ACCEPTED | OK | At risk |
+| [R-22](#r-22-popular-snapshot-hot-keys) | Popular-snapshot hot keys (locality index) | Scaling | OPEN (Q-1) | N/A | At risk |
+| [R-23](#r-23-single-az-vs-multi-az-undecided) | Single-AZ vs multi-AZ deployment undecided | Scaling | ACTIVE | Tolerable | **Blocking** |
+
+**Quick scan**: 8 risks are **blocking for target scale** (need to be
+resolved before scaling beyond MVP); 6 are blocking for MVP or
+already biting; the remainder are accepted with documented rationale
+or scaling-only concerns. The biggest concentrations are durability
+(R-1 through R-5) and scaling-readiness (R-20 through R-23).
+
+## Durability & data-loss risks
+
+### R-1: No off-cluster backups
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Data loss. **Status.** ACTIVE.
+
+**What it costs.** If both PVCs of a shard are lost (node loss with
+node-local storage, accidental PVC deletion, storage-class outage),
+all data on that shard is permanently gone. No external recovery
+path exists today.
+
+**Current state.** No backup mechanism is configured. Recovery
+procedures ([`recovery-procedures.md`](./recovery-procedures.md)
+R-3 Branch C) explicitly document this as escalation-only.
+
+**Mitigation levers.**
+
+- **Periodic `BGSAVE` + off-cluster copy** of the resulting RDB
+  file. Buys point-in-time recovery to the last snapshot.
+  Cost: snapshot creation forks the primary process (transient
+  memory doubling on the affected shard); off-cluster transfer
+  consumes network. Snapshot cadence vs RPO is the trade.
+- **Continuous AOF shipping** to an off-cluster destination via
+  log-tail. Stronger RPO (seconds rather than minutes / hours).
+  Cost: continuous I/O / network overhead; more moving parts.
+- **Resilient storage class with cross-AZ replication** (e.g. GCP
+  regional PD-SSD). Reduces single-PVC-loss probability but does
+  not protect against logical errors (accidental delete, app-side
+  corruption).
+
+**Recommended action.**
+
+- **MVP**: tolerable if alpha customers accept the documented data
+  loss risk. Add a one-line warning to operator-facing docs.
+- **Target scale**: **blocking**. Pick a strategy (the periodic
+  RDB + off-cluster copy is the lowest-effort start) and budget
+  for it.
+
+**Cross-references.** [`failure-modes.md`](./failure-modes.md)
+Whole-shard loss; [`recovery-procedures.md`](./recovery-procedures.md)
+R-3.
+
+</details>
+
+### R-2: `appendfsync everysec` AOF default
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Data loss (bounded ≤ 1 s). **Status.** ACCEPTED.
+
+**What it costs.** On a sudden shard outage (both pods lost
+simultaneously, power-loss-style crash), up to ~1 s of acked writes
+can be lost during AOF replay.
+
+**Current state.** Default — no `appendfsync` override in
+`valkey.yaml`. The AOF buffer flushes to disk once per second.
+
+**Mitigation levers.**
+
+- **`appendfsync always`** — fsync every write. Closes the window
+  entirely. Cost: catastrophic for latency on cloud block storage
+  — main-thread fsync stalls turn the <10 ms budget into a ~10–30 ms
+  P99 floor on PD-SSD-class disks, 5–10× throughput collapse. Not
+  viable as the primary durability lever.
+- **`min-replicas-to-write 1` + `min-replicas-max-lag 10`** —
+  approximates synchronous-ish durability at no latency cost (it's
+  a precondition gate, not synchronous replication). Trades
+  availability for durability. See R-3 — this lever covers both
+  R-2 and R-3.
+
+**Recommended action.**
+
+- **MVP**: keep current. The 1 s window is bounded and acceptable
+  for early users.
+- **Target scale**: revisit jointly with R-3. The right lever is
+  almost always `min-replicas-to-write` over `appendfsync always`.
+
+**Cross-references.** [`topology.md`](./topology.md) latency
+section; [`failure-modes.md`](./failure-modes.md) AOF / whole-shard
+loss.
+
+</details>
+
+### R-3: Async-replication tail on failover
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Data loss (variable window). **Status.** ACCEPTED.
+
+**What it costs.** When a primary fails and a replica is promoted,
+any write the old primary acked but had not yet shipped to the
+replica is lost. Under light load this is sub-millisecond; under
+burst load or network blips it can be hundreds of milliseconds to
+seconds of writes.
+
+**Current state.** No `min-replicas-to-write` config; primary
+acks writes regardless of replica state.
+
+**Mitigation levers.**
+
+- **`min-replicas-to-write 1` + `min-replicas-max-lag 10`** —
+  primary refuses writes if no replica is within 10 s of lag. This
+  is a precondition gate (in-memory check), **not synchronous
+  replication** — happy-path write latency is unchanged.
+  - **Cost: availability.** During any window where the replica is
+    restarting, lagging, or down, writes refuse on that shard
+    with `NOREPLICAS`. A rolling deploy that takes the replica
+    down briefly = a brief window of write refusals for that
+    shard. The right setting requires
+    `repl-ping-replica-period 1` so lag info is fresh (default 10
+    is borderline).
+- **`appendfsync always`** — see R-2; covers a different failure
+  mode (whole-shard outage AOF replay) at huge latency cost.
+
+**Recommended action.**
+
+- **MVP**: tolerable. Async tail is small under expected light
+  load; data-loss risk surfaces in postmortems as "we lost ~N
+  writes during the X event."
+- **Target scale**: **blocking**. At 100k workers' sustained
+  write rate, the tail under burst load becomes large enough that
+  any failover is a real data-loss event. Adopt
+  `min-replicas-to-write 1` + `min-replicas-max-lag 10` with the
+  ping-period change. Plan the availability trade explicitly.
+
+**Cross-references.** [`failure-modes.md`](./failure-modes.md)
+Primary loss; [`topology.md`](./topology.md) latency section.
+
+</details>
+
+### R-4: No anti-affinity or topology spread
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Data loss + cluster-wide availability. **Status.** ACTIVE.
+
+**What it costs.** Nothing in the StatefulSet manifest prevents
+Kubernetes from scheduling both a primary and its replica onto the
+same node. A single node failure can then take out both pods of a
+shard simultaneously — a whole-shard loss event with all the
+consequences thereof (cluster-wide pause under R-5, potential data
+loss under R-1).
+
+**Current state.** No `affinity` or `topologySpreadConstraints`
+configured in `valkey.yaml`.
+
+**Mitigation levers.**
+
+- **Pod anti-affinity (required-during-scheduling)** — Kubernetes
+  refuses to schedule pods of the same shard pair onto the same
+  node. Cost: requires N nodes for N primaries' worth of pods;
+  cannot be fully enforced in tiny clusters.
+- **Topology spread constraints across zones/AZs** — distributes
+  pods across failure domains. Cost: increased intra-cluster
+  network latency (slight); requires multi-AZ deployment.
+- **Pod anti-affinity (preferred-during-scheduling)** — softer
+  variant. Kubernetes tries but doesn't fail scheduling. Cost:
+  none, but provides no guarantee.
+
+**Recommended action.**
+
+- **MVP**: add required-during-scheduling anti-affinity. At 6
+  pods on a typical kind / dev cluster the constraint is easily
+  satisfied. Removes the most embarrassing single-node-loss
+  scenario.
+- **Target scale**: **blocking**. Required anti-affinity plus
+  topology spread across AZs (joint decision with R-23).
+
+**Cross-references.** [`topology.md`](./topology.md);
+[`failure-modes.md`](./failure-modes.md) Multi-pod node loss /
+Whole-shard loss; [`recovery-procedures.md`](./recovery-procedures.md)
+R-14.
+
+</details>
+
+## Cluster-wide availability risks
+
+### R-5: `cluster-require-full-coverage yes`
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Cluster-wide availability. **Status.** ACCEPTED for MVP.
+
+**What it costs.** With this setting (the Valkey default, in effect
+today), *any* shard whose slot range is briefly uncovered — even
+during a normal primary failover, not just on whole-shard loss —
+flips `cluster_state` to `fail` and pauses **all** writes
+cluster-wide. The blast radius of a single-primary failure is the
+entire cluster for the ~5–10 s of the failover window.
+
+**Current state.** Default; no override in `valkey.yaml`.
+
+**Mitigation levers.**
+
+- **`cluster-require-full-coverage no`** — surviving shards
+  continue serving their slot ranges during a partial outage.
+  Cost: callers receive errors for actors on the affected slot
+  range specifically, not cluster-wide. A different operational
+  contract — applications must be ready to handle per-actor
+  unavailability rather than all-or-nothing.
+
+**Recommended action.**
+
+- **MVP**: keep current. 3-primary cluster, failover windows are
+  brief, the failure semantics are simpler.
+- **Target scale**: **blocking**. At 50+ primaries the
+  probability of *some* shard being mid-failover is meaningful at
+  any given second. With full-coverage on, the cluster has
+  effectively zero steady-state availability above a certain
+  shard count. Flip to `no`; document the per-slot-availability
+  contract.
+
+**Cross-references.** [`topology.md`](./topology.md);
+[`failure-modes.md`](./failure-modes.md) Primary loss / Whole-shard
+loss; [`recovery-procedures.md`](./recovery-procedures.md) R-1, R-3.
+
+</details>
+
+### R-6: CA bundle rotation hazard
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Cluster-wide availability. **Status.** ACTIVE.
+
+**What it costs.** A botched CA rotation (`valkey-ca-certs` secret
+swapped without overlap) takes down every mTLS handshake in the
+cluster simultaneously. Effectively a whole-cluster TLS outage
+until rolled back.
+
+**Current state.** No documented or enforced rotation procedure.
+The rollback procedure exists in
+[`recovery-procedures.md`](./recovery-procedures.md) R-11 but
+relies on the operator knowing to apply it under time pressure.
+
+**Mitigation levers.**
+
+- **Documented bundle-overlap rotation procedure** in
+  team-facing docs (referenced from R-11). Cost: process
+  discipline.
+- **Tooling guard** — a wrapper around the secret update that
+  rejects a CA bundle change unless it contains both old and new
+  CA. Cost: build the tool; small ongoing maintenance.
+- **CA rotation as a planned-maintenance event with rehearsal** —
+  rather than ad-hoc. Cost: planning overhead per rotation.
+
+**Recommended action.**
+
+- **MVP / Target scale**: build the documented procedure now
+  (cheap). Decide on tooling guard at the same time as the
+  team's broader secret-management discipline.
+
+**Cross-references.** [`failure-modes.md`](./failure-modes.md) CA
+bundle rotation; [`recovery-procedures.md`](./recovery-procedures.md)
+R-11.
+
+</details>
+
+### R-7: No pod-certificate monitoring
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Cluster-wide availability. **Status.** ACTIVE.
+
+**What it costs.** Per-pod certs come from the `podCertificate`
+projected volume. If the signing controller fails to rotate before
+expiry, mTLS breaks for every affected pod simultaneously. If the
+controller is broken cluster-wide and TTLs are short, the entire
+Valkey cluster (and the API server's connection to it) goes down
+within hours.
+
+**Current state.** No monitoring on cert TTL or controller
+health is configured (or, at least, none surfaced in the
+handbook today).
+
+**Mitigation levers.**
+
+- **TTL-based alert at 50 % remaining lifetime.** Cost: minor
+  monitoring setup; gives ample lead time for any rotation
+  failure.
+- **Controller-health alert** on the pod-certificate signer
+  itself. Cost: same.
+- **Shorter cert TTLs paired with reliable monitoring** —
+  controlled by the signing controller's policy. Cost: more
+  rotation events; only safe with reliable monitoring.
+
+**Recommended action.**
+
+- **MVP / Target scale**: build the alerts now. Cheapest, highest
+  ROI item in this register.
+
+**Cross-references.** [`failure-modes.md`](./failure-modes.md) Pod
+certificate expiry / rotation failure;
+[`recovery-procedures.md`](./recovery-procedures.md) R-10.
+
+</details>
+
+## Per-shard availability risks
+
+### R-8: `cluster-node-timeout` 5 s
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Availability (per failover event). **Status.** ACCEPTED.
+
+**What it costs.** A primary loss event is unavailable for at least
+`cluster-node-timeout + election + slot-map refresh` = roughly 5–10
+seconds. Under R-5 (current default) this is cluster-wide.
+
+**Current state.** `cluster-node-timeout 5000` in
+`valkey.yaml`.
+
+**Mitigation levers.**
+
+- **Lower `cluster-node-timeout`** (e.g. 2000). Faster failover
+  detection. Cost: spurious failovers under brief network blips,
+  which are common on cloud networks. Practical floor for most
+  cloud environments is 2–3 s.
+- **Address R-5 first** — even with a 5 s timeout, per-slot
+  availability (instead of cluster-wide) is the bigger win.
+
+**Recommended action.**
+
+- **MVP**: keep current.
+- **Target scale**: revisit jointly with R-5. After flipping
+  `cluster-require-full-coverage no`, consider lowering timeout
+  to 3 s. Test under realistic network conditions before
+  committing.
+
+**Cross-references.** [`topology.md`](./topology.md);
+[`failure-modes.md`](./failure-modes.md) Primary loss.
+
+</details>
+
+### R-9: No Pod Disruption Budget
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Availability. **Status.** ACTIVE.
+
+**What it costs.** Nothing prevents Kubernetes (rolling deploys,
+node drains, autoscaler scale-downs) from disrupting multiple
+Valkey pods simultaneously. The likely failure modes are:
+
+- Two pods of the same shard down together → whole-shard loss
+  during the disruption window.
+- Multiple replicas restarted concurrently → resync storm
+  ([`failure-modes.md`](./failure-modes.md), R-8 procedure).
+
+**Current state.** No PDB on the `valkey-cluster` StatefulSet.
+
+**Mitigation levers.**
+
+- **PDB with `maxUnavailable: 1`** — enforces that K8s never
+  voluntarily disrupts more than one Valkey pod at a time.
+  Cost: rolling deploys are slower; node drains may block.
+- **PDB with `minAvailable: N`** — alternative form, expresses
+  the same constraint.
+
+**Recommended action.**
+
+- **MVP**: add the PDB. One line; closes the resync-storm path
+  and the worst voluntary-disruption scenarios.
+- **Target scale**: **blocking** — at high pod count, voluntary
+  disruptions during maintenance are far more frequent.
+
+**Cross-references.** [`failure-modes.md`](./failure-modes.md)
+Resync storm / Whole-shard loss;
+[`recovery-procedures.md`](./recovery-procedures.md) R-8.
+
+</details>
+
+## Latency & performance risks
+
+### R-10: `ListWorkers` on critical path
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Latency. **Status.** ACTIVE.
+
+**What it costs.** Every `ResumeActor` call invokes `ListWorkers`,
+which performs O(N) round trips across every primary. At 1 000
+workers this is ~1 s; at 10 000 workers ~11 s; at 100 000 workers
+~110 s. The <10 ms whole-path budget is unreachable.
+
+**Current state.** Implementation as documented in
+[`admin-operations.md`](./admin-operations.md).
+
+**Mitigation levers.**
+
+A full design-space discussion lives in
+[`critical-questions.md`](./critical-questions.md) Q-1 (which
+explicitly assumes this will be fixed and asks what the
+architectural shape of worker selection should be). Short list of
+near-term levers:
+
+- **Pipeline / `MGET` per shard.** 5–10× latency relief; still
+  O(N).
+- **In-process worker cache from the K8s informer.** Removes
+  storage tier from the worker-selection path entirely; reads in
+  microseconds.
+- **Pool-scoped Valkey set.** Filters at the storage tier;
+  reduces read volume but still O(workers in pool).
+
+**Recommended action.**
+
+- **MVP**: pipeline / `MGET` fix is mechanically small;
+  bake before any worker pool exceeds ~1k workers.
+- **Target scale**: **blocking**. The architectural decision in
+  [`critical-questions.md`](./critical-questions.md) Q-1 must be
+  resolved.
+
+**Cross-references.** [`admin-operations.md`](./admin-operations.md);
+[`actor-lifecycle.md`](./actor-lifecycle.md);
+[`critical-questions.md`](./critical-questions.md) Q-1.
+
+</details>
+
+### R-11: No retry on terminal lifecycle steps
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Operational (with availability impact on stranded
+actors). **Status.** ACTIVE.
+
+**What it costs.** `FinalizeRunning` and `FinalizeSuspended` (the
+terminal steps of the resume / suspend workflows) have no
+`RetryBackoff()`. A single CAS conflict — easily caused by a racing
+`releaseActorOnDeadWorker` from the syncer (R-15) — strands the
+actor in RESUMING / SUSPENDING. Recovery requires external retry.
+
+**Current state.** Code as documented in
+[`actor-lifecycle.md`](./actor-lifecycle.md).
+
+**Mitigation levers.**
+
+- **Add `RetryBackoff` to both terminal steps** with the same
+  pattern as `AssignWorker`. Cost: mechanically one-line per
+  step; the contention model under the resulting retry pressure
+  needs to be understood (related to R-15).
+- **Background reconciler** that scans for actors stuck
+  transitional longer than some threshold and re-runs the
+  appropriate workflow. Cost: build the reconciler; another
+  source of write pressure on actor records.
+
+**Recommended action.**
+
+- **MVP / Target scale**: add the retry backoff first (cheap).
+  Reconciler is a larger investment and overlaps with the broader
+  lifecycle design.
+
+**Cross-references.** [`actor-lifecycle.md`](./actor-lifecycle.md).
+
+</details>
+
+### R-12: 1 Gi PVC default
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Latency + Operational. **Status.** ACTIVE.
+
+**What it costs.** Each Valkey pod is provisioned with a 1 Gi PVC.
+This is enough for the AOF of a small / dev cluster but tight for
+any realistic workload — AOF growth between rewrites can fill the
+volume, at which point writes fail and pods crash.
+
+**Current state.** `storage: 1Gi` in `valkey.yaml`.
+
+**Mitigation levers.**
+
+- **Increase default PVC size.** Cost: more provisioned storage;
+  if the storage class is paid per-Gi, real money. Reasonable
+  defaults: 10 Gi for dev / MVP, 50–100 Gi for production.
+- **Tune AOF rewrite** (`auto-aof-rewrite-percentage`,
+  `auto-aof-rewrite-min-size`). Cost: occasional fork/IO spikes
+  when rewrites run; doesn't change the eventual ceiling.
+- **Monitor PVC usage** at 50 / 70 / 90 % thresholds. Cost:
+  monitoring setup; gives lead time before disk-full.
+- **Storage class with online PVC expansion** so emergency growth
+  doesn't require migration. Cost: depends on platform support.
+
+**Recommended action.**
+
+- **MVP**: bump to 10 Gi default and add monitoring.
+- **Target scale**: **blocking**. Per-shard PVC sized to expected
+  AOF + recovery headroom; expansion-capable storage class
+  required.
+
+**Cross-references.** [`topology.md`](./topology.md);
+[`failure-modes.md`](./failure-modes.md) Disk full / IOPS
+exhaustion; [`recovery-procedures.md`](./recovery-procedures.md)
+R-5.
+
+</details>
+
+### R-13: No `maxmemory` set
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Data loss + Availability. **Status.** ACTIVE.
+
+**What it costs.** Without an explicit `maxmemory`, Valkey grows
+until the K8s pod memory limit triggers OOMKill. Each OOMKill is
+a pod restart with AOF replay (~1 s data loss per R-2) and, if
+the killed pod is a primary, a cluster-wide pause per R-5. Memory
+pressure tends to be correlated across primary and replica
+(same workload, same data) — a single OOM can cascade.
+
+**Current state.** No `maxmemory` configured; relies on K8s pod
+limit as the only ceiling.
+
+**Mitigation levers.**
+
+- **`maxmemory` at ~75 % of K8s pod limit, with `maxmemory-policy
+  noeviction`.** Cost: writes fail with a clear OOM error when
+  the limit is reached, instead of triggering opaque OOMKill +
+  AOF replay. **`noeviction` is the correct policy** for a
+  persistence store — any other policy would silently delete
+  actor records.
+- **Sized K8s pod memory limit** that headroom-budgets for
+  fork-on-BGSAVE (transient memory doubling), client buffers,
+  replication backlog. Cost: more memory provisioned per pod.
+
+**Recommended action.**
+
+- **MVP**: set both. Cheap; pre-empts the OOMKill cycle as a
+  whole class of incident.
+- **Target scale**: **blocking**. Combined with shard-splitting
+  discipline (see [`topology.md`](./topology.md) sizing) to keep
+  per-shard memory in a safe operating range.
+
+**Cross-references.** [`failure-modes.md`](./failure-modes.md)
+Memory pressure & OOM; [`recovery-procedures.md`](./recovery-procedures.md)
+R-7.
+
+</details>
+
+## Operational sharp edges
+
+### R-14: `DebugClearAll` package-public
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Operational hazard. **Status.** ACTIVE.
+
+**What it costs.** `DebugClearAll` calls `FlushAllAsync` on every
+primary. It exists for test fixtures. The symbol is package-public
+and reachable from any code that holds a `*Persistence`. If
+accidentally invoked (or exposed via an API surface), it
+catastrophically wipes the cluster.
+
+**Current state.** No runtime guard. No naming convention to
+flag the danger.
+
+**Mitigation levers.**
+
+- **Rename with explicit suffix** (`DebugClearAll_TESTONLY`).
+  Cost: tiny refactor; readers can no longer miss the danger.
+- **Build-tag guard** restricting compilation to test binaries.
+  Cost: slightly more invasive; requires moving the function or
+  marking it.
+- **Environment check at runtime** (refuse to run in production).
+  Cost: needs a reliable "is this production" signal.
+
+**Recommended action.**
+
+- **MVP / Target scale**: rename now. Cheapest defense-in-depth
+  available.
+
+**Cross-references.** [`admin-operations.md`](./admin-operations.md).
+
+</details>
+
+### R-15: Syncer bypasses actor lock
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Operational (with rare data-loss path). **Status.** ACCEPTED.
+
+**What it costs.** `releaseActorOnDeadWorker` mutates the actor
+record without acquiring `lock:actor:<id>`. Optimistic CAS catches
+most races, but one specific interleaving silently drops the
+user's snapshot intent: worker dies during suspend → syncer
+resets actor first → SuspendActor fast-forwards and reports
+success without checkpointing.
+
+**Current state.** Code as documented in
+[`actor-lifecycle.md`](./actor-lifecycle.md).
+
+**Mitigation levers.**
+
+- **Make the syncer acquire the lock** before mutating the actor.
+  Cost: contention against in-flight workflows; needs a short
+  timeout to keep the syncer responsive (otherwise the syncer
+  itself stalls behind a long workflow).
+- **Add explicit metrics** on `releaseActorOnDeadWorker` outcomes
+  (won race / lost race / no actor bound). Cost: minor; surfaces
+  the race rate so the operational decision is informed.
+
+**Recommended action.**
+
+- **MVP**: accept; add metrics so the race rate is visible.
+- **Target scale**: revisit. If metrics show meaningful
+  "won-race" rate (cases where the user-visible snapshot intent
+  was silently dropped), close the gap with the lock.
+
+**Cross-references.** [`actor-lifecycle.md`](./actor-lifecycle.md).
+
+</details>
+
+### R-16: Atelet-side idempotency assumed but undocumented
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Operational. **Status.** ACTIVE.
+
+**What it costs.** The lifecycle workflows assume that atelet's
+`Restore` and `Checkpoint` RPCs can be safely re-invoked with the
+same arguments — used during retry / recovery paths (e.g. after a
+crash between `CallAteletRestore` and `FinalizeRunning`). If
+atelet does not actually enforce idempotency, retries can
+double-resume (two workloads booting against the same actor) or
+double-checkpoint (races on the same snapshot URI).
+
+**Current state.** The contract is implicit; not documented in
+the atelet protobuf.
+
+**Mitigation levers.**
+
+- **Document and enforce idempotency in atelet's API surface.**
+  Cost: spec work; atelet implementation work to add dedup if
+  not present.
+- **Wrap retries with a request-ID / dedup token** that atelet
+  uses to short-circuit duplicates. Cost: small protocol change.
+- **Avoid the retry path at this layer** by adding stronger
+  state checks in the workflow. Cost: more workflow complexity;
+  doesn't help against crash recovery.
+
+**Recommended action.**
+
+- **MVP**: document the assumed contract on the atelet proto
+  and verify atelet honors it in tests.
+- **Target scale**: enforce via the dedup-token mechanism.
+
+**Cross-references.** [`actor-lifecycle.md`](./actor-lifecycle.md).
+
+</details>
+
+### R-17: No bounded retry budget on client errors
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Operational. **Status.** ACTIVE.
+
+**What it costs.** When the API returns `Aborted` ("concurrent
+update conflict, please retry"), there's no server-side guidance
+on retry cadence and no per-actor circuit breaker. A pathological
+caller can hot-loop the same actor and starve other operations on
+the same shard.
+
+**Current state.** No retry-budget mechanism. Clients are
+trusted to back off appropriately.
+
+**Mitigation levers.**
+
+- **Per-actor circuit breaker** on the API server side. After N
+  Aborted errors for the same actor in a window, reject further
+  attempts with `Unavailable` instead of `Aborted`. Cost: state
+  per actor in the API server; cleanup logic.
+- **Server-side retry hints** (e.g. `RetryAfter` metadata on the
+  Aborted response). Cost: protocol addition; clients that
+  ignore the hint are unaffected.
+- **Rate limit at the gateway** rather than per actor. Cost:
+  coarser; may rate-limit legitimate traffic.
+
+**Recommended action.**
+
+- **MVP**: tolerable. Real clients don't hot-loop today.
+- **Target scale**: at risk. 100k workers create more
+  contention; one bad client could starve a shard. Add the
+  circuit breaker before scale-up.
+
+**Cross-references.** [`actor-lifecycle.md`](./actor-lifecycle.md).
+
+</details>
+
+### R-18: `AcquireLock` has no fencing token
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Operational (narrow window). **Status.** ACCEPTED.
+
+**What it costs.** A caller that holds the actor lock, stalls past
+the TTL, then attempts a state mutation can in principle write
+through. The actor's version-CAS catches the common case (someone
+else updated the version while we were stalled), but in the narrow
+window where the lock has expired AND no one else has updated the
+actor, a stalled caller can write through stale state.
+
+**Current state.** Lock is `SET NX EX` with a UUID token; release
+is Lua CAS. No fencing token tied to the mutation.
+
+**Mitigation levers.**
+
+- **Add a fencing token** — every lock acquire returns a
+  monotonically-increasing token; every mutation includes the
+  token; storage rejects mutations whose token is older than the
+  last-seen one. Cost: storage-side state per actor or per
+  resource; protocol addition.
+- **Tighten the lock TTL** so stalled callers are caught sooner.
+  Cost: more lock-loss-during-workflow false positives.
+- **Defensively re-acquire the lock** in long workflows. Cost:
+  more storage ops in the lifecycle.
+
+**Recommended action.**
+
+- **MVP / Target scale**: accept. The lock TTL (30 s) is well
+  longer than the workflow timeout (28 s) padding; the
+  stalled-window is realistically tiny. Revisit if locks are
+  ever extended to longer-running operations (multi-minute
+  snapshots, batch jobs).
+
+**Cross-references.** [`admin-operations.md`](./admin-operations.md);
+[`actor-lifecycle.md`](./actor-lifecycle.md).
+
+</details>
+
+### R-19: Snapshot leak on `DeleteActor`
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Operational (cost / storage growth). **Status.** ACTIVE.
+
+**What it costs.** `DeleteActor` removes the actor record from
+Valkey but leaves the snapshot URIs in `Actor.LastSnapshot` (and
+any in-progress snapshot) pointing at object storage that is
+**not cleaned up**. Over time, deleted actors leave dangling
+snapshot blobs that consume storage and cost.
+
+**Current state.** No cleanup mechanism. Storage grows unbounded.
+
+**Mitigation levers.**
+
+- **Cascading delete** — `DeleteActor` enqueues a cleanup task
+  that removes the snapshot blobs from object storage. Cost:
+  cleanup must be reliable even across API server crashes
+  (durable queue, retry logic).
+- **Background GC** — periodic scan of object storage that
+  reconciles against the live actor set and deletes orphans.
+  Cost: O(snapshots) periodic work; risk of GC-ing live data if
+  the actor set is inconsistent.
+- **Lifecycle policy on the object-storage bucket** (e.g. TTL on
+  snapshot prefixes). Cost: implicit data loss if TTL is shorter
+  than an actor's suspended lifetime.
+
+**Recommended action.**
+
+- **MVP**: at risk; tolerable while actor delete volume is
+  low. Document the leak so operators don't see surprise
+  object-storage costs.
+- **Target scale**: at risk; pick a strategy. Cascading delete
+  is the cleanest for correctness; background GC is the
+  cheapest to bolt onto an existing system.
+
+**Cross-references.** [`actor-lifecycle.md`](./actor-lifecycle.md)
+DeleteActor.
+
+</details>
+
+## Scaling-only concerns
+
+### R-20: Cluster-bus O(N²) gossip
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Scaling. **Status.** ACCEPTED for MVP.
+
+**What it costs.** Every primary pings every other primary
+periodically. At 200+ primaries, gossip traffic and per-primary
+CPU consumed by gossip processing becomes a meaningful overhead.
+Practical comfort ceiling: ~500 primaries.
+
+**Current state.** 3 primaries; no concern.
+
+**Mitigation levers.**
+
+- **Cap primary count** at the comfort ceiling. Cost: at very
+  large scale, requires a different shard-sizing strategy
+  (bigger per-shard memory) to fit total working set.
+- **Shard across multiple Valkey clusters** at higher scale.
+  Cost: application-side cluster routing; double the operational
+  footprint.
+
+**Recommended action.**
+
+- **MVP**: nothing to do.
+- **Target scale**: model the primary-count requirement (see
+  [`topology.md`](./topology.md) sizing). If above 200 primaries
+  is on the curve, plan multi-cluster shape in advance.
+
+**Cross-references.** [`topology.md`](./topology.md);
+[`failure-modes.md`](./failure-modes.md) Cluster bus / gossip
+storm.
+
+</details>
+
+### R-21: `BGSAVE` / `BGREWRITEAOF` fork latency at high per-shard memory
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Scaling. **Status.** ACCEPTED for MVP.
+
+**What it costs.** Valkey forks the main process for `BGSAVE` and
+`BGREWRITEAOF`. On modern Linux this is copy-on-write, so the
+initial fork is cheap, but as the working set grows the fork
+duration grows and write activity during the fork drives memory
+expansion (CoW pages get duplicated). At ~10 GB+ per shard, the
+fork can transiently double memory usage and impact serving
+latency.
+
+**Current state.** Working sets are tiny; not a concern.
+
+**Mitigation levers.**
+
+- **Cap per-shard memory** by sharding more finely. Cost: more
+  primaries (interacts with R-20).
+- **Use storage class with adequate IOPS** so `BGSAVE` writes
+  don't compete with serving I/O.
+- **Schedule `BGREWRITEAOF` carefully** (during low-traffic
+  windows). Cost: tuning per workload.
+
+**Recommended action.**
+
+- **MVP**: nothing to do.
+- **Target scale**: enforce per-shard memory ceiling via
+  `maxmemory` (R-13) and shard-count discipline.
+
+**Cross-references.** [`topology.md`](./topology.md);
+[`failure-modes.md`](./failure-modes.md) Memory & OOM.
+
+</details>
+
+### R-22: Popular-snapshot hot keys (locality index)
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Scaling. **Status.** OPEN — see
+[`critical-questions.md`](./critical-questions.md) Q-1.
+
+**What it costs.** If the project adopts a snapshot-locality index
+in Valkey, a "popular" snapshot (e.g. a golden snapshot for an
+ActorTemplate used by many actors) becomes a single set with many
+members. Every node-cache update is a write to that same hot key;
+under cluster mode's single-threaded primary execution, this
+becomes a write bottleneck.
+
+**Current state.** No locality index exists; this is a future
+concern dependent on the answer to Q-1.
+
+**Mitigation levers.** See
+[`critical-questions.md`](./critical-questions.md) Q-1 design
+space. The lever choice depends on which locality scheme is
+adopted (no Valkey-side index avoids this risk entirely).
+
+**Recommended action.**
+
+- **MVP / Target scale**: no action until Q-1 is decided. If a
+  Valkey-side locality index is selected, this risk re-enters
+  the register with a specific mitigation tied to the chosen
+  scheme.
+
+**Cross-references.** [`critical-questions.md`](./critical-questions.md)
+Q-1.
+
+</details>
+
+### R-23: Single-AZ vs multi-AZ undecided
+<details>
+<summary><em>Expand</em></summary>
+
+**Severity.** Scaling + availability. **Status.** ACTIVE.
+
+**What it costs.** Current deployment is single-cluster, single
+namespace, no AZ-spread enforcement. A single AZ outage takes
+the entire cluster down (with all the consequences under R-5).
+A correlated multi-pod loss (R-14) on a single-AZ deployment is
+fatal.
+
+**Current state.** No `topologySpreadConstraints` configured.
+Single-AZ vs multi-AZ is implicitly decided by node pool layout,
+not explicitly by the deployment.
+
+**Mitigation levers.**
+
+- **Multi-AZ deployment with topology spread** across at least
+  two AZs (three for proper quorum-style availability). Cost:
+  cross-AZ network latency (typically 1–3 ms intra-region),
+  cross-AZ data transfer cost, more complex topology.
+- **Single-AZ with disciplined backups** (R-1). Cost: an AZ
+  outage is a full outage; recovery from backup is operationally
+  heavy.
+
+**Recommended action.**
+
+- **MVP**: single-AZ tolerable with documented expectation. Set
+  basic anti-affinity (R-4) so a single node loss doesn't kill
+  a shard.
+- **Target scale**: **blocking**. Multi-AZ with topology spread
+  is effectively required for SLO. Decide jointly with R-1
+  (backups) and R-4 (anti-affinity) — these three together
+  define the durability / availability story.
+
+**Cross-references.** [`topology.md`](./topology.md);
+[`failure-modes.md`](./failure-modes.md) Network partition /
+Multi-pod node loss.
+
+</details>
+
+## What to do with this register
+
+The register is meant to be **acted on**, not just maintained. The
+recommended cadence:
+
+- **Before MVP launch**: triage every `ACTIVE` row tagged
+  "MVP at risk." Decide explicitly per row whether to fix, accept
+  with documented rationale, or defer with a trigger.
+- **Before target-scale work begins**: triage every row tagged
+  "Target blocking." Each one is a workstream of its own; budget
+  for them in the scaling plan, not as afterthoughts.
+- **Per incident**: update the matching row in this register.
+  Severity assessments are inferences until reality validates
+  them; every real incident is data that should sharpen the
+  numbers.
+- **Per quarter**: re-read the register end-to-end. Roll up
+  `ACCEPTED` rows whose conditions have changed back to `ACTIVE`;
+  close `MITIGATED` rows whose fixes have landed.
+
+A risk register that doesn't change is either a perfect system or
+an unused document. Neither describes this one.

--- a/docs/valkey/topology.md
+++ b/docs/valkey/topology.md
@@ -1,0 +1,358 @@
+# Valkey Topology
+
+This page documents the current Valkey deployment, projects what the topology
+must look like at Substrate's target scale, and offers an explicit go/no-go
+verdict for both the alpha/MVP release and the long-term 1B-actor / 100k-worker
+target.
+
+The framing is intentional. Substrate's persistence layer is pluggable behind
+`store.Interface` (10 methods, no Valkey types leak through), so the question
+this page exists to answer is not "is Valkey perfect" — it is "is Valkey
+good-enough for the next milestone, and at what point do we need to have an
+alternative ready."
+
+## Current deployment
+
+Source of truth: `manifests/ate-install/valkey.yaml`, `cmd/ateapi/main.go`
+(see `connectRedis`).
+
+```mermaid
+graph TB
+  subgraph clients["ate-api-server (clients)"]
+    API["ate-api-server pod<br/>redis.ClusterClient<br/>reads + writes → primary"]
+  end
+
+  subgraph atesys["ate-system namespace"]
+    SVC["Service valkey-cluster<br/>ClusterIP :6379<br/>bootstrap endpoint"]
+    SVCH["Service valkey-cluster-service<br/>headless<br/>per-pod DNS for cluster bus"]
+
+    subgraph ss["StatefulSet valkey-cluster · 6 pods · podManagementPolicy: Parallel"]
+      subgraph shardA["Shard A · slots 0–5460"]
+        A0["valkey-cluster-0<br/>PRIMARY"]
+        A1["valkey-cluster-3<br/>replica"]
+        A0 -. async replication .-> A1
+      end
+      subgraph shardB["Shard B · slots 5461–10922"]
+        B0["valkey-cluster-1<br/>PRIMARY"]
+        B1["valkey-cluster-4<br/>replica"]
+        B0 -. async replication .-> B1
+      end
+      subgraph shardC["Shard C · slots 10923–16383"]
+        C0["valkey-cluster-2<br/>PRIMARY"]
+        C1["valkey-cluster-5<br/>replica"]
+        C0 -. async replication .-> C1
+      end
+    end
+
+    INIT["Job valkey-cluster-init<br/>one-shot bootstrap<br/>valkey-cli --cluster create<br/>--cluster-replicas 1"]
+
+    PV0[("PVC 1Gi · data + AOF")]
+    PV1[("PVC 1Gi")]
+    PV2[("PVC 1Gi")]
+    PV3[("PVC 1Gi")]
+    PV4[("PVC 1Gi")]
+    PV5[("PVC 1Gi")]
+  end
+
+  subgraph identity["Identity & TLS"]
+    POD["podCertificate signer<br/>servicedns.podcert.ate.dev/identity<br/>ECDSA P-256"]
+    CA["Secret valkey-ca-certs<br/>ca.crt"]
+  end
+
+  API -->|mTLS 6379| SVC
+  SVC --> A0
+  SVC --> B0
+  SVC --> C0
+
+  A0 --- PV0
+  B0 --- PV1
+  C0 --- PV2
+  A1 --- PV3
+  B1 --- PV4
+  C1 --- PV5
+
+  INIT -. resolves via .-> SVCH
+  INIT -. one-shot bootstrap .-> A0
+
+  POD -. projected per-pod cert .-> ss
+  CA -. mounted /etc/valkey-ca .-> ss
+  POD -. client cert .-> API
+  CA -. CA bundle .-> API
+```
+
+### Component summary
+
+- **StatefulSet** `valkey-cluster`, 6 pods, image `valkey/valkey:8.0`,
+  `podManagementPolicy: Parallel`. Each pod gets a 1 Gi PVC for AOF +
+  `nodes.conf`.
+- **Cluster mode**: `cluster-enabled yes`, `cluster-node-timeout 5000`,
+  `appendonly yes`. No override of `appendfsync` (defaults to `everysec`),
+  no `min-replicas-to-write`, no `cluster-require-full-coverage` override.
+- **Shape**: 6 nodes bootstrapped with `--cluster-replicas 1` → **3 primaries
+  + 3 replicas**, one replica per primary. The 16,384 hash slots are split
+  into three roughly-equal ranges, one per primary.
+- **Services**: a headless service `valkey-cluster-service` provides per-pod
+  DNS for the cluster bus, and a ClusterIP service `valkey-cluster` is the
+  client bootstrap endpoint. Clients populate their slot map from the
+  bootstrap node and connect to every primary directly thereafter.
+- **TLS**: full mTLS on the data path. Per-pod server certificates come from
+  a `podCertificate` projected volume signed by
+  `servicedns.podcert.ate.dev/identity` (ECDSA P-256). The CA bundle is
+  mounted from the `valkey-ca-certs` secret. The `ate-api-server` mounts
+  matching client credentials.
+- **Bootstrap**: an idempotent `valkey-cluster-init` Job waits for all 6 pod
+  DNS names to resolve, then runs `valkey-cli --cluster create` if the
+  cluster is not already initialized. Safe to re-run.
+
+### Client wiring
+
+`connectRedis` in `cmd/ateapi/main.go` constructs `redis.ClusterClient` with
+only `Addrs` and `TLSConfig`. Defaults from go-redis apply:
+
+- `MaxRetries = 3`, `MaxRedirects = 3` — three transparent retries plus three
+  hops to follow `MOVED`/`ASK` redirections after a slot-map staleness event.
+- `ReadOnly = false` — **all reads route to primaries**. Replicas serve only
+  failover capacity; they do not provide read scale-out.
+- No `RouteByLatency` / `RouteRandomly` — same conclusion.
+
+### Sharding model
+
+A key's home slot is `CRC16(key) mod 16384`. The keys used by the storage layer
+(`cmd/ateapi/internal/store/ateredis/ateredis.go`, see `actorDBKey` and
+`workerDBKey`) are `actor:<id>` and `worker:<ns>:<pool>:<pod>` — no hash
+tags, so every key hashes independently and the load distribution across
+primaries is roughly uniform.
+
+A single write touches **one** primary (and is asynchronously copied to its
+replica). A multi-key operation that spans two slots is **forbidden by
+Valkey Cluster** — the codebase calls this out in its package doc and
+denormalizes worker state into the Actor record to avoid the cross-slot
+trap.
+
+## Scaling projection
+
+At Substrate's stated long-term target — **1 billion actors, 100,000+
+workers** — the topology must grow significantly. The mechanics of Valkey
+Cluster do not change with scale; the number of pods, services, and the
+operational burden do.
+
+```mermaid
+graph TB
+  subgraph clients2["ate-api-server (clients, autoscaled)"]
+    APIN["N × api-server pods<br/>each holds slot map for all primaries"]
+  end
+
+  subgraph atesys2["ate-system namespace (target scale)"]
+    SVC2["Service valkey-cluster<br/>bootstrap endpoint"]
+    SVCH2["Service valkey-cluster-service<br/>headless · per-pod DNS"]
+
+    subgraph ss2["StatefulSet valkey-cluster · 2 × P pods"]
+      subgraph s1["Shard 1"]
+        P1["primary"] -. repl .-> R1["replica"]
+      end
+      subgraph s2["Shard 2"]
+        P2["primary"] -. repl .-> R2["replica"]
+      end
+      subgraph sk["… Shard k …"]
+        PK["primary"] -. repl .-> RK["replica"]
+      end
+      subgraph sP["Shard P"]
+        PP["primary"] -. repl .-> RP["replica"]
+      end
+    end
+
+    BUS["Cluster bus · port 16379<br/>O P² gossip messages"]
+  end
+
+  APIN -->|mTLS| SVC2
+  SVC2 --> P1
+  SVC2 --> P2
+  SVC2 --> PK
+  SVC2 --> PP
+
+  ss2 --- BUS
+```
+
+### Sizing math
+
+The `Actor` proto (defined in `pkg/proto/ateapipb/ateapi.proto`) is twelve
+scalar/string fields. JSON-serialized with realistic snapshot URIs, an
+in-memory Actor record lands in the range **~500 bytes (lean) to ~1 KB
+(populated)**. Add roughly **60–100 bytes per key** for Valkey's `dictEntry`,
+expiration metadata, and the key string itself. Worst-case budget for the
+following table: **1 KB per actor in primary memory**.
+
+A practical per-primary working-set ceiling on cloud-hosted Valkey is
+**4–32 GB**. Above that, `BGSAVE`/`BGREWRITEAOF` fork latency, full-resync
+times after a replica restart, and OOM blast radius all get ugly. The
+ceiling is not an absolute Valkey limit, it is an operational one.
+
+| Actor count | Working set (1 KB/actor) | Primaries @ 8 GB | Primaries @ 16 GB | Primaries @ 32 GB |
+|---|---|---|---|---|
+| 1 M     | 1 GB    | 1   | 1  | 1  |
+| 10 M    | 10 GB   | 2   | 1  | 1  |
+| 100 M   | 100 GB  | 13  | 7  | 4  |
+| 500 M   | 500 GB  | 63  | 32 | 16 |
+| **1 B** | **1 TB** | **125** | **63** | **32** |
+
+Multiply by 2 to include replicas. At target scale on 16 GB primaries, that
+is **126 pods** in the StatefulSet (63 primaries + 63 replicas); on 32 GB
+primaries, **64 pods**.
+
+### What changes with scale
+
+The mechanics that stay the same:
+
+- 16,384 hash slots, regardless of primary count.
+- Async replication, single-threaded command execution per primary, AOF
+  per pod, cluster bus gossip.
+
+The properties that degrade non-linearly:
+
+- **Gossip cost.** Each node periodically pings every other node, so total
+  cluster-bus traffic grows O(P²). The Valkey project tests configurations
+  up to 1,000 nodes, but the practical comfort zone is widely cited as
+  ≤500 primaries. At P = 63 we are well inside; at P = 200+ we are
+  approaching the operational edge.
+- **Failover frequency.** With more nodes, the probability that *some* node
+  is failing over at any given moment grows. Every failover spends
+  `cluster-node-timeout` (5 s here) plus election + slot-map refresh on the
+  affected slot range. At P = 63 with reasonable per-node MTBF, expect
+  multiple failover events per day; the SLO impact compounds.
+- **Full-coverage failure mode.** Default `cluster-require-full-coverage
+  yes` means **one shard's total loss takes down the entire cluster**.
+  Independent shard failure probability of even 0.1 % gives cluster
+  availability of `(1 − 0.001)^63 ≈ 93.9 %`, vs. 99.9 % per shard.
+  Operating at target scale almost certainly requires flipping this to `no`
+  and accepting per-slot availability instead.
+- **Per-primary write QPS ceiling.** Single-threaded command execution caps
+  each primary's write QPS regardless of cluster size. Published benchmarks
+  put modest cloud VMs at 50k–150k QPS per primary; the cluster-wide
+  ceiling scales linearly with primary count. At 100k workers issuing
+  heartbeats + state updates, this is binding and must be measured under
+  realistic load before committing to a primary count.
+- **Reboot / rebalance time.** Each replica resyncs from its primary on
+  restart. Full resync of a 16 GB shard over a network-attached link is
+  measured in minutes, during which the shard runs without HA.
+
+### What does *not* change with scale
+
+- The sharding model. Adding primaries just slices the existing 16,384
+  slots more finely.
+- The cluster-mode constraints in application code. Cross-slot atomicity is
+  forbidden at any cluster size; the denormalization choices in
+  `ateredis.go` remain correct.
+- The client. `redis.ClusterClient` handles slot-map updates automatically.
+  The client wiring needs no changes from 6 pods to 200 pods.
+
+## Go/no-go for alpha/MVP
+
+**Verdict: GO.** Valkey in the current 6-node topology is the right call
+for the alpha/MVP release and very probably for the first general-purpose
+production release as well.
+
+Reasoning:
+
+- The 6-node cluster has headroom of **3–4 orders of magnitude** over
+  realistic alpha scale (think 10k–10M actors, hundreds to a few thousand
+  workers). Memory, QPS, and gossip overhead are all far below any
+  binding constraint.
+- mTLS, cluster mode, AOF persistence, and replica failover are all
+  configured and exercised today. The operational story is real, not
+  aspirational.
+- The pluggable `store.Interface` means MVP commits do not lock in the
+  long-term choice. The contract is small, free of Valkey-specific types,
+  and could be reimplemented against any backend that provides per-key
+  CAS and bounded list iteration.
+
+What to watch during MVP and the first production release:
+
+- Per-primary memory utilization. The first time any primary exceeds ~50 %
+  of its node's memory budget, treat that as the early-warning signal
+  that scale planning needs to start.
+- p99 latency on `GetActor` / `UpdateActor` end-to-end. If steady-state
+  p99 starts trending toward the <10 ms whole-path budget under modest
+  load, that points at either the optimistic-concurrency retry pattern or
+  network round-trips, both of which need to be characterized before
+  scale-up.
+- Failover incidents. Every real failover event is data: how long did the
+  slot range stay unavailable, did go-redis retries cover it, did
+  application code surface a user-visible error.
+
+## Pivot triggers for target scale
+
+A pivot away from Valkey should be **planned, not reactive**. The
+following conditions should each trigger a formal re-evaluation of the
+storage choice rather than a config tweak:
+
+1. **Working set approaches per-primary ceiling.** Once any primary's
+   resident-set size hits 50–70 % of its node's memory budget under
+   steady-state load, the runway to target scale needs to be sized
+   explicitly. If sharding further is the answer, do it before the
+   ceiling is hit, not after.
+2. **Sustained write QPS approaches per-primary ceiling.** Single-threaded
+   command execution puts a hard ceiling on per-primary throughput. If a
+   primary spends >50 % of a measurement window at its measured QPS
+   ceiling, the cluster is already throttled at the queue.
+3. **Failover-induced unavailability becomes user-visible.** If even one
+   failover event per quarter surfaces to API clients as errors beyond
+   the go-redis retry budget, the assumption that "failover is invisible"
+   is wrong for Substrate's latency profile.
+4. **`cluster-require-full-coverage yes` fires for real.** A single
+   correlated shard loss taking down the whole cluster at any non-trivial
+   scale is the loudest possible signal that the current configuration
+   does not match the durability story.
+5. **Operational burden grows faster than scale.** If the team spends
+   more than ~10 % of its on-call cycles on Valkey rebalance / resync /
+   failover incidents, the operational cost is no longer free.
+
+## Pluggable persistence: the safety net
+
+The store contract in `cmd/ateapi/internal/store/store.go` (see
+`Interface`) is the reason this evaluation can be honest rather than
+anxious. The interface
+exposes:
+
+- Per-entity CRUD with optimistic concurrency (`expectedVersion` on
+  updates).
+- Paginated listing with explicitly soft semantics (the proto comments
+  acknowledge actors may be missed or duplicated under churn).
+- A distributed-lock primitive (`AcquireLock` / `ReleaseLock`).
+- No Valkey-specific types in the surface. The implementation in
+  `ateredis.go` is the *only* place that knows about cluster slots,
+  pipelines, or Lua scripting.
+
+The pivot insurance only stays valid if the interface stays clean and at
+least one alternative implementation is kept alive. Whichever backend the
+project selects as the formal "plan B" should land on main as a real
+implementation behind `store.Interface`, with a comparative benchmark in
+CI, even while Valkey is the production backend. That way a forced pivot
+is a deployment decision rather than a months-long port, and interface
+drift is caught the moment it happens rather than discovered during the
+pivot.
+
+## What this analysis cannot answer alone
+
+To convert these projections into a defensible production plan, the
+following measurements are required and currently absent:
+
+- **Actual per-actor byte cost.** The 1 KB estimate is conservative but
+  unverified. A measurement under realistic actor lifecycle (with
+  snapshot URIs of production-realistic length) would tighten every
+  sizing entry on this page.
+- **Per-primary QPS ceiling on the deployment's actual VM / disk class.**
+  Published Valkey benchmarks vary across hardware by 3–5×; the only
+  number that matters is the one measured on the platform Substrate
+  will actually run on.
+- **`UpdateActor` retry rates under contention.** The optimistic
+  concurrency pattern is fine at low contention and pathological at
+  high contention. Measuring the retry distribution at 1k, 10k, 100k
+  concurrent workers is the only way to know which regime we are in.
+- **End-to-end p99 latency budget breakdown.** A clear decomposition of
+  the <10 ms budget across API server, network, Valkey, and retries is
+  required to know how much of the budget is actually available to the
+  storage tier today.
+
+The forthcoming `latency-budget.md` and `failure-modes.md` pages should
+treat the items above as work-in-flight requirements rather than
+assumptions.


### PR DESCRIPTION
Operational handbook for the Valkey storage tier, written as a go/no-go evaluation for MVP and a forward-looking design reference for target scale (1B actors, 100k+ workers).

  README.md             - entry point, scope, contributing
  topology.md           - current deployment + scaling projection
  actor-lifecycle.md    - state machine, per-transition cost analysis
  admin-operations.md   - list / debug / lock primitives
  critical-questions.md - open architectural questions (Q-1..Q-3)
  failure-modes.md      - catalogued failure modes with detection
  recovery-procedures.md - runbooks (R-1..R-14) for incidents
  risk-register.md      - consolidated risk catalogue (R-1..R-23)

#12 

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
