### PR TITLE
Wait for the subscription confirmation (pubsub.Receive) before returning the watch.

### DIFF
--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -256,6 +256,13 @@ func (s *Persistence) WatchWorkers(ctx context.Context) (*store.WorkerWatch, err
 	// caller via WorkerWatch.Close or when the parent ctx is cancelled.
 	watchCtx, cancel := context.WithCancel(ctx)
 	pubsub := s.rdb.Subscribe(watchCtx, workerPubSubChannel)
+	// Wait for the server to confirm the subscription; otherwise events published
+	// right after we return can race the SUBSCRIBE and be lost for good.
+	if _, err := pubsub.Receive(watchCtx); err != nil {
+		pubsub.Close()
+		cancel()
+		return nil, fmt.Errorf("while subscribing to %s: %w", workerPubSubChannel, err)
+	}
 	ch := make(chan store.WorkerEvent, 128)
 	go func() {
 		defer close(ch)


### PR DESCRIPTION
Attempt to fix the flaky run-tests

Hit this during tests
```
2026/07/07 21:55:05 INFO Handle RPC method=/ateapi.Control/ListWorkers req="" resp="workers:{worker_namespace:\"ns-list-workers-1783461303995756942\"  worker_pool:\"pool1\"  worker_pod:\"worker-1\"  ip:\"127.0.0.1\"  version:1  worker_pod_uid:\"5b2e6977-365a-4566-94dd-72d5e17e6de7\"  node_name:\"node1\"}  workers:{worker_namespace:\"ns-multi-pool-1783461304982213577\" .....

2026/07/07 21:55:05 INFO Handle RPC method=/ateapi.Control/ResumeActor req="actor_ref:{atespace:\"test-atespace\"  name:\"id1\"}" resp=<nil> err="workflow failed at step AssignWorker: rpc error: code = FailedPrecondition desc = no free workers available" elapsed-time=465.688µs
    functional_test.go:1495: ResumeActor failed: rpc error: code = FailedPrecondition desc = no free workers available
--- FAIL: TestSuspendActor (0.16s)
```
The test failed at 1st run but succeed in the 2nd attempt without any change. 
<img width="1323" height="372" alt="image" src="https://github.com/user-attachments/assets/65512bbc-f92d-4a14-b3c2-11dffd457363" />


`ListWorker` finds workers but `WatchWorkers` failed since it use the workerCache code path to check existence. So making sure we receive the pub/sub message should fix it.



> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
