### PR TITLE
Add Valkey operations handbook

### DIFF
--- a/docs/valkey/README.md
+++ b/docs/valkey/README.md
@@ -12,16 +12,22 @@ own documentation.
 
 ## Pages
 
-- [`topology.md`](./topology.md) — what's deployed, how the pieces fit
-  together, sizing math for MVP and target scale, identity / TLS wiring,
-  and the configuration knobs we have not set yet.
-- [`lifecycle.md`](./lifecycle.md) — the actor state machine, the four
-  lifecycle workflows (Create, Resume, Suspend, Pause), the
-  worker-cache subscription model, and the per-actor scheduling
-  eligibility rules.
+- [`topology.md`](./topology.md) — what's deployed, how the pieces
+  fit together, and identity / TLS wiring.
+- [`lifecycle.md`](./lifecycle.md) — the actor state machine
+  (including the CRASHED parking state), the lifecycle workflows
+  (Create, Resume, Suspend, Pause, Delete), the worker-cache
+  subscription model, and the per-worker scheduling eligibility
+  rules.
 - [`operations.md`](./operations.md) — failure modes with inline
-  recovery for each, common admin operations, and the short list of
+  recovery for each, common admin operations (including coordinated
+  maintenance failovers and backup/restore), and the short list of
   open operational risks.
+- [`scaling_to_10m.md`](./scaling_to_10m.md) — the growth path from
+  a 10-actor pilot to the supported envelope of 10 million actors:
+  tiered requirements with graduation triggers, capacity math, the
+  durability contract, and the deployed-today vs. target
+  configuration ladder.
 
 ## Conventions
 

--- a/docs/valkey/README.md
+++ b/docs/valkey/README.md
@@ -1,0 +1,49 @@
+# Valkey Operations Handbook
+
+Operational reference for Agent Substrate's persistence tier — the Valkey
+cluster that stores actor and worker state, plus the in-process worker
+cache that sits in front of it inside `ate-api-server`.
+
+This handbook is for operators, on-call engineers, and contributors who
+need to reason about the storage tier without first reading the code. It
+is intentionally narrow: it covers what's deployed, how state moves
+through it, and what to do when it breaks. It does not retell Valkey's
+own documentation.
+
+## Pages
+
+- [`topology.md`](./topology.md) — what's deployed, how the pieces fit
+  together, sizing math for MVP and target scale, identity / TLS wiring,
+  and the configuration knobs we have not set yet.
+- [`lifecycle.md`](./lifecycle.md) — the actor state machine, the four
+  lifecycle workflows (Create, Resume, Suspend, Pause), the
+  worker-cache subscription model, and the per-actor scheduling
+  eligibility rules.
+- [`operations.md`](./operations.md) — failure modes with inline
+  recovery for each, common admin operations, and the short list of
+  open operational risks.
+
+## Conventions
+
+- Source citations use **path + symbol name** (e.g.
+  `cmd/ateapi/internal/store/store.go` (`Interface`)), never line
+  numbers. Line numbers drift on every refactor; symbol references
+  survive.
+- Code examples assume `valkey-cli` is invoked with the full TLS flag
+  set; for brevity the pages use a `vcli` alias defined in
+  [`operations.md`](./operations.md).
+- Diagrams are mermaid blocks; GitHub renders them inline.
+
+## Updating
+
+Update the handbook whenever you learn something new about how the
+storage tier behaves — new failure modes, recovery steps that worked
+(or didn't) during a real incident, configuration changes, surprising
+behavior from upgrades. A handbook that captures the *why* of a past
+decision is more valuable than one that perfectly describes the
+current code, because the code is already self-describing.
+
+Substantive changes belong in their own PR rather than folded into a
+feature change, so the doc review gets focused attention. Trivial
+touch-ups (renamed flag, updated path) can ride with the code change
+that prompted them.

--- a/docs/valkey/lifecycle.md
+++ b/docs/valkey/lifecycle.md
@@ -24,7 +24,13 @@ stateDiagram-v2
 
   RUNNING --> SUSPENDED: syncer · worker pod deleted
 
+  RESUMING   --> CRASHED: atelet crash directive
+  SUSPENDING --> CRASHED: atelet crash directive
+  PAUSING    --> CRASHED: atelet crash directive
+  CRASHED    --> RESUMING: ResumeActor
+
   SUSPENDED --> [*]: DeleteActor
+  CRASHED   --> [*]: DeleteActor
 ```
 
 The two "at rest" states differ in durability and resume cost:
@@ -35,7 +41,23 @@ The two "at rest" states differ in durability and resume cost:
   running. Faster resume from local cache, but lost if that node
   fails. The actor record carries
   `latest_snapshot_info.local.node_vms_with_local_snapshots` so the
-  scheduler can prefer a worker on the same node for the next resume.
+  scheduler can route the next resume to that node. Note: this list
+  is written once, at pause time — nothing updates it if the node
+  later dies or evicts the checkpoint, so it can go stale silently
+  (tracked in the [`operations.md`](./operations.md) risks table).
+
+There is also a failure state:
+
+- **CRASHED** — the atelet reported an unrecoverable workload failure
+  (a crash directive returned from `Checkpoint`, `Restore`, or `Run`),
+  or a suspend/pause workflow found the actor mid-transition with no
+  pod coordinates left. `crashActor` / `maybeCrashActor`
+  (`cmd/ateapi/internal/controlapi/crash.go`) park the actor here and
+  surface `DataLoss` to the caller. CRASHED is not a dead end:
+  `ResumeActor` accepts it (the resume path has no status gate) and
+  `DeleteActor` accepts it alongside SUSPENDED. The syncer's
+  dead-worker release path deliberately **preserves** CRASHED rather
+  than resetting it to SUSPENDED.
 
 The transitional states (`RESUMING`, `SUSPENDING`, `PAUSING`) only
 exist for the duration of the corresponding workflow. An actor stuck
@@ -52,16 +74,20 @@ worker pods. The `WorkerPoolSyncer` (`cmd/ateapi/internal/controlapi/syncer.go`)
 watches worker pods via a K8s informer and reflects pod events into
 the store:
 
-- Pod **Added** (eligible) → `CreateWorker`
-- Pod **Updated** (IP changed; in practice unreachable) → `UpdateWorker`
+- Pod **Added** (eligible) → `CreateWorker`, with the pool's labels
+  and sandbox class copied onto the worker record
+- Pod **Updated** → `UpdateWorker` when the pod IP, the pool's
+  sandbox class, or the pool's labels changed. Note the fan-out:
+  editing a pool's labels re-writes (and publishes a pub/sub event
+  for) **every worker in that pool**
 - Pod **Deleted** (or `DeletionTimestamp` set) →
   `releaseActorOnDeadWorker` (resets the actor bound to the dying
   worker, if any) followed by `DeleteWorker`
 
 The syncer is the only writer for worker create/delete; the lifecycle
-workflows below only mutate the **assignment** fields
-(`actor_id` / `actor_namespace` / `actor_template`) of existing
-worker records.
+workflows below only mutate the **`Assignment`** sub-message (a
+reference to the assigned actor and its template) on existing worker
+records.
 
 ### Worker cache
 
@@ -88,7 +114,9 @@ How it stays in sync (list + watch + relist):
    subscription drop).
 4. **Disconnect resync.** If the subscriber's channel closes, the
    cache marks itself not-ready and re-runs the initial sync with
-   exponential backoff (1 s → 30 s cap, 5 attempts).
+   exponential backoff (1 s doubling to a 30 s cap). It retries
+   indefinitely until success or shutdown — the backoff's step count
+   bounds the *growth* of the delay, not the number of attempts.
 
 The cache is **per API-server pod**. Each pod independently
 subscribes to the cluster-wide pub/sub channel, so all pods see the
@@ -96,45 +124,57 @@ same events. Pods stay eventually-consistent with each other on the
 order of pub/sub latency (sub-second steady state).
 
 `Workers()` returns pointers directly into the cache map. Callers
-that need to mutate a worker proto (e.g. setting `actor_id` during
-assignment) must `proto.Clone` first to avoid corrupting the cache.
+that need to mutate a worker proto (e.g. setting its `Assignment`
+during scheduling) must `proto.Clone` first to avoid corrupting the
+cache.
 
 ### Eligibility — which workers can run which actor
 
-Not every free worker can run any actor. The scheduler filters via
-**`eligibleWorkerPools`** (in
-`cmd/ateapi/internal/controlapi/workflow_resume.go`), which intersects
-three constraints:
+Not every free worker can run any actor. The scheduler filters
+per-worker via **`isWorkerEligibleForActor`** (in
+`cmd/ateapi/internal/controlapi/workflow_resume.go`), which checks
+three constraints against fields cached on the Worker record itself:
 
 1. **Sandbox class match.** Snapshots are not portable across sandbox
-   classes (gvisor, microvm, etc.). The pool's `Spec.SandboxClass`
-   must equal the template's `Spec.SandboxClass`. Hard gate.
-2. **Template's worker-selector.** A K8s `LabelSelector` on the
-   `ActorTemplate.Spec.WorkerSelector` that must match the pool's
-   labels.
+   classes (gvisor, microvm, etc.). The worker's `sandbox_class` must
+   equal the template's `Spec.SandboxClass`. Hard gate.
+2. **Template's worker-selector.** A K8s `LabelSelector` on
+   `ActorTemplate.Spec.WorkerSelector`, matched against the worker's
+   `labels`.
 3. **Actor's worker-selector.** A `Selector` (match-labels only) on
    the `Actor.WorkerSelector` field, set at CreateActor and
-   updatable. Also matched against the pool's labels.
+   updatable. Also matched against the worker's `labels`.
 
-The result is a set of `(namespace, name)` pairs of eligible worker
-pools. `AssignWorkerStep` then picks a free worker whose
-`(WorkerNamespace, WorkerPool)` is in that set.
+The worker's `labels` and `sandbox_class` are copied from its
+WorkerPool by the syncer at creation and kept current when the pool
+changes — so matching is *evaluated* per worker, but the values are
+still pool-derived: two workers of the same pool always match
+identically today. The payoff of caching them on the worker record
+is that the resume path no longer reads WorkerPool CRDs at all —
+scheduling runs entirely against the worker cache. One consequence:
+there is no distinct "no worker pool matches" error anymore; an
+over-constrained selector surfaces as `no free workers available`.
 
-Note: today eligibility is **per-pool**, not per-individual-worker.
-There is no per-worker label scheduling yet — every worker in an
-eligible pool is treated equivalently except for the locality
-preference (next section).
+### Locality restriction (paused actors)
 
-### Locality preference
-
-Within the eligible-pool set, the scheduler prefers a worker on a
-node that already has the actor's local snapshot. The actor's
-`latest_snapshot_info.local.node_vms_with_local_snapshots` carries
-the list of node IDs that hold the snapshot; `findFreeWorker`
-filters candidate workers to that node set if non-empty. If no
-candidate workers are on a matching node, the resume falls back to
-any free worker in the eligible pool set (and the snapshot will be
-pulled from durable storage during `Restore`).
+When the actor's latest snapshot is a **local** checkpoint, locality
+is a hard constraint, not a preference: the checkpoint physically
+exists only on the node(s) listed in
+`latest_snapshot_info.local.node_vms_with_local_snapshots`, and
+`findFreeWorker` restricts candidates to workers on those nodes.
+There is **no fallback** — a local snapshot cannot be restored
+elsewhere, and the `SnapshotInfo` oneof means a paused actor holds no
+external-snapshot URI to fall back to. If the listed node has no free
+eligible worker, the resume fails (`no free workers available`) until
+one frees up there. If the node itself is **gone**, the actor is
+stuck: `boot=true` does not help — it only skips the template's
+*golden* snapshot when the actor has no snapshot of its own; an
+existing local checkpoint is always restored — and the syncer's
+dead-worker reset does not apply to a finalized PAUSED actor (its pod
+coordinates were already cleared at pause time). There is no
+API-level escape hatch today; tracked in the
+[`operations.md`](./operations.md) risks table. This is a known
+modeling limit of the current snapshot schema.
 
 ## The four workflows
 
@@ -142,7 +182,9 @@ All four workflows live in `cmd/ateapi/internal/controlapi/` and are
 orchestrated via a generic step engine in `workflow.go`. Resume,
 Suspend, and Pause all acquire a per-actor distributed lock
 (`lock:actor:<id>`, 30 s TTL, 28 s workflow timeout) before running
-their step sequence.
+their step sequence. Note the lock key is **not** atespace-scoped:
+same-named actors in different atespaces contend on one lock (safe,
+but a cross-tenant fairness quirk).
 
 ### CreateActor
 
@@ -150,11 +192,14 @@ Trigger: client API call. No lock; relies on storage-level CAS.
 
 Steps:
 
-1. Validate request, fetch the `ActorTemplate` from the K8s lister.
+1. Validate request, fetch the `ActorTemplate` from the K8s lister,
+   and check the target atespace exists (`AtespaceExists`) —
+   `FailedPrecondition` if not. Actor identity is
+   `(atespace, name)`; the record lands at `actor:<atespace>:<id>`.
 2. Construct an `Actor` proto with `version=1`,
    `status=STATUS_SUSPENDED`.
 3. `CreateActor` (storage `SET NX`) — returns `ErrAlreadyExists` if
-   the id is taken.
+   the `(atespace, id)` pair is taken.
 4. `GetActor` to return the stored record.
 
 Failure modes covered in [`operations.md`](./operations.md).
@@ -166,24 +211,31 @@ Trigger: client API call. Acquires `lock:actor:<id>`.
 Steps:
 
 1. **LoadActorForResume** — `GetActor` + `Get ActorTemplate`.
-2. **AssignWorker** — compute `eligibleWorkerPools`, read
-   `workerCache.Workers()`, look for an existing assignment from a
-   previous failed attempt (idempotency), otherwise call
-   `findFreeWorker` (filtered to eligible pools + node-locality
-   preference) and pick a random match. Update worker (CAS) with
-   the new assignment, update actor to `RESUMING` with pod
-   coordinates.
-3. **CallAteletRestore** — gRPC `Restore` (or `Run` if no snapshot
-   exists) against the chosen worker's atelet. The atelet either
-   loads from the local cache (if the node has the snapshot) or
-   pulls from durable storage.
+2. **AssignWorker** — read `workerCache.Workers()`, look for an
+   existing assignment from a previous failed attempt (idempotency) —
+   releasing it back to the free pool first if it is no longer
+   eligible (a selector changed since) — otherwise call
+   `findFreeWorker` (filtered per-worker by
+   `isWorkerEligibleForActor`, and hard-restricted to the
+   local-snapshot node set when one exists) and pick a random match.
+   Update worker (CAS) with the new `Assignment`, update actor to
+   `RESUMING` with pod coordinates.
+3. **CallAteletRestore** — a three-way branch against the chosen
+   worker's atelet: if the actor has its own snapshot, gRPC `Restore`
+   from it (local or external per the `SnapshotInfo` oneof); else if
+   the template has a golden snapshot and the request did not set
+   `boot=true`, `Restore` from the golden snapshot; else `Run` from
+   scratch (resolving sandbox assets from the pool's SandboxConfig).
+   `boot` is consulted only in that middle branch — it cannot bypass
+   an actor's own snapshot. Atelet errors route through
+   `maybeCrashActor`, which parks the actor in `CRASHED` when the
+   atelet reports the workload unrecoverable.
 4. **FinalizeRunning** — refresh actor record, set status `RUNNING`
    (CAS).
 
-A successful resume ends with actor `RUNNING`, worker `actor_id` =
-this actor, the worker record reflecting the assignment, and a pub/sub
-event from the `UpdateWorker` so other API server pods' caches see
-the change.
+A successful resume ends with actor `RUNNING`, the worker's
+`Assignment` pointing at this actor, and a pub/sub event from the
+`UpdateWorker` so other API server pods' caches see the change.
 
 `AssignWorker` has exponential backoff (5 attempts) on CAS conflicts.
 `FinalizeRunning` does not — a single CAS conflict here strands the
@@ -197,8 +249,8 @@ Steps:
 
 1. **LoadActorForSuspend**.
 2. **MarkSuspending** — update actor to `SUSPENDING`, record an
-   `in_progress_snapshot` URI (constructed from template's snapshot
-   location + actor id + timestamp).
+   `in_progress_snapshot` URI (constructed from the template's
+   snapshot location + actor id + a timestamp-random suffix).
 3. **CallAteletSuspend** — gRPC `Checkpoint` to the actor's atelet.
    The atelet writes the snapshot to durable storage at the
    `in_progress_snapshot` URI. If the worker pod has vanished
@@ -206,7 +258,7 @@ Steps:
    actor record will still be transitioned, but no fresh snapshot
    is written.
 4. **FinalizeSuspended** — refresh actor, release the worker
-   (`UpdateWorker` clearing `actor_id`), set actor status
+   (`UpdateWorker` clearing its `Assignment`), set actor status
    `SUSPENDED`, promote `in_progress_snapshot` to the
    `latest_snapshot_info.external` field, clear pod coordinates.
 
@@ -222,30 +274,40 @@ Steps mirror Suspend but the snapshot is **kept local on the node**
 rather than uploaded to durable storage:
 
 1. **LoadActorForPause**.
-2. **MarkPausing** — update actor to `PAUSING`.
+2. **MarkPausing** — update actor to `PAUSING` and record an
+   `in_progress_snapshot` local prefix (actor id + timestamp-random
+   suffix).
 3. **CallAteletPause** — gRPC `Pause` to the actor's atelet, which
-   snapshots in-place on the node.
+   snapshots in-place on the node under that prefix.
 4. **FinalizePaused** — release the worker, set actor status
    `PAUSED`, record the node in
    `latest_snapshot_info.local.node_vms_with_local_snapshots`,
    clear pod coordinates.
 
 Pause is faster than Suspend (no network upload) and produces no
-durable artifact. A subsequent ResumeActor will prefer a worker on a
-node in the local-snapshot set; if none are available, the resume
-falls back to a worker without locality and the snapshot is
-unavailable (PAUSED actors that lose their node go to
-`SUSPENDED`-without-snapshot via syncer-driven release; the actor
-record's snapshot fields no longer reference a valid blob).
+durable artifact. A subsequent ResumeActor **must** land on a worker
+whose node is in the local-snapshot set (see "Locality restriction"
+above); if that node has no free worker, the resume fails rather
+than falling back. And because `FinalizePaused` clears both the
+worker's `Assignment` and the actor's pod coordinates, the syncer's
+dead-worker release path **ignores** a finalized PAUSED actor — a
+later worker-pod deletion does not reset it to SUSPENDED. If the
+node itself survives, a new worker there can restore normally; if
+the node is **gone**, the actor is stuck: `boot=true` does not
+bypass an existing local snapshot, so there is no API-level way to
+abandon the checkpoint today (tracked in the
+[`operations.md`](./operations.md) risks table). In short: pause
+trades durability for speed, and a paused actor is exactly as
+durable as the node holding its checkpoint.
 
-### DeleteActor (SUSPENDED → ∅)
+### DeleteActor (SUSPENDED or CRASHED → ∅)
 
 Trigger: client API call. No lock; relies on storage-level CAS with
 status precondition.
 
-`DeleteActor` does a `WATCH`/`GET`/check `status == SUSPENDED`/
-`MULTI`/`DEL` against the actor key. Returns
-`ErrFailedPrecondition` if the actor is not SUSPENDED;
+`DeleteActor` does a `WATCH`/`GET`/check
+`status ∈ {SUSPENDED, CRASHED}`/`MULTI`/`DEL` against the actor key.
+Returns `ErrFailedPrecondition` if the actor is in any other state;
 `ErrPersistenceRetry` if another writer changed the key during the
 check.
 

--- a/docs/valkey/lifecycle.md
+++ b/docs/valkey/lifecycle.md
@@ -1,0 +1,288 @@
+# Lifecycle
+
+This page describes how state moves through the storage tier — the
+actor state machine, the four lifecycle workflows that drive it, the
+worker side (creation, assignment, release, deletion), and the worker
+cache that makes scheduling fast.
+
+## Actor state machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> SUSPENDED: CreateActor
+
+  SUSPENDED --> RESUMING: ResumeActor
+  RESUMING  --> RUNNING
+
+  RUNNING --> SUSPENDING: SuspendActor
+  SUSPENDING --> SUSPENDED
+
+  RUNNING --> PAUSING: PauseActor
+  PAUSING --> PAUSED
+
+  PAUSED --> RESUMING: ResumeActor
+
+  RUNNING --> SUSPENDED: syncer · worker pod deleted
+
+  SUSPENDED --> [*]: DeleteActor
+```
+
+The two "at rest" states differ in durability and resume cost:
+
+- **SUSPENDED** — snapshot lives in durable object storage. Survives
+  node loss. Slower resume (network pull of the snapshot).
+- **PAUSED** — snapshot lives on the node where the actor was
+  running. Faster resume from local cache, but lost if that node
+  fails. The actor record carries
+  `latest_snapshot_info.local.node_vms_with_local_snapshots` so the
+  scheduler can prefer a worker on the same node for the next resume.
+
+The transitional states (`RESUMING`, `SUSPENDING`, `PAUSING`) only
+exist for the duration of the corresponding workflow. An actor stuck
+in a transitional state past the lock TTL (30 s) is stranded — see
+[`operations.md`](./operations.md).
+
+## Worker side
+
+### Source of truth: the syncer
+
+Worker records in Valkey are not created or deleted by application
+calls — they're driven entirely by the Kubernetes pod lifecycle of
+worker pods. The `WorkerPoolSyncer` (`cmd/ateapi/internal/controlapi/syncer.go`)
+watches worker pods via a K8s informer and reflects pod events into
+the store:
+
+- Pod **Added** (eligible) → `CreateWorker`
+- Pod **Updated** (IP changed; in practice unreachable) → `UpdateWorker`
+- Pod **Deleted** (or `DeletionTimestamp` set) →
+  `releaseActorOnDeadWorker` (resets the actor bound to the dying
+  worker, if any) followed by `DeleteWorker`
+
+The syncer is the only writer for worker create/delete; the lifecycle
+workflows below only mutate the **assignment** fields
+(`actor_id` / `actor_namespace` / `actor_template`) of existing
+worker records.
+
+### Worker cache
+
+The `cmd/ateapi/internal/workercache` package keeps an in-process
+mirror of all worker records inside every `ate-api-server` pod. The
+cache exists so `AssignWorkerStep` does not pay an O(N) `ListWorkers`
+scan against Valkey on every actor resume — it reads `Workers()` in
+microseconds.
+
+How it stays in sync (list + watch + relist):
+
+1. **Initial sync.** On startup, `Cache.Start` subscribes to
+   `WatchWorkers` (Valkey pub/sub), then runs `ListWorkers` once to
+   populate the map. `Workers()` returns "not ready" until this
+   completes.
+2. **Live updates.** Every `CreateWorker` / `UpdateWorker` /
+   `DeleteWorker` against the store publishes a `WorkerEvent` on the
+   `worker-changes` channel. The cache's subscriber goroutine
+   receives events and applies them to the map. Events are compared
+   by `version`; a stale event cannot overwrite a fresher cache
+   entry.
+3. **Periodic relist.** Re-runs `ListWorkers` on a schedule to catch
+   anything pub/sub missed (slow consumer, dropped events, transient
+   subscription drop).
+4. **Disconnect resync.** If the subscriber's channel closes, the
+   cache marks itself not-ready and re-runs the initial sync with
+   exponential backoff (1 s → 30 s cap, 5 attempts).
+
+The cache is **per API-server pod**. Each pod independently
+subscribes to the cluster-wide pub/sub channel, so all pods see the
+same events. Pods stay eventually-consistent with each other on the
+order of pub/sub latency (sub-second steady state).
+
+`Workers()` returns pointers directly into the cache map. Callers
+that need to mutate a worker proto (e.g. setting `actor_id` during
+assignment) must `proto.Clone` first to avoid corrupting the cache.
+
+### Eligibility — which workers can run which actor
+
+Not every free worker can run any actor. The scheduler filters via
+**`eligibleWorkerPools`** (in
+`cmd/ateapi/internal/controlapi/workflow_resume.go`), which intersects
+three constraints:
+
+1. **Sandbox class match.** Snapshots are not portable across sandbox
+   classes (gvisor, microvm, etc.). The pool's `Spec.SandboxClass`
+   must equal the template's `Spec.SandboxClass`. Hard gate.
+2. **Template's worker-selector.** A K8s `LabelSelector` on the
+   `ActorTemplate.Spec.WorkerSelector` that must match the pool's
+   labels.
+3. **Actor's worker-selector.** A `Selector` (match-labels only) on
+   the `Actor.WorkerSelector` field, set at CreateActor and
+   updatable. Also matched against the pool's labels.
+
+The result is a set of `(namespace, name)` pairs of eligible worker
+pools. `AssignWorkerStep` then picks a free worker whose
+`(WorkerNamespace, WorkerPool)` is in that set.
+
+Note: today eligibility is **per-pool**, not per-individual-worker.
+There is no per-worker label scheduling yet — every worker in an
+eligible pool is treated equivalently except for the locality
+preference (next section).
+
+### Locality preference
+
+Within the eligible-pool set, the scheduler prefers a worker on a
+node that already has the actor's local snapshot. The actor's
+`latest_snapshot_info.local.node_vms_with_local_snapshots` carries
+the list of node IDs that hold the snapshot; `findFreeWorker`
+filters candidate workers to that node set if non-empty. If no
+candidate workers are on a matching node, the resume falls back to
+any free worker in the eligible pool set (and the snapshot will be
+pulled from durable storage during `Restore`).
+
+## The four workflows
+
+All four workflows live in `cmd/ateapi/internal/controlapi/` and are
+orchestrated via a generic step engine in `workflow.go`. Resume,
+Suspend, and Pause all acquire a per-actor distributed lock
+(`lock:actor:<id>`, 30 s TTL, 28 s workflow timeout) before running
+their step sequence.
+
+### CreateActor
+
+Trigger: client API call. No lock; relies on storage-level CAS.
+
+Steps:
+
+1. Validate request, fetch the `ActorTemplate` from the K8s lister.
+2. Construct an `Actor` proto with `version=1`,
+   `status=STATUS_SUSPENDED`.
+3. `CreateActor` (storage `SET NX`) — returns `ErrAlreadyExists` if
+   the id is taken.
+4. `GetActor` to return the stored record.
+
+Failure modes covered in [`operations.md`](./operations.md).
+
+### ResumeActor (SUSPENDED or PAUSED → RUNNING)
+
+Trigger: client API call. Acquires `lock:actor:<id>`.
+
+Steps:
+
+1. **LoadActorForResume** — `GetActor` + `Get ActorTemplate`.
+2. **AssignWorker** — compute `eligibleWorkerPools`, read
+   `workerCache.Workers()`, look for an existing assignment from a
+   previous failed attempt (idempotency), otherwise call
+   `findFreeWorker` (filtered to eligible pools + node-locality
+   preference) and pick a random match. Update worker (CAS) with
+   the new assignment, update actor to `RESUMING` with pod
+   coordinates.
+3. **CallAteletRestore** — gRPC `Restore` (or `Run` if no snapshot
+   exists) against the chosen worker's atelet. The atelet either
+   loads from the local cache (if the node has the snapshot) or
+   pulls from durable storage.
+4. **FinalizeRunning** — refresh actor record, set status `RUNNING`
+   (CAS).
+
+A successful resume ends with actor `RUNNING`, worker `actor_id` =
+this actor, the worker record reflecting the assignment, and a pub/sub
+event from the `UpdateWorker` so other API server pods' caches see
+the change.
+
+`AssignWorker` has exponential backoff (5 attempts) on CAS conflicts.
+`FinalizeRunning` does not — a single CAS conflict here strands the
+actor in `RESUMING` and requires an external retry.
+
+### SuspendActor (RUNNING → SUSPENDED)
+
+Trigger: client API call. Acquires `lock:actor:<id>`.
+
+Steps:
+
+1. **LoadActorForSuspend**.
+2. **MarkSuspending** — update actor to `SUSPENDING`, record an
+   `in_progress_snapshot` URI (constructed from template's snapshot
+   location + actor id + timestamp).
+3. **CallAteletSuspend** — gRPC `Checkpoint` to the actor's atelet.
+   The atelet writes the snapshot to durable storage at the
+   `in_progress_snapshot` URI. If the worker pod has vanished
+   (`ErrWorkerPodNotFound`), the step skips with a warning — the
+   actor record will still be transitioned, but no fresh snapshot
+   is written.
+4. **FinalizeSuspended** — refresh actor, release the worker
+   (`UpdateWorker` clearing `actor_id`), set actor status
+   `SUSPENDED`, promote `in_progress_snapshot` to the
+   `latest_snapshot_info.external` field, clear pod coordinates.
+
+Suspend ends with the worker free (pub/sub event broadcast) and the
+actor pointing at a fresh durable snapshot. Suspend is the only path
+that produces a durably-stored snapshot.
+
+### PauseActor (RUNNING → PAUSED)
+
+Trigger: client API call. Acquires `lock:actor:<id>`.
+
+Steps mirror Suspend but the snapshot is **kept local on the node**
+rather than uploaded to durable storage:
+
+1. **LoadActorForPause**.
+2. **MarkPausing** — update actor to `PAUSING`.
+3. **CallAteletPause** — gRPC `Pause` to the actor's atelet, which
+   snapshots in-place on the node.
+4. **FinalizePaused** — release the worker, set actor status
+   `PAUSED`, record the node in
+   `latest_snapshot_info.local.node_vms_with_local_snapshots`,
+   clear pod coordinates.
+
+Pause is faster than Suspend (no network upload) and produces no
+durable artifact. A subsequent ResumeActor will prefer a worker on a
+node in the local-snapshot set; if none are available, the resume
+falls back to a worker without locality and the snapshot is
+unavailable (PAUSED actors that lose their node go to
+`SUSPENDED`-without-snapshot via syncer-driven release; the actor
+record's snapshot fields no longer reference a valid blob).
+
+### DeleteActor (SUSPENDED → ∅)
+
+Trigger: client API call. No lock; relies on storage-level CAS with
+status precondition.
+
+`DeleteActor` does a `WATCH`/`GET`/check `status == SUSPENDED`/
+`MULTI`/`DEL` against the actor key. Returns
+`ErrFailedPrecondition` if the actor is not SUSPENDED;
+`ErrPersistenceRetry` if another writer changed the key during the
+check.
+
+Snapshot URIs in the actor record are **not cleaned up** by
+`DeleteActor` — durable snapshots leak in object storage. Tracked
+under operations risks.
+
+## Worker lifecycle, end to end
+
+Putting the pieces together for a typical "worker pod gets created,
+gets used, gets deleted" cycle:
+
+1. **Pod created** in K8s (manually or by an autoscaler controller).
+2. K8s informer in syncer sees the Add event, calls `CreateWorker`
+   on the store.
+3. `CreateWorker` writes to Valkey AND publishes
+   `WorkerEvent{Created, worker}` on `worker-changes`.
+4. Every API-server pod's worker cache receives the event and adds
+   the worker to its map. Worker is now visible to all schedulers.
+5. A `ResumeActor` call lands; `AssignWorker` reads
+   `workerCache.Workers()`, picks this worker, `UpdateWorker` is
+   called with the new assignment.
+6. `UpdateWorker` writes to Valkey AND publishes
+   `WorkerEvent{Updated, worker}`. Caches everywhere update.
+7. Actor lifecycle continues; eventually `SuspendActor` releases the
+   worker via another `UpdateWorker`/`WorkerEvent{Updated}` and the
+   worker is idle again.
+8. Steps 5–7 may repeat many times — the worker is reused across
+   actors.
+9. Eventually the pod is deleted (scale-down, node maintenance,
+   crash). K8s informer sees the Delete event, syncer calls
+   `releaseActorOnDeadWorker` then `DeleteWorker`.
+10. `DeleteWorker` removes the key from Valkey AND publishes
+    `WorkerEvent{Deleted, worker}`. Caches everywhere remove the
+    worker. Worker is no longer visible to any scheduler.
+
+Pub/sub is the load-bearing mechanism keeping all caches in step
+with reality. Operational concerns around this — missed events,
+broadcast amplification at scale, subscriber backpressure — are in
+[`operations.md`](./operations.md).

--- a/docs/valkey/operations.md
+++ b/docs/valkey/operations.md
@@ -1,0 +1,670 @@
+# Operations
+
+Operational reference: failure modes with inline recovery, common
+admin commands, and the short list of risks worth tracking as the
+deployment grows.
+
+## How to use this page
+
+During an incident: identify the failure mode by symptom (the
+**Symptom** line at the top of each entry), follow the **Recovery**
+steps, capture the **Postmortem** items before closing the ticket.
+
+Outside an incident: read it end-to-end periodically. The risks
+section is the rollup of "things we know are not yet addressed."
+
+Each failure-mode entry is collapsed by default — click to expand.
+The category headers and the at-a-glance risks table at the end stay
+visible.
+
+## Universal preflight
+
+Run these before any non-trivial action. They preserve evidence and
+confirm scope.
+
+```bash
+# Snapshot K8s state
+kubectl -n ate-system get pods -l app=valkey-cluster -o wide > /tmp/incident-pods-$(date +%s).txt
+kubectl -n ate-system get events --sort-by=.lastTimestamp | tail -100 > /tmp/incident-events-$(date +%s).txt
+
+# vcli alias — substitute into every valkey-cli call below
+alias vcli='valkey-cli --tls \
+  --cacert /etc/valkey-ca/ca.crt \
+  --cert /run/servicedns.podcert.ate.dev/credential-bundle.pem \
+  --key /run/servicedns.podcert.ate.dev/credential-bundle.pem'
+
+# Snapshot cluster's view of itself
+kubectl -n ate-system exec valkey-cluster-0 -- vcli cluster info > /tmp/incident-cluster-info-$(date +%s).txt
+kubectl -n ate-system exec valkey-cluster-0 -- vcli cluster nodes > /tmp/incident-cluster-nodes-$(date +%s).txt
+```
+
+## Pod & process failures
+
+> **`cluster-require-full-coverage yes` amplifies these.** All three
+> pod-level failures below interact with the current setting: *any*
+> shard whose slot range is briefly uncovered — including a normal
+> primary failover — flips `cluster_state` to `fail` and pauses
+> **all** writes cluster-wide until coverage is restored. Flipping
+> to `no` would localize each failure to its own slot range. See
+> [`topology.md`](./topology.md).
+
+### Single replica loss
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** K8s pod restart for a Valkey pod that is currently a
+replica. No client-visible errors.
+
+**What's happening:** StatefulSet recreates the pod with the same
+PVC. Valkey performs a partial resync if recent enough; full resync
+if not. The shard runs without HA until resync completes (elevated
+risk during this window).
+
+**Recovery:** automatic — verify only.
+
+```bash
+kubectl -n ate-system exec <restarted-pod> -- vcli info replication
+# Expect: role:slave, master_link_status:up
+# slave_repl_offset should advance toward master_repl_offset
+```
+
+Do **not** restart any other Valkey pod until resync completes —
+parallel restarts cascade into a resync storm.
+
+**Postmortem:** what caused the restart (OOMKilled? manual? deploy?
+node maintenance?). If full resync, note duration — informs
+`repl-backlog-size` tuning.
+
+</details>
+
+### Primary loss & automatic failover
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** K8s pod restart for a Valkey pod that was a primary.
+Spike of `MOVED` / `CLUSTERDOWN` errors in `ate-api-server` logs.
+Under current `cluster-require-full-coverage yes`, this is a
+**cluster-wide write pause** for ~5–10 s (cluster-node-timeout 5 s +
+election + slot-map refresh), not per-slot.
+
+**Data loss window:** any writes the old primary acked but had not
+yet shipped to its replica are lost. Sub-millisecond under light
+load; can be hundreds of milliseconds to seconds under burst load.
+
+**Recovery:** automatic — verify and sweep for stranded actors.
+
+```bash
+# Confirm failover completed
+kubectl -n ate-system exec valkey-cluster-1 -- vcli cluster info
+# Expect: cluster_state:ok
+
+# Verify the recreated pod rejoined as replica
+kubectl -n ate-system exec <recreated-pod> -- vcli info replication
+
+# Sweep for stranded actors (RESUMING/SUSPENDING/PAUSING past lock TTL)
+# This requires an admin command or direct query; if none exists yet,
+# log into ateapi and check actor status counts via the API.
+```
+
+**Postmortem:** failover trigger; measured cluster-pause duration
+(first CLUSTERDOWN to first successful write); any actors found
+stranded and how they were unstuck.
+
+</details>
+
+### Whole-shard loss (both pods of one shard down simultaneously)
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** Multiple shard pods restarting at once; cluster-wide
+writes failing; `cluster_state:fail` persists past ~30 s.
+
+**What's happening:** both primary and replica of a shard are down.
+Most common cause is a shared infrastructure failure (both pods on
+the same K8s node — anti-affinity not configured today, so this is
+possible).
+
+**Recovery:** depends on whether PVCs survived.
+
+> **WARNING:** several branches below involve discarding data.
+> Capture PVC contents and logs *before* any destructive action.
+
+```bash
+# 1. Identify the affected shard and its PVCs
+kubectl -n ate-system get pods -l app=valkey-cluster -o wide
+kubectl -n ate-system get pvc
+
+# 2. PVCs survived → wait for AOF replay on pod restart
+#    Up to ~1s of acked writes lost (appendfsync everysec default).
+
+# 3. One PVC survived, one lost → surviving pod replays AOF and
+#    serves; lost pod's new PVC will full-resync from the surviving
+#    pod. No additional data loss beyond (2).
+
+# 4. Both PVCs lost → permanent data loss for that shard's slot
+#    range. No off-cluster backups today. Escalate; do not attempt
+#    re-bootstrap without senior on-call involvement.
+```
+
+**Postmortem:** correlation cause (same node? same AZ?); PVC state
+and recoverability; whether anti-affinity should be configured
+before next deployment.
+
+</details>
+
+## Worker cache failures
+
+### Cache not ready (during startup or resync)
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** ResumeActor calls return errors mentioning "worker
+cache not ready"; happens at API-server pod startup and during
+post-pub/sub-disconnect resync windows.
+
+**What's happening:** the cache is mid-`ListWorkers` initial sync.
+At 10k workers this is seconds; at 100k workers it's tens of
+seconds. During this window the pod accepts connections but
+`Workers()` refuses with a clear error.
+
+**Recovery:** wait. The cache will become ready when sync completes.
+If the window is longer than expected, it means `ListWorkers` is
+slow (Valkey cluster pressure, network issues) or the initial
+worker count is unexpectedly large.
+
+```bash
+# Watch the API server logs for "worker cache synced" message
+kubectl -n ate-system logs deployment/ate-api-server -f | grep -i "cache"
+```
+
+**Mitigation to consider:** stagger API-server pod restarts so the
+fleet doesn't all sync at once. PDB with `maxSurge: 1` helps.
+
+</details>
+
+### Ghost workers (cache sees workers that don't exist)
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** AssignWorker picks a worker, atelet dial fails (pod
+unreachable), workflow retries, picks another, sometimes the same
+ghost again. Background of intermittent `CallAteletRestore` errors.
+
+**What's happening:** A K8s node failure has taken down worker pods,
+but K8s has not yet evicted them from the API view. The default
+node-failure-to-eviction delay is **several minutes**
+(`node-monitor-grace-period` 40s + `pod-eviction-timeout` 5min).
+During that window the cache contains records pointing at dead
+pods. The syncer only sees the delete events after eviction, so the
+cache doesn't update until then.
+
+**Recovery:** the system self-heals once K8s evicts the dead pods
+(syncer sees deletes → `DeleteWorker` → `WorkerEvent{Deleted}` →
+caches update). The scheduler retry budget covers the meantime —
+each failed dial moves to a different worker.
+
+If the window is unacceptable for the workload:
+
+```bash
+# Identify the dead node and force pod eviction
+kubectl get nodes
+kubectl cordon <dead-node>
+kubectl drain <dead-node> --ignore-daemonsets --delete-emptydir-data --force
+# This causes immediate pod deletion; syncer will see the events and clean caches.
+```
+
+**Postmortem:** how long was the ghost window; how many ResumeActor
+calls failed; whether `node-monitor-grace-period` should be tuned
+for the workload sensitivity.
+
+</details>
+
+### Missed pub/sub events
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** Worker state observed in `ate actor list` (or via
+`vcli`) doesn't match what the cache returns. Typically: a worker
+visible via direct Valkey query but not in the cache, or vice versa.
+
+**What's happening:** Redis pub/sub is fire-and-forget. Events can be
+dropped when the subscriber's connection blips, when the subscriber
+buffer (128 events deep) fills under burst, or during a primary
+failover. The periodic relist is the durability backstop but only
+catches up at its scheduled interval.
+
+**Recovery:** the periodic relist will fix it. If the discrepancy
+needs to be resolved immediately, restart the affected API-server
+pod — the new pod will run a fresh initial sync.
+
+```bash
+kubectl -n ate-system rollout restart deployment ate-api-server
+# Wait for new pod to become ready (initial-sync cost applies)
+```
+
+**Postmortem:** what caused the drop; whether the periodic-relist
+interval is appropriate (shorter = faster catch-up at cost of
+periodic O(N) read).
+
+</details>
+
+### Pub/sub cluster-bus amplification
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** at scale (50+ primaries), elevated CPU on every
+Valkey primary, growing roughly with worker churn rate.
+
+**What's happening:** classic Redis pub/sub (`PUBLISH` / `SUBSCRIBE`)
+in cluster mode broadcasts every published message to every primary
+via the cluster bus, regardless of where subscribers are. Each
+worker event amplifies O(N) in primary count. The cost is invisible
+at 3 primaries; meaningful at 50+; potentially binding at 200+.
+
+**Recovery:** none in-incident — this is a scaling-curve concern,
+not an outage.
+
+**Mitigation:** migrate `Publish`/`Subscribe` to **sharded pub/sub**
+(`SPublish`/`SSubscribe`, Redis 7+) — events propagate only within
+the shard. Mechanical change in `ateredis.go` and `workercache.go`,
+but it changes the routing semantics so all subscribers and
+publishers must agree.
+
+</details>
+
+## Data & storage failures
+
+### AOF corruption
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** Pod in `CrashLoopBackOff` with logs showing `Bad file
+format reading the append only file` or `Unexpected EOF`.
+
+**What's happening:** AOF was torn — typically a power-loss-style
+crash. Valkey refuses to start a primary with an unparseable AOF.
+If the affected pod is a primary, this becomes a primary-loss event
+(see above) inheriting the cluster-wide pause window; the corrupted
+pod then comes up as the new replica in crash-loop until repaired.
+
+**Recovery:**
+
+```bash
+# Copy the AOF off for postmortem before fixing
+kubectl -n ate-system cp <affected-pod>:/data/appendonly.aof /tmp/incident-aof-$(date +%s).aof
+
+# Attach a debug container that mounts the affected pod's PVC,
+# then truncate the AOF to the last valid command:
+kubectl -n ate-system exec -it <debug-pod> -- valkey-check-aof --fix /data/appendonly.aof
+# Confirm acceptable loss; type 'y' to truncate.
+
+# Delete the affected pod; StatefulSet recreates and AOF loads cleanly.
+kubectl -n ate-system delete pod <affected-pod>
+```
+
+**Mitigation to consider:** `aof-load-truncated yes` is the modern
+default and auto-handles cleanly-truncated tails; verify it's set
+in your `valkey.conf`. Storage with stronger crash semantics
+(PD-SSD with journaling) reduces corruption rate.
+
+</details>
+
+### Memory pressure / OOM
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** K8s `OOMKilled` event on a Valkey pod. Pod restarts with
+AOF replay. If primary, becomes a failover event.
+
+**What's happening:** `maxmemory` is not set today — Valkey grows
+until the pod's K8s memory limit triggers OOMKill.
+
+**Recovery (immediate):** the pod restarts; verify per "Replica loss"
+or "Primary loss" as appropriate.
+
+**Mitigation (prevent recurrence):**
+
+```bash
+# Set maxmemory explicitly, below the K8s pod limit, with noeviction
+kubectl -n ate-system exec <pod> -- vcli config set maxmemory 3gb
+kubectl -n ate-system exec <pod> -- vcli config set maxmemory-policy noeviction
+# Persist in valkey.yaml so it survives restarts.
+```
+
+`noeviction` makes writes fail with a clear OOM error rather than
+silently evicting actor records.
+
+</details>
+
+### Disk full / PVC expansion
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** writes failing with disk-related errors; PVC usage at
+or near 100%.
+
+**What's happening:** AOF grew past the PVC capacity (currently
+1 Gi default).
+
+**Recovery:**
+
+```bash
+# Confirm storage class supports online expansion
+kubectl get storageclass <class> -o yaml | grep allowVolumeExpansion
+
+# Patch the PVC to a larger size
+kubectl -n ate-system patch pvc data-<affected-pod> \
+  -p '{"spec":{"resources":{"requests":{"storage":"10Gi"}}}}'
+
+# Wait for FileSystemResizeSuccessful; may require pod restart
+kubectl -n ate-system describe pvc data-<affected-pod>
+```
+
+If the storage class doesn't support expansion, migrate the shard to
+a new PVC of the right size.
+
+</details>
+
+### IOPS exhaustion
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** client p99 latency spike with no corresponding QPS
+spike; fsync latency elevated; cloud-provider burst-credit metrics
+showing exhaustion.
+
+**What's happening:** the storage tier's IOPS budget is exhausted
+(PD-SSD throttling, EBS burst credits gone). Valkey's
+single-threaded primary blocks on the next fsync, queueing every
+other operation.
+
+**Recovery:** usually transient — credits replenish. If sustained,
+upgrade the storage class or provision explicit IOPS (PD-Extreme,
+gp3 with provisioned IOPS). Not an in-incident fix.
+
+</details>
+
+## Network failures
+
+### Network partition / split-brain
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** `MASTERDOWN` / `CLUSTERDOWN` from a subset of pods;
+cluster-state divergence between subsets.
+
+**What's happening:** A network partition cuts some Valkey pods from
+others. Cluster mode uses majority-quorum elections, so strict
+split-brain (two primaries on same slots both accepting writes) is
+avoided — replicas only promote with majority quorum.
+
+**Recovery:** **do not** manually promote anything during a live
+partition. Engage networking on-call. The cluster heals
+automatically when network is restored; some writes from the
+minority side may be lost on heal.
+
+After heal, run the "Primary loss" recovery for each shard whose
+primary was on the minority side.
+
+</details>
+
+### Client slot-map staleness
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** transient `MOVED` / `ASK` errors in `ate-api-server`
+logs after a failover.
+
+**What's happening:** each `redis.ClusterClient` caches the slot
+map; after a failover, the cached map is briefly stale until the
+client refreshes it on the next `MOVED` response. go-redis handles
+this transparently with 3 retries by default.
+
+**Recovery:** none needed — auto-resolves within a few operations.
+If redirect storms are frequent, increase `MaxRedirects` in the
+client config.
+
+</details>
+
+## Security failures
+
+### Pod certificate expiry
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** TLS handshake errors in `ate-api-server` or Valkey logs.
+
+**What's happening:** under normal operation Valkey re-reads its
+cert from the projected volume every 12 hours
+(`tls-auto-reload-interval 43200`), so the routine "signer rotated
+the cert, Valkey picks it up" path is automatic and silent. TLS
+errors mean one of:
+
+1. **The signing controller failed to rotate** before the old cert
+   expired. The projected volume still holds the expired cert.
+2. **The signer rotated but Valkey hasn't reloaded yet.** The
+   12-hour reload window means there's up to a 12-hour gap between
+   a new cert appearing in the volume and Valkey actually serving
+   it. Usually invisible (signer rotates well before expiry); only
+   matters if the cert TTL is short or rotation happened during a
+   tight window.
+3. **CA bundle mismatch** — see next section.
+
+**Recovery:**
+
+```bash
+# 1. Verify the controller is healthy.
+kubectl -n <controller-ns> get pods -l app=pod-certificate-controller
+# Fix it first if it's down — neither auto-reload nor a manual restart
+# will help if the signer can't issue new certs.
+
+# 2. Check whether the projected volume already has a fresh cert.
+#    If it does, Valkey will pick it up at its next 12h reload; you
+#    can wait, or force an immediate reload by restarting pods.
+kubectl -n ate-system exec valkey-cluster-0 -- \
+  openssl x509 -in /run/servicedns.podcert.ate.dev/credential-bundle.pem \
+  -noout -dates
+
+# 3. If immediate reload is needed (cert is fresh on disk, you don't
+#    want to wait up to 12h), restart pods. Stagger to avoid
+#    simultaneous failovers — replicas first, then primaries:
+for pod in valkey-cluster-{3,4,5}; do
+  kubectl -n ate-system delete pod $pod
+  kubectl -n ate-system wait pod/$pod --for=condition=Ready --timeout=120s
+done
+for pod in valkey-cluster-{0,1,2}; do
+  kubectl -n ate-system delete pod $pod
+  kubectl -n ate-system wait pod/$pod --for=condition=Ready --timeout=120s
+done
+```
+
+For most cert-rotation incidents under the auto-reload setup, the
+pod restart in step 3 is **not** needed — fix the signer (step 1)
+and the next 12h reload picks up the new cert. The restart loop is
+the lever for cases where you can't wait 12h (emergency revocation,
+CA bundle change requiring immediate effect).
+
+**Mitigation:** alert on cert TTL at 50% remaining, not at 5% —
+gives the signer + 12h reload window plenty of room. Monitor the
+signing controller's own health independently; an unhealthy signer
+will silently let certs age out even with auto-reload working
+perfectly.
+
+</details>
+
+### CA bundle rotation
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** TLS verification failures cluster-wide immediately
+after a `valkey-ca-certs` secret change.
+
+**What's happening:** the K8s projected volume updates the
+on-disk CA bundle within ~60 s of the secret change. Valkey
+re-reads its CA file from disk on the **same 12-hour auto-reload
+cycle as the server cert** (`tls-auto-reload-interval 43200`). So
+even after the secret is corrected, Valkey continues serving with
+its previously-loaded CA until the next reload — up to 12 hours
+unless you force a restart.
+
+**Recovery (time-critical):** revert the CA bundle, then force an
+immediate reload via pod restart.
+
+```bash
+# 1. Revert to the known-good CA bundle
+kubectl -n ate-system apply -f /path/to/known-good-valkey-ca-certs.yaml
+
+# 2. Wait briefly for the projected volume to pick up the secret
+#    change (~60s)
+
+# 3. Force Valkey to reload from disk immediately by restarting pods.
+#    Stagger as in the cert-expiry recovery — replicas first, then
+#    primaries:
+for pod in valkey-cluster-{3,4,5}; do
+  kubectl -n ate-system delete pod $pod
+  kubectl -n ate-system wait pod/$pod --for=condition=Ready --timeout=120s
+done
+for pod in valkey-cluster-{0,1,2}; do
+  kubectl -n ate-system delete pod $pod
+  kubectl -n ate-system wait pod/$pod --for=condition=Ready --timeout=120s
+done
+```
+
+Do **not** retry the CA rotation in-incident. Plan a proper
+bundle-overlap rotation as a separate change: apply a CA bundle
+containing *both* old and new CAs first; wait for at least the
+auto-reload window (12h) or force a restart to ensure every pod has
+loaded the bundle; only then narrow to new-CA-only and again wait
+or restart.
+
+</details>
+
+## Kubernetes-level failures
+
+### Pod stuck Pending
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** a Valkey pod in `Pending` for more than a few minutes.
+
+**Recovery:** read K8s events to find the cause and fix it.
+
+```bash
+kubectl -n ate-system describe pod <pending-pod>
+# Common causes: insufficient resources, PVC binding failure,
+# image pull failure, taint/toleration mismatch.
+```
+
+</details>
+
+### PVC / PV failure
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** PVC stuck `Pending` or PV in `Failed` state; pod can't
+start because volume won't mount.
+
+**Recovery:** depends on whether the underlying storage failure is
+transient or permanent.
+
+> **WARNING:** PVC deletion is permanent unless the PV reclaim
+> policy is `Retain`. Confirm before any destructive action.
+
+```bash
+kubectl get pv | grep ate-system
+kubectl describe pv <pv-name>
+
+# If transient: wait or trigger retry
+# If permanent + worker pod is a replica: delete PVC, let StatefulSet
+#   create fresh; new pod full-resyncs from primary (no cluster-wide
+#   data loss).
+# If permanent + worker pod is a primary: replica gets promoted via
+#   failover (see Primary loss); handle the new replica as above.
+# If both PVCs of a shard lost: see Whole-shard loss.
+```
+
+</details>
+
+### Multi-pod node loss
+<details>
+<summary><em>Expand</em></summary>
+
+**Symptom:** K8s node `NotReady`; multiple Valkey pods restarting or
+Pending; potentially a whole-shard loss if a shard's two pods
+co-located on the lost node.
+
+**Recovery:** identify the affected shards and apply the appropriate
+single-failure recovery for each. If a shard had both pods on the
+lost node, this is whole-shard loss.
+
+This is the failure scenario anti-affinity prevents. Adding
+required-during-scheduling pod anti-affinity to the Valkey
+StatefulSet before the next production deployment closes this class
+of incident.
+
+</details>
+
+## Common admin operations
+
+### Inspect cluster state
+
+```bash
+kubectl -n ate-system exec valkey-cluster-0 -- vcli cluster info
+kubectl -n ate-system exec valkey-cluster-0 -- vcli cluster nodes
+# Expect cluster_state:ok, cluster_slots_ok:16384
+```
+
+### Inspect worker cache state from an API server pod
+
+```bash
+# Number of workers in the cache (via the API)
+kubectl -n ate-system exec deployment/ate-api-server -- ate worker list | wc -l
+
+# Compare against the source-of-truth count in Valkey
+kubectl -n ate-system exec valkey-cluster-0 -- vcli --cluster call valkey-cluster-0:6379 --no-auth-warning eval "return #redis.call('keys', 'worker:*')" 0
+```
+
+If the two numbers differ persistently, the cache is missing events
+— see "Missed pub/sub events" above.
+
+### Trace which actor a worker is bound to
+
+```bash
+# Direct from Valkey
+kubectl -n ate-system exec valkey-cluster-0 -- vcli get worker:<ns>:<pool>:<pod>
+# Look for the actor_id field in the returned JSON.
+```
+
+### Force the workercache to re-sync
+
+```bash
+# Restart the API server pod — it will run a fresh initial sync
+kubectl -n ate-system rollout restart deployment ate-api-server
+```
+
+## Open risks
+
+The shortlist worth tracking as the deployment grows. Each one is
+either accepted-with-rationale or carried-pending-action.
+
+| Risk | Severity | Status |
+|---|---|---|
+| `cluster-require-full-coverage yes` makes any failover a cluster-wide pause | Cluster-wide availability | Accepted at MVP; flip to `no` before any scale-out |
+| No pod anti-affinity → primary + replica can co-locate | Data loss + availability | **Active**: add before next production deployment |
+| No off-cluster backups → PVC loss = permanent shard data loss | Data loss | Active: blocking for GA |
+| Async-replication tail lost on failover (no `min-replicas-to-write`) | Data loss (variable) | Accepted at MVP; revisit at scale |
+| No `maxmemory` set; relies on K8s pod limit as ceiling | Data loss + availability | **Active**: cheap fix, high ROI |
+| 1 Gi PVC default; can fill under AOF growth | Latency / operational | **Active**: bump default + add monitoring |
+| No Pod Disruption Budget on the Valkey StatefulSet | Availability | **Active**: cheap fix, prevents resync storms |
+| No pod-certificate expiry alerting | Cluster-wide availability | **Active**: alert at 50% TTL remaining |
+| Pub/sub broadcast amplification at high primary count | Scaling | Watch — migrate to `SPUBLISH`/`SSUBSCRIBE` if/when N > ~50 primaries |
+| Worker cache initial-sync cost on every API-server restart | Operational | Bounded; stagger restarts via PDB |
+| K8s node-failure → ghost workers in cache for minutes | Operational | Bounded by K8s eviction timeouts; consider tuning if user-visible |
+| `DebugClearAll` is package-public with no production guard | Operational hazard | **Active**: rename to `_TESTONLY` or build-tag guard |
+
+**Items marked Active are the short list of cheap, high-ROI
+hardening steps that should land before any meaningful production
+exposure.** Most are one-line config changes or single-line code
+changes. The bigger architectural items (off-cluster backups,
+anti-affinity, sharded pub/sub, `min-replicas-to-write`) deserve
+their own design conversations and aren't single-PR work.

--- a/docs/valkey/operations.md
+++ b/docs/valkey/operations.md
@@ -45,8 +45,9 @@ kubectl -n ate-system exec valkey-cluster-0 -- vcli cluster nodes > /tmp/inciden
 > shard whose slot range is briefly uncovered — including a normal
 > primary failover — flips `cluster_state` to `fail` and pauses
 > **all** writes cluster-wide until coverage is restored. Flipping
-> to `no` would localize each failure to its own slot range. See
-> [`topology.md`](./topology.md).
+> to `no` would localize each failure to its own slot range. See the
+> configuration ladder in
+> [`scaling_to_10m.md`](./scaling_to_10m.md).
 
 ### Single replica loss
 <details>
@@ -90,6 +91,11 @@ election + slot-map refresh), not per-slot.
 **Data loss window:** any writes the old primary acked but had not
 yet shipped to its replica are lost. Sub-millisecond under light
 load; can be hundreds of milliseconds to seconds under burst load.
+**This window applies to every *unplanned* failover.** Planned
+maintenance (upgrades, node drains) should never pay it — use the
+coordinated-failover procedure under
+[Common admin operations](#planned-maintenance-coordinated-failover),
+which hands off with zero tail loss.
 
 **Recovery:** automatic — verify and sweep for stranded actors.
 
@@ -101,9 +107,11 @@ kubectl -n ate-system exec valkey-cluster-1 -- vcli cluster info
 # Verify the recreated pod rejoined as replica
 kubectl -n ate-system exec <recreated-pod> -- vcli info replication
 
-# Sweep for stranded actors (RESUMING/SUSPENDING/PAUSING past lock TTL)
+# Sweep for stranded actors: RESUMING/SUSPENDING/PAUSING past the
+# lock TTL, plus CRASHED actors parked by crash detection (these are
+# deliberate, but each one represents a workload that died mid-op).
 # This requires an admin command or direct query; if none exists yet,
-# log into ateapi and check actor status counts via the API.
+# check actor status counts via `kubectl ate get actors`.
 ```
 
 **Postmortem:** failover trigger; measured cluster-pause duration
@@ -141,8 +149,12 @@ kubectl -n ate-system get pvc
 #    serves; lost pod's new PVC will full-resync from the surviving
 #    pod. No additional data loss beyond (2).
 
-# 4. Both PVCs lost → permanent data loss for that shard's slot
-#    range. No off-cluster backups today. Escalate; do not attempt
+# 4. Both PVCs lost, backups configured (10M target) → restore the
+#    shard's most recent RDB from object storage; loss is bounded by
+#    the backup interval. See "Backups and restore" below.
+
+# 5. Both PVCs lost, no backups (deployed today) → permanent data
+#    loss for that shard's slot range. Escalate; do not attempt
 #    re-bootstrap without senior on-call involvement.
 ```
 
@@ -159,22 +171,24 @@ before next deployment.
 <summary><em>Expand</em></summary>
 
 **Symptom:** ResumeActor calls return errors mentioning "worker
-cache not ready"; happens at API-server pod startup and during
-post-pub/sub-disconnect resync windows.
+cache not ready".
 
-**What's happening:** the cache is mid-`ListWorkers` initial sync.
-At 10k workers this is seconds; at 100k workers it's tens of
-seconds. During this window the pod accepts connections but
-`Workers()` refuses with a clear error.
+**What's happening:** the cache is mid-`ListWorkers` sync after its
+pub/sub subscription dropped. At 10k workers a sync is seconds; at
+100k workers it's tens of seconds. Note this error is only reachable
+in the post-disconnect **resync** window: at pod *startup* the
+initial sync runs before the gRPC listener opens (a failed startup
+sync is fatal), so clients see the pod as not-ready/refusing
+connections rather than this error.
 
 **Recovery:** wait. The cache will become ready when sync completes.
 If the window is longer than expected, it means `ListWorkers` is
-slow (Valkey cluster pressure, network issues) or the initial
-worker count is unexpectedly large.
+slow (Valkey cluster pressure, network issues) or the worker count
+is unexpectedly large.
 
 ```bash
 # Watch the API server logs for "worker cache synced" message
-kubectl -n ate-system logs deployment/ate-api-server -f | grep -i "cache"
+kubectl -n ate-system logs deployment/ate-api-server-deployment -f | grep -i "cache"
 ```
 
 **Mitigation to consider:** stagger API-server pod restarts so the
@@ -223,22 +237,27 @@ for the workload sensitivity.
 <details>
 <summary><em>Expand</em></summary>
 
-**Symptom:** Worker state observed in `ate actor list` (or via
-`vcli`) doesn't match what the cache returns. Typically: a worker
+**Symptom:** Worker state observed via `kubectl ate get workers` (or
+direct `vcli` queries) doesn't match what the cache returns. Typically: a worker
 visible via direct Valkey query but not in the cache, or vice versa.
 
 **What's happening:** Redis pub/sub is fire-and-forget. Events can be
 dropped when the subscriber's connection blips, when the subscriber
-buffer (128 events deep) fills under burst, or during a primary
-failover. The periodic relist is the durability backstop but only
-catches up at its scheduled interval.
+buffer (128 events deep) fills under burst (note: editing a
+WorkerPool's labels fans out one `UpdateWorker` event **per worker
+in the pool**), or during a primary failover. Two backstop caveats:
+the periodic relist only catches up on its schedule (**5 minutes**),
+and while Created/Updated events are guarded by the worker `version`
+(a stale event cannot overwrite a fresher entry), **Deleted events
+carry no version** and are applied unconditionally — a late delete
+can briefly remove a fresher entry until the next relist.
 
 **Recovery:** the periodic relist will fix it. If the discrepancy
 needs to be resolved immediately, restart the affected API-server
 pod — the new pod will run a fresh initial sync.
 
 ```bash
-kubectl -n ate-system rollout restart deployment ate-api-server
+kubectl -n ate-system rollout restart deployment ate-api-server-deployment
 # Wait for new pod to become ready (initial-sync cost applies)
 ```
 
@@ -290,12 +309,16 @@ pod then comes up as the new replica in crash-loop until repaired.
 **Recovery:**
 
 ```bash
-# Copy the AOF off for postmortem before fixing
-kubectl -n ate-system cp <affected-pod>:/data/appendonly.aof /tmp/incident-aof-$(date +%s).aof
+# Valkey ≥7 uses a multi-part AOF: /data/appendonlydir/ holds a base
+# file, incr files, and a manifest. Copy the whole directory off for
+# postmortem before fixing.
+kubectl -n ate-system cp <affected-pod>:/data/appendonlydir /tmp/incident-aof-$(date +%s)/
 
 # Attach a debug container that mounts the affected pod's PVC,
-# then truncate the AOF to the last valid command:
-kubectl -n ate-system exec -it <debug-pod> -- valkey-check-aof --fix /data/appendonly.aof
+# then truncate the AOF to the last valid command (point the tool
+# at the manifest so it repairs the whole set):
+kubectl -n ate-system exec -it <debug-pod> -- \
+  valkey-check-aof --fix /data/appendonlydir/appendonly.aof.manifest
 # Confirm acceptable loss; type 'y' to truncate.
 
 # Delete the affected pod; StatefulSet recreates and AOF loads cleanly.
@@ -606,6 +629,62 @@ of incident.
 
 ## Common admin operations
 
+### Planned maintenance (coordinated failover)
+
+Any planned action that takes down a **primary** — node drain, rolling
+upgrade, resize — should hand the primary role off *first* with
+`CLUSTER FAILOVER`, run from the shard's replica. The replica fully
+syncs before taking over, so the handoff loses **zero acked writes**;
+letting the eviction race the gossip timeout instead turns every
+planned upgrade into an unplanned-failover loss event (see "Primary
+loss" above).
+
+```bash
+# 1. Find the role of the pod you intend to take down
+kubectl -n ate-system exec <target-pod> -- vcli info replication
+# role:master → coordinated failover required. role:slave → just drain it.
+
+# 2. Identify the shard's replica (cluster nodes maps replicas to primaries)
+kubectl -n ate-system exec valkey-cluster-0 -- vcli cluster nodes
+
+# 3. On the REPLICA of that shard, request a graceful takeover
+kubectl -n ate-system exec <replica-pod> -- vcli cluster failover
+# (no FORCE/TAKEOVER argument — the graceful form is the whole point)
+
+# 4. Wait for the role swap to complete before touching the pod
+kubectl -n ate-system exec <replica-pod> -- vcli info replication
+# Expect: role:master. And cluster_state:ok on any node.
+
+# 5. Now drain/delete the demoted pod (it is a replica; only HA is
+#    briefly reduced). One shard at a time; wait for full resync
+#    before moving to the next shard.
+```
+
+Rules of thumb: never run two shards' maintenance concurrently, and
+never skip step 4 — deleting the old primary while the failover is
+mid-election produces exactly the unplanned pause this procedure
+exists to avoid.
+
+### Backups and restore
+
+**Deployed today: none.** Everything below is the 10M-target design
+(see [`scaling_to_10m.md`](./scaling_to_10m.md)) so the whole-shard
+recovery path above has somewhere to point; treat it as the spec for
+the backlog item, not a description of a running system.
+
+- **Take backups from replicas, never primaries**: a CronJob triggers
+  `BGSAVE` on each shard's replica and streams the resulting RDB to
+  object storage. Interval 15–60 min by tier; retain 7–30 days.
+- **Restore (single shard)**: scale down the affected shard's pods,
+  place the RDB on a fresh PVC, start the pod with `appendonly no`
+  for the initial load, let it rejoin and re-replicate, then re-enable
+  AOF. Loss is bounded by the backup interval for that shard's slot
+  range only.
+- **Drill it**: a restore that has never been exercised is a
+  hypothesis, not a capability. Run one restore drill per release
+  cycle; at single-digit-GB shard sizes this is a sub-30-minute
+  exercise.
+
 ### Inspect cluster state
 
 ```bash
@@ -614,11 +693,13 @@ kubectl -n ate-system exec valkey-cluster-0 -- vcli cluster nodes
 # Expect cluster_state:ok, cluster_slots_ok:16384
 ```
 
-### Inspect worker cache state from an API server pod
+### Inspect worker cache state
 
 ```bash
-# Number of workers in the cache (via the API)
-kubectl -n ate-system exec deployment/ate-api-server -- ate worker list | wc -l
+# Number of workers according to the control plane (kubectl-ate
+# plugin, run from your workstation — the API-server image is a bare
+# binary with no CLI inside)
+kubectl ate get workers | wc -l
 
 # Compare against the source-of-truth count in Valkey
 kubectl -n ate-system exec valkey-cluster-0 -- vcli --cluster call valkey-cluster-0:6379 --no-auth-warning eval "return #redis.call('keys', 'worker:*')" 0
@@ -632,14 +713,15 @@ If the two numbers differ persistently, the cache is missing events
 ```bash
 # Direct from Valkey
 kubectl -n ate-system exec valkey-cluster-0 -- vcli get worker:<ns>:<pool>:<pod>
-# Look for the actor_id field in the returned JSON.
+# Look at the "assignment" field in the returned JSON:
+# assignment.actor is {atespace, name}; absent assignment = idle worker.
 ```
 
 ### Force the workercache to re-sync
 
 ```bash
 # Restart the API server pod — it will run a fresh initial sync
-kubectl -n ate-system rollout restart deployment ate-api-server
+kubectl -n ate-system rollout restart deployment ate-api-server-deployment
 ```
 
 ## Open risks
@@ -661,6 +743,9 @@ either accepted-with-rationale or carried-pending-action.
 | Worker cache initial-sync cost on every API-server restart | Operational | Bounded; stagger restarts via PDB |
 | K8s node-failure → ghost workers in cache for minutes | Operational | Bounded by K8s eviction timeouts; consider tuning if user-visible |
 | `DebugClearAll` is package-public with no production guard | Operational hazard | **Active**: rename to `_TESTONLY` or build-tag guard |
+| PAUSED actor on a dead node is unrecoverable via the API — `boot=true` cannot bypass an existing local snapshot, and the syncer never resets a finalized pause | Per-actor availability | **Active**: needs an API-level escape hatch (force-boot or snapshot-clear) |
+| `node_vms_with_local_snapshots` written once at pause — node death or checkpoint eviction never updates it, so it can silently go stale | Operational | Watch — largely subsumed by the paused-actor escape-hatch fix above |
+| Durable snapshots are never cleaned up — `DeleteActor` leaves blobs in object storage | Cost / hygiene | Active: needs delete-time cleanup or a GC sweep |
 
 **Items marked Active are the short list of cheap, high-ROI
 hardening steps that should land before any meaningful production

--- a/docs/valkey/scaling_to_10m.md
+++ b/docs/valkey/scaling_to_10m.md
@@ -1,0 +1,354 @@
+# Scaling to 10M actors
+
+This page is the growth path for Substrate's storage tier: how the
+same architecture serves a 10-actor pilot and a 10-million-actor
+deployment, what must change between those points, and — just as
+important — what never changes. Find the tier that matches your
+deployment, deploy what that tier requires, and watch the graduation
+triggers that tell you when to move up.
+
+Scope: the Valkey cluster and its direct posture (sizing, durability,
+backups, configuration). How state moves through the tier is
+[`lifecycle.md`](./lifecycle.md); what is deployed and how it's wired
+is [`topology.md`](./topology.md); incident response is
+[`operations.md`](./operations.md).
+
+Three conventions used throughout:
+
+- **Deployed today** vs. **required at tier N** — every requirement
+  is labeled. The gap between the two is the hardening backlog, not
+  an inconsistency.
+- **Estimates are labeled with their basis.** Most numbers here are
+  engineering estimates (allocator analysis, protocol math), not
+  measurements of this system under load. They are good enough to
+  size against and honest about their provenance.
+- **Every graduation includes a validation gate** — the load test or
+  drill that turns the next tier's estimates into observations
+  *before* production traffic depends on them.
+
+## The invariant architecture
+
+**The 3-shard Valkey cluster is the floor and, for a long time, the
+ceiling.** From 10 actors to 10M actors, the architecture is the same
+3-primaries + replicas cluster described in
+[`topology.md`](./topology.md); what scales is resources, replica
+count, durability posture, and operational maturity — never the
+shape. There is no "small mode" to outgrow and no migration event
+anywhere inside the envelope.
+
+Three shards is deliberate, not just the bootstrap default:
+
+- Per-shard heaps stay small at every tier (~2.5–3.5 GB even at 10M),
+  which keeps `BGSAVE`/`BGREWRITEAOF` forks in the
+  tens-of-milliseconds range and copy-on-write spikes trivial. The
+  operationally painful fork-stall regime documented by large Redis
+  operators starts an order of magnitude higher.
+- Blast radius per shard is 1/3 of actors; rolling upgrades touch a
+  third of the data at a time.
+- There is headroom to ~30–50 M actors by *online resharding* before
+  anything structural changes (see "Beyond the envelope").
+
+More shards at small scale buy nothing except more failovers and more
+operational objects. The one exception: the **strict durability
+profile** pairs with 6 primaries to halve per-shard write rate (see
+"Durability contract").
+
+## Workload model
+
+The sizing below assumes an agentic duty-cycle workload. All values
+are estimates — stated so they can be checked against reality as the
+deployment grows, and revised when they disagree.
+
+| Parameter | Planning value | Basis |
+|---|---|---|
+| Registered actors | up to 10 M | the supported envelope |
+| Active + paused fraction | 1–5 % → 100–500 k | duty-cycle assumption; sizing uses the 500 k ceiling |
+| Worker records | ≤ 500 k, typically far fewer | one per concurrently-active actor, upper bound |
+| Sustained lifecycle ops | ~500–1 000/s at 10 M | 10 M actors × 2–4 suspend/resume cycles/day, plus create/delete |
+| Burst (wake storm) | 10× sustained → ~10 k lifecycle ops/s | design point for the durability discussion |
+| Valkey ops per lifecycle op | ~8–10 | protocol count: lock pair, reads, actor CAS, worker CAS |
+| Cluster-wide Valkey ops at burst | ~10⁵/s | product of the above; comfortably inside 3 primaries' capacity |
+
+## Capacity math
+
+### Per-record footprint
+
+Records are protojson blobs (see `cmd/ateapi/internal/store/ateredis`
+package docs), plus Valkey's per-key overhead and allocator rounding.
+
+- **Actor**: twelve scalar/string/enum fields plus two sub-messages
+  (`SnapshotInfo` with realistic snapshot URIs, and the
+  `worker_selector` labels map). Plan for **~650 B – 1 KB per actor**
+  in primary memory. *Basis: allocator analysis of representative
+  records; unvalidated against a loaded cluster.*
+- **Worker**: smaller strings than an actor, but the record carries a
+  `labels` map cached from its pool plus the `Assignment`
+  sub-message. Plan for **~0.5–1 KB per worker**. *Same basis; label
+  cardinality is the swing factor.*
+
+### Dataset by tier
+
+| Actors | Actor data | + workers, locks, buffers, ×1.3 fragmentation | Provision (across primaries) |
+|---|---|---|---|
+| 1 k | ~1 MB | negligible | any |
+| 100 k | ~100 MB | ~1.2 GB total | ~2 GB |
+| 1 M | ~1 GB | ~2.5 GB total | ~4 GB |
+| 10 M | ~6.5–10 GB | ~10–13 GB total | ~12–16 GB |
+
+The fixed ~1 GB line item (replication backlog, client and pub/sub
+buffers, AOF-rewrite buffer) dominates at small tiers and disappears
+into the noise at large ones.
+
+**The AOF sizing rule**: the append-only file runs **2–3× the
+dataset** between rewrites. PVCs must be sized for that multiple —
+the deployed **1 Gi PVC fills under any sustained write load and
+stalls the shard with no failure required**. This is the single
+config item worth fixing at every tier including T0.
+
+### Worker cache (per API-server pod)
+
+Each API-server pod mirrors every worker record in memory
+(`cmd/ateapi/internal/workercache`). Plan for ~0.5–1 KB per worker in
+the cache map (proto + map overhead, labels included).
+
+| Workers | Cache per pod | `ListWorkers` full sync |
+|---|---|---|
+| 1 k | ~1 MB | sub-second |
+| 10 k | ~5–10 MB | seconds |
+| 100 k | ~50–100 MB | tens of seconds |
+| 500 k (ceiling) | ~250–500 MB | ~minutes |
+
+The sync cost is paid at pod startup (before the gRPC listener
+opens — the pod is simply not Ready during it) and during
+post-disconnect resyncs. From ~100 k workers up: budget API-server
+memory for the cache, keep readiness probes patient enough to cover
+the sync, and never restart the whole API-server fleet
+simultaneously.
+
+## The tiers
+
+| | **T0 · Pilot** | **T1 · Production** | **T2 · Scale** | **T3 · Envelope** |
+|---|---|---|---|---|
+| Actors | ≤ 1 k | ≤ 100 k | ≤ 1 M | ≤ 10 M |
+| Workers | ≤ 50 | ≤ 5 k | ≤ 50 k | ≤ 100–500 k |
+| Shards | 3 (invariant) | 3 | 3 | 3 (6 for strict profile) |
+| Replicas/shard | 1 | 1 | 1–2 | 1 (standard) / 2 (strict) |
+| Pod `maxmemory` / limit | 512 Mi / 1 Gi | 1 Gi / 2 Gi | 2 Gi / 4 Gi | 4 Gi / 6–8 Gi |
+| PVC | 5 Gi | 10 Gi | 25 Gi | 25 Gi, regional class |
+| Backups | none required | daily + one restore drill | ≤ 60 min + drill per release | 15–60 min + drill per release |
+| Durability profile | best-effort | standard | standard | standard or strict |
+| Ops maturity | none | config hardening set | + coordinated failovers | + sweeps, storm-tested |
+
+### T0 — Pilot (≤ 1 k actors, ≤ 50 workers)
+
+What the deployed manifests give you, minus one trap. **Required:**
+
+- **PVC ≥ 5 Gi** (deployed today: 1 Gi). Even a pilot writes enough
+  AOF to fill 1 Gi; the failure is a write stall that looks like a
+  mystery outage.
+- `maxmemory` set with `noeviction` (deployed today: unset — the pod
+  grows until an opaque OOMKill instead of failing writes cleanly).
+
+Everything else can wait. Loss posture: a lost shard loses that
+third of the pilot's actors; acceptable by definition at this tier —
+if it isn't, you are not at T0.
+
+**Graduate to T1 when** real users or non-recreatable actors arrive.
+That's a policy trigger, not a capacity one — T0's capacity headroom
+is enormous.
+
+### T1 — Production (≤ 100 k actors, ≤ 5 k workers)
+
+The tier where the **config hardening set** becomes mandatory. All
+items are labeled in the configuration ladder below; the set is:
+required pod anti-affinity + zone spread, PodDisruptionBudgets,
+`maxmemory`, `cluster-require-full-coverage no` with typed
+slot-unavailable errors, PVC class/reclaim hardening, daily backups,
+and gating `DebugClear` (deployed today: a standing one-RPC wipe of
+the entire registry — see `operations.md` risks).
+
+Why here and not later: **deployed today, full-coverage `yes` + no
+anti-affinity + no PDB compose so that a single node event can pause
+the entire control plane.** That trio is the highest-ROI fix set in
+this handbook, and T1 is defined as the point where you can no
+longer shrug it off.
+
+**Validation gate:** perform one full restore from a backup into a
+scratch cluster. A backup that has never been restored is a
+hypothesis, not a capability.
+
+**Graduate to T2 when** any of: actor count approaches 100 k;
+sustained lifecycle ops exceed ~100/s; worker count approaches 10 k
+(cache syncs move from seconds to tens of seconds); or backup-drill
+duration starts flirting with your maintenance window.
+
+### T2 — Scale (≤ 1 M actors, ≤ 50 k workers)
+
+Same architecture, bigger pods, tighter operations. **Required, in
+addition to T1:**
+
+- Pod sizing per the tier table; backup interval ≤ 60 min; restore
+  drill every release cycle.
+- **Coordinated maintenance failovers** become procedure, not
+  advice: every planned drain/upgrade uses the `CLUSTER FAILOVER`
+  runbook in [`operations.md`](./operations.md). At T2 event
+  frequency, skipping it converts routine maintenance into a
+  recurring data-loss source.
+- API-server memory budgeted for the worker cache; staggered
+  restarts enforced by PDB/rollout policy.
+- Watch pub/sub burst sources: a WorkerPool label edit publishes one
+  event per worker in the pool — at 50 k workers that is a
+  meaningful subscriber-buffer burst (see `operations.md`, "Missed
+  pub/sub events").
+
+**Validation gate:** a load test at 2× your observed peak lifecycle
+rate, watching p99 write latency, subscriber-buffer drops, and AOF
+disk headroom. This is the test that converts the workload-model
+estimates into your numbers.
+
+**Graduate to T3 when** actor count approaches 1 M, or you need to
+offer users a stated durability contract (the moment the contract
+below stops being an internal detail and becomes a promise).
+
+### T3 — Envelope (≤ 10 M actors, ≤ 100–500 k workers)
+
+The supported ceiling. **Required, in addition to T2:**
+
+- Pod sizing per the tier table; 25 Gi regional-class PVCs with
+  `Retain` reclaim everywhere.
+- **Reconciliation sweeps** for stuck-transitional actors and
+  orphaned worker claims. At T3 event rates, failovers are routine —
+  stranded records must be re-driven mechanically, not by an on-call
+  human reading the risks table.
+- **The published durability contract** (next section), with the
+  strict profile implemented if any user needs it.
+- Backups every 15–60 min; restore drill every release (at 1–3 GB
+  per shard, a drill is a sub-30-minute exercise — one of the
+  genuine luxuries of this scale).
+
+**Validation gate:** a wake-storm test at 10× sustained rate
+(~10 k lifecycle ops/s) on the exact production topology — and, if
+offering strict, the same storm on the strict profile (this is the
+test most likely to fail; see the write-ceiling row in the contract).
+
+## Durability contract
+
+One misconception to retire before any tuning conversation:
+
+> **`appendfsync always` closes the crash gap, not the failover
+> gap.** It guarantees an acked write is on the *primary's* disk —
+> but a failover promotes a **replica**, and replication is
+> asynchronous regardless of fsync policy. A primary that fsyncs
+> every write and then dies still takes its un-replicated tail with
+> it. There is no fsync setting that yields RPO=0.
+>
+> The per-write lever that *does* address failover loss is `WAIT`:
+> blocking a specific write until ≥1 replica has received it
+> (~0.5–1 ms in-region, *protocol estimate*). fsync policy is
+> per-server; `WAIT` is per-operation — so the writes that are
+> irreplaceable (suspend finalization, actor creation) can be
+> protected individually without taxing the hot path.
+
+Two deployment profiles. **Deployed today is neither** — it is
+standard minus backups and minus the coordinated-failover procedure;
+strict additionally requires store-layer `WAIT` support that does not
+exist yet.
+
+| | **standard** (default) | **strict** |
+|---|---|---|
+| AOF | `everysec` | `always` |
+| Replicas per shard | 1 | 2 |
+| `min-replicas-to-write` / `min-replicas-max-lag` | unset | `1` / `10` |
+| Store-level `WAIT 1` on suspend-finalize + create | no | yes *(not implemented)* |
+| Primaries | 3 | 6 (halves per-shard write rate) |
+| Loss on primary **crash** | ≤ 1 s of acked writes | none (on disk) |
+| Loss on unplanned **failover** | replication tail (ms–s) | bounded by max-lag; **none** for suspend/create (WAIT'd) |
+| Loss on planned failover (coordinated) | none | none |
+| Hot-path write latency | ~0.1 ms | ~1–5 ms on PD-class disks *(estimate)* |
+| Per-shard write ceiling | ~50 k+/s | **~0.3–1 k/s** on PD-class disks (fsync serializes the event loop) *(estimate — the storm-test gate exists to measure this)* |
+
+The strict profile's real price is that last row: at the T3 burst
+point (~10 k lifecycle ops/s ≈ ~1.3 k writes/s/shard on 3 shards),
+strict on PD-class disks sits at or above its fsync ceiling — hence
+the 6-primary pairing, and hence the rule that **strict must pass
+the storm test before being offered to anyone**. Local-SSD node
+pools make fsync nearly free but sacrifice disk-survives-pod-loss
+semantics — only acceptable with 2 replicas plus aggressive backups.
+
+The contract worth publishing to users, either profile:
+
+> Planned operations lose nothing. An unplanned primary failure may
+> lose up to [1 s / max-lag] of the most recent acknowledged
+> writes — except suspend and create acknowledgments in the strict
+> profile, which survive any single failure. Whole-shard loss with
+> backups configured is bounded by the backup interval, for that
+> shard's third of actors.
+
+Publish it as a stated property, not a discovered one. A durability
+posture users learn about during an incident is a broken promise;
+the same posture stated up front is an engineering trade.
+
+## Configuration ladder
+
+Every delta between the deployed manifests and the envelope, with
+the tier where it becomes required.
+
+| Setting | Deployed today | Required | From tier | Why |
+|---|---|---|---|---|
+| PVC size | 1 Gi | ≥ 5 Gi (T0/T1), 10 Gi (T2), 25 Gi (T3) | **T0** | AOF runs 2–3× dataset between rewrites; a full disk stalls writes with no failure required. |
+| `maxmemory` | unset (grows to OOMKill) | ~75 % of pod limit, `noeviction` | **T0** | Writes fail with a clear error instead of an opaque OOMKill-and-replay cycle. |
+| Pod anti-affinity / topology spread | none — primary and replica can share a node | required node anti-affinity per shard; zone spread | **T1** | One node event must not take a whole shard. The cluster-init job cannot compensate — its placement is IP-based and node-blind. |
+| PodDisruptionBudget | none | `maxUnavailable: 1` per shard | **T1** | Voluntary evictions must never take a primary and its replica together. |
+| `cluster-require-full-coverage` | `yes` (default) | **`no`** + typed slot-unavailable errors in the store layer | **T1** | With `yes`, any single-shard outage — including a routine failover window — pauses **all** writes cluster-wide. Partial availability is the right trade for a platform. |
+| PVC class / reclaim | default class, default reclaim | regional-class storage, `Retain` reclaim + StatefulSet PVC retention | **T1** (class by T3) | Zonal disks die with their zone; `Retain` protects against namespace/StatefulSet-deletion accidents. |
+| Off-cluster backups | none | replica `BGSAVE` → object storage; daily (T1) → ≤ 60 min (T2) → 15–60 min (T3) | **T1** | Turns whole-shard loss from *permanent* into *bounded by backup interval*. Runbook in `operations.md`. |
+| `DebugClear` exposure | reachable in production builds | build-tag or break-glass gated | **T1** | One authenticated RPC currently equals total registry loss. |
+| Upgrade / drain procedure | evictions race the gossip timeout | coordinated `CLUSTER FAILOVER` first | **T2** | Zero-tail-loss handoff; converts the most frequent loss event (planned maintenance) into a lossless one. |
+| Reconciliation sweeps | none | stuck-transitional + orphaned-claim sweeps | **T3** | At envelope event rates, stranded records must be re-driven mechanically. |
+| Strict profile (`always` + 2 replicas + `min-replicas-*` + `WAIT`) | not implemented | per the contract table | **T3** (optional) | Only if a user needs suspend/create acks to survive any single failure. |
+| Pub/sub → `SPUBLISH`/`SSUBSCRIBE` | broadcast | migrate only past ~50 primaries | beyond envelope | Broadcast amplification is a scaling-curve concern, not a 10M concern. |
+
+## Beyond the envelope
+
+The edges of the 10M envelope, with observable triggers:
+
+- **~30–50 M actors**: reshard 3 → 6–12 primaries. Online,
+  gigabyte-scale slot migration — routine, no architecture change,
+  no downtime. Trigger: provisioned dataset approaching per-shard
+  `maxmemory` headroom.
+- **~100 M actors**: this architecture should be **re-evaluated
+  rather than stretched**. Per-shard heaps or shard counts re-enter
+  the regimes that hurt: fork stalls at multi-GB heaps,
+  multi-minute restores, meaningful gossip and pub/sub
+  amplification, and RAM economics that climb linearly with a
+  dataset that is mostly cold. The storage layer's seam
+  (`cmd/ateapi/internal/store`, `Interface`) is what keeps that
+  future re-evaluation a backend swap rather than a rewrite.
+- **Signals to watch before any actor-count trigger**: sustained
+  fsync-ceiling saturation in the strict profile; backup/restore
+  drill duration creeping past the maintenance window; failover
+  frequency × observed tail-loss size exceeding what the published
+  contract promises.
+
+## Gap checklist
+
+Rollup of everything above that is not deployed today, in rough
+order of ROI. Items marked **T0/T1** are the pre-production set.
+
+- [ ] PVC resize 1 Gi → ≥ 5 Gi (T0)
+- [ ] `maxmemory` + `noeviction` (T0)
+- [ ] Required node anti-affinity + zone topology spread (T1)
+- [ ] PodDisruptionBudget per shard (T1)
+- [ ] `cluster-require-full-coverage no` + typed slot-unavailable
+      error mapping in the store layer (T1)
+- [ ] Backup CronJob (replica `BGSAVE` → object storage) + restore
+      runbook + first drill (T1)
+- [ ] `Retain` reclaim + StatefulSet PVC retention (T1)
+- [ ] Gate `DebugClear` behind a break-glass flag (T1)
+- [ ] Coordinated-failover drain procedure adopted for all planned
+      maintenance (T2)
+- [ ] Load test at 2× observed peak (T2 gate)
+- [ ] Regional-class PVCs (T3)
+- [ ] Reconciliation sweeps: stuck-transitional, orphaned-claim (T3)
+- [ ] Wake-storm load test at 10× sustained (T3 gate)
+- [ ] Strict profile implementation + storm test (T3, optional)

--- a/docs/valkey/topology.md
+++ b/docs/valkey/topology.md
@@ -1,0 +1,227 @@
+# Topology
+
+This page describes what is deployed for Substrate's storage tier, how
+the pieces fit together, and how it sizes against MVP and target-scale
+workloads. The storage tier has two cooperating components: a Valkey
+cluster (source of truth) and a per-API-server in-process worker cache
+(read-side optimization for the actor-scheduling critical path).
+
+## Deployment overview
+
+```mermaid
+graph TB
+  subgraph apisrv["ate-api-server (one or more replicas)"]
+    SRV["request handlers"]
+    CACHE["workercache.Cache<br/>in-process worker map<br/>fed by Valkey pub/sub"]
+    SRV --> CACHE
+  end
+
+  subgraph atesys["ate-system namespace"]
+    SVC["Service valkey-cluster<br/>ClusterIP :6379<br/>bootstrap endpoint"]
+    SVCH["Service valkey-cluster-service<br/>headless · per-pod DNS<br/>for cluster bus"]
+
+    subgraph ss["StatefulSet valkey-cluster · 6 pods · podManagementPolicy Parallel"]
+      subgraph shA["Shard A · slots 0–5460"]
+        A0["primary"] -. async repl .-> A1["replica"]
+      end
+      subgraph shB["Shard B · slots 5461–10922"]
+        B0["primary"] -. async repl .-> B1["replica"]
+      end
+      subgraph shC["Shard C · slots 10923–16383"]
+        C0["primary"] -. async repl .-> C1["replica"]
+      end
+    end
+
+    INIT["Job valkey-cluster-init<br/>one-shot bootstrap<br/>--cluster-replicas 1"]
+
+    PV0[("PVC 1Gi · AOF")]
+    PV1[("PVC 1Gi")]
+    PV2[("PVC 1Gi")]
+    PV3[("PVC 1Gi")]
+    PV4[("PVC 1Gi")]
+    PV5[("PVC 1Gi")]
+  end
+
+  subgraph identity["Identity & TLS"]
+    POD["podCertificate signer<br/>servicedns.podcert.ate.dev/identity"]
+    CA["Secret valkey-ca-certs<br/>ca.crt"]
+  end
+
+  CACHE -->|SUBSCRIBE worker-changes| SVC
+  SRV -->|mTLS 6379| SVC
+  SVC --> A0
+  SVC --> B0
+  SVC --> C0
+
+  A0 --- PV0
+  B0 --- PV1
+  C0 --- PV2
+  A1 --- PV3
+  B1 --- PV4
+  C1 --- PV5
+
+  INIT -. resolves via .-> SVCH
+  INIT -. one-shot bootstrap .-> A0
+
+  POD -. projected per-pod cert .-> ss
+  CA -. mounted /etc/valkey-ca .-> ss
+  POD -. client cert .-> apisrv
+  CA -. CA bundle .-> apisrv
+```
+
+## Valkey cluster
+
+Source of truth: `manifests/ate-install/valkey.yaml`.
+
+- **StatefulSet** `valkey-cluster`, image `valkey/valkey:9.1` (pinned
+  by SHA), 6 pods, `podManagementPolicy: Parallel`. Each pod gets a
+  **1 Gi PVC** for AOF + `nodes.conf`.
+- **Cluster mode** enabled via the ConfigMap (`cluster-enabled yes`,
+  `cluster-node-timeout 5000`, `appendonly yes`). No override of
+  `appendfsync` (defaults to `everysec`), no `min-replicas-to-write`,
+  no `cluster-require-full-coverage` override (default `yes`), no
+  `maxmemory` override.
+- **TLS auto-reload** via `tls-auto-reload-interval 43200` — Valkey
+  re-reads its cert and key from the projected volume every 12 hours,
+  so routine cert rotation does not require pod restarts. The path
+  to a stale cert is still possible if the gap between the volume
+  refresh and the next reload is operationally important — see
+  `operations.md`.
+- **Shape**: bootstrapped with `--cluster-replicas 1` → **3 primaries
+  + 3 replicas**, one replica per primary. The 16,384 hash slots are
+  split into three roughly equal ranges.
+- **Services**: a headless service `valkey-cluster-service` provides
+  per-pod DNS for cluster-bus gossip. A ClusterIP service
+  `valkey-cluster` is the client bootstrap endpoint; clients populate
+  their slot map and then talk to each primary directly.
+- **mTLS**: full mTLS on the data path. Per-pod server certs come
+  from a `podCertificate` projected volume signed by
+  `servicedns.podcert.ate.dev/identity` (ECDSA P-256). The CA bundle
+  is mounted from the `valkey-ca-certs` secret. The `ate-api-server`
+  mounts matching client credentials.
+- **Bootstrap**: an idempotent `valkey-cluster-init` Job waits for
+  all 6 pod DNS names to resolve, then runs `valkey-cli --cluster
+  create` if the cluster is not already initialized. Safe to re-run.
+
+### Sharding model
+
+A key's home slot is `CRC16(key) mod 16384`. Application keys:
+
+- **Actors**: `actor:<actor-id>` (set in
+  `cmd/ateapi/internal/store/ateredis/ateredis.go`, `actorDBKey`).
+- **Workers**: `worker:<ns>:<pool>:<pod>` (`workerDBKey`).
+- **Locks**: `lock:actor:<id>` (`AcquireLock` call sites in
+  `controlapi/workflow.go`).
+
+No hash tags are used today, so every key hashes independently and
+distribution is roughly uniform across primaries. Multi-key
+operations across slots are forbidden — the application either
+denormalizes (worker status inlined into actor) or accepts
+non-atomicity across keys.
+
+## API server worker cache
+
+Source of truth: `cmd/ateapi/internal/workercache/workercache.go`.
+
+Each `ate-api-server` pod holds an in-process worker cache that
+mirrors the workers stored in Valkey. The cache exists so that the
+actor-scheduling critical path (`AssignWorkerStep`) does not pay an
+O(N) `ListWorkers` scan against Valkey per resume — it reads the
+cache in microseconds.
+
+How the cache stays current:
+
+1. On startup, the cache calls `WatchWorkers` to open a Valkey pub/sub
+   subscription, then runs `ListWorkers` once to load the initial
+   snapshot. The `Workers()` method returns "not ready" until this
+   completes.
+2. On every `CreateWorker` / `UpdateWorker` / `DeleteWorker` against
+   the store, ateredis publishes a `WorkerEvent` on the
+   `worker-changes` channel.
+3. The cache's subscriber goroutine receives events and applies them.
+   Version-based ordering protects against out-of-order delivery.
+4. A periodic relist re-runs `ListWorkers` to catch events that pub/sub
+   missed (slow subscriber, transient drops, subscriber disconnect).
+5. On subscription disconnect, the cache marks itself not-ready and
+   resyncs with exponential backoff.
+
+The cache is **per API-server pod**. Each pod has its own subscriber
+and its own copy of the map. Pub/sub broadcasts cluster-wide, so all
+pods see the same events; pods stay eventually-consistent with each
+other on the order of pub/sub latency (sub-second steady state).
+
+`Workers()` returns pointers directly from the cache. Callers that
+need to mutate a worker (e.g. setting `actor_id` during assignment)
+must `proto.Clone` first to avoid corrupting the cache.
+
+## Sizing math
+
+Two memory budgets that grow with scale.
+
+### Valkey working set
+
+The Actor record dominates Valkey memory. The proto is twelve
+scalar/string fields plus a `SnapshotInfo` sub-message; JSON-encoded
+with realistic snapshot URIs it lands in the **500 B – 1 KB** range
+in practice. Add ~60–100 B per key for Valkey's `dictEntry` and key
+string, so plan for **~1 KB per actor** in primary memory.
+
+A practical per-primary memory ceiling on cloud-hosted Valkey is
+**4–32 GB**. Above that, `BGSAVE` / `BGREWRITEAOF` fork latency and
+full-resync time after a replica restart all become operationally
+painful.
+
+| Actor count | Working set | Primaries @ 8 GB | Primaries @ 16 GB | Primaries @ 32 GB |
+|---|---|---|---|---|
+| 1 M     | 1 GB    | 1   | 1  | 1  |
+| 10 M    | 10 GB   | 2   | 1  | 1  |
+| 100 M   | 100 GB  | 13  | 7  | 4  |
+| 1 B     | 1 TB    | **125** | **63** | **32** |
+
+Multiply by 2 for replicas. At target scale, primary counts approach
+the practical cluster-bus comfort ceiling (~500 primaries); above
+that, gossip cost grows O(N²) and becomes meaningful.
+
+### Worker cache memory (per API-server pod)
+
+Each API-server pod's cache holds every worker proto in memory.
+Worker protos are smaller than Actor protos (no snapshot URIs) —
+plan for **~200 B per worker** in the cache map.
+
+| Worker count | Cache memory per API-server pod |
+|---|---|
+| 1 k    | ~200 KB |
+| 10 k   | ~2 MB   |
+| 100 k  | ~20 MB  |
+| 1 M    | ~200 MB |
+
+At 100 k workers across, say, 5 API-server pods, the cache adds
+~100 MB of resident memory across the fleet. Workable; observable.
+
+The cache also pays a one-time `ListWorkers` cost at every API-server
+pod startup (the initial sync). At 10 k workers this is seconds; at
+100 k workers it's tens of seconds, during which the pod accepts
+connections but `Workers()` returns "not ready" and ResumeActor calls
+fail with a clear error.
+
+## Configuration knobs not set today
+
+Several Valkey-level safety knobs ship at defaults that are fine at
+MVP and concerning at target scale. They are not bugs; they are
+deliberate deferrals that should be revisited before scaling
+significantly.
+
+| Setting | Default | Why it matters | When to revisit |
+|---|---|---|---|
+| `cluster-require-full-coverage` | `yes` | Any uncovered slot range (including during a normal primary failover) pauses **all** writes cluster-wide, not just for the affected slot. | Flip to `no` before any deployment that can't tolerate brief cluster-wide pauses during routine failovers. |
+| `min-replicas-to-write` | unset | Primary acks writes even with zero healthy replicas — async-replication tail can be lost on failover. | Set to `1` with `min-replicas-max-lag 10` before durability becomes a hard requirement. **No per-write latency cost** — the check is in-memory; cost is availability under replica trouble. |
+| `maxmemory` | unset | Pod grows until K8s OOMKills it (which means AOF replay on restart, lost writes, possible failover). | Set explicitly at ~75 % of pod memory limit with `maxmemory-policy noeviction` (writes fail with a clear error instead of triggering opaque OOMKill). |
+| Pod anti-affinity / topology spread | none | Primary and replica of the same shard can land on the same K8s node, so a single node failure can take both pods of a shard. | Add required anti-affinity before any production deployment. |
+| Off-cluster backups | none | Total loss of both PVCs of a shard = permanent data loss. | Required before GA. |
+| Pod Disruption Budget | none | Rolling deploys / autoscaler actions can disrupt multiple Valkey pods at once. | Add `maxUnavailable: 1` before any deployment with concurrent K8s lifecycle activity. |
+
+These flags compose. The combination of `cluster-require-full-coverage yes`
++ no anti-affinity + no PDB is the single largest source of
+"unexpected cluster-wide outage on small disturbance" risk in the
+current configuration. Even one of them addressed materially
+reduces that risk.

--- a/docs/valkey/topology.md
+++ b/docs/valkey/topology.md
@@ -1,10 +1,16 @@
 # Topology
 
-This page describes what is deployed for Substrate's storage tier, how
-the pieces fit together, and how it sizes against MVP and target-scale
-workloads. The storage tier has two cooperating components: a Valkey
-cluster (source of truth) and a per-API-server in-process worker cache
-(read-side optimization for the actor-scheduling critical path).
+This page describes what is deployed for Substrate's storage tier and
+how the pieces fit together. The storage tier has two cooperating
+components: a Valkey cluster (source of truth) and a per-API-server
+in-process worker cache (read-side optimization for the
+actor-scheduling critical path).
+
+This page intentionally describes the **deployed** system. Sizing
+math, the tiered growth path from pilot to the supported envelope of
+10 million actors, durability profiles, and the deployed-vs-target
+configuration ladder all live in
+[`scaling_to_10m.md`](./scaling_to_10m.md).
 
 ## Deployment overview
 
@@ -80,7 +86,9 @@ Source of truth: `manifests/ate-install/valkey.yaml`.
   `cluster-node-timeout 5000`, `appendonly yes`). No override of
   `appendfsync` (defaults to `everysec`), no `min-replicas-to-write`,
   no `cluster-require-full-coverage` override (default `yes`), no
-  `maxmemory` override.
+  `maxmemory` override. What each of these should become as the
+  deployment grows is the configuration ladder in
+  [`scaling_to_10m.md`](./scaling_to_10m.md).
 - **TLS auto-reload** via `tls-auto-reload-interval 43200` — Valkey
   re-reads its cert and key from the projected volume every 12 hours,
   so routine cert rotation does not require pod restarts. The path
@@ -94,26 +102,37 @@ Source of truth: `manifests/ate-install/valkey.yaml`.
   per-pod DNS for cluster-bus gossip. A ClusterIP service
   `valkey-cluster` is the client bootstrap endpoint; clients populate
   their slot map and then talk to each primary directly.
-- **mTLS**: full mTLS on the data path. Per-pod server certs come
-  from a `podCertificate` projected volume signed by
-  `servicedns.podcert.ate.dev/identity` (ECDSA P-256). The CA bundle
-  is mounted from the `valkey-ca-certs` secret. The `ate-api-server`
-  mounts matching client credentials.
+- **TLS and client auth**: full TLS on the data path with
+  `tls-auth-clients yes`. Per-pod server certs come from a
+  `podCertificate` projected volume signed by
+  `servicedns.podcert.ate.dev/identity` (ECDSA P-256); the CA bundle
+  is mounted from the `valkey-ca-certs` secret. On the client side,
+  `ate-api-server` authenticates with either an mTLS client cert
+  (`--redis-client-cert`) or a Google IAM token
+  (`--redis-use-iam-auth`, the flag default) — which one is active
+  is deployment configuration, not a fixed property.
 - **Bootstrap**: an idempotent `valkey-cluster-init` Job waits for
   all 6 pod DNS names to resolve, then runs `valkey-cli --cluster
   create` if the cluster is not already initialized. Safe to re-run.
 
 ### Sharding model
 
-A key's home slot is `CRC16(key) mod 16384`. Application keys:
+A key's home slot is `CRC16(key) mod 16384`. Application key
+families (all in `cmd/ateapi/internal/store/ateredis/ateredis.go`
+unless noted):
 
-- **Actors**: `actor:<actor-id>` (set in
-  `cmd/ateapi/internal/store/ateredis/ateredis.go`, `actorDBKey`).
+- **Actors**: `actor:<atespace>:<actor-id>` (`actorDBKey`). The
+  atespace is part of the key, which is what makes the scoped
+  listing pattern `actor:<atespace>:*` possible.
+- **Atespaces**: `atespace:<name>` (`atespaceDBKey`) — one small
+  record per atespace; existence is checked at CreateActor.
 - **Workers**: `worker:<ns>:<pool>:<pod>` (`workerDBKey`).
-- **Locks**: `lock:actor:<id>` (`AcquireLock` call sites in
-  `controlapi/workflow.go`).
+- **Locks**: `lock:actor:<id>` (`acquireActorLock` in
+  `controlapi/workflow.go`). Note the lock key is **not**
+  atespace-scoped — same-named actors in different atespaces share
+  one lock.
 
-No hash tags are used today, so every key hashes independently and
+No hash tags are used, so every key hashes independently and
 distribution is roughly uniform across primaries. Multi-key
 operations across slots are forbidden — the application either
 denormalizes (worker status inlined into actor) or accepts
@@ -133,17 +152,22 @@ How the cache stays current:
 
 1. On startup, the cache calls `WatchWorkers` to open a Valkey pub/sub
    subscription, then runs `ListWorkers` once to load the initial
-   snapshot. The `Workers()` method returns "not ready" until this
-   completes.
+   snapshot. This happens **before** the gRPC listener opens — a pod
+   that is still syncing is simply not serving yet, and a failed
+   startup sync is fatal.
 2. On every `CreateWorker` / `UpdateWorker` / `DeleteWorker` against
    the store, ateredis publishes a `WorkerEvent` on the
    `worker-changes` channel.
 3. The cache's subscriber goroutine receives events and applies them.
-   Version-based ordering protects against out-of-order delivery.
-4. A periodic relist re-runs `ListWorkers` to catch events that pub/sub
-   missed (slow subscriber, transient drops, subscriber disconnect).
-5. On subscription disconnect, the cache marks itself not-ready and
-   resyncs with exponential backoff.
+   Created/Updated events are guarded by the worker `version` so a
+   stale event cannot overwrite a fresher entry (Deleted events carry
+   no version — see `operations.md`, "Missed pub/sub events").
+4. A periodic relist (5 minutes) re-runs `ListWorkers` to catch events
+   that pub/sub missed (slow subscriber, transient drops, subscriber
+   disconnect).
+5. On subscription disconnect, the cache marks itself not-ready —
+   this is the window where callers see "worker cache not ready" —
+   and resyncs with exponential backoff until it succeeds.
 
 The cache is **per API-server pod**. Each pod has its own subscriber
 and its own copy of the map. Pub/sub broadcasts cluster-wide, so all
@@ -151,77 +175,19 @@ pods see the same events; pods stay eventually-consistent with each
 other on the order of pub/sub latency (sub-second steady state).
 
 `Workers()` returns pointers directly from the cache. Callers that
-need to mutate a worker (e.g. setting `actor_id` during assignment)
-must `proto.Clone` first to avoid corrupting the cache.
+need to mutate a worker (e.g. setting its `Assignment` during
+scheduling) must `proto.Clone` first to avoid corrupting the cache.
 
-## Sizing math
+Worker records carry the scheduling metadata the resume path needs
+(`labels` and `sandbox_class`, cached from the owning WorkerPool by
+the syncer), so scheduling decisions read only this cache — never
+the WorkerPool CRDs. See [`lifecycle.md`](./lifecycle.md) for the
+eligibility rules.
 
-Two memory budgets that grow with scale.
+## Sizing and scaling
 
-### Valkey working set
-
-The Actor record dominates Valkey memory. The proto is twelve
-scalar/string fields plus a `SnapshotInfo` sub-message; JSON-encoded
-with realistic snapshot URIs it lands in the **500 B – 1 KB** range
-in practice. Add ~60–100 B per key for Valkey's `dictEntry` and key
-string, so plan for **~1 KB per actor** in primary memory.
-
-A practical per-primary memory ceiling on cloud-hosted Valkey is
-**4–32 GB**. Above that, `BGSAVE` / `BGREWRITEAOF` fork latency and
-full-resync time after a replica restart all become operationally
-painful.
-
-| Actor count | Working set | Primaries @ 8 GB | Primaries @ 16 GB | Primaries @ 32 GB |
-|---|---|---|---|---|
-| 1 M     | 1 GB    | 1   | 1  | 1  |
-| 10 M    | 10 GB   | 2   | 1  | 1  |
-| 100 M   | 100 GB  | 13  | 7  | 4  |
-| 1 B     | 1 TB    | **125** | **63** | **32** |
-
-Multiply by 2 for replicas. At target scale, primary counts approach
-the practical cluster-bus comfort ceiling (~500 primaries); above
-that, gossip cost grows O(N²) and becomes meaningful.
-
-### Worker cache memory (per API-server pod)
-
-Each API-server pod's cache holds every worker proto in memory.
-Worker protos are smaller than Actor protos (no snapshot URIs) —
-plan for **~200 B per worker** in the cache map.
-
-| Worker count | Cache memory per API-server pod |
-|---|---|
-| 1 k    | ~200 KB |
-| 10 k   | ~2 MB   |
-| 100 k  | ~20 MB  |
-| 1 M    | ~200 MB |
-
-At 100 k workers across, say, 5 API-server pods, the cache adds
-~100 MB of resident memory across the fleet. Workable; observable.
-
-The cache also pays a one-time `ListWorkers` cost at every API-server
-pod startup (the initial sync). At 10 k workers this is seconds; at
-100 k workers it's tens of seconds, during which the pod accepts
-connections but `Workers()` returns "not ready" and ResumeActor calls
-fail with a clear error.
-
-## Configuration knobs not set today
-
-Several Valkey-level safety knobs ship at defaults that are fine at
-MVP and concerning at target scale. They are not bugs; they are
-deliberate deferrals that should be revisited before scaling
-significantly.
-
-| Setting | Default | Why it matters | When to revisit |
-|---|---|---|---|
-| `cluster-require-full-coverage` | `yes` | Any uncovered slot range (including during a normal primary failover) pauses **all** writes cluster-wide, not just for the affected slot. | Flip to `no` before any deployment that can't tolerate brief cluster-wide pauses during routine failovers. |
-| `min-replicas-to-write` | unset | Primary acks writes even with zero healthy replicas — async-replication tail can be lost on failover. | Set to `1` with `min-replicas-max-lag 10` before durability becomes a hard requirement. **No per-write latency cost** — the check is in-memory; cost is availability under replica trouble. |
-| `maxmemory` | unset | Pod grows until K8s OOMKills it (which means AOF replay on restart, lost writes, possible failover). | Set explicitly at ~75 % of pod memory limit with `maxmemory-policy noeviction` (writes fail with a clear error instead of triggering opaque OOMKill). |
-| Pod anti-affinity / topology spread | none | Primary and replica of the same shard can land on the same K8s node, so a single node failure can take both pods of a shard. | Add required anti-affinity before any production deployment. |
-| Off-cluster backups | none | Total loss of both PVCs of a shard = permanent data loss. | Required before GA. |
-| Pod Disruption Budget | none | Rolling deploys / autoscaler actions can disrupt multiple Valkey pods at once. | Add `maxUnavailable: 1` before any deployment with concurrent K8s lifecycle activity. |
-
-These flags compose. The combination of `cluster-require-full-coverage yes`
-+ no anti-affinity + no PDB is the single largest source of
-"unexpected cluster-wide outage on small disturbance" risk in the
-current configuration. Even one of them addressed materially
-reduces that risk.
+Deliberately not on this page. Capacity math, worker-cache memory
+growth, the tier table from pilot deployments to the 10M-actor
+envelope, durability profiles, and the full deployed-today vs.
+target configuration ladder live in
+[`scaling_to_10m.md`](./scaling_to_10m.md).


### PR DESCRIPTION
Operational reference for the Valkey persistence tier and the in-process worker cache that sits in front of it. Written for operators, on-call engineers, and contributors who need to reason about the storage tier without first reading the code. This will be used as ref for further investigation on if Valkey will really stand-up.

NOTE: We chose Valkey due to it's speed for the critical scheduling requirements. With WorkerCache now being in memory, we get the speed for scheduling and still rely on eventual consistency. Do we now want more durability? Also still need to answer: what data can we 100% NOT lose in these failure situations.

  README.md       — entry point, scope, conventions
  topology.md     — what's deployed, sizing math, configuration knobs
  lifecycle.md    — actor state machine, four workflows, worker cache
                    and eligibility model
  operations.md   — failure modes with inline recovery, common admin
                    operations, open risks

#12 



- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
