### PR TITLE
fix: misc doc fixes across multiple files

### DIFF
--- a/cmd/atenet/internal/dns/README.md
+++ b/cmd/atenet/internal/dns/README.md
@@ -1,6 +1,6 @@
 # DNS Controller
 
-The DNS Controller orchsterates the configuration needed to setup the ATE routing.
+The DNS Controller orchestrates the configuration needed to setup the ATE routing.
 
 We want to resolve requests for <actor id>.actors.resources.substrate.ate.dev to the router service address.
 

--- a/docs/dev/valkey-direct-access.md
+++ b/docs/dev/valkey-direct-access.md
@@ -1,6 +1,10 @@
 # Accessing valkey directly
 
-Sometimes you need to access the valkey instance directly, you can do this with one "simple" command:
+Valkey is the state store used by `ate-api-server` to track actor and worker records. Direct access is useful for debugging state issues.
+
+> **Warning:** Avoid destructive commands (`FLUSHALL`, `DEL`, etc.) on a live cluster.
+
+To open a `valkey-cli` session:
 
 1. `kubectl exec -n=ate-system -it valkey-cluster-0 -- valkey-cli -h valkey-cluster-service -c --tls --cacert /etc/valkey-ca/ca.crt --cer
 t /run/servicedns.podcert.ate.dev/credential-bundle.pem --key /run/servicedns.podcert.ate.dev/credential-bundle.pem`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,7 +54,6 @@ Below is a collection of finer-grained efforts which we believe align with the a
   * incremental snapshots
 * Support for S3 (via plugin)
 * Distinct lifecycle for “rootfs” and memory snapshots vs. “working” space.  Needs API surface of where to mount.
-*
 * ConfigMaps as volumes
 * Data locality in scheduling (needs to expose per-node available snapshots via API)
 

--- a/hack/update/README.md
+++ b/hack/update/README.md
@@ -4,4 +4,4 @@ This directory holds simple scripts which update the current tree in some way
 (e.g. generated code).
 
 Every script in this directory should have a corresponding entry in
-`../update`.
+`../update-all.sh`.

--- a/hack/verify/README.md
+++ b/hack/verify/README.md
@@ -4,4 +4,4 @@ This directory holds simple scripts which verify the current tree in some way
 (e.g. generated code).
 
 Most of the scripts in this directory should have a corresponding entry in
-`../verify`.
+`../verify-all.sh`.


### PR DESCRIPTION
- roadmap.md: remove empty bullet point
- hack/update/README.md: fix self-referential path (`../update` -> `../update-all.sh`)
- hack/verify/README.md: fix self-referential path (`../verify` -> `../verify-all.sh`)
- cmd/atenet/internal/dns/README.md: fix typo (`orchsterates` -> `orchestrates`)
- docs/dev/valkey-direct-access.md: add context and warning about destructive commands