### PR TITLE
fix: update DNS suffix in agent-secret demo

### DIFF
--- a/demos/agent-secret/README.md
+++ b/demos/agent-secret/README.md
@@ -40,7 +40,7 @@ Create a single actor and watch it automatically yield compute after use:
 ./kubectl-ate create actor my-agent --template ate-demo-secret-agent-v2/agent-secret
 
 # Send a request via the Substrate Router (Note the official DNS suffix)
-curl -H "Host: my-agent.actors.resources.substrate.k8s.io" http://localhost:8000
+curl -H "Host: my-agent.actors.resources.substrate.ate.dev" http://localhost:8000
 ```
 
 **What to observe:**
@@ -50,7 +50,7 @@ curl -H "Host: my-agent.actors.resources.substrate.k8s.io" http://localhost:8000
 ### 2. Verify Identity Persistence
 Send another request to the same actor:
 ```bash
-curl -H "Host: my-agent.actors.resources.substrate.k8s.io" http://localhost:8000
+curl -H "Host: my-agent.actors.resources.substrate.ate.dev" http://localhost:8000
 ```
 The "Identity" secret returned will be identical to the first response, even if the actor was resumed on a different physical pod. This proves the volatile RAM survived the hibernation cycle.
 
@@ -71,7 +71,7 @@ for wave in 0 1 2; do
   echo "Triggering Wave $((wave + 1))..."
   for i in {1..8}; do
     num=$(printf "%03d" $((wave * 8 + i)))
-    curl -s -H "Host: session-$num.actors.resources.substrate.k8s.io" http://localhost:8000 &
+    curl -s -H "Host: session-$num.actors.resources.substrate.ate.dev" http://localhost:8000 &
   done
   sleep 8 # 7s linger + 1s buffer
 done


### PR DESCRIPTION
Fixes incorrect DNS suffix in demo curl commands.

- `actors.resources.substrate.k8s.io` -> `actors.resources.substrate.ate.dev` (3 occurrences)