### PR TITLE
feat: add SandboxClass support to ActorTemplate

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -1131,7 +1131,7 @@ func TestResumeActor_NoEligiblePool(t *testing.T) {
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
 		ActorId: createResp.GetActor().GetActorId(),
 	})
-	assertGrpcError(t, err, codes.FailedPrecondition, "no worker pool matches the template and actor selectors")
+	assertGrpcError(t, err, codes.FailedPrecondition, "no worker pool matches the template's sandboxClass and the template/actor selectors")
 }
 
 // TestResumeActor_MultiPoolSelector exercises the AND-of-two-selectors path

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -80,7 +80,7 @@ func (s *LoadActorForResumeStep) Execute(ctx context.Context, input *ResumeInput
 
 func (s *LoadActorForResumeStep) RetryBackoff() *wait.Backoff { return nil }
 
-func eligibleWorkerPools(pools []*atev1alpha1.WorkerPool, templateSelector *metav1.LabelSelector, actorSelector *ateapipb.Selector) (map[types.NamespacedName]struct{}, error) {
+func eligibleWorkerPools(pools []*atev1alpha1.WorkerPool, templateClass atev1alpha1.SandboxClass, templateSelector *metav1.LabelSelector, actorSelector *ateapipb.Selector) (map[types.NamespacedName]struct{}, error) {
 	templateSel := labels.Everything()
 	if templateSelector != nil {
 		sel, err := metav1.LabelSelectorAsSelector(templateSelector)
@@ -94,6 +94,13 @@ func eligibleWorkerPools(pools []*atev1alpha1.WorkerPool, templateSelector *meta
 
 	eligible := make(map[types.NamespacedName]struct{})
 	for _, pool := range pools {
+		// Snapshots are not portable across sandbox classes, so the pool's class
+		// must match the template's. This is a hard gate AND'd with the label
+		// selectors below. Both classes are populated by the CRD default (gvisor),
+		// so we compare them directly.
+		if pool.Spec.SandboxClass != templateClass {
+			continue
+		}
 		set := labels.Set(pool.GetLabels())
 		if templateSel.Matches(set) && actorSel.Matches(set) {
 			eligible[types.NamespacedName{Namespace: pool.GetNamespace(), Name: pool.GetName()}] = struct{}{}
@@ -117,12 +124,12 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 	if err != nil {
 		return fmt.Errorf("while listing worker pools: %w", err)
 	}
-	eligible, err := eligibleWorkerPools(pools, state.ActorTemplate.Spec.WorkerSelector, state.Actor.GetWorkerSelector())
+	eligible, err := eligibleWorkerPools(pools, state.ActorTemplate.Spec.SandboxClass, state.ActorTemplate.Spec.WorkerSelector, state.Actor.GetWorkerSelector())
 	if err != nil {
 		return fmt.Errorf("while computing eligible worker pools: %w", err)
 	}
 	if len(eligible) == 0 {
-		return status.Errorf(codes.FailedPrecondition, "no worker pool matches the template and actor selectors")
+		return status.Errorf(codes.FailedPrecondition, "no worker pool matches the template's sandboxClass and the template/actor selectors")
 	}
 
 	workers, err := s.store.ListWorkers(ctx)

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -33,10 +33,17 @@ func pool(namespace, name string, labels map[string]string) *atev1alpha1.WorkerP
 	}
 }
 
+func poolWithClass(namespace, name string, class atev1alpha1.SandboxClass, labels map[string]string) *atev1alpha1.WorkerPool {
+	p := pool(namespace, name, labels)
+	p.Spec.SandboxClass = class
+	return p
+}
+
 func TestEligibleWorkerPools(t *testing.T) {
 	tests := []struct {
 		name              string
 		pools             []*atev1alpha1.WorkerPool
+		templateClass     atev1alpha1.SandboxClass
 		templateSelector  *metav1.LabelSelector
 		actorSelector     *ateapipb.Selector
 		wantEligibleNames []string // pool names expected in the result
@@ -120,11 +127,44 @@ func TestEligibleWorkerPools(t *testing.T) {
 			actorSelector:     nil,
 			wantEligibleNames: nil,
 		},
+		{
+			name: "microvm template matches only microvm pools",
+			pools: []*atev1alpha1.WorkerPool{
+				poolWithClass("ns", "micro", atev1alpha1.SandboxClassMicroVM, nil),
+				poolWithClass("ns", "gvisor", atev1alpha1.SandboxClassGvisor, nil),
+			},
+			templateClass:     atev1alpha1.SandboxClassMicroVM,
+			wantEligibleNames: []string{"micro"},
+		},
+		{
+			name: "gvisor template excludes microvm pools",
+			pools: []*atev1alpha1.WorkerPool{
+				poolWithClass("ns", "micro", atev1alpha1.SandboxClassMicroVM, nil),
+				poolWithClass("ns", "gvisor", atev1alpha1.SandboxClassGvisor, nil),
+			},
+			templateClass:     atev1alpha1.SandboxClassGvisor,
+			wantEligibleNames: []string{"gvisor"},
+		},
+		{
+			name: "class gate AND's with label selector",
+			pools: []*atev1alpha1.WorkerPool{
+				poolWithClass("ns", "match", atev1alpha1.SandboxClassMicroVM, map[string]string{"tier": "paid"}),
+				// Right class, wrong label.
+				poolWithClass("ns", "wrong-label", atev1alpha1.SandboxClassMicroVM, map[string]string{"tier": "free"}),
+				// Right label, wrong class.
+				poolWithClass("ns", "wrong-class", atev1alpha1.SandboxClassGvisor, map[string]string{"tier": "paid"}),
+			},
+			templateClass: atev1alpha1.SandboxClassMicroVM,
+			templateSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"tier": "paid"},
+			},
+			wantEligibleNames: []string{"match"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := eligibleWorkerPools(tt.pools, tt.templateSelector, tt.actorSelector)
+			got, err := eligibleWorkerPools(tt.pools, tt.templateClass, tt.templateSelector, tt.actorSelector)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -81,11 +81,14 @@ The `ActorTemplate` defines the code, environment, and state-management policies
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `containers` | `[]Container` | **Required.** The workload definition (image, command, env, ports). |
+| `sandboxClass` | `string` | Optional. The sandbox runtime family this template's actors require: `gvisor` (default) or `microvm`. Only `WorkerPool`s whose `sandboxClass` matches are eligible. |
 | `workerSelector` | `*LabelSelector` | Optional. Gates which `WorkerPool`s actors from this template may use, by matching against each pool's labels. If unset, all pools are eligible (subject to the actor's own `worker_selector`). |
 | `snapshotsConfig` | `SnapshotsConfig` | **Required.** GCS bucket and folder where memory snapshots are stored. |
 | `pauseImage` | `string` | **Required.** The image used for the sandbox root (e.g. `gcr.io/gke-release/pause`). |
 
 The sandbox binaries (e.g. the gVisor `runsc` binary) are **no longer configured on the `ActorTemplate`**. They are resolved from the referenced `WorkerPool`'s [`SandboxConfig`](#3-sandboxconfig-sandbox-binaries) — by name (`workerPool.spec.sandboxConfigName`) or, by default, the cluster default `SandboxConfig` for the pool's `sandboxClass`.
+
+Because a snapshot is not restorable across sandbox runtimes, `sandboxClass` is a **hard scheduling gate**: an actor is only ever placed on a `WorkerPool` of the matching class. It is AND'd with `workerSelector` (and the actor's `worker_selector`), which can only narrow the eligible pools further. It defaults to `gvisor` and, like the rest of the spec, is immutable, so each template's class is fixed at creation.
 
 Container environment variables support literal `value` entries and `valueFrom.secretKeyRef`. Secret references are resolved by `ate-api-server` from the `ActorTemplate` namespace when a workload spec is materialized. For the golden actor, the resolved values are captured in the golden snapshot and future actors inherit those values until the golden snapshot is recreated. For an actor that bypasses the golden snapshot and boots from the current template spec, the resolved values are sent to atelet but are not serialized into the public Actor API. Other Kubernetes `valueFrom` sources are not supported yet. Secret changes do not automatically restart actors or invalidate snapshots; rotating a Secret requires an explicit actor or template lifecycle action.
 
@@ -117,6 +120,8 @@ spec:
     command: ["/app/server"]
     ports:
     - containerPort: 80
+  # sandboxClass defaults to gvisor; set to microvm to require micro-VM pools.
+  sandboxClass: gvisor
   workerSelector:
     matchLabels:
       workload: secret-agent

--- a/manifests/ate-install/generated/ate.dev_actortemplates.yaml
+++ b/manifests/ate-install/generated/ate.dev_actortemplates.yaml
@@ -30,7 +30,11 @@ spec:
     singular: actortemplate
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sandboxClass
+      name: Class
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -167,6 +171,25 @@ spec:
                 - message: All images must be pinned (changing the image invalidates
                     snapshots)
                   rule: self.contains('@')
+              sandboxClass:
+                default: gvisor
+                description: |-
+                  SandboxClass selects the sandbox runtime family this template's actors run
+                  on. Only worker pools whose SandboxClass matches are eligible. Snapshots are
+                  not portable across classes, so this is a hard gate, AND'd with WorkerSelector
+                  and the actor's worker_selector. Defaults to gvisor.
+
+
+                  1) How does someone discover what classes are available, or what they mean?
+                  2) How does someone define a new sandbox class?
+                  3) Does a class mean the specific type of sandbox tech or does it include some aspect of config (e.g. can we have 2 different classes which both use gVisor with different config, or 2 classes which use different microvms)
+                  4) How does the default get set and who sets it?
+
+                  See Also: WorkerPool SandboxClass
+                enum:
+                - gvisor
+                - microvm
+                type: string
               snapshotsConfig:
                 description: Snapshots configuration for the actor.
                 properties:

--- a/manifests/ate-install/generated/ate.dev_workerpools.yaml
+++ b/manifests/ate-install/generated/ate.dev_workerpools.yaml
@@ -82,6 +82,8 @@ spec:
                   the worker pod shape (KVM/vhost device mounts and node placement) and which
                   SandboxConfigs are eligible. The concrete binary is still selected by
                   AteomImage. Defaults to gvisor.
+
+                  See Also: TODOs in ActorTemplate SandboxClass
                 enum:
                 - gvisor
                 - microvm

--- a/pkg/api/v1alpha1/actortemplate_types.go
+++ b/pkg/api/v1alpha1/actortemplate_types.go
@@ -157,6 +157,26 @@ type ActorTemplateSpec struct {
 	// +required
 	SnapshotsConfig SnapshotsConfig `json:"snapshotsConfig"`
 
+	// SandboxClass selects the sandbox runtime family this template's actors run
+	// on. Only worker pools whose SandboxClass matches are eligible. Snapshots are
+	// not portable across classes, so this is a hard gate, AND'd with WorkerSelector
+	// and the actor's worker_selector. Defaults to gvisor.
+	//
+	// TODO: This is almost certainly insufficient.  We have to decide a number of things:
+	//
+	// 1) How does someone discover what classes are available, or what they mean?
+	// 2) How does someone define a new sandbox class?
+	// 3) Does a class mean the specific type of sandbox tech or does it include some aspect of config (e.g. can we have 2 different classes which both use gVisor with different config, or 2 classes which use different microvms)
+	// 4) How does the default get set and who sets it?
+	//
+	// See Also: WorkerPool SandboxClass
+	//
+	//
+	// +optional
+	// +kubebuilder:validation:Enum=gvisor;microvm
+	// +kubebuilder:default=gvisor
+	SandboxClass SandboxClass `json:"sandboxClass,omitempty"`
+
 	// WorkerSelector restricts which worker pools actors from this template may
 	// use. The scheduler only considers pools whose labels match this selector.
 	// If nil, all pools are eligible (subject to the actor's own worker_selector).
@@ -187,6 +207,7 @@ type ActorTemplateStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=actortemplate
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Class",type=string,JSONPath=`.spec.sandboxClass`
 type ActorTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/actortemplate_validation_test.go
+++ b/pkg/api/v1alpha1/actortemplate_validation_test.go
@@ -364,6 +364,19 @@ func TestActorTemplateValidation(t *testing.T) {
 		},
 		wantErr: true,
 		errMsg:  "Invalid value",
+	}, {
+		name: "valid SandboxClass microvm",
+		mutate: func(at *ActorTemplate) {
+			at.Spec.SandboxClass = SandboxClassMicroVM
+		},
+		wantErr: false,
+	}, {
+		name: "invalid SandboxClass",
+		mutate: func(at *ActorTemplate) {
+			at.Spec.SandboxClass = "kvm"
+		},
+		wantErr: true,
+		errMsg:  "Unsupported value",
 	}}
 
 	for _, tt := range tests {
@@ -429,6 +442,12 @@ func TestActorTemplateSpecImmutability(t *testing.T) {
 			name: "update-worker-selector",
 			mutate: func(at *ActorTemplate) {
 				at.Spec.WorkerSelector.MatchLabels["pool"] = "new-pool"
+			},
+		},
+		{
+			name: "update-sandbox-class",
+			mutate: func(at *ActorTemplate) {
+				at.Spec.SandboxClass = SandboxClassMicroVM
 			},
 		},
 	}

--- a/pkg/api/v1alpha1/workerpool_types.go
+++ b/pkg/api/v1alpha1/workerpool_types.go
@@ -66,6 +66,9 @@ type WorkerPoolSpec struct {
 	// the worker pod shape (KVM/vhost device mounts and node placement) and which
 	// SandboxConfigs are eligible. The concrete binary is still selected by
 	// AteomImage. Defaults to gvisor.
+	//
+	// See Also: TODOs in ActorTemplate SandboxClass
+	//
 	// +optional
 	// +kubebuilder:validation:Enum=gvisor;microvm
 	// +kubebuilder:default=gvisor


### PR DESCRIPTION
Big UX improvement for iterating on #123 

Follow-up to https://github.com/agent-substrate/substrate/pull/270 (previously worker pools were directly referenced by actors so you just made sure to pick an appropriate workerpool, we discussed there)

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
