### PR TITLE
fix InvalidImageName in claude code multiplex demo

### DIFF
--- a/hack/install-demo-claude-code-multiplex.sh
+++ b/hack/install-demo-claude-code-multiplex.sh
@@ -78,7 +78,7 @@ demo-claude-code-multiplex_deploy() {
       -e "s|\${ANTHROPIC_API_KEY}|${ANTHROPIC_API_KEY}|g" \
       -e "s|\${WORKLOAD_IMAGE}|${workload_image}|g" \
       demos/claude-code-multiplex/claude-code-multiplex.yaml.tmpl \
-    | run_kubectl apply -f -
+    | run_ko apply -f -
 }
 
 demo-claude-code-multiplex_delete() {


### PR DESCRIPTION
The claude code multiplex demo improperly uses `kubectl` to apply its template, causing `InvalidImageName` errors in the pods.

This PR fixes it by replacing `kubectl` with `ko`.