### PR TITLE
ateom/atelet: Remove actor template name/namespace from directories

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -216,7 +216,7 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
+	actorID := req.GetActorId()
 
 	sandboxRec, err := recordFromRequest(req.GetSandboxAssets())
 	if err != nil {
@@ -227,18 +227,18 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 		return nil, err
 	}
 
-	if err := resetActorDirs(ns, tmpl, actorID); err != nil {
+	if err := resetActorDirs(actorID); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
 	// Record the sandbox binaries this actor is running so a later Checkpoint
 	// (whose request no longer carries the sandbox config) can re-fetch the same
 	// version and pin it into the snapshot manifest.
-	if err := writeSandboxRecord(ns, tmpl, actorID, sandboxRec); err != nil {
+	if err := writeSandboxRecord(actorID, sandboxRec); err != nil {
 		return nil, fmt.Errorf("while recording sandbox assets: %w", err)
 	}
 
-	if err := s.prepareOCIBundles(ctx, ns, tmpl, actorID,
+	if err := s.prepareOCIBundles(ctx, actorID,
 		req.GetSpec(), req.GetTargetAteomUid(),
 	); err != nil {
 		return nil, err
@@ -252,12 +252,10 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 	// Tell ateom to start the workload. gVisor uses RunscPath; the micro-VM
 	// runtime uses the full RuntimeAssetPaths set.
 	if _, err := client.RunWorkload(ctx, &ateompb.RunWorkloadRequest{
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      tmpl,
-		ActorId:                actorID,
-		RunscPath:              runscPathFor(assetPaths),
-		RuntimeAssetPaths:      assetPaths,
-		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
+		ActorId:           actorID,
+		RunscPath:         runscPathFor(assetPaths),
+		RuntimeAssetPaths: assetPaths,
+		Spec:              buildAteomWorkloadSpec(req.GetSpec()),
 	}); err != nil {
 		return nil, fmt.Errorf("while calling ateom.RunWorkload: %w", err)
 	}
@@ -306,13 +304,13 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
+	actorID := req.GetActorId()
 
 	// Checkpoint requests no longer carry the sandbox config; recover the
 	// version this actor was started with from the on-node record and re-fetch
 	// it (a cache hit) so ateom can drive runsc, and so we can pin it into the
 	// snapshot manifest below.
-	sandboxRec, err := readSandboxRecord(ns, tmpl, actorID)
+	sandboxRec, err := readSandboxRecord(actorID)
 	if err != nil {
 		return nil, fmt.Errorf("while loading recorded sandbox assets: %w", err)
 	}
@@ -321,7 +319,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, err
 	}
 
-	checkpointDir := ateompath.CheckpointStateDir(ns, tmpl, actorID)
+	checkpointDir := ateompath.CheckpointStateDir(actorID)
 
 	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
 	if err != nil {
@@ -332,13 +330,11 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	// exact files it wrote so we ship precisely that set (gVisor's image files,
 	// cloud-hypervisor's snapshot set, ...) rather than a hardcoded list.
 	resp, err := client.CheckpointWorkload(ctx, &ateompb.CheckpointWorkloadRequest{
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      tmpl,
-		ActorId:                actorID,
-		RunscPath:              runscPathFor(assetPaths),
-		RuntimeAssetPaths:      assetPaths,
-		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
-		Scope:                  toAteomSnapshotScope(req.GetScope()),
+		ActorId:           actorID,
+		RunscPath:         runscPathFor(assetPaths),
+		RuntimeAssetPaths: assetPaths,
+		Spec:              buildAteomWorkloadSpec(req.GetSpec()),
+		Scope:             toAteomSnapshotScope(req.GetScope()),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("while calling ateom.CheckpointWorkload: %w", err)
@@ -361,7 +357,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, fmt.Errorf("unexpected checkpoint type: %v", req.GetType())
 	}
 
-	if err := resetActorDirs(ns, tmpl, actorID); err != nil {
+	if err := resetActorDirs(actorID); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
@@ -379,7 +375,7 @@ func toAteomSnapshotScope(scope ateletpb.SnapshotScope) ateompb.SnapshotScope {
 }
 
 func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string, rec *sandboxAssetsRecord) error {
-	localCheckpointPath := filepath.Join(ateompath.LocalCheckpointsDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()), req.GetLocalConfig().GetSnapshotPrefix())
+	localCheckpointPath := filepath.Join(ateompath.LocalCheckpointsDir(req.GetActorId()), req.GetLocalConfig().GetSnapshotPrefix())
 	if err := os.MkdirAll(localCheckpointPath, 0o700); err != nil {
 		return fmt.Errorf("while creating local checkpoint directory: %w", err)
 	}
@@ -448,13 +444,13 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
+	actorID := req.GetActorId()
 
-	if err := resetActorDirs(ns, tmpl, actorID); err != nil {
+	if err := resetActorDirs(actorID); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
-	checkpointDir := ateompath.RestoreStateDir(ns, tmpl, actorID)
+	checkpointDir := ateompath.RestoreStateDir(actorID)
 
 	// Per-step timing so we can attribute resume latency between the rustfs
 	// download/decompress, the OCI image unpack, and ateom's own work. Logged at the end.
@@ -480,7 +476,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			return nil, err
 		}
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-		localCheckpointDir := ateompath.LocalCheckpointsDir(ns, tmpl, actorID)
+		localCheckpointDir := ateompath.LocalCheckpointsDir(actorID)
 		snapshotPrefix := req.GetLocalConfig().GetSnapshotPrefix()
 		manifest, err := os.ReadFile(filepath.Join(localCheckpointDir, snapshotPrefix, sandboxManifestName))
 		if err != nil {
@@ -510,7 +506,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 				return err
 			}
 		case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-			if err := s.copyLocalCheckpoint(gctx, req.GetLocalConfig().GetSnapshotPrefix(), ateompath.LocalCheckpointsDir(ns, tmpl, actorID), checkpointDir, sandboxRec.SnapshotFiles); err != nil {
+			if err := s.copyLocalCheckpoint(gctx, req.GetLocalConfig().GetSnapshotPrefix(), ateompath.LocalCheckpointsDir(actorID), checkpointDir, sandboxRec.SnapshotFiles); err != nil {
 				return err
 			}
 		}
@@ -523,7 +519,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			return err
 		}
 		t := time.Now()
-		if err := s.prepareOCIBundles(gctx, ns, tmpl, actorID, req.GetSpec(), req.GetTargetAteomUid()); err != nil {
+		if err := s.prepareOCIBundles(gctx, actorID, req.GetSpec(), req.GetTargetAteomUid()); err != nil {
 			return err
 		}
 		dBundles = time.Since(t)
@@ -542,13 +538,11 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	// all application containers.
 	tAteom := time.Now()
 	if _, err := client.RestoreWorkload(ctx, &ateompb.RestoreWorkloadRequest{
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      tmpl,
-		ActorId:                actorID,
-		RunscPath:              runscPathFor(assetPaths),
-		RuntimeAssetPaths:      assetPaths,
-		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
-		Scope:                  toAteomSnapshotScope(req.GetScope()),
+		ActorId:           actorID,
+		RunscPath:         runscPathFor(assetPaths),
+		RuntimeAssetPaths: assetPaths,
+		Spec:              buildAteomWorkloadSpec(req.GetSpec()),
+		Scope:             toAteomSnapshotScope(req.GetScope()),
 	}); err != nil {
 		return nil, fmt.Errorf("while calling ateom.RestoreWorkload: %w", err)
 	}
@@ -556,7 +550,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 
 	// Record the (manifest-pinned) sandbox binaries on-node so a subsequent
 	// Checkpoint of this restored actor can re-pin the same version.
-	if err := writeSandboxRecord(ns, tmpl, actorID, sandboxRec); err != nil {
+	if err := writeSandboxRecord(actorID, sandboxRec); err != nil {
 		return nil, fmt.Errorf("while recording sandbox assets: %w", err)
 	}
 
@@ -632,7 +626,7 @@ func (s *AteomHerder) downloadExternalCheckpoint(ctx context.Context, snapshotUr
 // container and every application container in spec, in parallel.
 func (s *AteomHerder) prepareOCIBundles(
 	ctx context.Context,
-	actorTemplateNamespace, actorTemplateName, actorID string,
+	actorID string,
 	spec *ateletpb.WorkloadSpec,
 	targetAteomUid string,
 ) error {
@@ -641,7 +635,7 @@ func (s *AteomHerder) prepareOCIBundles(
 	// Populate the per-actor identity directory that gets bind-mounted into
 	// the application containers. Regenerated on every resume, so it carries
 	// the correct per-actor ID even when restoring from the golden snapshot.
-	identityDir := ateompath.ActorIdentityDirPath(actorTemplateNamespace, actorTemplateName, actorID)
+	identityDir := ateompath.ActorIdentityDirPath(actorID)
 	if err := os.MkdirAll(identityDir, 0o755); err != nil {
 		return fmt.Errorf("while creating actor identity dir: %w", err)
 	}
@@ -654,7 +648,7 @@ func (s *AteomHerder) prepareOCIBundles(
 	for _, vol := range spec.GetVolumes() {
 		if vol.GetType() == ateletpb.VolumeType_VOLUME_TYPE_DURABLE_DIR {
 			ddVolumes[vol.GetName()] = true
-			volPath := ateompath.DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actorID, vol.GetName())
+			volPath := ateompath.DurableDirVolumeMountPoint(actorID, vol.GetName())
 			if err := os.MkdirAll(volPath, 0o700); err != nil {
 				return fmt.Errorf("while creating %q: %w", volPath, err)
 			}
@@ -675,14 +669,14 @@ func (s *AteomHerder) prepareOCIBundles(
 			if vol.GetType() == ateletpb.VolumeType_VOLUME_TYPE_DURABLE_DIR {
 				annotations["dev.gvisor.spec.mount.durabledir.type"] = "bind"
 				annotations["dev.gvisor.spec.mount.durabledir.share"] = "container"
-				annotations["dev.gvisor.spec.mount.durabledir.source"] = ateompath.DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actorID, vol.GetName())
+				annotations["dev.gvisor.spec.mount.durabledir.source"] = ateompath.DurableDirVolumeMountPoint(actorID, vol.GetName())
 			}
 		}
 
 		if err := prepareOCIDirectory(
 			gCtx,
 			s.pullCache,
-			actorTemplateNamespace, actorTemplateName, actorID,
+			actorID,
 			"pause",
 			spec.GetPauseImage(),
 			[]string{"/pause"},
@@ -714,7 +708,7 @@ func (s *AteomHerder) prepareOCIBundles(
 			if err := prepareOCIDirectory(
 				gCtx,
 				s.pullCache,
-				actorTemplateNamespace, actorTemplateName, actorID,
+				actorID,
 				ctr.GetName(),
 				ctr.GetImage(),
 				ctr.GetCommand(),
@@ -826,11 +820,11 @@ func (d *AteomDialer) DialAteomPod(ctx context.Context, podUID string) (*grpc.Cl
 // boundary, before any path is built. The field rules live in
 // internal/resources so other components can apply them at their boundaries.
 func validateRunRequest(req *ateletpb.RunRequest) error {
-	return validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec())
+	return validateActorRequest(req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec())
 }
 
 func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
-	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+	if err := validateActorRequest(req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
 		return err
 	}
 
@@ -854,7 +848,7 @@ func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
 }
 
 func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
-	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+	if err := validateActorRequest(req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
 		return err
 	}
 
@@ -891,8 +885,8 @@ func validateSnapshotScope(scope ateletpb.SnapshotScope) error {
 
 // validateActorRequest is the shared core for the fields common to all three
 // RPCs.
-func validateActorRequest(namespace, template, actorID, targetAteomUID string, spec *ateletpb.WorkloadSpec) error {
-	if err := resources.ValidateActorRef(namespace, template, actorID); err != nil {
+func validateActorRequest(actorID, targetAteomUID string, spec *ateletpb.WorkloadSpec) error {
+	if err := resources.ValidateActorRef(actorID); err != nil {
 		return err
 	}
 	if err := resources.ValidateAteomUID(targetAteomUID); err != nil {
@@ -944,10 +938,10 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	return dir.Sync()
 }
 
-func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) error {
+func resetActorDirs(actorID string) error {
 	// Explicitly leave runsc logs dir untouched.
 
-	bundleDir := ateompath.OCIBundleDir(actorTemplateNamespace, actorTemplateName, actorID)
+	bundleDir := ateompath.OCIBundleDir(actorID)
 	if err := os.RemoveAll(bundleDir); err != nil {
 		return fmt.Errorf("while deleting bundle dir: %w", err)
 	}
@@ -955,7 +949,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating bundle dir: %w", err)
 	}
 
-	runscDir := ateompath.RunSCStateDir(actorTemplateNamespace, actorTemplateName, actorID)
+	runscDir := ateompath.RunSCStateDir(actorID)
 	if err := os.RemoveAll(runscDir); err != nil {
 		return fmt.Errorf("while deleting runsc state dir: %w", err)
 	}
@@ -963,7 +957,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating runsc state dir: %w", err)
 	}
 
-	pidFileDir := ateompath.PIDFileDir(actorTemplateNamespace, actorTemplateName, actorID)
+	pidFileDir := ateompath.PIDFileDir(actorID)
 	if err := os.RemoveAll(pidFileDir); err != nil {
 		return fmt.Errorf("while deleting PID file dir: %w", err)
 	}
@@ -971,7 +965,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating PID file dir: %w", err)
 	}
 
-	checkpointDir := ateompath.CheckpointStateDir(actorTemplateNamespace, actorTemplateName, actorID)
+	checkpointDir := ateompath.CheckpointStateDir(actorID)
 	if err := os.RemoveAll(checkpointDir); err != nil {
 		return fmt.Errorf("while deleting checkpoint-state dir: %w", err)
 	}
@@ -979,7 +973,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating checkpoint-state dir: %w", err)
 	}
 
-	restoreStateDir := ateompath.RestoreStateDir(actorTemplateNamespace, actorTemplateName, actorID)
+	restoreStateDir := ateompath.RestoreStateDir(actorID)
 	if err := os.RemoveAll(restoreStateDir); err != nil {
 		return fmt.Errorf("while deleting restore-state dir: %w", err)
 	}
@@ -989,7 +983,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 
 	// World-readable (0o755): bind-mounted into the actor, whose workload
 	// reads it through the gofer.
-	identityDir := ateompath.ActorIdentityDirPath(actorTemplateNamespace, actorTemplateName, actorID)
+	identityDir := ateompath.ActorIdentityDirPath(actorID)
 	if err := os.RemoveAll(identityDir); err != nil {
 		return fmt.Errorf("while deleting actor identity dir: %w", err)
 	}
@@ -997,7 +991,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating actor identity dir: %w", err)
 	}
 
-	durableDirVolumesMountDir := ateompath.DurableDirVolumeMountsDir(actorTemplateNamespace, actorTemplateName, actorID)
+	durableDirVolumesMountDir := ateompath.DurableDirVolumeMountsDir(actorID)
 	if err := os.RemoveAll(durableDirVolumesMountDir); err != nil {
 		return fmt.Errorf("while deleting durable-dir volumes mount dir: %w", err)
 	}

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -89,20 +89,19 @@ func TestValidateActorRequest(t *testing.T) {
 	okSpec := &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}}
 
 	tests := []struct {
-		name              string
-		ns, tmpl, id, uid string
-		spec              *ateletpb.WorkloadSpec
-		wantErr           bool
+		name    string
+		id, uid string
+		spec    *ateletpb.WorkloadSpec
+		wantErr bool
 	}{
-		{"all valid", okNS, okTmpl, okID, okUID, okSpec, false},
-		{"bad namespace", "../x", okTmpl, okID, okUID, okSpec, true},
-		{"bad actor id", okNS, okTmpl, "../x", okUID, okSpec, true},
-		{"bad uid", okNS, okTmpl, okID, "../x", okSpec, true},
-		{"bad container", okNS, okTmpl, okID, okUID, &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "../x"}}}, true},
+		{"all valid", okID, okUID, okSpec, false},
+		{"bad actor id", "../x", okUID, okSpec, true},
+		{"bad uid", okID, "../x", okSpec, true},
+		{"bad container", okID, okUID, &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "../x"}}}, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := validateActorRequest(tc.ns, tc.tmpl, tc.id, tc.uid, tc.spec); (err != nil) != tc.wantErr {
+			if err := validateActorRequest(tc.id, tc.uid, tc.spec); (err != nil) != tc.wantErr {
 				t.Errorf("validateActorRequest err = %v, wantErr %v", err, tc.wantErr)
 			}
 		})

--- a/cmd/atelet/oci.go
+++ b/cmd/atelet/oci.go
@@ -53,14 +53,14 @@ const (
 	ActorIDFileName = "actor-id"
 )
 
-func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryPullCache, actorTemplateNamespace, actorTemplateName, actorID, containerName, ref string, args []string, env []string, annotations map[string]string, netns string, identityDir string, durableDirVolumeMounts []*ateletpb.VolumeMount) error {
+func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryPullCache, actorID, containerName, ref string, args []string, env []string, annotations map[string]string, netns string, identityDir string, durableDirVolumeMounts []*ateletpb.VolumeMount) error {
 	tracer := otel.Tracer("prepareOCIDirectory")
 
 	ctx, span := tracer.Start(ctx, "prepareOCIDirectory")
 	span.SetAttributes(attribute.String("image", ref))
 	defer span.End()
 
-	bundlePath := ateompath.OCIBundlePath(actorTemplateNamespace, actorTemplateName, actorID, containerName)
+	bundlePath := ateompath.OCIBundlePath(actorID, containerName)
 	rootPath := path.Join(bundlePath, "rootfs")
 
 	if err := os.RemoveAll(rootPath); err != nil {
@@ -90,7 +90,7 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 		}
 	}
 
-	ociSpec := buildActorOCISpec(actorTemplateNamespace, actorTemplateName, actorID, args, env, annotations, netns, identityDir, durableDirVolumeMounts)
+	ociSpec := buildActorOCISpec(actorID, args, env, annotations, netns, identityDir, durableDirVolumeMounts)
 	ociSpecBytes, err := json.MarshalIndent(ociSpec, "", "  ")
 	if err != nil {
 		return fmt.Errorf("while marshaling OCI spec: %w", err)
@@ -107,7 +107,7 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 // When identityDir is non-empty it adds a read-only bind mount of that host
 // directory at IdentityMountPath so the actor can read its own ID (see
 // IdentityMountPath for why this is a bind mount rather than env vars).
-func buildActorOCISpec(actorTemplateNamespace string, actorTemplateName string, actorID string, args []string, env []string, annotations map[string]string, netns string, identityDir string, durableDirVolumeMounts []*ateletpb.VolumeMount) *specs.Spec {
+func buildActorOCISpec(actorID string, args, env []string, annotations map[string]string, netns, identityDir string, durableDirVolumeMounts []*ateletpb.VolumeMount) *specs.Spec {
 	envVars := []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}
@@ -225,7 +225,7 @@ func buildActorOCISpec(actorTemplateNamespace string, actorTemplateName string, 
 		spec.Mounts = append(spec.Mounts, specs.Mount{
 			Destination: vm.GetMountPath(),
 			Type:        "bind",
-			Source:      ateompath.DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actorID, vm.GetName()),
+			Source:      ateompath.DurableDirVolumeMountPoint(actorID, vm.GetName()),
 		})
 	}
 

--- a/cmd/atelet/oci_test.go
+++ b/cmd/atelet/oci_test.go
@@ -87,7 +87,7 @@ func runUntar(t *testing.T, entries []tarEntry) (string, error) {
 // With an identity dir, a read-only bind mount appears at IdentityMountPath.
 func TestBuildActorOCISpec_IdentityMount(t *testing.T) {
 	spec := buildActorOCISpec(
-		"ns", "tmpl", "id",
+		"id",
 		[]string{"/app"},
 		[]string{"FOO=bar"},
 		map[string]string{"k": "v"},
@@ -118,7 +118,7 @@ func TestBuildActorOCISpec_IdentityMount(t *testing.T) {
 
 // Without an identity dir (the pause container), no identity mount appears.
 func TestBuildActorOCISpec_NoIdentityMountForPause(t *testing.T) {
-	bare := buildActorOCISpec("ns", "tmpl", "id", []string{"/pause"}, nil, nil, "/run/netns/x", "", nil)
+	bare := buildActorOCISpec("id", []string{"/pause"}, nil, nil, "/run/netns/x", "", nil)
 	for _, m := range bare.Mounts {
 		if m.Destination == IdentityMountPath {
 			t.Errorf("identity mount must be absent when identityDir is empty")
@@ -129,13 +129,13 @@ func TestBuildActorOCISpec_NoIdentityMountForPause(t *testing.T) {
 // Each durable-dir volume mount becomes a bind mount whose source is the
 // per-actor on-host DurableDirVolumeMountPoint for that volume name.
 func TestBuildActorOCISpec_DurableDirVolumeMounts(t *testing.T) {
-	const ns, tmpl, id = "ns", "tmpl", "id"
+	const id = "id"
 	durableDirs := []*ateletpb.VolumeMount{
 		{Name: "data", MountPath: "/var/data"},
 		{Name: "cache", MountPath: "/var/cache"},
 	}
 	spec := buildActorOCISpec(
-		ns, tmpl, id,
+		id,
 		[]string{"/app"}, nil, nil,
 		"/run/netns/x",
 		"",
@@ -143,7 +143,7 @@ func TestBuildActorOCISpec_DurableDirVolumeMounts(t *testing.T) {
 	)
 
 	for _, vm := range durableDirs {
-		wantSrc := ateompath.DurableDirVolumeMountPoint(ns, tmpl, id, vm.Name)
+		wantSrc := ateompath.DurableDirVolumeMountPoint(id, vm.Name)
 		found := false
 		for _, m := range spec.Mounts {
 			if m.Destination != vm.MountPath {

--- a/cmd/atelet/sandbox_assets.go
+++ b/cmd/atelet/sandbox_assets.go
@@ -203,12 +203,12 @@ func (s *AteomHerder) openAsset(ctx context.Context, url string) (io.ReadCloser,
 // writeSandboxRecord persists the actor's running sandbox assets on-node so a
 // later Checkpoint (whose request no longer carries the sandbox config) can
 // re-fetch the same binaries and pin them into the snapshot manifest.
-func writeSandboxRecord(actorTemplateNamespace, actorTemplateName, actorID string, rec *sandboxAssetsRecord) error {
+func writeSandboxRecord(actorID string, rec *sandboxAssetsRecord) error {
 	data, err := json.Marshal(rec)
 	if err != nil {
 		return fmt.Errorf("while marshaling sandbox record: %w", err)
 	}
-	path := ateompath.ActorSandboxAssetsFile(actorTemplateNamespace, actorTemplateName, actorID)
+	path := ateompath.ActorSandboxAssetsFile(actorID)
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("while creating actor dir: %w", err)
 	}
@@ -220,8 +220,8 @@ func writeSandboxRecord(actorTemplateNamespace, actorTemplateName, actorID strin
 
 // readSandboxRecord loads the actor's on-node sandbox record written at
 // Run/Restore.
-func readSandboxRecord(actorTemplateNamespace, actorTemplateName, actorID string) (*sandboxAssetsRecord, error) {
-	path := ateompath.ActorSandboxAssetsFile(actorTemplateNamespace, actorTemplateName, actorID)
+func readSandboxRecord(actorID string) (*sandboxAssetsRecord, error) {
+	path := ateompath.ActorSandboxAssetsFile(actorID)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("while reading sandbox record %s: %w", path, err)

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -181,7 +181,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.actorLogger.EmitLifecycleLog("Actor starting", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor starting", req.GetActorId())
 
 	// Contract with atelet:
 	//
@@ -198,10 +198,8 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	}()
 
 	rcmd := &runsc{
-		path:                   req.GetRunscPath(),
-		actorTemplateNamespace: req.GetActorTemplateNamespace(),
-		actorTemplateName:      req.GetActorTemplateName(),
-		actorID:                req.GetActorId(),
+		path:    req.GetRunscPath(),
+		actorID: req.GetActorId(),
 	}
 
 	// Create and start pause container
@@ -215,7 +213,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	// Create and start each application container, each with its own log pipe so
 	// every line is tagged with the originating container (ate.dev/container_name).
 	for _, ac := range req.GetSpec().GetContainers() {
-		pw, err := s.actorLogger.StartJSONLogPipe(req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace(), ac.GetName())
+		pw, err := s.actorLogger.StartJSONLogPipe(req.GetActorId(), ac.GetName())
 		if err != nil {
 			return nil, fmt.Errorf("while starting json log pipe for %q: %w", ac.GetName(), err)
 		}
@@ -233,7 +231,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 		return nil, fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor started", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor started", req.GetActorId())
 
 	return &ateompb.RunWorkloadResponse{}, nil
 }
@@ -242,7 +240,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointing", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor checkpointing", req.GetActorId())
 
 	// Contract with atelet:
 	//
@@ -250,13 +248,11 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	//   * After we exit, atelet will tear down OCI bundles and reset the actor directory.
 
 	rcmd := &runsc{
-		path:                   req.GetRunscPath(),
-		actorTemplateNamespace: req.GetActorTemplateNamespace(),
-		actorTemplateName:      req.GetActorTemplateName(),
-		actorID:                req.GetActorId(),
+		path:    req.GetRunscPath(),
+		actorID: req.GetActorId(),
 	}
 
-	checkpointPath := ateompath.CheckpointStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	checkpointPath := ateompath.CheckpointStateDir(req.GetActorId())
 	if err := os.MkdirAll(checkpointPath, 0o700); err != nil {
 		return nil, fmt.Errorf("while creating checkpoint directory: %w", err)
 	}
@@ -291,8 +287,6 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	if err := rcmd.cleanupContainersAfterCheckpoint(ctx, req.GetSpec().GetContainers()); err != nil {
 		slog.WarnContext(ctx, "Failed to clean up runsc containers after checkpoint",
 			"actorID", req.GetActorId(),
-			"actorTemplateName", req.GetActorTemplateName(),
-			"actorTemplateNamespace", req.GetActorTemplateNamespace(),
 			"err", err)
 	}
 
@@ -305,7 +299,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		return nil, fmt.Errorf("while listing checkpoint files: %w", err)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointed", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor checkpointed", req.GetActorId())
 
 	return &ateompb.CheckpointWorkloadResponse{SnapshotFiles: snapshotFiles}, nil
 }
@@ -357,7 +351,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.actorLogger.EmitLifecycleLog("Actor restoring", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor restoring", req.GetActorId())
 
 	// Contract with atelet:
 	//
@@ -375,13 +369,11 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	}()
 
 	rcmd := &runsc{
-		path:                   req.GetRunscPath(),
-		actorTemplateNamespace: req.GetActorTemplateNamespace(),
-		actorTemplateName:      req.GetActorTemplateName(),
-		actorID:                req.GetActorId(),
+		path:    req.GetRunscPath(),
+		actorID: req.GetActorId(),
 	}
 
-	checkpointDir := ateompath.RestoreStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	checkpointDir := ateompath.RestoreStateDir(req.GetActorId())
 
 	switch req.GetScope() {
 	case ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA:
@@ -407,7 +399,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	// Create and restore each application container, each with its own log pipe so
 	// every line is tagged with the originating container (ate.dev/container_name).
 	for _, ac := range req.GetSpec().GetContainers() {
-		pw, err := s.actorLogger.StartJSONLogPipe(req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace(), ac.GetName())
+		pw, err := s.actorLogger.StartJSONLogPipe(req.GetActorId(), ac.GetName())
 		if err != nil {
 			return nil, fmt.Errorf("while starting json log pipe for %q: %w", ac.GetName(), err)
 		}
@@ -437,7 +429,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		return nil, fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor restored", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor restored", req.GetActorId())
 
 	return &ateompb.RestoreWorkloadResponse{}, nil
 }

--- a/cmd/ateom-gvisor/runsc.go
+++ b/cmd/ateom-gvisor/runsc.go
@@ -28,10 +28,8 @@ import (
 )
 
 type runsc struct {
-	path                   string
-	actorTemplateNamespace string
-	actorTemplateName      string
-	actorID                string
+	path    string
+	actorID string
 }
 
 func (r *runsc) cmdCreate(ctx context.Context, out io.Writer, containerName string, additionalArgs []string) error {
@@ -48,10 +46,10 @@ func (r *runsc) cmdCreate(ctx context.Context, out io.Writer, containerName stri
 		// "-debug-to-user-log",
 		// "-log-packets",
 		// "-strace",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.actorID),
 		"create",
-		"-bundle", ateompath.OCIBundlePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
-		"-pid-file", ateompath.PIDFilePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
+		"-bundle", ateompath.OCIBundlePath(r.actorID, containerName),
+		"-pid-file", ateompath.PIDFilePath(r.actorID, containerName),
 	}
 
 	args = append(args, additionalArgs...)
@@ -89,7 +87,7 @@ func (r *runsc) cmdStart(ctx context.Context, out io.Writer, containerName strin
 		// "-log-packets",
 		// "-strace",
 		"-allow-connected-on-save",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.actorID),
 		"start",
 		containerName, // Name of the container
 	)
@@ -120,7 +118,7 @@ func (r *runsc) cmdCheckpoint(ctx context.Context, containerName, checkpointPath
 		// "-debug-to-user-log",
 		// "-log-packets",
 		// "-strace",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.actorID),
 		"checkpoint",
 		"-image-path", checkpointPath,
 		containerName, // Name of the container
@@ -144,11 +142,11 @@ func (r *runsc) cmdFsCheckpoint(ctx context.Context, containerName, checkpointPa
 		"-log-format", "json",
 		"--alsologtostderr",
 		// "-debug",
-		// "-debug-log", ateompath.RunscDebugLogDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName)+"/",
+		// "-debug-log", ateompath.RunscDebugLogDir(r.actorID, containerName)+"/",
 		// "-debug-to-user-log",
 		// "-log-packets",
 		// "-strace",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.actorID),
 		"fscheckpoint",
 		"-image-path", checkpointPath,
 	}
@@ -191,11 +189,11 @@ func (r *runsc) cmdRestore(ctx context.Context, out io.Writer, containerName, ch
 		// "-debug-to-user-log",
 		// "-log-packets",
 		// "-strace",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.actorID),
 		"restore",
-		"-bundle", ateompath.OCIBundlePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
+		"-bundle", ateompath.OCIBundlePath(r.actorID, containerName),
 		"-image-path", checkpointPath,
-		"-pid-file", ateompath.PIDFilePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
+		"-pid-file", ateompath.PIDFilePath(r.actorID, containerName),
 		"-background",
 		"-direct",
 		"-detach",
@@ -222,7 +220,7 @@ func (r *runsc) cmdDelete(ctx context.Context, containerName string) error {
 		"-log-format", "json",
 		"--alsologtostderr",
 		// "-debug",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.actorID),
 		"delete",
 		"-force",
 		containerName,
@@ -247,7 +245,7 @@ func (r *runsc) cmdState(ctx context.Context, containerName string) error {
 		r.path,
 		"-log-format", "json",
 		"--alsologtostderr",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.actorID),
 		"state",
 		containerName,
 	)

--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -45,11 +45,9 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	ns := req.GetActorTemplateNamespace()
-	name := req.GetActorTemplateName()
 	id := req.GetActorId()
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointing", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor checkpointing", id)
 
 	// The actor's CH was booted by RunWorkload or relaunched by RestoreWorkload;
 	// either way ateom owns it and tracks its api-socket.
@@ -69,7 +67,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	}
 	dPause := time.Since(tPause)
 
-	checkpointDir := ateompath.CheckpointStateDir(ns, name, id)
+	checkpointDir := ateompath.CheckpointStateDir(id)
 	// Start from a clean dir so CH's snapshot files are the only contents.
 	if err := os.RemoveAll(checkpointDir); err != nil {
 		return nil, fmt.Errorf("while clearing checkpoint dir %q: %w", checkpointDir, err)
@@ -144,7 +142,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		slog.WarnContext(ctx, "Failed to clean up actor network after checkpoint", slog.Any("err", err))
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointed", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor checkpointed", id)
 	slog.InfoContext(ctx, "Actor checkpointed", slog.String("id", id), slog.Any("snapshot_files", snapshotFiles),
 		slog.Duration("pause", dPause),
 		slog.Duration("snapshot", dSnapshot), slog.Duration("teardown", dTeardown))

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -53,13 +53,11 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	ns := req.GetActorTemplateNamespace()
-	name := req.GetActorTemplateName()
 	id := req.GetActorId()
-	restoreDir := ateompath.RestoreStateDir(ns, name, id)
+	restoreDir := ateompath.RestoreStateDir(id)
 	tStart := time.Now()
 
-	s.actorLogger.EmitLifecycleLog("Actor restoring", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor restoring", id)
 
 	rr := s.resolveRuntime(req.GetRuntimeAssetPaths())
 	kata.CleanupSandboxState(ctx, id)
@@ -94,7 +92,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	if len(containers) > maxActorContainers {
 		return nil, status.Errorf(codes.Unimplemented, "ateom-microvm supports at most %d containers, got %d", maxActorContainers, len(containers))
 	}
-	ctrs, err := s.buildActorContainers(ns, name, id, containers)
+	ctrs, err := s.buildActorContainers(id, containers)
 	if err != nil {
 		return nil, err
 	}
@@ -193,12 +191,12 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	} else {
 		ra.logAgent = logAC
 		for _, c := range containers {
-			s.startActorLogForwarding(logAC, id, overlayWorkloadID(c.GetName()), c.GetName(), name, ns)
+			s.startActorLogForwarding(logAC, id, overlayWorkloadID(c.GetName()), c.GetName())
 		}
 	}
 
 	s.running[id] = ra
-	s.actorLogger.EmitLifecycleLog("Actor restored", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor restored", id)
 	slog.InfoContext(ctx, "Actor restored (overlay rootfs)",
 		slog.String("id", id), slog.Duration("total", time.Since(tStart)))
 	return &ateompb.RestoreWorkloadResponse{}, nil

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -188,11 +188,9 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	ns := req.GetActorTemplateNamespace()
-	name := req.GetActorTemplateName()
 	id := req.GetActorId()
 
-	s.actorLogger.EmitLifecycleLog("Actor starting", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor starting", id)
 
 	// All of the actor's containers share the one micro-VM (which is the pod
 	// sandbox): each gets its own overlay rootfs and its own kata-agent
@@ -230,7 +228,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 
 	// Prepare each container's OCI spec + record its bundle rootfs (the overlay RO
 	// lower). No host disk — the rootfs is overlay(virtio-fs lower + guest-tmpfs upper).
-	ctrs, err := s.buildActorContainers(ns, name, id, containers)
+	ctrs, err := s.buildActorContainers(id, containers)
 	if err != nil {
 		return nil, err
 	}
@@ -357,10 +355,10 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	// that and tag with the display container name. The goroutines read over ac for the
 	// actor's lifetime and exit (io.EOF) when teardownActor closes ac.
 	for _, c := range ctrs {
-		s.startActorLogForwarding(ac, id, overlayWorkloadID(c.name), c.name, name, ns)
+		s.startActorLogForwarding(ac, id, overlayWorkloadID(c.name), c.name)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor started", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor started", id)
 	slog.InfoContext(ctx, "Actor started (overlay rootfs)", slog.String("id", id))
 	return &ateompb.RunWorkloadResponse{}, nil
 }
@@ -371,12 +369,12 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 // built — the rootfs is overlay(virtio-fs RO lower + guest-tmpfs upper); the lowers
 // are bound into virtiofsd's shared dir in stageOverlayLowers after the sandbox state
 // is clean. Both RunWorkload and RestoreWorkload go through here.
-func (s *AteomService) buildActorContainers(ns, name, id string, containers []*ateompb.Container) ([]actorContainer, error) {
+func (s *AteomService) buildActorContainers(id string, containers []*ateompb.Container) ([]actorContainer, error) {
 	netnsPath := ateompath.AteomNetNSPath(s.podUID)
 	ctrs := make([]actorContainer, len(containers))
 	for i, c := range containers {
 		cn := c.GetName()
-		bundle := ateompath.OCIBundlePath(ns, name, id, cn)
+		bundle := ateompath.OCIBundlePath(id, cn)
 		spec, err := ensureKataCompatibleSpec(bundle, id, netnsPath)
 		if err != nil {
 			return nil, fmt.Errorf("while preparing kata OCI spec for %q: %w", cn, err)
@@ -549,9 +547,9 @@ func startOverlayContainer(ctx context.Context, ac *kata.AgentClient, vsockPath 
 // ending WrapContainerLogs. This keeps the agent connection (which ttrpc allows
 // concurrent Calls on) alive for forwarding while guaranteeing no goroutine outlives
 // the connection.
-func (s *AteomService) startActorLogForwarding(ac *kata.AgentClient, actorID, streamID, containerName, name, ns string) {
-	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, false), actorID, name, ns, containerName)
-	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, true), actorID, name, ns, containerName)
+func (s *AteomService) startActorLogForwarding(ac *kata.AgentClient, actorID, streamID, containerName string) {
+	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, false), actorID, containerName)
+	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, true), actorID, containerName)
 }
 
 // dialAgentRetry polls DialAgent until the kata-agent answers the hybrid-vsock

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -8,8 +8,6 @@ This guide explains how Agent Substrate achieves observability across these susp
 
 To make underlying infrastructure transitions transparent, Agent Substrate establishes a standardized metadata model to identify actors across worker pods:
 * `ate.dev/actor_id`: The unique identifier of the actor (e.g., `my-counter-1` or `test`).
-* `ate.dev/actor_template_name`: The name of the actor's ActorTemplate (e.g., `counter`).
-* `ate.dev/actor_template_namespace`: The Kubernetes namespace of the actor's ActorTemplate (e.g., `ate-demo-counter`).
 * `ate.dev/container_name`: The name of the container within the actor that produced the log line (e.g., `counter`), so a multi-container actor's logs can be demultiplexed by container.
 
 Currently, Agent Substrate automatically wraps container output and injects these metadata labels into **container logs**. For metrics and distributed tracing, Agent Substrate provides foundational system telemetry and on-demand request tracing, with roadmap plans to fully integrate actor-level correlation.
@@ -75,14 +73,7 @@ To track the unified, continuous lifecycle of a single actor regardless of how m
 labels.actor_id="test"
 ```
 
-#### 2. Template-Centric View
-To monitor or debug all actor instances created from a specific template (e.g., analyzing the collective behavior or error rates of all counter actors):
-
-```text
-labels.actor_template="counter"
-```
-
-#### 3. Pod-Centric View
+#### 2. Pod-Centric View
 To inspect the physical worker pod's aggregate stream and see all co-located actors multiplexed together (useful for investigating pod-level resource exhaustion or noisy neighbor issues):
 
 ```text

--- a/internal/actorlog/logger.go
+++ b/internal/actorlog/logger.go
@@ -66,14 +66,12 @@ func NewActorLogger(w io.Writer, isOnGCE bool) *ActorLogger {
 }
 
 // EmitLifecycleLog logs a synthetic actor lifecycle event.
-func (al *ActorLogger) EmitLifecycleLog(msg, actorID, actorTemplateName, actorTemplateNamespace string) {
+func (al *ActorLogger) EmitLifecycleLog(msg, actorID string) {
 	envelope := map[string]any{
 		"time":    time.Now().Format(time.RFC3339Nano),
 		"message": msg,
 		al.labelsKey: map[string]string{
-			"ate.dev/actor_id":                 actorID,
-			"ate.dev/actor_template_name":      actorTemplateName,
-			"ate.dev/actor_template_namespace": actorTemplateNamespace,
+			"ate.dev/actor_id": actorID,
 		},
 	}
 	if envBytes, err := json.Marshal(envelope); err == nil {
@@ -86,13 +84,13 @@ func (al *ActorLogger) EmitLifecycleLog(msg, actorID, actorTemplateName, actorTe
 // through the logger. containerName tags every line with the originating container;
 // callers that multiplex multiple containers should give each its own pipe so the
 // tag is meaningful.
-func (al *ActorLogger) StartJSONLogPipe(actorID, actorTemplateName, actorTemplateNamespace, containerName string) (io.WriteCloser, error) {
+func (al *ActorLogger) StartJSONLogPipe(actorID, containerName string) (io.WriteCloser, error) {
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
 	go func() {
-		al.WrapContainerLogs(pr, actorID, actorTemplateName, actorTemplateNamespace, containerName)
+		al.WrapContainerLogs(pr, actorID, containerName)
 		pr.Close()
 	}()
 	return pw, nil
@@ -101,7 +99,7 @@ func (al *ActorLogger) StartJSONLogPipe(actorID, actorTemplateName, actorTemplat
 // WrapContainerLogs reads log lines from r, parses them, and logs them in a unified
 // structured format. containerName is added as the ate.dev/container_name label so
 // multi-container actors can be demultiplexed.
-func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplateName, actorTemplateNamespace, containerName string) {
+func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, containerName string) {
 	rdr := bufio.NewReader(r)
 	for {
 		lineBytes, err := rdr.ReadBytes('\n')
@@ -128,10 +126,8 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplateName
 
 			if unmarshalErr != nil {
 				labels := map[string]string{
-					"ate.dev/actor_id":                 actorID,
-					"ate.dev/actor_template_name":      actorTemplateName,
-					"ate.dev/actor_template_namespace": actorTemplateNamespace,
-					"ate.dev/container_name":           containerName,
+					"ate.dev/actor_id":       actorID,
+					"ate.dev/container_name": containerName,
 				}
 				envelope = map[string]any{
 					"time":       time.Now().Format(time.RFC3339Nano),
@@ -148,8 +144,6 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplateName
 					m[al.labelsKey] = labels
 				}
 				labels["ate.dev/actor_id"] = actorID
-				labels["ate.dev/actor_template_name"] = actorTemplateName
-				labels["ate.dev/actor_template_namespace"] = actorTemplateNamespace
 				labels["ate.dev/container_name"] = containerName
 				envelope = m
 			}

--- a/internal/actorlog/logger_test.go
+++ b/internal/actorlog/logger_test.go
@@ -28,7 +28,7 @@ func TestWrapContainerLogs(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "act-1", "ctr-1")
 
 	var m map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
@@ -57,12 +57,6 @@ func TestWrapContainerLogs(t *testing.T) {
 	if labels["ate.dev/actor_id"] != "act-1" {
 		t.Errorf("got actor_id = %v, want 'act-1'", labels["ate.dev/actor_id"])
 	}
-	if labels["ate.dev/actor_template_name"] != "tmpl-1" {
-		t.Errorf("got actor_template_name = %v, want 'tmpl-1'", labels["ate.dev/actor_template_name"])
-	}
-	if labels["ate.dev/actor_template_namespace"] != "default" {
-		t.Errorf("got actor_template_namespace = %v, want 'default'", labels["ate.dev/actor_template_namespace"])
-	}
 	if labels["ate.dev/container_name"] != "ctr-1" {
 		t.Errorf("got container_name = %v, want 'ctr-1'", labels["ate.dev/container_name"])
 	}
@@ -75,7 +69,7 @@ func TestWrapContainerLogs_JSONInput(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "act-1", "ctr-1")
 
 	dec := json.NewDecoder(&buf)
 	dec.UseNumber()
@@ -164,7 +158,7 @@ func TestWrapContainerLogs_MergeLabels(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false) // labelsKey will be "labels"
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "act-1", "ctr-1")
 
 	var m map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
@@ -200,7 +194,7 @@ func TestWrapContainerLogs_LabelCollision(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "act-1", "ctr-1")
 
 	var m map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
@@ -230,7 +224,7 @@ func TestWrapContainerLogs_TrailingGarbage(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "act-1", "ctr-1")
 
 	var m map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {

--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -60,11 +60,11 @@ func AteomNetNSPath(podUID string) string {
 	)
 }
 
-func ActorPath(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func ActorPath(actorID string) string {
 	return filepath.Join(
 		BasePath,
 		"actors",
-		actorTemplateNamespace+":"+actorTemplateName+":"+actorID,
+		actorID,
 	)
 }
 
@@ -73,9 +73,9 @@ func ActorPath(actorTemplateNamespace, actorTemplateName, actorID string) string
 // bind-mounts read-only into the actor. It is per-actor and regenerated on
 // every resume, so (unlike the checkpointed process environment) it reflects
 // the correct ID after a restore from the golden snapshot.
-func ActorIdentityDirPath(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func ActorIdentityDirPath(actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"identity",
 	)
 }
@@ -86,69 +86,69 @@ func ActorIdentityDirPath(actorTemplateNamespace, actorTemplateName, actorID str
 // Checkpoint (when the request no longer carries the sandbox config). It lives
 // directly under ActorPath — NOT under a subdir wiped by atelet's
 // resetActorDirs — so it survives between Run and a later Checkpoint.
-func ActorSandboxAssetsFile(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func ActorSandboxAssetsFile(actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"sandbox-assets.json",
 	)
 }
 
-func RunSCStateDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func RunSCStateDir(actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"runsc-state",
 	)
 }
 
-func OCIBundleDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func OCIBundleDir(actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"bundles",
 	)
 }
 
-func OCIBundlePath(actorTemplateNamespace, actorTemplateName, actorID, containerName string) string {
+func OCIBundlePath(actorID, containerName string) string {
 	return filepath.Join(
-		OCIBundleDir(actorTemplateNamespace, actorTemplateName, actorID),
+		OCIBundleDir(actorID),
 		containerName,
 	)
 }
 
-func RunscDebugLogDir(actorTemplateNamespace, actorTemplateName, actorID, containerName string) string {
+func RunscDebugLogDir(actorID, containerName string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"runsc-debug-logs",
 		containerName,
 	)
 }
 
-func CheckpointStateDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func CheckpointStateDir(actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"checkpoint-state",
 	)
 }
 
-func LocalCheckpointsDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func LocalCheckpointsDir(actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"local-checkpoint",
 	)
 }
 
 // DurableDirVolumeMountsDir is the directory where individual durable-dir
 // volumes are mounted.
-func DurableDirVolumeMountsDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func DurableDirVolumeMountsDir(actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"durable-dir",
 	)
 }
 
 // DurableDirVolumeMountPoint returns the path where a specific durable-dir volume is mounted on the nodeVM.
-func DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actorID, volumeName string) string {
+func DurableDirVolumeMountPoint(actorID, volumeName string) string {
 	return filepath.Join(
-		DurableDirVolumeMountsDir(actorTemplateNamespace, actorTemplateName, actorID),
+		DurableDirVolumeMountsDir(actorID),
 		volumeName,
 	)
 }
@@ -164,23 +164,23 @@ func DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actor
 // make sure we write the suspension checkpoint to a different location.  This
 // will work properly, with `runsc checkpoint` paging in any data that hasn't
 // yet been loaded.
-func RestoreStateDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func RestoreStateDir(actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"restore-state",
 	)
 }
 
-func PIDFileDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func PIDFileDir(actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(actorID),
 		"pidfiles",
 	)
 }
 
-func PIDFilePath(actorTemplateNamespace, actorTemplateName, actorID, containerName string) string {
+func PIDFilePath(actorID, containerName string) string {
 	return filepath.Join(
-		PIDFileDir(actorTemplateNamespace, actorTemplateName, actorID),
+		PIDFileDir(actorID),
 		containerName+".pid",
 	)
 }

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -91,12 +91,10 @@ func (SnapshotScope) EnumDescriptor() ([]byte, []int) {
 }
 
 type RunWorkloadRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,1,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,2,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	ActorId                string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,4,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	ActorId   string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	RunscPath string                 `protobuf:"bytes,4,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec      *WorkloadSpec          `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
 	// runtime_asset_paths maps a runtime asset name (e.g. "cloud-hypervisor",
 	// "virtiofsd", "kata-kernel", "kata-image", "kata-config")
 	// to the local on-disk path atelet fetched it to (content-addressed, like
@@ -134,20 +132,6 @@ func (x *RunWorkloadRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use RunWorkloadRequest.ProtoReflect.Descriptor instead.
 func (*RunWorkloadRequest) Descriptor() ([]byte, []int) {
 	return file_ateom_proto_rawDescGZIP(), []int{0}
-}
-
-func (x *RunWorkloadRequest) GetActorTemplateNamespace() string {
-	if x != nil {
-		return x.ActorTemplateNamespace
-	}
-	return ""
-}
-
-func (x *RunWorkloadRequest) GetActorTemplateName() string {
-	if x != nil {
-		return x.ActorTemplateName
-	}
-	return ""
 }
 
 func (x *RunWorkloadRequest) GetActorId() string {
@@ -421,12 +405,10 @@ func (*RunWorkloadResponse) Descriptor() ([]byte, []int) {
 }
 
 type CheckpointWorkloadRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,1,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,2,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	ActorId                string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,4,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	ActorId   string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	RunscPath string                 `protobuf:"bytes,4,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec      *WorkloadSpec          `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
 	// An object storage URI prefix below which the checkpoint data will be
 	// stored.
 	//
@@ -473,20 +455,6 @@ func (x *CheckpointWorkloadRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use CheckpointWorkloadRequest.ProtoReflect.Descriptor instead.
 func (*CheckpointWorkloadRequest) Descriptor() ([]byte, []int) {
 	return file_ateom_proto_rawDescGZIP(), []int{6}
-}
-
-func (x *CheckpointWorkloadRequest) GetActorTemplateNamespace() string {
-	if x != nil {
-		return x.ActorTemplateNamespace
-	}
-	return ""
-}
-
-func (x *CheckpointWorkloadRequest) GetActorTemplateName() string {
-	if x != nil {
-		return x.ActorTemplateName
-	}
-	return ""
 }
 
 func (x *CheckpointWorkloadRequest) GetActorId() string {
@@ -579,12 +547,10 @@ func (x *CheckpointWorkloadResponse) GetSnapshotFiles() []string {
 }
 
 type RestoreWorkloadRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,1,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,2,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	ActorId                string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,4,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	ActorId   string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	RunscPath string                 `protobuf:"bytes,4,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec      *WorkloadSpec          `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
 	// The object storage URI prefix of the snapshot to restore.
 	SnapshotUriPrefix string `protobuf:"bytes,6,opt,name=snapshot_uri_prefix,json=snapshotUriPrefix,proto3" json:"snapshot_uri_prefix,omitempty"`
 	// runtime_asset_paths maps a runtime asset name to the local on-disk path
@@ -624,20 +590,6 @@ func (x *RestoreWorkloadRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use RestoreWorkloadRequest.ProtoReflect.Descriptor instead.
 func (*RestoreWorkloadRequest) Descriptor() ([]byte, []int) {
 	return file_ateom_proto_rawDescGZIP(), []int{8}
-}
-
-func (x *RestoreWorkloadRequest) GetActorTemplateNamespace() string {
-	if x != nil {
-		return x.ActorTemplateNamespace
-	}
-	return ""
-}
-
-func (x *RestoreWorkloadRequest) GetActorTemplateName() string {
-	if x != nil {
-		return x.ActorTemplateName
-	}
-	return ""
 }
 
 func (x *RestoreWorkloadRequest) GetActorId() string {
@@ -722,10 +674,8 @@ var File_ateom_proto protoreflect.FileDescriptor
 
 const file_ateom_proto_rawDesc = "" +
 	"\n" +
-	"\vateom.proto\x12\x05ateom\"\x89\x03\n" +
-	"\x12RunWorkloadRequest\x128\n" +
-	"\x18actor_template_namespace\x18\x01 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x02 \x01(\tR\x11actorTemplateName\x12\x19\n" +
+	"\vateom.proto\x12\x05ateom\"\xda\x02\n" +
+	"\x12RunWorkloadRequest\x12\x19\n" +
 	"\bactor_id\x18\x03 \x01(\tR\aactorId\x12\x1d\n" +
 	"\n" +
 	"runsc_path\x18\x04 \x01(\tR\trunscPath\x12'\n" +
@@ -733,7 +683,7 @@ const file_ateom_proto_rawDesc = "" +
 	"\x13runtime_asset_paths\x18\a \x03(\v20.ateom.RunWorkloadRequest.RuntimeAssetPathsEntryR\x11runtimeAssetPaths\x1aD\n" +
 	"\x16RuntimeAssetPathsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"@\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x01\x10\x02J\x04\b\x02\x10\x03R\x18actor_template_namespaceR\x13actor_template_name\"@\n" +
 	"\fWorkloadSpec\x120\n" +
 	"\n" +
 	"containers\x18\x01 \x03(\v2\x10.ateom.ContainerR\n" +
@@ -747,10 +697,8 @@ const file_ateom_proto_rawDesc = "" +
 	"\rHTTPGetAction\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\"\x15\n" +
-	"\x13RunWorkloadResponse\"\xf3\x03\n" +
-	"\x19CheckpointWorkloadRequest\x128\n" +
-	"\x18actor_template_namespace\x18\x01 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x02 \x01(\tR\x11actorTemplateName\x12\x19\n" +
+	"\x13RunWorkloadResponse\"\xc4\x03\n" +
+	"\x19CheckpointWorkloadRequest\x12\x19\n" +
 	"\bactor_id\x18\x03 \x01(\tR\aactorId\x12\x1d\n" +
 	"\n" +
 	"runsc_path\x18\x04 \x01(\tR\trunscPath\x12'\n" +
@@ -760,12 +708,10 @@ const file_ateom_proto_rawDesc = "" +
 	"\x05scope\x18\b \x01(\x0e2\x14.ateom.SnapshotScopeR\x05scope\x1aD\n" +
 	"\x16RuntimeAssetPathsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"C\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x01\x10\x02J\x04\b\x02\x10\x03R\x18actor_template_namespaceR\x13actor_template_name\"C\n" +
 	"\x1aCheckpointWorkloadResponse\x12%\n" +
-	"\x0esnapshot_files\x18\x01 \x03(\tR\rsnapshotFiles\"\xed\x03\n" +
-	"\x16RestoreWorkloadRequest\x128\n" +
-	"\x18actor_template_namespace\x18\x01 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x02 \x01(\tR\x11actorTemplateName\x12\x19\n" +
+	"\x0esnapshot_files\x18\x01 \x03(\tR\rsnapshotFiles\"\xbe\x03\n" +
+	"\x16RestoreWorkloadRequest\x12\x19\n" +
 	"\bactor_id\x18\x03 \x01(\tR\aactorId\x12\x1d\n" +
 	"\n" +
 	"runsc_path\x18\x04 \x01(\tR\trunscPath\x12'\n" +
@@ -775,7 +721,7 @@ const file_ateom_proto_rawDesc = "" +
 	"\x05scope\x18\b \x01(\x0e2\x14.ateom.SnapshotScopeR\x05scope\x1aD\n" +
 	"\x16RuntimeAssetPathsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x19\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x01\x10\x02J\x04\b\x02\x10\x03R\x18actor_template_namespaceR\x13actor_template_name\"\x19\n" +
 	"\x17RestoreWorkloadResponse*a\n" +
 	"\rSnapshotScope\x12\x1e\n" +
 	"\x1aSNAPSHOT_SCOPE_UNSPECIFIED\x10\x00\x12\x17\n" +

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -48,9 +48,7 @@ service Ateom {
 }
 
 message RunWorkloadRequest {
-  string actor_template_namespace = 1;
-  string actor_template_name      = 2;
-  string actor_id                 = 3;
+  string actor_id = 3;
 
   string runsc_path = 4;
 
@@ -61,6 +59,8 @@ message RunWorkloadRequest {
   // to the local on-disk path atelet fetched it to (content-addressed, like
   // runsc_path). Empty for the gVisor runtime, which uses runsc_path.
   map<string, string> runtime_asset_paths = 7;
+  reserved 1, 2;
+  reserved "actor_template_namespace", "actor_template_name";
 }
 
 // WorkloadSpec parallels Pod, but with far fewer configurable fields.
@@ -104,9 +104,7 @@ enum SnapshotScope {
 }
 
 message CheckpointWorkloadRequest {
-  string actor_template_namespace = 1;
-  string actor_template_name      = 2;
-  string actor_id                 = 3;
+  string actor_id = 3;
 
   string runsc_path = 4;
 
@@ -128,6 +126,8 @@ message CheckpointWorkloadRequest {
 
   // What content to include in the checkpoint.
   SnapshotScope scope = 8;
+  reserved 1, 2;
+  reserved "actor_template_namespace", "actor_template_name";
 }
 
 message CheckpointWorkloadResponse {
@@ -138,9 +138,7 @@ message CheckpointWorkloadResponse {
 }
 
 message RestoreWorkloadRequest {
-  string actor_template_namespace = 1;
-  string actor_template_name      = 2;
-  string actor_id                 = 3;
+  string actor_id = 3;
 
   string runsc_path = 4;
 
@@ -155,6 +153,8 @@ message RestoreWorkloadRequest {
 
   // What content to restore from the snapshot.
   SnapshotScope scope = 8;
+  reserved 1, 2;
+  reserved "actor_template_namespace", "actor_template_name";
 }
 
 message RestoreWorkloadResponse {

--- a/internal/resources/validate.go
+++ b/internal/resources/validate.go
@@ -30,31 +30,15 @@ import (
 // tree, or collide OCI bundles. They are exported so the API server and
 // controller can apply the same rules at their own boundaries.
 
-// ValidateActorRef ensures every component of the per-actor directory tree is
-// a valid DNS-1123 name. namespace+template+actorID are concatenated by
-// ateompath.ActorPath into a host path on which atelet runs os.RemoveAll and
-// os.MkdirAll, so all three must be validated. Checking only one would still
-// leave a traversal window via the others. Template names are DNS-1123
-// subdomains (dots allowed); namespaces and actor IDs are labels.
+// ValidateActorRef ensures that the actor ID is a valid DNS-1123 name. The
+// actor ID forms part of a host path on which atelet runs os.RemoveAll and
+// os.MkdirAll.
 //
 // The actor ID rule here is DNS-1123 label, which matches ValidateActorID;
 // unifying the two implementations is tracked separately.
-func ValidateActorRef(namespace, template, actorID string) error {
-	if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
-		return fmt.Errorf("invalid namespace %q: %s", namespace, strings.Join(errs, "; "))
-	}
-	if errs := validation.IsDNS1123Subdomain(template); len(errs) > 0 {
-		return fmt.Errorf("invalid template %q: %s", template, strings.Join(errs, "; "))
-	}
+func ValidateActorRef(actorID string) error {
 	if errs := validation.IsDNS1123Label(actorID); len(errs) > 0 {
 		return fmt.Errorf("invalid actor ID %q: %s", actorID, strings.Join(errs, "; "))
-	}
-	// The three names are joined into a single path component
-	// (<namespace>:<template>:<actorID>, see ateompath.ActorPath), which must
-	// fit the 255-byte filename limit of common filesystems. Individually
-	// valid DNS names can exceed it: 63 + 253 + 63 plus separators is 381.
-	if n := len(namespace) + 1 + len(template) + 1 + len(actorID); n > 255 {
-		return fmt.Errorf("actor ref %s:%s:%s is %d bytes; the combined path component must be at most 255", namespace, template, actorID, n)
 	}
 	return nil
 }

--- a/internal/resources/validate_test.go
+++ b/internal/resources/validate_test.go
@@ -20,44 +20,31 @@ import (
 )
 
 func TestValidateActorRef(t *testing.T) {
-	const okNS, okTmpl, okID = "ate-demo", "counter", "counter-1"
+	const okID = "counter-1"
 
 	tests := []struct {
-		name         string
-		ns, tmpl, id string
-		wantErr      bool
+		name    string
+		id      string
+		wantErr bool
 	}{
-		{"all valid", okNS, okTmpl, okID, false},
-		{"uuid id valid", okNS, okTmpl, "422938ba-8860-4983-a25d-d6bcb0a69d4e", false},
+		{"all valid", okID, false},
+		{"uuid id valid", "422938ba-8860-4983-a25d-d6bcb0a69d4e", false},
 
 		// Label vs subdomain distinction: template names are DNS-1123
 		// subdomains (dots allowed); namespaces and actor IDs are labels.
-		{"dotted template valid (subdomain)", okNS, "probe.v1", okID, false},
-		{"dotted namespace invalid (label)", "ate.demo", okTmpl, okID, true},
-		{"dotted id invalid (label)", okNS, okTmpl, "probe.alpha", true},
+		{"dotted id invalid (label)", "probe.alpha", true},
 
-		{"id traversal", okNS, okTmpl, "..", true},
-		{"id separator", okNS, okTmpl, "a/b", true},
-		{"id empty", okNS, okTmpl, "", true},
-		{"id uppercase", okNS, okTmpl, "Counter", true},
-		{"id too long", okNS, okTmpl, strings.Repeat("a", 64), true},
-
-		{"namespace separator", "a/b", okTmpl, okID, true},
-		{"namespace traversal", "..", okTmpl, okID, true},
-		{"namespace empty", "", okTmpl, okID, true},
-		{"template separator", okNS, "a/b", okID, true},
-		{"template traversal", okNS, "..", okID, true},
-
-		// The names join into one <ns>:<tmpl>:<id> path component, capped at
-		// 255 bytes even when each name is individually valid.
-		{"combined fits filename limit", strings.Repeat("a", 63), strings.Repeat("b", 120), strings.Repeat("c", 63), false},
-		{"combined exceeds filename limit", strings.Repeat("a", 63), strings.Repeat("b", 253), strings.Repeat("c", 63), true},
+		{"id traversal", "..", true},
+		{"id separator", "a/b", true},
+		{"id empty", "", true},
+		{"id uppercase", "Counter", true},
+		{"id too long", strings.Repeat("a", 64), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateActorRef(tt.ns, tt.tmpl, tt.id)
+			err := ValidateActorRef(tt.id)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateActorRef(%q, %q, %q) err = %v, wantErr %v", tt.ns, tt.tmpl, tt.id, err, tt.wantErr)
+				t.Errorf("ValidateActorRef(%q) err = %v, wantErr %v", tt.id, err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Earlier in development, the actor ID was namespaced under its corresponding ActorTemplate.  This is no longer the case --- Actor IDs are now unique within the substrate database, and we want to support migration of actors between ActorTemplates (for upgrade scenarios).

This means that some of the the things atelet/ateom do no longer make sense:
* The actor state directory no longer needs to be qualified with ActorTemplate information.
* The actor logs should not be qualified with the ActorTemplate information
* The ActorTemplate information no longer needs to be passed through the atelet / ateom layers.
