### PR TITLE
Make substrate's namespace, Service names and ServiceAccount names configurable

### DIFF
--- a/cmd/ateapi/internal/actoridentity/actoridentity.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity.go
@@ -59,21 +59,21 @@ type Server struct {
 	store   store.Interface
 	workers *workercache.Cache
 
-	// ateletNamespace is the namespace the calling atelet runs in, which its
-	// SPIFFE ID names.
-	ateletNamespace string
+	// ateletSPIFFEID is the identity the calling atelet must present to mint
+	// actor credentials.
+	ateletSPIFFEID string
 }
 
 var _ ateapipb.ActorIdentityServer = (*Server)(nil)
 
-func New(actorIdentityJWTIssuer string, actorIDJWTPool localjwtauthority.Pool, actorIDCAPool localca.Pool, store store.Interface, workers *workercache.Cache, ateletNamespace string) *Server {
+func New(actorIdentityJWTIssuer string, actorIDJWTPool localjwtauthority.Pool, actorIDCAPool localca.Pool, store store.Interface, workers *workercache.Cache, ateletSPIFFEID string) *Server {
 	return &Server{
 		actorIdentityJWTIssuer: actorIdentityJWTIssuer,
 		actorIDJWTPool:         actorIDJWTPool,
 		actorIDCAPool:          actorIDCAPool,
 		store:                  store,
 		workers:                workers,
-		ateletNamespace:        ateletNamespace,
+		ateletSPIFFEID:         ateletSPIFFEID,
 	}
 }
 
@@ -128,7 +128,7 @@ func (s *Server) MintJWT(ctx context.Context, req *ateapipb.MintJWTRequest) (*at
 }
 
 func (s *Server) MintCert(ctx context.Context, req *ateapipb.MintCertRequest) (*ateapipb.MintCertResponse, error) {
-	caller, err := ateletauth.Authenticate(ctx, s.ateletNamespace)
+	caller, err := ateletauth.Authenticate(ctx, s.ateletSPIFFEID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ateapi/internal/actoridentity/actoridentity.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity.go
@@ -58,17 +58,22 @@ type Server struct {
 	// is entitled to the actor it is asking for a credential for.
 	store   store.Interface
 	workers *workercache.Cache
+
+	// ateletNamespace is the namespace the calling atelet runs in, which its
+	// SPIFFE ID names.
+	ateletNamespace string
 }
 
 var _ ateapipb.ActorIdentityServer = (*Server)(nil)
 
-func New(actorIdentityJWTIssuer string, actorIDJWTPool localjwtauthority.Pool, actorIDCAPool localca.Pool, store store.Interface, workers *workercache.Cache) *Server {
+func New(actorIdentityJWTIssuer string, actorIDJWTPool localjwtauthority.Pool, actorIDCAPool localca.Pool, store store.Interface, workers *workercache.Cache, ateletNamespace string) *Server {
 	return &Server{
 		actorIdentityJWTIssuer: actorIdentityJWTIssuer,
 		actorIDJWTPool:         actorIDJWTPool,
 		actorIDCAPool:          actorIDCAPool,
 		store:                  store,
 		workers:                workers,
+		ateletNamespace:        ateletNamespace,
 	}
 }
 
@@ -123,7 +128,7 @@ func (s *Server) MintJWT(ctx context.Context, req *ateapipb.MintJWTRequest) (*at
 }
 
 func (s *Server) MintCert(ctx context.Context, req *ateapipb.MintCertRequest) (*ateapipb.MintCertResponse, error) {
-	caller, err := ateletauth.Authenticate(ctx)
+	caller, err := ateletauth.Authenticate(ctx, s.ateletNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ateapi/internal/actoridentity/actoridentity_test.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity_test.go
@@ -63,6 +63,10 @@ const (
 	testOtherNode    = "node-b"
 )
 
+// ateletSPIFFEID is the identity a default install's atelet presents, and what
+// the Server under test is configured to accept.
+var ateletSPIFFEID = installdefaults.SPIFFEID(installdefaults.SystemNamespace, installdefaults.AteletServiceAccount)
+
 // newTestCert builds a self-signed leaf carrying the given SPIFFE URI path
 // (skipped when empty) and, when podIdentity is non-nil, a PodIdentity
 // extension.
@@ -106,7 +110,7 @@ func newTestServer(t *testing.T, st store.Interface) *Server {
 			t.Fatalf("start worker cache: %v", err)
 		}
 	}
-	return New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers, installdefaults.SystemNamespace)
+	return New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers, ateletSPIFFEID)
 }
 
 // staleWatchStore wraps a store with a WatchWorkers that never delivers,
@@ -328,7 +332,7 @@ func newTestServerWithCache(t *testing.T, st store.Interface, workers *workercac
 		ActiveForSigning: "1",
 	}
 
-	return New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers, installdefaults.SystemNamespace)
+	return New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers, ateletSPIFFEID)
 }
 
 func TestMintJWTRequiresConfiguredJWTProvider(t *testing.T) {
@@ -937,7 +941,7 @@ func TestMintCertAuthorizesBeforeSigning(t *testing.T) {
 		ActiveForSigning: "1",
 	}
 
-	srv := New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers, installdefaults.SystemNamespace)
+	srv := New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers, ateletSPIFFEID)
 
 	actor, err := st.GetActor(ctx, resources.ActorRef{Atespace: testAtespace, Name: testActorName})
 	if err != nil {

--- a/cmd/ateapi/internal/actoridentity/actoridentity_test.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity_test.go
@@ -26,12 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-substrate/substrate/cmd/ateapi/internal/ateletauth"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/ateletauth/ateletauthtest"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/localca"
 	"github.com/agent-substrate/substrate/internal/localjwtauthority"
 	"github.com/agent-substrate/substrate/internal/principal"
@@ -106,7 +106,7 @@ func newTestServer(t *testing.T, st store.Interface) *Server {
 			t.Fatalf("start worker cache: %v", err)
 		}
 	}
-	return New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers)
+	return New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers, installdefaults.SystemNamespace)
 }
 
 // staleWatchStore wraps a store with a WatchWorkers that never delivers,
@@ -328,7 +328,7 @@ func newTestServerWithCache(t *testing.T, st store.Interface, workers *workercac
 		ActiveForSigning: "1",
 	}
 
-	return New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers)
+	return New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers, installdefaults.SystemNamespace)
 }
 
 func TestMintJWTRequiresConfiguredJWTProvider(t *testing.T) {
@@ -519,7 +519,7 @@ func TestMintCertAuthorization(t *testing.T) {
 			cert: func(t *testing.T) *x509.Certificate {
 				id := ateletauthtest.PodIdentityOn(testNode)
 				id.ServiceAccountName = "some-workload"
-				return ateletauthtest.Cert(t, path.Join("ns", ateletauth.Namespace, "sa", "some-workload"), id)
+				return ateletauthtest.Cert(t, path.Join("ns", installdefaults.SystemNamespace, "sa", "some-workload"), id)
 			},
 			fixture:  runningOnNode(testNode),
 			wantCode: codes.PermissionDenied,
@@ -528,7 +528,7 @@ func TestMintCertAuthorization(t *testing.T) {
 			cert: func(t *testing.T) *x509.Certificate {
 				id := ateletauthtest.PodIdentityOn(testNode)
 				id.Namespace = "someone-elses-system"
-				return ateletauthtest.Cert(t, path.Join("ns", "someone-elses-system", "sa", ateletauth.ServiceAccount), id)
+				return ateletauthtest.Cert(t, path.Join("ns", "someone-elses-system", "sa", installdefaults.AteletServiceAccount), id)
 			},
 			fixture:  runningOnNode(testNode),
 			wantCode: codes.PermissionDenied,
@@ -542,7 +542,7 @@ func TestMintCertAuthorization(t *testing.T) {
 		},
 		"certificate carries no PodIdentity extension": {
 			cert: func(t *testing.T) *x509.Certificate {
-				return ateletauthtest.Cert(t, path.Join("ns", ateletauth.Namespace, "sa", ateletauth.ServiceAccount), nil)
+				return ateletauthtest.Cert(t, path.Join("ns", installdefaults.SystemNamespace, "sa", installdefaults.AteletServiceAccount), nil)
 			},
 			fixture:  runningOnNode(testNode),
 			wantCode: codes.PermissionDenied,
@@ -937,7 +937,7 @@ func TestMintCertAuthorizesBeforeSigning(t *testing.T) {
 		ActiveForSigning: "1",
 	}
 
-	srv := New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers)
+	srv := New("issuer", jwtAuthorityPool, certificateAuthorityPool, st, workers, installdefaults.SystemNamespace)
 
 	actor, err := st.GetActor(ctx, resources.ActorRef{Atespace: testAtespace, Name: testActorName})
 	if err != nil {

--- a/cmd/ateapi/internal/ateletauth/ateletauth.go
+++ b/cmd/ateapi/internal/ateletauth/ateletauth.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/substratex509"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -34,15 +33,15 @@ type Caller struct {
 	NodeName string
 }
 
-// Authenticate verifies that the RPC arrived over mTLS from an atelet running
-// in ateletNamespace, and returns the identity that atelet's certificate
-// asserts.
+// Authenticate verifies that the RPC arrived over mTLS from an atelet
+// presenting ateletSPIFFEID, and returns the identity that atelet's
+// certificate asserts.
 //
 // The certificate chain is already verified by the TLS layer against the
 // pod-identity CA (see buildServerCreds in cmd/ateapi/main.go), so the
 // extensions read here are trustworthy: only the pod-identity signer can mint
 // a certificate carrying a given pod's node name.
-func Authenticate(ctx context.Context, ateletNamespace string) (*Caller, error) {
+func Authenticate(ctx context.Context, ateletSPIFFEID string) (*Caller, error) {
 	p, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, status.Errorf(codes.Unauthenticated, "no peer transport information found")
@@ -61,7 +60,7 @@ func Authenticate(ctx context.Context, ateletNamespace string) (*Caller, error) 
 	// Only atelet may call these RPCs. Everything else with a valid
 	// pod-identity certificate — including the actor workloads themselves — is
 	// rejected here.
-	expected := installdefaults.AteletSPIFFEID(ateletNamespace)
+	expected := ateletSPIFFEID
 	if len(leaf.URIs) == 0 || leaf.URIs[0].String() != expected {
 		slog.WarnContext(ctx, "Denied: caller is not atelet",
 			slog.Any("uris", leaf.URIs), slog.String("expected", expected))

--- a/cmd/ateapi/internal/ateletauth/ateletauth.go
+++ b/cmd/ateapi/internal/ateletauth/ateletauth.go
@@ -19,26 +19,13 @@ package ateletauth
 import (
 	"context"
 	"log/slog"
-	"net/url"
-	"path"
 
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/substratex509"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-)
-
-// The SPIFFE identity that atelet client certs carry, as minted by the
-// podidentity signer (cmd/podcertcontroller/internal/podidentitysigner).
-//
-// These mirror the constants the atelet dialer verifies against in
-// cmd/ateapi/internal/controlapi/dialer.go, duplicated rather than imported so
-// that this package does not depend on controlapi for three strings.
-const (
-	TrustDomain    = "cluster.local"
-	Namespace      = "ate-system"
-	ServiceAccount = "atelet"
 )
 
 // Caller is the verified identity of an atelet.
@@ -47,14 +34,15 @@ type Caller struct {
 	NodeName string
 }
 
-// Authenticate verifies that the RPC arrived over mTLS from an atelet, and
-// returns the identity that atelet's certificate asserts.
+// Authenticate verifies that the RPC arrived over mTLS from an atelet running
+// in ateletNamespace, and returns the identity that atelet's certificate
+// asserts.
 //
 // The certificate chain is already verified by the TLS layer against the
 // pod-identity CA (see buildServerCreds in cmd/ateapi/main.go), so the
 // extensions read here are trustworthy: only the pod-identity signer can mint
 // a certificate carrying a given pod's node name.
-func Authenticate(ctx context.Context) (*Caller, error) {
+func Authenticate(ctx context.Context, ateletNamespace string) (*Caller, error) {
 	p, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, status.Errorf(codes.Unauthenticated, "no peer transport information found")
@@ -73,11 +61,7 @@ func Authenticate(ctx context.Context) (*Caller, error) {
 	// Only atelet may call these RPCs. Everything else with a valid
 	// pod-identity certificate — including the actor workloads themselves — is
 	// rejected here.
-	expected := (&url.URL{
-		Scheme: "spiffe",
-		Host:   TrustDomain,
-		Path:   path.Join("ns", Namespace, "sa", ServiceAccount),
-	}).String()
+	expected := installdefaults.AteletSPIFFEID(ateletNamespace)
 	if len(leaf.URIs) == 0 || leaf.URIs[0].String() != expected {
 		slog.WarnContext(ctx, "Denied: caller is not atelet",
 			slog.Any("uris", leaf.URIs), slog.String("expected", expected))

--- a/cmd/ateapi/internal/ateletauth/ateletauth_test.go
+++ b/cmd/ateapi/internal/ateletauth/ateletauth_test.go
@@ -22,28 +22,30 @@ import (
 	"github.com/agent-substrate/substrate/internal/installdefaults"
 )
 
-// TestAuthenticateHonorsConfiguredNamespace checks that the namespace
+// TestAuthenticateHonorsConfiguredIdentity checks that the identity
 // Authenticate is given is the one it accepts, and that the canonical
-// namespace is rejected when the install lives elsewhere.
+// identity is rejected when the install lives elsewhere.
 //
-// The authorization table test in actoridentity covers a caller from the
-// wrong namespace, but it always passes the default namespace, so it holds
-// against a hardcoded "ate-system" too. Only the relocated case distinguishes
-// "reads its configuration" from "happens to agree with the constant".
-func TestAuthenticateHonorsConfiguredNamespace(t *testing.T) {
+// The authorization table test in actoridentity covers a caller with the
+// wrong identity, but it always expects the default identity, so it holds
+// against a hardcoded "ate-system"/"atelet" too. Only the relocated case
+// distinguishes "reads its configuration" from "happens to agree with the
+// constant".
+func TestAuthenticateHonorsConfiguredIdentity(t *testing.T) {
 	const relocated = "substrate-test"
 	const node = "test-node"
+	relocatedID := installdefaults.AteletSPIFFEID(relocated)
 
-	t.Run("accepts atelet from the configured namespace", func(t *testing.T) {
+	t.Run("accepts atelet with the configured identity", func(t *testing.T) {
 		ctx := ateletauthtest.ContextWith(ateletauthtest.CertIn(t, relocated, node))
-		if _, err := ateletauth.Authenticate(ctx, relocated); err != nil {
+		if _, err := ateletauth.Authenticate(ctx, relocatedID); err != nil {
 			t.Errorf("Authenticate() = %v, want success for an atelet in %q", err, relocated)
 		}
 	})
 
-	t.Run("rejects atelet from the canonical namespace", func(t *testing.T) {
+	t.Run("rejects atelet with the canonical identity", func(t *testing.T) {
 		ctx := ateletauthtest.ContextWith(ateletauthtest.CertIn(t, installdefaults.SystemNamespace, node))
-		if _, err := ateletauth.Authenticate(ctx, relocated); err == nil {
+		if _, err := ateletauth.Authenticate(ctx, relocatedID); err == nil {
 			t.Errorf("Authenticate() accepted an atelet from %q, want rejection when configured for %q",
 				installdefaults.SystemNamespace, relocated)
 		}

--- a/cmd/ateapi/internal/ateletauth/ateletauth_test.go
+++ b/cmd/ateapi/internal/ateletauth/ateletauth_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ateletauth_test
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/ateletauth"
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/ateletauth/ateletauthtest"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
+)
+
+// TestAuthenticateHonorsConfiguredNamespace checks that the namespace
+// Authenticate is given is the one it accepts, and that the canonical
+// namespace is rejected when the install lives elsewhere.
+//
+// The authorization table test in actoridentity covers a caller from the
+// wrong namespace, but it always passes the default namespace, so it holds
+// against a hardcoded "ate-system" too. Only the relocated case distinguishes
+// "reads its configuration" from "happens to agree with the constant".
+func TestAuthenticateHonorsConfiguredNamespace(t *testing.T) {
+	const relocated = "substrate-test"
+	const node = "test-node"
+
+	t.Run("accepts atelet from the configured namespace", func(t *testing.T) {
+		ctx := ateletauthtest.ContextWith(ateletauthtest.CertIn(t, relocated, node))
+		if _, err := ateletauth.Authenticate(ctx, relocated); err != nil {
+			t.Errorf("Authenticate() = %v, want success for an atelet in %q", err, relocated)
+		}
+	})
+
+	t.Run("rejects atelet from the canonical namespace", func(t *testing.T) {
+		ctx := ateletauthtest.ContextWith(ateletauthtest.CertIn(t, installdefaults.SystemNamespace, node))
+		if _, err := ateletauth.Authenticate(ctx, relocated); err == nil {
+			t.Errorf("Authenticate() accepted an atelet from %q, want rejection when configured for %q",
+				installdefaults.SystemNamespace, relocated)
+		}
+	})
+}

--- a/cmd/ateapi/internal/ateletauth/ateletauthtest/ateletauthtest.go
+++ b/cmd/ateapi/internal/ateletauth/ateletauthtest/ateletauthtest.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-substrate/substrate/cmd/ateapi/internal/ateletauth"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/substratex509"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
@@ -53,7 +53,7 @@ func Cert(t *testing.T, spiffePath string, podIdentity *substratex509.PodIdentit
 		NotAfter:     time.Now().Add(time.Hour),
 	}
 	if spiffePath != "" {
-		template.URIs = []*url.URL{{Scheme: "spiffe", Host: ateletauth.TrustDomain, Path: spiffePath}}
+		template.URIs = []*url.URL{{Scheme: "spiffe", Host: installdefaults.AteletTrustDomain, Path: spiffePath}}
 	}
 	if podIdentity != nil {
 		if err := substratex509.AddPodIdentityToCertificate(podIdentity, template); err != nil {
@@ -72,11 +72,18 @@ func Cert(t *testing.T, spiffePath string, podIdentity *substratex509.PodIdentit
 	return cert
 }
 
-// PodIdentityOn returns a well-formed atelet PodIdentity pinned to nodeName.
+// PodIdentityOn returns a well-formed atelet PodIdentity pinned to nodeName,
+// for an atelet running in the default install namespace.
 func PodIdentityOn(nodeName string) *substratex509.PodIdentity {
+	return PodIdentityIn(installdefaults.SystemNamespace, nodeName)
+}
+
+// PodIdentityIn returns a well-formed atelet PodIdentity pinned to nodeName,
+// for an atelet running in namespace.
+func PodIdentityIn(namespace, nodeName string) *substratex509.PodIdentity {
 	return &substratex509.PodIdentity{
-		Namespace:          ateletauth.Namespace,
-		ServiceAccountName: ateletauth.ServiceAccount,
+		Namespace:          namespace,
+		ServiceAccountName: installdefaults.AteletServiceAccount,
 		ServiceAccountUID:  "sa-uid",
 		PodName:            "atelet-xyz",
 		PodUID:             "pod-uid",
@@ -85,10 +92,17 @@ func PodIdentityOn(nodeName string) *substratex509.PodIdentity {
 	}
 }
 
-// CertOn returns the certificate of the atelet running on nodeName.
+// CertOn returns the certificate of the atelet running on nodeName in the
+// default install namespace.
 func CertOn(t *testing.T, nodeName string) *x509.Certificate {
 	t.Helper()
-	return Cert(t, path.Join("ns", ateletauth.Namespace, "sa", ateletauth.ServiceAccount), PodIdentityOn(nodeName))
+	return CertIn(t, installdefaults.SystemNamespace, nodeName)
+}
+
+// CertIn returns the certificate of the atelet running on nodeName in namespace.
+func CertIn(t *testing.T, namespace, nodeName string) *x509.Certificate {
+	t.Helper()
+	return Cert(t, path.Join("ns", namespace, "sa", installdefaults.AteletServiceAccount), PodIdentityIn(namespace, nodeName))
 }
 
 // ContextWith injects cert as the transport-authenticated peer certificate. A

--- a/cmd/ateapi/internal/controlapi/dialer.go
+++ b/cmd/ateapi/internal/controlapi/dialer.go
@@ -47,7 +47,7 @@ var ErrNoAteletOnNode = errors.New("no atelet pod found on node")
 
 // The SPIFFE identity that atelet serving certs carry, as minted by the
 // podidentity signer (cmd/podcertcontroller/internal/podidentitysigner).
-// The namespace part is ateletNamespace, declared in informer.go.
+// The namespace part is the dialer's ateletNamespace.
 const (
 	trustDomainName = "cluster.local"
 	ateletSA        = "atelet"
@@ -75,14 +75,16 @@ func WithDialCredentials(build func(expectedPodUID string) (credentials.Transpor
 }
 
 // NewAteletDialer creates a new AteletDialer. clientBundlePath and serverCAPath
-// are used to build the per-atelet mTLS credentials used for every atelet connection.
-func NewAteletDialer(workerIndexer cache.Indexer, ateletIndexer cache.Indexer, clientBundlePath, serverCAPath string, opts ...DialerOption) *AteletDialer {
+// are used to build the per-atelet mTLS credentials used for every atelet
+// connection, and ateletNamespace is the namespace segment of the SPIFFE ID
+// those credentials expect on the atelet serving cert.
+func NewAteletDialer(workerIndexer cache.Indexer, ateletIndexer cache.Indexer, ateletNamespace, clientBundlePath, serverCAPath string, opts ...DialerOption) *AteletDialer {
 	d := &AteletDialer{
 		workerIndexer: workerIndexer,
 		ateletIndexer: ateletIndexer,
 		ateletConns:   newAteletConnCache(1024),
 		dialCredentials: func(expectedPodUID string) (credentials.TransportCredentials, error) {
-			tlsConfig, err := buildTLSConfig(clientBundlePath, serverCAPath, expectedPodUID)
+			tlsConfig, err := buildTLSConfig(ateletNamespace, clientBundlePath, serverCAPath, expectedPodUID)
 			if err != nil {
 				return nil, err
 			}
@@ -189,7 +191,7 @@ func (d *AteletDialer) DialForAteletOnNode(nodeName string) (*grpc.ClientConn, e
 	return ateletConn, nil
 }
 
-func buildTLSConfig(clientBundlePath, serverCAPath, expectedPodUID string) (*tls.Config, error) {
+func buildTLSConfig(ateletNamespace, clientBundlePath, serverCAPath, expectedPodUID string) (*tls.Config, error) {
 	trustDomain, err := spiffeid.TrustDomainFromString(trustDomainName)
 	if err != nil {
 		return nil, fmt.Errorf("while parsing trust domain %q: %w", trustDomainName, err)

--- a/cmd/ateapi/internal/controlapi/dialer.go
+++ b/cmd/ateapi/internal/controlapi/dialer.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/atelet"
 	"github.com/agent-substrate/substrate/internal/credbundle"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/substratex509"
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -44,14 +45,6 @@ var ErrWorkerPodNotFound = errors.New("worker pod not found")
 // Distinct from ErrWorkerPodNotFound, which callers treat as crash-worthy;
 // this one is retryable.
 var ErrNoAteletOnNode = errors.New("no atelet pod found on node")
-
-// The SPIFFE identity that atelet serving certs carry, as minted by the
-// podidentity signer (cmd/podcertcontroller/internal/podidentitysigner).
-// The namespace part is the dialer's ateletNamespace.
-const (
-	trustDomainName = "cluster.local"
-	ateletSA        = "atelet"
-)
 
 // AteletDialer handles gRPC connections to Atelet pods.
 type AteletDialer struct {
@@ -192,15 +185,15 @@ func (d *AteletDialer) DialForAteletOnNode(nodeName string) (*grpc.ClientConn, e
 }
 
 func buildTLSConfig(ateletNamespace, clientBundlePath, serverCAPath, expectedPodUID string) (*tls.Config, error) {
-	trustDomain, err := spiffeid.TrustDomainFromString(trustDomainName)
+	trustDomain, err := spiffeid.TrustDomainFromString(installdefaults.AteletTrustDomain)
 	if err != nil {
-		return nil, fmt.Errorf("while parsing trust domain %q: %w", trustDomainName, err)
+		return nil, fmt.Errorf("while parsing trust domain %q: %w", installdefaults.AteletTrustDomain, err)
 	}
 	bundle, err := x509bundle.Load(trustDomain, serverCAPath)
 	if err != nil {
 		return nil, fmt.Errorf("while loading CA bundle from %s: %w", serverCAPath, err)
 	}
-	expectedID, err := spiffeid.FromSegments(trustDomain, "ns", ateletNamespace, "sa", ateletSA)
+	expectedID, err := spiffeid.FromSegments(trustDomain, "ns", ateletNamespace, "sa", installdefaults.AteletServiceAccount)
 	if err != nil {
 		return nil, fmt.Errorf("while building expected atelet SPIFFE ID: %w", err)
 	}

--- a/cmd/ateapi/internal/controlapi/dialer.go
+++ b/cmd/ateapi/internal/controlapi/dialer.go
@@ -69,15 +69,15 @@ func WithDialCredentials(build func(expectedPodUID string) (credentials.Transpor
 
 // NewAteletDialer creates a new AteletDialer. clientBundlePath and serverCAPath
 // are used to build the per-atelet mTLS credentials used for every atelet
-// connection, and ateletNamespace is the namespace segment of the SPIFFE ID
-// those credentials expect on the atelet serving cert.
-func NewAteletDialer(workerIndexer cache.Indexer, ateletIndexer cache.Indexer, ateletNamespace, clientBundlePath, serverCAPath string, opts ...DialerOption) *AteletDialer {
+// connection, and ateletSPIFFEID is the identity those credentials expect on
+// the atelet serving cert.
+func NewAteletDialer(workerIndexer cache.Indexer, ateletIndexer cache.Indexer, ateletSPIFFEID, clientBundlePath, serverCAPath string, opts ...DialerOption) *AteletDialer {
 	d := &AteletDialer{
 		workerIndexer: workerIndexer,
 		ateletIndexer: ateletIndexer,
 		ateletConns:   newAteletConnCache(1024),
 		dialCredentials: func(expectedPodUID string) (credentials.TransportCredentials, error) {
-			tlsConfig, err := buildTLSConfig(ateletNamespace, clientBundlePath, serverCAPath, expectedPodUID)
+			tlsConfig, err := buildTLSConfig(ateletSPIFFEID, clientBundlePath, serverCAPath, expectedPodUID)
 			if err != nil {
 				return nil, err
 			}
@@ -184,7 +184,7 @@ func (d *AteletDialer) DialForAteletOnNode(nodeName string) (*grpc.ClientConn, e
 	return ateletConn, nil
 }
 
-func buildTLSConfig(ateletNamespace, clientBundlePath, serverCAPath, expectedPodUID string) (*tls.Config, error) {
+func buildTLSConfig(ateletSPIFFEID, clientBundlePath, serverCAPath, expectedPodUID string) (*tls.Config, error) {
 	trustDomain, err := spiffeid.TrustDomainFromString(installdefaults.AteletTrustDomain)
 	if err != nil {
 		return nil, fmt.Errorf("while parsing trust domain %q: %w", installdefaults.AteletTrustDomain, err)
@@ -193,9 +193,9 @@ func buildTLSConfig(ateletNamespace, clientBundlePath, serverCAPath, expectedPod
 	if err != nil {
 		return nil, fmt.Errorf("while loading CA bundle from %s: %w", serverCAPath, err)
 	}
-	expectedID, err := spiffeid.FromSegments(trustDomain, "ns", ateletNamespace, "sa", installdefaults.AteletServiceAccount)
+	expectedID, err := spiffeid.FromString(ateletSPIFFEID)
 	if err != nil {
-		return nil, fmt.Errorf("while building expected atelet SPIFFE ID: %w", err)
+		return nil, fmt.Errorf("while parsing expected atelet SPIFFE ID %q: %w", ateletSPIFFEID, err)
 	}
 
 	verify, err := verifyAteletServerCert(bundle, expectedID, expectedPodUID)

--- a/cmd/ateapi/internal/controlapi/dialer_test.go
+++ b/cmd/ateapi/internal/controlapi/dialer_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/substratex509"
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -198,7 +199,7 @@ func TestDialForWorkerTarget(t *testing.T) {
 				Spec:       corev1.PodSpec{NodeName: "node-1"},
 			}
 			ateletPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Namespace: ateletNamespace, Name: "atelet-abc", UID: "atelet-uid"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: installdefaults.SystemNamespace, Name: "atelet-abc", UID: "atelet-uid"},
 				Spec:       corev1.PodSpec{NodeName: "node-1"},
 				Status:     corev1.PodStatus{PodIPs: []corev1.PodIP{{IP: tc.ateletIP}}},
 			}
@@ -225,7 +226,7 @@ func TestDialForWorkerErrors(t *testing.T) {
 
 	t.Run("unknown worker pod", func(t *testing.T) {
 		ateletPod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Namespace: ateletNamespace, Name: "atelet-abc", UID: "atelet-uid"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: installdefaults.SystemNamespace, Name: "atelet-abc", UID: "atelet-uid"},
 			Spec:       corev1.PodSpec{NodeName: "node-1"},
 			Status:     corev1.PodStatus{PodIPs: []corev1.PodIP{{IP: "10.244.1.7"}}},
 		}
@@ -237,7 +238,7 @@ func TestDialForWorkerErrors(t *testing.T) {
 
 	t.Run("atelet without assigned IPs", func(t *testing.T) {
 		ateletPod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Namespace: ateletNamespace, Name: "atelet-abc", UID: "atelet-uid"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: installdefaults.SystemNamespace, Name: "atelet-abc", UID: "atelet-uid"},
 			Spec:       corev1.PodSpec{NodeName: "node-1"},
 		}
 		d := newDialerForPods(t, workerPod, ateletPod)
@@ -363,7 +364,7 @@ func TestDialForAteletOnNode(t *testing.T) {
 	}
 
 	t.Run("no atelet on node", func(t *testing.T) {
-		d := NewAteletDialer(nil, newTestAteletIndexer(t), "", "")
+		d := NewAteletDialer(nil, newTestAteletIndexer(t), installdefaults.SystemNamespace, "", "")
 		if _, err := d.DialForAteletOnNode("node1"); !errors.Is(err, ErrNoAteletOnNode) {
 			t.Fatalf("DialForAteletOnNode = %v, want ErrNoAteletOnNode", err)
 		}
@@ -373,7 +374,7 @@ func TestDialForAteletOnNode(t *testing.T) {
 		d := NewAteletDialer(nil, newTestAteletIndexer(t,
 			ateletPod("atelet-1", "uid-1", "node1", "10.0.0.1"),
 			ateletPod("atelet-2", "uid-2", "node1", "10.0.0.2"),
-		), "", "")
+		), installdefaults.SystemNamespace, "", "")
 		_, err := d.DialForAteletOnNode("node1")
 		if err == nil || errors.Is(err, ErrNoAteletOnNode) {
 			t.Fatalf("DialForAteletOnNode = %v, want a non-ErrNoAteletOnNode error", err)
@@ -383,7 +384,7 @@ func TestDialForAteletOnNode(t *testing.T) {
 	t.Run("dials and caches the node's atelet", func(t *testing.T) {
 		d := NewAteletDialer(nil, newTestAteletIndexer(t,
 			ateletPod("atelet-1", "uid-1", "node1", "10.0.0.1"),
-		), "", "")
+		), installdefaults.SystemNamespace, "", "")
 		var credsUID string
 		d.dialCredentials = func(expectedPodUID string) (credentials.TransportCredentials, error) {
 			credsUID = expectedPodUID
@@ -410,7 +411,7 @@ func TestDialForAteletOnNode(t *testing.T) {
 		d := NewAteletDialer(nil, newTestAteletIndexer(t,
 			ateletPod("atelet-1", "uid-1", "node1", "10.0.0.1"),
 			ateletPod("atelet-2", "uid-2", "node2", "10.0.0.2"),
-		), "", "", WithDialCredentials(func(string) (credentials.TransportCredentials, error) {
+		), installdefaults.SystemNamespace, "", "", WithDialCredentials(func(string) (credentials.TransportCredentials, error) {
 			return insecure.NewCredentials(), nil
 		}))
 		d.ateletConns = newAteletConnCache(1)

--- a/cmd/ateapi/internal/controlapi/dialer_test.go
+++ b/cmd/ateapi/internal/controlapi/dialer_test.go
@@ -364,7 +364,7 @@ func TestDialForAteletOnNode(t *testing.T) {
 	}
 
 	t.Run("no atelet on node", func(t *testing.T) {
-		d := NewAteletDialer(nil, newTestAteletIndexer(t), installdefaults.SystemNamespace, "", "")
+		d := NewAteletDialer(nil, newTestAteletIndexer(t), installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace), "", "")
 		if _, err := d.DialForAteletOnNode("node1"); !errors.Is(err, ErrNoAteletOnNode) {
 			t.Fatalf("DialForAteletOnNode = %v, want ErrNoAteletOnNode", err)
 		}
@@ -374,7 +374,7 @@ func TestDialForAteletOnNode(t *testing.T) {
 		d := NewAteletDialer(nil, newTestAteletIndexer(t,
 			ateletPod("atelet-1", "uid-1", "node1", "10.0.0.1"),
 			ateletPod("atelet-2", "uid-2", "node1", "10.0.0.2"),
-		), installdefaults.SystemNamespace, "", "")
+		), installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace), "", "")
 		_, err := d.DialForAteletOnNode("node1")
 		if err == nil || errors.Is(err, ErrNoAteletOnNode) {
 			t.Fatalf("DialForAteletOnNode = %v, want a non-ErrNoAteletOnNode error", err)
@@ -384,7 +384,7 @@ func TestDialForAteletOnNode(t *testing.T) {
 	t.Run("dials and caches the node's atelet", func(t *testing.T) {
 		d := NewAteletDialer(nil, newTestAteletIndexer(t,
 			ateletPod("atelet-1", "uid-1", "node1", "10.0.0.1"),
-		), installdefaults.SystemNamespace, "", "")
+		), installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace), "", "")
 		var credsUID string
 		d.dialCredentials = func(expectedPodUID string) (credentials.TransportCredentials, error) {
 			credsUID = expectedPodUID
@@ -411,7 +411,7 @@ func TestDialForAteletOnNode(t *testing.T) {
 		d := NewAteletDialer(nil, newTestAteletIndexer(t,
 			ateletPod("atelet-1", "uid-1", "node1", "10.0.0.1"),
 			ateletPod("atelet-2", "uid-2", "node2", "10.0.0.2"),
-		), installdefaults.SystemNamespace, "", "", WithDialCredentials(func(string) (credentials.TransportCredentials, error) {
+		), installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace), "", "", WithDialCredentials(func(string) (credentials.TransportCredentials, error) {
 			return insecure.NewCredentials(), nil
 		}))
 		d.ateletConns = newAteletConnCache(1)

--- a/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/objectstore/objectstoretest"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/internal/volume"
@@ -130,7 +131,7 @@ func setupTestWithVolumePlugins(t *testing.T, ns string, plugins map[string]volu
 
 	// 3. Initialize Informers
 	workerFactory, workerInformer := controlapi.WorkerPodInformer(k8sClient)
-	ateletFactory, ateletInformer := controlapi.AteletInformer(k8sClient)
+	ateletFactory, ateletInformer := controlapi.AteletInformer(k8sClient, installdefaults.SystemNamespace)
 	scFactory := informers.NewSharedInformerFactory(k8sClient, 0)
 	scLister := scFactory.Storage().V1().StorageClasses().Lister()
 
@@ -161,7 +162,7 @@ func setupTestWithVolumePlugins(t *testing.T, ns string, plugins map[string]volu
 
 	// Dial the fake atelet over insecure transport instead of per-atelet mTLS,
 	// so DialForWorker's real lookup/dial/cache path is exercised under test.
-	dialer := controlapi.NewAteletDialer(workerInformer.GetIndexer(), ateletInformer.GetIndexer(), "", "",
+	dialer := controlapi.NewAteletDialer(workerInformer.GetIndexer(), ateletInformer.GetIndexer(), installdefaults.SystemNamespace, "", "",
 		controlapi.WithDialCredentials(func(_ string) (credentials.TransportCredentials, error) {
 			return insecure.NewCredentials(), nil
 		}))

--- a/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
@@ -162,7 +162,7 @@ func setupTestWithVolumePlugins(t *testing.T, ns string, plugins map[string]volu
 
 	// Dial the fake atelet over insecure transport instead of per-atelet mTLS,
 	// so DialForWorker's real lookup/dial/cache path is exercised under test.
-	dialer := controlapi.NewAteletDialer(workerInformer.GetIndexer(), ateletInformer.GetIndexer(), installdefaults.SystemNamespace, "", "",
+	dialer := controlapi.NewAteletDialer(workerInformer.GetIndexer(), ateletInformer.GetIndexer(), installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace), "", "",
 		controlapi.WithDialCredentials(func(_ string) (credentials.TransportCredentials, error) {
 			return insecure.NewCredentials(), nil
 		}))

--- a/cmd/ateapi/internal/controlapi/informer.go
+++ b/cmd/ateapi/internal/controlapi/informer.go
@@ -25,13 +25,13 @@ import (
 )
 
 const (
-	ateletNamespace    = "ate-system"
 	byNamespaceAndName = "by-namespace-and-name"
 	byNode             = "by-node"
 )
 
-// AteletInformer creates a SharedInformerFactory and SharedIndexInformer for Atelet pods.
-func AteletInformer(kc kubernetes.Interface) (informers.SharedInformerFactory, cache.SharedIndexInformer) {
+// AteletInformer creates a SharedInformerFactory and SharedIndexInformer for
+// Atelet pods in the given namespace.
+func AteletInformer(kc kubernetes.Interface, ateletNamespace string) (informers.SharedInformerFactory, cache.SharedIndexInformer) {
 	factory := informers.NewSharedInformerFactoryWithOptions(kc, 0,
 		informers.WithNamespace(ateletNamespace),
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
@@ -216,7 +217,7 @@ func newDanglingDialer() *AteletDialer {
 		byNamespaceAndName: func(obj any) ([]string, error) { return nil, nil },
 		byNode:             func(obj any) ([]string, error) { return nil, nil },
 	})
-	return NewAteletDialer(empty, empty, "", "")
+	return NewAteletDialer(empty, empty, installdefaults.SystemNamespace, "", "")
 }
 
 func TestEnsureAteletSuspended_DanglingWorkerDoesNotRecordPhantomSnapshot(t *testing.T) {

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -217,7 +217,7 @@ func newDanglingDialer() *AteletDialer {
 		byNamespaceAndName: func(obj any) ([]string, error) { return nil, nil },
 		byNode:             func(obj any) ([]string, error) { return nil, nil },
 	})
-	return NewAteletDialer(empty, empty, installdefaults.SystemNamespace, "", "")
+	return NewAteletDialer(empty, empty, installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace), "", "")
 }
 
 func TestEnsureAteletSuspended_DanglingWorkerDoesNotRecordPhantomSnapshot(t *testing.T) {

--- a/cmd/ateapi/internal/workerservice/capacity.go
+++ b/cmd/ateapi/internal/workerservice/capacity.go
@@ -41,18 +41,22 @@ type Server struct {
 	// store is where a Worker's reported capacity is recorded, and the
 	// authoritative state the report is authorized against.
 	store store.Interface
+
+	// ateletNamespace is the namespace the calling atelet runs in, which its
+	// SPIFFE ID names.
+	ateletNamespace string
 }
 
 var _ ateapipb.WorkerServiceServer = (*Server)(nil)
 
-func New(store store.Interface) *Server {
-	return &Server{store: store}
+func New(store store.Interface, ateletNamespace string) *Server {
+	return &Server{store: store, ateletNamespace: ateletNamespace}
 }
 
 // SetWorkerCapacity records a Worker's reported capacity. As with MintCert,
 // the caller must be an atelet running on the Worker's node.
 func (s *Server) SetWorkerCapacity(ctx context.Context, req *ateapipb.SetWorkerCapacityRequest) (*ateapipb.SetWorkerCapacityResponse, error) {
-	caller, err := ateletauth.Authenticate(ctx)
+	caller, err := ateletauth.Authenticate(ctx, s.ateletNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ateapi/internal/workerservice/capacity.go
+++ b/cmd/ateapi/internal/workerservice/capacity.go
@@ -42,21 +42,20 @@ type Server struct {
 	// authoritative state the report is authorized against.
 	store store.Interface
 
-	// ateletNamespace is the namespace the calling atelet runs in, which its
-	// SPIFFE ID names.
-	ateletNamespace string
+	// ateletSPIFFEID is the identity the calling atelet must present.
+	ateletSPIFFEID string
 }
 
 var _ ateapipb.WorkerServiceServer = (*Server)(nil)
 
-func New(store store.Interface, ateletNamespace string) *Server {
-	return &Server{store: store, ateletNamespace: ateletNamespace}
+func New(store store.Interface, ateletSPIFFEID string) *Server {
+	return &Server{store: store, ateletSPIFFEID: ateletSPIFFEID}
 }
 
 // SetWorkerCapacity records a Worker's reported capacity. As with MintCert,
 // the caller must be an atelet running on the Worker's node.
 func (s *Server) SetWorkerCapacity(ctx context.Context, req *ateapipb.SetWorkerCapacityRequest) (*ateapipb.SetWorkerCapacityResponse, error) {
-	caller, err := ateletauth.Authenticate(ctx, s.ateletNamespace)
+	caller, err := ateletauth.Authenticate(ctx, s.ateletSPIFFEID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ateapi/internal/workerservice/capacity_test.go
+++ b/cmd/ateapi/internal/workerservice/capacity_test.go
@@ -71,7 +71,7 @@ func setRequest(actors int32) *ateapipb.SetWorkerCapacityRequest {
 func TestSetWorkerCapacity(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st, installdefaults.SystemNamespace)
+	s := New(st, installdefaults.SPIFFEID(installdefaults.SystemNamespace, installdefaults.AteletServiceAccount))
 	seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 1, Resources: resources.CPUMemory(2000, 0)})
 
 	got, err := s.SetWorkerCapacity(ateletauthtest.ContextWith(ateletauthtest.CertOn(t, capNode)), setRequest(4094))
@@ -95,7 +95,7 @@ func TestSetWorkerCapacity(t *testing.T) {
 func TestSetWorkerCapacity_OtherNodeIsNotFound(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st, installdefaults.SystemNamespace)
+	s := New(st, installdefaults.SPIFFEID(installdefaults.SystemNamespace, installdefaults.AteletServiceAccount))
 	seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 1})
 
 	_, err := s.SetWorkerCapacity(ateletauthtest.ContextWith(ateletauthtest.CertOn(t, "some-other-node")), setRequest(4094))
@@ -119,7 +119,7 @@ func TestSetWorkerCapacity_OtherNodeIsNotFound(t *testing.T) {
 func TestSetWorkerCapacity_UnchangedDoesNotWrite(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st, installdefaults.SystemNamespace)
+	s := New(st, installdefaults.SPIFFEID(installdefaults.SystemNamespace, installdefaults.AteletServiceAccount))
 	seeded := seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 4094})
 
 	for range 3 {
@@ -139,7 +139,7 @@ func TestSetWorkerCapacity_UnchangedDoesNotWrite(t *testing.T) {
 func TestSetWorkerCapacity_Errors(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st, installdefaults.SystemNamespace)
+	s := New(st, installdefaults.SPIFFEID(installdefaults.SystemNamespace, installdefaults.AteletServiceAccount))
 	seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 1})
 	authed := ateletauthtest.ContextWith(ateletauthtest.CertOn(t, capNode))
 
@@ -177,7 +177,7 @@ func TestSetWorkerCapacity_Errors(t *testing.T) {
 func TestSetWorkerCapacity_RejectsNonsense(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st, installdefaults.SystemNamespace)
+	s := New(st, installdefaults.SPIFFEID(installdefaults.SystemNamespace, installdefaults.AteletServiceAccount))
 	seeded := seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 4094})
 	authed := ateletauthtest.ContextWith(ateletauthtest.CertOn(t, capNode))
 

--- a/cmd/ateapi/internal/workerservice/capacity_test.go
+++ b/cmd/ateapi/internal/workerservice/capacity_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/ateletauth/ateletauthtest"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
@@ -70,7 +71,7 @@ func setRequest(actors int32) *ateapipb.SetWorkerCapacityRequest {
 func TestSetWorkerCapacity(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st)
+	s := New(st, installdefaults.SystemNamespace)
 	seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 1, Resources: resources.CPUMemory(2000, 0)})
 
 	got, err := s.SetWorkerCapacity(ateletauthtest.ContextWith(ateletauthtest.CertOn(t, capNode)), setRequest(4094))
@@ -94,7 +95,7 @@ func TestSetWorkerCapacity(t *testing.T) {
 func TestSetWorkerCapacity_OtherNodeIsNotFound(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st)
+	s := New(st, installdefaults.SystemNamespace)
 	seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 1})
 
 	_, err := s.SetWorkerCapacity(ateletauthtest.ContextWith(ateletauthtest.CertOn(t, "some-other-node")), setRequest(4094))
@@ -118,7 +119,7 @@ func TestSetWorkerCapacity_OtherNodeIsNotFound(t *testing.T) {
 func TestSetWorkerCapacity_UnchangedDoesNotWrite(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st)
+	s := New(st, installdefaults.SystemNamespace)
 	seeded := seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 4094})
 
 	for range 3 {
@@ -138,7 +139,7 @@ func TestSetWorkerCapacity_UnchangedDoesNotWrite(t *testing.T) {
 func TestSetWorkerCapacity_Errors(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st)
+	s := New(st, installdefaults.SystemNamespace)
 	seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 1})
 	authed := ateletauthtest.ContextWith(ateletauthtest.CertOn(t, capNode))
 
@@ -176,7 +177,7 @@ func TestSetWorkerCapacity_Errors(t *testing.T) {
 func TestSetWorkerCapacity_RejectsNonsense(t *testing.T) {
 	st, cleanup := storetest.SetupTestStore(t)
 	defer cleanup()
-	s := New(st)
+	s := New(st, installdefaults.SystemNamespace)
 	seeded := seedReportedWorker(t, st, capNode, &ateapipb.WorkerResources{Actors: 4094})
 	authed := ateletauthtest.ContextWith(ateletauthtest.CertOn(t, capNode))
 

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -81,6 +81,7 @@ var (
 	actorIDCAPoolFile      = pflag.String("actor-id-ca-pool", "", "The file that contains the CA pool for signing actor JWTs")
 	podIdentityCACerts     = pflag.String("pod-identity-ca-certs", "", "The file that contains the pod-identity CA bundle, used both for verifying client certificates presented to the gRPC server and for verifying atelet serving certificates when dialing atelet. If empty, client-cert verification is disabled and atelet dials will fail.")
 	ateletClientCredBundle = pflag.String("atelet-client-cred-bundle", "", "Credential bundle presented as the client certificate when dialing atelet.")
+	ateletServiceAccount   = pflag.String("atelet-service-account", installdefaults.AteletServiceAccount, "ServiceAccount atelet runs as. It is the service-account segment of the SPIFFE ID expected on atelet's certificate, so it has to match what the deployment actually creates; a Helm release that prefixes resource names needs it set.")
 
 	drainDelay   = pflag.Duration("drain-delay", 13*time.Second, "How long to keep accepting new work after SIGTERM, before starting the gRPC drain.")
 	drainTimeout = pflag.Duration("drain-timeout", 15*time.Second, "Deadline for the graceful gRPC drain on shutdown. In-flight RPCs still running past it are forcefully cancelled.")
@@ -166,7 +167,14 @@ func main() {
 	// atelet shares ateapi's namespace in every supported deployment topology,
 	// so we read it from Kubernetes' downward API rather than expose a flag.
 	ateletNamespace := installdefaults.NamespaceFromPodEnv()
-	slog.InfoContext(ctx, "Resolved atelet namespace", slog.String("atelet-namespace", ateletNamespace))
+	// An empty ServiceAccount would not fail here: path.Join drops the empty
+	// segment, yielding an identity that parses but matches nothing, so every
+	// atelet dial would be rejected with no hint at the cause.
+	if *ateletServiceAccount == "" {
+		serverboot.Fatal(ctx, "Invalid flags", fmt.Errorf("--atelet-service-account must not be empty"))
+	}
+	ateletSPIFFEID := installdefaults.SPIFFEID(ateletNamespace, *ateletServiceAccount)
+	slog.InfoContext(ctx, "Resolved atelet namespace", slog.String("atelet-namespace", ateletNamespace), slog.String("atelet-spiffe-id", ateletSPIFFEID))
 
 	workerPodInformerFactory, workerPodInformer := controlapi.WorkerPodInformer(clientset)
 	ateletPodInformerFactory, ateletPodInformer := controlapi.AteletInformer(clientset, ateletNamespace)
@@ -203,7 +211,7 @@ func main() {
 	}
 
 	volPlugins := make(map[string]volume.VolumePluginControlPlane)
-	ateletDialer := controlapi.NewAteletDialer(workerPodInformer.GetIndexer(), ateletPodInformer.GetIndexer(), ateletNamespace, *ateletClientCredBundle, *podIdentityCACerts)
+	ateletDialer := controlapi.NewAteletDialer(workerPodInformer.GetIndexer(), ateletPodInformer.GetIndexer(), ateletSPIFFEID, *ateletClientCredBundle, *podIdentityCACerts)
 	controlSrv := controlapi.NewRPCService(persistence, workerCache, sandboxConfigLister, csiDriverConfigLister, storageClassLister, ateletDialer, instruments, *egressGatewayAddress, volPlugins, objectStore)
 
 	// Drive stored ActorTemplates through the golden actor flow.
@@ -220,7 +228,7 @@ func main() {
 		serverboot.Fatal(ctx, "while loading the Actor ID JWT authority pool", err)
 	}
 
-	actorIdentitySrv := actoridentity.New(actorIdentityJWTIssuer, actorIDJWTAuthorityPool, actorIDCAPool, persistence, workerCache, ateletNamespace)
+	actorIdentitySrv := actoridentity.New(actorIdentityJWTIssuer, actorIDJWTAuthorityPool, actorIDCAPool, persistence, workerCache, ateletSPIFFEID)
 
 	lisCfg := &net.ListenConfig{}
 	lis, err := lisCfg.Listen(ctx, "tcp", *listenAddr)
@@ -255,7 +263,7 @@ func main() {
 	reflection.Register(mux)
 	ateapipb.RegisterControlServer(mux, controlSrv)
 	ateapipb.RegisterActorIdentityServer(mux, actorIdentitySrv)
-	ateapipb.RegisterWorkerServiceServer(mux, workerservice.New(persistence, ateletNamespace))
+	ateapipb.RegisterWorkerServiceServer(mux, workerservice.New(persistence, ateletSPIFFEID))
 
 	readiness := &serverboot.Readiness{}
 	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -220,7 +220,7 @@ func main() {
 		serverboot.Fatal(ctx, "while loading the Actor ID JWT authority pool", err)
 	}
 
-	actorIdentitySrv := actoridentity.New(actorIdentityJWTIssuer, actorIDJWTAuthorityPool, actorIDCAPool, persistence, workerCache)
+	actorIdentitySrv := actoridentity.New(actorIdentityJWTIssuer, actorIDJWTAuthorityPool, actorIDCAPool, persistence, workerCache, ateletNamespace)
 
 	lisCfg := &net.ListenConfig{}
 	lis, err := lisCfg.Listen(ctx, "tcp", *listenAddr)
@@ -255,7 +255,7 @@ func main() {
 	reflection.Register(mux)
 	ateapipb.RegisterControlServer(mux, controlSrv)
 	ateapipb.RegisterActorIdentityServer(mux, actorIdentitySrv)
-	ateapipb.RegisterWorkerServiceServer(mux, workerservice.New(persistence))
+	ateapipb.RegisterWorkerServiceServer(mux, workerservice.New(persistence, ateletNamespace))
 
 	readiness := &serverboot.Readiness{}
 	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateapiauth"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/credbundle"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/localca"
 	"github.com/agent-substrate/substrate/internal/localjwtauthority"
 	"github.com/agent-substrate/substrate/internal/objectstore"
@@ -162,8 +163,13 @@ func main() {
 	sandboxConfigLister := ateFactory.Api().V1alpha1().SandboxConfigs().Lister()
 	csiDriverConfigLister := ateFactory.Api().V1alpha1().CSIDriverConfigs().Lister()
 
+	// atelet shares ateapi's namespace in every supported deployment topology,
+	// so we read it from Kubernetes' downward API rather than expose a flag.
+	ateletNamespace := installdefaults.NamespaceFromPodEnv()
+	slog.InfoContext(ctx, "Resolved atelet namespace", slog.String("atelet-namespace", ateletNamespace))
+
 	workerPodInformerFactory, workerPodInformer := controlapi.WorkerPodInformer(clientset)
-	ateletPodInformerFactory, ateletPodInformer := controlapi.AteletInformer(clientset)
+	ateletPodInformerFactory, ateletPodInformer := controlapi.AteletInformer(clientset, ateletNamespace)
 	scInformerFactory := informers.NewSharedInformerFactory(clientset, 0)
 	storageClassLister := scInformerFactory.Storage().V1().StorageClasses().Lister()
 
@@ -197,7 +203,7 @@ func main() {
 	}
 
 	volPlugins := make(map[string]volume.VolumePluginControlPlane)
-	ateletDialer := controlapi.NewAteletDialer(workerPodInformer.GetIndexer(), ateletPodInformer.GetIndexer(), *ateletClientCredBundle, *podIdentityCACerts)
+	ateletDialer := controlapi.NewAteletDialer(workerPodInformer.GetIndexer(), ateletPodInformer.GetIndexer(), ateletNamespace, *ateletClientCredBundle, *podIdentityCACerts)
 	controlSrv := controlapi.NewRPCService(persistence, workerCache, sandboxConfigLister, csiDriverConfigLister, storageClassLister, ateletDialer, instruments, *egressGatewayAddress, volPlugins, objectStore)
 
 	// Drive stored ActorTemplates through the golden actor flow.

--- a/cmd/atecontroller/internal/controllers/egressmitmtrust_controller.go
+++ b/cmd/atecontroller/internal/controllers/egressmitmtrust_controller.go
@@ -45,8 +45,8 @@ type EgressMITMTrustReconciler struct {
 	SystemNamespace string
 }
 
-// EgressMITMCAPoolRef names the Secret in systemNamespace holding the CA pool
-// the egress gateway's sdsmint sidecar signs per-SNI leaves with.
+// EgressMITMCAPoolRef names the Secret holding the CA pool the egress gateway's
+// sdsmint sidecar signs per-SNI leaves with.
 func EgressMITMCAPoolRef(systemNamespace string) types.NamespacedName {
 	const egressMITMCAPoolSecret = "egress-mitm-ca-pool"
 	return types.NamespacedName{Namespace: systemNamespace, Name: egressMITMCAPoolSecret}

--- a/cmd/atecontroller/internal/controllers/egressmitmtrust_controller.go
+++ b/cmd/atecontroller/internal/controllers/egressmitmtrust_controller.go
@@ -40,13 +40,16 @@ import (
 // CA pool.
 type EgressMITMTrustReconciler struct {
 	client.Client
+
+	// SystemNamespace is the namespace holding the egress MITM CA pool Secret.
+	SystemNamespace string
 }
 
-// EgressMITMCAPoolRef names the Secret holding the CA pool the egress gateway's
-// sdsmint sidecar signs per-SNI leaves with.
-func EgressMITMCAPoolRef() types.NamespacedName {
+// EgressMITMCAPoolRef names the Secret in systemNamespace holding the CA pool
+// the egress gateway's sdsmint sidecar signs per-SNI leaves with.
+func EgressMITMCAPoolRef(systemNamespace string) types.NamespacedName {
 	const egressMITMCAPoolSecret = "egress-mitm-ca-pool"
-	return types.NamespacedName{Namespace: ateSystemNamespace, Name: egressMITMCAPoolSecret}
+	return types.NamespacedName{Namespace: systemNamespace, Name: egressMITMCAPoolSecret}
 }
 
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
@@ -162,7 +165,7 @@ func (r *EgressMITMTrustReconciler) deleteTrustBundle(ctx context.Context) error
 }
 
 func (r *EgressMITMTrustReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	poolRef := EgressMITMCAPoolRef()
+	poolRef := EgressMITMCAPoolRef(r.SystemNamespace)
 
 	// The pool Secret is the only object reconciled from. The bundle is watched
 	// as well so that deleting or hand-editing the derived object is reverted

--- a/cmd/atecontroller/internal/controllers/egressmitmtrust_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/egressmitmtrust_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/localca"
 )
 
@@ -66,7 +67,7 @@ func secretForPool(t *testing.T, pool *localca.ConcretePool) *corev1.Secret {
 	if err != nil {
 		t.Fatalf("marshal CA pool: %v", err)
 	}
-	ref := EgressMITMCAPoolRef()
+	ref := EgressMITMCAPoolRef(installdefaults.SystemNamespace)
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ref.Namespace, Name: ref.Name},
 		Data:       map[string][]byte{"pool": wire},
@@ -86,8 +87,8 @@ func rootPEM(t *testing.T, pool *localca.ConcretePool) string {
 
 func reconcilePool(t *testing.T, c client.Client) error {
 	t.Helper()
-	r := &EgressMITMTrustReconciler{Client: c}
-	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: EgressMITMCAPoolRef()})
+	r := &EgressMITMTrustReconciler{Client: c, SystemNamespace: installdefaults.SystemNamespace}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: EgressMITMCAPoolRef(installdefaults.SystemNamespace)})
 	return err
 }
 
@@ -170,7 +171,7 @@ func TestEgressMITMTrustFollowsPoolRotation(t *testing.T) {
 
 	rotated, rotatedPool := caPoolSecret(t, "mitm", "mitm-next")
 	current := &corev1.Secret{}
-	if err := c.Get(context.Background(), EgressMITMCAPoolRef(), current); err != nil {
+	if err := c.Get(context.Background(), EgressMITMCAPoolRef(installdefaults.SystemNamespace), current); err != nil {
 		t.Fatalf("get pool secret: %v", err)
 	}
 	current.Data = rotated.Data
@@ -279,7 +280,7 @@ func TestEgressMITMTrustKeepsLastGoodBundleOnBadPool(t *testing.T) {
 			}
 
 			current := &corev1.Secret{}
-			if err := c.Get(context.Background(), EgressMITMCAPoolRef(), current); err != nil {
+			if err := c.Get(context.Background(), EgressMITMCAPoolRef(installdefaults.SystemNamespace), current); err != nil {
 				t.Fatalf("get pool secret: %v", err)
 			}
 			current.Data = tc.data

--- a/cmd/atecontroller/internal/controllers/networkpolicy_controller.go
+++ b/cmd/atecontroller/internal/controllers/networkpolicy_controller.go
@@ -33,13 +33,17 @@ import (
 
 const (
 	networkPolicyFieldOwner = "ate-networkpolicy"
-	ateSystemNamespace      = "ate-system"
 	atenetRouterAppName     = "atenet-router"
 )
 
 type NetworkPolicyReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	// SystemNamespace is the namespace atenet-router runs in. The generated
+	// ingress policy admits only that namespace, so a value that does not
+	// match the running router blocks every request to the worker pool.
+	SystemNamespace string
 }
 
 //+kubebuilder:rbac:groups=ate.dev,resources=workerpools,verbs=get;list;watch
@@ -74,7 +78,7 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *NetworkPolicyReconciler) reconcileImpl(ctx context.Context, wp *atev1alpha1.WorkerPool) error {
 	log := log.FromContext(ctx)
 
-	npAC := buildNetworkPolicyApplyConfig(wp)
+	npAC := r.buildNetworkPolicyApplyConfig(wp)
 
 	if err := r.Apply(ctx, npAC, client.FieldOwner(networkPolicyFieldOwner), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply NetworkPolicy %s:%s: %w", *npAC.Namespace, *npAC.Name, err)
@@ -86,7 +90,7 @@ func (r *NetworkPolicyReconciler) reconcileImpl(ctx context.Context, wp *atev1al
 	return nil
 }
 
-func buildNetworkPolicyApplyConfig(wp *atev1alpha1.WorkerPool) *networkingv1ac.NetworkPolicyApplyConfiguration {
+func (r *NetworkPolicyReconciler) buildNetworkPolicyApplyConfig(wp *atev1alpha1.WorkerPool) *networkingv1ac.NetworkPolicyApplyConfiguration {
 	np := networkingv1ac.NetworkPolicy(resources.NetworkPolicyName(wp.Name), wp.Namespace).
 		WithLabels(map[string]string{
 			"ate.dev/worker-pool": wp.Name,
@@ -110,7 +114,7 @@ func buildNetworkPolicyApplyConfig(wp *atev1alpha1.WorkerPool) *networkingv1ac.N
 					WithFrom(
 						networkingv1ac.NetworkPolicyPeer().
 							WithNamespaceSelector(metav1ac.LabelSelector().
-								WithMatchLabels(map[string]string{"kubernetes.io/metadata.name": ateSystemNamespace})).
+								WithMatchLabels(map[string]string{"kubernetes.io/metadata.name": r.SystemNamespace})).
 							WithPodSelector(metav1ac.LabelSelector().
 								WithMatchLabels(map[string]string{"app": atenetRouterAppName})),
 					),

--- a/cmd/atecontroller/internal/controllers/networkpolicy_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/networkpolicy_controller_test.go
@@ -91,3 +91,24 @@ func TestWorkerPoolCreatesNetworkPolicy(t *testing.T) {
 		return true, nil
 	})
 }
+
+// TestBuildNetworkPolicyRelocatedNamespace pins the ingress peer to the
+// reconciler's SystemNamespace rather than the canonical install namespace.
+// The rest of the suite configures the reconciler with the default, so it
+// passes just as well against a hardcoded "ate-system"; this is the case that
+// catches that. A policy naming the wrong namespace admits nobody, and the CNI
+// drops every request to the pool with no error from substrate itself.
+func TestBuildNetworkPolicyRelocatedNamespace(t *testing.T) {
+	const relocated = "substrate-test"
+
+	r := &NetworkPolicyReconciler{SystemNamespace: relocated}
+	np := r.buildNetworkPolicyApplyConfig(testWorkerPoolApplyConfig(nil))
+
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].From) != 1 {
+		t.Fatalf("expected exactly one ingress rule with one peer, got %+v", np.Spec.Ingress)
+	}
+	got := np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]
+	if got != relocated {
+		t.Errorf("ingress namespace selector = %q, want %q", got, relocated)
+	}
+}

--- a/cmd/atecontroller/internal/controllers/networkpolicy_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/networkpolicy_controller_test.go
@@ -21,6 +21,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/resources"
 )
 
@@ -75,7 +76,7 @@ func TestWorkerPoolCreatesNetworkPolicy(t *testing.T) {
 			return false, nil
 		}
 		fromPeer := ingressRule.From[0]
-		if fromPeer.NamespaceSelector == nil || fromPeer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != ateSystemNamespace {
+		if fromPeer.NamespaceSelector == nil || fromPeer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != installdefaults.SystemNamespace {
 			return false, nil
 		}
 		if fromPeer.PodSelector == nil || fromPeer.PodSelector.MatchLabels["app"] != atenetRouterAppName {

--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -27,6 +27,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateomcapacity"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/deviceplugin"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 )
 
@@ -76,7 +77,7 @@ const (
 // Deployment managed by a WorkerPool. Only fields owned by this controller
 // are declared here. otel, when it carries an endpoint, is propagated to the
 // ateom container so it pushes telemetry to that collector.
-func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettings) *appsv1ac.DeploymentApplyConfiguration {
+func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettings, systemNamespace string) *appsv1ac.DeploymentApplyConfiguration {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	if wp.Spec.Template != nil {
@@ -98,6 +99,11 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettin
 			"--atunnel-connect-listen-address=:8443",
 			"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
 			"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
+			// The peers atunnel authenticates live in substrate's namespace,
+			// not the worker's, so the controller passes their identities
+			// rather than letting ateom assume the default install.
+			"--atunnel-client-identity="+installdefaults.RouterSPIFFEID(systemNamespace),
+			"--atunnel-broker-identity="+installdefaults.AteletSPIFFEID(systemNamespace),
 			"--atunnel-egress-listen-address=0.0.0.0:15001",
 			"--atunnel-egress-trust-bundle="+atunnelEgressTrustMountPath+"/trust-bundle.pem",
 		).

--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -77,7 +77,7 @@ const (
 // Deployment managed by a WorkerPool. Only fields owned by this controller
 // are declared here. otel, when it carries an endpoint, is propagated to the
 // ateom container so it pushes telemetry to that collector.
-func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettings, systemNamespace string) *appsv1ac.DeploymentApplyConfiguration {
+func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettings, systemNamespace, ateletServiceAccount, routerServiceAccount string) *appsv1ac.DeploymentApplyConfiguration {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	if wp.Spec.Template != nil {
@@ -90,23 +90,42 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettin
 	}
 	labels["ate.dev/worker-pool"] = wp.Name
 
+	args := []string{
+		"--pod-uid=$(POD_UID)",
+		"--atunnel-listen-address=:443",
+		"--atunnel-connect-listen-address=:8443",
+		"--atunnel-credential-bundle=" + atunnelIdentityMountPath + "/credential-bundle.pem",
+		"--atunnel-trust-bundle=" + atunnelIdentityMountPath + "/trust-bundle.pem",
+		// The peers atunnel authenticates live in substrate's namespace, not
+		// the worker's, so the controller passes their identities rather than
+		// letting ateom assume the default install. --atunnel-client-identity
+		// has been accepted by every ateom that carries this controller's
+		// contemporaries, so it is always safe to pass.
+		"--atunnel-client-identity=" + installdefaults.SPIFFEID(systemNamespace, routerServiceAccount),
+	}
+
+	// --atunnel-broker-identity is newer than the oldest ateom a rolling
+	// upgrade still has running. docs/upgrade.md keeps the outgoing worker pool
+	// serving alongside the new one, and that pool's Deployment is reconciled
+	// by this controller while still pinned to its old image, which exits on an
+	// unrecognized flag. An ateom without the flag hardcodes the canonical
+	// identity, and an ateom with it defaults to the same, so omitting the flag
+	// when it carries that value is equivalent for both and keeps the upgrade
+	// intact. A relocated or renamed install passes something else and needs an
+	// image new enough to accept it, which it necessarily has.
+	if brokerIdentity := installdefaults.SPIFFEID(systemNamespace, ateletServiceAccount); brokerIdentity != installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace) {
+		args = append(args, "--atunnel-broker-identity="+brokerIdentity)
+	}
+
+	args = append(args,
+		"--atunnel-egress-listen-address=0.0.0.0:15001",
+		"--atunnel-egress-trust-bundle="+atunnelEgressTrustMountPath+"/trust-bundle.pem",
+	)
+
 	containerAC := corev1ac.Container().
 		WithName("ateom").
 		WithImage(wp.Spec.WorkerImage).
-		WithArgs(
-			"--pod-uid=$(POD_UID)",
-			"--atunnel-listen-address=:443",
-			"--atunnel-connect-listen-address=:8443",
-			"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
-			"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
-			// The peers atunnel authenticates live in substrate's namespace,
-			// not the worker's, so the controller passes their identities
-			// rather than letting ateom assume the default install.
-			"--atunnel-client-identity="+installdefaults.RouterSPIFFEID(systemNamespace),
-			"--atunnel-broker-identity="+installdefaults.AteletSPIFFEID(systemNamespace),
-			"--atunnel-egress-listen-address=0.0.0.0:15001",
-			"--atunnel-egress-trust-bundle="+atunnelEgressTrustMountPath+"/trust-bundle.pem",
-		).
+		WithArgs(args...).
 		WithPorts(corev1ac.ContainerPort().
 			WithName("https").
 			WithContainerPort(443).

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateomcapacity"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/deviceplugin"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 )
 
@@ -206,7 +207,7 @@ func TestBuildDeploymentApplyConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildDeploymentApplyConfig(tt.wp, ateomOTelSettings{})
+			got := buildDeploymentApplyConfig(tt.wp, ateomOTelSettings{}, installdefaults.SystemNamespace)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("buildDeploymentApplyConfig() mismatch (-want +got):\n%s", diff)
 			}
@@ -226,7 +227,7 @@ func TestBuildDeploymentApplyConfigMetadata(t *testing.T) {
 		},
 	})
 
-	got := buildDeploymentApplyConfig(wp, ateomOTelSettings{})
+	got := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace)
 	wantLabels := map[string]string{
 		"project":             "agent-substrate",
 		"team":                "compute",
@@ -268,7 +269,7 @@ func TestMicroVMPodShape(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wp := testWorkerPoolApplyConfig(nil)
 			wp.Spec.SandboxClass = tt.class
-			ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}).Spec.Template.Spec
+			ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace).Spec.Template.Spec
 
 			// /dev/kvm must come from the device plugin, never a hostPath: a
 			// hostPath mount carries no cgroup device allow rule, and the
@@ -361,7 +362,7 @@ func TestMicroVMDeviceRequestsPreserveTemplateResources(t *testing.T) {
 		},
 	})
 	wp.Spec.SandboxClass = atev1alpha1.SandboxClassMicroVM
-	c := buildDeploymentApplyConfig(wp, ateomOTelSettings{}).Spec.Template.Spec.Containers[0]
+	c := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace).Spec.Template.Spec.Containers[0]
 
 	if got, ok := deviceLimit(c, string(corev1.ResourceMemory)); !ok || got != "2Gi" {
 		t.Errorf("memory limit = %q (present=%v), want 2Gi", got, ok)
@@ -426,7 +427,7 @@ func TestAteomSecurityContextByClass(t *testing.T) {
 // TestTerminationGracePeriodSeconds asserts the pod's grace period is hardcoded to 3600s.
 func TestTerminationGracePeriodSeconds(t *testing.T) {
 	wp := testWorkerPoolApplyConfig(nil)
-	ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}).Spec.Template.Spec
+	ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace).Spec.Template.Spec
 	if ps.TerminationGracePeriodSeconds == nil {
 		t.Fatalf("TerminationGracePeriodSeconds not set")
 	}
@@ -450,7 +451,7 @@ func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{Endpoint: tt.endpoint}).
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{Endpoint: tt.endpoint}, installdefaults.SystemNamespace).
 				Spec.Template.Spec.Containers[0]
 			env := envByName(c.Env)
 
@@ -536,7 +537,7 @@ func TestBuildDeploymentApplyConfigMetricExportTuning(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel).
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel, installdefaults.SystemNamespace).
 				Spec.Template.Spec.Containers[0]
 			env := envByName(c.Env)
 			for _, k := range []string{"OTEL_METRIC_EXPORT_INTERVAL", "OTEL_METRIC_EXPORT_TIMEOUT"} {
@@ -593,7 +594,7 @@ func TestBuildDeploymentApplyConfigTracesSamplerPropagation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel).
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel, installdefaults.SystemNamespace).
 				Spec.Template.Spec.Containers[0]
 			env := envByName(c.Env)
 			for _, k := range []string{"OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG"} {
@@ -728,6 +729,8 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 				"--atunnel-connect-listen-address=:8443",
 				"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
 				"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
+				"--atunnel-client-identity="+installdefaults.RouterSPIFFEID(installdefaults.SystemNamespace),
+				"--atunnel-broker-identity="+installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace),
 				"--atunnel-egress-listen-address=0.0.0.0:15001",
 				"--atunnel-egress-trust-bundle="+atunnelEgressTrustMountPath+"/trust-bundle.pem",
 			).

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -814,3 +814,35 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 				WithLabels(map[string]string{"ate.dev/worker-pool": wp.Name}).
 				WithSpec(podSpecAC)))
 }
+
+// TestBuildDeploymentAtunnelIdentitiesRelocatedNamespace pins the SPIFFE
+// identities handed to ateom to the controller's namespace. atunnel runs in
+// the actor's pod, so it cannot derive atelet's or the router's namespace
+// itself; if these carry the wrong one, the credential broker handshake and
+// actor ingress both fail closed. Every other case here passes the canonical
+// namespace and so would pass against a hardcoded value too.
+func TestBuildDeploymentAtunnelIdentitiesRelocatedNamespace(t *testing.T) {
+	const relocated = "substrate-test"
+
+	c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{}, relocated).
+		Spec.Template.Spec.Containers[0]
+
+	want := map[string]string{
+		"--atunnel-client-identity=": "spiffe://cluster.local/ns/substrate-test/sa/atenet-router",
+		"--atunnel-broker-identity=": "spiffe://cluster.local/ns/substrate-test/sa/atelet",
+	}
+	for flag, wantVal := range want {
+		var got string
+		for _, arg := range c.Args {
+			if strings.HasPrefix(arg, flag) {
+				got = strings.TrimPrefix(arg, flag)
+			}
+		}
+		if got == "" {
+			t.Fatalf("no %s argument found in %v", flag, c.Args)
+		}
+		if got != wantVal {
+			t.Errorf("%s%s, want %s%s", flag, got, flag, wantVal)
+		}
+	}
+}

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -207,7 +207,7 @@ func TestBuildDeploymentApplyConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildDeploymentApplyConfig(tt.wp, ateomOTelSettings{}, installdefaults.SystemNamespace)
+			got := buildDeploymentApplyConfig(tt.wp, ateomOTelSettings{}, installdefaults.SystemNamespace, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("buildDeploymentApplyConfig() mismatch (-want +got):\n%s", diff)
 			}
@@ -227,7 +227,7 @@ func TestBuildDeploymentApplyConfigMetadata(t *testing.T) {
 		},
 	})
 
-	got := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace)
+	got := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount)
 	wantLabels := map[string]string{
 		"project":             "agent-substrate",
 		"team":                "compute",
@@ -269,7 +269,7 @@ func TestMicroVMPodShape(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wp := testWorkerPoolApplyConfig(nil)
 			wp.Spec.SandboxClass = tt.class
-			ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace).Spec.Template.Spec
+			ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount).Spec.Template.Spec
 
 			// /dev/kvm must come from the device plugin, never a hostPath: a
 			// hostPath mount carries no cgroup device allow rule, and the
@@ -362,7 +362,7 @@ func TestMicroVMDeviceRequestsPreserveTemplateResources(t *testing.T) {
 		},
 	})
 	wp.Spec.SandboxClass = atev1alpha1.SandboxClassMicroVM
-	c := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace).Spec.Template.Spec.Containers[0]
+	c := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount).Spec.Template.Spec.Containers[0]
 
 	if got, ok := deviceLimit(c, string(corev1.ResourceMemory)); !ok || got != "2Gi" {
 		t.Errorf("memory limit = %q (present=%v), want 2Gi", got, ok)
@@ -427,7 +427,7 @@ func TestAteomSecurityContextByClass(t *testing.T) {
 // TestTerminationGracePeriodSeconds asserts the pod's grace period is hardcoded to 3600s.
 func TestTerminationGracePeriodSeconds(t *testing.T) {
 	wp := testWorkerPoolApplyConfig(nil)
-	ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace).Spec.Template.Spec
+	ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}, installdefaults.SystemNamespace, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount).Spec.Template.Spec
 	if ps.TerminationGracePeriodSeconds == nil {
 		t.Fatalf("TerminationGracePeriodSeconds not set")
 	}
@@ -451,7 +451,7 @@ func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{Endpoint: tt.endpoint}, installdefaults.SystemNamespace).
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{Endpoint: tt.endpoint}, installdefaults.SystemNamespace, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount).
 				Spec.Template.Spec.Containers[0]
 			env := envByName(c.Env)
 
@@ -537,7 +537,7 @@ func TestBuildDeploymentApplyConfigMetricExportTuning(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel, installdefaults.SystemNamespace).
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel, installdefaults.SystemNamespace, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount).
 				Spec.Template.Spec.Containers[0]
 			env := envByName(c.Env)
 			for _, k := range []string{"OTEL_METRIC_EXPORT_INTERVAL", "OTEL_METRIC_EXPORT_TIMEOUT"} {
@@ -594,7 +594,7 @@ func TestBuildDeploymentApplyConfigTracesSamplerPropagation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel, installdefaults.SystemNamespace).
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel, installdefaults.SystemNamespace, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount).
 				Spec.Template.Spec.Containers[0]
 			env := envByName(c.Env)
 			for _, k := range []string{"OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG"} {
@@ -730,7 +730,6 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 				"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
 				"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
 				"--atunnel-client-identity="+installdefaults.RouterSPIFFEID(installdefaults.SystemNamespace),
-				"--atunnel-broker-identity="+installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace),
 				"--atunnel-egress-listen-address=0.0.0.0:15001",
 				"--atunnel-egress-trust-bundle="+atunnelEgressTrustMountPath+"/trust-bundle.pem",
 			).
@@ -824,7 +823,7 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 func TestBuildDeploymentAtunnelIdentitiesRelocatedNamespace(t *testing.T) {
 	const relocated = "substrate-test"
 
-	c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{}, relocated).
+	c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{}, relocated, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount).
 		Spec.Template.Spec.Containers[0]
 
 	want := map[string]string{
@@ -844,5 +843,69 @@ func TestBuildDeploymentAtunnelIdentitiesRelocatedNamespace(t *testing.T) {
 		if got != wantVal {
 			t.Errorf("%s%s, want %s%s", flag, got, flag, wantVal)
 		}
+	}
+}
+
+// TestBuildDeploymentAtunnelIdentitiesPrefixedServiceAccounts covers a release
+// that renames the ServiceAccounts — what the Helm chart does for any release
+// not called "substrate", which is every install that consumes substrate as a
+// subchart. The SPIFFE ID embeds the ServiceAccount name, so identities built
+// from the compiled-in defaults name accounts that do not exist and atunnel
+// rejects the peer.
+func TestBuildDeploymentAtunnelIdentitiesPrefixedServiceAccounts(t *testing.T) {
+	const (
+		namespace = "kagent-system"
+		atelet    = "kagent-atelet"
+		router    = "kagent-atenet-router"
+	)
+
+	c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{}, namespace, atelet, router).
+		Spec.Template.Spec.Containers[0]
+
+	want := map[string]string{
+		"--atunnel-client-identity=": "spiffe://cluster.local/ns/kagent-system/sa/kagent-atenet-router",
+		"--atunnel-broker-identity=": "spiffe://cluster.local/ns/kagent-system/sa/kagent-atelet",
+	}
+	for flag, wantVal := range want {
+		var got string
+		for _, arg := range c.Args {
+			if strings.HasPrefix(arg, flag) {
+				got = strings.TrimPrefix(arg, flag)
+			}
+		}
+		if got != wantVal {
+			t.Errorf("%s%s, want %s%s", flag, got, flag, wantVal)
+		}
+	}
+}
+
+// TestBuildDeploymentOmitsBrokerIdentityForCanonicalInstall pins the flag's
+// absence, which is what keeps a rolling upgrade working. docs/upgrade.md runs
+// the outgoing worker pool alongside the new one, and this controller
+// reconciles that pool's Deployment while it is still pinned to its old image.
+// An ateom from before --atunnel-broker-identity existed exits on the
+// unrecognized flag, so passing it would crashloop every old worker the moment
+// the control plane rolled out.
+func TestBuildDeploymentOmitsBrokerIdentityForCanonicalInstall(t *testing.T) {
+	c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{},
+		installdefaults.SystemNamespace, installdefaults.AteletServiceAccount, installdefaults.RouterServiceAccount).
+		Spec.Template.Spec.Containers[0]
+
+	for _, arg := range c.Args {
+		if strings.HasPrefix(arg, "--atunnel-broker-identity=") {
+			t.Fatalf("canonical install passed %q; an ateom predating the flag exits on it", arg)
+		}
+	}
+
+	// The value it would have carried is the one such an ateom already assumes,
+	// so omitting it changes nothing for either binary.
+	var clientIdentity string
+	for _, arg := range c.Args {
+		if strings.HasPrefix(arg, "--atunnel-client-identity=") {
+			clientIdentity = strings.TrimPrefix(arg, "--atunnel-client-identity=")
+		}
+	}
+	if want := installdefaults.RouterSPIFFEID(installdefaults.SystemNamespace); clientIdentity != want {
+		t.Errorf("--atunnel-client-identity=%s, want %s", clientIdentity, want)
 	}
 }

--- a/cmd/atecontroller/internal/controllers/workerpool_controller.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller.go
@@ -52,10 +52,15 @@ type WorkerPoolReconciler struct {
 	// OTelTracesSamplerArg is the OTEL_TRACES_SAMPLER_ARG propagated to ateom
 	// pods. Ignored unless OTelTracesSampler is set.
 	OTelTracesSamplerArg string
-	// SystemNamespace is the namespace substrate's control plane runs in. It
-	// names the atenet-router and atelet SPIFFE identities that atunnel
-	// authenticates inside each worker.
-	SystemNamespace string
+	// SystemNamespace is the namespace substrate's control plane runs in, and
+	// AteletServiceAccount / RouterServiceAccount are the ServiceAccounts those
+	// components run as. Together they name the SPIFFE identities that atunnel
+	// authenticates inside each worker, which is why the ServiceAccount names
+	// are configuration and not constants: a Helm release that prefixes
+	// resource names changes them.
+	SystemNamespace      string
+	AteletServiceAccount string
+	RouterServiceAccount string
 
 	desiredWorkers metric.Int64ObservableUpDownCounter
 	readyWorkers   metric.Int64ObservableUpDownCounter
@@ -120,7 +125,7 @@ func (r *WorkerPoolReconciler) applyDeployment(ctx context.Context, wp *atev1alp
 		MetricExportTimeout:  r.OTelMetricExportTimeout,
 		TracesSampler:        r.OTelTracesSampler,
 		TracesSamplerArg:     r.OTelTracesSamplerArg,
-	}, r.SystemNamespace)
+	}, r.SystemNamespace, r.AteletServiceAccount, r.RouterServiceAccount)
 	if err := r.Apply(ctx, depAC, client.FieldOwner(workerPoolFieldOwner), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply Deployment: %w", err)
 	}

--- a/cmd/atecontroller/internal/controllers/workerpool_controller.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller.go
@@ -52,6 +52,10 @@ type WorkerPoolReconciler struct {
 	// OTelTracesSamplerArg is the OTEL_TRACES_SAMPLER_ARG propagated to ateom
 	// pods. Ignored unless OTelTracesSampler is set.
 	OTelTracesSamplerArg string
+	// SystemNamespace is the namespace substrate's control plane runs in. It
+	// names the atenet-router and atelet SPIFFE identities that atunnel
+	// authenticates inside each worker.
+	SystemNamespace string
 
 	desiredWorkers metric.Int64ObservableUpDownCounter
 	readyWorkers   metric.Int64ObservableUpDownCounter
@@ -116,7 +120,7 @@ func (r *WorkerPoolReconciler) applyDeployment(ctx context.Context, wp *atev1alp
 		MetricExportTimeout:  r.OTelMetricExportTimeout,
 		TracesSampler:        r.OTelTracesSampler,
 		TracesSamplerArg:     r.OTelTracesSamplerArg,
-	})
+	}, r.SystemNamespace)
 	if err := r.Apply(ctx, depAC, client.FieldOwner(workerPoolFieldOwner), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply Deployment: %w", err)
 	}

--- a/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
@@ -43,6 +43,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/testenv"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 )
@@ -86,8 +87,9 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := (&NetworkPolicyReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		SystemNamespace: installdefaults.SystemNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		fmt.Fprintf(os.Stderr, "netpolicy controller setup failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/atecontroller/internal/controllers"
 	"github.com/agent-substrate/substrate/cmd/atecontroller/internal/workersync"
 	"github.com/agent-substrate/substrate/internal/ateapiauth"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/serverboot"
 	clientv1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/client/clientset/versioned"
@@ -152,7 +153,8 @@ func main() {
 	ateapiClient := ateapipb.NewControlClient(ateapiConn)
 
 	// EgressMITMTrustReconciler watches the Secret `egress-mitm-ca-pool`.
-	egressMITMCAPool := controllers.EgressMITMCAPoolRef()
+	systemNamespace := installdefaults.NamespaceFromPodEnv()
+	egressMITMCAPool := controllers.EgressMITMCAPoolRef(systemNamespace)
 	mgr, err := ctrl.NewManager(k8sConfig, ctrl.Options{
 		Scheme: scheme,
 		Cache: cache.Options{
@@ -180,21 +182,24 @@ func main() {
 		OTelMetricExportTimeout:  *otelMetricExportTimeout,
 		OTelTracesSampler:        *otelTracesSampler,
 		OTelTracesSamplerArg:     *otelTracesSamplerArg,
+		SystemNamespace:          systemNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkerPool")
 		os.Exit(1)
 	}
 
 	if err = (&controllers.NetworkPolicyReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		SystemNamespace: systemNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NetPolicy")
 		os.Exit(1)
 	}
 
 	if err = (&controllers.EgressMITMTrustReconciler{
-		Client: mgr.GetClient(),
+		Client:          mgr.GetClient(),
+		SystemNamespace: systemNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EgressMITMTrust")
 		os.Exit(1)

--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -71,6 +71,9 @@ var (
 	otelTracesSamplerArg = pflag.String("otel-traces-sampler-arg", os.Getenv("OTEL_TRACES_SAMPLER_ARG"),
 		"Trace sampler argument set on ateom worker pods, ignored unless --otel-traces-sampler is set. Defaults to the controller's own OTEL_TRACES_SAMPLER_ARG.")
 
+	ateletServiceAccount = pflag.String("atelet-service-account", installdefaults.AteletServiceAccount, "ServiceAccount atelet runs as. It is the service-account segment of the SPIFFE ID each worker's atunnel expects on the credential broker, so it has to match what the deployment actually creates.")
+	routerServiceAccount = pflag.String("router-service-account", installdefaults.RouterServiceAccount, "ServiceAccount atenet-router runs as. It is the service-account segment of the SPIFFE ID each worker's atunnel accepts on actor ingress, so it has to match what the deployment actually creates.")
+
 	ateapiCAFile     = pflag.String("ateapi-ca-file", ateapiauth.DefaultServiceAccountCAFile, "PEM file with CAs trusted to verify the ateapi server cert.")
 	ateapiServerName = pflag.String("ateapi-server-name", "", "SNI / hostname expected on the ateapi server cert. Optional.")
 	ateapiClientCert = pflag.String("ateapi-client-cert", "", "Credential bundle presented as the client certificate when dialing ateapi. Required.")
@@ -152,6 +155,16 @@ func main() {
 
 	ateapiClient := ateapipb.NewControlClient(ateapiConn)
 
+	// Empty ServiceAccounts would not fail here: path.Join drops the empty
+	// segment, yielding identities that parse but match nothing, so every
+	// worker would reject both of its peers with no hint at the cause.
+	for flag, value := range map[string]string{"--atelet-service-account": *ateletServiceAccount, "--router-service-account": *routerServiceAccount} {
+		if value == "" {
+			setupLog.Error(nil, "invalid flag", "flag", flag, "reason", "must not be empty")
+			os.Exit(1)
+		}
+	}
+
 	// EgressMITMTrustReconciler watches the Secret `egress-mitm-ca-pool`.
 	systemNamespace := installdefaults.NamespaceFromPodEnv()
 	egressMITMCAPool := controllers.EgressMITMCAPoolRef(systemNamespace)
@@ -183,6 +196,8 @@ func main() {
 		OTelTracesSampler:        *otelTracesSampler,
 		OTelTracesSamplerArg:     *otelTracesSamplerArg,
 		SystemNamespace:          systemNamespace,
+		AteletServiceAccount:     *ateletServiceAccount,
+		RouterServiceAccount:     *routerServiceAccount,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkerPool")
 		os.Exit(1)

--- a/cmd/atenet/internal/router/cmd.go
+++ b/cmd/atenet/internal/router/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/agent-substrate/substrate/cmd/atenet/internal/router/ingress"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 )
 
 func NewRouterCmd() *cobra.Command {
@@ -46,6 +47,7 @@ func NewRouterCmd() *cobra.Command {
 	cmd.Flags().StringVar(&cfg.MetricsAddr, "metrics-listen-addr", ":9090", "Address and port the prometheus metrics server should listen on.")
 	cmd.Flags().StringVar(&cfg.AtenetRouter, "atenet-router", string(atenetRouterEnvoy), "Router dataplane: envoy or agentgateway")
 	cmd.Flags().StringVar(&cfg.Namespace, "namespace", "default", "Target operations namespace")
+	cmd.Flags().StringVar(&cfg.RouterServiceName, "router-service-name", installdefaults.RouterServiceName, "Service name of this atenet-router in the operations namespace. Override when the deployment renames the Service.")
 	cmd.Flags().StringVar(&cfg.Kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig configuration file")
 	cmd.Flags().StringVar(&cfg.AteapiAddr, "ateapi-address", "k8s:///api.ate-system.svc:443", "gRPC dial target for the cluster ateapi Control instance.")
 	cmd.Flags().IntVar(&cfg.HttpPort, "port-http", 8080, "TCP port for workload traffic entering through the Envoy Router")

--- a/cmd/atenet/internal/router/config.go
+++ b/cmd/atenet/internal/router/config.go
@@ -74,18 +74,22 @@ type authConfig struct {
 // routerConfig holds deployment setup and endpoint options for the router node instance.
 type routerConfig struct {
 	// Mode restricts the instance to one traffic direction. Empty means ModeAll.
-	Mode           Mode
-	AtenetRouter   string
-	Namespace      string
-	Kubeconfig     string
-	AteapiAddr     string
-	HttpPort       int
-	XdsPort        int
-	ExtprocPort    int
-	ExtprocAddr    string
-	StatusPort     int
-	HealthInterval time.Duration
-	HttpsPort      int
+	Mode         Mode
+	AtenetRouter string
+	Namespace    string
+	// RouterServiceName is the Service name of this atenet-router in the
+	// operations namespace, used by /statusz to look up its own ClusterIP.
+	// Defaults to installdefaults.RouterServiceName.
+	RouterServiceName string
+	Kubeconfig        string
+	AteapiAddr        string
+	HttpPort          int
+	XdsPort           int
+	ExtprocPort       int
+	ExtprocAddr       string
+	StatusPort        int
+	HealthInterval    time.Duration
+	HttpsPort         int
 	// ConnectPlainTextPort and ConnectTLSPort are the plaintext and TLS
 	// listener ports for CONNECT-tunneled traffic. Non-positive disables the
 	// corresponding listener.

--- a/cmd/atenet/internal/router/status.go
+++ b/cmd/atenet/internal/router/status.go
@@ -68,7 +68,7 @@ func (s *RouterServer) getRouterIP(ctx context.Context) string {
 		return "Offline Mode (No Cluster IP)"
 	}
 
-	svc, err := s.clientset.CoreV1().Services(s.cfg.Namespace).Get(ctx, "atenet-router", metav1.GetOptions{})
+	svc, err := s.clientset.CoreV1().Services(s.cfg.Namespace).Get(ctx, s.cfg.RouterServiceName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Sprintf("Lookup Failed: %v", err)
 	}

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/childreap"
 	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/agent-substrate/substrate/internal/imagecache"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/ocispec"
 	"github.com/agent-substrate/substrate/internal/otlprelay"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
@@ -74,7 +75,8 @@ var (
 	atunnelConnectListenAddress = pflag.String("atunnel-connect-listen-address", ":8443", "Address for actor ingress mTLS CONNECT")
 	workerCredentialBundle      = pflag.String("atunnel-credential-bundle", "/run/podidentity.podcert.ate.dev/credential-bundle.pem", "Worker Pod credential bundle used by atunnel for inbound serving and outbound mTLS")
 	podIdentityTrustBundle      = pflag.String("atunnel-trust-bundle", "/run/podidentity.podcert.ate.dev/trust-bundle.pem", "Pod identity trust bundle used for router clients and the node-local atelet")
-	atunnelClientIdentity       = pflag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")
+	atunnelClientIdentity       = pflag.String("atunnel-client-identity", installdefaults.RouterSPIFFEID(installdefaults.SystemNamespace), "SPIFFE identity allowed to call actor ingress HTTPS")
+	ateletIdentity              = pflag.String("atunnel-broker-identity", installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace), "SPIFFE identity the node-local atelet must present on the credential broker connection. Override when atelet runs outside the default namespace.")
 	atunnelEgressListenAddress  = pflag.String("atunnel-egress-listen-address", "0.0.0.0:15001", "Address for transparently intercepted actor egress TCP")
 	egressGatewayTrustBundle    = pflag.String("atunnel-egress-trust-bundle", "/run/servicedns.podcert.ate.dev/trust-bundle.pem", "Service DNS trust bundle for the remote egress gateway")
 	readinessListenAddress      = pflag.String("readiness-listen-address", "0.0.0.0:8080", "Address for HTTP readiness checks")
@@ -214,7 +216,7 @@ func do(ctx context.Context) error {
 		return err
 	}
 
-	ateomService := NewService(interiorNetNS, actorLogger, atunnelIngress, atunnelEgress, atunnelEgressPort, *workerCredentialBundle, *podIdentityTrustBundle, *egressGatewayTrustBundle)
+	ateomService := NewService(interiorNetNS, actorLogger, atunnelIngress, atunnelEgress, atunnelEgressPort, *workerCredentialBundle, *podIdentityTrustBundle, *egressGatewayTrustBundle, *ateletIdentity)
 
 	svr := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
@@ -250,6 +252,7 @@ func do(ctx context.Context) error {
 			SocketPath:           ateompath.CredentialBrokerSocket,
 			CredentialBundlePath: *workerCredentialBundle,
 			TrustBundlePath:      *podIdentityTrustBundle,
+			AteletSPIFFEID:       *ateletIdentity,
 		})
 		if err != nil && ctx.Err() == nil {
 			serverboot.Fatal(ctx, "Failed to report worker capacity", err)
@@ -389,6 +392,10 @@ type AteomService struct {
 	podIdentityTrustBundlePath string
 	// egressGatewayTrustBundlePath verifies the remote gateway's serving cert.
 	egressGatewayTrustBundlePath string
+	// ateletSPIFFEID is the identity the node-local atelet must present on the
+	// credential broker connection. It names atelet's namespace, not this
+	// worker's, so it is configured rather than derived from the downward API.
+	ateletSPIFFEID string
 
 	// activeActor is the actor whose workload this ateom is currently running,
 	// or nil when it is "available". An ateom serves one actor at a time, so a
@@ -440,7 +447,7 @@ type AteomService struct {
 var _ ateompb.AteomServer = (*AteomService)(nil)
 
 // NewService creates a new AteomService.
-func NewService(interiorNetNS netns.NsHandle, actorLogger *actorlog.ActorLogger, atunnelIngress *atunnel.Server, atunnelEgress *atunnel.Egress, atunnelEgressPort uint16, workerCredentialBundlePath, podIdentityTrustBundlePath, egressGatewayTrustBundlePath string) *AteomService {
+func NewService(interiorNetNS netns.NsHandle, actorLogger *actorlog.ActorLogger, atunnelIngress *atunnel.Server, atunnelEgress *atunnel.Egress, atunnelEgressPort uint16, workerCredentialBundlePath, podIdentityTrustBundlePath, egressGatewayTrustBundlePath, ateletSPIFFEID string) *AteomService {
 	return &AteomService{
 		lock:                         newCancelableMutex(),
 		interiorNetNS:                interiorNetNS,
@@ -451,6 +458,7 @@ func NewService(interiorNetNS netns.NsHandle, actorLogger *actorlog.ActorLogger,
 		workerCredentialBundlePath:   workerCredentialBundlePath,
 		podIdentityTrustBundlePath:   podIdentityTrustBundlePath,
 		egressGatewayTrustBundlePath: egressGatewayTrustBundlePath,
+		ateletSPIFFEID:               ateletSPIFFEID,
 		cgroupRoot:                   defaultCgroupRoot,
 	}
 }
@@ -1085,6 +1093,7 @@ func (s *AteomService) prepareActorEgress(ctx context.Context, actorUID string, 
 		CredentialBundlePath: s.workerCredentialBundlePath,
 		TrustBundlePath:      s.podIdentityTrustBundlePath,
 		ExpectedActorUID:     actorUID,
+		AteletSPIFFEID:       s.ateletSPIFFEID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("while configuring actor certificate broker: %w", err)

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateomnet"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/atunnel"
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/otlprelay"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	"github.com/agent-substrate/substrate/internal/resources"
@@ -78,7 +79,8 @@ var (
 	atunnelConnectListenAddress = flag.String("atunnel-connect-listen-address", ":8443", "Address for actor ingress mTLS CONNECT")
 	workerCredentialBundle      = flag.String("atunnel-credential-bundle", "/run/podidentity.podcert.ate.dev/credential-bundle.pem", "Worker Pod credential bundle used by atunnel for inbound serving and outbound mTLS")
 	podIdentityTrustBundle      = flag.String("atunnel-trust-bundle", "/run/podidentity.podcert.ate.dev/trust-bundle.pem", "Pod identity trust bundle used for router clients and the node-local atelet")
-	atunnelClientIdentity       = flag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")
+	atunnelClientIdentity       = flag.String("atunnel-client-identity", installdefaults.RouterSPIFFEID(installdefaults.SystemNamespace), "SPIFFE identity allowed to call actor ingress HTTPS")
+	ateletIdentity              = flag.String("atunnel-broker-identity", installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace), "SPIFFE identity the node-local atelet must present on the credential broker connection. Override when atelet runs outside the default namespace.")
 	atunnelEgressListenAddress  = flag.String("atunnel-egress-listen-address", "0.0.0.0:15001", "Address for transparently intercepted actor egress TCP")
 	egressGatewayTrustBundle    = flag.String("atunnel-egress-trust-bundle", "/run/servicedns.podcert.ate.dev/trust-bundle.pem", "Service DNS trust bundle for the remote egress gateway")
 	readinessListenAddress      = flag.String("readiness-listen-address", "0.0.0.0:8080", "Address for HTTP readiness checks")
@@ -257,7 +259,7 @@ func do(ctx context.Context) error {
 	}()
 	slog.InfoContext(ctx, "atunnel egress serving", slog.String("address", *atunnelEgressListenAddress))
 
-	ateomService := NewService(*podUID, *chBinary, *kataConfig, *kataDebug, *vmmMemReserve, interiorNetNS, actorLogger, atunnelIngress, atunnelEgress, atunnelEgressPort, *workerCredentialBundle, *podIdentityTrustBundle, *egressGatewayTrustBundle)
+	ateomService := NewService(*podUID, *chBinary, *kataConfig, *kataDebug, *vmmMemReserve, interiorNetNS, actorLogger, atunnelIngress, atunnelEgress, atunnelEgressPort, *workerCredentialBundle, *podIdentityTrustBundle, *egressGatewayTrustBundle, *ateletIdentity)
 
 	svr := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
@@ -297,6 +299,7 @@ func do(ctx context.Context) error {
 			SocketPath:           ateompath.CredentialBrokerSocket,
 			CredentialBundlePath: *workerCredentialBundle,
 			TrustBundlePath:      *podIdentityTrustBundle,
+			AteletSPIFFEID:       *ateletIdentity,
 		})
 		if err != nil && ctx.Err() == nil {
 			serverboot.Fatal(ctx, "Failed to report worker capacity", err)
@@ -440,6 +443,10 @@ type AteomService struct {
 	podIdentityTrustBundlePath string
 	// egressGatewayTrustBundlePath verifies the remote gateway's serving cert.
 	egressGatewayTrustBundlePath string
+	// ateletSPIFFEID is the identity the node-local atelet must present on the
+	// credential broker connection. It names atelet's namespace, not this
+	// worker's, so it is configured rather than derived from the downward API.
+	ateletSPIFFEID string
 
 	// running maps actor UID -> the live micro-VM, kept so CheckpointWorkload can
 	// pause+snapshot+teardown the same sandbox (and RestoreWorkload can track the
@@ -493,7 +500,7 @@ type AteomService struct {
 var _ ateompb.AteomServer = (*AteomService)(nil)
 
 // NewService creates a new AteomService.
-func NewService(podUID, chBinary, kataConfig string, kataDebug bool, memReserveMiB int, interiorNetNS netns.NsHandle, actorLogger *actorlog.ActorLogger, atunnelIngress *atunnel.Server, atunnelEgress *atunnel.Egress, atunnelEgressPort uint16, workerCredentialBundlePath, podIdentityTrustBundlePath, egressGatewayTrustBundlePath string) *AteomService {
+func NewService(podUID, chBinary, kataConfig string, kataDebug bool, memReserveMiB int, interiorNetNS netns.NsHandle, actorLogger *actorlog.ActorLogger, atunnelIngress *atunnel.Server, atunnelEgress *atunnel.Egress, atunnelEgressPort uint16, workerCredentialBundlePath, podIdentityTrustBundlePath, egressGatewayTrustBundlePath, ateletSPIFFEID string) *AteomService {
 	return &AteomService{
 		lock:                         newCancelableMutex(),
 		podUID:                       podUID,
@@ -509,6 +516,7 @@ func NewService(podUID, chBinary, kataConfig string, kataDebug bool, memReserveM
 		workerCredentialBundlePath:   workerCredentialBundlePath,
 		podIdentityTrustBundlePath:   podIdentityTrustBundlePath,
 		egressGatewayTrustBundlePath: egressGatewayTrustBundlePath,
+		ateletSPIFFEID:               ateletSPIFFEID,
 		running:                      map[string]*runningActor{},
 	}
 }
@@ -537,6 +545,7 @@ func (s *AteomService) prepareActorEgress(ctx context.Context, actorUID string, 
 		CredentialBundlePath: s.workerCredentialBundlePath,
 		TrustBundlePath:      s.podIdentityTrustBundlePath,
 		ExpectedActorUID:     actorUID,
+		AteletSPIFFEID:       s.ateletSPIFFEID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("while configuring actor certificate broker: %w", err)

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -47,6 +47,11 @@ fi
 # below refuses the combination that would half-install.
 ATE_NAMESPACE="${ATE_NAMESPACE:-ate-system}"
 
+# Service name fronting ateapi. It is the audience the API authentication config
+# accepts, so it has to match the Service the deployment actually creates; a
+# Helm release that prefixes resource names needs it set.
+ATE_API_SERVICE_NAME="${ATE_API_SERVICE_NAME:-api}"
+
 # ATE_DEMOS is an array that registers the prefix name of the demo functions.
 ATE_DEMOS=()
 
@@ -345,6 +350,13 @@ require_default_namespace_for_manifests() {
     echo "       manifests/ate-install/ hardcodes the ate-system namespace. Install into" >&2
     echo "       another namespace with the Helm chart, then use this script only for the" >&2
     echo "       --create-* bootstrap steps." >&2
+    exit 1
+  fi
+  if [[ "${ATE_API_SERVICE_NAME}" != "api" ]]; then
+    echo "error: ATE_API_SERVICE_NAME=${ATE_API_SERVICE_NAME} cannot be used with the manifest-applying subcommands." >&2
+    echo "       manifests/ate-install/ creates the Service literally named api, so tokens" >&2
+    echo "       minted for this audience would all be rejected. A renamed Service comes" >&2
+    echo "       from a Helm install; use this script only for the --create-* bootstrap steps." >&2
     exit 1
   fi
 }
@@ -870,7 +882,7 @@ create_api_authentication_config() {
       ;;
   esac
   local authentication_config
-  authentication_config=$(printf 'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: %s\n  audiences: [api.%s.svc]\n%s' "${jwt_issuer}" "${ATE_NAMESPACE}" "${discovery_config}")
+  authentication_config=$(printf 'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: %s\n  audiences: [%s.%s.svc]\n%s' "${jwt_issuer}" "${ATE_API_SERVICE_NAME}" "${ATE_NAMESPACE}" "${discovery_config}")
   echo "ate-api-authentication authentication.yaml:"
   echo "  | ${authentication_config//$'\n'/$'\n'  | }"
   run_kubectl create configmap -n "${ATE_NAMESPACE}" ate-api-authentication \

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -35,6 +35,18 @@ if [[ -z "${KUBECTL_CONTEXT:-}" ]]; then
 fi
 # otherwise just use the current cluster in KUBECONFIG ...
 
+# Namespace the substrate control plane is installed into. Defaults to the
+# canonical ate-system so existing flows are unaffected.
+#
+# This applies to the resources this script creates and waits on: the mTLS
+# authorities, the api-server ConfigMaps, and the rollout checks. It does NOT
+# relocate the checked-in manifests, which carry `namespace: ate-system`
+# literally and are applied verbatim by render_ate_system_manifests. Installing
+# into another namespace means installing with the Helm chart and using this
+# script only for the bootstrap steps; require_default_namespace_for_manifests
+# below refuses the combination that would half-install.
+ATE_NAMESPACE="${ATE_NAMESPACE:-ate-system}"
+
 # ATE_DEMOS is an array that registers the prefix name of the demo functions.
 ATE_DEMOS=()
 
@@ -247,8 +259,20 @@ rollout_timeout() {
   echo "${timeout}"
 }
 
+# ensure_ate_namespace creates ATE_NAMESPACE and waits for it to go Active.
+ensure_ate_namespace() {
+  if [[ "${ATE_NAMESPACE}" == "ate-system" ]]; then
+    run_kubectl apply -f manifests/ate-install/ate-system-namespace.yaml
+  else
+    run_kubectl create namespace "${ATE_NAMESPACE}" --dry-run=client -o yaml \
+      | run_kubectl apply -f -
+  fi
+  run_kubectl wait --for=jsonpath='{.status.phase}'=Active \
+    "namespace/${ATE_NAMESPACE}" --timeout=60s
+}
+
 default_postgres_connection_string() {
-  echo "postgresql://postgres@postgres.ate-system.svc:5432/atepg?sslmode=verify-full&sslrootcert=/run/servicedns.podcert.ate.dev/trust-bundle.pem&sslcert=/run/podidentity.podcert.ate.dev/credential-bundle.pem&sslkey=/run/podidentity.podcert.ate.dev/credential-bundle.pem"
+  echo "postgresql://postgres@postgres.${ATE_NAMESPACE}.svc:5432/atepg?sslmode=verify-full&sslrootcert=/run/servicedns.podcert.ate.dev/trust-bundle.pem&sslcert=/run/podidentity.podcert.ate.dev/credential-bundle.pem&sslkey=/run/podidentity.podcert.ate.dev/credential-bundle.pem"
 }
 
 # True if deploying the bundled in-cluster PostgreSQL. Returns false if an
@@ -310,7 +334,23 @@ label_nodes_substrate_version() {
   done
 }
 
+# require_default_namespace_for_manifests stops the manifest-applying paths when
+# ATE_NAMESPACE has been overridden. Those manifests name ate-system literally,
+# so proceeding would put the workloads in ate-system while this script created
+# their secrets and ConfigMaps somewhere else — an install that comes up far
+# enough to look healthy and then fails on a missing envFrom source.
+require_default_namespace_for_manifests() {
+  if [[ "${ATE_NAMESPACE}" != "ate-system" ]]; then
+    echo "error: ATE_NAMESPACE=${ATE_NAMESPACE} cannot be used with the manifest-applying subcommands." >&2
+    echo "       manifests/ate-install/ hardcodes the ate-system namespace. Install into" >&2
+    echo "       another namespace with the Helm chart, then use this script only for the" >&2
+    echo "       --create-* bootstrap steps." >&2
+    exit 1
+  fi
+}
+
 render_ate_system_manifests() {
+  require_default_namespace_for_manifests
   local router=""
   router="$(atenet_router)"
 
@@ -387,14 +427,14 @@ apply_atenet_egress() {
   # bootstrap arrives as a ConfigMap change, and an otherwise unchanged
   # Deployment will not pick that up on its own.
   local running=false
-  if run_kubectl -n ate-system get deployment/atenet-egress >/dev/null 2>&1; then
+  if run_kubectl -n "${ATE_NAMESPACE}" get deployment/atenet-egress >/dev/null 2>&1; then
     running=true
   fi
 
   echo "${manifests}" | run_kubectl apply -f -
 
   if [[ "${running}" == "true" ]] && additional_egress_extproc_enabled; then
-    run_kubectl -n ate-system rollout restart deployment/atenet-egress
+    run_kubectl -n "${ATE_NAMESPACE}" rollout restart deployment/atenet-egress
   fi
 }
 
@@ -443,28 +483,28 @@ apply_otel_endpoint_override() {
   fi
 
   local current=""
-  current="$(run_kubectl -n ate-system get configmap ate-otel-config \
+  current="$(run_kubectl -n "${ATE_NAMESPACE}" get configmap ate-otel-config \
     -o jsonpath='{.data.OTEL_EXPORTER_OTLP_ENDPOINT}' 2>/dev/null || true)"
   if [[ "${current}" == "${ATE_OTLP_ENDPOINT}" ]]; then
     return 0
   fi
 
   echo "Overriding OTEL_EXPORTER_OTLP_ENDPOINT with ${ATE_OTLP_ENDPOINT}"
-  run_kubectl -n ate-system patch configmap ate-otel-config --type=merge \
+  run_kubectl -n "${ATE_NAMESPACE}" patch configmap ate-otel-config --type=merge \
     -p "{\"data\":{\"OTEL_EXPORTER_OTLP_ENDPOINT\":\"${ATE_OTLP_ENDPOINT}\"}}"
 
   local workload
   for workload in deployment/ate-api-server deployment/ate-controller \
                   deployment/atenet-router; do
-    if run_kubectl -n ate-system get "${workload}" >/dev/null 2>&1; then
-      run_kubectl -n ate-system rollout restart "${workload}"
+    if run_kubectl -n "${ATE_NAMESPACE}" get "${workload}" >/dev/null 2>&1; then
+      run_kubectl -n "${ATE_NAMESPACE}" rollout restart "${workload}"
     fi
   done
   # atelet DaemonSet names carry a version suffix; restart whichever versions
   # are installed.
   local ds=""
-  for ds in $(run_kubectl -n ate-system get daemonset -l app=atelet -o name 2>/dev/null); do
-    run_kubectl -n ate-system rollout restart "${ds}"
+  for ds in $(run_kubectl -n "${ATE_NAMESPACE}" get daemonset -l app=atelet -o name 2>/dev/null); do
+    run_kubectl -n "${ATE_NAMESPACE}" rollout restart "${ds}"
   done
 }
 
@@ -486,7 +526,7 @@ create_jwt_authority_pool_secret() {
   run_kubectl_ate admin make-jwt-pool \
     --key-id="1" \
     --name="actor-id-jwt-pool" \
-    --secret-namespace=ate-system
+    --secret-namespace="${ATE_NAMESPACE}"
 }
 
 create_actor_id_ca_pool_secret() {
@@ -494,7 +534,7 @@ create_actor_id_ca_pool_secret() {
   run_kubectl_ate admin make-ca-pool \
     --ca-id="1" \
     --name="actor-id-ca-pool" \
-    --secret-namespace=ate-system
+    --secret-namespace="${ATE_NAMESPACE}"
 }
 
 # The egress gateway has to verify actor client certificates, which means it
@@ -508,7 +548,7 @@ create_actor_id_ca_certs_secret() {
   # inside the create-secret argument list, which would silently produce an
   # empty trust bundle and an egress gateway that rejects every actor.
   local actorid_root=""
-  actorid_root=$(ca_pool_root_pem actor-id-ca-pool ate-system)
+  actorid_root=$(ca_pool_root_pem actor-id-ca-pool "${ATE_NAMESPACE}")
   if [[ -z "${actorid_root}" ]]; then
     echo "error: failed to extract the actor-identity CA root for actor-id-ca-certs" >&2
     return 1
@@ -516,7 +556,7 @@ create_actor_id_ca_certs_secret() {
 
   run_kubectl create secret generic actor-id-ca-certs \
     --from-literal=ca.crt="${actorid_root}" \
-    -n ate-system \
+    -n "${ATE_NAMESPACE}" \
     --dry-run=client -o yaml \
     | run_kubectl apply -f -
 }
@@ -530,7 +570,7 @@ create_egress_mitm_ca_pool_secret() {
   run_kubectl_ate admin make-ca-pool \
     --ca-id="1" \
     --name="egress-mitm-ca-pool" \
-    --secret-namespace=ate-system \
+    --secret-namespace="${ATE_NAMESPACE}" \
     --key-type=ECDSAP256
 }
 
@@ -541,7 +581,7 @@ ensure_egress_mitm_ca_pool_secret() {
   if [[ "${ATE_EXPERIMENTAL_USE_SDSMINT:-false}" != "true" ]]; then
     return 0
   fi
-  run_kubectl get secret -n ate-system egress-mitm-ca-pool >/dev/null 2>&1 \
+  run_kubectl get secret -n "${ATE_NAMESPACE}" egress-mitm-ca-pool >/dev/null 2>&1 \
     || create_egress_mitm_ca_pool_secret
 }
 
@@ -576,7 +616,7 @@ resolve_cloudsql_instance() {
     echo "${ATE_API_POSTGRES_CLOUDSQL_INSTANCE}"
     return
   fi
-  run_kubectl get configmap -n ate-system ate-api-server-envvars \
+  run_kubectl get configmap -n "${ATE_NAMESPACE}" ate-api-server-envvars \
     -o jsonpath='{.data.ATE_API_POSTGRES_CLOUDSQL_INSTANCE}' 2>/dev/null || true
 }
 
@@ -587,13 +627,13 @@ resolve_cloudsql_gsa() {
     echo "${ATE_API_POSTGRES_CLOUDSQL_GSA}"
     return
   fi
-  run_kubectl get serviceaccount ate-api-server -n ate-system \
+  run_kubectl get serviceaccount ate-api-server -n "${ATE_NAMESPACE}" \
     -o "jsonpath={.metadata.annotations.iam\.gke\.io/gcp-service-account}" 2>/dev/null || true
 }
 
 # recorded_envvar echoes one key from the ate-api-server-envvars ConfigMap.
 recorded_envvar() {
-  run_kubectl get configmap -n ate-system ate-api-server-envvars \
+  run_kubectl get configmap -n "${ATE_NAMESPACE}" ate-api-server-envvars \
     -o "jsonpath={.data.$1}" 2>/dev/null || true
 }
 
@@ -602,11 +642,11 @@ recorded_envvar() {
 # would prune the ConfigMap key and leave the running Deployment without a DSN.
 # Full deploys are safe because they update the Deployment manifest immediately.
 ensure_env_vars_safe_standalone() {
-  if ! run_kubectl get deployment ate-api-server -n ate-system >/dev/null 2>&1; then
+  if ! run_kubectl get deployment ate-api-server -n "${ATE_NAMESPACE}" >/dev/null 2>&1; then
     return 0 # fresh install: the manifest applied later carries the secretRef
   fi
   local refs
-  refs="$(run_kubectl get deployment ate-api-server -n ate-system \
+  refs="$(run_kubectl get deployment ate-api-server -n "${ATE_NAMESPACE}" \
     -o jsonpath='{.spec.template.spec.containers[0].envFrom[*].secretRef.name}' 2>/dev/null || true)"
   if [[ "${refs}" != *ate-api-server-secret-envvars* ]]; then
     echo "Error: the running ate-api-server Deployment does not reference the" \
@@ -621,22 +661,22 @@ ensure_env_vars_safe_standalone() {
 # updates don't roll pods automatically, we patch a hash of the config into
 # the deployment template.
 annotate_api_server_env_hash() {
-  if ! run_kubectl get deployment ate-api-server -n ate-system >/dev/null 2>&1; then
+  if ! run_kubectl get deployment ate-api-server -n "${ATE_NAMESPACE}" >/dev/null 2>&1; then
     return 0 # fresh install: the first rollout starts with the new values
   fi
   local hash
-  hash="$({ run_kubectl get configmap -n ate-system ate-api-server-envvars \
+  hash="$({ run_kubectl get configmap -n "${ATE_NAMESPACE}" ate-api-server-envvars \
               -o jsonpath='{.data}' 2>/dev/null || true
-            run_kubectl get secret -n ate-system ate-api-server-secret-envvars \
+            run_kubectl get secret -n "${ATE_NAMESPACE}" ate-api-server-secret-envvars \
               -o jsonpath='{.data}' 2>/dev/null || true; } \
           | openssl dgst -sha256 | awk '{print $NF}')"
-  run_kubectl patch deployment ate-api-server -n ate-system --type=strategic -p \
+  run_kubectl patch deployment ate-api-server -n "${ATE_NAMESPACE}" --type=strategic -p \
     "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"ate.dev/env-hash\":\"${hash}\"}}}}}"
 }
 
 create_api_server_env_vars() {
   log_step "create_api_server_env_vars"
-  run_kubectl create namespace ate-system --dry-run=client -o yaml \
+  run_kubectl create namespace "${ATE_NAMESPACE}" --dry-run=client -o yaml \
     | run_kubectl apply -f -
 
   local postgres_connection_string="${ATE_API_POSTGRES_CONNECTION_STRING:-}"
@@ -670,7 +710,7 @@ create_api_server_env_vars() {
         fi
       fi
       if [[ -z "${postgres_connection_string}" ]]; then
-        postgres_connection_string="$(run_kubectl get secret -n ate-system ate-api-server-secret-envvars \
+        postgres_connection_string="$(run_kubectl get secret -n "${ATE_NAMESPACE}" ate-api-server-secret-envvars \
           -o jsonpath='{.data.ATE_API_POSTGRES_CONNECTION_STRING}' 2>/dev/null | base64 --decode || true)"
       fi
     fi
@@ -754,7 +794,7 @@ create_api_server_env_vars() {
         ;;
     esac
   fi
-  run_kubectl create configmap -n ate-system ate-api-server-envvars \
+  run_kubectl create configmap -n "${ATE_NAMESPACE}" ate-api-server-envvars \
     ${cm_args[@]+"${cm_args[@]}"} \
     --dry-run=client -o yaml \
     | run_kubectl apply -f -
@@ -763,7 +803,7 @@ create_api_server_env_vars() {
   # auth), so it lives in a Secret, not the ConfigMap above. The deployment
   # lists the secretRef after the configMapRef, so this value wins if both
   # define the key.
-  run_kubectl create secret generic -n ate-system ate-api-server-secret-envvars \
+  run_kubectl create secret generic -n "${ATE_NAMESPACE}" ate-api-server-secret-envvars \
     --from-literal=ATE_API_POSTGRES_CONNECTION_STRING="${postgres_connection_string}" \
     --from-literal=ATE_API_POSTGRES_SCHEMA="${postgres_schema}" \
     --dry-run=client -o yaml \
@@ -774,7 +814,7 @@ create_api_server_env_vars() {
   # Cloud SQL: gcloud sql ssl server-ca-certs list --instance=<name> \
   #   --format="value(cert)" > server-ca.pem
   if [[ -n "${ATE_API_POSTGRES_SERVER_CA_FILE:-}" ]]; then
-    run_kubectl create secret generic -n ate-system postgres-server-ca \
+    run_kubectl create secret generic -n "${ATE_NAMESPACE}" postgres-server-ca \
       --from-file=server-ca.pem="${ATE_API_POSTGRES_SERVER_CA_FILE}" \
       --dry-run=client -o yaml \
       | run_kubectl apply -f -
@@ -805,7 +845,7 @@ apply_podcert_workers_override() {
 
 create_api_authentication_config() {
   log_step "create_api_authentication_config"
-  run_kubectl create namespace ate-system --dry-run=client -o yaml \
+  run_kubectl create namespace "${ATE_NAMESPACE}" --dry-run=client -o yaml \
     | run_kubectl apply -f -
 
   # ate-api-server accepts a token only if its iss claim equals this string
@@ -830,10 +870,10 @@ create_api_authentication_config() {
       ;;
   esac
   local authentication_config
-  authentication_config=$(printf 'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: %s\n  audiences: [api.ate-system.svc]\n%s' "${jwt_issuer}" "${discovery_config}")
+  authentication_config=$(printf 'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: %s\n  audiences: [api.%s.svc]\n%s' "${jwt_issuer}" "${ATE_NAMESPACE}" "${discovery_config}")
   echo "ate-api-authentication authentication.yaml:"
   echo "  | ${authentication_config//$'\n'/$'\n'  | }"
-  run_kubectl create configmap -n ate-system ate-api-authentication \
+  run_kubectl create configmap -n "${ATE_NAMESPACE}" ate-api-authentication \
     --from-literal=authentication.yaml="${authentication_config}" \
     --dry-run=client -o yaml \
     | run_kubectl apply -f -
@@ -894,8 +934,7 @@ deploy_ate_system() {
   ensure_substrate_version
 
   # Ensure namespace exists before applying RBAC or CRDs
-  run_kubectl apply -f manifests/ate-install/ate-system-namespace.yaml \
-    && run_kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/ate-system --timeout=60s
+  ensure_ate_namespace
 
   # The atelet DaemonSet applied below and the demo WorkerPools' worker pods
   # schedule only to version-labeled nodes.
@@ -967,13 +1006,13 @@ deploy_ate_system() {
 
   log_step "Waiting for ATE system components to be ready..."
   if use_bundled_postgres; then
-    run_kubectl rollout status statefulset/postgres -n ate-system --timeout="$(rollout_timeout)"
+    run_kubectl rollout status statefulset/postgres -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
   fi
-  run_kubectl rollout status deployment/ate-api-server -n ate-system --timeout="$(rollout_timeout)"
-  run_kubectl rollout status deployment/ate-controller -n ate-system --timeout="$(rollout_timeout)"
-  run_kubectl rollout status deployment/atenet-router -n ate-system --timeout="$(rollout_timeout)"
-  run_kubectl rollout status deployment/atenet-egress -n ate-system --timeout="$(rollout_timeout)"
-  run_kubectl rollout status "daemonset/$(atelet_daemonset_name)" -n ate-system --timeout="$(rollout_timeout)"
+  run_kubectl rollout status deployment/ate-api-server -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
+  run_kubectl rollout status deployment/ate-controller -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
+  run_kubectl rollout status deployment/atenet-router -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
+  run_kubectl rollout status deployment/atenet-egress -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
+  run_kubectl rollout status "daemonset/$(atelet_daemonset_name)" -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
 
   # After the bundle, which carries its own copy of ate-otel-config.
   apply_otel_endpoint_override
@@ -982,18 +1021,18 @@ deploy_ate_system() {
 # Ensure secrets and configmaps required by ate-apiserver
 ensure_apiserver_prerequisites() {
   log_step "ensure_apiserver_prerequisites"
-  run_kubectl get secret -n ate-system actor-id-jwt-pool >/dev/null 2>&1 \
+  run_kubectl get secret -n "${ATE_NAMESPACE}" actor-id-jwt-pool >/dev/null 2>&1 \
     || create_jwt_authority_pool_secret
-  run_kubectl get secret -n ate-system actor-id-ca-pool >/dev/null 2>&1 \
+  run_kubectl get secret -n "${ATE_NAMESPACE}" actor-id-ca-pool >/dev/null 2>&1 \
     || create_actor_id_ca_pool_secret
   # Derived from actor-id-ca-pool above, so it must come after it.
-  run_kubectl get secret -n ate-system actor-id-ca-certs >/dev/null 2>&1 \
+  run_kubectl get secret -n "${ATE_NAMESPACE}" actor-id-ca-certs >/dev/null 2>&1 \
     || create_actor_id_ca_certs_secret
   run_kubectl get secret -n podcertificate-controller-system service-dns-ca-pool >/dev/null 2>&1 \
     || create_podcertificate_controller_cas
   # Always reconcile the PostgreSQL connection settings.
   create_api_server_env_vars
-  run_kubectl get configmap -n ate-system ate-api-authentication >/dev/null 2>&1 \
+  run_kubectl get configmap -n "${ATE_NAMESPACE}" ate-api-authentication >/dev/null 2>&1 \
     || create_api_authentication_config
 }
 
@@ -1003,8 +1042,7 @@ deploy_ate_apiserver() {
   ensure_crds
 
   # Ensure namespace exists
-  run_kubectl apply -f manifests/ate-install/ate-system-namespace.yaml \
-    && run_kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/ate-system --timeout=60s
+  ensure_ate_namespace
 
   ensure_apiserver_prerequisites
   apply_otel_config
@@ -1012,7 +1050,7 @@ deploy_ate_apiserver() {
 
   run_ko apply -f manifests/ate-install/ate-api-server.yaml
   reconcile_cloudsql_proxy_sidecar
-  run_kubectl rollout status deployment/ate-api-server -n ate-system --timeout="$(rollout_timeout)"
+  run_kubectl rollout status deployment/ate-api-server -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
 }
 
 # Reconciles the Cloud SQL Auth Proxy sidecar and Workload Identity
@@ -1032,19 +1070,19 @@ reconcile_cloudsql_proxy_sidecar() {
     # SQL IAM database user.
     gsa="$(resolve_cloudsql_gsa)"
     if [[ -n "${gsa}" ]]; then
-      run_kubectl annotate serviceaccount ate-api-server -n ate-system \
+      run_kubectl annotate serviceaccount ate-api-server -n "${ATE_NAMESPACE}" \
         "iam.gke.io/gcp-service-account=${gsa}" --overwrite
     fi
-    run_kubectl patch deployment ate-api-server -n ate-system \
+    run_kubectl patch deployment ate-api-server -n "${ATE_NAMESPACE}" \
       --patch-file manifests/ate-install/cloudsql/proxy-sidecar-patch.yaml
-  elif run_kubectl get deployment ate-api-server -n ate-system \
+  elif run_kubectl get deployment ate-api-server -n "${ATE_NAMESPACE}" \
       -o jsonpath='{.spec.template.spec.initContainers[*].name}' 2>/dev/null \
       | grep -qw cloud-sql-proxy; then
     log_step "reconcile_cloudsql_proxy_sidecar (remove)"
     # shellcheck disable=SC2016
-    run_kubectl patch deployment ate-api-server -n ate-system --type=strategic \
+    run_kubectl patch deployment ate-api-server -n "${ATE_NAMESPACE}" --type=strategic \
       -p '{"spec":{"template":{"spec":{"initContainers":[{"name":"cloud-sql-proxy","$patch":"delete"}]}}}}'
-    run_kubectl annotate serviceaccount ate-api-server -n ate-system \
+    run_kubectl annotate serviceaccount ate-api-server -n "${ATE_NAMESPACE}" \
       "iam.gke.io/gcp-service-account-" >/dev/null 2>&1 || true
   fi
 }
@@ -1055,8 +1093,7 @@ deploy_atelet() {
   ensure_crds
 
   # Ensure namespace exists
-  run_kubectl apply -f manifests/ate-install/ate-system-namespace.yaml \
-    && run_kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/ate-system --timeout=60s
+  ensure_ate_namespace
 
   label_nodes_substrate_version
   apply_otel_config
@@ -1071,7 +1108,7 @@ deploy_atelet() {
     manifest=$(run_ko resolve -f manifests/ate-install/atelet.yaml | substitute_version)
   fi
   echo "${manifest}" | run_kubectl apply -f -
-  run_kubectl rollout status "daemonset/$(atelet_daemonset_name)" -n ate-system --timeout="$(rollout_timeout)"
+  run_kubectl rollout status "daemonset/$(atelet_daemonset_name)" -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
 }
 
 deploy_atenet() {
@@ -1079,8 +1116,7 @@ deploy_atenet() {
   ensure_crds
 
   # Ensure namespace exists
-  run_kubectl apply -f manifests/ate-install/ate-system-namespace.yaml \
-    && run_kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/ate-system --timeout=60s
+  ensure_ate_namespace
 
   apply_otel_config
   apply_otel_endpoint_override
@@ -1091,8 +1127,8 @@ deploy_atenet() {
 
   ensure_egress_mitm_ca_pool_secret
   apply_atenet_egress
-  run_kubectl rollout status deployment/atenet-router -n ate-system --timeout="$(rollout_timeout)"
-  run_kubectl rollout status deployment/atenet-egress -n ate-system --timeout="$(rollout_timeout)"
+  run_kubectl rollout status deployment/atenet-router -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
+  run_kubectl rollout status deployment/atenet-egress -n "${ATE_NAMESPACE}" --timeout="$(rollout_timeout)"
 }
 
 # get_actor_state echoes the actor's state enum (e.g. ACTOR_STATE_SUSPENDED).
@@ -1160,7 +1196,7 @@ delete_demo_actors_substrate() {
     return 1
   fi
 
-  if ! run_kubectl get deployment/ate-api-server -n ate-system >/dev/null 2>&1; then
+  if ! run_kubectl get deployment/ate-api-server -n "${ATE_NAMESPACE}" >/dev/null 2>&1; then
     log_step "ate-api-server not found; skipping actor cleanup"
     return 0
   fi
@@ -1341,7 +1377,7 @@ delete_ate_system() {
     run_kubectl delete --ignore-not-found -f manifests/ate-install
   fi
 
-  run_kubectl delete --ignore-not-found -n ate-system daemonset -l app=atelet
+  run_kubectl delete --ignore-not-found -n "${ATE_NAMESPACE}" daemonset -l app=atelet
   run_kubectl delete --ignore-not-found \
     -f manifests/ate-install/components/agentgateway/configmap.yaml
   run_kubectl delete --ignore-not-found -f manifests/ate-install/postgres/postgres.yaml

--- a/internal/ateclient/builder.go
+++ b/internal/ateclient/builder.go
@@ -44,9 +44,25 @@ import (
 	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
-// apiServerName is the in-cluster DNS name of the ateapi Service, used as the
-// audience of the bearer token minted for it.
-var apiServerName = fmt.Sprintf("%s.%s.svc", installdefaults.APIServiceName, installdefaults.SystemNamespace)
+// NamespaceEnv overrides the namespace the client looks for substrate in. The
+// client runs outside the cluster, so it has no downward API to read and no pod
+// namespace to fall back on.
+const NamespaceEnv = "ATE_NAMESPACE"
+
+// systemNamespace is the namespace the client expects ateapi to be running in.
+func systemNamespace() string {
+	if ns := os.Getenv(NamespaceEnv); ns != "" {
+		return ns
+	}
+	return installdefaults.SystemNamespace
+}
+
+// apiServerName is the in-cluster DNS name of the ateapi Service. It is both the
+// name checked on ateapi's serving cert and the audience of the bearer token
+// minted for it, so it has to track the namespace ateapi actually runs in.
+func apiServerName() string {
+	return fmt.Sprintf("%s.%s.svc", installdefaults.APIServiceName, systemNamespace())
+}
 
 const (
 	// serviceDNSSignerName and liveBundleSelector mirror the
@@ -187,7 +203,7 @@ func dialPortForward(ctx context.Context, kubeconfigPath, k8sContext, tokenFile 
 
 	// TODO: Should we special-case a LoadBalancer "api" Service and dial its
 	// address directly instead of port-forwarding?
-	localPort, stopForward, err := portforward.ServicePortForward(ctx, config, clientset, installdefaults.SystemNamespace, installdefaults.APIServiceName, 443)
+	localPort, stopForward, err := portforward.ServicePortForward(ctx, config, clientset, systemNamespace(), installdefaults.APIServiceName, 443)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +268,7 @@ func serverTLSConfig(ctx context.Context, clientset kubernetes.Interface) (*tls.
 	return &tls.Config{
 		MinVersion: tls.VersionTLS13,
 		RootCAs:    pool,
-		ServerName: apiServerName,
+		ServerName: apiServerName(),
 	}, nil
 }
 
@@ -272,11 +288,11 @@ func bearerTokenDialOption(ctx context.Context, clientset *kubernetes.Clientset,
 	expirationSeconds := int64(3600)
 	tokenRequest := &authv1.TokenRequest{
 		Spec: authv1.TokenRequestSpec{
-			Audiences:         []string{apiServerName},
+			Audiences:         []string{apiServerName()},
 			ExpirationSeconds: &expirationSeconds,
 		},
 	}
-	token, err := clientset.CoreV1().ServiceAccounts(installdefaults.SystemNamespace).CreateToken(ctx, "ate-client", tokenRequest, metav1.CreateOptions{})
+	token, err := clientset.CoreV1().ServiceAccounts(systemNamespace()).CreateToken(ctx, "ate-client", tokenRequest, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to request ateapi bearer token: %w", err)
 	}

--- a/internal/ateclient/builder.go
+++ b/internal/ateclient/builder.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/portforward"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -43,9 +44,11 @@ import (
 	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
-const (
-	apiServerName = "api.ate-system.svc"
+// apiServerName is the in-cluster DNS name of the ateapi Service, used as the
+// audience of the bearer token minted for it.
+var apiServerName = fmt.Sprintf("%s.%s.svc", installdefaults.APIServiceName, installdefaults.SystemNamespace)
 
+const (
 	// serviceDNSSignerName and liveBundleSelector mirror the
 	// clusterTrustBundle projected-volume sources that in-cluster clients
 	// mount to verify ateapi's serving cert.
@@ -82,8 +85,8 @@ func (c *Client) Close() {
 	}
 }
 
-// NewClient creates a new Ate API client. If endpoint is empty, it automatically port-forwards
-// to the ate-api-server pod in the ate-system namespace.
+// NewClient creates a new Ate API client. If endpoint is empty, it automatically
+// port-forwards to the ate-api-server pod in substrate's system namespace.
 func NewClient(ctx context.Context, kubeconfigPath, k8sContext, endpoint, tokenFile string, traceEnabled bool) (*Client, error) {
 	tp, err := initTracing(ctx, traceEnabled)
 	if err != nil {
@@ -184,7 +187,7 @@ func dialPortForward(ctx context.Context, kubeconfigPath, k8sContext, tokenFile 
 
 	// TODO: Should we special-case a LoadBalancer "api" Service and dial its
 	// address directly instead of port-forwarding?
-	localPort, stopForward, err := portforward.ServicePortForward(ctx, config, clientset, "ate-system", "api", 443)
+	localPort, stopForward, err := portforward.ServicePortForward(ctx, config, clientset, installdefaults.SystemNamespace, installdefaults.APIServiceName, 443)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +276,7 @@ func bearerTokenDialOption(ctx context.Context, clientset *kubernetes.Clientset,
 			ExpirationSeconds: &expirationSeconds,
 		},
 	}
-	token, err := clientset.CoreV1().ServiceAccounts("ate-system").CreateToken(ctx, "ate-client", tokenRequest, metav1.CreateOptions{})
+	token, err := clientset.CoreV1().ServiceAccounts(installdefaults.SystemNamespace).CreateToken(ctx, "ate-client", tokenRequest, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to request ateapi bearer token: %w", err)
 	}

--- a/internal/ateclient/builder.go
+++ b/internal/ateclient/builder.go
@@ -49,6 +49,31 @@ import (
 // namespace to fall back on.
 const NamespaceEnv = "ATE_NAMESPACE"
 
+// APIServiceEnv and ClientServiceAccountEnv override the ateapi Service and the
+// ServiceAccount the client mints its token from. The Helm chart prefixes both
+// names for a release not called "substrate", and the client has no way to
+// discover that from outside the cluster.
+const (
+	APIServiceEnv           = "ATE_API_SERVICE_NAME"
+	ClientServiceAccountEnv = "ATE_CLIENT_SERVICE_ACCOUNT"
+)
+
+// apiServiceName is the Service that fronts ateapi.
+func apiServiceName() string {
+	if n := os.Getenv(APIServiceEnv); n != "" {
+		return n
+	}
+	return installdefaults.APIServiceName
+}
+
+// clientServiceAccount is the ServiceAccount the bearer token is minted from.
+func clientServiceAccount() string {
+	if n := os.Getenv(ClientServiceAccountEnv); n != "" {
+		return n
+	}
+	return installdefaults.ClientServiceAccount
+}
+
 // systemNamespace is the namespace the client expects ateapi to be running in.
 func systemNamespace() string {
 	if ns := os.Getenv(NamespaceEnv); ns != "" {
@@ -61,7 +86,7 @@ func systemNamespace() string {
 // name checked on ateapi's serving cert and the audience of the bearer token
 // minted for it, so it has to track the namespace ateapi actually runs in.
 func apiServerName() string {
-	return fmt.Sprintf("%s.%s.svc", installdefaults.APIServiceName, systemNamespace())
+	return fmt.Sprintf("%s.%s.svc", apiServiceName(), systemNamespace())
 }
 
 const (
@@ -203,7 +228,7 @@ func dialPortForward(ctx context.Context, kubeconfigPath, k8sContext, tokenFile 
 
 	// TODO: Should we special-case a LoadBalancer "api" Service and dial its
 	// address directly instead of port-forwarding?
-	localPort, stopForward, err := portforward.ServicePortForward(ctx, config, clientset, systemNamespace(), installdefaults.APIServiceName, 443)
+	localPort, stopForward, err := portforward.ServicePortForward(ctx, config, clientset, systemNamespace(), apiServiceName(), 443)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +317,7 @@ func bearerTokenDialOption(ctx context.Context, clientset *kubernetes.Clientset,
 			ExpirationSeconds: &expirationSeconds,
 		},
 	}
-	token, err := clientset.CoreV1().ServiceAccounts(systemNamespace()).CreateToken(ctx, "ate-client", tokenRequest, metav1.CreateOptions{})
+	token, err := clientset.CoreV1().ServiceAccounts(systemNamespace()).CreateToken(ctx, clientServiceAccount(), tokenRequest, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to request ateapi bearer token: %w", err)
 	}

--- a/internal/ateletdial/ateletdial.go
+++ b/internal/ateletdial/ateletdial.go
@@ -22,9 +22,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net"
-	"net/url"
 	"os"
-	"path"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -34,10 +32,12 @@ import (
 )
 
 // TLSConfig authenticates this worker to atelet with its Pod certificate, and
-// accepts only the atelet on this worker's own node.
-func TLSConfig(credentialBundlePath, trustBundlePath string) (*tls.Config, error) {
-	if credentialBundlePath == "" || trustBundlePath == "" {
-		return nil, fmt.Errorf("worker credentials and trust bundle are required")
+// accepts only the atelet on this worker's own node. ateletSPIFFEID is the
+// identity atelet presents; it names atelet's namespace, not this worker's, so
+// the caller passes it in rather than deriving it from the downward API.
+func TLSConfig(credentialBundlePath, trustBundlePath, ateletSPIFFEID string) (*tls.Config, error) {
+	if credentialBundlePath == "" || trustBundlePath == "" || ateletSPIFFEID == "" {
+		return nil, fmt.Errorf("worker credentials, trust bundle, and atelet SPIFFE ID are required")
 	}
 	localCert, err := credbundle.Parse(credentialBundlePath)
 	if err != nil {
@@ -55,7 +55,6 @@ func TLSConfig(credentialBundlePath, trustBundlePath string) (*tls.Config, error
 	if !roots.AppendCertsFromPEM(trustPEM) {
 		return nil, fmt.Errorf("atelet trust bundle contains no certificates")
 	}
-	expectedURI := (&url.URL{Scheme: "spiffe", Host: "cluster.local", Path: path.Join("ns", "ate-system", "sa", "atelet")}).String()
 	return &tls.Config{
 		MinVersion:           tls.VersionTLS13,
 		InsecureSkipVerify:   true, // Verification below supports SPIFFE Pod certificates without a DNS name.
@@ -75,7 +74,7 @@ func TLSConfig(credentialBundlePath, trustBundlePath string) (*tls.Config, error
 				return fmt.Errorf("verify atelet certificate: %w", err)
 			}
 			leaf := state.PeerCertificates[0]
-			if len(leaf.URIs) != 1 || leaf.URIs[0].String() != expectedURI {
+			if len(leaf.URIs) != 1 || leaf.URIs[0].String() != ateletSPIFFEID {
 				return fmt.Errorf("node-local peer is not atelet")
 			}
 			identity, err := substratex509.PodIdentityFromCertificate(leaf)

--- a/internal/ateomcapacity/ateomcapacity.go
+++ b/internal/ateomcapacity/ateomcapacity.go
@@ -99,6 +99,10 @@ type ReportConfig struct {
 	SocketPath           string
 	CredentialBundlePath string
 	TrustBundlePath      string
+	// AteletSPIFFEID is the identity the node-local atelet must present. It
+	// names atelet's namespace, not this worker's, so it is configured rather
+	// than derived from the downward API.
+	AteletSPIFFEID string
 }
 
 // Report tells the node-local atelet what this ateom can supply, retrying
@@ -109,7 +113,7 @@ type ReportConfig struct {
 // an ateom first comes up. Nothing else reports this, so giving up would leave
 // the Worker holding no capacity and hosting nothing.
 func Report(ctx context.Context, cfg ReportConfig) error {
-	tlsConfig, err := ateletdial.TLSConfig(cfg.CredentialBundlePath, cfg.TrustBundlePath)
+	tlsConfig, err := ateletdial.TLSConfig(cfg.CredentialBundlePath, cfg.TrustBundlePath, cfg.AteletSPIFFEID)
 	if err != nil {
 		return fmt.Errorf("capacity report: %w", err)
 	}

--- a/internal/atunnel/credential.go
+++ b/internal/atunnel/credential.go
@@ -55,6 +55,10 @@ type BrokerConfig struct {
 	// ExpectedActorUID prevents a mint started for an old activation from
 	// receiving the newly assigned actor's certificate.
 	ExpectedActorUID string
+	// AteletSPIFFEID is the identity the node-local atelet must present on the
+	// credential broker connection. It names atelet's namespace, not this
+	// worker's, so it is configured rather than derived from the downward API.
+	AteletSPIFFEID string
 }
 
 // NewBrokerCertificateSource creates one actor key for this activation. The key
@@ -64,7 +68,10 @@ func NewBrokerCertificateSource(cfg BrokerConfig) (*BrokerCertificateSource, err
 	if cfg.SocketPath == "" || cfg.CredentialBundlePath == "" || cfg.TrustBundlePath == "" || cfg.ExpectedActorUID == "" {
 		return nil, fmt.Errorf("atunnel: credential broker socket, credentials, trust bundle, and expected actor UID are required")
 	}
-	tlsConfig, err := ateletdial.TLSConfig(cfg.CredentialBundlePath, cfg.TrustBundlePath)
+	if cfg.AteletSPIFFEID == "" {
+		return nil, fmt.Errorf("atunnel: expected atelet SPIFFE ID is required")
+	}
+	tlsConfig, err := ateletdial.TLSConfig(cfg.CredentialBundlePath, cfg.TrustBundlePath, cfg.AteletSPIFFEID)
 	if err != nil {
 		return nil, fmt.Errorf("atunnel: %w", err)
 	}

--- a/internal/atunnel/credential_test.go
+++ b/internal/atunnel/credential_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/substratex509"
 	"google.golang.org/grpc"
@@ -185,6 +186,7 @@ func newTestBrokerCertificateSource(t *testing.T, ateletIdentity *substratex509.
 		CredentialBundlePath: credentialPath,
 		TrustBundlePath:      trustPath,
 		ExpectedActorUID:     "actor-uid",
+		AteletSPIFFEID:       installdefaults.AteletSPIFFEID(installdefaults.SystemNamespace),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/e2e/env.go
+++ b/internal/e2e/env.go
@@ -17,6 +17,8 @@ package e2e
 import (
 	"fmt"
 	"os"
+
+	"github.com/agent-substrate/substrate/internal/installdefaults"
 )
 
 // CheckEnv checks the list of env vars exist and returns their value.
@@ -31,4 +33,18 @@ func CheckEnv(keys ...string) (map[string]string, error) {
 		env[key] = value
 	}
 	return env, nil
+}
+
+// SystemNamespaceEnv names the namespace the substrate control plane under test
+// was installed into. It mirrors the ATE_NAMESPACE hack/install-ate.sh
+// installed with, and the --namespace the chart was released into.
+const SystemNamespaceEnv = "E2E_SYSTEM_NAMESPACE"
+
+// SystemNamespace returns the namespace the control plane under test runs in,
+// falling back to the canonical install namespace.
+func SystemNamespace() string {
+	if ns := os.Getenv(SystemNamespaceEnv); ns != "" {
+		return ns
+	}
+	return installdefaults.SystemNamespace
 }

--- a/internal/e2e/env.go
+++ b/internal/e2e/env.go
@@ -48,3 +48,14 @@ func SystemNamespace() string {
 	}
 	return installdefaults.SystemNamespace
 }
+
+// ResourcePrefixEnv is the prefix the install under test puts on substrate's
+// resource names. The Helm chart prefixes them with the release name for any
+// release not called "substrate", which is what a subchart install produces,
+// and the harness addresses several of those resources by name.
+const ResourcePrefixEnv = "E2E_RESOURCE_PREFIX"
+
+// ResourceName returns name as the install under test renders it.
+func ResourceName(name string) string {
+	return os.Getenv(ResourcePrefixEnv) + name
+}

--- a/internal/e2e/fixtures/testserver/egressprobe.yaml.tmpl
+++ b/internal/e2e/fixtures/testserver/egressprobe.yaml.tmpl
@@ -15,7 +15,7 @@
 # The egress probe used by internal/e2e/suites/egressauthz: testserver's probe
 # subcommand, with the credential volumes that suite mints. It is not a
 # ServerPod because it needs those volumes and a namespace the suite populates
-# first, so it stays a bespoke manifest. ${NAMESPACE} is substituted by the
+# first, so it stays a bespoke manifest. ${NAMESPACE} and ${SYSTEM_NAMESPACE} are substituted by the
 # suite with the randomized namespace it created, so the probe is torn down with
 # that namespace and leaves nothing behind.
 apiVersion: v1
@@ -33,6 +33,10 @@ spec:
     args:
     - "egressprobe"
     - "--listen=:8080"
+    # The gateway lives in substrate's namespace, which the probe cannot infer
+    # from inside the sandbox. ${SYSTEM_NAMESPACE} is substituted alongside
+    # ${NAMESPACE} by the suite.
+    - "--gateway-address=atenet-egress.${SYSTEM_NAMESPACE}.svc:443"
     ports:
     - name: http
       containerPort: 8080

--- a/internal/e2e/fixtures/testserver/egressprobe.yaml.tmpl
+++ b/internal/e2e/fixtures/testserver/egressprobe.yaml.tmpl
@@ -36,7 +36,7 @@ spec:
     # The gateway lives in substrate's namespace, which the probe cannot infer
     # from inside the sandbox. ${SYSTEM_NAMESPACE} is substituted alongside
     # ${NAMESPACE} by the suite.
-    - "--gateway-address=atenet-egress.${SYSTEM_NAMESPACE}.svc:443"
+    - "--gateway-address=${EGRESS_GATEWAY_SERVICE}.${SYSTEM_NAMESPACE}.svc:443"
     ports:
     - name: http
       containerPort: 8080

--- a/internal/e2e/preflight.go
+++ b/internal/e2e/preflight.go
@@ -41,7 +41,7 @@ func PreflightChecks() error {
 		"ate-controller",
 		"ate-api-server",
 	}
-	namespace := "ate-system"
+	namespace := SystemNamespace()
 	for _, depName := range deployments {
 		dep, err := clients.K8s.AppsV1().Deployments(namespace).Get(ctx, depName, metav1.GetOptions{})
 		if err != nil {

--- a/internal/e2e/preflight.go
+++ b/internal/e2e/preflight.go
@@ -38,8 +38,8 @@ func PreflightChecks() error {
 
 	// Check deployments.
 	deployments := []string{
-		"ate-controller",
-		"ate-api-server",
+		ResourceName("ate-controller"),
+		ResourceName("ate-api-server"),
 	}
 	namespace := SystemNamespace()
 	for _, depName := range deployments {

--- a/internal/e2e/router_client.go
+++ b/internal/e2e/router_client.go
@@ -37,7 +37,6 @@ import (
 )
 
 const (
-	routerService = "atenet-router"
 	// routerConnectServicePort is atenet-router's Service port for
 	// CONNECT-tunneled traffic (see manifests/ate-install/atenet-router.yaml).
 	// It is a distinct listener from the plain HTTP one Get/PostJSON use:
@@ -79,7 +78,7 @@ func NewRouterClient(ctx context.Context) (*RouterClient, error) {
 		return nil, fmt.Errorf("creating k8s client: %w", err)
 	}
 
-	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, SystemNamespace(), routerService, 80)
+	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, SystemNamespace(), ResourceName("atenet-router"), 80)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +188,7 @@ func (c *RouterClient) Connect(ctx context.Context, actorRef resources.ActorRef,
 // in one test don't each pay for a fresh port-forward.
 func (c *RouterClient) ensureConnectPortForward(ctx context.Context) error {
 	c.connectOnce.Do(func() {
-		localPort, stop, err := portforward.ServicePortForward(ctx, c.config, c.clientset, SystemNamespace(), routerService, routerConnectServicePort)
+		localPort, stop, err := portforward.ServicePortForward(ctx, c.config, c.clientset, SystemNamespace(), ResourceName("atenet-router"), routerConnectServicePort)
 		if err != nil {
 			c.connectErr = fmt.Errorf("port-forwarding to the router's CONNECT listener: %w", err)
 			return

--- a/internal/e2e/router_client.go
+++ b/internal/e2e/router_client.go
@@ -37,8 +37,7 @@ import (
 )
 
 const (
-	routerNamespace = "ate-system"
-	routerService   = "atenet-router"
+	routerService = "atenet-router"
 	// routerConnectServicePort is atenet-router's Service port for
 	// CONNECT-tunneled traffic (see manifests/ate-install/atenet-router.yaml).
 	// It is a distinct listener from the plain HTTP one Get/PostJSON use:
@@ -80,7 +79,7 @@ func NewRouterClient(ctx context.Context) (*RouterClient, error) {
 		return nil, fmt.Errorf("creating k8s client: %w", err)
 	}
 
-	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, routerNamespace, routerService, 80)
+	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, SystemNamespace(), routerService, 80)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +189,7 @@ func (c *RouterClient) Connect(ctx context.Context, actorRef resources.ActorRef,
 // in one test don't each pay for a fresh port-forward.
 func (c *RouterClient) ensureConnectPortForward(ctx context.Context) error {
 	c.connectOnce.Do(func() {
-		localPort, stop, err := portforward.ServicePortForward(ctx, c.config, c.clientset, routerNamespace, routerService, routerConnectServicePort)
+		localPort, stop, err := portforward.ServicePortForward(ctx, c.config, c.clientset, SystemNamespace(), routerService, routerConnectServicePort)
 		if err != nil {
 			c.connectErr = fmt.Errorf("port-forwarding to the router's CONNECT listener: %w", err)
 			return

--- a/internal/e2e/statusz.go
+++ b/internal/e2e/statusz.go
@@ -51,7 +51,7 @@ func NewStatuszClient(ctx context.Context) (*StatuszClient, error) {
 		return nil, fmt.Errorf("creating k8s client: %w", err)
 	}
 
-	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, routerNamespace, routerService, routerStatusPort)
+	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, SystemNamespace(), routerService, routerStatusPort)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/e2e/statusz.go
+++ b/internal/e2e/statusz.go
@@ -51,7 +51,7 @@ func NewStatuszClient(ctx context.Context) (*StatuszClient, error) {
 		return nil, fmt.Errorf("creating k8s client: %w", err)
 	}
 
-	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, SystemNamespace(), routerService, routerStatusPort)
+	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, SystemNamespace(), ResourceName("atenet-router"), routerStatusPort)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -1220,13 +1220,13 @@ func callActorPathOnce(t *testing.T, actorRef resources.ActorRef, method, path s
 	t.Helper()
 	clients := e2e.GetClients()
 
-	svc, err := clients.K8s.CoreV1().Services("ate-system").Get(context.Background(), "atenet-router", metav1.GetOptions{})
+	svc, err := clients.K8s.CoreV1().Services(e2e.SystemNamespace()).Get(context.Background(), "atenet-router", metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get atenet-router service: %w", err)
 	}
 
 	selector := labels.SelectorFromSet(svc.Spec.Selector).String()
-	pods, err := clients.K8s.CoreV1().Pods("ate-system").List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+	pods, err := clients.K8s.CoreV1().Pods(e2e.SystemNamespace()).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return "", fmt.Errorf("failed to list atenet-router pods: %w", err)
 	}

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -1220,7 +1220,7 @@ func callActorPathOnce(t *testing.T, actorRef resources.ActorRef, method, path s
 	t.Helper()
 	clients := e2e.GetClients()
 
-	svc, err := clients.K8s.CoreV1().Services(e2e.SystemNamespace()).Get(context.Background(), "atenet-router", metav1.GetOptions{})
+	svc, err := clients.K8s.CoreV1().Services(e2e.SystemNamespace()).Get(context.Background(), e2e.ResourceName("atenet-router"), metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get atenet-router service: %w", err)
 	}

--- a/internal/e2e/suites/egressauthz/actoridentity_test.go
+++ b/internal/e2e/suites/egressauthz/actoridentity_test.go
@@ -73,16 +73,16 @@ const (
 // the secret ateapi signs with.
 func actorIdentityCA(t *testing.T, ctx context.Context) *localca.CA {
 	t.Helper()
-	secret, err := e2e.GetClients().K8s.CoreV1().Secrets(egressNamespace).Get(ctx, actorIDCASecret, metav1.GetOptions{})
+	secret, err := e2e.GetClients().K8s.CoreV1().Secrets(e2e.SystemNamespace()).Get(ctx, actorIDCASecret, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("reading actor-identity CA pool secret %s/%s: %v", egressNamespace, actorIDCASecret, err)
+		t.Fatalf("reading actor-identity CA pool secret %s/%s: %v", e2e.SystemNamespace(), actorIDCASecret, err)
 	}
 	pool, err := localca.Unmarshal(secret.Data[actorIDCASecretKey])
 	if err != nil {
-		t.Fatalf("parsing actor-identity CA pool from %s/%s key %q: %v", egressNamespace, actorIDCASecret, actorIDCASecretKey, err)
+		t.Fatalf("parsing actor-identity CA pool from %s/%s key %q: %v", e2e.SystemNamespace(), actorIDCASecret, actorIDCASecretKey, err)
 	}
 	if len(pool.CAs) == 0 {
-		t.Fatalf("actor-identity CA pool %s/%s contains no CA", egressNamespace, actorIDCASecret)
+		t.Fatalf("actor-identity CA pool %s/%s contains no CA", e2e.SystemNamespace(), actorIDCASecret)
 	}
 	// CAs[0] is the one that signs: ateapi's MintCert makes the same choice.
 	return pool.CAs[0]

--- a/internal/e2e/suites/egressauthz/egressauthz_test.go
+++ b/internal/e2e/suites/egressauthz/egressauthz_test.go
@@ -55,7 +55,6 @@ import (
 
 const (
 	// Where the gateway's CA lives, fixed by hack/install-ate.sh.
-	egressNamespace = "ate-system"
 
 	probeName = "egressprobe"
 )
@@ -163,6 +162,7 @@ func startProbe(t *testing.T, ctx context.Context) *probeClient {
 	}
 	manifest := filepath.Join(t.TempDir(), "egressprobe.yaml")
 	rendered := strings.ReplaceAll(string(tmpl), "${NAMESPACE}", ns)
+	rendered = strings.ReplaceAll(rendered, "${SYSTEM_NAMESPACE}", e2e.SystemNamespace())
 	if err := os.WriteFile(manifest, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("writing rendered egressprobe manifest: %v", err)
 	}

--- a/internal/e2e/suites/egressauthz/egressauthz_test.go
+++ b/internal/e2e/suites/egressauthz/egressauthz_test.go
@@ -54,8 +54,6 @@ import (
 )
 
 const (
-	// Where the gateway's CA lives, fixed by hack/install-ate.sh.
-
 	probeName = "egressprobe"
 )
 
@@ -163,6 +161,7 @@ func startProbe(t *testing.T, ctx context.Context) *probeClient {
 	manifest := filepath.Join(t.TempDir(), "egressprobe.yaml")
 	rendered := strings.ReplaceAll(string(tmpl), "${NAMESPACE}", ns)
 	rendered = strings.ReplaceAll(rendered, "${SYSTEM_NAMESPACE}", e2e.SystemNamespace())
+	rendered = strings.ReplaceAll(rendered, "${EGRESS_GATEWAY_SERVICE}", e2e.ResourceName("atenet-egress"))
 	if err := os.WriteFile(manifest, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("writing rendered egressprobe manifest: %v", err)
 	}

--- a/internal/e2e/suites/networking/grpcingress_test.go
+++ b/internal/e2e/suites/networking/grpcingress_test.go
@@ -308,7 +308,7 @@ func routerAddress(t *testing.T, ctx context.Context) string {
 	if err != nil {
 		t.Fatalf("creating k8s client: %v", err)
 	}
-	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, "ate-system", "atenet-router", 80)
+	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, e2e.SystemNamespace(), "atenet-router", 80)
 	if err != nil {
 		t.Fatalf("port-forwarding to the router: %v", err)
 	}

--- a/internal/e2e/suites/networking/grpcingress_test.go
+++ b/internal/e2e/suites/networking/grpcingress_test.go
@@ -308,7 +308,7 @@ func routerAddress(t *testing.T, ctx context.Context) string {
 	if err != nil {
 		t.Fatalf("creating k8s client: %v", err)
 	}
-	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, e2e.SystemNamespace(), "atenet-router", 80)
+	localPort, stop, err := portforward.ServicePortForward(ctx, config, clientset, e2e.SystemNamespace(), e2e.ResourceName("atenet-router"), 80)
 	if err != nil {
 		t.Fatalf("port-forwarding to the router: %v", err)
 	}

--- a/internal/e2e/suites/networking/networking_test.go
+++ b/internal/e2e/suites/networking/networking_test.go
@@ -283,8 +283,8 @@ func assertEgressGatewayConnect(t *testing.T, ctx context.Context, since metav1.
 // replica, until predicate accepts the lines written since.
 func waitForAccessLog(t *testing.T, ctx context.Context, since metav1.Time, want string, predicate func(lines []string) (bool, error)) {
 	t.Helper()
+	gatewayNamespace := e2e.SystemNamespace()
 	const (
-		gatewayNamespace = "ate-system"
 		gatewaySelector  = "app=atenet-egress"
 		gatewayContainer = "envoy"
 		// The access log's line prefix, from the HttpConnectionManager

--- a/internal/e2e/suites/networkpolicy/networkpolicy_test.go
+++ b/internal/e2e/suites/networkpolicy/networkpolicy_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 const (
-	ateSystemNamespace  = "ate-system"
 	atenetRouterAppName = "atenet-router"
 )
 
@@ -103,8 +102,8 @@ func TestNetworkPolicyLifecycleAndReconciliation(t *testing.T) {
 		t.Fatalf("expected exactly 1 ingress from peer, got %d", len(ingressRule.From))
 	}
 	fromPeer := ingressRule.From[0]
-	if fromPeer.NamespaceSelector == nil || fromPeer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != ateSystemNamespace {
-		t.Errorf("expected namespace selector for %s, got %v", ateSystemNamespace, fromPeer.NamespaceSelector)
+	if fromPeer.NamespaceSelector == nil || fromPeer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != e2e.SystemNamespace() {
+		t.Errorf("expected namespace selector for %s, got %v", e2e.SystemNamespace(), fromPeer.NamespaceSelector)
 	}
 	if fromPeer.PodSelector == nil || fromPeer.PodSelector.MatchLabels["app"] != atenetRouterAppName {
 		t.Errorf("expected pod selector for %s, got %v", atenetRouterAppName, fromPeer.PodSelector)

--- a/internal/e2e/trustbundle.go
+++ b/internal/e2e/trustbundle.go
@@ -39,7 +39,6 @@ const (
 	// EgressTrustBundleObjectName is the reconciler-owned ClusterTrustBundle.
 	EgressTrustBundleObjectName = "egress-mitm.ate.dev:mitm:primary-bundle"
 
-	egressCAPoolNamespace  = "ate-system"
 	egressCAPoolSecretName = "egress-mitm-ca-pool"
 	egressCAPoolSecretKey  = "pool"
 )
@@ -68,12 +67,12 @@ func ReplaceEgressTrustPool(t *testing.T, ctx context.Context, clients *Clients,
 	if !createEgressTrustPool(t, ctx, clients, secret) {
 		// Took over an existing pool: overwrite its contents without adopting
 		// its cleanup, since whoever created it registered one already.
-		existing, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{})
+		existing, err := clients.K8s.CoreV1().Secrets(SystemNamespace()).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("reading existing CA pool secret: %v", err)
 		}
 		existing.Data = secret.Data
-		if _, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+		if _, err := clients.K8s.CoreV1().Secrets(SystemNamespace()).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
 			t.Fatalf("updating CA pool secret: %v", err)
 		}
 	}
@@ -103,7 +102,7 @@ func newEgressTrustPool(t *testing.T) (*corev1.Secret, string) {
 		t.Fatalf("encoding the egress CA private key: %v", err)
 	}
 	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Namespace: egressCAPoolNamespace, Name: egressCAPoolSecretName},
+		ObjectMeta: metav1.ObjectMeta{Namespace: SystemNamespace(), Name: egressCAPoolSecretName},
 		Type:       corev1.SecretTypeTLS,
 		Data: map[string][]byte{
 			egressCAPoolSecretKey:   poolBytes,
@@ -120,14 +119,14 @@ func newEgressTrustPool(t *testing.T) (*corev1.Secret, string) {
 // behind, and no caller removes a pool it merely found.
 func createEgressTrustPool(t *testing.T, ctx context.Context, clients *Clients, secret *corev1.Secret) bool {
 	t.Helper()
-	if _, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+	if _, err := clients.K8s.CoreV1().Secrets(SystemNamespace()).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			t.Fatalf("creating CA pool secret %s/%s: %v", egressCAPoolNamespace, egressCAPoolSecretName, err)
+			t.Fatalf("creating CA pool secret %s/%s: %v", SystemNamespace(), egressCAPoolSecretName, err)
 		}
 		return false
 	}
 	t.Cleanup(func() {
-		_ = clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Delete(context.Background(), egressCAPoolSecretName, metav1.DeleteOptions{})
+		_ = clients.K8s.CoreV1().Secrets(SystemNamespace()).Delete(context.Background(), egressCAPoolSecretName, metav1.DeleteOptions{})
 	})
 	return true
 }

--- a/internal/e2e/trustbundle.go
+++ b/internal/e2e/trustbundle.go
@@ -39,8 +39,12 @@ const (
 	// EgressTrustBundleObjectName is the reconciler-owned ClusterTrustBundle.
 	EgressTrustBundleObjectName = "egress-mitm.ate.dev:mitm:primary-bundle"
 
+	// egressCAPoolSecretName is not release-prefixed: hack/install-ate.sh
+	// creates it under this fixed name and the reconciler looks it up the same
+	// way, so it does not follow the chart's naming.
 	egressCAPoolSecretName = "egress-mitm-ca-pool"
-	egressCAPoolSecretKey  = "pool"
+
+	egressCAPoolSecretKey = "pool"
 )
 
 // EnsureEgressTrustBundle makes sure the egress trust bundle exists, then

--- a/internal/installdefaults/guard_test.go
+++ b/internal/installdefaults/guard_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installdefaults
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This guard exists because hardcoded install-layout assumptions fail closed
+// in a relocated or renamed install, in ways that do not point at the naming
+// (see the ateletauth, ateletdial and NetworkPolicy histories). New namespace
+// or SPIFFE-identity literals belong in this package, in a flag default, or —
+// deliberately — in the allowlist below.
+
+// excludedTrees are directories whose tooling targets the canonical install
+// layout by design and is not expected to work against a relocated one.
+var excludedTrees = []string{
+	"cmd/ate-setup",         // canonical GCP installer
+	"cmd/benchmarking",      // canonical load-testing workers
+	"internal/benchmarking", // canonical load-testing harness
+}
+
+// allowedLiterals maps a repo-relative file to the canonical-layout string
+// literals it may carry. Everything here is either a flag/env default that an
+// operator overrides (the sanctioned pattern: default to the canonical
+// layout, configure the rest), or a string nothing verifies against.
+var allowedLiterals = map[string][]string{
+	// Flag defaults, overridden by the deployment or the e2e manifest templates.
+	"cmd/atecontroller/main.go":                       {"k8s:///api.ate-system.svc:443"},
+	"cmd/atelet/main.go":                              {"k8s:///api.ate-system.svc:443", "api.ate-system.svc"},
+	"cmd/atenet/internal/router/cmd.go":               {"k8s:///api.ate-system.svc:443", "spiffe://cluster.local/"},
+	"internal/e2e/fixtures/testserver/egressprobe.go": {"atenet-egress.ate-system.svc:443"},
+	// Env-var defaults, overridden by ATE_* / E2E_* variables.
+	"internal/ateclient/builder.go": {"api.ate-system.svc"},
+	// Inert: the actor JWT issuer is an upstream TODO nothing validates, and
+	// an x509 template's Issuer field is overwritten by the signer.
+	"cmd/ateapi/internal/actoridentity/actoridentity.go": {"https://api.ate-system.svc", "api.ate-system.svc.cluster.local"},
+}
+
+// suspect reports whether a string literal encodes canonical install layout.
+func suspect(s string) bool {
+	return strings.Contains(s, "ate-system") || strings.Contains(s, "spiffe://cluster.local")
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate this test file")
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+}
+
+func allowed(relPath, lit string) bool {
+	for _, tree := range excludedTrees {
+		if strings.HasPrefix(relPath, tree+string(filepath.Separator)) {
+			return true
+		}
+	}
+	for _, a := range allowedLiterals[filepath.ToSlash(relPath)] {
+		if a == lit {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNoNewHardcodedInstallLayoutInGo walks every non-test Go file under cmd/
+// and internal/ and fails on string literals that name the canonical
+// namespace or a full SPIFFE identity outside this package. Comments are not
+// scanned, so kubebuilder markers (which must name a literal namespace) pass.
+func TestNoNewHardcodedInstallLayoutInGo(t *testing.T) {
+	root := repoRoot(t)
+	selfDir := filepath.Join("internal", "installdefaults")
+
+	var offenders []string
+	for _, tree := range []string{"cmd", "internal"} {
+		err := filepath.WalkDir(filepath.Join(root, tree), func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			if strings.HasPrefix(rel, selfDir) {
+				return nil
+			}
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				return err
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				val, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					return true
+				}
+				if suspect(val) && !allowed(rel, val) {
+					offenders = append(offenders, fset.Position(lit.Pos()).String()+": "+lit.Value)
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("hardcoded install-layout strings outside internal/installdefaults; "+
+			"derive them from installdefaults or a configured value, or allowlist them "+
+			"in this test with a justification:\n  %s", strings.Join(offenders, "\n  "))
+	}
+}

--- a/internal/installdefaults/installdefaults.go
+++ b/internal/installdefaults/installdefaults.go
@@ -32,6 +32,9 @@ const (
 	APIServiceName = "api"
 	// RouterServiceName is the Service name of atenet-router.
 	RouterServiceName = "atenet-router"
+	// ClientServiceAccount is the ServiceAccount an out-of-cluster client mints
+	// its ateapi bearer token from.
+	ClientServiceAccount = "ate-client"
 
 	// AteletTrustDomain, AteletServiceAccount and RouterServiceAccount are the
 	// trust-domain and service-account segments of the SPIFFE IDs that atelet

--- a/internal/installdefaults/installdefaults.go
+++ b/internal/installdefaults/installdefaults.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package installdefaults holds the default namespace and Service names
+// that match the canonical install layout in manifests/ate-install/.
+// Binaries use these as flag defaults; deployments that diverge from
+// the canonical layout pass actual values via the corresponding flags.
+package installdefaults
+
+import "os"
+
+const (
+	// SystemNamespace is the namespace where substrate's control-plane
+	// components and the atelet DaemonSet run.
+	SystemNamespace = "ate-system"
+	// APIServiceName is the Service name of ate-api-server.
+	APIServiceName = "api"
+	// RouterServiceName is the Service name of atenet-router.
+	RouterServiceName = "atenet-router"
+
+	// PodNamespaceEnv is the conventional env var name for the namespace
+	// a pod is running in, exposed via Kubernetes' downward API.
+	PodNamespaceEnv = "POD_NAMESPACE"
+)
+
+// NamespaceFromPodEnv returns the namespace from the PodNamespaceEnv env
+// var when set (typically populated via Kubernetes' downward API), and
+// falls back to SystemNamespace for non-k8s invocations (tests, local dev).
+func NamespaceFromPodEnv() string {
+	if ns := os.Getenv(PodNamespaceEnv); ns != "" {
+		return ns
+	}
+	return SystemNamespace
+}

--- a/internal/installdefaults/installdefaults.go
+++ b/internal/installdefaults/installdefaults.go
@@ -18,7 +18,11 @@
 // the canonical layout pass actual values via the corresponding flags.
 package installdefaults
 
-import "os"
+import (
+	"net/url"
+	"os"
+	"path"
+)
 
 const (
 	// SystemNamespace is the namespace where substrate's control-plane
@@ -28,6 +32,16 @@ const (
 	APIServiceName = "api"
 	// RouterServiceName is the Service name of atenet-router.
 	RouterServiceName = "atenet-router"
+
+	// AteletTrustDomain, AteletServiceAccount and RouterServiceAccount are the
+	// trust-domain and service-account segments of the SPIFFE IDs that atelet
+	// and atenet-router Pod certificates carry, as minted by the podidentity
+	// signer (cmd/podcertcontroller/internal/podidentitysigner). The namespace
+	// segment is the namespace they run in, which callers resolve themselves
+	// rather than assume.
+	AteletTrustDomain    = "cluster.local"
+	AteletServiceAccount = "atelet"
+	RouterServiceAccount = "atenet-router"
 
 	// PodNamespaceEnv is the conventional env var name for the namespace
 	// a pod is running in, exposed via Kubernetes' downward API.
@@ -42,4 +56,24 @@ func NamespaceFromPodEnv() string {
 		return ns
 	}
 	return SystemNamespace
+}
+
+// SPIFFEID returns the SPIFFE ID that Pod certificates for serviceAccount in
+// namespace carry. Peers authenticate by comparing against this exact string.
+func SPIFFEID(namespace, serviceAccount string) string {
+	return (&url.URL{
+		Scheme: "spiffe",
+		Host:   AteletTrustDomain,
+		Path:   path.Join("ns", namespace, "sa", serviceAccount),
+	}).String()
+}
+
+// AteletSPIFFEID returns the SPIFFE ID atelet presents when it runs in namespace.
+func AteletSPIFFEID(namespace string) string {
+	return SPIFFEID(namespace, AteletServiceAccount)
+}
+
+// RouterSPIFFEID returns the SPIFFE ID atenet-router presents when it runs in namespace.
+func RouterSPIFFEID(namespace string) string {
+	return SPIFFEID(namespace, RouterServiceAccount)
 }

--- a/internal/installdefaults/installdefaults_test.go
+++ b/internal/installdefaults/installdefaults_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installdefaults
+
+import "testing"
+
+func TestAteletSPIFFEID(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		want      string
+	}{
+		{
+			// The canonical install. Peers reject any other string, so this
+			// value is effectively wire format: changing it breaks the atelet
+			// mTLS handshake for every existing deployment.
+			name:      "default namespace",
+			namespace: SystemNamespace,
+			want:      "spiffe://cluster.local/ns/ate-system/sa/atelet",
+		},
+		{
+			name:      "namespace the install was relocated to",
+			namespace: "team-a-substrate",
+			want:      "spiffe://cluster.local/ns/team-a-substrate/sa/atelet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AteletSPIFFEID(tt.namespace); got != tt.want {
+				t.Errorf("AteletSPIFFEID(%q) = %q, want %q", tt.namespace, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouterSPIFFEID(t *testing.T) {
+	// Matches the --atunnel-client-identity default the ateom binaries ship
+	// with, which is what actor ingress authenticates the router against.
+	const want = "spiffe://cluster.local/ns/ate-system/sa/atenet-router"
+	if got := RouterSPIFFEID(SystemNamespace); got != want {
+		t.Errorf("RouterSPIFFEID(%q) = %q, want %q", SystemNamespace, got, want)
+	}
+}
+
+func TestNamespaceFromPodEnv(t *testing.T) {
+	t.Run("falls back to the install default when unset", func(t *testing.T) {
+		t.Setenv(PodNamespaceEnv, "")
+		if got := NamespaceFromPodEnv(); got != SystemNamespace {
+			t.Errorf("NamespaceFromPodEnv() = %q, want %q", got, SystemNamespace)
+		}
+	})
+
+	t.Run("prefers the downward API value", func(t *testing.T) {
+		t.Setenv(PodNamespaceEnv, "team-a-substrate")
+		if got := NamespaceFromPodEnv(); got != "team-a-substrate" {
+			t.Errorf("NamespaceFromPodEnv() = %q, want %q", got, "team-a-substrate")
+		}
+	})
+}


### PR DESCRIPTION
# Description

**Substrate assumes the canonical install layout, and every deviation fails closed.** The namespace `ate-system`, the Services `api` / `atenet-router`, and the ServiceAccounts `atelet` / `atenet-router` are compiled-in constants. An install in a per-developer namespace, or under a deployment that prefixes resource names, breaks — and no failure points at the naming.

This series makes the namespace, the Service names, and the ServiceAccount names configurable. Every option defaults to the canonical value. A canonical install is byte-for-byte unaffected.

| Hardcoded assumption | Failure | What it looks like instead |
|---|---|---|
| atelet's namespace in ateapi's SPIFFE check | ateapi rejects every atelet | an mTLS handshake failure, not a naming error |
| atelet's namespace in the worker's broker check | no actor obtains a certificate | `credential broker is not atelet` |
| NetworkPolicy's ingress namespace | the CNI drops every request to the pool | a silent network fault |
| ateapi Service name and namespace in the client | the client cannot authenticate | `services "api" not found`, then `invalid bearer token` |
| Resource names in `hack/install-ate.sh` and the e2e harness | authorities land in the wrong namespace | suites die in preflight |

**A SPIFFE ID breaks on two axes.** It names a namespace and a ServiceAccount. Both were constants, and the failure surfaces as a rejected peer, not a missing object.

## Design notes

- **ate-controller passes the worker-side identities.** ateom already took `--atunnel-client-identity` as a flag but relied on its default. A new `--atunnel-broker-identity` flag alone would be inert: correct only where the constant was already correct. The controller knows the control plane's namespace, so it supplies both.
- **ateapi takes the whole expected identity, not a namespace.** The dialer and `ateletauth` used the namespace only to build one string. One place decides how atelet's identity is spelled.
- **`ateletauth` deduplicates without taking the dependency it was avoiding.** Its constants are duplicated rather than imported so the package does not depend on `controlapi` for three strings. `ateletdial` would make a third copy, so the strings move to `internal/installdefaults` instead — a leaf package of constants that imports only the standard library, so consuming it does not reintroduce the coupling the duplication was there to prevent.
- **The client reads environment variables, not flags.** It runs outside the cluster. It has no downward API and nothing to discover from.
- **Namespaces come from the downward API, not flags.** Every supported topology co-locates these components. Only Service and ServiceAccount names, which a deployment may legitimately rename, get flags.
- **`hack/install-ate.sh` and the e2e harness are in scope.** A relocated install cannot be bootstrapped or exercised without them. The script refuses `ATE_NAMESPACE` or `ATE_API_SERVICE_NAME` overrides on the manifest-applying subcommands, which would half-install: `manifests/ate-install/` names `ate-system` and `api` literally.

## Why this is one PR

The series is stacked, not parallel. Commit 1 creates `internal/installdefaults` and seeds seven imports; commit 2 adds fourteen more; every later commit builds on those constants. Split into separate PRs, each blocks on the previous merging and none reviews independently.

The guard test cannot land first. Applied to `main` it fails on eleven hardcoded literals across `ateletauth`, `controlapi/informer.go`, `networkpolicy_controller.go`, both `ateom` mains, `ateclient`, `ateletdial` and three e2e files. It is green only because the preceding commits removed them.

A partial series still fails closed. Each commit's audit turned up more places assuming `ate-system`, so landing commits 1-3 without 4-5 leaves a relocated install broken later and less legibly than before.

`CONTRIBUTING.md` covers this case: when the intermediate steps are not useful on their own, keep the change as one PR split into commits at logical break points. Review commit by commit, and preserve the commits on merge. If you would still rather split, the one defensible cut is by axis — relocation (commits 1-3) then renaming (commits 4-5) with the guard test rebased on top.

## Rebase notes (2026-09-15)

The series is rebased onto `main` at `2b255001`, forty-nine commits on from the previous base:

- `main` moved actor JWT and certificate minting out of `cmd/ateapi/internal/actoridentity` into `controlapi`, deleting the package and dropping its inline atelet authorization check in favor of the unified authorizer. This series previously threaded the expected atelet identity into that check; the check no longer exists, so that adaptation is gone. `ateletauth` survives with one caller, `workerservice.SetWorkerCapacity`, which still takes the configured identity.
- The same refactor replaced `BrokerConfig.ExpectedActorUID` with an `ActorAtespace` / `ActorName` / `ActorUID` triple. `AteletSPIFFEID` is additive and still required by `ateletdial.TLSConfig`.
- `ateletauth` (ateapi's side) and `ateletdial` (the worker's side) each re-declared the hardcoded SPIFFE ID. Both take the expected identity as a parameter.
- `main` deleted the atenet DNS subsystem. The series no longer touches it, and `installdefaults` carries no DNS Service name.
- The controller passes `--atunnel-broker-identity` only when it differs from the canonical default. An ateom old enough to predate the flag exits on it, and `docs/upgrade.md` keeps such a pool serving during a rolling upgrade. A relocated install gets the flag and necessarily runs an image that accepts it.
- `main` added `internal/e2e/collector_metrics.go` (agentgateway CI support), which addresses the router through the package-level `routerNamespace` and `routerService` that this series replaces. Its two call sites become `SystemNamespace()` and `ResourceName("atenet-router")`, matching `router_client.go` and `statusz.go`. A reviewer diffing against the older base sees those call sites move; nothing else in that file changes.
- The guard test's allowlist entry for the two inert `ate-system` literals follows the code from `actoridentity.go` to `controlapi/actor.go`. The refactor re-introduced exactly the class of constant this series removes, so the guard earns its place.

# Testing

- `go test -race ./...` passes. `make verify` passes boilerplate, codegen, go-modules, gofmt, golangci-lint, kube-api-linter, licenses, metrics and postgresql-migrations. `proto-fmt` needs `clang-format`, which is absent locally; this series touches no `.proto` files.
- Every commit builds and vets individually, via `git rebase -x 'go build ./... && go vet ./...'`.
- On a fresh kind cluster, all twelve e2e suites pass: `capabilities`, `combinedvolumes`, `demo`, `egressauthz`, `egressmitm`, `example`, `identity`, `metrics`, `networking`, `networkpolicy`, `parking`, `sizing`. The `demo`, `metrics`, `networkpolicy`, `parking` and `networking` suites need the `--deploy-demo-counter` and `--deploy-demo-egress` fixtures, and the MITM path needs `--deploy-demo-egress-mitm`; without them they fail on `actor template not found`, which reads as a control-plane fault rather than a missing fixture.
- With the sdsmint egress gateway (`--deploy-atenet --experimental-use-sdsmint`, `E2E_EGRESS_MITM=1`), `TestActorEgressMITMTrust` and `TestActorEgressHTTPSByHostnameMITM` both pass, and the `networking` suite is green at 25 passed. The two modes are mutually exclusive by design: `TestActorEgressHTTPSByHostnamePassthrough` covers the plain gateway and skips under MITM, and the two MITM tests skip without it. Both modes were run, so every case executed in one of them.
- The new unit tests use a relocated namespace and renamed ServiceAccounts. Reintroducing each hardcoding makes them fail.

One e2e caveat that predates this series and misleads: the `identity` suite calls `ReplaceEgressTrustPool`, which takes over the shared `egress-mitm-ca-pool` Secret, overwrites it and registers no cleanup. Any MITM test running afterwards fails with `certificate signed by unknown authority`, which reads as a broken interception path rather than a mutated fixture. Reinstall the gateway before running `egressmitm`.

# Additional Notes

**Credential contents stay canonical.** `controlapi/actor.go` still mints credentials naming `api.ate-system.svc`: the JWT issuer and the certificate's Issuer CN. Relying parties validate these, so changing them is a compatibility decision, not a lookup fix. The code carries a TODO to make the issuer a globally unique, OIDC-compliant name.

