### PR TITLE
feat: kubectl ate logs filter container supervisor

### DIFF
--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -162,16 +162,19 @@ kubectl ate delete actor my-actor -a <atespace>
 ```bash
 # Stream logs for an actor (aggregated across worker reassignments so the same
 # actor is queryable as it teleports between pods).
-kubectl ate logs actors my-actor
+kubectl ate logs actors my-actor -a <atespace>
 
 # Show logs from a single container within the actor (-c for short).
-kubectl ate logs actors my-actor --container my-container
+kubectl ate logs actors my-actor -a <atespace> --container my-container
 
 # Show only the ateom supervisor (lifecycle) logs, e.g. "Actor started".
-kubectl ate logs actors my-actor --supervisor
+kubectl ate logs actors my-actor -a <atespace> --supervisor
+
+# Combine both: that container's logs plus the supervisor lifecycle logs.
+kubectl ate logs actors my-actor -a <atespace> --container my-container --supervisor
 ```
 
-By default all of the actor's logs are shown. Use `-c`/`--container <name>` to restrict output to a single container, or `--supervisor` to show only ateom's lifecycle logs. The two flags are mutually exclusive.
+By default all of the actor's logs are shown. Use `-c`/`--container <name>` to show only that container's logs, or `--supervisor` to show only ateom's lifecycle logs. The two flags are additive: pass both to see that container's logs together with the supervisor lifecycle logs.
 
 Logs are streamable only while the actor is bound to a worker (i.e., `STATUS_RUNNING`). For history across worker migrations, route through a centralized log backend (Cloud Logging, Loki, etc.); see `docs/observability.md`.
 

--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -160,10 +160,18 @@ kubectl ate delete actor my-actor -a <atespace>
 `kubectl ate logs` requires a resource-type subcommand; running `kubectl ate logs <id>` on its own prints help. The only supported resource type is `actors`:
 
 ```bash
-# Stream logs for an actor (follows by default; aggregated across worker
-# reassignments so the same actor is queryable as it teleports between pods).
+# Stream logs for an actor (aggregated across worker reassignments so the same
+# actor is queryable as it teleports between pods).
 kubectl ate logs actors my-actor
+
+# Show logs from a single container within the actor (-c for short).
+kubectl ate logs actors my-actor --container my-container
+
+# Show only the ateom supervisor (lifecycle) logs, e.g. "Actor started".
+kubectl ate logs actors my-actor --supervisor
 ```
+
+By default all of the actor's logs are shown. Use `-c`/`--container <name>` to restrict output to a single container, or `--supervisor` to show only ateom's lifecycle logs. The two flags are mutually exclusive.
 
 Logs are streamable only while the actor is bound to a worker (i.e., `STATUS_RUNNING`). For history across worker migrations, route through a centralized log backend (Cloud Logging, Loki, etc.); see `docs/observability.md`.
 

--- a/cmd/kubectl-ate/internal/cmd/logs_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors.go
@@ -38,8 +38,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var followLogs bool
-var logsAtespaceFlag string
+var (
+	followLogs       bool
+	containerFlag    string
+	supervisorFlag   bool
+	logsAtespaceFlag string
+)
 
 var logsActorsCmd = &cobra.Command{
 	Use:     "actors <actor-id>",
@@ -53,6 +57,8 @@ func init() {
 	logsActorsCmd.Flags().BoolVarP(&followLogs, "follow", "f", false, "Specify if the logs should be streamed.")
 	logsActorsCmd.Flags().StringVarP(&logsAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
 	_ = logsActorsCmd.MarkFlagRequired("atespace")
+	logsActorsCmd.Flags().StringVarP(&containerFlag, "container", "c", "", "Show logs only from the named container within the actor. Mutually exclusive with --supervisor.")
+	logsActorsCmd.Flags().BoolVar(&supervisorFlag, "supervisor", false, "Show only the ateom supervisor (lifecycle) logs. Mutually exclusive with --container.")
 	logsCmd.AddCommand(logsActorsCmd)
 }
 
@@ -84,6 +90,8 @@ type LogsActorRunner struct {
 	stdout            io.Writer
 	stderr            io.Writer
 	follow            bool
+	container         string
+	supervisor        bool
 	pollInterval      time.Duration
 	reconnectInterval time.Duration
 	tickerInterval    time.Duration
@@ -102,6 +110,9 @@ func (r *LogsActorRunner) Run(ctx context.Context, actorID string) error {
 	}
 
 	defer r.apiClient.Close()
+	if err := validateLogFilterFlags(r.container, r.supervisor); err != nil {
+		return err
+	}
 	if r.follow {
 		return r.runFollow(ctx, actorID)
 	}
@@ -132,12 +143,13 @@ func (r *LogsActorRunner) runOneShot(ctx context.Context, actorID string) error 
 	}
 	defer stream.Close()
 
+	filter := logLineFilter{actorID: actorID, container: r.container, supervisor: r.supervisor}
 	scanner := bufio.NewScanner(stream)
 	buf := make([]byte, 0, 64*1024)
 	scanner.Buffer(buf, 1024*1024) // Support up to 1MB lines
 	for scanner.Scan() {
 		line := scanner.Text()
-		filterAndDisplayLogLine(line, actorID, r.stdout)
+		filterAndDisplayLogLine(line, filter, r.stdout)
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("error reading log stream: %w", err)
@@ -210,12 +222,13 @@ func (r *LogsActorRunner) runFollow(ctx context.Context, actorID string) error {
 		var wg sync.WaitGroup
 		r.startMigrationMonitor(streamCtx, streamCancel, &wg, actorID, podName)
 
+		filter := logLineFilter{actorID: actorID, container: r.container, supervisor: r.supervisor}
 		scanner := bufio.NewScanner(stream)
 		buf := make([]byte, 0, 64*1024)
 		scanner.Buffer(buf, 1024*1024) // Support up to 1MB lines
 		for scanner.Scan() {
 			line := scanner.Text()
-			logTime, _ := filterAndDisplayLogLine(line, actorID, r.stdout)
+			logTime, _ := filterAndDisplayLogLine(line, filter, r.stdout)
 			if !logTime.IsZero() {
 				lastSeenTime = logTime
 			}
@@ -278,9 +291,22 @@ func (r *LogsActorRunner) startMigrationMonitor(
 	}()
 }
 
+// validateLogFilterFlags rejects the one unsupported filter combination: a
+// container filter and the supervisor filter cannot be requested together.
+func validateLogFilterFlags(container string, supervisor bool) error {
+	if container != "" && supervisor {
+		return fmt.Errorf("--container and --supervisor are mutually exclusive; specify only one")
+	}
+	return nil
+}
+
 func runLogsActor(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	actorID := args[0]
+
+	if err := validateLogFilterFlags(containerFlag, supervisorFlag); err != nil {
+		return err
+	}
 
 	apiClient, err := ateclient.NewClient(ctx, kubeconfig, k8sContext, endpoint, traceEnabled)
 	if err != nil {
@@ -300,6 +326,8 @@ func runLogsActor(cmd *cobra.Command, args []string) error {
 		stdout:            os.Stdout,
 		stderr:            os.Stderr,
 		follow:            followLogs,
+		container:         containerFlag,
+		supervisor:        supervisorFlag,
 		pollInterval:      2 * time.Second,
 		reconnectInterval: 1 * time.Second,
 		tickerInterval:    2 * time.Second,
@@ -308,7 +336,43 @@ func runLogsActor(cmd *cobra.Command, args []string) error {
 	return runner.Run(ctx, actorID)
 }
 
-func filterAndDisplayLogLine(line, targetActorID string, w io.Writer) (time.Time, bool) {
+// logLineFilter selects which of an actor's log lines are displayed. container
+// and supervisor are mutually exclusive; zero values show all of the lines.
+type logLineFilter struct {
+	actorID    string
+	container  string // when non-empty, show only lines from this container
+	supervisor bool   // when true, show only supervisor (non-container) lines
+}
+
+// matchesSource reports whether a line from the given container (empty for
+// supervisor lines) passes the filter's source selection.
+func (f logLineFilter) matchesSource(containerName string) bool {
+	switch {
+	case f.supervisor:
+		return containerName == ""
+	case f.container != "":
+		return containerName == f.container
+	default:
+		return true
+	}
+}
+
+// Reserved Substrate log labels, written under one of logActorLabelKeys.
+const (
+	ateLabelPrefix        = "ate.dev/"
+	ateActorIDLabel       = ateLabelPrefix + "actor_id"
+	ateContainerNameLabel = ateLabelPrefix + "container_name"
+)
+
+// logActorLabelKeys are the keys a line may carry labels under, GCE key first.
+var logActorLabelKeys = []string{"logging.googleapis.com/labels", "labels"}
+
+// filterAndDisplayLogLine writes the cleaned line (ate.dev labels stripped) to w
+// when it belongs to the target actor and passes the filter. It returns the
+// line's timestamp only for displayed lines (zero otherwise), so follow mode
+// never advances its resume cursor past a filtered-out or foreign line and skips
+// logs on reconnect. The bool reports whether the line was written.
+func filterAndDisplayLogLine(line string, filter logLineFilter, w io.Writer) (time.Time, bool) {
 	var m map[string]any
 	dec := json.NewDecoder(strings.NewReader(line))
 	dec.UseNumber()
@@ -325,30 +389,41 @@ func filterAndDisplayLogLine(line, targetActorID string, w io.Writer) (time.Time
 		}
 	}
 
-	var actorID string
-	for _, labelKey := range []string{"logging.googleapis.com/labels", "labels"} {
-		if labelsAny, ok := m[labelKey]; ok {
-			if labels, ok := labelsAny.(map[string]any); ok {
-				if id, ok := labels["ate.dev/actor_id"].(string); ok && id != "" {
-					actorID = id
-					break
-				}
-			}
+	// Read actor_id and container_name from the same (first actor-identifying)
+	// label map so a line's source is never split across the two keys.
+	var actorID, containerName string
+	for _, labelKey := range logActorLabelKeys {
+		labelsAny, ok := m[labelKey]
+		if !ok {
+			continue
 		}
+		labels, ok := labelsAny.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := labels[ateActorIDLabel].(string)
+		if id == "" {
+			continue
+		}
+		actorID = id
+		containerName, _ = labels[ateContainerNameLabel].(string)
+		break
 	}
 
-	matched := (actorID != "" && actorID == targetActorID)
+	if actorID == "" || actorID != filter.actorID {
+		return time.Time{}, false
+	}
 
-	if !matched {
-		return logTime, false
+	if !filter.matchesSource(containerName) {
+		return time.Time{}, false
 	}
 
 	// remove actor labels from CLI output
-	for _, labelKey := range []string{"logging.googleapis.com/labels", "labels"} {
+	for _, labelKey := range logActorLabelKeys {
 		if labelsAny, ok := m[labelKey]; ok {
 			if labels, ok := labelsAny.(map[string]any); ok {
 				for k := range labels {
-					if strings.HasPrefix(k, "ate.dev/") {
+					if strings.HasPrefix(k, ateLabelPrefix) {
 						delete(labels, k)
 					}
 				}
@@ -368,7 +443,7 @@ func filterAndDisplayLogLine(line, targetActorID string, w io.Writer) (time.Time
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(m); err != nil {
-		return logTime, false
+		return time.Time{}, false
 	}
 
 	encodedStr := strings.TrimSpace(buf.String())

--- a/cmd/kubectl-ate/internal/cmd/logs_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors.go
@@ -367,6 +367,24 @@ const (
 // logActorLabelKeys are the keys a line may carry labels under, GCE key first.
 var logActorLabelKeys = []string{"logging.googleapis.com/labels", "labels"}
 
+// actorSource returns the actor_id and container_name from the first recognized
+// label map that carries a non-empty ate.dev/actor_id. Both are read from that
+// same map so a line's source is never split across the two keys; actor_id is ""
+// when no map identifies an actor.
+func actorSource(m map[string]any) (actorID, containerName string) {
+	for _, key := range logActorLabelKeys {
+		labels, ok := m[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, _ := labels[ateActorIDLabel].(string); id != "" {
+			containerName, _ = labels[ateContainerNameLabel].(string)
+			return id, containerName
+		}
+	}
+	return "", ""
+}
+
 // filterAndDisplayLogLine writes the cleaned line (ate.dev labels stripped) to w
 // when it belongs to the target actor and passes the filter. It returns the
 // line's timestamp only for displayed lines (zero otherwise), so follow mode
@@ -389,27 +407,7 @@ func filterAndDisplayLogLine(line string, filter logLineFilter, w io.Writer) (ti
 		}
 	}
 
-	// Read actor_id and container_name from the same (first actor-identifying)
-	// label map so a line's source is never split across the two keys.
-	var actorID, containerName string
-	for _, labelKey := range logActorLabelKeys {
-		labelsAny, ok := m[labelKey]
-		if !ok {
-			continue
-		}
-		labels, ok := labelsAny.(map[string]any)
-		if !ok {
-			continue
-		}
-		id, _ := labels[ateActorIDLabel].(string)
-		if id == "" {
-			continue
-		}
-		actorID = id
-		containerName, _ = labels[ateContainerNameLabel].(string)
-		break
-	}
-
+	actorID, containerName := actorSource(m)
 	if actorID == "" || actorID != filter.actorID {
 		return time.Time{}, false
 	}

--- a/cmd/kubectl-ate/internal/cmd/logs_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors.go
@@ -57,8 +57,8 @@ func init() {
 	logsActorsCmd.Flags().BoolVarP(&followLogs, "follow", "f", false, "Specify if the logs should be streamed.")
 	logsActorsCmd.Flags().StringVarP(&logsAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
 	_ = logsActorsCmd.MarkFlagRequired("atespace")
-	logsActorsCmd.Flags().StringVarP(&containerFlag, "container", "c", "", "Show logs only from the named container within the actor. Mutually exclusive with --supervisor.")
-	logsActorsCmd.Flags().BoolVar(&supervisorFlag, "supervisor", false, "Show only the ateom supervisor (lifecycle) logs. Mutually exclusive with --container.")
+	logsActorsCmd.Flags().StringVarP(&containerFlag, "container", "c", "", "Show logs from the named container, filtering out other containers and the supervisor; add --supervisor to also include lifecycle logs.")
+	logsActorsCmd.Flags().BoolVar(&supervisorFlag, "supervisor", false, "Show only the ateom supervisor (lifecycle) logs, filtering out container logs; add --container to also include that container's logs.")
 	logsCmd.AddCommand(logsActorsCmd)
 }
 
@@ -110,9 +110,6 @@ func (r *LogsActorRunner) Run(ctx context.Context, actorID string) error {
 	}
 
 	defer r.apiClient.Close()
-	if err := validateLogFilterFlags(r.container, r.supervisor); err != nil {
-		return err
-	}
 	if r.follow {
 		return r.runFollow(ctx, actorID)
 	}
@@ -291,22 +288,9 @@ func (r *LogsActorRunner) startMigrationMonitor(
 	}()
 }
 
-// validateLogFilterFlags rejects the one unsupported filter combination: a
-// container filter and the supervisor filter cannot be requested together.
-func validateLogFilterFlags(container string, supervisor bool) error {
-	if container != "" && supervisor {
-		return fmt.Errorf("--container and --supervisor are mutually exclusive; specify only one")
-	}
-	return nil
-}
-
 func runLogsActor(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	actorID := args[0]
-
-	if err := validateLogFilterFlags(containerFlag, supervisorFlag); err != nil {
-		return err
-	}
 
 	apiClient, err := ateclient.NewClient(ctx, kubeconfig, k8sContext, endpoint, traceEnabled)
 	if err != nil {
@@ -337,24 +321,30 @@ func runLogsActor(cmd *cobra.Command, args []string) error {
 }
 
 // logLineFilter selects which of an actor's log lines are displayed. container
-// and supervisor are mutually exclusive; zero values show all of the lines.
+// and supervisor each select a log source: container alone shows only the named
+// container's lines, supervisor alone shows only the supervisor (lifecycle)
+// lines, and setting both shows the union of the two. When neither is set, all
+// lines are shown.
 type logLineFilter struct {
 	actorID    string
-	container  string // when non-empty, show only lines from this container
-	supervisor bool   // when true, show only supervisor (non-container) lines
+	container  string // when non-empty, include lines from this container
+	supervisor bool   // when true, include supervisor (non-container) lines
 }
 
 // matchesSource reports whether a line from the given container (empty for
-// supervisor lines) passes the filter's source selection.
+// supervisor lines) passes the filter's source selection: container alone
+// matches only the named container, supervisor alone matches only supervisor
+// lines, setting both matches the union, and setting neither matches every
+// line. Supervisor lines are identified by the absence of a container name (the
+// producer tags every container line, so only lifecycle events lack one).
 func (f logLineFilter) matchesSource(containerName string) bool {
-	switch {
-	case f.supervisor:
-		return containerName == ""
-	case f.container != "":
-		return containerName == f.container
-	default:
+	if f.container == "" && !f.supervisor {
 		return true
 	}
+	if f.supervisor && containerName == "" {
+		return true
+	}
+	return f.container != "" && containerName == f.container
 }
 
 // Reserved Substrate log labels, written under one of logActorLabelKeys.

--- a/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
@@ -196,6 +196,57 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			wantTime:      "",
 			wantOutput:    "",
 		},
+		{
+			// Empty actor_id under the GCE key must not shadow the labels key.
+			name:          "empty actor_id under GCE key falls through to labels key",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":""},"labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"counter"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
+		},
+		{
+			// Non-string actor_id under the GCE key fails the type assertion and falls through.
+			name:          "non-string actor_id under GCE key falls through to labels key",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":123},"labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"counter"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
+		},
+		{
+			// An empty actor_id with no other identifying key is not our actor.
+			name:          "empty actor_id under the only key is dropped",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":""}}`,
+			targetActorID: "act-1",
+			wantMatched:   false,
+			wantTime:      "",
+			wantOutput:    "",
+		},
+		{
+			// actor_id is under the GCE key (which carries no container_name);
+			// container_name lives only under the labels key. Filtering by container
+			// must not borrow it from the non-selected map, so the line is not matched.
+			name:          "container_name only under non-selected key is not borrowed",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"},"labels":{"ate.dev/container_name":"counter"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			wantMatched:   false,
+			wantTime:      "",
+			wantOutput:    "",
+		},
+		{
+			// Same line, default filter: the line is the actor's and is shown, and the
+			// stray container_name under the labels key is stripped, not adopted.
+			name:          "container_name under non-selected key, default filter shows the line",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"},"labels":{"ate.dev/container_name":"counter"}}`,
+			targetActorID: "act-1",
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -247,6 +248,40 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			wantTime:      "2026-05-16T01:03:38Z",
 			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
 		},
+		{
+			// Union: with both --container and --supervisor, the named container's
+			// lines are included.
+			name:          "container+supervisor includes the named container line",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"counter"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			supervisor:    true,
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
+		},
+		{
+			// Union: supervisor lifecycle lines are included alongside the container.
+			name:          "container+supervisor includes the supervisor line",
+			line:          `{"time":"2026-05-16T01:03:38Z","message":"Actor started","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			supervisor:    true,
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","message":"Actor started"}`,
+		},
+		{
+			// Union still excludes other containers: only the named one and supervisor.
+			name:          "container+supervisor excludes a different container",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"sidecar"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			supervisor:    true,
+			wantMatched:   false,
+			wantTime:      "",
+			wantOutput:    "",
+		},
 	}
 
 	for _, tc := range tests {
@@ -463,49 +498,35 @@ func TestLogsActorRunner_Run_OneShot_SupervisorFilter(t *testing.T) {
 	}
 }
 
-func TestValidateLogFilterFlags(t *testing.T) {
-	tests := []struct {
-		name       string
-		container  string
-		supervisor bool
-		wantErr    bool
-	}{
-		{"neither", "", false, false},
-		{"container only", "counter", false, false},
-		{"supervisor only", "", true, false},
-		{"both", "counter", true, true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validateLogFilterFlags(tc.container, tc.supervisor)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected an error, got nil")
-				}
-				if !strings.Contains(err.Error(), "mutually exclusive") {
-					t.Errorf("error %q missing substring %q", err, "mutually exclusive")
-				}
-			} else if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-		})
-	}
-}
+// TestLogsActorRunner_Run_OneShot_ContainerAndSupervisor verifies that
+// --container and --supervisor are additive when constructed directly: the
+// named container's lines and the supervisor lifecycle lines are both shown,
+// while other containers are excluded.
+func TestLogsActorRunner_Run_OneShot_ContainerAndSupervisor(t *testing.T) {
+	actorID := "act-123"
+	podName := "pod-xyz"
+	namespace := "ns-abc"
 
-// TestLogsActorRunner_Run_RejectsContainerAndSupervisor verifies the runner
-// enforces its own invariant when constructed directly (not only via the CLI),
-// failing fast before any control-plane or pod calls.
-func TestLogsActorRunner_Run_RejectsContainerAndSupervisor(t *testing.T) {
 	mockAPI := &mockAteAPIClient{
 		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
-			t.Error("GetActor should not be called when filters are mutually exclusive")
-			return nil, fmt.Errorf("should not be called")
+			return &ateapipb.GetActorResponse{
+				Actor: &ateapipb.Actor{
+					ActorId:           actorID,
+					AteomPodName:      podName,
+					AteomPodNamespace: namespace,
+					Status:            ateapipb.Actor_STATUS_RUNNING,
+				},
+			}, nil
 		},
 	}
+
+	counterLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"from counter","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123","ate.dev/container_name":"counter"}}`
+	sidecarLine := `{"time":"2026-05-16T01:03:39Z","level":"info","msg":"from sidecar","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123","ate.dev/container_name":"sidecar"}}`
+	supervisorLine := `{"time":"2026-05-16T01:03:40Z","message":"Actor started","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123"}}`
+
 	mockStreamer := &mockPodLogsStreamer{
 		StreamLogsFunc: func(ctx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
-			t.Error("StreamLogs should not be called when filters are mutually exclusive")
-			return nil, fmt.Errorf("should not be called")
+			return io.NopCloser(strings.NewReader(counterLine + "\n" + sidecarLine + "\n" + supervisorLine + "\n")), nil
 		},
 	}
 
@@ -515,16 +536,20 @@ func TestLogsActorRunner_Run_RejectsContainerAndSupervisor(t *testing.T) {
 		streamer:   mockStreamer,
 		stdout:     &stdout,
 		stderr:     &stderr,
+		follow:     false,
 		container:  "counter",
 		supervisor: true,
 	}
 
-	err := runner.Run(context.Background(), "act-1")
-	if err == nil {
-		t.Fatal("expected an error when both --container and --supervisor are set, got nil")
+	if err := runner.Run(context.Background(), actorID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "mutually exclusive") {
-		t.Errorf("unexpected error: %v (want substring %q)", err, "mutually exclusive")
+
+	gotOutput := strings.TrimSpace(stdout.String())
+	wantOutput := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"from counter"}` + "\n" +
+		`{"time":"2026-05-16T01:03:40Z","message":"Actor started"}`
+	if gotOutput != wantOutput {
+		t.Errorf("got stdout %q, want counter + supervisor lines %q", gotOutput, wantOutput)
 	}
 	if mockAPI.CloseCalls != 1 {
 		t.Errorf("expected Close to be called once, got %d", mockAPI.CloseCalls)
@@ -652,7 +677,7 @@ func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
 	}
 
 	err := runner.Run(ctx, actorID)
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -670,6 +695,157 @@ func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
 	wantStdout := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Follow hello"}`
 	if gotStdout != wantStdout {
 		t.Errorf("got stdout %q, want %q", gotStdout, wantStdout)
+	}
+}
+
+// lineSignalWriter is a concurrency-safe writer that closes done once its
+// accumulated output contains needle, letting a test wait for specific output
+// before acting instead of racing on the follow loop's internal timing.
+type lineSignalWriter struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	needle string
+	done   chan struct{}
+	once   sync.Once
+}
+
+func (w *lineSignalWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	n, err := w.buf.Write(p)
+	if strings.Contains(w.buf.String(), w.needle) {
+		w.once.Do(func() { close(w.done) })
+	}
+	return n, err
+}
+
+func (w *lineSignalWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// TestLogsActorRunner_Run_Follow_ContainerAndSupervisor verifies that the
+// streaming (follow) path applies the same additive --container + --supervisor
+// union semantics as one-shot mode: interleaved lines from the named container
+// and the supervisor are both shown, while a different container is excluded.
+func TestLogsActorRunner_Run_Follow_ContainerAndSupervisor(t *testing.T) {
+	actorID := "act-123"
+	podName := "pod-xyz"
+	namespace := "ns-abc"
+
+	mockAPI := &mockAteAPIClient{
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+			return &ateapipb.GetActorResponse{
+				Actor: &ateapipb.Actor{
+					ActorId:           actorID,
+					AteomPodName:      podName,
+					AteomPodNamespace: namespace,
+					Status:            ateapipb.Actor_STATUS_RUNNING,
+				},
+			}, nil
+		},
+	}
+
+	// Interleaved sources on a single stream: counter (selected), sidecar
+	// (different container, excluded), supervisor (selected), counter again.
+	counterLine1 := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"from counter","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123","ate.dev/container_name":"counter"}}`
+	sidecarLine := `{"time":"2026-05-16T01:03:39Z","level":"info","msg":"from sidecar","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123","ate.dev/container_name":"sidecar"}}`
+	supervisorLine := `{"time":"2026-05-16T01:03:40Z","message":"Actor started","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123"}}`
+	counterLine2 := `{"time":"2026-05-16T01:03:41Z","level":"info","msg":"from counter again","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123","ate.dev/container_name":"counter"}}`
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	var streamCalls int
+
+	mockStreamer := &mockPodLogsStreamer{
+		StreamLogsFunc: func(streamCtx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+			mu.Lock()
+			streamCalls++
+			call := streamCalls
+			mu.Unlock()
+
+			if call > 1 {
+				// A second call means an unexpected reconnect; block until
+				// cancel (no busy-spin) and let the streamCalls assertion flag it.
+				<-streamCtx.Done()
+				return nil, streamCtx.Err()
+			}
+			if !opts.Follow {
+				return nil, fmt.Errorf("expected follow to be true in follow mode")
+			}
+
+			// Deliver all lines on one stream, then stay open like a live follow
+			// until cancel, so the test never relies on reconnect-after-EOF.
+			pr, pw := io.Pipe()
+			go func() {
+				_, _ = io.WriteString(pw,
+					counterLine1+"\n"+sidecarLine+"\n"+supervisorLine+"\n"+counterLine2+"\n")
+				<-streamCtx.Done()
+				_ = pw.CloseWithError(streamCtx.Err())
+			}()
+			return pr, nil
+		},
+	}
+
+	// stdout signals once the final expected line is printed, so the test
+	// cancels only after the runner has drained and displayed every line.
+	stdout := &lineSignalWriter{needle: "from counter again", done: make(chan struct{})}
+	var stderr bytes.Buffer
+	runner := &LogsActorRunner{
+		apiClient:         mockAPI,
+		streamer:          mockStreamer,
+		stdout:            stdout,
+		stderr:            &stderr,
+		follow:            true,
+		container:         "counter",
+		supervisor:        true,
+		pollInterval:      50 * time.Millisecond,
+		reconnectInterval: 50 * time.Millisecond,
+		tickerInterval:    time.Hour, // keep the migration monitor out of the way
+	}
+
+	done := make(chan struct{})
+	var runErr error
+	go func() {
+		runErr = runner.Run(ctx, actorID)
+		close(done)
+	}()
+
+	// Cancel only after the final expected line is printed, so the assertion
+	// never races with the follow loop draining the stream.
+	select {
+	case <-stdout.done:
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("follow stream never printed the final line")
+	}
+
+	cancel()
+	<-done
+
+	if runErr != nil && !errors.Is(runErr, context.Canceled) {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+
+	mu.Lock()
+	gotCalls := streamCalls
+	mu.Unlock()
+	if gotCalls != 1 {
+		t.Errorf("expected exactly one StreamLogs call (single follow stream), got %d", gotCalls)
+	}
+
+	gotStdout := strings.TrimSpace(stdout.String())
+	wantStdout := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"from counter"}` + "\n" +
+		`{"time":"2026-05-16T01:03:40Z","message":"Actor started"}` + "\n" +
+		`{"time":"2026-05-16T01:03:41Z","level":"info","msg":"from counter again"}`
+	if gotStdout != wantStdout {
+		t.Errorf("got stdout %q, want counter + supervisor lines (sidecar excluded) %q", gotStdout, wantStdout)
+	}
+	if strings.Contains(gotStdout, "from sidecar") {
+		t.Errorf("sidecar line should be excluded, but stdout was %q", gotStdout)
 	}
 }
 
@@ -903,7 +1079,7 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 	}
 
 	err := runner.Run(ctx, actorID)
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1023,7 +1199,7 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 	}
 
 	err := runner.Run(ctx, actorID)
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
@@ -36,6 +36,8 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		name          string
 		line          string
 		targetActorID string
+		container     string
+		supervisor    bool
 		wantMatched   bool
 		wantTime      string
 		wantOutput    string
@@ -77,7 +79,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			line:          `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-2"}}`,
 			targetActorID: "act-1",
 			wantMatched:   false,
-			wantTime:      "2026-05-16T01:03:38Z",
+			wantTime:      "", // zero time: another actor's line must not advance follow's resume cursor
 			wantOutput:    "",
 		},
 		{
@@ -120,12 +122,86 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			wantTime:      "2026-05-16T01:03:38Z",
 			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","logging.googleapis.com/labels":{"app":"my-app"},"msg":"Hello"}`,
 		},
+		{
+			name:          "container filter matches the named container",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"counter"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
+		},
+		{
+			name:          "container filter excludes a different container",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"sidecar"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			wantMatched:   false,
+			wantTime:      "", // filtered out: only displayed lines may advance follow's resume cursor
+			wantOutput:    "",
+		},
+		{
+			name:          "supervisor filter matches a lifecycle line without container_name",
+			line:          `{"time":"2026-05-16T01:03:38Z","message":"Actor started","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"}}`,
+			targetActorID: "act-1",
+			supervisor:    true,
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","message":"Actor started"}`,
+		},
+		{
+			name:          "supervisor filter excludes a container line",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"counter"}}`,
+			targetActorID: "act-1",
+			supervisor:    true,
+			wantMatched:   false,
+			wantTime:      "", // filtered out: only displayed lines may advance follow's resume cursor
+			wantOutput:    "",
+		},
+		{
+			name:          "default filter shows a container line",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"counter"}}`,
+			targetActorID: "act-1",
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
+		},
+		{
+			// Non-GCE shape: actor metadata under "labels", app labels under the GCE key.
+			name:          "metadata under labels key, app data under GCE key",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"app":"my-app"},"labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"counter"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","logging.googleapis.com/labels":{"app":"my-app"},"msg":"hi"}`,
+		},
+		{
+			// Both keys carry metadata: GCE key wins; container read from its map (counter).
+			name:          "both keys carry metadata, GCE key wins atomically",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"counter"},"labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"sidecar"}}`,
+			targetActorID: "act-1",
+			container:     "counter",
+			wantMatched:   true,
+			wantTime:      "2026-05-16T01:03:38Z",
+			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
+		},
+		{
+			// Same line: the non-authoritative key's container (sidecar) is ignored.
+			name:          "both keys carry metadata, non-GCE container is ignored",
+			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"counter"},"labels":{"ate.dev/actor_id":"act-1","ate.dev/container_name":"sidecar"}}`,
+			targetActorID: "act-1",
+			container:     "sidecar",
+			wantMatched:   false,
+			wantTime:      "",
+			wantOutput:    "",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			logTime, matched := filterAndDisplayLogLine(tc.line, tc.targetActorID, &buf)
+			logTime, matched := filterAndDisplayLogLine(tc.line, logLineFilter{actorID: tc.targetActorID, container: tc.container, supervisor: tc.supervisor}, &buf)
 
 			if matched != tc.wantMatched {
 				t.Errorf("got matched = %v, want %v", matched, tc.wantMatched)
@@ -236,6 +312,171 @@ func TestLogsActorRunner_Run_OneShotSuccess(t *testing.T) {
 	wantOutput := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello world"}`
 	if gotOutput != wantOutput {
 		t.Errorf("got stdout %q, want %q", gotOutput, wantOutput)
+	}
+}
+
+func TestLogsActorRunner_Run_OneShot_ContainerFilter(t *testing.T) {
+	actorID := "act-123"
+	podName := "pod-xyz"
+	namespace := "ns-abc"
+
+	mockAPI := &mockAteAPIClient{
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+			return &ateapipb.GetActorResponse{
+				Actor: &ateapipb.Actor{
+					ActorId:           actorID,
+					AteomPodName:      podName,
+					AteomPodNamespace: namespace,
+					Status:            ateapipb.Actor_STATUS_RUNNING,
+				},
+			}, nil
+		},
+	}
+
+	counterLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"from counter","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123","ate.dev/container_name":"counter"}}`
+	sidecarLine := `{"time":"2026-05-16T01:03:39Z","level":"info","msg":"from sidecar","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123","ate.dev/container_name":"sidecar"}}`
+	supervisorLine := `{"time":"2026-05-16T01:03:40Z","message":"Actor started","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123"}}`
+
+	mockStreamer := &mockPodLogsStreamer{
+		StreamLogsFunc: func(ctx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(counterLine + "\n" + sidecarLine + "\n" + supervisorLine + "\n")), nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	runner := &LogsActorRunner{
+		apiClient: mockAPI,
+		streamer:  mockStreamer,
+		stdout:    &stdout,
+		stderr:    &stderr,
+		follow:    false,
+		container: "counter",
+	}
+
+	if err := runner.Run(context.Background(), actorID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotOutput := strings.TrimSpace(stdout.String())
+	wantOutput := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"from counter"}`
+	if gotOutput != wantOutput {
+		t.Errorf("got stdout %q, want only the counter line %q", gotOutput, wantOutput)
+	}
+}
+
+func TestLogsActorRunner_Run_OneShot_SupervisorFilter(t *testing.T) {
+	actorID := "act-123"
+	podName := "pod-xyz"
+	namespace := "ns-abc"
+
+	mockAPI := &mockAteAPIClient{
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+			return &ateapipb.GetActorResponse{
+				Actor: &ateapipb.Actor{
+					ActorId:           actorID,
+					AteomPodName:      podName,
+					AteomPodNamespace: namespace,
+					Status:            ateapipb.Actor_STATUS_RUNNING,
+				},
+			}, nil
+		},
+	}
+
+	counterLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"from counter","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123","ate.dev/container_name":"counter"}}`
+	supervisorLine := `{"time":"2026-05-16T01:03:40Z","message":"Actor started","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123"}}`
+
+	mockStreamer := &mockPodLogsStreamer{
+		StreamLogsFunc: func(ctx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(counterLine + "\n" + supervisorLine + "\n")), nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	runner := &LogsActorRunner{
+		apiClient:  mockAPI,
+		streamer:   mockStreamer,
+		stdout:     &stdout,
+		stderr:     &stderr,
+		follow:     false,
+		supervisor: true,
+	}
+
+	if err := runner.Run(context.Background(), actorID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotOutput := strings.TrimSpace(stdout.String())
+	wantOutput := `{"time":"2026-05-16T01:03:40Z","message":"Actor started"}`
+	if gotOutput != wantOutput {
+		t.Errorf("got stdout %q, want only the supervisor line %q", gotOutput, wantOutput)
+	}
+}
+
+func TestValidateLogFilterFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		container  string
+		supervisor bool
+		wantErr    bool
+	}{
+		{"neither", "", false, false},
+		{"container only", "counter", false, false},
+		{"supervisor only", "", true, false},
+		{"both", "counter", true, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateLogFilterFlags(tc.container, tc.supervisor)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), "mutually exclusive") {
+					t.Errorf("error %q missing substring %q", err, "mutually exclusive")
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestLogsActorRunner_Run_RejectsContainerAndSupervisor verifies the runner
+// enforces its own invariant when constructed directly (not only via the CLI),
+// failing fast before any control-plane or pod calls.
+func TestLogsActorRunner_Run_RejectsContainerAndSupervisor(t *testing.T) {
+	mockAPI := &mockAteAPIClient{
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+			t.Error("GetActor should not be called when filters are mutually exclusive")
+			return nil, fmt.Errorf("should not be called")
+		},
+	}
+	mockStreamer := &mockPodLogsStreamer{
+		StreamLogsFunc: func(ctx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+			t.Error("StreamLogs should not be called when filters are mutually exclusive")
+			return nil, fmt.Errorf("should not be called")
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	runner := &LogsActorRunner{
+		apiClient:  mockAPI,
+		streamer:   mockStreamer,
+		stdout:     &stdout,
+		stderr:     &stderr,
+		container:  "counter",
+		supervisor: true,
+	}
+
+	err := runner.Run(context.Background(), "act-1")
+	if err == nil {
+		t.Fatal("expected an error when both --container and --supervisor are set, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("unexpected error: %v (want substring %q)", err, "mutually exclusive")
+	}
+	if mockAPI.CloseCalls != 1 {
+		t.Errorf("expected Close to be called once, got %d", mockAPI.CloseCalls)
 	}
 }
 
@@ -378,6 +619,98 @@ func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
 	wantStdout := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Follow hello"}`
 	if gotStdout != wantStdout {
 		t.Errorf("got stdout %q, want %q", gotStdout, wantStdout)
+	}
+}
+
+// TestLogsActorRunner_Run_Follow_ForeignActorLineDoesNotAdvanceCursor is a
+// regression test: a worker pod's log stream can contain lines from a different
+// actor that previously ran on it. Those foreign lines must never advance the
+// follow resume cursor (SinceTime); otherwise a reconnect could skip the target
+// actor's own logs.
+func TestLogsActorRunner_Run_Follow_ForeignActorLineDoesNotAdvanceCursor(t *testing.T) {
+	actorID := "act-123"
+	podName := "pod-xyz"
+	namespace := "ns-abc"
+
+	mockAPI := &mockAteAPIClient{
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+			return &ateapipb.GetActorResponse{
+				Actor: &ateapipb.Actor{
+					ActorId:           actorID,
+					AteomPodName:      podName,
+					AteomPodNamespace: namespace,
+					Status:            ateapipb.Actor_STATUS_RUNNING,
+				},
+			}, nil
+		},
+	}
+
+	// A line belonging to a DIFFERENT actor that shares the worker pod's stream.
+	// It carries a parseable timestamp but must not move the resume cursor.
+	foreignLine := `{"time":"2026-05-16T01:03:38Z","message":"not mine","logging.googleapis.com/labels":{"ate.dev/actor_id":"other"}}`
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	var streamCalls int
+	var reconnectHadSinceTime bool
+	secondCall := make(chan struct{})
+	var once sync.Once
+
+	mockStreamer := &mockPodLogsStreamer{
+		StreamLogsFunc: func(streamCtx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+			mu.Lock()
+			streamCalls++
+			call := streamCalls
+			mu.Unlock()
+
+			if call == 1 {
+				// First connection: emit one foreign line, then EOF to force a reconnect.
+				return io.NopCloser(strings.NewReader(foreignLine + "\n")), nil
+			}
+
+			// Reconnection: record whether a resume cursor was carried over.
+			mu.Lock()
+			reconnectHadSinceTime = opts.SinceTime != nil
+			mu.Unlock()
+			once.Do(func() { close(secondCall) })
+			<-streamCtx.Done()
+			return nil, streamCtx.Err()
+		},
+	}
+
+	runner := &LogsActorRunner{
+		apiClient:         mockAPI,
+		streamer:          mockStreamer,
+		stdout:            &bytes.Buffer{},
+		stderr:            &bytes.Buffer{},
+		follow:            true,
+		pollInterval:      1 * time.Millisecond,
+		reconnectInterval: 1 * time.Millisecond,
+		tickerInterval:    time.Hour, // keep the migration monitor out of the way
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = runner.Run(ctx, actorID)
+		close(done)
+	}()
+
+	select {
+	case <-secondCall:
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("reconnect (second StreamLogs call) never happened")
+	}
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reconnectHadSinceTime {
+		t.Error("reconnect carried a SinceTime cursor; a foreign actor's line must not advance the follow cursor")
 	}
 }
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,7 +27,7 @@ For quick, on-demand debugging of an active actor, use the Agent Substrate CLI:
 kubectl ate logs actors <actor_id> [--follow / -f]
 ```
 
-> **Note:** By default, `kubectl ate logs` queries the Kubernetes API of the worker pod where the actor is *currently* running. It is designed for immediate inspection of active actors. To view historical logs across past worker pods and suspension cycles, use a centralized logging backend.
+> **Note:** By default, `kubectl ate logs actors` queries the Kubernetes API of the worker pod where the actor is *currently* running. It is designed for immediate inspection of active actors. To view historical logs across past worker pods and suspension cycles, use a centralized logging backend.
 
 #### Example 1: Actor Not Currently Running
 If an actor is suspended or not assigned to a worker pod, the CLI informs you immediately:
@@ -60,6 +60,18 @@ Actor is currently running on pod ate-demo-counter/counter-deployment-ab123-x4y5
 {"time":"2026-05-22T21:50:02.123456789Z","count":2,"fshash":"mCY7...","level":"INFO","msg":"Count"}
 ```
 
+#### Example 4: Filtering by Container or Supervisor
+An actor may run multiple containers, and Agent Substrate also emits synthetic supervisor lifecycle events (e.g., `Actor started`, `Actor checkpointing`). By default `kubectl ate logs actors` shows all of an actor's log lines. You can narrow the output to a single container or to just the supervisor:
+
+```bash
+# Only logs from a specific container within the actor (-c for short).
+kubectl ate logs actors <actor_id> --container <container_name>
+
+# Only the ateom supervisor (lifecycle) logs.
+kubectl ate logs actors <actor_id> --supervisor
+```
+
+`--container` and `--supervisor` are mutually exclusive. Container log lines are identified by the `ate.dev/container_name` label; supervisor lifecycle lines do not carry that label.
 
 ---
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -61,17 +61,20 @@ Actor is currently running on pod ate-demo-counter/counter-deployment-ab123-x4y5
 ```
 
 #### Example 4: Filtering by Container or Supervisor
-An actor may run multiple containers, and Agent Substrate also emits synthetic supervisor lifecycle events (e.g., `Actor started`, `Actor checkpointing`). By default `kubectl ate logs actors` shows all of an actor's log lines. You can narrow the output to a single container or to just the supervisor:
+An actor may run multiple containers, and Agent Substrate also emits synthetic supervisor lifecycle events (e.g., `Actor started`, `Actor checkpointing`). By default `kubectl ate logs actors` shows all of an actor's log lines. Use `--container` and/or `--supervisor` to scope the output to a single container, to just the supervisor, or to both at once:
 
 ```bash
-# Only logs from a specific container within the actor (-c for short).
-kubectl ate logs actors <actor_id> --container <container_name>
+# Logs from a specific container within the actor (-c for short).
+kubectl ate logs actors <actor_id> -a <atespace> --container <container_name>
 
-# Only the ateom supervisor (lifecycle) logs.
-kubectl ate logs actors <actor_id> --supervisor
+# The ateom supervisor (lifecycle) logs.
+kubectl ate logs actors <actor_id> -a <atespace> --supervisor
+
+# Both together: the container's logs plus the supervisor lifecycle logs.
+kubectl ate logs actors <actor_id> -a <atespace> --container <container_name> --supervisor
 ```
 
-`--container` and `--supervisor` are mutually exclusive. Container log lines are identified by the `ate.dev/container_name` label; supervisor lifecycle lines do not carry that label.
+`--container` and `--supervisor` are additive selectors: passing both shows that container's lines together with the supervisor lines. Container log lines are identified by the `ate.dev/container_name` label; supervisor lifecycle lines do not carry that label.
 
 ---
 

--- a/internal/actorlog/logger.go
+++ b/internal/actorlog/logger.go
@@ -25,9 +25,16 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
+
+const ateLabelPrefix = "ate.dev/"
+
+// recognizedLabelKeys are the keys a log line may carry labels under
+// ("logging.googleapis.com/labels" on GCE, "labels" elsewhere).
+var recognizedLabelKeys = []string{"labels", "logging.googleapis.com/labels"}
 
 // SyncedWriter wraps an io.Writer and synchronizes writes across goroutines.
 type SyncedWriter struct {
@@ -141,6 +148,17 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplateName
 			} else {
 				if _, ok := m["time"]; !ok {
 					m["time"] = time.Now().Format(time.RFC3339Nano)
+				}
+				// Strip app-provided ate.dev/* labels from every recognized key
+				// (not just the one we write) so apps can't spoof Substrate metadata.
+				for _, key := range recognizedLabelKeys {
+					if existing, ok := m[key].(map[string]any); ok {
+						for k := range existing {
+							if strings.HasPrefix(k, ateLabelPrefix) {
+								delete(existing, k)
+							}
+						}
+					}
 				}
 				labels, ok := m[al.labelsKey].(map[string]any)
 				if !ok {

--- a/internal/actorlog/logger_test.go
+++ b/internal/actorlog/logger_test.go
@@ -224,6 +224,49 @@ func TestWrapContainerLogs_LabelCollision(t *testing.T) {
 	}
 }
 
+func TestWrapContainerLogs_CrossKeyLabelSpoofing(t *testing.T) {
+	// Non-GCE logger writes under "labels"; an app must not be able to spoof
+	// metadata under the other recognized key and have a consumer trust it.
+	input := `{"level":"info","msg":"App log","logging.googleapis.com/labels":{"ate.dev/actor_id":"victim","ate.dev/container_name":"spoofed","app":"keep-me"}}` + "\n"
+	rdr := strings.NewReader(input)
+
+	var buf bytes.Buffer
+	al := NewActorLogger(&buf, false) // non-GCE => authoritative key is "labels"
+	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("failed to parse JSON output: %v", err)
+	}
+
+	// Substrate's real metadata lives under the environment key ("labels").
+	authoritative, ok := m["labels"].(map[string]any)
+	if !ok {
+		t.Fatal("missing authoritative labels group")
+	}
+	if authoritative["ate.dev/actor_id"] != "act-1" {
+		t.Errorf("got actor_id = %v, want 'act-1'", authoritative["ate.dev/actor_id"])
+	}
+	if authoritative["ate.dev/container_name"] != "ctr-1" {
+		t.Errorf("got container_name = %v, want 'ctr-1'", authoritative["ate.dev/container_name"])
+	}
+
+	// The spoofed ate.dev/* labels are stripped; the app's own labels are kept.
+	spoofed, ok := m["logging.googleapis.com/labels"].(map[string]any)
+	if !ok {
+		t.Fatal("expected the application's logging.googleapis.com/labels map to survive")
+	}
+	if _, present := spoofed["ate.dev/actor_id"]; present {
+		t.Error("spoofed ate.dev/actor_id survived under logging.googleapis.com/labels")
+	}
+	if _, present := spoofed["ate.dev/container_name"]; present {
+		t.Error("spoofed ate.dev/container_name survived under logging.googleapis.com/labels")
+	}
+	if spoofed["app"] != "keep-me" {
+		t.Errorf("non-reserved app label not preserved: got %v", spoofed["app"])
+	}
+}
+
 func TestWrapContainerLogs_TrailingGarbage(t *testing.T) {
 	input := `{"count": 1} garbage` + "\n"
 	rdr := strings.NewReader(input)


### PR DESCRIPTION
Fixes #294 


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

## Summary
Implements `kubectl ate logs actors <id>` can now filter by source:

- **default** — all of the actor's logs (unchanged)
- **`-c, --container <name>`** — only that container's logs
- **`--supervisor`** — only ateom lifecycle logs (`Actor restoring`/`restored`/…)

`--container` and `--supervisor` are mutually exclusive. After #290 every
forwarded container line carries an `ate.dev/container_name` label and
supervisor lifecycle lines carry none, so this is implemented client-side.

## What changed
**CLI (`cmd/kubectl-ate`)**
- New `--container/-c` and `--supervisor` flags.
- `logLineFilter` + `matchesSource()` encode the selection rules.
- `filterAndDisplayLogLine` reads `actor_id` and `container_name` atomically
  from the first recognized label key, and returns the zero time for any
  non-displayed line so follow mode's resume cursor only advances on lines the
  user actually sees (a reconnect can't skip wanted lines).
- `validateLogFilterFlags` enforces mutual exclusion, called from the cobra
  command and from `LogsActorRunner.Run` (fail-fast for direct construction).

**ateom log wrapper (`cmd/ateom-gvisor`) — security hardening**
- `WrapContainerLogs` strips application-provided `ate.dev/*` labels from *both*
  recognized label keys before injecting Substrate metadata, so an app cannot
  spoof another actor's `actor_id`/`container_name` under the key a consumer
  treats as authoritative.

**Docs**
- `cmd/kubectl-ate/README.md` and `docs/observability.md` document the flags and
  mutual exclusivity; examples use the required `kubectl ate logs actors` form.

## Design notes
- Mutual exclusion uses a value-based check rather than cobra's
  `MarkFlagsMutuallyExclusive`, which keys off `flag.Changed` and would wrongly
  reject `--container x --supervisor=false`.

## Testing
- Unit: filter table cases (container/supervisor/default, dual-key precedence +
  atomicity, foreign-actor), `validateLogFilterFlags`, `Run` fail-fast,
  follow-mode resume-cursor regression, and `TestWrapContainerLogs_CrossKeyLabelSpoofing`.
- `make test` green; `gofmt` / `go vet` clean.
- Verified on a kind cluster (counter demo): default, `-c counter`, `--supervisor`,
  and the mutual-exclusion error all behave as expected.
