### PR TITLE
Include whole error message for gRPC `Internal(13)` errors.

### DIFF
--- a/internal/ateinterceptors/ateinterceptors.go
+++ b/internal/ateinterceptors/ateinterceptors.go
@@ -51,7 +51,7 @@ func ServerUnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServer
 		}
 
 		// No status error found in chain.
-		return nil, status.Error(codes.Internal, "internal server error")
+		return nil, status.Errorf(codes.Internal, "internal server error: %v", err)
 	}
 
 	return resp, err

--- a/internal/ateinterceptors/ateinterceptors_test.go
+++ b/internal/ateinterceptors/ateinterceptors_test.go
@@ -51,7 +51,7 @@ func TestStatusErrorInterceptor(t *testing.T) {
 			name:       "RawErrorFallback",
 			handlerErr: errors.New("database connection failed"),
 			wantCode:   codes.Internal,
-			wantMsg:    "internal server error",
+			wantMsg:    "internal server error: database connection failed",
 		},
 	}
 


### PR DESCRIPTION
Including the whole error helps during troubleshooting as it removes the need for looking at the server logs.
