### PR TITLE
perf: cache OIDC verification keys in k8sjwt

### DIFF
--- a/cmd/ateapi/internal/k8sjwt/k8sjwt.go
+++ b/cmd/ateapi/internal/k8sjwt/k8sjwt.go
@@ -31,7 +31,10 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // KeyAndID wraps a crypto.PublicKey along with the key ID that will identify it during
@@ -115,6 +118,167 @@ var (
 	defaultHTTPClient = &http.Client{Timeout: 10 * time.Second}
 )
 
+// keyRefetchInterval is the minimum time between key fetches for a single
+// issuer. The keyID that triggers a refetch comes from an unverified token,
+// so without this floor a client could force an OIDC discovery round-trip per
+// request just by minting tokens with bogus keyIDs.
+const keyRefetchInterval = 10 * time.Second
+
+// keyMaxAge is how long cached keys are used before a background refresh.
+// Unknown-keyID refetches only pick up keys ADDED to the issuer's JWKS;
+// without a periodic refresh, a key REMOVED from the JWKS (revoked) would be
+// trusted until process restart, because tokens signed by it keep hitting the
+// cache. keyMaxAge bounds that exposure. Refreshes are asynchronous: requests
+// are served from the current cache while the fetch runs, so this adds no
+// latency to any request.
+const keyMaxAge = 5 * time.Minute
+
+// CachedVerifier verifies Kubernetes JWTs, caching each issuer's verification
+// keys in memory. Keys are fetched on first use, refetched synchronously when
+// a JWT presents an unknown keyID (i.e. on key rotation, rate-limited to one
+// fetch per issuer per keyRefetchInterval), and refreshed in the background
+// once cached keys are older than keyMaxAge (so revoked keys age out).
+type CachedVerifier struct {
+	httpClient *http.Client
+
+	// flight coalesces concurrent key fetches for the same issuer.
+	flight singleflight.Group
+
+	mu sync.Mutex
+	// issuers holds one entry per issuer that has been used for verification.
+	// Its size is bounded by the number of distinct trusted issuers the
+	// process is configured with (in practice one): Verify rejects tokens
+	// whose issuer differs from expectedIssuer before consulting the cache,
+	// so unverified traffic cannot create entries.
+	issuers map[string]*issuerKeys
+}
+
+type issuerKeys struct {
+	keys      []*KeyAndID
+	lastFetch time.Time
+	// refreshing is true while a background max-age refresh is in flight,
+	// so cache hits don't spawn one goroutine each until it completes.
+	refreshing bool
+}
+
+// NewCachedVerifier creates a CachedVerifier. httpClient is used for OIDC
+// discovery and JWKS fetches; nil uses a default client with a whole-request
+// timeout.
+func NewCachedVerifier(httpClient *http.Client) *CachedVerifier {
+	return &CachedVerifier{
+		httpClient: httpClient,
+		issuers:    make(map[string]*issuerKeys),
+	}
+}
+
+// keyForIssuer returns the issuer's verification key with the given keyID,
+// (re)fetching the issuer's keys if the keyID is not already cached.
+func (v *CachedVerifier) keyForIssuer(ctx context.Context, issuer, keyID string, now time.Time) (crypto.PublicKey, error) {
+	// Can't defer Unlock(): the lock must be dropped before the network fetch
+	// below and re-taken afterwards, so it is managed manually at each return.
+	v.mu.Lock()
+	state, ok := v.issuers[issuer]
+	if !ok {
+		state = &issuerKeys{}
+		v.issuers[issuer] = state
+	}
+	if key := findKey(state.keys, keyID); key != nil {
+		// Serve from cache, but refresh in the background once the keys pass
+		// keyMaxAge so removed (revoked) keys age out; see keyMaxAge.
+		startRefresh := now.Sub(state.lastFetch) > keyMaxAge && !state.refreshing
+		if startRefresh {
+			state.refreshing = true
+		}
+		v.mu.Unlock()
+		if startRefresh {
+			go v.refreshIssuerKeys(issuer, state, now)
+		}
+		return key.PublicKey, nil
+	}
+	lastFetch := state.lastFetch
+	v.mu.Unlock()
+	if !lastFetch.IsZero() && now.Sub(lastFetch) < keyRefetchInterval {
+		return nil, fmt.Errorf("keyID %q not found in cache, refetch throttled, last fetch was at %v", keyID, lastFetch)
+	}
+
+	_, err, _ := v.flight.Do(issuer, func() (any, error) {
+		keys, err := discoverKeysForIssuer(ctx, v.httpClient, issuer)
+		v.mu.Lock()
+		defer v.mu.Unlock()
+		// Whether or not the fetch succeeded, don't try again for another
+		// interval, so a failing issuer isn't hammered.
+		state.lastFetch = now
+		if err != nil {
+			return nil, err
+		}
+		state.keys = keys
+		return nil, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("while discovering keys from issuer for keyID %q: %w", keyID, err)
+	}
+
+	v.mu.Lock()
+	key := findKey(state.keys, keyID)
+	v.mu.Unlock()
+	if key == nil {
+		return nil, fmt.Errorf("unknown keyID %q", keyID)
+	}
+	return key.PublicKey, nil
+}
+
+// refreshIssuerKeys refetches an issuer's keys, replacing the cached set on
+// success and keeping the previous keys on failure (a transient discovery
+// outage must not take down verification). Runs off the request path; the
+// caller must have set state.refreshing under the lock.
+func (v *CachedVerifier) refreshIssuerKeys(issuer string, state *issuerKeys, now time.Time) {
+	_, err, _ := v.flight.Do(issuer, func() (any, error) {
+		// context.Background(): this outlives the request that noticed the
+		// stale keys; the HTTP client's own timeout bounds the fetch.
+		keys, err := discoverKeysForIssuer(context.Background(), v.httpClient, issuer)
+		v.mu.Lock()
+		defer v.mu.Unlock()
+		// Whether or not the fetch succeeded, don't try again for another
+		// interval, so a failing issuer isn't hammered.
+		state.lastFetch = now
+		if err != nil {
+			return nil, err
+		}
+		state.keys = keys
+		return nil, nil
+	})
+	// Reset refreshing outside the closure: flight.Do coalesces with the
+	// unknown-keyID fetch path, so our closure may never run — the flag must
+	// clear whenever the shared flight completes.
+	v.mu.Lock()
+	state.refreshing = false
+	v.mu.Unlock()
+	if err != nil {
+		slog.Warn("Background refresh of issuer keys failed; keeping previous keys",
+			slog.String("issuer", issuer), slog.Any("err", err))
+	}
+}
+
+func findKey(keys []*KeyAndID, keyID string) *KeyAndID {
+	i := slices.IndexFunc(keys, func(k *KeyAndID) bool {
+		return k.KeyID == keyID
+	})
+	if i == -1 {
+		return nil
+	}
+	return keys[i]
+}
+
+// Verify is a convenience wrapper that performs a one-shot verification with
+// no key caching: every call refetches the issuer's keys. Hot paths should
+// share a CachedVerifier instead.
+//
+// httpClient is used for OIDC discovery and JWKS fetches; nil uses a default
+// client with a whole-request timeout.
+func Verify(ctx context.Context, httpClient *http.Client, jwt string, expectedIssuer, expectedAudience string, now time.Time) (*KubernetesClaims, error) {
+	return NewCachedVerifier(httpClient).Verify(ctx, jwt, expectedIssuer, expectedAudience, now)
+}
+
 // Verify verifies and extracts claims from a Kubernetes JWT.
 //
 // For bound service account tokens, this function performs cryptographic verification of the JWT,
@@ -122,10 +286,7 @@ var (
 // the object binding claims. If needed for your use case, you will need check the object bindings
 // by connecting to the cluster and seeing if the object(s) the bindings name still exist within the
 // cluster.
-//
-// httpClient is used for OIDC discovery and JWKS fetches; nil uses a default
-// client with a whole-request timeout.
-func Verify(ctx context.Context, httpClient *http.Client, jwt string, expectedIssuer, expectedAudience string, now time.Time) (*KubernetesClaims, error) {
+func (v *CachedVerifier) Verify(ctx context.Context, jwt string, expectedIssuer, expectedAudience string, now time.Time) (*KubernetesClaims, error) {
 	segments := strings.Split(jwt, ".")
 	if len(segments) != 3 {
 		return nil, fmt.Errorf("malformed JWT")
@@ -174,23 +335,14 @@ func Verify(ctx context.Context, httpClient *http.Client, jwt string, expectedIs
 		return nil, fmt.Errorf("unexpected issuer %q", rawClaims.Issuer)
 	}
 
-	// TODO: Cache keys, and only fetch new keys if the JWT's key ID is not in the cache.
-	keys, err := discoverKeysForIssuer(ctx, httpClient, rawClaims.Issuer)
-	if err != nil {
-		return nil, fmt.Errorf("while discovering keys from issuer: %w", err)
-	}
-
-	// Find the key we should use for verification based on the key ID in the JWT header.
+	// Find the key we should use for verification based on the keyID in the JWT header.
 	if header.KeyID == "" {
 		return nil, fmt.Errorf("key ID is required")
 	}
-	selectedKeyIndex := slices.IndexFunc(keys, func(k *KeyAndID) bool {
-		return k.KeyID == header.KeyID
-	})
-	if selectedKeyIndex == -1 {
-		return nil, fmt.Errorf("unknown key ID %q", header.KeyID)
+	selectedKey, err := v.keyForIssuer(ctx, rawClaims.Issuer, header.KeyID, now)
+	if err != nil {
+		return nil, err
 	}
-	selectedKey := keys[selectedKeyIndex].PublicKey
 
 	// Warning: don't ever refer to the payload data (except "iss") above this point. We need to
 	// ensure that we _never_ consider the contents of the payload when deciding how to perform

--- a/cmd/ateapi/internal/k8sjwt/k8sjwt_test.go
+++ b/cmd/ateapi/internal/k8sjwt/k8sjwt_test.go
@@ -30,6 +30,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -40,9 +41,14 @@ func b64url(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
 
 // testIssuer serves the OIDC discovery document and a JWKS built from the keys
 // registered on it, standing in for a Kubernetes API server's OIDC endpoints.
+// fetches counts discovery-document requests, so caching tests can assert how
+// often keys were actually (re)fetched.
 type testIssuer struct {
-	server *httptest.Server
-	jwks   jwkSetT
+	server  *httptest.Server
+	fetches atomic.Int64
+
+	mu   sync.Mutex // guards jwks: caching tests mutate it while a fetch may be serving
+	jwks jwkSetT
 }
 
 func newTestIssuer(t *testing.T) *testIssuer {
@@ -50,9 +56,12 @@ func newTestIssuer(t *testing.T) *testIssuer {
 	ti := &testIssuer{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		ti.fetches.Add(1)
 		writeJSON(t, w, oidcConfigT{JWKSURI: ti.server.URL + "/jwks"})
 	})
 	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		ti.mu.Lock()
+		defer ti.mu.Unlock()
 		writeJSON(t, w, ti.jwks)
 	})
 	ti.server = httptest.NewServer(mux)
@@ -63,12 +72,23 @@ func newTestIssuer(t *testing.T) *testIssuer {
 func (ti *testIssuer) issuer() string { return ti.server.URL }
 
 func (ti *testIssuer) addRSA(kid string, pub *rsa.PublicKey) {
+	ti.mu.Lock()
+	defer ti.mu.Unlock()
 	ti.jwks.Keys = append(ti.jwks.Keys, jwkT{
 		KeyType: "RSA",
 		KeyID:   kid,
 		RSAN:    b64url(pub.N.Bytes()),
 		RSAE:    b64url(big.NewInt(int64(pub.E)).Bytes()),
 	})
+}
+
+// setRSA replaces the entire JWKS with the single given key, simulating a
+// rotation that revokes every previously served key.
+func (ti *testIssuer) setRSA(kid string, pub *rsa.PublicKey) {
+	ti.mu.Lock()
+	ti.jwks = jwkSetT{}
+	ti.mu.Unlock()
+	ti.addRSA(kid, pub)
 }
 
 func (ti *testIssuer) addEC(t *testing.T, kid, crv string, pub *ecdsa.PublicKey) {
@@ -82,6 +102,8 @@ func (ti *testIssuer) addEC(t *testing.T, kid, crv string, pub *ecdsa.PublicKey)
 	}
 	raw := ecdhPub.Bytes()
 	size := (pub.Curve.Params().BitSize + 7) / 8
+	ti.mu.Lock()
+	defer ti.mu.Unlock()
 	ti.jwks.Keys = append(ti.jwks.Keys, jwkT{
 		KeyType:       "EC",
 		KeyID:         kid,
@@ -360,5 +382,146 @@ func TestEllipticCurveForJWK(t *testing.T) {
 	}
 	if _, err := ellipticCurveForJWK("P-192"); err == nil {
 		t.Error("ellipticCurveForJWK(P-192) = nil, want error")
+	}
+}
+
+func TestCachedVerifier_CachesKeysAcrossRequests(t *testing.T) {
+	ti := newTestIssuer(t)
+	key := testRSAKey(t)
+	ti.addRSA("kid-a", &key.PublicKey)
+	now := time.Now()
+
+	v := NewCachedVerifier(nil)
+	jwt := mintJWT(t, "RS256", "kid-a", key, validClaims(ti.issuer()))
+	for i := range 5 {
+		if _, err := v.Verify(context.Background(), jwt, ti.issuer(), testAudience, now); err != nil {
+			t.Fatalf("Verify #%d: %v", i, err)
+		}
+	}
+	if got := ti.fetches.Load(); got != 1 {
+		t.Errorf("issuer fetched %d times for 5 verifications, want 1", got)
+	}
+}
+
+func TestCachedVerifier_RefetchesOnKeyRotation(t *testing.T) {
+	ti := newTestIssuer(t)
+	key := testRSAKey(t)
+	ti.addRSA("kid-a", &key.PublicKey)
+	now := time.Now()
+
+	v := NewCachedVerifier(nil)
+	jwt := mintJWT(t, "RS256", "kid-a", key, validClaims(ti.issuer()))
+	if _, err := v.Verify(context.Background(), jwt, ti.issuer(), testAudience, now); err != nil {
+		t.Fatalf("Verify with old key: %v", err)
+	}
+
+	// Rotate: the JWKS gains kid-b and new tokens are signed with it. The
+	// unknown keyID triggers exactly one refetch once the throttle allows.
+	ti.addRSA("kid-b", &key.PublicKey)
+	later := now.Add(keyRefetchInterval + time.Second)
+	jwt = mintJWT(t, "RS256", "kid-b", key, validClaims(ti.issuer()))
+	if _, err := v.Verify(context.Background(), jwt, ti.issuer(), testAudience, later); err != nil {
+		t.Fatalf("Verify with rotated key: %v", err)
+	}
+	if got := ti.fetches.Load(); got != 2 {
+		t.Errorf("issuer fetched %d times, want 2 (initial + rotation)", got)
+	}
+}
+
+func TestCachedVerifier_UnknownKeyIDRefetchIsThrottled(t *testing.T) {
+	ti := newTestIssuer(t)
+	key := testRSAKey(t)
+	ti.addRSA("kid-a", &key.PublicKey)
+	now := time.Now()
+
+	v := NewCachedVerifier(nil)
+	jwt := mintJWT(t, "RS256", "kid-a", key, validClaims(ti.issuer()))
+	if _, err := v.Verify(context.Background(), jwt, ti.issuer(), testAudience, now); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	// A burst of tokens with a bogus keyID must not cause a fetch per
+	// request: within the throttle window they fail without refetching.
+	bogus := mintJWT(t, "RS256", "no-such-kid", key, validClaims(ti.issuer()))
+	for range 5 {
+		soon := now.Add(time.Second)
+		if _, err := v.Verify(context.Background(), bogus, ti.issuer(), testAudience, soon); err == nil {
+			t.Fatal("Verify with bogus keyID unexpectedly succeeded")
+		}
+	}
+	if got := ti.fetches.Load(); got != 1 {
+		t.Errorf("issuer fetched %d times during bogus-kid burst, want 1", got)
+	}
+
+	// Once the window passes, one refetch happens (and still fails).
+	later := now.Add(keyRefetchInterval + time.Second)
+	if _, err := v.Verify(context.Background(), bogus, ti.issuer(), testAudience, later); err == nil {
+		t.Fatal("Verify with bogus keyID unexpectedly succeeded")
+	}
+	if got := ti.fetches.Load(); got != 2 {
+		t.Errorf("issuer fetched %d times after throttle window, want 2", got)
+	}
+}
+
+func TestCachedVerifier_BackgroundRefreshDropsRevokedKeys(t *testing.T) {
+	ti := newTestIssuer(t)
+	key := testRSAKey(t)
+	ti.addRSA("kid-a", &key.PublicKey)
+	now := time.Now()
+
+	v := NewCachedVerifier(nil)
+	jwt := mintJWT(t, "RS256", "kid-a", key, validClaims(ti.issuer()))
+	if _, err := v.Verify(context.Background(), jwt, ti.issuer(), testAudience, now); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	// Revoke kid-a: the issuer's JWKS now only contains kid-b. Tokens signed
+	// with kid-a still hit the cache, so nothing refetches until keyMaxAge.
+	ti.setRSA("kid-b", &key.PublicKey)
+
+	// Within keyMaxAge the revoked key keeps verifying from cache, and no
+	// refresh is triggered.
+	if _, err := v.Verify(context.Background(), jwt, ti.issuer(), testAudience, now.Add(time.Minute)); err != nil {
+		t.Fatalf("Verify within keyMaxAge: %v", err)
+	}
+	if got := ti.fetches.Load(); got != 1 {
+		t.Fatalf("issuer fetched %d times within keyMaxAge, want 1", got)
+	}
+
+	// Past keyMaxAge, a hit still succeeds (stale-while-revalidate) but kicks
+	// off a background refresh.
+	stale := now.Add(keyMaxAge + time.Second)
+	if _, err := v.Verify(context.Background(), jwt, ti.issuer(), testAudience, stale); err != nil {
+		t.Fatalf("Verify at expiry (should serve stale): %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for ti.fetches.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := ti.fetches.Load(); got != 2 {
+		t.Fatalf("issuer fetched %d times after keyMaxAge, want 2 (background refresh)", got)
+	}
+
+	// The refresh may still be applying the new key set; poll until the
+	// revoked key stops verifying.
+	rejected := false
+	for time.Now().Before(deadline) {
+		if _, err := v.Verify(context.Background(), jwt, ti.issuer(), testAudience, stale.Add(time.Second)); err != nil {
+			rejected = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !rejected {
+		t.Fatal("token signed by revoked key still verifies after background refresh")
+	}
+
+	// The replacement key verifies from the refreshed cache with no extra fetch.
+	fresh := mintJWT(t, "RS256", "kid-b", key, validClaims(ti.issuer()))
+	if _, err := v.Verify(context.Background(), fresh, ti.issuer(), testAudience, stale.Add(time.Second)); err != nil {
+		t.Fatalf("Verify with rotated key after refresh: %v", err)
+	}
+	if got := ti.fetches.Load(); got != 2 {
+		t.Errorf("issuer fetched %d times, want 2 (new key served from refreshed cache)", got)
 	}
 }

--- a/cmd/ateapi/internal/sessionidentity/sessionidentity.go
+++ b/cmd/ateapi/internal/sessionidentity/sessionidentity.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -52,19 +51,19 @@ type Server struct {
 	sessionIDCAPoolFile  string
 
 	workerCACerts string
-	httpClient    *http.Client
+	verifier      *k8sjwt.CachedVerifier
 }
 
 var _ ateapipb.SessionIdentityServer = (*Server)(nil)
 
-func New(clientJWTIssuer, clientJWTAudience, sessionIDJWTPoolFile, sessionIDCAPoolFile, workerCACerts string, httpClient *http.Client) *Server {
+func New(clientJWTIssuer, clientJWTAudience, sessionIDJWTPoolFile, sessionIDCAPoolFile, workerCACerts string, verifier *k8sjwt.CachedVerifier) *Server {
 	return &Server{
 		clientJWTIssuer:      clientJWTIssuer,
 		clientJWTAudience:    clientJWTAudience,
 		sessionIDJWTPoolFile: sessionIDJWTPoolFile,
 		sessionIDCAPoolFile:  sessionIDCAPoolFile,
 		workerCACerts:        workerCACerts,
-		httpClient:           httpClient,
+		verifier:             verifier,
 	}
 }
 
@@ -81,7 +80,7 @@ func (s *Server) MintJWT(ctx context.Context, req *ateapipb.MintJWTRequest) (*at
 
 	clientJWT := strings.TrimPrefix(authorization[0], "Bearer ")
 
-	clientClaims, err := k8sjwt.Verify(ctx, s.httpClient, clientJWT, s.clientJWTIssuer, s.clientJWTAudience, time.Now())
+	clientClaims, err := s.verifier.Verify(ctx, clientJWT, s.clientJWTIssuer, s.clientJWTAudience, time.Now())
 	if err != nil {
 		slog.ErrorContext(ctx, "Error while verifying client JWT", slog.Any("err", err))
 		return nil, status.Errorf(codes.Unauthenticated, "Unauthenticated")

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -170,7 +170,11 @@ func main() {
 
 	jwtIssuerDiscoveryClient := buildK8sServiceAccountIssuerDiscoveryClient(ctx, *clientJWTCAFile, *clientJWTIssuer)
 
-	sessionIdentitySrv := sessionidentity.New(*clientJWTIssuer, *clientJWTAudience, *sessionIDJWTPoolFile, *sessionIDCAPoolFile, *podIdentityCACerts, jwtIssuerDiscoveryClient)
+	// One verifier shared by the auth interceptor and the session-identity
+	// service, so they share the issuer's cached verification keys.
+	jwtVerifier := k8sjwt.NewCachedVerifier(jwtIssuerDiscoveryClient)
+
+	sessionIdentitySrv := sessionidentity.New(*clientJWTIssuer, *clientJWTAudience, *sessionIDJWTPoolFile, *sessionIDCAPoolFile, *podIdentityCACerts, jwtVerifier)
 	debugSrv := debugapi.NewService(redisPersistence)
 
 	lisCfg := &net.ListenConfig{}
@@ -181,7 +185,7 @@ func main() {
 
 	authCfg := ateapiauth.ServerConfig{
 		VerifyBearerToken: func(ctx context.Context, bearer string) (string, error) {
-			claims, err := k8sjwt.Verify(ctx, jwtIssuerDiscoveryClient, bearer, *clientJWTIssuer, *clientJWTAudience, time.Now())
+			claims, err := jwtVerifier.Verify(ctx, bearer, *clientJWTIssuer, *clientJWTAudience, time.Now())
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
Previously every `k8sjwt.Verify` call performed a full OIDC discovery (two HTTP round trips: the discovery document plus the JWKS) against the issuer. In JWT auth mode that cost was paid on every authenticated RPC, and MintJWT paid it again for the client token.

Introduce `k8sjwt.Verifier`, which caches each issuer's verification keys in memory. Keys are only refetched when a JWT presents an unknown key ID (i.e. on key rotation). Since the triggering key ID comes from an unverified token, refetches are rate-limited to one per issuer per 10s so bogus key IDs cannot force a fetch storm, and concurrent misses are coalesced with `singleflight`. The auth interceptor and the session-identity service share one Verifier.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
