### PR TITLE
fix: correct service name in sandbox port-forward command

### DIFF
--- a/demos/sandbox/README.md
+++ b/demos/sandbox/README.md
@@ -60,7 +60,7 @@ If running clients locally, port-forward the API and router in separate terminal
 
 ```bash
 # Terminal 1: API Server
-kubectl port-forward -n ate-system svc/api 8080:443
+kubectl port-forward -n ate-system svc/ateapi 8080:443
 
 # Terminal 2: Router
 kubectl port-forward -n ate-system svc/atenet-router 8000:80


### PR DESCRIPTION
Fixes wrong service name in port-forward command.

- `svc/api` -> `svc/ateapi`