### PR TITLE
Add an in-memory workers cache.

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/ateredis"
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/envtestbins"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
@@ -290,8 +291,15 @@ func setupTest(t *testing.T, ns string) *testContext {
 	substrateInformerFactory.WaitForCacheSync(ctx.Done())
 
 	// 4. Initialize Service
+	wc := workercache.New(persistence)
+	if err := wc.Start(ctx); err != nil {
+		cancel()
+		mr.Close()
+		t.Fatalf("failed to start worker cache: %v", err)
+	}
+
 	dialer := NewAteletDialer(workerInformer.GetIndexer(), ateletInformer.GetIndexer())
-	service := NewService(persistence, actorTemplateLister, workerPoolLister, sandboxConfigLister, dialer, k8sClient)
+	service := NewService(persistence, wc, actorTemplateLister, workerPoolLister, sandboxConfigLister, dialer, k8sClient)
 
 	// 5. Start REAL gRPC Server for ATE API
 	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(ateinterceptors.ServerUnaryInterceptor))

--- a/cmd/ateapi/internal/controlapi/service.go
+++ b/cmd/ateapi/internal/controlapi/service.go
@@ -16,6 +16,7 @@ package controlapi
 
 import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"k8s.io/client-go/kubernetes"
@@ -36,6 +37,7 @@ var _ ateapipb.ControlServer = (*Service)(nil)
 // NewService creates a service.
 func NewService(
 	persistence store.Interface,
+	workerCache *workercache.Cache,
 	actorTemplateLister listersv1alpha1.ActorTemplateLister,
 	workerPoolLister listersv1alpha1.WorkerPoolLister,
 	sandboxConfigLister listersv1alpha1.SandboxConfigLister,
@@ -47,7 +49,7 @@ func NewService(
 		actorTemplateLister: actorTemplateLister,
 		workerPoolLister:    workerPoolLister,
 		dialer:              dialer,
-		actorWorkflow:       NewActorWorkflow(persistence, dialer, actorTemplateLister, workerPoolLister, sandboxConfigLister, kubeClient),
+		actorWorkflow:       NewActorWorkflow(persistence, workerCache, dialer, actorTemplateLister, workerPoolLister, sandboxConfigLister, kubeClient),
 	}
 
 	return s

--- a/cmd/ateapi/internal/controlapi/workflow.go
+++ b/cmd/ateapi/internal/controlapi/workflow.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/google/uuid"
@@ -115,6 +116,7 @@ func runStep[Params any, Context any](ctx context.Context, params Params, wCtx C
 // ActorWorkflow handles the workflows for actor's resume / suspend operations.
 type ActorWorkflow struct {
 	store               store.Interface
+	workerCache         *workercache.Cache
 	dialer              *AteletDialer
 	actorTemplateLister listersv1alpha1.ActorTemplateLister
 	workerPoolLister    listersv1alpha1.WorkerPoolLister
@@ -126,6 +128,7 @@ type ActorWorkflow struct {
 // NewActorWorkflow creates a new ActorWorkflow.
 func NewActorWorkflow(
 	store store.Interface,
+	workerCache *workercache.Cache,
 	dialer *AteletDialer,
 	actorTemplateLister listersv1alpha1.ActorTemplateLister,
 	workerPoolLister listersv1alpha1.WorkerPoolLister,
@@ -134,6 +137,7 @@ func NewActorWorkflow(
 ) *ActorWorkflow {
 	return &ActorWorkflow{
 		store:               store,
+		workerCache:         workerCache,
 		dialer:              dialer,
 		actorTemplateLister: actorTemplateLister,
 		workerPoolLister:    workerPoolLister,
@@ -161,7 +165,7 @@ func (w *ActorWorkflow) ResumeActor(ctx context.Context, id string, boot bool) (
 
 	steps := []WorkflowStep[*ResumeInput, *ResumeState]{
 		&LoadActorForResumeStep{store: w.store, actorTemplateLister: w.actorTemplateLister},
-		&AssignWorkerStep{store: w.store, workerPoolLister: w.workerPoolLister},
+		&AssignWorkerStep{store: w.store, workerCache: w.workerCache, workerPoolLister: w.workerPoolLister},
 		&CallAteletRestoreStep{dialer: w.dialer, kubeClient: w.kubeClient, secretCache: w.secretCache, workerPoolLister: w.workerPoolLister, sandboxConfigLister: w.sandboxConfigLister},
 		&FinalizeRunningStep{store: w.store},
 	}

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -24,12 +24,14 @@ import (
 	"time"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -111,6 +113,7 @@ func eligibleWorkerPools(pools []*atev1alpha1.WorkerPool, templateClass atev1alp
 
 type AssignWorkerStep struct {
 	store            store.Interface
+	workerCache      *workercache.Cache
 	workerPoolLister listersv1alpha1.WorkerPoolLister
 }
 
@@ -132,7 +135,7 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 		return status.Errorf(codes.FailedPrecondition, "no worker pool matches the template's sandboxClass and the template/actor selectors")
 	}
 
-	workers, err := s.store.ListWorkers(ctx)
+	workers, err := s.workerCache.Workers()
 	if err != nil {
 		return fmt.Errorf("while listing workers: %w", err)
 	}
@@ -152,10 +155,13 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 			assignedWorker = worker
 			break
 		}
-		worker.ActorId = ""
-		worker.ActorNamespace = ""
-		worker.ActorTemplate = ""
-		if err := s.store.UpdateWorker(ctx, worker, worker.Version); err != nil {
+		// Workers() returns pointers directly from the cache so we need to clone before
+		// mutating so that the cache is not corrupted if UpdateWorker fails.
+		release := proto.Clone(worker).(*ateapipb.Worker)
+		release.ActorId = ""
+		release.ActorNamespace = ""
+		release.ActorTemplate = ""
+		if err := s.store.UpdateWorker(ctx, release, release.Version); err != nil {
 			return fmt.Errorf("while releasing stale worker assignment: %w", err)
 		}
 	}
@@ -171,6 +177,9 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 		slog.InfoContext(ctx, "Picked worker", slog.Any("worker", pickedWorker.String()))
 	}
 
+	// Workers() returns pointers directly from the cache so we need to clone before
+	// mutating so that the cache is not corrupted if UpdateWorker fails.
+	assignedWorker = proto.Clone(assignedWorker).(*ateapipb.Worker)
 	assignedWorker.ActorId = input.ActorID
 	assignedWorker.ActorNamespace = state.Actor.GetActorTemplateNamespace()
 	assignedWorker.ActorTemplate = state.Actor.GetActorTemplateName()

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -47,6 +47,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -59,10 +60,16 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+type workerPubSubMsg struct {
+	Type   int    `json:"t"`
+	Worker string `json:"w"` // protojson-encoded Worker
+}
+
 type redisClient interface {
 	redis.Cmdable
 	ForEachMaster(ctx context.Context, fn func(ctx context.Context, client *redis.Client) error) error
 	Watch(ctx context.Context, fn func(*redis.Tx) error, keys ...string) error
+	Subscribe(ctx context.Context, channels ...string) *redis.PubSub
 }
 
 // Persistence is a service that stores information about applications in Redis.
@@ -85,6 +92,77 @@ func actorDBKey(id string) string {
 
 func workerDBKey(namespace, poolName, podName string) string {
 	return "worker:" + namespace + ":" + poolName + ":" + podName
+}
+
+func marshalWorkerEvent(eventType store.WorkerEventType, worker *ateapipb.Worker) (string, error) {
+	workerJSON, err := protojson.Marshal(worker)
+	if err != nil {
+		return "", fmt.Errorf("in protojson.Marshal: %w", err)
+	}
+	msg, err := json.Marshal(workerPubSubMsg{Type: int(eventType), Worker: string(workerJSON)})
+	if err != nil {
+		return "", fmt.Errorf("in json.Marshal: %w", err)
+	}
+	return string(msg), nil
+}
+
+func unmarshalWorkerEvent(payload string) (store.WorkerEvent, error) {
+	var msg workerPubSubMsg
+	if err := json.Unmarshal([]byte(payload), &msg); err != nil {
+		return store.WorkerEvent{}, fmt.Errorf("in json.Unmarshal: %w", err)
+	}
+	worker := &ateapipb.Worker{}
+	if err := protojson.Unmarshal([]byte(msg.Worker), worker); err != nil {
+		return store.WorkerEvent{}, fmt.Errorf("in protojson.Unmarshal: %w", err)
+	}
+	return store.WorkerEvent{Type: store.WorkerEventType(msg.Type), Worker: worker}, nil
+}
+
+const workerPubSubChannel = "worker-changes"
+
+func (s *Persistence) publishWorkerEvent(ctx context.Context, eventType store.WorkerEventType, worker *ateapipb.Worker) {
+	payload, err := marshalWorkerEvent(eventType, worker)
+	if err != nil {
+		slog.ErrorContext(ctx, "worker event marshal failed", slog.Any("err", err))
+		return
+	}
+	if err := s.rdb.Publish(ctx, workerPubSubChannel, payload).Err(); err != nil {
+		slog.ErrorContext(ctx, "worker event publish failed", slog.Any("err", err))
+	}
+}
+
+func (s *Persistence) WatchWorkers(ctx context.Context) (*store.WorkerWatch, error) {
+	// watchCtx scopes the subscription's lifetime: it is cancelled either by the
+	// caller via WorkerWatch.Close or when the parent ctx is cancelled.
+	watchCtx, cancel := context.WithCancel(ctx)
+	pubsub := s.rdb.Subscribe(watchCtx, workerPubSubChannel)
+	ch := make(chan store.WorkerEvent, 128)
+	go func() {
+		defer close(ch)
+		defer pubsub.Close()
+		msgCh := pubsub.Channel()
+		for {
+			select {
+			case <-watchCtx.Done():
+				return
+			case msg, ok := <-msgCh:
+				if !ok {
+					return
+				}
+				event, err := unmarshalWorkerEvent(msg.Payload)
+				if err != nil {
+					slog.ErrorContext(ctx, "worker event unmarshal failed", slog.Any("err", err))
+					continue
+				}
+				select {
+				case ch <- event:
+				case <-watchCtx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return store.NewWorkerWatch(ch, cancel), nil
 }
 
 // DebugClearAll flushes all data from Redis.
@@ -169,6 +247,7 @@ func (s *Persistence) CreateWorker(ctx context.Context, worker *ateapipb.Worker)
 		return store.ErrAlreadyExists
 	}
 
+	s.publishWorkerEvent(ctx, store.WorkerEventCreated, dbWorker)
 	return nil
 }
 
@@ -251,6 +330,7 @@ func (s *Persistence) UpdateWorker(ctx context.Context, worker *ateapipb.Worker,
 		return fmt.Errorf("while executing update worker transaction: %w", err)
 	}
 
+	s.publishWorkerEvent(ctx, store.WorkerEventUpdated, dbWorker)
 	return nil
 }
 
@@ -260,6 +340,10 @@ func (s *Persistence) DeleteWorker(ctx context.Context, namespace, pool, pod str
 	if err != nil {
 		return fmt.Errorf("while deleting worker key %q: %w", dbKey, err)
 	}
+	s.publishWorkerEvent(ctx, store.WorkerEventDeleted, &ateapipb.Worker{
+		WorkerNamespace: namespace,
+		WorkerPod:       pod,
+	})
 	return nil
 }
 

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -203,13 +203,18 @@ func TestCreateWorker_Success(t *testing.T) {
 	mr, s, ctx := setupTest(t)
 	defer mr.Close()
 
+	watch, err := s.WatchWorkers(ctx)
+	if err != nil {
+		t.Fatalf("WatchWorkers failed: %v", err)
+	}
+
 	worker := &ateapipb.Worker{
 		WorkerNamespace: "default",
 		WorkerPool:      "pool-1",
 		WorkerPod:       "pod-1",
 	}
 
-	err := s.CreateWorker(ctx, worker)
+	err = s.CreateWorker(ctx, worker)
 	if err != nil {
 		t.Fatalf("CreateWorker failed: %v", err)
 	}
@@ -227,6 +232,14 @@ func TestCreateWorker_Success(t *testing.T) {
 	if diff := cmp.Diff(worker, got, protocmp.Transform()); diff != "" {
 		t.Errorf("GetWorker returned unexpected worker (-want +got):\n%s", diff)
 	}
+
+	event := receiveEvent(t, watch.Events)
+	if event.Type != store.WorkerEventCreated {
+		t.Errorf("expected WorkerEventCreated, got %v", event.Type)
+	}
+	if diff := cmp.Diff(worker, event.Worker, protocmp.Transform()); diff != "" {
+		t.Errorf("created event worker mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestUpdateWorker_Success(t *testing.T) {
@@ -239,17 +252,21 @@ func TestUpdateWorker_Success(t *testing.T) {
 		WorkerPod:       "pod-1",
 	}
 
-	err := s.CreateWorker(ctx, worker)
-	if err != nil {
+	if err := s.CreateWorker(ctx, worker); err != nil {
 		t.Fatalf("CreateWorker failed: %v", err)
+	}
+
+	// Subscribe after create so the create event doesn't pollute the channel.
+	watch, err := s.WatchWorkers(ctx)
+	if err != nil {
+		t.Fatalf("WatchWorkers failed: %v", err)
 	}
 
 	worker.ActorNamespace = "default"
 	worker.ActorTemplate = "test-template"
 	worker.ActorId = "session-1"
 
-	err = s.UpdateWorker(ctx, worker, 1)
-	if err != nil {
+	if err := s.UpdateWorker(ctx, worker, 1); err != nil {
 		t.Fatalf("UpdateWorker failed: %v", err)
 	}
 
@@ -266,6 +283,14 @@ func TestUpdateWorker_Success(t *testing.T) {
 	if diff := cmp.Diff(worker, got, protocmp.Transform()); diff != "" {
 		t.Errorf("UpdateWorker yielded unexpected state in DB (-want +got):\n%s", diff)
 	}
+
+	event := receiveEvent(t, watch.Events)
+	if event.Type != store.WorkerEventUpdated {
+		t.Errorf("expected WorkerEventUpdated, got %v", event.Type)
+	}
+	if diff := cmp.Diff(worker, event.Worker, protocmp.Transform()); diff != "" {
+		t.Errorf("updated event worker mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestDeleteWorker(t *testing.T) {
@@ -278,19 +303,32 @@ func TestDeleteWorker(t *testing.T) {
 		WorkerPod:       "pod-1",
 	}
 
-	err := s.CreateWorker(ctx, worker)
-	if err != nil {
+	if err := s.CreateWorker(ctx, worker); err != nil {
 		t.Fatalf("CreateWorker failed: %v", err)
 	}
 
-	err = s.DeleteWorker(ctx, "default", "pool-1", "pod-1")
+	// Subscribe after create so the create event doesn't pollute the channel.
+	watch, err := s.WatchWorkers(ctx)
 	if err != nil {
+		t.Fatalf("WatchWorkers failed: %v", err)
+	}
+
+	if err := s.DeleteWorker(ctx, "default", "pool-1", "pod-1"); err != nil {
 		t.Fatalf("DeleteWorker failed: %v", err)
 	}
 
 	_, err = s.GetWorker(ctx, "default", "pool-1", "pod-1")
 	if !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+
+	event := receiveEvent(t, watch.Events)
+	if event.Type != store.WorkerEventDeleted {
+		t.Errorf("expected WorkerEventDeleted, got %v", event.Type)
+	}
+	want := &ateapipb.Worker{WorkerNamespace: "default", WorkerPod: "pod-1"}
+	if diff := cmp.Diff(want, event.Worker, protocmp.Transform()); diff != "" {
+		t.Errorf("deleted event worker mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -752,6 +790,20 @@ func TestAcquireLock_TTLExpiration(t *testing.T) {
 	}
 	if !acquired {
 		t.Errorf("expected lock to be acquired by token-2 after TTL expiration")
+	}
+}
+
+func receiveEvent(t *testing.T, ch <-chan store.WorkerEvent) store.WorkerEvent {
+	t.Helper()
+	select {
+	case event, ok := <-ch:
+		if !ok {
+			t.Fatal("watch channel closed unexpectedly")
+		}
+		return event
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for worker event")
+		return store.WorkerEvent{} // unreachable
 	}
 }
 

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -69,6 +69,13 @@ type Interface interface {
 	// Lists all known workers. Returns nil if none found.
 	ListWorkers(ctx context.Context) ([]*ateapipb.Worker, error)
 
+	// WatchWorkers returns an active subscription to track worker state changes.
+	// The watch's Events channel is closed when the caller calls Close, the
+	// context is cancelled, or the underlying notification system is lost.
+	// Callers should treat a closed channel as a signal to re-subscribe, and
+	// must Close the watch to release its subscription.
+	WatchWorkers(ctx context.Context) (*WorkerWatch, error)
+
 	// AcquireLock attempts to acquire a distributed lock with a TTL.
 	// Returns true if the lock was successfully acquired.
 	// Returns false if the lock is already held by another client (conflict).
@@ -84,3 +91,39 @@ type Interface interface {
 	// DebugClearAll drop all data from the database. Useful for debugging / local testing/
 	DebugClearAll(ctx context.Context) error
 }
+
+// WorkerEventType indicates the type of change to a Worker.
+type WorkerEventType int
+
+const (
+	WorkerEventCreated WorkerEventType = iota
+	WorkerEventUpdated
+	WorkerEventDeleted
+)
+
+// WorkerEvent carries a single worker state change notification.
+type WorkerEvent struct {
+	Type   WorkerEventType
+	Worker *ateapipb.Worker
+}
+
+// WorkerWatch is an active subscription to worker state changes. The caller
+// must call Close when done to release the underlying subscription. Events is
+// closed when Close is called, the originating context is cancelled, or the
+// underlying notification system is lost.
+type WorkerWatch struct {
+	// Events delivers worker state changes until the watch is torn down.
+	Events <-chan WorkerEvent
+	// stop releases the subscription backing Events. It is a context.CancelFunc,
+	// so it is safe to call multiple times.
+	stop context.CancelFunc
+}
+
+// NewWorkerWatch builds a WorkerWatch from an events channel and the cancel
+// func that tears down its subscription.
+func NewWorkerWatch(events <-chan WorkerEvent, stop context.CancelFunc) *WorkerWatch {
+	return &WorkerWatch{Events: events, stop: stop}
+}
+
+// Close releases the subscription. Safe to call multiple times.
+func (w *WorkerWatch) Close() { w.stop() }

--- a/cmd/ateapi/internal/workercache/workercache.go
+++ b/cmd/ateapi/internal/workercache/workercache.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package workercache maintains an in-memory view of all workers, kept current
+// via store.Interface.WatchWorkers. It exposes Workers() for fast O(1) reads
+// during actor scheduling and is the natural home for future indices (by node,
+// by label, etc.) as scheduling requirements grow.
+package workercache
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Cache maintains an in-memory snapshot of all workers.
+//
+// TODO: add metrics — at minimum a gauge for worker count, a counter for
+// resync events, and a counter for failed PUBLISH operations (in ateredis).
+type Cache struct {
+	store store.Interface
+
+	mu      sync.RWMutex
+	workers map[string]*ateapipb.Worker
+
+	ready atomic.Bool
+}
+
+// New creates a Cache backed by a given store.
+func New(store store.Interface) *Cache {
+	return &Cache{
+		store:   store,
+		workers: make(map[string]*ateapipb.Worker),
+	}
+}
+
+// Start syncs the cache synchronously, then spawns a background goroutine
+// that streams updates and resyncs on connection loss.
+// Returns as soon as the initial sync succeeds.
+func (c *Cache) Start(ctx context.Context) error {
+	watch, err := c.sync(ctx)
+	if err != nil {
+		return err
+	}
+	go c.watchEvents(ctx, watch)
+	return nil
+}
+
+// Workers returns a snapshot of all currently known workers. The returned
+// slice and its elements must not be modified by the caller. Returns an error
+// if the cache is not ready (brief window during reconnect); callers are
+// expected to retry.
+func (c *Cache) Workers() ([]*ateapipb.Worker, error) {
+	if !c.ready.Load() {
+		return nil, fmt.Errorf("worker cache not ready")
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]*ateapipb.Worker, 0, len(c.workers))
+	for _, w := range c.workers {
+		out = append(out, w)
+	}
+	return out, nil
+}
+
+func (c *Cache) sync(ctx context.Context) (*store.WorkerWatch, error) {
+	watch, err := c.store.WatchWorkers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("WatchWorkers: %w", err)
+	}
+
+	workers, err := c.store.ListWorkers(ctx)
+	if err != nil {
+		watch.Close()
+		return nil, fmt.Errorf("ListWorkers: %w", err)
+	}
+
+	newMap := make(map[string]*ateapipb.Worker, len(workers))
+	for _, w := range workers {
+		newMap[workerKey(w)] = w
+	}
+
+	c.mu.Lock()
+	c.workers = newMap
+	c.mu.Unlock()
+	c.ready.Store(true)
+
+	slog.InfoContext(ctx, "worker cache synced", slog.Int("count", len(newMap)))
+	return watch, nil
+}
+
+func (c *Cache) watchEvents(ctx context.Context, watch *store.WorkerWatch) {
+	for {
+		// TODO: Add a periodic "relist" so we can recover from state drifts
+		// caused by missed watch events.
+		select {
+		case event, ok := <-watch.Events:
+			if !ok {
+				c.ready.Store(false)
+				watch.Close()
+				if ctx.Err() != nil {
+					return
+				}
+				slog.WarnContext(ctx, "worker cache: watch channel closed, resyncing")
+				watch = c.resync(ctx)
+				if watch == nil {
+					return // context cancelled
+				}
+			} else {
+				c.applyEvent(event)
+			}
+		case <-ctx.Done():
+			c.ready.Store(false)
+			watch.Close()
+			return
+		}
+	}
+}
+
+func (c *Cache) resync(ctx context.Context) *store.WorkerWatch {
+	backoff := wait.Backoff{
+		Duration: time.Second,
+		Factor:   2.0,
+		Cap:      30 * time.Second,
+		Steps:    5,
+	}
+	var watch *store.WorkerWatch
+	_ = backoff.DelayFunc().Until(ctx, true, false, func(ctx context.Context) (bool, error) {
+		var err error
+		watch, err = c.sync(ctx)
+		if err != nil {
+			slog.WarnContext(ctx, "worker cache resync failed", slog.Any("err", err))
+			return false, nil
+		}
+		return true, nil
+	})
+	return watch
+}
+
+func (c *Cache) applyEvent(event store.WorkerEvent) {
+	key := workerKey(event.Worker)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch event.Type {
+	case store.WorkerEventDeleted:
+		delete(c.workers, key)
+	case store.WorkerEventCreated, store.WorkerEventUpdated:
+		existing, ok := c.workers[key]
+		if !ok || event.Worker.GetVersion() >= existing.GetVersion() {
+			c.workers[key] = event.Worker
+		}
+	}
+}
+
+func workerKey(w *ateapipb.Worker) string {
+	return w.GetWorkerNamespace() + ":" + w.GetWorkerPod()
+}

--- a/cmd/ateapi/internal/workercache/workercache_test.go
+++ b/cmd/ateapi/internal/workercache/workercache_test.go
@@ -1,0 +1,355 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workercache_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestCache_NotReadyBeforeStart(t *testing.T) {
+	c := workercache.New(newFakeStore())
+	_, err := c.Workers()
+	if err == nil {
+		t.Fatal("expected error from Workers before Start, got nil")
+	}
+}
+
+func TestCache_SyncsOnStart(t *testing.T) {
+	w1 := makeWorker("ns", "pod1", 1)
+	w2 := makeWorker("ns", "pod2", 1)
+
+	c := workercache.New(newFakeStore(w1, w2))
+	ctx := t.Context()
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got, err := c.Workers()
+	if err != nil {
+		t.Fatalf("Workers: %v", err)
+	}
+	if diff := cmp.Diff([]*ateapipb.Worker{w1, w2}, got, protocmp.Transform(), workerSortOpt); diff != "" {
+		t.Errorf("workers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCache_CreatedEvent(t *testing.T) {
+	fs := newFakeStore()
+	c := workercache.New(fs)
+	ctx := t.Context()
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	w := makeWorker("ns", "pod1", 1)
+	fs.send(store.WorkerEvent{Type: store.WorkerEventCreated, Worker: w})
+
+	eventually(t, func() bool {
+		workers, err := c.Workers()
+		return err == nil && len(workers) == 1
+	}, 2*time.Second)
+
+	got, _ := c.Workers()
+	if diff := cmp.Diff([]*ateapipb.Worker{w}, got, protocmp.Transform(), workerSortOpt); diff != "" {
+		t.Errorf("workers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCache_UpdatedEvent_NewerVersionApplied(t *testing.T) {
+	w := makeWorker("ns", "pod1", 1)
+	fs := newFakeStore(w)
+	c := workercache.New(fs)
+	ctx := t.Context()
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	updated := makeWorker("ns", "pod1", 2)
+	updated.ActorId = "actor-1"
+	fs.send(store.WorkerEvent{Type: store.WorkerEventUpdated, Worker: updated})
+
+	eventually(t, func() bool {
+		workers, err := c.Workers()
+		return err == nil && len(workers) == 1 && workers[0].GetActorId() == "actor-1"
+	}, 2*time.Second)
+
+	got, _ := c.Workers()
+	if diff := cmp.Diff([]*ateapipb.Worker{updated}, got, protocmp.Transform(), workerSortOpt); diff != "" {
+		t.Errorf("workers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCache_UpdatedEvent_OlderVersionIgnored(t *testing.T) {
+	w := makeWorker("ns", "pod1", 5)
+	fs := newFakeStore(w)
+	c := workercache.New(fs)
+	ctx := t.Context()
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Send a stale update followed by a sentinel we can detect.
+	stale := makeWorker("ns", "pod1", 3)
+	stale.ActorId = "stale-actor"
+	fs.send(store.WorkerEvent{Type: store.WorkerEventUpdated, Worker: stale})
+
+	sentinel := makeWorker("ns", "pod2", 1)
+	fs.send(store.WorkerEvent{Type: store.WorkerEventCreated, Worker: sentinel})
+
+	// Wait for the sentinel to be processed so we know the stale event was also handled.
+	eventually(t, func() bool {
+		workers, err := c.Workers()
+		return err == nil && len(workers) == 2
+	}, 2*time.Second)
+
+	got, _ := c.Workers()
+	if diff := cmp.Diff([]*ateapipb.Worker{w, sentinel}, got, protocmp.Transform(), workerSortOpt); diff != "" {
+		t.Errorf("workers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCache_DeletedEvent(t *testing.T) {
+	w := makeWorker("ns", "pod1", 1)
+	fs := newFakeStore(w)
+	c := workercache.New(fs)
+	ctx := t.Context()
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	fs.send(store.WorkerEvent{
+		Type:   store.WorkerEventDeleted,
+		Worker: &ateapipb.Worker{WorkerNamespace: "ns", WorkerPod: "pod1"},
+	})
+
+	eventually(t, func() bool {
+		workers, err := c.Workers()
+		return err == nil && len(workers) == 0
+	}, 2*time.Second)
+}
+
+func TestCache_Disconnect_ResyncsWithFreshSnapshot(t *testing.T) {
+	w1 := makeWorker("ns", "pod1", 1)
+	fs := newFakeStore(w1)
+	c := workercache.New(fs)
+	ctx := t.Context()
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Add a worker to the store snapshot and disconnect to trigger resync.
+	w2 := makeWorker("ns", "pod2", 1)
+	fs.setWorkers(w1, w2)
+	fs.disconnect()
+
+	// After resync the cache should reflect the updated snapshot.
+	eventually(t, func() bool {
+		workers, err := c.Workers()
+		return err == nil && len(workers) == 2
+	}, 2*time.Second)
+
+	got, _ := c.Workers()
+	if diff := cmp.Diff([]*ateapipb.Worker{w1, w2}, got, protocmp.Transform(), workerSortOpt); diff != "" {
+		t.Errorf("workers after resync (-want +got):\n%s", diff)
+	}
+}
+
+func TestCache_MultipleDisconnects(t *testing.T) {
+	fs := newFakeStore()
+	c := workercache.New(fs)
+	ctx := t.Context()
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Disconnect three times, each time adding a worker to the snapshot.
+	for i := range 3 {
+		pod := makeWorker("ns", string(rune('a'+i)), 1)
+		fs.setWorkers(append(fs.workers[:i], pod)...)
+		fs.disconnect()
+
+		want := i + 1
+		eventually(t, func() bool {
+			workers, err := c.Workers()
+			return err == nil && len(workers) == want
+		}, 2*time.Second)
+	}
+}
+
+func TestCache_WatchClosedOnListWorkersFailure(t *testing.T) {
+	fs := newFakeStore()
+	fs.listErr = errors.New("valkey unavailable")
+	c := workercache.New(fs)
+
+	if err := c.Start(t.Context()); err == nil {
+		t.Fatal("expected Start to fail when ListWorkers errors")
+	}
+
+	fs.mu.Lock()
+	closes := fs.closes
+	fs.mu.Unlock()
+	if closes != 1 {
+		t.Fatalf("expected watch to be closed once on sync failure, got %d closes", closes)
+	}
+}
+
+func TestCache_WatchClosedOnShutdown(t *testing.T) {
+	fs := newFakeStore()
+	c := workercache.New(fs)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cancel()
+
+	eventually(t, func() bool {
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
+		return fs.closes == 1
+	}, 2*time.Second)
+}
+
+func TestCache_WatchClosedOnDisconnectAndShutdown(t *testing.T) {
+	fs := newFakeStore()
+	c := workercache.New(fs)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Disconnect: the old watch should be closed and a new one opened.
+	fs.disconnect()
+	eventually(t, func() bool {
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
+		return fs.closes == 1
+	}, 2*time.Second)
+
+	// Shutdown: the new watch should also be closed.
+	cancel()
+	eventually(t, func() bool {
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
+		return fs.closes == 2
+	}, 2*time.Second)
+}
+
+type fakeStore struct {
+	store.Interface
+
+	mu      sync.Mutex
+	workers []*ateapipb.Worker
+	watchCh chan store.WorkerEvent
+	listErr error // if set, ListWorkers returns it
+	closes  int   // number of times a returned watch was Closed
+}
+
+func newFakeStore(workers ...*ateapipb.Worker) *fakeStore {
+	return &fakeStore{
+		workers: workers,
+		watchCh: make(chan store.WorkerEvent, 16),
+	}
+}
+
+func (f *fakeStore) WatchWorkers(_ context.Context) (*store.WorkerWatch, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return store.NewWorkerWatch(f.watchCh, func() {
+		f.mu.Lock()
+		f.closes++
+		f.mu.Unlock()
+	}), nil
+}
+
+func (f *fakeStore) ListWorkers(_ context.Context) ([]*ateapipb.Worker, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]*ateapipb.Worker, len(f.workers))
+	copy(out, f.workers)
+	return out, nil
+}
+
+func (f *fakeStore) send(event store.WorkerEvent) {
+	f.mu.Lock()
+	ch := f.watchCh
+	f.mu.Unlock()
+	ch <- event
+}
+
+func (f *fakeStore) setWorkers(workers ...*ateapipb.Worker) {
+	f.mu.Lock()
+	f.workers = workers
+	f.mu.Unlock()
+}
+
+func (f *fakeStore) disconnect() {
+	f.mu.Lock()
+	old := f.watchCh
+	f.watchCh = make(chan store.WorkerEvent, 16)
+	f.mu.Unlock()
+	close(old)
+}
+
+func makeWorker(namespace, pod string, version int64) *ateapipb.Worker {
+	return &ateapipb.Worker{
+		WorkerNamespace: namespace,
+		WorkerPod:       pod,
+		Version:         version,
+	}
+}
+
+// workerSortOpt compares workers ignoring ordering.
+var workerSortOpt = cmpopts.SortSlices(func(a, b *ateapipb.Worker) bool {
+	if a.GetWorkerNamespace() != b.GetWorkerNamespace() {
+		return a.GetWorkerNamespace() < b.GetWorkerNamespace()
+	}
+	return a.GetWorkerPod() < b.GetWorkerPod()
+})
+
+// eventually polls condition every 10ms until it returns true or timeout elapses.
+func eventually(t *testing.T, condition func() bool, timeout time.Duration) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(t.Context(), 10*time.Millisecond, timeout, true, func(context.Context) (bool, error) {
+		return condition(), nil
+	})
+	if err != nil {
+		t.Fatal("condition not met within timeout")
+	}
+}

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/credbundle"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/sessionidentity"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/ateredis"
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/serverboot"
 	"github.com/agent-substrate/substrate/internal/version"
@@ -111,6 +112,11 @@ func main() {
 
 	redisPersistence := ateredis.NewPersistence(redisClient)
 
+	workerCache := workercache.New(redisPersistence)
+	if err := workerCache.Start(ctx); err != nil {
+		serverboot.Fatal(ctx, "Failed to seed worker cache", err)
+	}
+
 	ateFactory := externalversions.NewSharedInformerFactory(ateClient, 0)
 	actorTemplateLister := ateFactory.Api().V1alpha1().ActorTemplates().Lister()
 	workerPoolLister := ateFactory.Api().V1alpha1().WorkerPools().Lister()
@@ -133,7 +139,7 @@ func main() {
 	ateFactory.WaitForCacheSync(stopCh)
 
 	dialer := controlapi.NewAteletDialer(workerPodInformer.GetIndexer(), ateletPodInformer.GetIndexer())
-	sm := controlapi.NewService(redisPersistence, actorTemplateLister, workerPoolLister, sandboxConfigLister, dialer, clientset)
+	sm := controlapi.NewService(redisPersistence, workerCache, actorTemplateLister, workerPoolLister, sandboxConfigLister, dialer, clientset)
 
 	sessionIdentitySrv := sessionidentity.New(*clientJWTIssuer, *clientJWTAudience, *sessionIDJWTPoolFile, *sessionIDCAPoolFile, *workerpoolCACerts)
 


### PR DESCRIPTION
Remove the need for scanning all workers from ValKey during `ResumeActor`. Extend store.Interface with a "watcher" interface so that clients can keep track of workers in memory and do cache invalidation.

For ValKey, the watcher is implemented by publishing events to a ValKey channel. Clients subscribe to changes using SUBSCRIBE and receive them via the WorkerWatch channel.
