### PR TITLE
fix: use correct snapshot path in sandbox template

### DIFF
--- a/demos/sandbox/sandbox.yaml.tmpl
+++ b/demos/sandbox/sandbox.yaml.tmpl
@@ -46,4 +46,4 @@ spec:
     - name: PORT
       value: "80"
   snapshotsConfig:
-    location: gs://${BUCKET_NAME}/ate-demo-counter/
+    location: gs://${BUCKET_NAME}/ate-demo-sandbox/


### PR DESCRIPTION
`snapshotsConfig.location` pointed to `ate-demo-counter/`, which is the counter demo's GCS prefix.

Sandbox snapshots would collide with counter demo snapshots. Changed to `ate-demo-sandbox/`.