### PR TITLE
Remove all the "(tenant)" description from atespace comments

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -868,7 +868,7 @@ func TestListActors_ByAtespace(t *testing.T) {
 }
 
 // TestListActors_AllAtespaces verifies that an empty atespace lists actors across
-// all atespaces (the `-A` / admin view), unlike the scoped single-tenant listing.
+// all atespaces (the `-A` / admin view), unlike the scoped single-atespace listing.
 func TestListActors_AllAtespaces(t *testing.T) {
 	ns := namespaceForTest("ns-list-all-atespaces")
 	tc := setupTest(t, ns)

--- a/cmd/ateapi/internal/controlapi/list_actors.go
+++ b/cmd/ateapi/internal/controlapi/list_actors.go
@@ -47,7 +47,7 @@ func (s *Service) ListActors(ctx context.Context, req *ateapipb.ListActorsReques
 
 func validateListActorsRequest(req *ateapipb.ListActorsRequest) error {
 	// An empty atespace is allowed here and means "all atespaces"(used by `kubectl ate get actors -A`).
-	// A non-empty atespace is validated and scopes the listing to that tenant.
+	// A non-empty atespace is validated and scopes the listing to that atespace.
 	if req.GetAtespace() != "" {
 		if err := resources.ValidateAtespace(req.GetAtespace()); err != nil {
 			return err

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -92,7 +92,7 @@ func actorDBKey(atespace, id string) string {
 
 // actorScanPattern returns the SCAN match pattern for listing actors. An empty
 // atespace lists across all atespaces (actor:*); a non-empty atespace scopes the
-// scan to that tenant (actor:<atespace>:*).
+// scan to that atespace (actor:<atespace>:*).
 func actorScanPattern(atespace string) string {
 	if atespace == "" {
 		return "actor:*"
@@ -635,7 +635,7 @@ func hashShardAddr(addr string) string {
 
 // ListActors lists actors, scoped to the given atespace. An empty atespace lists
 // across all atespaces (SCAN actor:*); a non-empty atespace restricts the scan to
-// that tenant (SCAN actor:<atespace>:*).
+// that atespace (SCAN actor:<atespace>:*).
 func (s *Persistence) ListActors(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.Actor, string, error) {
 	token, err := decodePageToken(pageTokenStr)
 	if err != nil {

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -1065,7 +1065,7 @@ func TestDeleteAtespace_EmptyAfterActorsRemoved(t *testing.T) {
 	}
 }
 
-func TestDeleteAtespace_EmptyWhileOtherTenantNonEmpty(t *testing.T) {
+func TestDeleteAtespace_EmptyWhileOtherAtespaceNonEmpty(t *testing.T) {
 	mr, s, ctx := setupTest(t)
 	defer mr.Close()
 

--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -74,7 +74,7 @@ These flags can be appended to any command:
 List and inspect the state of actors and workers across the cluster.
 
 ```bash
-# List actors in one atespace (tenant); -a is shorthand for --atespace
+# List actors in one atespace; -a is shorthand for --atespace
 kubectl ate get actors --atespace <atespace>
 kubectl ate get actors -a <atespace>
 
@@ -88,7 +88,7 @@ kubectl ate get actor <actor-id> --atespace <atespace> -o yaml
 kubectl ate get workers
 ```
 
-> **Note:** `get actors` requires either `--atespace <name>` / `-a <name>` (one tenant) or `-A`/`--all-atespaces` (all tenants) — there is no default atespace. Getting a single actor always requires `--atespace`/`-a`, since an actor is addressed by `(atespace, id)`. `-a` (lower-case) scopes to one atespace; `-A` (upper-case) spans all.
+> **Note:** `get actors` requires either `--atespace <name>` / `-a <name>` (one atespace) or `-A`/`--all-atespaces` (all atespaces) — there is no default atespace. Getting a single actor always requires `--atespace`/`-a`, since an actor is addressed by `(atespace, id)`. `-a` (lower-case) scopes to one atespace; `-A` (upper-case) spans all.
 
 > **Note:** Actors and workers are not Kubernetes CRDs — they live in the Substrate control plane (valkey/redis), not `etcd`. `kubectl get actor` and `kubectl get worker` will not return anything; only `kubectl ate get …` queries the control plane. `kubectl get actortemplate` and `kubectl get workerpool` *do* work, because those are CRDs.
 
@@ -96,7 +96,7 @@ kubectl ate get workers
 
 | Column | Meaning |
 |---|---|
-| `ATESPACE` | The atespace (tenant boundary) the actor belongs to. Part of the actor's identity; folded into the storage key as `actor:<atespace>:<id>`. |
+| `ATESPACE` | The atespace the actor belongs to. Part of the actor's identity; folded into the storage key as `actor:<atespace>:<id>`. |
 | `TEMPLATE NS` | The namespace of the `ActorTemplate` the actor was created from (distinct from `ATESPACE`). |
 | `TEMPLATE` | The `ActorTemplate` name. |
 | `ID` | Actor ID. User-provided for application actors; UUID for the golden actor that each template materialises during `ResumeGoldenActor`. |
@@ -117,7 +117,7 @@ kubectl ate get workers
 
 ### Atespaces
 
-An **atespace** is the tenant boundary an actor belongs to. It must exist before you can create actors in it.
+An **atespace** is the isolation boundary an actor belongs to. It must exist before you can create actors in it.
 
 ```bash
 # Create an atespace

--- a/cmd/kubectl-ate/internal/cmd/create_atespace.go
+++ b/cmd/kubectl-ate/internal/cmd/create_atespace.go
@@ -25,7 +25,7 @@ import (
 
 var createAtespaceCmd = &cobra.Command{
 	Use:   "atespace [name]",
-	Short: "Create an atespace (tenant boundary)",
+	Short: "Create an atespace",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()

--- a/cmd/kubectl-ate/internal/cmd/delete_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/delete_actor.go
@@ -50,7 +50,7 @@ var deleteActorCmd = &cobra.Command{
 }
 
 func init() {
-	deleteActorCmd.Flags().StringVarP(&deleteAtespaceFlag, "atespace", "a", "", "Atespace (tenant) the actor lives in")
+	deleteActorCmd.Flags().StringVarP(&deleteAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
 	_ = deleteActorCmd.MarkFlagRequired("atespace")
 	deleteCmd.AddCommand(deleteActorCmd)
 }

--- a/cmd/kubectl-ate/internal/cmd/get_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/get_actors.go
@@ -44,7 +44,7 @@ var getActorsCmd = &cobra.Command{
 
 		// 2. Handle Get Single Actor
 		if len(args) > 0 {
-			// A single actor is addressed by (atespace, id), so the tenant is
+			// A single actor is addressed by (atespace, id), so the atespace is
 			// mandatory and "all atespaces" is meaningless here.
 			if getActorsAllAtespaces {
 				return fmt.Errorf("-A/--all-atespaces cannot be used when getting a specific actor; pass --atespace")
@@ -59,8 +59,8 @@ var getActorsCmd = &cobra.Command{
 			return printer.PrintActor(resp.GetActor(), outputFmt)
 		}
 
-		// Listing requires exactly one of --atespace (one tenant) or -A (all
-		// tenants). There is no default atespace to fall back on.
+		// Listing requires exactly one of --atespace (one atespace) or -A (all
+		// atespaces). There is no default atespace to fall back on.
 		if getActorsAllAtespaces && getActorsAtespaceFlag != "" {
 			return fmt.Errorf("--atespace and -A/--all-atespaces are mutually exclusive")
 		}
@@ -94,7 +94,7 @@ var getActorsCmd = &cobra.Command{
 }
 
 func init() {
-	getActorsCmd.Flags().StringVarP(&getActorsAtespaceFlag, "atespace", "a", "", "Atespace (tenant) to list/get actors in. Required for a single actor; for listing, use this or -A.")
+	getActorsCmd.Flags().StringVarP(&getActorsAtespaceFlag, "atespace", "a", "", "Atespace to list/get actors in. Required for a single actor; for listing, use this or -A.")
 	getActorsCmd.Flags().BoolVarP(&getActorsAllAtespaces, "all-atespaces", "A", false, "List actors across all atespaces (listing only; mutually exclusive with --atespace)")
 	getCmd.AddCommand(getActorsCmd)
 }

--- a/cmd/kubectl-ate/internal/cmd/logs_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors.go
@@ -51,7 +51,7 @@ var logsActorsCmd = &cobra.Command{
 
 func init() {
 	logsActorsCmd.Flags().BoolVarP(&followLogs, "follow", "f", false, "Specify if the logs should be streamed.")
-	logsActorsCmd.Flags().StringVarP(&logsAtespaceFlag, "atespace", "a", "", "Atespace (tenant) the actor lives in")
+	logsActorsCmd.Flags().StringVarP(&logsAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
 	_ = logsActorsCmd.MarkFlagRequired("atespace")
 	logsCmd.AddCommand(logsActorsCmd)
 }

--- a/cmd/kubectl-ate/internal/cmd/pause_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/pause_actor.go
@@ -49,7 +49,7 @@ var pauseActorCmd = &cobra.Command{
 }
 
 func init() {
-	pauseActorCmd.Flags().StringVarP(&pauseAtespaceFlag, "atespace", "a", "", "Atespace (tenant) the actor lives in")
+	pauseActorCmd.Flags().StringVarP(&pauseAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
 	_ = pauseActorCmd.MarkFlagRequired("atespace")
 	pauseCmd.AddCommand(pauseActorCmd)
 }

--- a/cmd/kubectl-ate/internal/cmd/resume_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/resume_actor.go
@@ -52,7 +52,7 @@ var resumeActorCmd = &cobra.Command{
 
 func init() {
 	resumeActorCmd.Flags().BoolVarP(&bootFlag, "boot", "", false, "Skip golden snapshot and boot from scratch.")
-	resumeActorCmd.Flags().StringVarP(&resumeAtespaceFlag, "atespace", "a", "", "Atespace (tenant) the actor lives in")
+	resumeActorCmd.Flags().StringVarP(&resumeAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
 	_ = resumeActorCmd.MarkFlagRequired("atespace")
 	resumeCmd.AddCommand(resumeActorCmd)
 }

--- a/cmd/kubectl-ate/internal/cmd/suspend_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/suspend_actor.go
@@ -49,7 +49,7 @@ var suspendActorCmd = &cobra.Command{
 }
 
 func init() {
-	suspendActorCmd.Flags().StringVarP(&suspendAtespaceFlag, "atespace", "a", "", "Atespace (tenant) the actor lives in")
+	suspendActorCmd.Flags().StringVarP(&suspendAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
 	_ = suspendActorCmd.MarkFlagRequired("atespace")
 	suspendCmd.AddCommand(suspendActorCmd)
 }

--- a/demos/sandbox/client/main.go
+++ b/demos/sandbox/client/main.go
@@ -61,7 +61,7 @@ func dialAteAPI(endpoint string) (ateapipb.ControlClient, *grpc.ClientConn, erro
 
 func main() {
 	actorID := pflag.String("id", "", "ID of the sandbox actor (required)")
-	atespace := pflag.String("atespace", "", "Atespace (tenant) the actor lives in (required)")
+	atespace := pflag.String("atespace", "", "Atespace the actor lives in (required)")
 	ateapiAddr := pflag.String("ateapi", "localhost:8080", "Address of the ateapi gRPC server")
 	atenetAddr := pflag.String("atenet", "localhost:8000", "Address of the atenet HTTP router")
 	pflag.Parse()

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -405,7 +405,7 @@ type Actor struct {
 	// suspend/pause since eligibility is no longer a single fixed pool
 	// reference on the ActorTemplate.
 	WorkerPoolName string `protobuf:"bytes,14,opt,name=worker_pool_name,json=workerPoolName,proto3" json:"worker_pool_name,omitempty"`
-	// The atespace (tenant boundary) this actor belongs to. Part of the actor's
+	// The atespace this actor belongs to. Part of the actor's
 	// resource identity; folded into the Redis key as actor:<atespace>:<actor_id>.
 	Atespace      string `protobuf:"bytes,15,opt,name=atespace,proto3" json:"atespace,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -540,7 +540,7 @@ func (x *Actor) GetAtespace() string {
 	return ""
 }
 
-// Atespace is the tenant boundary an Actor is created into.
+// Atespace is the isolation boundary an Actor is created into.
 type Atespace struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -50,7 +50,7 @@ service Control {
   // List all actors currently reflected in redis.
   rpc ListActors(ListActorsRequest) returns (ListActorsResponse) {}
 
-  // Create a new Atespace (tenant boundary). Substrate-native, stored in Redis.
+  // Create a new Atespace. Substrate-native, stored in Redis.
   rpc CreateAtespace(CreateAtespaceRequest) returns (CreateAtespaceResponse) {}
 
   // Get an Atespace by name.
@@ -138,12 +138,12 @@ message Actor {
   // reference on the ActorTemplate.
   string worker_pool_name = 14;
 
-  // The atespace (tenant boundary) this actor belongs to. Part of the actor's
+  // The atespace this actor belongs to. Part of the actor's
   // resource identity; folded into the Redis key as actor:<atespace>:<actor_id>.
   string atespace = 15;
 }
 
-// Atespace is the tenant boundary an Actor is created into.
+// Atespace is the isolation boundary an Actor is created into.
 message Atespace {
   string name = 1;
 }

--- a/pkg/proto/ateapipb/ateapi_grpc.pb.go
+++ b/pkg/proto/ateapipb/ateapi_grpc.pb.go
@@ -75,7 +75,7 @@ type ControlClient interface {
 	ListWorkers(ctx context.Context, in *ListWorkersRequest, opts ...grpc.CallOption) (*ListWorkersResponse, error)
 	// List all actors currently reflected in redis.
 	ListActors(ctx context.Context, in *ListActorsRequest, opts ...grpc.CallOption) (*ListActorsResponse, error)
-	// Create a new Atespace (tenant boundary). Substrate-native, stored in Redis.
+	// Create a new Atespace. Substrate-native, stored in Redis.
 	CreateAtespace(ctx context.Context, in *CreateAtespaceRequest, opts ...grpc.CallOption) (*CreateAtespaceResponse, error)
 	// Get an Atespace by name.
 	GetAtespace(ctx context.Context, in *GetAtespaceRequest, opts ...grpc.CallOption) (*GetAtespaceResponse, error)
@@ -259,7 +259,7 @@ type ControlServer interface {
 	ListWorkers(context.Context, *ListWorkersRequest) (*ListWorkersResponse, error)
 	// List all actors currently reflected in redis.
 	ListActors(context.Context, *ListActorsRequest) (*ListActorsResponse, error)
-	// Create a new Atespace (tenant boundary). Substrate-native, stored in Redis.
+	// Create a new Atespace. Substrate-native, stored in Redis.
 	CreateAtespace(context.Context, *CreateAtespaceRequest) (*CreateAtespaceResponse, error)
 	// Get an Atespace by name.
 	GetAtespace(context.Context, *GetAtespaceRequest) (*GetAtespaceResponse, error)


### PR DESCRIPTION
followup cleaning for #280

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
