### PR TITLE
api: open the sandboxClass enum for out-of-tree ateom-* backends

### DIFF
--- a/manifests/ate-install/generated/ate.dev_actortemplates.yaml
+++ b/manifests/ate-install/generated/ate.dev_actortemplates.yaml
@@ -186,9 +186,8 @@ spec:
                   4) How does the default get set and who sets it?
 
                   See Also: WorkerPool SandboxClass
-                enum:
-                - gvisor
-                - microvm
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               snapshotsConfig:
                 description: Snapshots configuration for the actor.

--- a/manifests/ate-install/generated/ate.dev_sandboxconfigs.yaml
+++ b/manifests/ate-install/generated/ate.dev_sandboxconfigs.yaml
@@ -113,9 +113,8 @@ spec:
                 description: |-
                   SandboxClass is the sandbox runtime family this config applies to. A
                   WorkerPool only uses SandboxConfigs whose SandboxClass matches its own.
-                enum:
-                - gvisor
-                - microvm
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
             required:
             - sandboxClass

--- a/manifests/ate-install/generated/ate.dev_workerpools.yaml
+++ b/manifests/ate-install/generated/ate.dev_workerpools.yaml
@@ -84,9 +84,8 @@ spec:
                   AteomImage. Defaults to gvisor.
 
                   See Also: TODOs in ActorTemplate SandboxClass
-                enum:
-                - gvisor
-                - microvm
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               sandboxConfigName:
                 description: |-

--- a/pkg/api/v1alpha1/actortemplate_types.go
+++ b/pkg/api/v1alpha1/actortemplate_types.go
@@ -173,7 +173,8 @@ type ActorTemplateSpec struct {
 	//
 	//
 	// +optional
-	// +kubebuilder:validation:Enum=gvisor;microvm
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:default=gvisor
 	SandboxClass SandboxClass `json:"sandboxClass,omitempty"`
 

--- a/pkg/api/v1alpha1/actortemplate_validation_test.go
+++ b/pkg/api/v1alpha1/actortemplate_validation_test.go
@@ -371,12 +371,18 @@ func TestActorTemplateValidation(t *testing.T) {
 		},
 		wantErr: false,
 	}, {
-		name: "invalid SandboxClass",
+		name: "custom SandboxClass accepted (open class for out-of-tree backends)",
 		mutate: func(at *ActorTemplate) {
-			at.Spec.SandboxClass = "kvm"
+			at.Spec.SandboxClass = "foobar"
+		},
+		wantErr: false,
+	}, {
+		name: "invalid SandboxClass (violates DNS-label pattern)",
+		mutate: func(at *ActorTemplate) {
+			at.Spec.SandboxClass = "Bad_Class"
 		},
 		wantErr: true,
-		errMsg:  "Unsupported value",
+		errMsg:  "should match",
 	}}
 
 	for _, tt := range tests {

--- a/pkg/api/v1alpha1/sandboxconfig_types.go
+++ b/pkg/api/v1alpha1/sandboxconfig_types.go
@@ -20,13 +20,19 @@ import (
 
 // SandboxClass selects the sandbox runtime family. It is shared by WorkerPool
 // (which family a pool runs) and SandboxConfig (which family a config is for).
+//
+// It is an open lowercase DNS-label string. "gvisor" and "microvm" are the
+// built-in classes, but an out-of-tree backend (a custom ateom-*) may define its
+// own class value and ship a matching SandboxConfig + WorkerPool (the WorkerPool
+// declaring any device mounts / node placement via spec.template) without
+// changing substrate.
 type SandboxClass string
 
 const (
 	// SandboxClassGvisor is the gVisor/runsc runtime (cmd/ateom-gvisor). Default.
 	SandboxClassGvisor SandboxClass = "gvisor"
-	// SandboxClassMicroVM is the micro-VM runtime (cmd/ateom-microvm); needs
-	// /dev/kvm and vhost devices.
+	// SandboxClassMicroVM is the micro-VM runtime (cmd/ateom-microvm); it needs
+	// /dev/kvm and vhost devices, declared on the WorkerPool's spec.template.
 	SandboxClassMicroVM SandboxClass = "microvm"
 )
 
@@ -55,7 +61,8 @@ type SandboxConfigSpec struct {
 	// WorkerPool only uses SandboxConfigs whose SandboxClass matches its own.
 	//
 	// +required
-	// +kubebuilder:validation:Enum=gvisor;microvm
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:default=gvisor
 	SandboxClass SandboxClass `json:"sandboxClass"`
 

--- a/pkg/api/v1alpha1/workerpool_types.go
+++ b/pkg/api/v1alpha1/workerpool_types.go
@@ -75,7 +75,8 @@ type WorkerPoolSpec struct {
 	// See Also: TODOs in ActorTemplate SandboxClass
 	//
 	// +optional
-	// +kubebuilder:validation:Enum=gvisor;microvm
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:default=gvisor
 	SandboxClass SandboxClass `json:"sandboxClass,omitempty"`
 


### PR DESCRIPTION
Replace the closed `+kubebuilder:validation:Enum=gvisor;microvm` on `SandboxConfig`/`WorkerPool`/`ActorTemplate` `.spec.sandboxClass` with a DNS-label `Pattern` + `MaxLength=63`. `gvisor`/`microvm` stay the built-in defaults, but a custom `ateom-*` backend can now define its own `sandboxClass` (and ship a matching `SandboxConfig` + `WorkerPool`) without forking substrate — admission no longer rejects the class. Regenerate CRDs; update the ActorTemplate validation test (custom `foobar` accepted, pattern-violating `Bad_Class` rejected).

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
