### PR TITLE
hack/update/licenses.sh: mirror in-tree third_party licenses

### DIFF
--- a/hack/update/licenses.sh
+++ b/hack/update/licenses.sh
@@ -74,5 +74,23 @@ for target in "${targets[@]}"; do
   rm -rf "${tmp_out}"
 done
 
+# Collect upstream licenses for forked / copied-in third-party SOURCE under in-tree
+# third_party/ dirs. go-licenses only covers module dependencies (and treats our own
+# module — including these copies — as first-party), so mirror their LICENSE/NOTICE/
+# COPYING files into LICENSES/third_party/, keyed by their path under third_party/.
+# `git ls-files` is used so gitignored paths (e.g. nested worktrees under .claude/,
+# bin/) are skipped automatically; vendor/ and the output dir hold module deps /
+# generated output (not forked source), so skip those too. Mirrors kubernetes
+# hack/update-vendor-licenses.sh (see its LICENSES/third_party/). License paths are
+# plain ASCII, so newline-delimited iteration is safe.
+git ls-files --cached --others --exclude-standard \
+  | { grep -iE '(^|/)third_party/.*(licen[sc]e|notice|copying)[^/]*$' || true; } \
+  | while IFS= read -r f; do
+      case "${f}" in vendor/* | "${OUTDIR}"/*) continue ;; esac
+      dest="${OUTDIR}/third_party/${f##*third_party/}" # e.g. LICENSES/third_party/kata/agentpb/LICENSE
+      mkdir -p "$(dirname "${dest}")"
+      cp "${f}" "${dest}"
+    done
+
 # Clean up empty directories
 find "${OUTDIR}" -type d -empty -delete


### PR DESCRIPTION
go-licenses only covers module dependencies and treats our own module — including any copied-in / forked third-party SOURCE under in-tree third_party/ dirs — as first-party, so those upstream LICENSE/NOTICE/COPYING files are never collected.

Mirror them into `LICENSES/third_party/`, keyed by their path under third_party/, the same way kubernetes' `hack/update-vendor-licenses.sh` does. `git ls-files` is used so gitignored paths are skipped; `vendor/` and the output dir are excluded since they hold module deps / generated output rather than forked source.

This is a no-op today (there is no in-tree third_party source yet) and prepares the licenses tooling for forthcoming vendored third-party code.

Pulled out from https://github.com/agent-substrate/substrate/pull/287

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
