### PR TITLE
metrics: add worker cache metrics and store publish-failure counter

### DIFF
--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -56,6 +56,8 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -75,14 +77,31 @@ type redisClient interface {
 // Persistence is a service that stores information about applications in Redis.
 type Persistence struct {
 	rdb redisClient
+
+	// workerPublishFailures counts worker-change events that never reached the
+	// pub/sub channel. Subscribers only recover these through the worker
+	// cache's periodic relist, so a non-zero rate means watchers are running
+	// stale. Nil when metrics are unavailable (e.g. tests constructing
+	// Persistence directly).
+	workerPublishFailures metric.Int64Counter
 }
 
 var _ store.Interface = (*Persistence)(nil)
 
 // NewPersistence creates a new Persistence.
 func NewPersistence(redisClient *redis.ClusterClient) *Persistence {
+	workerPublishFailures, err := otel.Meter("ateapi").Int64Counter(
+		"ateapi.store.worker_event.publish_failures",
+		metric.WithUnit("{event}"),
+		metric.WithDescription("Number of worker-change events that failed to publish to the store's pub/sub channel."),
+	)
+	if err != nil {
+		// Losing a counter is not worth failing the store over.
+		slog.Warn("Failed to create worker publish failure counter", slog.Any("err", err))
+	}
 	return &Persistence{
-		rdb: redisClient,
+		rdb:                   redisClient,
+		workerPublishFailures: workerPublishFailures,
 	}
 }
 
@@ -244,10 +263,18 @@ func (s *Persistence) publishWorkerEvent(ctx context.Context, eventType store.Wo
 	payload, err := marshalWorkerEvent(eventType, worker)
 	if err != nil {
 		slog.ErrorContext(ctx, "worker event marshal failed", slog.Any("err", err))
+		s.countPublishFailure(ctx)
 		return
 	}
 	if err := s.rdb.Publish(ctx, workerPubSubChannel, payload).Err(); err != nil {
 		slog.ErrorContext(ctx, "worker event publish failed", slog.Any("err", err))
+		s.countPublishFailure(ctx)
+	}
+}
+
+func (s *Persistence) countPublishFailure(ctx context.Context) {
+	if s.workerPublishFailures != nil {
+		s.workerPublishFailures.Add(ctx, 1)
 	}
 }
 

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -1097,4 +1100,59 @@ func TestDeleteAtespace_EmptyWhileOtherAtespaceNonEmpty(t *testing.T) {
 	if err := s.DeleteAtespace(ctx, "team-b"); !errors.Is(err, store.ErrFailedPrecondition) {
 		t.Errorf("DeleteAtespace(team-b, non-empty) = %v, want ErrFailedPrecondition", err)
 	}
+}
+
+func TestPublishWorkerEvent_FailureCounted(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	rdb := redis.NewClusterClient(&redis.ClusterOptions{
+		Addrs: []string{mr.Addr()},
+	})
+	s := NewPersistence(rdb)
+	ctx := context.Background()
+	worker := &ateapipb.Worker{WorkerNamespace: "ns", WorkerPod: "pod1"}
+
+	// A successful publish must not count as a failure.
+	s.publishWorkerEvent(ctx, store.WorkerEventCreated, worker)
+	if got := publishFailureCount(t, reader); got != 0 {
+		t.Errorf("publish failures after successful publish = %d, want 0", got)
+	}
+
+	// With the backend gone, the lost event must be counted.
+	mr.Close()
+	s.publishWorkerEvent(ctx, store.WorkerEventCreated, worker)
+	if got := publishFailureCount(t, reader); got != 1 {
+		t.Errorf("publish failures after backend loss = %d, want 1", got)
+	}
+}
+
+// publishFailureCount collects from reader and returns the publish-failure
+// counter's value; a counter with no recordings yet is not reported, which
+// counts as 0.
+func publishFailureCount(t *testing.T, reader *sdkmetric.ManualReader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "ateapi.store.worker_event.publish_failures" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok || len(sum.DataPoints) != 1 {
+				t.Fatalf("counter has unexpected data: %#v", m.Data)
+			}
+			return sum.DataPoints[0].Value
+		}
+	}
+	return 0
 }

--- a/cmd/ateapi/internal/workercache/workercache.go
+++ b/cmd/ateapi/internal/workercache/workercache.go
@@ -28,13 +28,12 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // Cache maintains an in-memory snapshot of all workers.
-//
-// TODO: add metrics — at minimum a gauge for worker count, a counter for
-// resync events, and a counter for failed PUBLISH operations (in ateredis).
 type Cache struct {
 	store          store.Interface
 	relistInterval time.Duration
@@ -43,6 +42,9 @@ type Cache struct {
 	workers map[string]*ateapipb.Worker
 
 	ready atomic.Bool
+
+	resyncs      metric.Int64Counter
+	workersGauge metric.Registration
 }
 
 // New creates a Cache backed by a given store. relistInterval controls how
@@ -64,8 +66,44 @@ func (c *Cache) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if err := c.initMetrics(); err != nil {
+		watch.Close()
+		return err
+	}
 	c.ready.Store(true)
 	go c.watchEvents(ctx, watch)
+	return nil
+}
+
+// initMetrics registers the cache's instruments on the global meter provider.
+func (c *Cache) initMetrics() error {
+	meter := otel.Meter("ateapi")
+	var err error
+	c.resyncs, err = meter.Int64Counter(
+		"ateapi.workercache.resyncs",
+		metric.WithUnit("{resync}"),
+		metric.WithDescription("Number of times the worker cache lost its watch and rebuilt state from a full relist."),
+	)
+	if err != nil {
+		return fmt.Errorf("create ateapi.workercache.resyncs counter: %w", err)
+	}
+	workers, err := meter.Int64ObservableGauge(
+		"ateapi.workercache.workers",
+		metric.WithUnit("{worker}"),
+		metric.WithDescription("Number of workers currently tracked by the in-memory worker cache."),
+	)
+	if err != nil {
+		return fmt.Errorf("create ateapi.workercache.workers gauge: %w", err)
+	}
+	c.workersGauge, err = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+		o.ObserveInt64(workers, int64(len(c.workers)))
+		return nil
+	}, workers)
+	if err != nil {
+		return fmt.Errorf("register ateapi.workercache.workers callback: %w", err)
+	}
 	return nil
 }
 
@@ -115,6 +153,9 @@ func (c *Cache) relist(ctx context.Context) error {
 }
 
 func (c *Cache) watchEvents(ctx context.Context, watch *store.WorkerWatch) {
+	// The gauge callback observes this cache's contents; drop it once the
+	// cache stops updating so a dead cache can't report stale counts.
+	defer func() { _ = c.workersGauge.Unregister() }()
 	ticker := time.NewTicker(c.relistInterval)
 	defer ticker.Stop()
 	for {
@@ -127,6 +168,7 @@ func (c *Cache) watchEvents(ctx context.Context, watch *store.WorkerWatch) {
 					return
 				}
 				slog.WarnContext(ctx, "worker cache: watch channel closed, resyncing")
+				c.resyncs.Add(ctx, 1)
 				watch = c.resync(ctx)
 				if watch == nil {
 					return // context cancelled

--- a/cmd/ateapi/internal/workercache/workercache_test.go
+++ b/cmd/ateapi/internal/workercache/workercache_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"google.golang.org/protobuf/testing/protocmp"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -351,6 +354,98 @@ func TestCache_Relist_FailureIsNonFatal(t *testing.T) {
 	if diff := cmp.Diff([]*ateapipb.Worker{w1}, workers, protocmp.Transform(), workerSortOpt); diff != "" {
 		t.Errorf("workers mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func TestCache_Metrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	w1 := makeWorker("ns", "pod1", 1)
+	w2 := makeWorker("ns", "pod2", 1)
+	fs := newFakeStore(w1, w2)
+	c := workercache.New(fs, time.Hour)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if got := gaugeValue(t, reader, "ateapi.workercache.workers"); got != 2 {
+		t.Errorf("workers gauge after start = %d, want 2", got)
+	}
+	if got := counterValue(t, reader, "ateapi.workercache.resyncs"); got != 0 {
+		t.Errorf("resyncs counter after start = %d, want 0", got)
+	}
+
+	// Disconnect with a smaller snapshot: the resync counter should tick and
+	// the gauge should track the new size.
+	fs.setWorkers(w1)
+	fs.disconnect()
+	eventually(t, func() bool {
+		workers, err := c.Workers()
+		return err == nil && len(workers) == 1
+	}, 2*time.Second)
+
+	if got := counterValue(t, reader, "ateapi.workercache.resyncs"); got != 1 {
+		t.Errorf("resyncs counter after disconnect = %d, want 1", got)
+	}
+	if got := gaugeValue(t, reader, "ateapi.workercache.workers"); got != 1 {
+		t.Errorf("workers gauge after resync = %d, want 1", got)
+	}
+
+	// Shutdown unregisters the gauge callback, so the gauge stops reporting.
+	cancel()
+	eventually(t, func() bool {
+		_, ok := metricByName(t, reader, "ateapi.workercache.workers")
+		return !ok
+	}, 2*time.Second)
+}
+
+// metricByName collects from reader and returns the named metric, if reported.
+func metricByName(t *testing.T, reader *sdkmetric.ManualReader, name string) (metricdata.Metrics, bool) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m, true
+			}
+		}
+	}
+	return metricdata.Metrics{}, false
+}
+
+func gaugeValue(t *testing.T, reader *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+	m, ok := metricByName(t, reader, name)
+	if !ok {
+		t.Fatalf("gauge %q not reported", name)
+	}
+	gauge, ok := m.Data.(metricdata.Gauge[int64])
+	if !ok || len(gauge.DataPoints) != 1 {
+		t.Fatalf("gauge %q has unexpected data: %#v", name, m.Data)
+	}
+	return gauge.DataPoints[0].Value
+}
+
+// counterValue returns the named counter's value; a counter with no
+// recordings yet is not reported at all, which counts as 0.
+func counterValue(t *testing.T, reader *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+	m, ok := metricByName(t, reader, name)
+	if !ok {
+		return 0
+	}
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok || len(sum.DataPoints) != 1 {
+		t.Fatalf("counter %q has unexpected data: %#v", name, m.Data)
+	}
+	return sum.DataPoints[0].Value
 }
 
 type fakeStore struct {

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -100,6 +100,9 @@ Agent Substrate emits foundational OpenTelemetry system and server metrics to mo
 | `rpc.server.call.duration` | ateapi & atelet (gRPC servers, via `otelgrpc`) | histogram | per-method gRPC latency, request rate, and errors (labels `rpc.method`, `rpc.response.status_code`) |
 | `atenet.router.route.duration` | atenet-router | histogram | Substrate E2E — Envoy receiving a request to Envoy forwarding it to the resolved worker, excluding actor compute and the response |
 | `atelet.snapshot.size` | atelet | histogram | uncompressed size in bytes of each gVisor snapshot image written during checkpoint (labels `kind`, `actor_template_name`) |
+| `ateapi.workercache.workers` | ateapi | gauge | number of workers currently tracked by the in-memory worker cache |
+| `ateapi.workercache.resyncs` | ateapi | counter | times the worker cache lost its watch and rebuilt state from a full relist |
+| `ateapi.store.worker_event.publish_failures` | ateapi | counter | worker-change events that failed to publish to the store's pub/sub channel; watchers only recover via periodic relist, so a non-zero rate means they run stale in between |
 
 The table lists the OpenTelemetry instrument names. How a name appears in a query depends on the backend (Cloud Monitoring (GMP) / Kind collector).
 


### PR DESCRIPTION
Implements the workercache metrics TODO: a gauge for the number of cached workers (ateapi.workercache.workers), a counter for watch-loss resyncs (ateapi.workercache.resyncs), and a counter in ateredis for worker-change events that failed to PUBLISH (ateapi.store.worker_event.publish_failures). Documents the new instruments in docs/observability.md.


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
