### PR TITLE
ateom-microvm: give the micro-VM guest DNS so name-based egress works

### DIFF
--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -99,6 +99,12 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		slog.InfoContext(ctx, "Reset actor rootfs disk to golden (template)", slog.String("id", id))
 	} else {
 		bundleRootfs := filepath.Join(ateompath.OCIBundlePath(ns, name, id, containers[0].GetName()), "rootfs")
+		// Cross-node restore rebuilds from the bundle (no local golden template),
+		// so re-inject DNS here too; the same-node golden-copy path above already
+		// carries it from the golden boot.
+		if err := writeGuestResolvConf(bundleRootfs); err != nil {
+			return nil, fmt.Errorf("while writing guest resolv.conf: %w", err)
+		}
 		if err := kata.BuildExt4Image(ctx, bundleRootfs, diskPath); err != nil {
 			return nil, fmt.Errorf("while reconstructing rootfs disk from image: %w", err)
 		}

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -150,6 +150,28 @@ func (s *AteomService) resolveRuntime(paths map[string]string) resolvedRuntime {
 	}
 }
 
+// writeGuestResolvConf copies the worker pod's /etc/resolv.conf into the bundle
+// rootfs (before it's packed into the ext4 disk) so the guest gets cluster DNS:
+// ateom drops atelet's resolv.conf bind and sends no CreateSandbox.Dns, so the
+// guest can otherwise reach IPs but not resolve names.
+func writeGuestResolvConf(rootfs string) error {
+	content, err := os.ReadFile("/etc/resolv.conf")
+	if err != nil {
+		return fmt.Errorf("reading host resolv.conf: %w", err)
+	}
+	if len(content) == 0 {
+		return fmt.Errorf("host /etc/resolv.conf is empty")
+	}
+	etc := filepath.Join(rootfs, "etc")
+	if err := os.MkdirAll(etc, 0o755); err != nil {
+		return fmt.Errorf("creating %q: %w", etc, err)
+	}
+	if err := os.WriteFile(filepath.Join(etc, "resolv.conf"), content, 0o644); err != nil {
+		return fmt.Errorf("writing guest resolv.conf: %w", err)
+	}
+	return nil
+}
+
 // RunWorkload boots the actor as a cloud-hypervisor micro-VM that ateom owns.
 //
 // ateom boots cloud-hypervisor itself — no kata shim — and gives the actor a
@@ -217,6 +239,9 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	// Build the actor's writable rootfs as a raw ext4 virtio-blk disk from the
 	// atelet-populated OCI bundle rootfs. This becomes /dev/vdb.
 	diskPath := filepath.Join(actorDir, actorRootfsDiskName)
+	if err := writeGuestResolvConf(filepath.Join(bundle, "rootfs")); err != nil {
+		return nil, fmt.Errorf("while writing guest resolv.conf: %w", err)
+	}
 	if err := kata.BuildExt4Image(ctx, filepath.Join(bundle, "rootfs"), diskPath); err != nil {
 		return nil, fmt.Errorf("while building actor rootfs disk: %w", err)
 	}


### PR DESCRIPTION
## Problem
A micro-VM (`ateom-microvm`) actor gets a guest interface, default route, and host NAT, but no `/etc/resolv.conf`: ateom drops atelet's resolv.conf bind (a host bind is meaningless inside a VM) and never sends `CreateSandbox.Dns`. The guest can reach IPs but not resolve names, so workloads doing name-based egress — e.g. an OpenShell helpdesk agent calling Ollama Cloud (`/chat`) — fail; only no-egress paths work.

## Fix
Write `/etc/resolv.conf` into the bundle rootfs before `mkfs.ext4` at golden boot (`RunWorkload`), copied verbatim from the worker pod's own resolv.conf (cluster DNS) — the same source the kata shim's `getDNS` uses. Errors out if the host has no usable resolv.conf rather than guessing. The restore path reuses the golden disk, so it inherits the file. One helper + one call; no behavior change for workloads that don't resolve names.

## Validation (kind on a KVM host)
- A helpdesk micro-VM actor `/chat` returns real model completions and survives suspend/resume.
- counter-microvm unaffected.
