### PR TITLE
fix: prevent shard skip in ListActors when SCAN returns oversized batch

### DIFF
--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -741,6 +741,9 @@ func (s *Persistence) ListActors(ctx context.Context, atespace string, pageSize 
 				} else {
 					nextToken = ""
 				}
+				if len(result) >= int(pageSize) {
+					stop = true
+				}
 				break
 			}
 		}


### PR DESCRIPTION
Redis SCAN COUNT is a hint and not a cap. 
When SCAN returns more keys than remaining and cursor reaches 0 in the same call, the outer loop advances to the next shard where remaining<=0 triggers immediately. 
The next-token then points to the shard after that, permanently skipping one shard's actors from all subsequent pages. 
Fix: set stop=true when cursor==0 and result is already at or over pageSize.