### PR TITLE
fix: correct kubectl-ate install instructions in agent-secret README

### DIFF
--- a/demos/agent-secret/README.md
+++ b/demos/agent-secret/README.md
@@ -14,7 +14,7 @@ This demo showcases a "Zero-Idle" agentic lifecycle using a specialized Go serve
 ### 1. Prerequisites
 *   A GKE cluster with **Agent Substrate** installed.
 *   `ko` installed (for building and deploying Go images).
-*   `kubectl-ate` CLI built in the root directory.
+*   `kubectl-ate` CLI installed (can be installed via `go install ./cmd/kubectl-ate`).
 
 ### 2. Deploy the Infrastructure
 Use the core installation script to build the image and apply the manifests:


### PR DESCRIPTION
The prerequisites said kubectl-ate is built in the root directory, but the rest of the doc uses it as a kubectl plugin installed via go install. This matches the pattern used in the other demo READMEs.
Checked demos/sandbox/README.md and demos/counter/README.md for the same prerequisite wording.