### PR TITLE
test: serialize envtest binary setup to fix concurrent-download race

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
 	"testing"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/ateredis"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
+	"github.com/agent-substrate/substrate/internal/envtestbins"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/client/clientset/versioned"
@@ -60,14 +60,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	cmd := exec.Command("bash", "../../../../hack/run-tool.sh", "setup-envtest", "use", "--print", "path")
-	var stderr strings.Builder
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
+	binaryAssetsDirectory, err := envtestbins.BinaryAssetsDir()
 	if err != nil {
-		log.Fatalf("setup-envtest: %v (stderr: %s)", err, stderr.String())
+		log.Fatalf("%v", err)
 	}
-	binaryAssetsDirectory := strings.TrimSpace(string(out))
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{"../../../../manifests/ate-install/generated"},

--- a/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/agent-substrate/substrate/internal/envtestbins"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 )
 
@@ -49,13 +48,11 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	cmd := exec.Command("bash", "../../../../hack/run-tool.sh", "setup-envtest", "use", "--print", "path")
-	out, err := cmd.Output()
+	binaryAssetsDirectory, err := envtestbins.BinaryAssetsDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "setup-envtest failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-	binaryAssetsDirectory := strings.TrimSpace(string(out))
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{"../../../../manifests/ate-install/generated"},

--- a/internal/envtestbins/envtestbins.go
+++ b/internal/envtestbins/envtestbins.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package envtestbins resolves the shared envtest (kubebuilder) binary assets
+package envtestbins
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// BinaryAssetsDir resolves the envtest (kubebuilder) binary assets directory,
+// downloading it on first use via `setup-envtest`, and returns its path.
+//
+// The setup is guarded by a cross-process file lock. `go test ./...` runs the
+// envtest-backed packages (cmd/ateapi/internal/controlapi,
+// cmd/atecontroller/internal/controllers, pkg/api/v1alpha1) as separate test
+// binaries in parallel, and each one calls this during TestMain. On a cold
+// cache, concurrent `setup-envtest use` invocations would otherwise race to
+// download, extract, and exec the *shared* kubebuilder binaries — intermittently
+// failing with "fork/exec .../etcd: text file busy" or "unable to create file
+// ... from archive". Serializing the first download makes later callers hit a
+// warm cache (a no-op path lookup).
+func BinaryAssetsDir() (string, error) {
+	root, err := repoRoot()
+	if err != nil {
+		return "", err
+	}
+
+	unlock, err := lockEnvtestSetup()
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
+
+	cmd := exec.Command("bash", filepath.Join(root, "hack", "run-tool.sh"), "setup-envtest", "use", "--print", "path")
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("setup-envtest: %w (stderr: %s)", err, stderr.String())
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// lockEnvtestSetup takes an exclusive cross-process lock on a well-known file,
+// returning a function that releases it.
+//
+// The lock lives at a fixed name under os.TempDir(). The concurrent callers are
+// the per-package test binaries spawned by a single `go test ./...`; they
+// inherit the same TMPDIR (or all fall back to the same OS default), so
+// os.TempDir() resolves to the identical directory in every process and they all
+// lock the same file. A machine/user-global location is the right scope here:
+// the resource being guarded — the kubebuilder binary cache — is itself
+// user-global (shared even across repo checkouts).
+func lockEnvtestSetup() (func(), error) {
+	lockPath := filepath.Join(os.TempDir(), "substrate-setup-envtest.lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening envtest setup lock %s: %w", lockPath, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("acquiring envtest setup lock: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}
+
+func repoRoot() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("finding repo root for envtest setup: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/pkg/api/v1alpha1/actortemplate_validation_test.go
+++ b/pkg/api/v1alpha1/actortemplate_validation_test.go
@@ -17,11 +17,11 @@ package v1alpha1
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/envtestbins"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,13 +41,11 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	cmd := exec.Command("bash", "../../../hack/run-tool.sh", "setup-envtest", "use", "--print", "path")
-	out, err := cmd.Output()
+	binaryAssetsDirectory, err := envtestbins.BinaryAssetsDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "setup-envtest failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-	binaryAssetsDirectory := strings.TrimSpace(string(out))
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{"../../../manifests/ate-install/generated"},


### PR DESCRIPTION
## Problem

`go test -v ./...` (the `run-tests` job) intermittently fails during envtest **setup** — not in any test logic:

- `fork/exec .../kubebuilder-envtest/k8s/1.36.0-linux-amd64/etcd: text file busy`
- `setup-envtest: ... unable to create file kubectl from archive for version-platform pair 1.36.0-linux-amd64`

Three packages use envtest (`cmd/ateapi/internal/controlapi`, `cmd/atecontroller/internal/controllers`, `pkg/api/v1alpha1`). `go test ./...` runs them as separate test binaries **in parallel**, and each `TestMain` shells out to `setup-envtest use`. On a cold cache they race to download, extract, and exec the **shared** kubebuilder binaries — hence `text file busy` (exec'ing etcd while it's still being written) and the archive-extraction error.

Seen on `main` (e.g. the #259 push run) and on PRs. It only reproduces on a **cold** cache, which is why it's intermittent and doesn't show up locally once the cache is warm.

## Fix

Add `internal/envtestbins.BinaryAssetsDir()`, which runs `setup-envtest use` under a **cross-process file lock** (`flock` on a fixed file under `os.TempDir()`, shared by the sibling test binaries). The first caller populates the shared cache while the others wait, then they hit a warm no-op path lookup. The duplicated setup in all three `TestMain`s now calls this helper.

The lock scope (user/machine-global) matches the resource it guards — the kubebuilder binary cache is itself user-global, shared even across repo checkouts.

## Testing

Reproduced locally by moving the warm cache aside and running the three packages concurrently: it fails without the lock and passes with it. Full `go test ./...` green.

Test-only change; no production code touched.