### PR TITLE
Update default GKE cluster version and enable Managed OTel feature

### DIFF
--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -36,7 +36,9 @@ The CLI supports on-demand tracing using the `--trace` flag. When enabled, the C
 gcloud services enable cloudtrace.googleapis.com --project=PROJECT_ID
 ```
 
-2. The GKE cluster must have **Managed OpenTelemetry** enabled. If it is not enabled, you can enable it using the following `gcloud` command:
+2. The GKE cluster must have **Managed OpenTelemetry** enabled. Clusters created by
+`setup-gcp` (`--create-cluster` / `--all`) always enable it. For a cluster that does
+not have it, enable it with:
 
 ```bash
 gcloud beta container clusters update CLUSTER_NAME \

--- a/hack/ate-dev-env.sh.example
+++ b/hack/ate-dev-env.sh.example
@@ -25,9 +25,9 @@ export NETWORK=default
 export SUBNETWORK=default
 
 export CLUSTER_NAME=substrate-poc
-export CLUSTER_VERSION=1.35.0-gke.2398000
+export CLUSTER_VERSION=1.35.5-gke.1163012
 export NODE_POOL_NAME=gvisor-pool
-export NODE_POOL_VERSION=1.35.0-gke.2398000
+export NODE_POOL_VERSION=1.35.5-gke.1163012
 export GVISOR_NODE_MACHINE_TYPE=c3-standard-4
 
 # Set this if you are using an existing cluster with a different context name.

--- a/tools/setup-gcp/cmd/api.go
+++ b/tools/setup-gcp/cmd/api.go
@@ -37,6 +37,10 @@ func enableRequiredAPIs(ctx context.Context, cfg *Config) error {
 		"networkconnectivity.googleapis.com",
 		"serviceusage.googleapis.com",
 		"storage.googleapis.com",
+		"logging.googleapis.com",
+		"monitoring.googleapis.com",
+		"cloudtrace.googleapis.com",
+		"telemetry.googleapis.com",
 	}
 
 	slog.Info("Batch enabling services", slog.String("services", strings.Join(services, ", ")))

--- a/tools/setup-gcp/cmd/cluster.go
+++ b/tools/setup-gcp/cmd/cluster.go
@@ -79,9 +79,10 @@ func createClusterInternal(ctx context.Context, cfg *Config, client *container.C
 			WorkloadIdentityConfig: &containerpb.WorkloadIdentityConfig{
 				WorkloadPool: fmt.Sprintf("%s.svc.id.goog", cfg.ProjectID),
 			},
-			Network:       cfg.Network,
-			Subnetwork:    cfg.Subnetwork,
-			NetworkConfig: networkConfig,
+			Network:                    cfg.Network,
+			Subnetwork:                 cfg.Subnetwork,
+			NetworkConfig:              networkConfig,
+			ManagedOpentelemetryConfig: &containerpb.ManagedOpenTelemetryConfig{Scope: containerpb.ManagedOpenTelemetryConfig_COLLECTION_AND_INSTRUMENTATION_COMPONENTS.Enum()},
 		},
 	}
 	op, err := client.CreateCluster(ctx, req)
@@ -202,6 +203,28 @@ func createClusterIdempotent(ctx context.Context, cfg *Config) error {
 		}
 	} else {
 		slog.Info("Cluster EnableK8SBetaApis match perfectly.", slog.String("cluster", cfg.ClusterName))
+	}
+
+	desiredOTelScope := containerpb.ManagedOpenTelemetryConfig_COLLECTION_AND_INSTRUMENTATION_COMPONENTS
+	if cluster.GetManagedOpentelemetryConfig().GetScope() != desiredOTelScope {
+		slog.Info("Mismatch in Managed OpenTelemetry config",
+			slog.String("current", cluster.GetManagedOpentelemetryConfig().GetScope().String()),
+			slog.String("expected", desiredOTelScope.String()))
+		slog.Info("Updating cluster ManagedOpentelemetryConfig...")
+		op, err := client.UpdateCluster(ctx, &containerpb.UpdateClusterRequest{
+			Name: clusterName,
+			Update: &containerpb.ClusterUpdate{
+				DesiredManagedOpentelemetryConfig: &containerpb.ManagedOpenTelemetryConfig{Scope: desiredOTelScope.Enum()},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("update cluster managed opentelemetry: %w", err)
+		}
+		if err := waitContainerOperation(ctx, client, op.Name, cfg); err != nil {
+			return err
+		}
+	} else {
+		slog.Info("Cluster ManagedOpentelemetryConfig match perfectly.", slog.String("cluster", cfg.ClusterName))
 	}
 
 	return nil


### PR DESCRIPTION
1) Always create a cluster with GKE Managed OpenTelemetry feature and
2) Update the default cluster version to 1.35.5-gke.1163012 which is the current [regular channel default version](https://docs.cloud.google.com/kubernetes-engine/docs/release-notes#current_versions) to fix https://github.com/agent-substrate/substrate/issues/341

Tested:
* Successfully recreated GKE cluster, redeployed ate-system and ran counter demo.