### PR TITLE
Fix demo actor cleanup for atespaces

### DIFF
--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -366,10 +366,11 @@ deploy_atenet() {
 
 # get_actor_status echoes the actor's status enum (e.g. STATUS_SUSPENDED).
 get_actor_status() {
-  local actor_id="$1"
+  local atespace="$1"
+  local actor_id="$2"
   local json
 
-  if ! json=$(run_kubectl_ate get actor "${actor_id}" -o json 2>/dev/null); then
+  if ! json=$(run_kubectl_ate get actor "${actor_id}" -a "${atespace}" -o json 2>/dev/null); then
     return 1
   fi
   jq -r '.actors[0].status // empty' <<<"${json}"
@@ -378,13 +379,14 @@ get_actor_status() {
 # prepare_actor_for_delete suspends (or resumes then suspends) until DeleteActor
 # is allowed. Actors must be STATUS_SUSPENDED before deletion.
 prepare_actor_for_delete() {
-  local actor_id="$1"
-  local timeout_secs="${2:-120}"
+  local atespace="$1"
+  local actor_id="$2"
+  local timeout_secs="${3:-120}"
   local deadline=$((SECONDS + timeout_secs))
   local status
 
   while ((SECONDS < deadline)); do
-    if ! status=$(get_actor_status "${actor_id}"); then
+    if ! status=$(get_actor_status "${atespace}" "${actor_id}"); then
       return 0
     fi
 
@@ -393,22 +395,22 @@ prepare_actor_for_delete() {
         return 0
         ;;
       STATUS_PAUSED)
-        run_kubectl_ate resume actor "${actor_id}" -o json >/dev/null
+        run_kubectl_ate resume actor "${actor_id}" -a "${atespace}" -o json >/dev/null
         ;;
       STATUS_RUNNING)
-        run_kubectl_ate suspend actor "${actor_id}" -o json >/dev/null
+        run_kubectl_ate suspend actor "${actor_id}" -a "${atespace}" -o json >/dev/null
         ;;
       STATUS_RESUMING | STATUS_SUSPENDING | STATUS_PAUSING)
         ;;
       *)
-        echo "cannot delete actor ${actor_id}: unexpected status ${status}" >&2
+        echo "cannot delete actor ${atespace}/${actor_id}: unexpected status ${status}" >&2
         return 1
         ;;
     esac
     sleep 2
   done
 
-  echo "timed out waiting for actor ${actor_id} to reach STATUS_SUSPENDED" >&2
+  echo "timed out waiting for actor ${atespace}/${actor_id} to reach STATUS_SUSPENDED" >&2
   return 1
 }
 
@@ -434,26 +436,26 @@ delete_demo_actors() {
   fi
 
   local actors_json
-  if ! actors_json=$(run_kubectl_ate get actors -o json 2>/dev/null); then
+  if ! actors_json=$(run_kubectl_ate get actors -A -o json 2>/dev/null); then
     echo "warning: could not list actors; skipping actor cleanup" >&2
     return 0
   fi
 
-  local ns tmpl actor_id
+  local ns tmpl atespace actor_id
   while (($# > 0)); do
     ns="$1"
     tmpl="$2"
     shift 2
 
     log_step "Deleting actors for ${ns}/${tmpl}"
-    while IFS= read -r actor_id; do
-      [[ -z "${actor_id}" ]] && continue
-      log_step "  preparing actor ${actor_id} for delete"
-      prepare_actor_for_delete "${actor_id}"
-      run_kubectl_ate delete actor "${actor_id}"
+    while IFS=$'\t' read -r atespace actor_id; do
+      [[ -z "${atespace}" || -z "${actor_id}" ]] && continue
+      log_step "  preparing actor ${atespace}/${actor_id} for delete"
+      prepare_actor_for_delete "${atespace}" "${actor_id}"
+      run_kubectl_ate delete actor "${actor_id}" -a "${atespace}"
     done < <(
       jq -r --arg ns "${ns}" --arg tmpl "${tmpl}" \
-        '.actors[]? | select(.actorTemplateNamespace == $ns and .actorTemplateName == $tmpl) | .actorId' \
+        '.actors[]? | select(.actorTemplateNamespace == $ns and .actorTemplateName == $tmpl) | [.atespace, .actorId] | @tsv' \
         <<<"${actors_json}"
     )
   done


### PR DESCRIPTION
Pass the required `atespace` argument to `kubectl ate` in demo actor cleanup.