### PR TITLE
fix: typo and wrong script name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ eligible for the [Google Open Source Software Vulnerability Rewards Program](htt
 
 ## What is Agent Substrate?
 
-Agent substrate is a system built on top of Kubernetes which manages agent-like
+Agent Substrate is a system built on top of Kubernetes which manages agent-like
 workloads to achieve higher scale and efficiency than Kubernetes alone can
 offer, with lower latency.  It builds on top of Kubernetes features like
 Pods and Pod autoscaling, but takes the Kubernetes control-plane out of the
@@ -167,10 +167,10 @@ go run ./tools/setup-gcp --create-gvisor-node-pool
 Similarly, you can deploy or cleanup specific Agent Substrate components using the installation script. See `./hack/install-ate.sh --help` for all options.
 ```bash
 # Re-deploy only ate-apiserver of the ATE system
-./hack/install-ate-kind.sh --deploy-ate-apiserver
+./hack/install-ate.sh --deploy-ate-apiserver
 
 # Delete everything (core system and all demos)
-./hack/install-ate-kind.sh --delete-all
+./hack/install-ate.sh --delete-all
 ```
 
 #### Tearing down resources (GCP)


### PR DESCRIPTION
2 fixes in README

- `Agent substrate` -> `Agent Substrate` 
- `install-ate-kind.sh` -> `install-ate.sh` in GKE quickstart section