### PR TITLE
Propagate (atespace/actor_id) to atelet.

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -840,7 +840,7 @@ func TestListActors_ByAtespace(t *testing.T) {
 	createAtespace(t, tc, "team-a")
 	createAtespace(t, tc, "team-b")
 
-	create := func(id, atespace string) *ateapipb.Actor {
+	create := func(atespace, id string) *ateapipb.Actor {
 		resp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 			ActorRef:               &ateapipb.ActorRef{Atespace: atespace, Name: id},
 			ActorTemplateNamespace: ns,
@@ -851,9 +851,9 @@ func TestListActors_ByAtespace(t *testing.T) {
 		}
 		return resp.GetActor()
 	}
-	a1 := create("id1", "team-a")
-	a2 := create("id2", "team-a")
-	b1 := create("id3", "team-b")
+	a1 := create("team-a", "id1")
+	a2 := create("team-a", "id2")
+	b1 := create("team-b", "id3")
 
 	sortByID := []cmp.Option{
 		protocmp.Transform(),
@@ -897,7 +897,7 @@ func TestListActors_AllAtespaces(t *testing.T) {
 	createAtespace(t, tc, "team-a")
 	createAtespace(t, tc, "team-b")
 
-	create := func(id, atespace string) {
+	create := func(atespace, id string) {
 		if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 			ActorRef:               &ateapipb.ActorRef{Atespace: atespace, Name: id},
 			ActorTemplateNamespace: ns,
@@ -906,8 +906,8 @@ func TestListActors_AllAtespaces(t *testing.T) {
 			t.Fatalf("CreateActor(%s, atespace=%q) failed: %v", id, atespace, err)
 		}
 	}
-	create("id1", "team-a")
-	create("id2", "team-b")
+	create("team-a", "id1")
+	create("team-b", "id2")
 
 	// Empty atespace lists across all atespaces; returned actors carry their atespace.
 	resp, err := tc.client.ListActors(context.Background(), &ateapipb.ListActorsRequest{})

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -122,9 +122,10 @@ func (s *CallAteletPauseStep) Execute(ctx context.Context, input *PauseInput, st
 	// into the snapshot manifest.
 	req := &ateletpb.CheckpointRequest{
 		TargetAteomUid:         state.Actor.GetAteomPodUid(),
+		Atespace:               state.Actor.GetAtespace(),
+		ActorId:                state.Actor.GetActorId(),
 		ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
 		ActorTemplateName:      state.Actor.GetActorTemplateName(),
-		ActorId:                state.Actor.GetActorId(),
 		Spec:                   workloadSpec,
 		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL,
 		Config: &ateletpb.CheckpointRequest_LocalConfig{

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -271,9 +271,10 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 
 		req := &ateletpb.RestoreRequest{
 			TargetAteomUid:         state.Actor.GetAteomPodUid(),
+			Atespace:               state.Actor.GetAtespace(),
+			ActorId:                state.Actor.GetActorId(),
 			ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
 			ActorTemplateName:      state.Actor.GetActorTemplateName(),
-			ActorId:                state.Actor.GetActorId(),
 			Spec:                   workloadSpec,
 		}
 		switch state.Actor.GetLatestSnapshotInfo().GetType() {
@@ -309,9 +310,10 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 
 		req := &ateletpb.RestoreRequest{
 			TargetAteomUid:         state.Actor.GetAteomPodUid(),
+			Atespace:               state.Actor.GetAtespace(),
+			ActorId:                state.Actor.GetActorId(),
 			ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
 			ActorTemplateName:      state.Actor.GetActorTemplateName(),
-			ActorId:                state.Actor.GetActorId(),
 			Spec:                   workloadSpec,
 			Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
 			Config: &ateletpb.RestoreRequest_ExternalConfig{
@@ -339,9 +341,10 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 
 		req := &ateletpb.RunRequest{
 			TargetAteomUid:         state.Actor.GetAteomPodUid(),
+			Atespace:               state.Actor.GetAtespace(),
+			ActorId:                state.Actor.GetActorId(),
 			ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
 			ActorTemplateName:      state.Actor.GetActorTemplateName(),
-			ActorId:                state.Actor.GetActorId(),
 			SandboxAssets:          sandboxAssets,
 			Spec:                   workloadSpec,
 		}

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -124,9 +124,10 @@ func (s *CallAteletSuspendStep) Execute(ctx context.Context, input *SuspendInput
 	// into the snapshot manifest.
 	req := &ateletpb.CheckpointRequest{
 		TargetAteomUid:         state.Actor.GetAteomPodUid(),
+		Atespace:               state.Actor.GetAtespace(),
+		ActorId:                state.Actor.GetActorId(),
 		ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
 		ActorTemplateName:      state.Actor.GetActorTemplateName(),
-		ActorId:                state.Actor.GetActorId(),
 		Spec:                   workloadSpec,
 		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
 		Config: &ateletpb.CheckpointRequest_ExternalConfig{

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -844,7 +844,7 @@ func TestListActors_ScopedByAtespace(t *testing.T) {
 	mr, s, ctx := setupTest(t)
 	defer mr.Close()
 
-	mkActor := func(id, atespace string) *ateapipb.Actor {
+	mkActor := func(atespace, id string) *ateapipb.Actor {
 		return &ateapipb.Actor{
 			ActorId:                id,
 			Atespace:               atespace,
@@ -854,9 +854,9 @@ func TestListActors_ScopedByAtespace(t *testing.T) {
 		}
 	}
 	for _, a := range []*ateapipb.Actor{
-		mkActor("a1", "team-a"),
-		mkActor("a2", "team-a"),
-		mkActor("b1", "team-b"),
+		mkActor("team-a", "a1"),
+		mkActor("team-a", "a2"),
+		mkActor("team-b", "b1"),
 	} {
 		if err := s.CreateActor(ctx, a); err != nil {
 			t.Fatalf("CreateActor(%s/%s) failed: %v", a.GetAtespace(), a.GetActorId(), err)

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -55,6 +55,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/api/validate/content"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/lru"
 )
 
@@ -216,7 +218,7 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
+	atespace, actorID := req.GetAtespace(), req.GetActorId()
 
 	sandboxRec, err := recordFromRequest(req.GetSandboxAssets())
 	if err != nil {
@@ -227,18 +229,18 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 		return nil, err
 	}
 
-	if err := resetActorDirs(ns, tmpl, actorID); err != nil {
+	if err := resetActorDirs(atespace, actorID); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
 	// Record the sandbox binaries this actor is running so a later Checkpoint
 	// (whose request no longer carries the sandbox config) can re-fetch the same
 	// version and pin it into the snapshot manifest.
-	if err := writeSandboxRecord(ns, tmpl, actorID, sandboxRec); err != nil {
+	if err := writeSandboxRecord(atespace, actorID, sandboxRec); err != nil {
 		return nil, fmt.Errorf("while recording sandbox assets: %w", err)
 	}
 
-	if err := s.prepareOCIBundles(ctx, ns, tmpl, actorID,
+	if err := s.prepareOCIBundles(ctx, atespace, actorID,
 		req.GetSpec(), req.GetTargetAteomUid(),
 	); err != nil {
 		return nil, err
@@ -252,9 +254,10 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (*atele
 	// Tell ateom to start the workload. gVisor uses RunscPath; the micro-VM
 	// runtime uses the full RuntimeAssetPaths set.
 	if _, err := client.RunWorkload(ctx, &ateompb.RunWorkloadRequest{
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      tmpl,
+		Atespace:               atespace,
 		ActorId:                actorID,
+		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
+		ActorTemplateName:      req.GetActorTemplateName(),
 		RunscPath:              runscPathFor(assetPaths),
 		RuntimeAssetPaths:      assetPaths,
 		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
@@ -306,13 +309,13 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
+	atespace, actorID := req.GetAtespace(), req.GetActorId()
 
 	// Checkpoint requests no longer carry the sandbox config; recover the
 	// version this actor was started with from the on-node record and re-fetch
 	// it (a cache hit) so ateom can drive runsc, and so we can pin it into the
 	// snapshot manifest below.
-	sandboxRec, err := readSandboxRecord(ns, tmpl, actorID)
+	sandboxRec, err := readSandboxRecord(atespace, actorID)
 	if err != nil {
 		return nil, fmt.Errorf("while loading recorded sandbox assets: %w", err)
 	}
@@ -321,7 +324,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, err
 	}
 
-	checkpointDir := ateompath.CheckpointStateDir(ns, tmpl, actorID)
+	checkpointDir := ateompath.CheckpointStateDir(atespace, actorID)
 
 	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
 	if err != nil {
@@ -332,9 +335,10 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	// exact files it wrote so we ship precisely that set (gVisor's image files,
 	// cloud-hypervisor's snapshot set, ...) rather than a hardcoded list.
 	resp, err := client.CheckpointWorkload(ctx, &ateompb.CheckpointWorkloadRequest{
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      tmpl,
+		Atespace:               atespace,
 		ActorId:                actorID,
+		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
+		ActorTemplateName:      req.GetActorTemplateName(),
 		RunscPath:              runscPathFor(assetPaths),
 		RuntimeAssetPaths:      assetPaths,
 		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
@@ -361,7 +365,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, fmt.Errorf("unexpected checkpoint type: %v", req.GetType())
 	}
 
-	if err := resetActorDirs(ns, tmpl, actorID); err != nil {
+	if err := resetActorDirs(atespace, actorID); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
@@ -379,18 +383,16 @@ func toAteomSnapshotScope(scope ateletpb.SnapshotScope) ateompb.SnapshotScope {
 }
 
 func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string, rec *sandboxAssetsRecord) error {
-	localCheckpointPath := filepath.Join(ateompath.LocalCheckpointsDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()), req.GetLocalConfig().GetSnapshotPrefix())
+	localCheckpointPath := filepath.Join(ateompath.LocalCheckpointsDir(req.GetAtespace(), req.GetActorId()), req.GetLocalConfig().GetSnapshotPrefix())
 	if err := os.MkdirAll(localCheckpointPath, 0o700); err != nil {
 		return fmt.Errorf("while creating local checkpoint directory: %w", err)
 	}
-
-	ns, tmpl := req.GetActorTemplateNamespace(), req.GetActorTemplateName()
 
 	// Move exactly the files ateom reported.
 	for _, fileName := range rec.SnapshotFiles {
 		src := filepath.Join(checkpointDir, fileName)
 		dst := filepath.Join(localCheckpointPath, fileName)
-		recordSnapshotSize(ctx, strings.TrimSuffix(fileName, ".img"), src, ns, tmpl)
+		recordSnapshotSize(ctx, strings.TrimSuffix(fileName, ".img"), src, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
 		if err := os.Rename(src, dst); err != nil {
 			return fmt.Errorf("failed to move %s to %s: %w", src, dst, err)
@@ -411,7 +413,6 @@ func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.Che
 }
 
 func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string, rec *sandboxAssetsRecord) error {
-	ns, tmpl := req.GetActorTemplateNamespace(), req.GetActorTemplateName()
 	prefix := strings.TrimSuffix(req.GetExternalConfig().GetSnapshotUriPrefix(), "/")
 
 	// Upload exactly the files ateom reported (each zstd-compressed).
@@ -419,7 +420,7 @@ func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletp
 	for _, fileName := range rec.SnapshotFiles {
 		fileName := fileName
 		local := filepath.Join(checkpointDir, fileName)
-		recordSnapshotSize(ctx, strings.TrimSuffix(fileName, ".img"), local, ns, tmpl)
+		recordSnapshotSize(ctx, strings.TrimSuffix(fileName, ".img"), local, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 		g.Go(func() error {
 			if err := ategcs.SendLocalFileToGCSWithZstd(gCtx, s.gcsClient, prefix+"/"+fileName+".zstd", local); err != nil {
 				return fmt.Errorf("while uploading %s to GCS: %w", fileName, err)
@@ -448,13 +449,13 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	ns, tmpl, actorID := req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId()
+	atespace, actorID := req.GetAtespace(), req.GetActorId()
 
-	if err := resetActorDirs(ns, tmpl, actorID); err != nil {
+	if err := resetActorDirs(atespace, actorID); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
 
-	checkpointDir := ateompath.RestoreStateDir(ns, tmpl, actorID)
+	checkpointDir := ateompath.RestoreStateDir(atespace, actorID)
 
 	// Per-step timing so we can attribute resume latency between the rustfs
 	// download/decompress, the OCI image unpack, and ateom's own work. Logged at the end.
@@ -480,7 +481,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			return nil, err
 		}
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-		localCheckpointDir := ateompath.LocalCheckpointsDir(ns, tmpl, actorID)
+		localCheckpointDir := ateompath.LocalCheckpointsDir(atespace, actorID)
 		snapshotPrefix := req.GetLocalConfig().GetSnapshotPrefix()
 		manifest, err := os.ReadFile(filepath.Join(localCheckpointDir, snapshotPrefix, sandboxManifestName))
 		if err != nil {
@@ -510,7 +511,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 				return err
 			}
 		case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-			if err := s.copyLocalCheckpoint(gctx, req.GetLocalConfig().GetSnapshotPrefix(), ateompath.LocalCheckpointsDir(ns, tmpl, actorID), checkpointDir, sandboxRec.SnapshotFiles); err != nil {
+			if err := s.copyLocalCheckpoint(gctx, req.GetLocalConfig().GetSnapshotPrefix(), ateompath.LocalCheckpointsDir(atespace, actorID), checkpointDir, sandboxRec.SnapshotFiles); err != nil {
 				return err
 			}
 		}
@@ -523,7 +524,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			return err
 		}
 		t := time.Now()
-		if err := s.prepareOCIBundles(gctx, ns, tmpl, actorID, req.GetSpec(), req.GetTargetAteomUid()); err != nil {
+		if err := s.prepareOCIBundles(gctx, atespace, actorID, req.GetSpec(), req.GetTargetAteomUid()); err != nil {
 			return err
 		}
 		dBundles = time.Since(t)
@@ -542,9 +543,10 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	// all application containers.
 	tAteom := time.Now()
 	if _, err := client.RestoreWorkload(ctx, &ateompb.RestoreWorkloadRequest{
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      tmpl,
+		Atespace:               atespace,
 		ActorId:                actorID,
+		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
+		ActorTemplateName:      req.GetActorTemplateName(),
 		RunscPath:              runscPathFor(assetPaths),
 		RuntimeAssetPaths:      assetPaths,
 		Spec:                   buildAteomWorkloadSpec(req.GetSpec()),
@@ -556,7 +558,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 
 	// Record the (manifest-pinned) sandbox binaries on-node so a subsequent
 	// Checkpoint of this restored actor can re-pin the same version.
-	if err := writeSandboxRecord(ns, tmpl, actorID, sandboxRec); err != nil {
+	if err := writeSandboxRecord(atespace, actorID, sandboxRec); err != nil {
 		return nil, fmt.Errorf("while recording sandbox assets: %w", err)
 	}
 
@@ -632,7 +634,7 @@ func (s *AteomHerder) downloadExternalCheckpoint(ctx context.Context, snapshotUr
 // container and every application container in spec, in parallel.
 func (s *AteomHerder) prepareOCIBundles(
 	ctx context.Context,
-	actorTemplateNamespace, actorTemplateName, actorID string,
+	atespace, actorID string,
 	spec *ateletpb.WorkloadSpec,
 	targetAteomUid string,
 ) error {
@@ -641,7 +643,7 @@ func (s *AteomHerder) prepareOCIBundles(
 	// Populate the per-actor identity directory that gets bind-mounted into
 	// the application containers. Regenerated on every resume, so it carries
 	// the correct per-actor ID even when restoring from the golden snapshot.
-	identityDir := ateompath.ActorIdentityDirPath(actorTemplateNamespace, actorTemplateName, actorID)
+	identityDir := ateompath.ActorIdentityDirPath(atespace, actorID)
 	if err := os.MkdirAll(identityDir, 0o755); err != nil {
 		return fmt.Errorf("while creating actor identity dir: %w", err)
 	}
@@ -654,7 +656,7 @@ func (s *AteomHerder) prepareOCIBundles(
 	for _, vol := range spec.GetVolumes() {
 		if vol.GetType() == ateletpb.VolumeType_VOLUME_TYPE_DURABLE_DIR {
 			ddVolumes[vol.GetName()] = true
-			volPath := ateompath.DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actorID, vol.GetName())
+			volPath := ateompath.DurableDirVolumeMountPoint(atespace, actorID, vol.GetName())
 			if err := os.MkdirAll(volPath, 0o700); err != nil {
 				return fmt.Errorf("while creating %q: %w", volPath, err)
 			}
@@ -675,14 +677,14 @@ func (s *AteomHerder) prepareOCIBundles(
 			if vol.GetType() == ateletpb.VolumeType_VOLUME_TYPE_DURABLE_DIR {
 				annotations["dev.gvisor.spec.mount.durabledir.type"] = "bind"
 				annotations["dev.gvisor.spec.mount.durabledir.share"] = "container"
-				annotations["dev.gvisor.spec.mount.durabledir.source"] = ateompath.DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actorID, vol.GetName())
+				annotations["dev.gvisor.spec.mount.durabledir.source"] = ateompath.DurableDirVolumeMountPoint(atespace, actorID, vol.GetName())
 			}
 		}
 
 		if err := prepareOCIDirectory(
 			gCtx,
 			s.pullCache,
-			actorTemplateNamespace, actorTemplateName, actorID,
+			atespace, actorID,
 			"pause",
 			spec.GetPauseImage(),
 			[]string{"/pause"},
@@ -714,7 +716,7 @@ func (s *AteomHerder) prepareOCIBundles(
 			if err := prepareOCIDirectory(
 				gCtx,
 				s.pullCache,
-				actorTemplateNamespace, actorTemplateName, actorID,
+				atespace, actorID,
 				ctr.GetName(),
 				ctr.GetImage(),
 				ctr.GetCommand(),
@@ -826,11 +828,51 @@ func (d *AteomDialer) DialAteomPod(ctx context.Context, podUID string) (*grpc.Cl
 // boundary, before any path is built. The field rules live in
 // internal/resources so other components can apply them at their boundaries.
 func validateRunRequest(req *ateletpb.RunRequest) error {
-	return validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec())
+	var errs field.ErrorList
+	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
+	errs = append(errs, resources.ValidateResourceName(req.GetActorId(), field.NewPath("actor_id"))...)
+	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+	}
+	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
+	}
+	if len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+	// TODO: Migrate all validations below to the validation framework.
+	if err := resources.ValidateAteomUID(req.GetTargetAteomUid()); err != nil {
+		return err
+	}
+	names := make([]string, 0, len(req.GetSpec().GetContainers()))
+	for _, ctr := range req.GetSpec().GetContainers() {
+		names = append(names, ctr.GetName())
+	}
+	return resources.ValidateContainerNames(names)
 }
 
 func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
-	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+	var errs field.ErrorList
+	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
+	errs = append(errs, resources.ValidateResourceName(req.GetActorId(), field.NewPath("actor_id"))...)
+	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+	}
+	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
+	}
+	if len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+	// TODO: Migrate all validations below to the validation framework.
+	if err := resources.ValidateAteomUID(req.GetTargetAteomUid()); err != nil {
+		return err
+	}
+	names := make([]string, 0, len(req.GetSpec().GetContainers()))
+	for _, ctr := range req.GetSpec().GetContainers() {
+		names = append(names, ctr.GetName())
+	}
+	if err := resources.ValidateContainerNames(names); err != nil {
 		return err
 	}
 
@@ -854,7 +896,27 @@ func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
 }
 
 func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
-	if err := validateActorRequest(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId(), req.GetTargetAteomUid(), req.GetSpec()); err != nil {
+	var errs field.ErrorList
+	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
+	errs = append(errs, resources.ValidateResourceName(req.GetActorId(), field.NewPath("actor_id"))...)
+	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+	}
+	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
+	}
+	if len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+	// TODO: Migrate all validations below to the validation framework.
+	if err := resources.ValidateAteomUID(req.GetTargetAteomUid()); err != nil {
+		return err
+	}
+	names := make([]string, 0, len(req.GetSpec().GetContainers()))
+	for _, ctr := range req.GetSpec().GetContainers() {
+		names = append(names, ctr.GetName())
+	}
+	if err := resources.ValidateContainerNames(names); err != nil {
 		return err
 	}
 
@@ -887,22 +949,6 @@ func validateSnapshotScope(scope ateletpb.SnapshotScope) error {
 	default:
 		return fmt.Errorf("invalid snapshot scope: %v", scope)
 	}
-}
-
-// validateActorRequest is the shared core for the fields common to all three
-// RPCs.
-func validateActorRequest(namespace, template, actorID, targetAteomUID string, spec *ateletpb.WorkloadSpec) error {
-	if err := resources.ValidateActorRefFields(namespace, template, actorID); err != nil {
-		return err
-	}
-	if err := resources.ValidateAteomUID(targetAteomUID); err != nil {
-		return err
-	}
-	names := make([]string, 0, len(spec.GetContainers()))
-	for _, ctr := range spec.GetContainers() {
-		names = append(names, ctr.GetName())
-	}
-	return resources.ValidateContainerNames(names)
 }
 
 // writeFileAtomic writes data to path by writing a temp file in the same
@@ -944,10 +990,10 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	return dir.Sync()
 }
 
-func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) error {
+func resetActorDirs(atespace, actorID string) error {
 	// Explicitly leave runsc logs dir untouched.
 
-	bundleDir := ateompath.OCIBundleDir(actorTemplateNamespace, actorTemplateName, actorID)
+	bundleDir := ateompath.OCIBundleDir(atespace, actorID)
 	if err := os.RemoveAll(bundleDir); err != nil {
 		return fmt.Errorf("while deleting bundle dir: %w", err)
 	}
@@ -955,7 +1001,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating bundle dir: %w", err)
 	}
 
-	runscDir := ateompath.RunSCStateDir(actorTemplateNamespace, actorTemplateName, actorID)
+	runscDir := ateompath.RunSCStateDir(atespace, actorID)
 	if err := os.RemoveAll(runscDir); err != nil {
 		return fmt.Errorf("while deleting runsc state dir: %w", err)
 	}
@@ -963,7 +1009,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating runsc state dir: %w", err)
 	}
 
-	pidFileDir := ateompath.PIDFileDir(actorTemplateNamespace, actorTemplateName, actorID)
+	pidFileDir := ateompath.PIDFileDir(atespace, actorID)
 	if err := os.RemoveAll(pidFileDir); err != nil {
 		return fmt.Errorf("while deleting PID file dir: %w", err)
 	}
@@ -971,7 +1017,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating PID file dir: %w", err)
 	}
 
-	checkpointDir := ateompath.CheckpointStateDir(actorTemplateNamespace, actorTemplateName, actorID)
+	checkpointDir := ateompath.CheckpointStateDir(atespace, actorID)
 	if err := os.RemoveAll(checkpointDir); err != nil {
 		return fmt.Errorf("while deleting checkpoint-state dir: %w", err)
 	}
@@ -979,7 +1025,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating checkpoint-state dir: %w", err)
 	}
 
-	restoreStateDir := ateompath.RestoreStateDir(actorTemplateNamespace, actorTemplateName, actorID)
+	restoreStateDir := ateompath.RestoreStateDir(atespace, actorID)
 	if err := os.RemoveAll(restoreStateDir); err != nil {
 		return fmt.Errorf("while deleting restore-state dir: %w", err)
 	}
@@ -989,7 +1035,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 
 	// World-readable (0o755): bind-mounted into the actor, whose workload
 	// reads it through the gofer.
-	identityDir := ateompath.ActorIdentityDirPath(actorTemplateNamespace, actorTemplateName, actorID)
+	identityDir := ateompath.ActorIdentityDirPath(atespace, actorID)
 	if err := os.RemoveAll(identityDir); err != nil {
 		return fmt.Errorf("while deleting actor identity dir: %w", err)
 	}
@@ -997,7 +1043,7 @@ func resetActorDirs(actorTemplateNamespace, actorTemplateName, actorID string) e
 		return fmt.Errorf("while creating actor identity dir: %w", err)
 	}
 
-	durableDirVolumesMountDir := ateompath.DurableDirVolumeMountsDir(actorTemplateNamespace, actorTemplateName, actorID)
+	durableDirVolumesMountDir := ateompath.DurableDirVolumeMountsDir(atespace, actorID)
 	if err := os.RemoveAll(durableDirVolumesMountDir); err != nil {
 		return fmt.Errorf("while deleting durable-dir volumes mount dir: %w", err)
 	}

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -84,39 +84,15 @@ func TestWriteFileAtomic(t *testing.T) {
 	})
 }
 
-func TestValidateActorRequest(t *testing.T) {
-	const okNS, okTmpl, okID, okUID = "ate-demo", "counter", "counter-1", "422938ba-8860-4983-a25d-d6bcb0a69d4e"
-	okSpec := &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}}
-
-	tests := []struct {
-		name              string
-		ns, tmpl, id, uid string
-		spec              *ateletpb.WorkloadSpec
-		wantErr           bool
-	}{
-		{"all valid", okNS, okTmpl, okID, okUID, okSpec, false},
-		{"bad namespace", "../x", okTmpl, okID, okUID, okSpec, true},
-		{"bad actor id", okNS, okTmpl, "../x", okUID, okSpec, true},
-		{"bad uid", okNS, okTmpl, okID, "../x", okSpec, true},
-		{"bad container", okNS, okTmpl, okID, okUID, &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "../x"}}}, true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := validateActorRequest(tc.ns, tc.tmpl, tc.id, tc.uid, tc.spec); (err != nil) != tc.wantErr {
-				t.Errorf("validateActorRequest err = %v, wantErr %v", err, tc.wantErr)
-			}
-		})
-	}
-}
-
 // validRunRequest, validCheckpointRequest, and validRestoreRequest build
 // requests whose every field passes validation; the per-request tests below
 // break one field per case.
 func validRunRequest() *ateletpb.RunRequest {
 	return &ateletpb.RunRequest{
+		Atespace:               "ate-demo",
+		ActorId:                "counter-1",
 		ActorTemplateNamespace: "ate-demo",
 		ActorTemplateName:      "counter",
-		ActorId:                "counter-1",
 		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
 		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
 	}
@@ -124,9 +100,10 @@ func validRunRequest() *ateletpb.RunRequest {
 
 func validCheckpointRequest() *ateletpb.CheckpointRequest {
 	return &ateletpb.CheckpointRequest{
+		Atespace:               "ate-demo",
+		ActorId:                "counter-1",
 		ActorTemplateNamespace: "ate-demo",
 		ActorTemplateName:      "counter",
-		ActorId:                "counter-1",
 		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
 		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
 		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
@@ -141,9 +118,10 @@ func validCheckpointRequest() *ateletpb.CheckpointRequest {
 
 func validRestoreRequest() *ateletpb.RestoreRequest {
 	return &ateletpb.RestoreRequest{
+		Atespace:               "ate-demo",
+		ActorId:                "counter-1",
 		ActorTemplateNamespace: "ate-demo",
 		ActorTemplateName:      "counter",
-		ActorId:                "counter-1",
 		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
 		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
 		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
@@ -164,7 +142,13 @@ func TestValidateRunRequest(t *testing.T) {
 	}{
 		{"valid", func(*ateletpb.RunRequest) {}, false},
 		{"invalid ateom uid", func(r *ateletpb.RunRequest) { r.TargetAteomUid = "../escape" }, true},
+		{"invalid atespace", func(r *ateletpb.RunRequest) { r.Atespace = "../escape" }, true},
 		{"invalid actor id", func(r *ateletpb.RunRequest) { r.ActorId = "../escape" }, true},
+		{"invalid actor template namespace", func(r *ateletpb.RunRequest) { r.ActorTemplateNamespace = "Not_Valid" }, true},
+		{"invalid actor template name", func(r *ateletpb.RunRequest) { r.ActorTemplateName = "Not_Valid" }, true},
+		{"invalid container name", func(r *ateletpb.RunRequest) {
+			r.Spec.Containers = []*ateletpb.Container{{Name: "../escape"}}
+		}, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -197,6 +181,13 @@ func TestValidateCheckpointRequest(t *testing.T) {
 		{"empty snapshot uri", makeReq(func(r *ateletpb.CheckpointRequest) { r.GetExternalConfig().SnapshotUriPrefix = "" }), true},
 		{"bucketless snapshot uri", makeReq(func(r *ateletpb.CheckpointRequest) { r.GetExternalConfig().SnapshotUriPrefix = "relative/path" }), true},
 		{"invalid ateom uid", makeReq(func(r *ateletpb.CheckpointRequest) { r.TargetAteomUid = "../escape" }), true},
+		{"invalid atespace", makeReq(func(r *ateletpb.CheckpointRequest) { r.Atespace = "../escape" }), true},
+		{"invalid actor id", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorId = "../escape" }), true},
+		{"invalid actor template namespace", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorTemplateNamespace = "Not_Valid" }), true},
+		{"invalid actor template name", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorTemplateName = "Not_Valid" }), true},
+		{"invalid container name", makeReq(func(r *ateletpb.CheckpointRequest) {
+			r.Spec.Containers = []*ateletpb.Container{{Name: "../escape"}}
+		}), true},
 		{"invalid local snapshot prefix", makeReq(func(r *ateletpb.CheckpointRequest) {
 			r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL
 			r.Config = &ateletpb.CheckpointRequest_LocalConfig{LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotPrefix: ""}}
@@ -232,6 +223,13 @@ func TestValidateRestoreRequest(t *testing.T) {
 		{"empty snapshot uri", makeReq(func(r *ateletpb.RestoreRequest) { r.GetExternalConfig().SnapshotUriPrefix = "" }), true},
 		{"bucketless snapshot uri", makeReq(func(r *ateletpb.RestoreRequest) { r.GetExternalConfig().SnapshotUriPrefix = "relative/path" }), true},
 		{"invalid ateom uid", makeReq(func(r *ateletpb.RestoreRequest) { r.TargetAteomUid = "../escape" }), true},
+		{"invalid atespace", makeReq(func(r *ateletpb.RestoreRequest) { r.Atespace = "../escape" }), true},
+		{"invalid actor id", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorId = "../escape" }), true},
+		{"invalid actor template namespace", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorTemplateNamespace = "Not_Valid" }), true},
+		{"invalid actor template name", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorTemplateName = "Not_Valid" }), true},
+		{"invalid container name", makeReq(func(r *ateletpb.RestoreRequest) {
+			r.Spec.Containers = []*ateletpb.Container{{Name: "../escape"}}
+		}), true},
 		{"invalid local snapshot prefix", makeReq(func(r *ateletpb.RestoreRequest) {
 			r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL
 			r.Config = &ateletpb.RestoreRequest_LocalConfig{LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotPrefix: ""}}
@@ -350,7 +348,7 @@ func TestRPCBoundariesReject(t *testing.T) {
 	s := &AteomHerder{}
 	ctx := context.Background()
 	badUID := "../escape" // valid actor ref, invalid ateom UID
-	const okNS, okTmpl, okID = "ate-demo", "counter", "counter-1"
+	const okAtespace, okID = "ate-demo", "counter-1"
 	okSpec := &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}}
 
 	wantInvalidArgument := func(t *testing.T, rpc string, err error) {
@@ -366,21 +364,21 @@ func TestRPCBoundariesReject(t *testing.T) {
 
 	t.Run("Run", func(t *testing.T) {
 		_, err := s.Run(ctx, &ateletpb.RunRequest{
-			ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+			Atespace: okAtespace, ActorId: okID,
 			TargetAteomUid: badUID, Spec: okSpec,
 		})
 		wantInvalidArgument(t, "Run", err)
 	})
 	t.Run("Checkpoint", func(t *testing.T) {
 		_, err := s.Checkpoint(ctx, &ateletpb.CheckpointRequest{
-			ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+			Atespace: okAtespace, ActorId: okID,
 			TargetAteomUid: badUID, Spec: okSpec,
 		})
 		wantInvalidArgument(t, "Checkpoint", err)
 	})
 	t.Run("Restore", func(t *testing.T) {
 		_, err := s.Restore(ctx, &ateletpb.RestoreRequest{
-			ActorTemplateNamespace: okNS, ActorTemplateName: okTmpl, ActorId: okID,
+			Atespace: okAtespace, ActorId: okID,
 			TargetAteomUid: badUID, Spec: okSpec,
 		})
 		wantInvalidArgument(t, "Restore", err)

--- a/cmd/atelet/oci.go
+++ b/cmd/atelet/oci.go
@@ -53,14 +53,14 @@ const (
 	ActorIDFileName = "actor-id"
 )
 
-func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryPullCache, actorTemplateNamespace, actorTemplateName, actorID, containerName, ref string, args []string, env []string, annotations map[string]string, netns string, identityDir string, durableDirVolumeMounts []*ateletpb.VolumeMount) error {
+func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryPullCache, atespace, actorID, containerName, ref string, args []string, env []string, annotations map[string]string, netns string, identityDir string, durableDirVolumeMounts []*ateletpb.VolumeMount) error {
 	tracer := otel.Tracer("prepareOCIDirectory")
 
 	ctx, span := tracer.Start(ctx, "prepareOCIDirectory")
 	span.SetAttributes(attribute.String("image", ref))
 	defer span.End()
 
-	bundlePath := ateompath.OCIBundlePath(actorTemplateNamespace, actorTemplateName, actorID, containerName)
+	bundlePath := ateompath.OCIBundlePath(atespace, actorID, containerName)
 	rootPath := path.Join(bundlePath, "rootfs")
 
 	if err := os.RemoveAll(rootPath); err != nil {
@@ -90,7 +90,7 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 		}
 	}
 
-	ociSpec := buildActorOCISpec(actorTemplateNamespace, actorTemplateName, actorID, args, env, annotations, netns, identityDir, durableDirVolumeMounts)
+	ociSpec := buildActorOCISpec(atespace, actorID, args, env, annotations, netns, identityDir, durableDirVolumeMounts)
 	ociSpecBytes, err := json.MarshalIndent(ociSpec, "", "  ")
 	if err != nil {
 		return fmt.Errorf("while marshaling OCI spec: %w", err)
@@ -107,7 +107,7 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 // When identityDir is non-empty it adds a read-only bind mount of that host
 // directory at IdentityMountPath so the actor can read its own ID (see
 // IdentityMountPath for why this is a bind mount rather than env vars).
-func buildActorOCISpec(actorTemplateNamespace string, actorTemplateName string, actorID string, args []string, env []string, annotations map[string]string, netns string, identityDir string, durableDirVolumeMounts []*ateletpb.VolumeMount) *specs.Spec {
+func buildActorOCISpec(atespace string, actorID string, args []string, env []string, annotations map[string]string, netns string, identityDir string, durableDirVolumeMounts []*ateletpb.VolumeMount) *specs.Spec {
 	envVars := []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}
@@ -225,7 +225,7 @@ func buildActorOCISpec(actorTemplateNamespace string, actorTemplateName string, 
 		spec.Mounts = append(spec.Mounts, specs.Mount{
 			Destination: vm.GetMountPath(),
 			Type:        "bind",
-			Source:      ateompath.DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actorID, vm.GetName()),
+			Source:      ateompath.DurableDirVolumeMountPoint(atespace, actorID, vm.GetName()),
 		})
 	}
 

--- a/cmd/atelet/oci_test.go
+++ b/cmd/atelet/oci_test.go
@@ -87,12 +87,12 @@ func runUntar(t *testing.T, entries []tarEntry) (string, error) {
 // With an identity dir, a read-only bind mount appears at IdentityMountPath.
 func TestBuildActorOCISpec_IdentityMount(t *testing.T) {
 	spec := buildActorOCISpec(
-		"ns", "tmpl", "id",
+		"atespace", "id",
 		[]string{"/app"},
 		[]string{"FOO=bar"},
 		map[string]string{"k": "v"},
 		"/run/netns/x",
-		"/host/actors/ns:tmpl:id/identity",
+		"/host/actors/atespace:id/identity",
 		nil,
 	)
 	found := false
@@ -101,7 +101,7 @@ func TestBuildActorOCISpec_IdentityMount(t *testing.T) {
 			continue
 		}
 		found = true
-		if m.Source != "/host/actors/ns:tmpl:id/identity" {
+		if m.Source != "/host/actors/atespace:id/identity" {
 			t.Errorf("identity mount source = %q, want the per-actor identity dir", m.Source)
 		}
 		if m.Type != "bind" {
@@ -118,7 +118,7 @@ func TestBuildActorOCISpec_IdentityMount(t *testing.T) {
 
 // Without an identity dir (the pause container), no identity mount appears.
 func TestBuildActorOCISpec_NoIdentityMountForPause(t *testing.T) {
-	bare := buildActorOCISpec("ns", "tmpl", "id", []string{"/pause"}, nil, nil, "/run/netns/x", "", nil)
+	bare := buildActorOCISpec("atespace", "id", []string{"/pause"}, nil, nil, "/run/netns/x", "", nil)
 	for _, m := range bare.Mounts {
 		if m.Destination == IdentityMountPath {
 			t.Errorf("identity mount must be absent when identityDir is empty")
@@ -129,13 +129,13 @@ func TestBuildActorOCISpec_NoIdentityMountForPause(t *testing.T) {
 // Each durable-dir volume mount becomes a bind mount whose source is the
 // per-actor on-host DurableDirVolumeMountPoint for that volume name.
 func TestBuildActorOCISpec_DurableDirVolumeMounts(t *testing.T) {
-	const ns, tmpl, id = "ns", "tmpl", "id"
+	const atespace, id = "atespace", "id"
 	durableDirs := []*ateletpb.VolumeMount{
 		{Name: "data", MountPath: "/var/data"},
 		{Name: "cache", MountPath: "/var/cache"},
 	}
 	spec := buildActorOCISpec(
-		ns, tmpl, id,
+		atespace, id,
 		[]string{"/app"}, nil, nil,
 		"/run/netns/x",
 		"",
@@ -143,7 +143,7 @@ func TestBuildActorOCISpec_DurableDirVolumeMounts(t *testing.T) {
 	)
 
 	for _, vm := range durableDirs {
-		wantSrc := ateompath.DurableDirVolumeMountPoint(ns, tmpl, id, vm.Name)
+		wantSrc := ateompath.DurableDirVolumeMountPoint(atespace, id, vm.Name)
 		found := false
 		for _, m := range spec.Mounts {
 			if m.Destination != vm.MountPath {

--- a/cmd/atelet/sandbox_assets.go
+++ b/cmd/atelet/sandbox_assets.go
@@ -203,12 +203,12 @@ func (s *AteomHerder) openAsset(ctx context.Context, url string) (io.ReadCloser,
 // writeSandboxRecord persists the actor's running sandbox assets on-node so a
 // later Checkpoint (whose request no longer carries the sandbox config) can
 // re-fetch the same binaries and pin them into the snapshot manifest.
-func writeSandboxRecord(actorTemplateNamespace, actorTemplateName, actorID string, rec *sandboxAssetsRecord) error {
+func writeSandboxRecord(atespace, actorID string, rec *sandboxAssetsRecord) error {
 	data, err := json.Marshal(rec)
 	if err != nil {
 		return fmt.Errorf("while marshaling sandbox record: %w", err)
 	}
-	path := ateompath.ActorSandboxAssetsFile(actorTemplateNamespace, actorTemplateName, actorID)
+	path := ateompath.ActorSandboxAssetsFile(atespace, actorID)
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("while creating actor dir: %w", err)
 	}
@@ -220,8 +220,8 @@ func writeSandboxRecord(actorTemplateNamespace, actorTemplateName, actorID strin
 
 // readSandboxRecord loads the actor's on-node sandbox record written at
 // Run/Restore.
-func readSandboxRecord(actorTemplateNamespace, actorTemplateName, actorID string) (*sandboxAssetsRecord, error) {
-	path := ateompath.ActorSandboxAssetsFile(actorTemplateNamespace, actorTemplateName, actorID)
+func readSandboxRecord(atespace, actorID string) (*sandboxAssetsRecord, error) {
+	path := ateompath.ActorSandboxAssetsFile(atespace, actorID)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("while reading sandbox record %s: %w", path, err)

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -181,7 +181,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.actorLogger.EmitLifecycleLog("Actor starting", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor starting", req.GetAtespace(), req.GetActorId(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
 	// Contract with atelet:
 	//
@@ -198,10 +198,9 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	}()
 
 	rcmd := &runsc{
-		path:                   req.GetRunscPath(),
-		actorTemplateNamespace: req.GetActorTemplateNamespace(),
-		actorTemplateName:      req.GetActorTemplateName(),
-		actorID:                req.GetActorId(),
+		path:     req.GetRunscPath(),
+		atespace: req.GetAtespace(),
+		actorID:  req.GetActorId(),
 	}
 
 	// Create and start pause container
@@ -215,7 +214,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	// Create and start each application container, each with its own log pipe so
 	// every line is tagged with the originating container (ate.dev/container_name).
 	for _, ac := range req.GetSpec().GetContainers() {
-		pw, err := s.actorLogger.StartJSONLogPipe(req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace(), ac.GetName())
+		pw, err := s.actorLogger.StartJSONLogPipe(req.GetAtespace(), req.GetActorId(), req.GetActorTemplateNamespace(), req.GetActorTemplateName(), ac.GetName())
 		if err != nil {
 			return nil, fmt.Errorf("while starting json log pipe for %q: %w", ac.GetName(), err)
 		}
@@ -233,7 +232,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 		return nil, fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor started", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor started", req.GetAtespace(), req.GetActorId(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
 	return &ateompb.RunWorkloadResponse{}, nil
 }
@@ -242,7 +241,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointing", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor checkpointing", req.GetAtespace(), req.GetActorId(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
 	// Contract with atelet:
 	//
@@ -250,13 +249,12 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	//   * After we exit, atelet will tear down OCI bundles and reset the actor directory.
 
 	rcmd := &runsc{
-		path:                   req.GetRunscPath(),
-		actorTemplateNamespace: req.GetActorTemplateNamespace(),
-		actorTemplateName:      req.GetActorTemplateName(),
-		actorID:                req.GetActorId(),
+		path:     req.GetRunscPath(),
+		atespace: req.GetAtespace(),
+		actorID:  req.GetActorId(),
 	}
 
-	checkpointPath := ateompath.CheckpointStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	checkpointPath := ateompath.CheckpointStateDir(req.GetAtespace(), req.GetActorId())
 	if err := os.MkdirAll(checkpointPath, 0o700); err != nil {
 		return nil, fmt.Errorf("while creating checkpoint directory: %w", err)
 	}
@@ -291,8 +289,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	if err := rcmd.cleanupContainersAfterCheckpoint(ctx, req.GetSpec().GetContainers()); err != nil {
 		slog.WarnContext(ctx, "Failed to clean up runsc containers after checkpoint",
 			"actorID", req.GetActorId(),
-			"actorTemplateName", req.GetActorTemplateName(),
-			"actorTemplateNamespace", req.GetActorTemplateNamespace(),
+			"atespace", req.GetAtespace(),
 			"err", err)
 	}
 
@@ -305,7 +302,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		return nil, fmt.Errorf("while listing checkpoint files: %w", err)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointed", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor checkpointed", req.GetAtespace(), req.GetActorId(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
 	return &ateompb.CheckpointWorkloadResponse{SnapshotFiles: snapshotFiles}, nil
 }
@@ -357,7 +354,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.actorLogger.EmitLifecycleLog("Actor restoring", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor restoring", req.GetAtespace(), req.GetActorId(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
 	// Contract with atelet:
 	//
@@ -375,13 +372,12 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	}()
 
 	rcmd := &runsc{
-		path:                   req.GetRunscPath(),
-		actorTemplateNamespace: req.GetActorTemplateNamespace(),
-		actorTemplateName:      req.GetActorTemplateName(),
-		actorID:                req.GetActorId(),
+		path:     req.GetRunscPath(),
+		atespace: req.GetAtespace(),
+		actorID:  req.GetActorId(),
 	}
 
-	checkpointDir := ateompath.RestoreStateDir(req.GetActorTemplateNamespace(), req.GetActorTemplateName(), req.GetActorId())
+	checkpointDir := ateompath.RestoreStateDir(req.GetAtespace(), req.GetActorId())
 
 	switch req.GetScope() {
 	case ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA:
@@ -407,7 +403,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	// Create and restore each application container, each with its own log pipe so
 	// every line is tagged with the originating container (ate.dev/container_name).
 	for _, ac := range req.GetSpec().GetContainers() {
-		pw, err := s.actorLogger.StartJSONLogPipe(req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace(), ac.GetName())
+		pw, err := s.actorLogger.StartJSONLogPipe(req.GetAtespace(), req.GetActorId(), req.GetActorTemplateNamespace(), req.GetActorTemplateName(), ac.GetName())
 		if err != nil {
 			return nil, fmt.Errorf("while starting json log pipe for %q: %w", ac.GetName(), err)
 		}
@@ -437,7 +433,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		return nil, fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor restored", req.GetActorId(), req.GetActorTemplateName(), req.GetActorTemplateNamespace())
+	s.actorLogger.EmitLifecycleLog("Actor restored", req.GetAtespace(), req.GetActorId(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
 	return &ateompb.RestoreWorkloadResponse{}, nil
 }

--- a/cmd/ateom-gvisor/runsc.go
+++ b/cmd/ateom-gvisor/runsc.go
@@ -28,10 +28,9 @@ import (
 )
 
 type runsc struct {
-	path                   string
-	actorTemplateNamespace string
-	actorTemplateName      string
-	actorID                string
+	path     string
+	atespace string
+	actorID  string
 }
 
 func (r *runsc) cmdCreate(ctx context.Context, out io.Writer, containerName string, additionalArgs []string) error {
@@ -44,14 +43,14 @@ func (r *runsc) cmdCreate(ctx context.Context, out io.Writer, containerName stri
 		"-log-format", "json",
 		"--alsologtostderr",
 		// "-debug",
-		// "-debug-log", ateompath.RunscDebugLogDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName) + "/",
+		// "-debug-log", ateompath.RunscDebugLogDir(r.atespace, r.actorID, containerName) + "/",
 		// "-debug-to-user-log",
 		// "-log-packets",
 		// "-strace",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.atespace, r.actorID),
 		"create",
-		"-bundle", ateompath.OCIBundlePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
-		"-pid-file", ateompath.PIDFilePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
+		"-bundle", ateompath.OCIBundlePath(r.atespace, r.actorID, containerName),
+		"-pid-file", ateompath.PIDFilePath(r.atespace, r.actorID, containerName),
 	}
 
 	args = append(args, additionalArgs...)
@@ -84,12 +83,12 @@ func (r *runsc) cmdStart(ctx context.Context, out io.Writer, containerName strin
 		"-log-format", "json",
 		"--alsologtostderr",
 		// "-debug",
-		// "-debug-log", ateompath.RunscDebugLogDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName)+"/",
+		// "-debug-log", ateompath.RunscDebugLogDir(r.atespace, r.actorID, containerName)+"/",
 		// "-debug-to-user-log",
 		// "-log-packets",
 		// "-strace",
 		"-allow-connected-on-save",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.atespace, r.actorID),
 		"start",
 		containerName, // Name of the container
 	)
@@ -116,11 +115,11 @@ func (r *runsc) cmdCheckpoint(ctx context.Context, containerName, checkpointPath
 		"-log-format", "json",
 		"--alsologtostderr",
 		// "-debug",
-		// "-debug-log", ateompath.RunscDebugLogDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName)+"/",
+		// "-debug-log", ateompath.RunscDebugLogDir(r.atespace, r.actorID, containerName)+"/",
 		// "-debug-to-user-log",
 		// "-log-packets",
 		// "-strace",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.atespace, r.actorID),
 		"checkpoint",
 		"-image-path", checkpointPath,
 		containerName, // Name of the container
@@ -144,11 +143,11 @@ func (r *runsc) cmdFsCheckpoint(ctx context.Context, containerName, checkpointPa
 		"-log-format", "json",
 		"--alsologtostderr",
 		// "-debug",
-		// "-debug-log", ateompath.RunscDebugLogDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName)+"/",
+		// "-debug-log", ateompath.RunscDebugLogDir(r.atespace, r.actorID, containerName)+"/",
 		// "-debug-to-user-log",
 		// "-log-packets",
 		// "-strace",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.atespace, r.actorID),
 		"fscheckpoint",
 		"-image-path", checkpointPath,
 	}
@@ -187,15 +186,15 @@ func (r *runsc) cmdRestore(ctx context.Context, out io.Writer, containerName, ch
 		"-log-format", "json",
 		"--alsologtostderr",
 		// "-debug",
-		// "-debug-log", ateompath.RunscDebugLogDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName)+"/",
+		// "-debug-log", ateompath.RunscDebugLogDir(r.atespace, r.actorID, containerName)+"/",
 		// "-debug-to-user-log",
 		// "-log-packets",
 		// "-strace",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.atespace, r.actorID),
 		"restore",
-		"-bundle", ateompath.OCIBundlePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
+		"-bundle", ateompath.OCIBundlePath(r.atespace, r.actorID, containerName),
 		"-image-path", checkpointPath,
-		"-pid-file", ateompath.PIDFilePath(r.actorTemplateNamespace, r.actorTemplateName, r.actorID, containerName),
+		"-pid-file", ateompath.PIDFilePath(r.atespace, r.actorID, containerName),
 		"-background",
 		"-direct",
 		"-detach",
@@ -222,7 +221,7 @@ func (r *runsc) cmdDelete(ctx context.Context, containerName string) error {
 		"-log-format", "json",
 		"--alsologtostderr",
 		// "-debug",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.atespace, r.actorID),
 		"delete",
 		"-force",
 		containerName,
@@ -247,7 +246,7 @@ func (r *runsc) cmdState(ctx context.Context, containerName string) error {
 		r.path,
 		"-log-format", "json",
 		"--alsologtostderr",
-		"-root", ateompath.RunSCStateDir(r.actorTemplateNamespace, r.actorTemplateName, r.actorID),
+		"-root", ateompath.RunSCStateDir(r.atespace, r.actorID),
 		"state",
 		containerName,
 	)

--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -45,11 +45,12 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	ns := req.GetActorTemplateNamespace()
-	name := req.GetActorTemplateName()
+	atespace := req.GetAtespace()
 	id := req.GetActorId()
+	templateNS := req.GetActorTemplateNamespace()
+	templateName := req.GetActorTemplateName()
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointing", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor checkpointing", atespace, id, templateNS, templateName)
 
 	// The actor's CH was booted by RunWorkload or relaunched by RestoreWorkload;
 	// either way ateom owns it and tracks its api-socket.
@@ -69,7 +70,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	}
 	dPause := time.Since(tPause)
 
-	checkpointDir := ateompath.CheckpointStateDir(ns, name, id)
+	checkpointDir := ateompath.CheckpointStateDir(atespace, id)
 	// Start from a clean dir so CH's snapshot files are the only contents.
 	if err := os.RemoveAll(checkpointDir); err != nil {
 		return nil, fmt.Errorf("while clearing checkpoint dir %q: %w", checkpointDir, err)
@@ -144,7 +145,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		slog.WarnContext(ctx, "Failed to clean up actor network after checkpoint", slog.Any("err", err))
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointed", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor checkpointed", atespace, id, templateNS, templateName)
 	slog.InfoContext(ctx, "Actor checkpointed", slog.String("id", id), slog.Any("snapshot_files", snapshotFiles),
 		slog.Duration("pause", dPause),
 		slog.Duration("snapshot", dSnapshot), slog.Duration("teardown", dTeardown))

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -53,13 +53,14 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	ns := req.GetActorTemplateNamespace()
-	name := req.GetActorTemplateName()
+	atespace := req.GetAtespace()
 	id := req.GetActorId()
-	restoreDir := ateompath.RestoreStateDir(ns, name, id)
+	templateNS := req.GetActorTemplateNamespace()
+	templateName := req.GetActorTemplateName()
+	restoreDir := ateompath.RestoreStateDir(atespace, id)
 	tStart := time.Now()
 
-	s.actorLogger.EmitLifecycleLog("Actor restoring", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor restoring", atespace, id, templateNS, templateName)
 
 	rr := s.resolveRuntime(req.GetRuntimeAssetPaths())
 	kata.CleanupSandboxState(ctx, id)
@@ -94,7 +95,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	if len(containers) > maxActorContainers {
 		return nil, status.Errorf(codes.Unimplemented, "ateom-microvm supports at most %d containers, got %d", maxActorContainers, len(containers))
 	}
-	ctrs, err := s.buildActorContainers(ns, name, id, containers)
+	ctrs, err := s.buildActorContainers(atespace, id, containers)
 	if err != nil {
 		return nil, err
 	}
@@ -193,12 +194,12 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	} else {
 		ra.logAgent = logAC
 		for _, c := range containers {
-			s.startActorLogForwarding(logAC, id, overlayWorkloadID(c.GetName()), c.GetName(), name, ns)
+			s.startActorLogForwarding(logAC, atespace, id, templateNS, templateName, overlayWorkloadID(c.GetName()), c.GetName())
 		}
 	}
 
 	s.running[id] = ra
-	s.actorLogger.EmitLifecycleLog("Actor restored", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor restored", atespace, id, templateNS, templateName)
 	slog.InfoContext(ctx, "Actor restored (overlay rootfs)",
 		slog.String("id", id), slog.Duration("total", time.Since(tStart)))
 	return &ateompb.RestoreWorkloadResponse{}, nil

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -188,11 +188,12 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	ns := req.GetActorTemplateNamespace()
-	name := req.GetActorTemplateName()
+	atespace := req.GetAtespace()
 	id := req.GetActorId()
+	templateNS := req.GetActorTemplateNamespace()
+	templateName := req.GetActorTemplateName()
 
-	s.actorLogger.EmitLifecycleLog("Actor starting", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor starting", atespace, id, templateNS, templateName)
 
 	// All of the actor's containers share the one micro-VM (which is the pod
 	// sandbox): each gets its own overlay rootfs and its own kata-agent
@@ -230,7 +231,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 
 	// Prepare each container's OCI spec + record its bundle rootfs (the overlay RO
 	// lower). No host disk — the rootfs is overlay(virtio-fs lower + guest-tmpfs upper).
-	ctrs, err := s.buildActorContainers(ns, name, id, containers)
+	ctrs, err := s.buildActorContainers(atespace, id, containers)
 	if err != nil {
 		return nil, err
 	}
@@ -357,10 +358,10 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	// that and tag with the display container name. The goroutines read over ac for the
 	// actor's lifetime and exit (io.EOF) when teardownActor closes ac.
 	for _, c := range ctrs {
-		s.startActorLogForwarding(ac, id, overlayWorkloadID(c.name), c.name, name, ns)
+		s.startActorLogForwarding(ac, atespace, id, templateNS, templateName, overlayWorkloadID(c.name), c.name)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor started", id, name, ns)
+	s.actorLogger.EmitLifecycleLog("Actor started", atespace, id, templateNS, templateName)
 	slog.InfoContext(ctx, "Actor started (overlay rootfs)", slog.String("id", id))
 	return &ateompb.RunWorkloadResponse{}, nil
 }
@@ -371,12 +372,12 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 // built — the rootfs is overlay(virtio-fs RO lower + guest-tmpfs upper); the lowers
 // are bound into virtiofsd's shared dir in stageOverlayLowers after the sandbox state
 // is clean. Both RunWorkload and RestoreWorkload go through here.
-func (s *AteomService) buildActorContainers(ns, name, id string, containers []*ateompb.Container) ([]actorContainer, error) {
+func (s *AteomService) buildActorContainers(atespace, id string, containers []*ateompb.Container) ([]actorContainer, error) {
 	netnsPath := ateompath.AteomNetNSPath(s.podUID)
 	ctrs := make([]actorContainer, len(containers))
 	for i, c := range containers {
 		cn := c.GetName()
-		bundle := ateompath.OCIBundlePath(ns, name, id, cn)
+		bundle := ateompath.OCIBundlePath(atespace, id, cn)
 		spec, err := ensureKataCompatibleSpec(bundle, id, netnsPath)
 		if err != nil {
 			return nil, fmt.Errorf("while preparing kata OCI spec for %q: %w", cn, err)
@@ -549,9 +550,9 @@ func startOverlayContainer(ctx context.Context, ac *kata.AgentClient, vsockPath 
 // ending WrapContainerLogs. This keeps the agent connection (which ttrpc allows
 // concurrent Calls on) alive for forwarding while guaranteeing no goroutine outlives
 // the connection.
-func (s *AteomService) startActorLogForwarding(ac *kata.AgentClient, actorID, streamID, containerName, name, ns string) {
-	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, false), actorID, name, ns, containerName)
-	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, true), actorID, name, ns, containerName)
+func (s *AteomService) startActorLogForwarding(ac *kata.AgentClient, atespace, actorID, actorTemplateNamespace, actorTemplateName, streamID, containerName string) {
+	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, false), atespace, actorID, actorTemplateNamespace, actorTemplateName, containerName)
+	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, true), atespace, actorID, actorTemplateNamespace, actorTemplateName, containerName)
 }
 
 // dialAgentRetry polls DialAgent until the kata-agent answers the hybrid-vsock

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -8,6 +8,7 @@ This guide explains how Agent Substrate achieves observability across these susp
 
 To make underlying infrastructure transitions transparent, Agent Substrate establishes a standardized metadata model to identify actors across worker pods:
 * `ate.dev/actor_id`: The unique identifier of the actor (e.g., `my-counter-1` or `test`).
+* `ate.dev/actor_atespace`: The atespace the actor lives in (e.g., `ate-demo-counter`).
 * `ate.dev/actor_template_name`: The name of the actor's ActorTemplate (e.g., `counter`).
 * `ate.dev/actor_template_namespace`: The Kubernetes namespace of the actor's ActorTemplate (e.g., `ate-demo-counter`).
 * `ate.dev/container_name`: The name of the container within the actor that produced the log line (e.g., `counter`), so a multi-container actor's logs can be demultiplexed by container.
@@ -75,14 +76,21 @@ To track the unified, continuous lifecycle of a single actor regardless of how m
 labels.actor_id="test"
 ```
 
-#### 2. Template-Centric View
-To monitor or debug all actor instances created from a specific template (e.g., analyzing the collective behavior or error rates of all counter actors):
+#### 2. Atespace-Centric View
+To monitor or debug all actor instances in a specific atespace (e.g., analyzing the collective behavior or error rates of all actors belonging to one tenant):
 
 ```text
-labels.actor_template="counter"
+labels.actor_atespace="ate-demo-counter"
 ```
 
-#### 3. Pod-Centric View
+#### 3. Template-Centric View
+To monitor or debug all actor instances created from a specific ActorTemplate (e.g., analyzing the collective behavior or error rates of all counter actors). One atespace can run actors from many templates, so this is a distinct dimension from the atespace view above:
+
+```text
+labels.actor_template_name="counter"
+```
+
+#### 4. Pod-Centric View
 To inspect the physical worker pod's aggregate stream and see all co-located actors multiplexed together (useful for investigating pod-level resource exhaustion or noisy neighbor issues):
 
 ```text
@@ -99,7 +107,7 @@ Agent Substrate emits foundational OpenTelemetry system and server metrics to mo
 |--------|------------|------|----------|
 | `rpc.server.call.duration` | ateapi & atelet (gRPC servers, via `otelgrpc`) | histogram | per-method gRPC latency, request rate, and errors (labels `rpc.method`, `rpc.response.status_code`) |
 | `atenet.router.route.duration` | atenet-router | histogram | Substrate E2E — Envoy receiving a request to Envoy forwarding it to the resolved worker, excluding actor compute and the response |
-| `atelet.snapshot.size` | atelet | histogram | uncompressed size in bytes of each gVisor snapshot image written during checkpoint (labels `kind`, `actor_template_name`) |
+| `atelet.snapshot.size` | atelet | histogram | uncompressed size in bytes of each gVisor snapshot image written during checkpoint (labels `kind`, `actor_template_namespace`, `actor_template_name`) |
 
 The table lists the OpenTelemetry instrument names. How a name appears in a query depends on the backend (Cloud Monitoring (GMP) / Kind collector).
 

--- a/internal/actorlog/logger.go
+++ b/internal/actorlog/logger.go
@@ -66,14 +66,15 @@ func NewActorLogger(w io.Writer, isOnGCE bool) *ActorLogger {
 }
 
 // EmitLifecycleLog logs a synthetic actor lifecycle event.
-func (al *ActorLogger) EmitLifecycleLog(msg, actorID, actorTemplateName, actorTemplateNamespace string) {
+func (al *ActorLogger) EmitLifecycleLog(msg, atespace, actorID, actorTemplateNamespace, actorTemplateName string) {
 	envelope := map[string]any{
 		"time":    time.Now().Format(time.RFC3339Nano),
 		"message": msg,
 		al.labelsKey: map[string]string{
+			"ate.dev/actor_atespace":           atespace,
 			"ate.dev/actor_id":                 actorID,
-			"ate.dev/actor_template_name":      actorTemplateName,
 			"ate.dev/actor_template_namespace": actorTemplateNamespace,
+			"ate.dev/actor_template_name":      actorTemplateName,
 		},
 	}
 	if envBytes, err := json.Marshal(envelope); err == nil {
@@ -86,13 +87,13 @@ func (al *ActorLogger) EmitLifecycleLog(msg, actorID, actorTemplateName, actorTe
 // through the logger. containerName tags every line with the originating container;
 // callers that multiplex multiple containers should give each its own pipe so the
 // tag is meaningful.
-func (al *ActorLogger) StartJSONLogPipe(actorID, actorTemplateName, actorTemplateNamespace, containerName string) (io.WriteCloser, error) {
+func (al *ActorLogger) StartJSONLogPipe(atespace, actorID, actorTemplateNamespace, actorTemplateName, containerName string) (io.WriteCloser, error) {
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
 	go func() {
-		al.WrapContainerLogs(pr, actorID, actorTemplateName, actorTemplateNamespace, containerName)
+		al.WrapContainerLogs(pr, atespace, actorID, actorTemplateNamespace, actorTemplateName, containerName)
 		pr.Close()
 	}()
 	return pw, nil
@@ -101,7 +102,7 @@ func (al *ActorLogger) StartJSONLogPipe(actorID, actorTemplateName, actorTemplat
 // WrapContainerLogs reads log lines from r, parses them, and logs them in a unified
 // structured format. containerName is added as the ate.dev/container_name label so
 // multi-container actors can be demultiplexed.
-func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplateName, actorTemplateNamespace, containerName string) {
+func (al *ActorLogger) WrapContainerLogs(r io.Reader, atespace, actorID, actorTemplateNamespace, actorTemplateName, containerName string) {
 	rdr := bufio.NewReader(r)
 	for {
 		lineBytes, err := rdr.ReadBytes('\n')
@@ -128,9 +129,10 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplateName
 
 			if unmarshalErr != nil {
 				labels := map[string]string{
+					"ate.dev/actor_atespace":           atespace,
 					"ate.dev/actor_id":                 actorID,
-					"ate.dev/actor_template_name":      actorTemplateName,
 					"ate.dev/actor_template_namespace": actorTemplateNamespace,
+					"ate.dev/actor_template_name":      actorTemplateName,
 					"ate.dev/container_name":           containerName,
 				}
 				envelope = map[string]any{
@@ -147,9 +149,10 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorID, actorTemplateName
 					labels = make(map[string]any)
 					m[al.labelsKey] = labels
 				}
+				labels["ate.dev/actor_atespace"] = atespace
 				labels["ate.dev/actor_id"] = actorID
-				labels["ate.dev/actor_template_name"] = actorTemplateName
 				labels["ate.dev/actor_template_namespace"] = actorTemplateNamespace
+				labels["ate.dev/actor_template_name"] = actorTemplateName
 				labels["ate.dev/container_name"] = containerName
 				envelope = m
 			}

--- a/internal/actorlog/logger_test.go
+++ b/internal/actorlog/logger_test.go
@@ -28,7 +28,7 @@ func TestWrapContainerLogs(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "default", "act-1", "tmpl-ns", "tmpl-1", "ctr-1")
 
 	var m map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
@@ -57,11 +57,14 @@ func TestWrapContainerLogs(t *testing.T) {
 	if labels["ate.dev/actor_id"] != "act-1" {
 		t.Errorf("got actor_id = %v, want 'act-1'", labels["ate.dev/actor_id"])
 	}
+	if labels["ate.dev/actor_atespace"] != "default" {
+		t.Errorf("got actor_atespace = %v, want 'default'", labels["ate.dev/actor_atespace"])
+	}
+	if labels["ate.dev/actor_template_namespace"] != "tmpl-ns" {
+		t.Errorf("got actor_template_namespace = %v, want 'tmpl-ns'", labels["ate.dev/actor_template_namespace"])
+	}
 	if labels["ate.dev/actor_template_name"] != "tmpl-1" {
 		t.Errorf("got actor_template_name = %v, want 'tmpl-1'", labels["ate.dev/actor_template_name"])
-	}
-	if labels["ate.dev/actor_template_namespace"] != "default" {
-		t.Errorf("got actor_template_namespace = %v, want 'default'", labels["ate.dev/actor_template_namespace"])
 	}
 	if labels["ate.dev/container_name"] != "ctr-1" {
 		t.Errorf("got container_name = %v, want 'ctr-1'", labels["ate.dev/container_name"])
@@ -75,7 +78,7 @@ func TestWrapContainerLogs_JSONInput(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "default", "act-1", "tmpl-ns", "tmpl-1", "ctr-1")
 
 	dec := json.NewDecoder(&buf)
 	dec.UseNumber()
@@ -114,6 +117,12 @@ func TestWrapContainerLogs_JSONInput(t *testing.T) {
 
 	if labels["ate.dev/actor_id"] != "act-1" {
 		t.Errorf("got actor_id = %v, want 'act-1'", labels["ate.dev/actor_id"])
+	}
+	if labels["ate.dev/actor_template_namespace"] != "tmpl-ns" {
+		t.Errorf("got actor_template_namespace = %v, want 'tmpl-ns'", labels["ate.dev/actor_template_namespace"])
+	}
+	if labels["ate.dev/actor_template_name"] != "tmpl-1" {
+		t.Errorf("got actor_template_name = %v, want 'tmpl-1'", labels["ate.dev/actor_template_name"])
 	}
 }
 
@@ -164,7 +173,7 @@ func TestWrapContainerLogs_MergeLabels(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false) // labelsKey will be "labels"
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "default", "act-1", "tmpl-ns", "tmpl-1", "ctr-1")
 
 	var m map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
@@ -200,7 +209,7 @@ func TestWrapContainerLogs_LabelCollision(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "default", "act-1", "tmpl-ns", "tmpl-1", "ctr-1")
 
 	var m map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
@@ -230,7 +239,7 @@ func TestWrapContainerLogs_TrailingGarbage(t *testing.T) {
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, "act-1", "tmpl-1", "default", "ctr-1")
+	al.WrapContainerLogs(rdr, "default", "act-1", "tmpl-ns", "tmpl-1", "ctr-1")
 
 	var m map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {

--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -60,11 +60,11 @@ func AteomNetNSPath(podUID string) string {
 	)
 }
 
-func ActorPath(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func ActorPath(atespace, actorID string) string {
 	return filepath.Join(
 		BasePath,
 		"actors",
-		actorTemplateNamespace+":"+actorTemplateName+":"+actorID,
+		atespace+":"+actorID,
 	)
 }
 
@@ -73,9 +73,9 @@ func ActorPath(actorTemplateNamespace, actorTemplateName, actorID string) string
 // bind-mounts read-only into the actor. It is per-actor and regenerated on
 // every resume, so (unlike the checkpointed process environment) it reflects
 // the correct ID after a restore from the golden snapshot.
-func ActorIdentityDirPath(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func ActorIdentityDirPath(atespace, actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"identity",
 	)
 }
@@ -86,69 +86,69 @@ func ActorIdentityDirPath(actorTemplateNamespace, actorTemplateName, actorID str
 // Checkpoint (when the request no longer carries the sandbox config). It lives
 // directly under ActorPath — NOT under a subdir wiped by atelet's
 // resetActorDirs — so it survives between Run and a later Checkpoint.
-func ActorSandboxAssetsFile(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func ActorSandboxAssetsFile(atespace, actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"sandbox-assets.json",
 	)
 }
 
-func RunSCStateDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func RunSCStateDir(atespace, actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"runsc-state",
 	)
 }
 
-func OCIBundleDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func OCIBundleDir(atespace, actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"bundles",
 	)
 }
 
-func OCIBundlePath(actorTemplateNamespace, actorTemplateName, actorID, containerName string) string {
+func OCIBundlePath(atespace, actorID, containerName string) string {
 	return filepath.Join(
-		OCIBundleDir(actorTemplateNamespace, actorTemplateName, actorID),
+		OCIBundleDir(atespace, actorID),
 		containerName,
 	)
 }
 
-func RunscDebugLogDir(actorTemplateNamespace, actorTemplateName, actorID, containerName string) string {
+func RunscDebugLogDir(atespace, actorID, containerName string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"runsc-debug-logs",
 		containerName,
 	)
 }
 
-func CheckpointStateDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func CheckpointStateDir(atespace, actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"checkpoint-state",
 	)
 }
 
-func LocalCheckpointsDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func LocalCheckpointsDir(atespace, actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"local-checkpoint",
 	)
 }
 
 // DurableDirVolumeMountsDir is the directory where individual durable-dir
 // volumes are mounted.
-func DurableDirVolumeMountsDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func DurableDirVolumeMountsDir(atespace, actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"durable-dir",
 	)
 }
 
 // DurableDirVolumeMountPoint returns the path where a specific durable-dir volume is mounted on the nodeVM.
-func DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actorID, volumeName string) string {
+func DurableDirVolumeMountPoint(atespace, actorID, volumeName string) string {
 	return filepath.Join(
-		DurableDirVolumeMountsDir(actorTemplateNamespace, actorTemplateName, actorID),
+		DurableDirVolumeMountsDir(atespace, actorID),
 		volumeName,
 	)
 }
@@ -164,23 +164,23 @@ func DurableDirVolumeMountPoint(actorTemplateNamespace, actorTemplateName, actor
 // make sure we write the suspension checkpoint to a different location.  This
 // will work properly, with `runsc checkpoint` paging in any data that hasn't
 // yet been loaded.
-func RestoreStateDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func RestoreStateDir(atespace, actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"restore-state",
 	)
 }
 
-func PIDFileDir(actorTemplateNamespace, actorTemplateName, actorID string) string {
+func PIDFileDir(atespace, actorID string) string {
 	return filepath.Join(
-		ActorPath(actorTemplateNamespace, actorTemplateName, actorID),
+		ActorPath(atespace, actorID),
 		"pidfiles",
 	)
 }
 
-func PIDFilePath(actorTemplateNamespace, actorTemplateName, actorID, containerName string) string {
+func PIDFilePath(atespace, actorID, containerName string) string {
 	return filepath.Join(
-		PIDFileDir(actorTemplateNamespace, actorTemplateName, actorID),
+		PIDFileDir(atespace, actorID),
 		containerName+".pid",
 	)
 }

--- a/internal/proto/ateletpb/atelet.pb.go
+++ b/internal/proto/ateletpb/atelet.pb.go
@@ -191,14 +191,15 @@ func (SnapshotScope) EnumDescriptor() ([]byte, []int) {
 type RunRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,3,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,4,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	ActorId                string                 `protobuf:"bytes,5,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	Atespace               string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorId                string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	ActorTemplateNamespace string                 `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	Spec                   *WorkloadSpec          `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
 	// The sandbox binaries to use for booting this actor from scratch. atelet
 	// fetches the relevant assets and records them with the actor's on-node state
 	// so a later Checkpoint can pin the same version into the snapshot manifest.
-	SandboxAssets *SandboxAssets `protobuf:"bytes,9,opt,name=sandbox_assets,json=sandboxAssets,proto3" json:"sandbox_assets,omitempty"`
+	SandboxAssets *SandboxAssets `protobuf:"bytes,7,opt,name=sandbox_assets,json=sandboxAssets,proto3" json:"sandbox_assets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -240,6 +241,20 @@ func (x *RunRequest) GetTargetAteomUid() string {
 	return ""
 }
 
+func (x *RunRequest) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *RunRequest) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
 func (x *RunRequest) GetActorTemplateNamespace() string {
 	if x != nil {
 		return x.ActorTemplateNamespace
@@ -250,13 +265,6 @@ func (x *RunRequest) GetActorTemplateNamespace() string {
 func (x *RunRequest) GetActorTemplateName() string {
 	if x != nil {
 		return x.ActorTemplateName
-	}
-	return ""
-}
-
-func (x *RunRequest) GetActorId() string {
-	if x != nil {
-		return x.ActorId
 	}
 	return ""
 }
@@ -1040,11 +1048,15 @@ func (x *ExternalCheckpointConfiguration) GetSnapshotUriPrefix() string {
 type CheckpointRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,3,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,4,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	ActorId                string                 `protobuf:"bytes,5,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
-	Type                   CheckpointType         `protobuf:"varint,9,opt,name=type,proto3,enum=atelet.CheckpointType" json:"type,omitempty"`
+	Atespace               string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorId                string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	ActorTemplateNamespace string                 `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	// Sandbox binary config is not sent on checkpoint: atelet uses the version the
+	// actor is currently running (recorded with the actor's on-node state at
+	// Run/Restore) and records it into the snapshot manifest.
+	Spec *WorkloadSpec  `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	Type CheckpointType `protobuf:"varint,7,opt,name=type,proto3,enum=atelet.CheckpointType" json:"type,omitempty"`
 	// The checkpoint configuration, depending on the type.
 	//
 	// Types that are valid to be assigned to Config:
@@ -1053,7 +1065,7 @@ type CheckpointRequest struct {
 	//	*CheckpointRequest_ExternalConfig
 	Config isCheckpointRequest_Config `protobuf_oneof:"config"`
 	// What should be included in the checkpoint.
-	Scope         SnapshotScope `protobuf:"varint,12,opt,name=scope,proto3,enum=atelet.SnapshotScope" json:"scope,omitempty"`
+	Scope         SnapshotScope `protobuf:"varint,10,opt,name=scope,proto3,enum=atelet.SnapshotScope" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1095,6 +1107,20 @@ func (x *CheckpointRequest) GetTargetAteomUid() string {
 	return ""
 }
 
+func (x *CheckpointRequest) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *CheckpointRequest) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
 func (x *CheckpointRequest) GetActorTemplateNamespace() string {
 	if x != nil {
 		return x.ActorTemplateNamespace
@@ -1105,13 +1131,6 @@ func (x *CheckpointRequest) GetActorTemplateNamespace() string {
 func (x *CheckpointRequest) GetActorTemplateName() string {
 	if x != nil {
 		return x.ActorTemplateName
-	}
-	return ""
-}
-
-func (x *CheckpointRequest) GetActorId() string {
-	if x != nil {
-		return x.ActorId
 	}
 	return ""
 }
@@ -1167,11 +1186,11 @@ type isCheckpointRequest_Config interface {
 }
 
 type CheckpointRequest_LocalConfig struct {
-	LocalConfig *LocalCheckpointConfiguration `protobuf:"bytes,10,opt,name=local_config,json=localConfig,proto3,oneof"`
+	LocalConfig *LocalCheckpointConfiguration `protobuf:"bytes,8,opt,name=local_config,json=localConfig,proto3,oneof"`
 }
 
 type CheckpointRequest_ExternalConfig struct {
-	ExternalConfig *ExternalCheckpointConfiguration `protobuf:"bytes,11,opt,name=external_config,json=externalConfig,proto3,oneof"`
+	ExternalConfig *ExternalCheckpointConfiguration `protobuf:"bytes,9,opt,name=external_config,json=externalConfig,proto3,oneof"`
 }
 
 func (*CheckpointRequest_LocalConfig) isCheckpointRequest_Config() {}
@@ -1217,11 +1236,15 @@ func (*CheckpointResponse) Descriptor() ([]byte, []int) {
 type RestoreRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,3,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,4,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	ActorId                string                 `protobuf:"bytes,5,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
-	Type                   CheckpointType         `protobuf:"varint,9,opt,name=type,proto3,enum=atelet.CheckpointType" json:"type,omitempty"`
+	Atespace               string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorId                string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	ActorTemplateNamespace string                 `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	// Sandbox binary config is not sent on restore: the snapshot is
+	// self-describing. atelet reads the snapshot manifest to recover the pinned
+	// sandbox version that created it.
+	Spec *WorkloadSpec  `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	Type CheckpointType `protobuf:"varint,7,opt,name=type,proto3,enum=atelet.CheckpointType" json:"type,omitempty"`
 	// The checkpoint configuration, depending on the type.
 	//
 	// Types that are valid to be assigned to Config:
@@ -1230,7 +1253,7 @@ type RestoreRequest struct {
 	//	*RestoreRequest_ExternalConfig
 	Config isRestoreRequest_Config `protobuf_oneof:"config"`
 	// What content to restore from the checkpoint.
-	Scope         SnapshotScope `protobuf:"varint,12,opt,name=scope,proto3,enum=atelet.SnapshotScope" json:"scope,omitempty"`
+	Scope         SnapshotScope `protobuf:"varint,10,opt,name=scope,proto3,enum=atelet.SnapshotScope" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1272,6 +1295,20 @@ func (x *RestoreRequest) GetTargetAteomUid() string {
 	return ""
 }
 
+func (x *RestoreRequest) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *RestoreRequest) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
 func (x *RestoreRequest) GetActorTemplateNamespace() string {
 	if x != nil {
 		return x.ActorTemplateNamespace
@@ -1282,13 +1319,6 @@ func (x *RestoreRequest) GetActorTemplateNamespace() string {
 func (x *RestoreRequest) GetActorTemplateName() string {
 	if x != nil {
 		return x.ActorTemplateName
-	}
-	return ""
-}
-
-func (x *RestoreRequest) GetActorId() string {
-	if x != nil {
-		return x.ActorId
 	}
 	return ""
 }
@@ -1344,11 +1374,11 @@ type isRestoreRequest_Config interface {
 }
 
 type RestoreRequest_LocalConfig struct {
-	LocalConfig *LocalCheckpointConfiguration `protobuf:"bytes,10,opt,name=local_config,json=localConfig,proto3,oneof"`
+	LocalConfig *LocalCheckpointConfiguration `protobuf:"bytes,8,opt,name=local_config,json=localConfig,proto3,oneof"`
 }
 
 type RestoreRequest_ExternalConfig struct {
-	ExternalConfig *ExternalCheckpointConfiguration `protobuf:"bytes,11,opt,name=external_config,json=externalConfig,proto3,oneof"`
+	ExternalConfig *ExternalCheckpointConfiguration `protobuf:"bytes,9,opt,name=external_config,json=externalConfig,proto3,oneof"`
 }
 
 func (*RestoreRequest_LocalConfig) isRestoreRequest_Config() {}
@@ -1395,15 +1425,16 @@ var File_atelet_proto protoreflect.FileDescriptor
 
 const file_atelet_proto_rawDesc = "" +
 	"\n" +
-	"\fatelet.proto\x12\x06atelet\"\xa9\x02\n" +
+	"\fatelet.proto\x12\x06atelet\"\xbf\x02\n" +
 	"\n" +
 	"RunRequest\x12(\n" +
-	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x128\n" +
-	"\x18actor_template_namespace\x18\x03 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x04 \x01(\tR\x11actorTemplateName\x12\x19\n" +
-	"\bactor_id\x18\x05 \x01(\tR\aactorId\x12(\n" +
-	"\x04spec\x18\a \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12<\n" +
-	"\x0esandbox_assets\x18\t \x01(\v2\x15.atelet.SandboxAssetsR\rsandboxAssetsJ\x04\b\b\x10\t\"5\n" +
+	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
+	"\batespace\x18\x02 \x01(\tR\batespace\x12\x19\n" +
+	"\bactor_id\x18\x03 \x01(\tR\aactorId\x128\n" +
+	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12(\n" +
+	"\x04spec\x18\x06 \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12<\n" +
+	"\x0esandbox_assets\x18\a \x01(\v2\x15.atelet.SandboxAssetsR\rsandboxAssets\"5\n" +
 	"\tAssetFile\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12\x16\n" +
 	"\x06sha256\x18\x02 \x01(\tR\x06sha256\"\x8e\x01\n" +
@@ -1457,32 +1488,34 @@ const file_atelet_proto_rawDesc = "" +
 	"\x1cLocalCheckpointConfiguration\x12'\n" +
 	"\x0fsnapshot_prefix\x18\x01 \x01(\tR\x0esnapshotPrefix\"Q\n" +
 	"\x1fExternalCheckpointConfiguration\x12.\n" +
-	"\x13snapshot_uri_prefix\x18\x01 \x01(\tR\x11snapshotUriPrefix\"\xfa\x03\n" +
+	"\x13snapshot_uri_prefix\x18\x01 \x01(\tR\x11snapshotUriPrefix\"\x8a\x04\n" +
 	"\x11CheckpointRequest\x12(\n" +
-	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x128\n" +
-	"\x18actor_template_namespace\x18\x03 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x04 \x01(\tR\x11actorTemplateName\x12\x19\n" +
-	"\bactor_id\x18\x05 \x01(\tR\aactorId\x12(\n" +
-	"\x04spec\x18\a \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12*\n" +
-	"\x04type\x18\t \x01(\x0e2\x16.atelet.CheckpointTypeR\x04type\x12I\n" +
-	"\flocal_config\x18\n" +
-	" \x01(\v2$.atelet.LocalCheckpointConfigurationH\x00R\vlocalConfig\x12R\n" +
-	"\x0fexternal_config\x18\v \x01(\v2'.atelet.ExternalCheckpointConfigurationH\x00R\x0eexternalConfig\x12+\n" +
-	"\x05scope\x18\f \x01(\x0e2\x15.atelet.SnapshotScopeR\x05scopeB\b\n" +
-	"\x06configJ\x04\b\x06\x10\aJ\x04\b\b\x10\t\"\x14\n" +
-	"\x12CheckpointResponse\"\xf7\x03\n" +
+	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
+	"\batespace\x18\x02 \x01(\tR\batespace\x12\x19\n" +
+	"\bactor_id\x18\x03 \x01(\tR\aactorId\x128\n" +
+	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12(\n" +
+	"\x04spec\x18\x06 \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12*\n" +
+	"\x04type\x18\a \x01(\x0e2\x16.atelet.CheckpointTypeR\x04type\x12I\n" +
+	"\flocal_config\x18\b \x01(\v2$.atelet.LocalCheckpointConfigurationH\x00R\vlocalConfig\x12R\n" +
+	"\x0fexternal_config\x18\t \x01(\v2'.atelet.ExternalCheckpointConfigurationH\x00R\x0eexternalConfig\x12+\n" +
+	"\x05scope\x18\n" +
+	" \x01(\x0e2\x15.atelet.SnapshotScopeR\x05scopeB\b\n" +
+	"\x06config\"\x14\n" +
+	"\x12CheckpointResponse\"\x87\x04\n" +
 	"\x0eRestoreRequest\x12(\n" +
-	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x128\n" +
-	"\x18actor_template_namespace\x18\x03 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x04 \x01(\tR\x11actorTemplateName\x12\x19\n" +
-	"\bactor_id\x18\x05 \x01(\tR\aactorId\x12(\n" +
-	"\x04spec\x18\a \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12*\n" +
-	"\x04type\x18\t \x01(\x0e2\x16.atelet.CheckpointTypeR\x04type\x12I\n" +
-	"\flocal_config\x18\n" +
-	" \x01(\v2$.atelet.LocalCheckpointConfigurationH\x00R\vlocalConfig\x12R\n" +
-	"\x0fexternal_config\x18\v \x01(\v2'.atelet.ExternalCheckpointConfigurationH\x00R\x0eexternalConfig\x12+\n" +
-	"\x05scope\x18\f \x01(\x0e2\x15.atelet.SnapshotScopeR\x05scopeB\b\n" +
-	"\x06configJ\x04\b\x06\x10\aJ\x04\b\b\x10\t\"\x11\n" +
+	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
+	"\batespace\x18\x02 \x01(\tR\batespace\x12\x19\n" +
+	"\bactor_id\x18\x03 \x01(\tR\aactorId\x128\n" +
+	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12(\n" +
+	"\x04spec\x18\x06 \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12*\n" +
+	"\x04type\x18\a \x01(\x0e2\x16.atelet.CheckpointTypeR\x04type\x12I\n" +
+	"\flocal_config\x18\b \x01(\v2$.atelet.LocalCheckpointConfigurationH\x00R\vlocalConfig\x12R\n" +
+	"\x0fexternal_config\x18\t \x01(\v2'.atelet.ExternalCheckpointConfigurationH\x00R\x0eexternalConfig\x12+\n" +
+	"\x05scope\x18\n" +
+	" \x01(\x0e2\x15.atelet.SnapshotScopeR\x05scopeB\b\n" +
+	"\x06config\"\x11\n" +
 	"\x0fRestoreResponse*F\n" +
 	"\n" +
 	"VolumeType\x12\x1b\n" +

--- a/internal/proto/ateletpb/atelet.proto
+++ b/internal/proto/ateletpb/atelet.proto
@@ -35,18 +35,18 @@ service AteomHerder {
 message RunRequest {
   string target_ateom_uid = 1;
 
-  string actor_template_namespace = 3;
-  string actor_template_name      = 4;
-  string actor_id                 = 5;
+  string atespace = 2;
+  string actor_id = 3;
 
-  reserved 8; // was RunscConfig runsc
+  string actor_template_namespace = 4;
+  string actor_template_name      = 5;
 
-  WorkloadSpec spec = 7;
+  WorkloadSpec spec = 6;
 
   // The sandbox binaries to use for booting this actor from scratch. atelet
   // fetches the relevant assets and records them with the actor's on-node state
   // so a later Checkpoint can pin the same version into the snapshot manifest.
-  SandboxAssets sandbox_assets = 9;
+  SandboxAssets sandbox_assets = 7;
 }
 
 // AssetFile is one content-addressed file atelet fetches for a sandbox runtime
@@ -178,30 +178,27 @@ enum SnapshotScope {
 message CheckpointRequest {
   string target_ateom_uid = 1;
 
-  string actor_template_namespace = 3;
-  string actor_template_name      = 4;
-  string actor_id                 = 5;
+  string atespace = 2;
+  string actor_id = 3;
+
+  string actor_template_namespace = 4;
+  string actor_template_name      = 5;
 
   // Sandbox binary config is not sent on checkpoint: atelet uses the version the
   // actor is currently running (recorded with the actor's on-node state at
   // Run/Restore) and records it into the snapshot manifest.
-  reserved 6; // was RunscConfig runsc
+  WorkloadSpec spec = 6;
 
-  WorkloadSpec spec = 7;
-
-  // deprecated snapshot_uri_prefix
-  reserved 8;
-
-  CheckpointType type = 9;
+  CheckpointType type = 7;
 
   // The checkpoint configuration, depending on the type.
   oneof config {
-    LocalCheckpointConfiguration local_config    = 10;
-    ExternalCheckpointConfiguration external_config = 11;
+    LocalCheckpointConfiguration local_config    = 8;
+    ExternalCheckpointConfiguration external_config = 9;
   }
 
   // What should be included in the checkpoint.
-  SnapshotScope scope = 12;
+  SnapshotScope scope = 10;
 }
 
 message CheckpointResponse {
@@ -211,30 +208,27 @@ message CheckpointResponse {
 message RestoreRequest {
   string target_ateom_uid = 1;
 
-  string actor_template_namespace = 3;
-  string actor_template_name      = 4;
-  string actor_id                 = 5;
+  string atespace = 2;
+  string actor_id = 3;
+
+  string actor_template_namespace = 4;
+  string actor_template_name      = 5;
 
   // Sandbox binary config is not sent on restore: the snapshot is
   // self-describing. atelet reads the snapshot manifest to recover the pinned
   // sandbox version that created it.
-  reserved 6; // was RunscConfig runsc
+  WorkloadSpec spec = 6;
 
-  WorkloadSpec spec = 7;
-
-  // deprecated snapshot_uri_prefix
-  reserved 8;
-
-  CheckpointType type = 9;
+  CheckpointType type = 7;
 
   // The checkpoint configuration, depending on the type.
   oneof config {
-    LocalCheckpointConfiguration local_config    = 10;
-    ExternalCheckpointConfiguration external_config = 11;
+    LocalCheckpointConfiguration local_config    = 8;
+    ExternalCheckpointConfiguration external_config = 9;
   }
 
   // What content to restore from the checkpoint.
-  SnapshotScope scope = 12;
+  SnapshotScope scope = 10;
 }
 
 message RestoreResponse {

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -92,11 +92,12 @@ func (SnapshotScope) EnumDescriptor() ([]byte, []int) {
 
 type RunWorkloadRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,1,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,2,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	ActorId                string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,4,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorId                string                 `protobuf:"bytes,2,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	ActorTemplateNamespace string                 `protobuf:"bytes,3,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string                 `protobuf:"bytes,4,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	RunscPath              string                 `protobuf:"bytes,5,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec                   *WorkloadSpec          `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
 	// runtime_asset_paths maps a runtime asset name (e.g. "cloud-hypervisor",
 	// "virtiofsd", "kata-kernel", "kata-image", "kata-config")
 	// to the local on-disk path atelet fetched it to (content-addressed, like
@@ -136,6 +137,20 @@ func (*RunWorkloadRequest) Descriptor() ([]byte, []int) {
 	return file_ateom_proto_rawDescGZIP(), []int{0}
 }
 
+func (x *RunWorkloadRequest) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *RunWorkloadRequest) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
 func (x *RunWorkloadRequest) GetActorTemplateNamespace() string {
 	if x != nil {
 		return x.ActorTemplateNamespace
@@ -146,13 +161,6 @@ func (x *RunWorkloadRequest) GetActorTemplateNamespace() string {
 func (x *RunWorkloadRequest) GetActorTemplateName() string {
 	if x != nil {
 		return x.ActorTemplateName
-	}
-	return ""
-}
-
-func (x *RunWorkloadRequest) GetActorId() string {
-	if x != nil {
-		return x.ActorId
 	}
 	return ""
 }
@@ -422,11 +430,12 @@ func (*RunWorkloadResponse) Descriptor() ([]byte, []int) {
 
 type CheckpointWorkloadRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,1,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,2,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	ActorId                string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,4,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorId                string                 `protobuf:"bytes,2,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	ActorTemplateNamespace string                 `protobuf:"bytes,3,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string                 `protobuf:"bytes,4,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	RunscPath              string                 `protobuf:"bytes,5,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec                   *WorkloadSpec          `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
 	// An object storage URI prefix below which the checkpoint data will be
 	// stored.
 	//
@@ -435,12 +444,12 @@ type CheckpointWorkloadRequest struct {
 	// memory, sentry state, and filesystem deltas.
 	//
 	// For example: "gs://bucket/actors/1234/snapshots/5678/"
-	SnapshotUriPrefix string `protobuf:"bytes,6,opt,name=snapshot_uri_prefix,json=snapshotUriPrefix,proto3" json:"snapshot_uri_prefix,omitempty"`
+	SnapshotUriPrefix string `protobuf:"bytes,7,opt,name=snapshot_uri_prefix,json=snapshotUriPrefix,proto3" json:"snapshot_uri_prefix,omitempty"`
 	// runtime_asset_paths maps a runtime asset name to the local on-disk path
 	// atelet fetched it to (see RunWorkloadRequest). Empty for gVisor.
-	RuntimeAssetPaths map[string]string `protobuf:"bytes,7,rep,name=runtime_asset_paths,json=runtimeAssetPaths,proto3" json:"runtime_asset_paths,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	RuntimeAssetPaths map[string]string `protobuf:"bytes,8,rep,name=runtime_asset_paths,json=runtimeAssetPaths,proto3" json:"runtime_asset_paths,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// What content to include in the checkpoint.
-	Scope         SnapshotScope `protobuf:"varint,8,opt,name=scope,proto3,enum=ateom.SnapshotScope" json:"scope,omitempty"`
+	Scope         SnapshotScope `protobuf:"varint,9,opt,name=scope,proto3,enum=ateom.SnapshotScope" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -475,6 +484,20 @@ func (*CheckpointWorkloadRequest) Descriptor() ([]byte, []int) {
 	return file_ateom_proto_rawDescGZIP(), []int{6}
 }
 
+func (x *CheckpointWorkloadRequest) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *CheckpointWorkloadRequest) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
 func (x *CheckpointWorkloadRequest) GetActorTemplateNamespace() string {
 	if x != nil {
 		return x.ActorTemplateNamespace
@@ -485,13 +508,6 @@ func (x *CheckpointWorkloadRequest) GetActorTemplateNamespace() string {
 func (x *CheckpointWorkloadRequest) GetActorTemplateName() string {
 	if x != nil {
 		return x.ActorTemplateName
-	}
-	return ""
-}
-
-func (x *CheckpointWorkloadRequest) GetActorId() string {
-	if x != nil {
-		return x.ActorId
 	}
 	return ""
 }
@@ -580,18 +596,19 @@ func (x *CheckpointWorkloadResponse) GetSnapshotFiles() []string {
 
 type RestoreWorkloadRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,1,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,2,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	ActorId                string                 `protobuf:"bytes,3,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,4,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorId                string                 `protobuf:"bytes,2,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	ActorTemplateNamespace string                 `protobuf:"bytes,3,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string                 `protobuf:"bytes,4,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	RunscPath              string                 `protobuf:"bytes,5,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec                   *WorkloadSpec          `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
 	// The object storage URI prefix of the snapshot to restore.
-	SnapshotUriPrefix string `protobuf:"bytes,6,opt,name=snapshot_uri_prefix,json=snapshotUriPrefix,proto3" json:"snapshot_uri_prefix,omitempty"`
+	SnapshotUriPrefix string `protobuf:"bytes,7,opt,name=snapshot_uri_prefix,json=snapshotUriPrefix,proto3" json:"snapshot_uri_prefix,omitempty"`
 	// runtime_asset_paths maps a runtime asset name to the local on-disk path
 	// atelet fetched it to (see RunWorkloadRequest). Empty for gVisor.
-	RuntimeAssetPaths map[string]string `protobuf:"bytes,7,rep,name=runtime_asset_paths,json=runtimeAssetPaths,proto3" json:"runtime_asset_paths,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	RuntimeAssetPaths map[string]string `protobuf:"bytes,8,rep,name=runtime_asset_paths,json=runtimeAssetPaths,proto3" json:"runtime_asset_paths,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// What content to restore from the snapshot.
-	Scope         SnapshotScope `protobuf:"varint,8,opt,name=scope,proto3,enum=ateom.SnapshotScope" json:"scope,omitempty"`
+	Scope         SnapshotScope `protobuf:"varint,9,opt,name=scope,proto3,enum=ateom.SnapshotScope" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -626,6 +643,20 @@ func (*RestoreWorkloadRequest) Descriptor() ([]byte, []int) {
 	return file_ateom_proto_rawDescGZIP(), []int{8}
 }
 
+func (x *RestoreWorkloadRequest) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *RestoreWorkloadRequest) GetActorId() string {
+	if x != nil {
+		return x.ActorId
+	}
+	return ""
+}
+
 func (x *RestoreWorkloadRequest) GetActorTemplateNamespace() string {
 	if x != nil {
 		return x.ActorTemplateNamespace
@@ -636,13 +667,6 @@ func (x *RestoreWorkloadRequest) GetActorTemplateNamespace() string {
 func (x *RestoreWorkloadRequest) GetActorTemplateName() string {
 	if x != nil {
 		return x.ActorTemplateName
-	}
-	return ""
-}
-
-func (x *RestoreWorkloadRequest) GetActorId() string {
-	if x != nil {
-		return x.ActorId
 	}
 	return ""
 }
@@ -722,14 +746,15 @@ var File_ateom_proto protoreflect.FileDescriptor
 
 const file_ateom_proto_rawDesc = "" +
 	"\n" +
-	"\vateom.proto\x12\x05ateom\"\x89\x03\n" +
-	"\x12RunWorkloadRequest\x128\n" +
-	"\x18actor_template_namespace\x18\x01 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x02 \x01(\tR\x11actorTemplateName\x12\x19\n" +
-	"\bactor_id\x18\x03 \x01(\tR\aactorId\x12\x1d\n" +
+	"\vateom.proto\x12\x05ateom\"\xa5\x03\n" +
+	"\x12RunWorkloadRequest\x12\x1a\n" +
+	"\batespace\x18\x01 \x01(\tR\batespace\x12\x19\n" +
+	"\bactor_id\x18\x02 \x01(\tR\aactorId\x128\n" +
+	"\x18actor_template_namespace\x18\x03 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x04 \x01(\tR\x11actorTemplateName\x12\x1d\n" +
 	"\n" +
-	"runsc_path\x18\x04 \x01(\tR\trunscPath\x12'\n" +
-	"\x04spec\x18\x05 \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\x12`\n" +
+	"runsc_path\x18\x05 \x01(\tR\trunscPath\x12'\n" +
+	"\x04spec\x18\x06 \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\x12`\n" +
 	"\x13runtime_asset_paths\x18\a \x03(\v20.ateom.RunWorkloadRequest.RuntimeAssetPathsEntryR\x11runtimeAssetPaths\x1aD\n" +
 	"\x16RuntimeAssetPathsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
@@ -747,32 +772,34 @@ const file_ateom_proto_rawDesc = "" +
 	"\rHTTPGetAction\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\"\x15\n" +
-	"\x13RunWorkloadResponse\"\xf3\x03\n" +
-	"\x19CheckpointWorkloadRequest\x128\n" +
-	"\x18actor_template_namespace\x18\x01 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x02 \x01(\tR\x11actorTemplateName\x12\x19\n" +
-	"\bactor_id\x18\x03 \x01(\tR\aactorId\x12\x1d\n" +
+	"\x13RunWorkloadResponse\"\x8f\x04\n" +
+	"\x19CheckpointWorkloadRequest\x12\x1a\n" +
+	"\batespace\x18\x01 \x01(\tR\batespace\x12\x19\n" +
+	"\bactor_id\x18\x02 \x01(\tR\aactorId\x128\n" +
+	"\x18actor_template_namespace\x18\x03 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x04 \x01(\tR\x11actorTemplateName\x12\x1d\n" +
 	"\n" +
-	"runsc_path\x18\x04 \x01(\tR\trunscPath\x12'\n" +
-	"\x04spec\x18\x05 \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\x12.\n" +
-	"\x13snapshot_uri_prefix\x18\x06 \x01(\tR\x11snapshotUriPrefix\x12g\n" +
-	"\x13runtime_asset_paths\x18\a \x03(\v27.ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntryR\x11runtimeAssetPaths\x12*\n" +
-	"\x05scope\x18\b \x01(\x0e2\x14.ateom.SnapshotScopeR\x05scope\x1aD\n" +
+	"runsc_path\x18\x05 \x01(\tR\trunscPath\x12'\n" +
+	"\x04spec\x18\x06 \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\x12.\n" +
+	"\x13snapshot_uri_prefix\x18\a \x01(\tR\x11snapshotUriPrefix\x12g\n" +
+	"\x13runtime_asset_paths\x18\b \x03(\v27.ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntryR\x11runtimeAssetPaths\x12*\n" +
+	"\x05scope\x18\t \x01(\x0e2\x14.ateom.SnapshotScopeR\x05scope\x1aD\n" +
 	"\x16RuntimeAssetPathsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"C\n" +
 	"\x1aCheckpointWorkloadResponse\x12%\n" +
-	"\x0esnapshot_files\x18\x01 \x03(\tR\rsnapshotFiles\"\xed\x03\n" +
-	"\x16RestoreWorkloadRequest\x128\n" +
-	"\x18actor_template_namespace\x18\x01 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x02 \x01(\tR\x11actorTemplateName\x12\x19\n" +
-	"\bactor_id\x18\x03 \x01(\tR\aactorId\x12\x1d\n" +
+	"\x0esnapshot_files\x18\x01 \x03(\tR\rsnapshotFiles\"\x89\x04\n" +
+	"\x16RestoreWorkloadRequest\x12\x1a\n" +
+	"\batespace\x18\x01 \x01(\tR\batespace\x12\x19\n" +
+	"\bactor_id\x18\x02 \x01(\tR\aactorId\x128\n" +
+	"\x18actor_template_namespace\x18\x03 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x04 \x01(\tR\x11actorTemplateName\x12\x1d\n" +
 	"\n" +
-	"runsc_path\x18\x04 \x01(\tR\trunscPath\x12'\n" +
-	"\x04spec\x18\x05 \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\x12.\n" +
-	"\x13snapshot_uri_prefix\x18\x06 \x01(\tR\x11snapshotUriPrefix\x12d\n" +
-	"\x13runtime_asset_paths\x18\a \x03(\v24.ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntryR\x11runtimeAssetPaths\x12*\n" +
-	"\x05scope\x18\b \x01(\x0e2\x14.ateom.SnapshotScopeR\x05scope\x1aD\n" +
+	"runsc_path\x18\x05 \x01(\tR\trunscPath\x12'\n" +
+	"\x04spec\x18\x06 \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\x12.\n" +
+	"\x13snapshot_uri_prefix\x18\a \x01(\tR\x11snapshotUriPrefix\x12d\n" +
+	"\x13runtime_asset_paths\x18\b \x03(\v24.ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntryR\x11runtimeAssetPaths\x12*\n" +
+	"\x05scope\x18\t \x01(\x0e2\x14.ateom.SnapshotScopeR\x05scope\x1aD\n" +
 	"\x16RuntimeAssetPathsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x19\n" +

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -48,13 +48,15 @@ service Ateom {
 }
 
 message RunWorkloadRequest {
-  string actor_template_namespace = 1;
-  string actor_template_name      = 2;
-  string actor_id                 = 3;
+  string atespace = 1;
+  string actor_id = 2;
 
-  string runsc_path = 4;
+  string actor_template_namespace = 3;
+  string actor_template_name      = 4;
 
-  WorkloadSpec spec = 5;
+  string runsc_path = 5;
+
+  WorkloadSpec spec = 6;
 
   // runtime_asset_paths maps a runtime asset name (e.g. "cloud-hypervisor",
   // "virtiofsd", "kata-kernel", "kata-image", "kata-config")
@@ -104,13 +106,15 @@ enum SnapshotScope {
 }
 
 message CheckpointWorkloadRequest {
-  string actor_template_namespace = 1;
-  string actor_template_name      = 2;
-  string actor_id                 = 3;
+  string atespace = 1;
+  string actor_id = 2;
 
-  string runsc_path = 4;
+  string actor_template_namespace = 3;
+  string actor_template_name      = 4;
 
-  WorkloadSpec spec = 5;
+  string runsc_path = 5;
+
+  WorkloadSpec spec = 6;
 
   // An object storage URI prefix below which the checkpoint data will be
   // stored.
@@ -120,14 +124,14 @@ message CheckpointWorkloadRequest {
   // memory, sentry state, and filesystem deltas.
   //
   // For example: "gs://bucket/actors/1234/snapshots/5678/"
-  string snapshot_uri_prefix = 6;
+  string snapshot_uri_prefix = 7;
 
   // runtime_asset_paths maps a runtime asset name to the local on-disk path
   // atelet fetched it to (see RunWorkloadRequest). Empty for gVisor.
-  map<string, string> runtime_asset_paths = 7;
+  map<string, string> runtime_asset_paths = 8;
 
   // What content to include in the checkpoint.
-  SnapshotScope scope = 8;
+  SnapshotScope scope = 9;
 }
 
 message CheckpointWorkloadResponse {
@@ -138,23 +142,25 @@ message CheckpointWorkloadResponse {
 }
 
 message RestoreWorkloadRequest {
-  string actor_template_namespace = 1;
-  string actor_template_name      = 2;
-  string actor_id                 = 3;
+  string atespace = 1;
+  string actor_id = 2;
 
-  string runsc_path = 4;
+  string actor_template_namespace = 3;
+  string actor_template_name      = 4;
 
-  WorkloadSpec spec = 5;
+  string runsc_path = 5;
+
+  WorkloadSpec spec = 6;
 
   // The object storage URI prefix of the snapshot to restore.
-  string snapshot_uri_prefix = 6;
+  string snapshot_uri_prefix = 7;
 
   // runtime_asset_paths maps a runtime asset name to the local on-disk path
   // atelet fetched it to (see RunWorkloadRequest). Empty for gVisor.
-  map<string, string> runtime_asset_paths = 7;
+  map<string, string> runtime_asset_paths = 8;
 
   // What content to restore from the snapshot.
-  SnapshotScope scope = 8;
+  SnapshotScope scope = 9;
 }
 
 message RestoreWorkloadResponse {

--- a/internal/resources/validate.go
+++ b/internal/resources/validate.go
@@ -63,36 +63,6 @@ func ValidateActorRef(ref *ateapipb.ActorRef, fldPath *field.Path) field.ErrorLi
 	return errs
 }
 
-// ValidateActorRefFields ensures every component of the per-actor directory tree is
-// a valid DNS-1123 name. namespace+template+actorID are concatenated by
-// ateompath.ActorPath into a host path on which atelet runs os.RemoveAll and
-// os.MkdirAll, so all three must be validated. Checking only one would still
-// leave a traversal window via the others. Template names are DNS-1123
-// subdomains (dots allowed); namespaces and actor IDs are labels.
-//
-// The actor ID rule here is DNS-1123 label, which matches ValidateActorID;
-// unifying the two implementations is tracked separately.
-// TODO(thockin): unify this with the more structural validation to come.
-func ValidateActorRefFields(namespace, template, actorID string) error {
-	if errs := content.IsDNS1123Label(namespace); len(errs) > 0 {
-		return fmt.Errorf("invalid namespace %q: %s", namespace, strings.Join(errs, "; "))
-	}
-	if errs := content.IsDNS1123Subdomain(template); len(errs) > 0 {
-		return fmt.Errorf("invalid template %q: %s", template, strings.Join(errs, "; "))
-	}
-	if errs := content.IsDNS1123Label(actorID); len(errs) > 0 {
-		return fmt.Errorf("invalid actor ID %q: %s", actorID, strings.Join(errs, "; "))
-	}
-	// The three names are joined into a single path component
-	// (<namespace>:<template>:<actorID>, see ateompath.ActorPath), which must
-	// fit the 255-byte filename limit of common filesystems. Individually
-	// valid DNS names can exceed it: 63 + 253 + 63 plus separators is 381.
-	if n := len(namespace) + 1 + len(template) + 1 + len(actorID); n > 255 {
-		return fmt.Errorf("actor ref %s:%s:%s is %d bytes; the combined path component must be at most 255", namespace, template, actorID, n)
-	}
-	return nil
-}
-
 // ValidateAteomUID rejects a target ateom pod UID that could escape the host
 // paths built from it: the netns path (/run/netns/ateom:<uid>) and the ateom
 // control socket (.../ateoms/<uid>/ateom.sock). Kubernetes pod UIDs are UUIDs,

--- a/internal/resources/validate_test.go
+++ b/internal/resources/validate_test.go
@@ -65,50 +65,6 @@ func TestValidateActorRef(t *testing.T) {
 	}
 }
 
-func TestValidateActorRefFields(t *testing.T) {
-	const okNS, okTmpl, okID = "ate-demo", "counter", "counter-1"
-
-	tests := []struct {
-		name         string
-		ns, tmpl, id string
-		wantErr      bool
-	}{
-		{"all valid", okNS, okTmpl, okID, false},
-		{"uuid id valid", okNS, okTmpl, "422938ba-8860-4983-a25d-d6bcb0a69d4e", false},
-
-		// Label vs subdomain distinction: template names are DNS-1123
-		// subdomains (dots allowed); namespaces and actor IDs are labels.
-		{"dotted template valid (subdomain)", okNS, "probe.v1", okID, false},
-		{"dotted namespace invalid (label)", "ate.demo", okTmpl, okID, true},
-		{"dotted id invalid (label)", okNS, okTmpl, "probe.alpha", true},
-
-		{"id traversal", okNS, okTmpl, "..", true},
-		{"id separator", okNS, okTmpl, "a/b", true},
-		{"id empty", okNS, okTmpl, "", true},
-		{"id uppercase", okNS, okTmpl, "Counter", true},
-		{"id too long", okNS, okTmpl, strings.Repeat("a", 64), true},
-
-		{"namespace separator", "a/b", okTmpl, okID, true},
-		{"namespace traversal", "..", okTmpl, okID, true},
-		{"namespace empty", "", okTmpl, okID, true},
-		{"template separator", okNS, "a/b", okID, true},
-		{"template traversal", okNS, "..", okID, true},
-
-		// The names join into one <ns>:<tmpl>:<id> path component, capped at
-		// 255 bytes even when each name is individually valid.
-		{"combined fits filename limit", strings.Repeat("a", 63), strings.Repeat("b", 120), strings.Repeat("c", 63), false},
-		{"combined exceeds filename limit", strings.Repeat("a", 63), strings.Repeat("b", 253), strings.Repeat("c", 63), true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateActorRefFields(tt.ns, tt.tmpl, tt.id)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateActorRefFields(%q, %q, %q) err = %v, wantErr %v", tt.ns, tt.tmpl, tt.id, err, tt.wantErr)
-			}
-		})
-	}
-}
-
 func TestValidateAteomUID(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
This fixes an issue where atelet/ateom will clash the state of actors with same ID within different atespaces.

Once substrate resources get UIDs, we should revisit the way atelet / ateom does the bookkeeping and check in which cases it should use UID instead of (atespace,actor_id).
