### PR TITLE
atelet: drop cosmetic gVisor-isms (generic hostname + tracer name)

### DIFF
--- a/cmd/atelet/oci.go
+++ b/cmd/atelet/oci.go
@@ -193,7 +193,7 @@ func buildActorOCISpec(args []string, env []string, annotations map[string]strin
 			Path:     "rootfs",
 			Readonly: false,
 		},
-		Hostname: "runsc",
+		Hostname: "actor",
 		Mounts:   mounts,
 		Linux: &specs.Linux{
 			Namespaces: []specs.LinuxNamespace{
@@ -256,7 +256,7 @@ func validateTarName(name string) (cleaned string, skip bool, err error) {
 }
 
 func untar(ctx context.Context, tarData io.Reader, rootPath string) error {
-	tracer := otel.Tracer("ateom-gvisor")
+	tracer := otel.Tracer("atelet")
 	ctx, span := tracer.Start(ctx, "untar")
 	defer span.End()
 


### PR DESCRIPTION
Two vestigial gVisor labels in atelet's actor prep that mislead a non-gVisor backend: the generic OCI spec hard-set `Hostname: "runsc"` (the gVisor binary name), and the untar tracer was scoped `"ateom-gvisor"` though it runs in atelet. Switch to a runtime-neutral `Hostname: "actor"` and tracer `"atelet"`. Cosmetic; no behavior change.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
