### PR TITLE
fix: remove nonexistent atenet sidecar command from README

### DIFF
--- a/cmd/atenet/README.md
+++ b/cmd/atenet/README.md
@@ -3,7 +3,6 @@
 atenet is a combined daemon for all networking functionality.
 
 * DNS server for ATE Actor resolution: `atenet dns`
-* Lightweight mTLS proxy sidecar for demonstrating using ATE identities. `atenet sidecar`
 * Envoy control plane for programming ATE resolution. `atenet router`
 
 This is built as a single binary for convenience in the prototyping.


### PR DESCRIPTION
The README lists atenet sidecar as a subcommand, but no such command is registered. cmd/atenet only defines dns and router (cmd/atenet/internal/root.go).
Verified only dns and router are registered as Use: in cmd/atenet/internal/*.go.