### PR TITLE
fix(demo): remove ports from sandbox and agent-secret manifests

### DIFF
--- a/demos/agent-secret/agent-secret.yaml.tmpl
+++ b/demos/agent-secret/agent-secret.yaml.tmpl
@@ -67,8 +67,9 @@ spec:
   - name: agent-secret
     image: ko://github.com/agent-substrate/substrate/demos/agent-secret
     command: ["/ko-app/agent-secret"]
-    ports:
-    - containerPort: 80
+    env:
+    - name: PORT
+      value: "80"
   workerSelector:
     matchLabels:
       workload: agent-secret

--- a/demos/sandbox/sandbox.yaml.tmpl
+++ b/demos/sandbox/sandbox.yaml.tmpl
@@ -42,8 +42,6 @@ spec:
   - name: sandbox
     image: ko://github.com/agent-substrate/substrate/demos/sandbox
     command: ["/ko-app/sandbox"]
-    ports:
-    - containerPort: 80
     env:
     - name: PORT
       value: "80"


### PR DESCRIPTION
The `port` and `containerPort` were removed from AgentTemplate in #201. Also adds the `PORT` env var for agent-secret to match sandbox and ensure it is configured explicitly.

Fixes #273

- [X] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
