### PR TITLE
ci: run the micro-VM e2e in the kind e2e job

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -17,6 +17,11 @@ on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    # Weekly run on the default branch keeps the micro-VM asset cache warm (GitHub
+    # evicts caches idle for 7 days). The push-to-main run populates the cache that
+    # PRs inherit; this refreshes it so PRs keep hitting it (no virtiofsd rebuild).
+    - cron: '37 4 * * 1'
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -30,6 +35,9 @@ jobs:
     - run: go test -v ./...
     - name: verify
       run: hack/verify-all.sh
+  # One kind cluster exercises BOTH runtimes. Free x86-64 ubuntu-latest runners
+  # expose /dev/kvm (with a udev rule), so create-kind-cluster.sh mounts it and the
+  # micro-VM (kata + cloud-hypervisor) sandbox class works alongside gVisor.
   e2e-test:
     runs-on: ubuntu-latest
     steps:
@@ -39,11 +47,70 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
+    - name: Free disk space
+      # The micro-VM guest image/kernel + cloud-hypervisor + kind node image +
+      # control-plane images + snapshots are tight on the ~14GB runner disk.
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        df -h /
+    - name: Cache micro-VM assets
+      id: microvm-assets
+      uses: actions/cache@v4
+      with:
+        # Assembling the assets (download kata-static + cloud-hypervisor, build
+        # virtiofsd from source for the overlay rootfs) is the slow part and is fully
+        # pinned by assemble.sh, so key the cache on its hash. The push-to-main run
+        # populates the default-branch cache PRs inherit; the weekly schedule refreshes
+        # it. run-microvm-demo-kind.sh skips assembling when these are present.
+        path: bin/microvm-assets/amd64
+        key: microvm-assets-amd64-${{ hashFiles('hack/microvm-assets/assemble.sh') }}
+    - name: Install micro-VM asset build deps
+      # Only needed when (re)assembling (cache miss): building virtiofsd from source.
+      if: steps.microvm-assets.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libcap-ng-dev libseccomp-dev pkg-config
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+    - name: Enable KVM
+      # Grant the runner access to /dev/kvm so create-kind-cluster.sh mounts it into
+      # the node and labels it for the micro-VM sandbox class.
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+          | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
     - name: Create cluster
       run: hack/create-kind-cluster.sh
     - name: Install Agent Substrate
       run: hack/install-ate-kind.sh --deploy-ate-system
-    - name: Deploy Counter Demo
+    - name: Deploy micro-VM counter demo
+      # Stages the (cached) assets into the cluster's rustfs and applies the
+      # counter-microvm demo onto the control plane installed above.
+      run: hack/run-microvm-demo-kind.sh
+    - name: Deploy gVisor counter demo
       run: hack/install-ate-kind.sh --deploy-demo-counter
-    - name: Run E2E tests
+    - name: Wait for micro-VM golden snapshot
+      run: |
+        kubectl --context kind-kind wait --for=condition=Ready \
+          actortemplate/counter-microvm -n ate-demo-counter-microvm --timeout=600s
+    - name: Run E2E tests (gVisor)
       run: hack/run-e2e-kind.sh -v -args --no-color
+    - name: Run E2E tests (micro-VM)
+      # Same demo lifecycle suite (create -> suspend -> resume -> in-RAM continuity),
+      # pointed at the micro-VM counter via env (see createActorTemplate in demo_test.go).
+      env:
+        E2E_TEMPLATE_NAMESPACE: ate-demo-counter-microvm
+        E2E_TEMPLATE_NAME: counter-microvm
+        E2E_TEMPLATE_READY_TIMEOUT: 600s
+      run: hack/run-e2e-kind.sh ./internal/e2e/suites/demo -v -args --no-color
+    - name: Dump diagnostics on failure
+      if: failure()
+      run: |
+        kubectl --context kind-kind get actortemplate,workerpool,pods -A -o wide || true
+        for ns in ate-demo-counter-microvm ate-demo-counter ate-system; do
+          for p in $(kubectl --context kind-kind get pods -n "$ns" -o name 2>/dev/null); do
+            echo "=== logs: $ns/$p ==="
+            kubectl --context kind-kind logs -n "$ns" "$p" --all-containers --tail=200 2>/dev/null || true
+          done
+        done

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -301,15 +302,27 @@ func createActorTemplate(ctx context.Context, t *testing.T, clients *e2e.Clients
 		t.Fatalf("CheckEnv failed: %v", err)
 	}
 
-	// Query existing WorkerPool and ActorTemplate to get the resolved container images
-	existingWp, err := clients.SubstrateK8s.ApiV1alpha1().WorkerPools("ate-demo-counter").Get(ctx, "counter", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("failed to get existing WorkerPool: %v", err)
+	// The source WorkerPool+ActorTemplate to copy the resolved runtime (sandbox class,
+	// ateom image, container images) from. Defaults to the gVisor counter demo; CI
+	// overrides these to point this same lifecycle test at the micro-VM counter.
+	srcNS := "ate-demo-counter"
+	if v := os.Getenv("E2E_TEMPLATE_NAMESPACE"); v != "" {
+		srcNS = v
+	}
+	srcName := "counter"
+	if v := os.Getenv("E2E_TEMPLATE_NAME"); v != "" {
+		srcName = v
 	}
 
-	existingAt, err := clients.SubstrateK8s.ApiV1alpha1().ActorTemplates("ate-demo-counter").Get(ctx, "counter", metav1.GetOptions{})
+	// Query existing WorkerPool and ActorTemplate to get the resolved container images
+	existingWp, err := clients.SubstrateK8s.ApiV1alpha1().WorkerPools(srcNS).Get(ctx, srcName, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("failed to get existing ActorTemplate: %v", err)
+		t.Fatalf("failed to get existing WorkerPool %s/%s: %v", srcNS, srcName, err)
+	}
+
+	existingAt, err := clients.SubstrateK8s.ApiV1alpha1().ActorTemplates(srcNS).Get(ctx, srcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get existing ActorTemplate %s/%s: %v", srcNS, srcName, err)
 	}
 
 	// Create WorkerPool. Labeled uniquely to this test's namespace so the
@@ -343,8 +356,12 @@ func createActorTemplate(ctx context.Context, t *testing.T, clients *e2e.Clients
 			WorkerSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"demo": nsObj.Name},
 			},
-			PauseImage: existingAt.Spec.PauseImage,
-			Containers: existingAt.Spec.Containers,
+			// SandboxClass must match the per-test WorkerPool's (copied above) so the
+			// ActorTemplate↔WorkerPool match succeeds. The micro-VM source sets
+			// "microvm"; the gVisor source leaves it "" — copying keeps both correct.
+			SandboxClass: existingAt.Spec.SandboxClass,
+			PauseImage:   existingAt.Spec.PauseImage,
+			Containers:   existingAt.Spec.Containers,
 			SnapshotsConfig: v1alpha1.SnapshotsConfig{
 				Location: "gs://" + env["BUCKET_NAME"] + "/ate-demo-counter",
 			},
@@ -356,8 +373,17 @@ func createActorTemplate(ctx context.Context, t *testing.T, clients *e2e.Clients
 	}
 
 	// Wait for ActorTemplate to be Ready (golden snapshot created) before creating an actor.
+	// The micro-VM golden (CH boot + checkpoint on nested KVM) is slower than gVisor, so
+	// CI raises this via E2E_TEMPLATE_READY_TIMEOUT.
 	t.Logf("Waiting for ActorTemplate %s to be Ready...", at.Name)
-	const tmplTimeout = 90 * time.Second
+	tmplTimeout := 90 * time.Second
+	if v := os.Getenv("E2E_TEMPLATE_READY_TIMEOUT"); v != "" {
+		d, perr := time.ParseDuration(v)
+		if perr != nil {
+			t.Fatalf("invalid E2E_TEMPLATE_READY_TIMEOUT %q: %v", v, perr)
+		}
+		tmplTimeout = d
+	}
 	tmplCtx, tmplCancel := context.WithTimeout(ctx, tmplTimeout)
 	defer tmplCancel()
 	var lastPhase v1alpha1.PhaseType


### PR DESCRIPTION
Free x86-64 ubuntu-latest runners expose /dev/kvm, so the existing kind e2e job can exercise the micro-VM (kata + cloud-hypervisor) runtime alongside gVisor on one shared control plane:
  - enable /dev/kvm (udev rule) before create-kind-cluster.sh, which then mounts it and labels the node for the microvm sandbox class;
  - deploy the counter-microvm demo (run-microvm-demo-kind.sh) next to the gVisor counter and run the demo lifecycle suite against both;
  - cache the assembled micro-VM assets (keyed on assemble.sh) so the expensive virtiofsd-from-source build only runs when the pins change; push-to-main + a weekly schedule keep the cache warm for PRs.

The demo lifecycle suite (create -> suspend -> resume -> in-RAM continuity) is reused for the micro-VM by parameterizing the source ActorTemplate via E2E_TEMPLATE_NAMESPACE/NAME (default the gVisor counter) and the golden-ready wait via E2E_TEMPLATE_READY_TIMEOUT.

PR AI assisted.