### PR TITLE
controlapi: Add worker pool metadata to workers

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -283,7 +283,7 @@ func setupTest(t *testing.T, ns string) *testContext {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	syncer := NewWorkerPoolSyncer(persistence, workerInformer)
+	syncer := NewWorkerPoolSyncer(persistence, workerInformer, workerPoolLister)
 	syncer.Start(ctx)
 
 	workerFactory.Start(ctx.Done())
@@ -1044,15 +1044,17 @@ func TestListActors_PageSizeValidation(t *testing.T) {
 
 // TestListWorkers tests that workers mirrored to Redis are listed.
 // Workflow:
-// 1. Creates a mock worker Pod in Kubernetes.
-// 2. Waits for the background WorkerPoolSyncer to mirror it to Redis.
-// 3. Calls ListWorkers RPC.
-// 4. Verifies that the worker appears in the response.
+// 1. Creates a mock WorkerPool in Kubernetes.
+// 2. Creates a mock worker Pod in Kubernetes belonging to that pool.
+// 3. Waits for the background WorkerPoolSyncer to mirror it to Redis.
+// 4. Calls ListWorkers RPC.
+// 5. Verifies that the worker appears in the response.
 func TestListWorkers(t *testing.T) {
 	ns := namespaceForTest("ns-list-workers")
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
 
+	createWorkerPool(t, tc, ns, "pool1", map[string]string{"foo": "bar"})
 	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
 
 	listResp, err := tc.client.ListWorkers(context.Background(), &ateapipb.ListWorkersRequest{})
@@ -1075,6 +1077,8 @@ func TestListWorkers(t *testing.T) {
 			NodeName:        "node1",
 			Ip:              "127.0.0.1",
 			Version:         1,
+			SandboxClass:    "gvisor",
+			Labels:          map[string]string{"foo": "bar"},
 		},
 	}
 
@@ -1176,8 +1180,10 @@ func TestResumeActor(t *testing.T) {
 				Atespace: testAtespace,
 			},
 		},
-		Ip:       "127.0.0.1",
-		NodeName: "node1",
+		Ip:           "127.0.0.1",
+		NodeName:     "node1",
+		SandboxClass: "gvisor",
+		Labels:       map[string]string{poolLabelKey: ns},
 	}
 
 	if diff := cmp.Diff(wantWorker, actorWorker, protocmp.Transform(), protocmp.IgnoreFields(&ateapipb.Worker{}, "version"), protocmp.IgnoreFields(&ateapipb.Worker{}, "worker_pod_uid")); diff != "" {
@@ -1296,34 +1302,6 @@ func TestResumeActor_NoWorkers(t *testing.T) {
 		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: id},
 	})
 	assertGrpcError(t, err, codes.FailedPrecondition, "no free workers available")
-}
-
-// TestResumeActor_NoEligiblePool tests the distinct failure mode from
-// TestResumeActor_NoWorkers: here no WorkerPool's labels satisfy the
-// template's WorkerSelector at all, so there isn't even a pool to look for
-// free workers in.
-func TestResumeActor_NoEligiblePool(t *testing.T) {
-	ns := namespaceForTest("ns-resume-no-eligible-pool")
-	tc := setupTest(t, ns)
-	defer tc.cleanup()
-
-	createTemplateWithSelector(t, tc, ns, "tmpl1", &metav1.LabelSelector{
-		MatchLabels: map[string]string{"nonexistent": ns},
-	})
-
-	createResp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
-	})
-	if err != nil {
-		t.Fatalf("CreateActor failed: %v", err)
-	}
-
-	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: createResp.GetActor().GetActorId()},
-	})
-	assertGrpcError(t, err, codes.FailedPrecondition, "no worker pool matches the template's sandboxClass and the template/actor selectors")
 }
 
 // TestResumeActor_MultiPoolSelector exercises the AND-of-two-selectors path

--- a/cmd/ateapi/internal/controlapi/syncer.go
+++ b/cmd/ateapi/internal/controlapi/syncer.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"maps"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/resources"
+	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -31,15 +33,17 @@ import (
 // WorkerPoolSyncer reconciles the state of worker pods from Kubernetes Informer
 // into the store.
 type WorkerPoolSyncer struct {
-	persistence    store.Interface
-	workerInformer cache.SharedIndexInformer
+	persistence      store.Interface
+	workerInformer   cache.SharedIndexInformer
+	workerPoolLister listersv1alpha1.WorkerPoolLister
 }
 
 // NewWorkerPoolSyncer creates a new WorkerPoolSyncer.
-func NewWorkerPoolSyncer(persistence store.Interface, workerInformer cache.SharedIndexInformer) *WorkerPoolSyncer {
+func NewWorkerPoolSyncer(persistence store.Interface, workerInformer cache.SharedIndexInformer, workerPoolLister listersv1alpha1.WorkerPoolLister) *WorkerPoolSyncer {
 	return &WorkerPoolSyncer{
-		persistence:    persistence,
-		workerInformer: workerInformer,
+		persistence:      persistence,
+		workerInformer:   workerInformer,
+		workerPoolLister: workerPoolLister,
 	}
 }
 
@@ -113,17 +117,26 @@ func (s *WorkerPoolSyncer) syncWorkerToStore(ctx context.Context, pod *corev1.Po
 		return
 	}
 
-	w, err := s.persistence.GetWorker(ctx, pod.Namespace, pod.Labels[workerPodLabel], pod.Name)
+	poolName := pod.Labels[workerPodLabel]
+	pool, err := s.workerPoolLister.WorkerPools(pod.Namespace).Get(poolName)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to get WorkerPool for worker pod", slog.String("worker", pod.Namespace+"/"+pod.Name), slog.String("pool", poolName), slog.Any("err", err))
+		return
+	}
+
+	w, err := s.persistence.GetWorker(ctx, pod.Namespace, poolName, pod.Name)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			slog.InfoContext(ctx, "Syncer: creating worker in store", slog.String("worker", pod.Namespace+"/"+pod.Name))
 			worker := &ateapipb.Worker{
 				WorkerNamespace: pod.Namespace,
-				WorkerPool:      pod.Labels[workerPodLabel],
+				WorkerPool:      poolName,
 				WorkerPod:       pod.Name,
 				Ip:              pod.Status.PodIP,
 				WorkerPodUid:    string(pod.UID),
 				NodeName:        pod.Spec.NodeName,
+				SandboxClass:    string(pool.Spec.SandboxClass),
+				Labels:          pool.GetLabels(),
 			}
 			// TODO(thockin): for now this is the only place Workers are
 			// created.  If/when this becomes a regular API, validation should
@@ -143,10 +156,25 @@ func (s *WorkerPoolSyncer) syncWorkerToStore(ctx context.Context, pod *corev1.Po
 		return
 	}
 
+	changed := false
 	if w.Ip != pod.Status.PodIP {
 		// TODO: I don't think this is possible, but handling this case so we can log it just in case we can reproduce it.
 		slog.InfoContext(ctx, "Syncer: updating worker in store (IP changed)", slog.String("worker", pod.Namespace+"/"+pod.Name))
 		w.Ip = pod.Status.PodIP
+		changed = true
+	}
+	if w.SandboxClass != string(pool.Spec.SandboxClass) {
+		slog.InfoContext(ctx, "Syncer: updating worker in store (SandboxClass changed)", slog.String("worker", pod.Namespace+"/"+pod.Name))
+		w.SandboxClass = string(pool.Spec.SandboxClass)
+		changed = true
+	}
+	if !maps.Equal(w.Labels, pool.GetLabels()) {
+		slog.InfoContext(ctx, "Syncer: updating worker in store (labels changed)", slog.String("worker", pod.Namespace+"/"+pod.Name))
+		w.Labels = pool.GetLabels()
+		changed = true
+	}
+
+	if changed {
 		if err = s.persistence.UpdateWorker(ctx, w, w.Version); err != nil {
 			slog.ErrorContext(ctx, "Failed to update worker in store", slog.Any("err", err))
 		}

--- a/cmd/ateapi/internal/controlapi/syncer_test.go
+++ b/cmd/ateapi/internal/controlapi/syncer_test.go
@@ -18,20 +18,25 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	atefake "github.com/agent-substrate/substrate/pkg/client/clientset/versioned/fake"
+	"github.com/agent-substrate/substrate/pkg/client/informers/externalversions"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 // setupSyncerTest sets up a real store with fake Redis and a fake K8s client with informer.
-func setupSyncerTest(t *testing.T, ctx context.Context) (store.Interface, *fake.Clientset, func()) {
+func setupSyncerTest(t *testing.T, ctx context.Context, initPools ...*atev1alpha1.WorkerPool) (store.Interface, *fake.Clientset, *atefake.Clientset, func()) {
 	t.Helper()
 
 	persistence, cleanup := storetest.SetupTestStore(t)
@@ -39,25 +44,48 @@ func setupSyncerTest(t *testing.T, ctx context.Context) (store.Interface, *fake.
 	fakeK8s := fake.NewSimpleClientset()
 	workerFactory, workerInformer := WorkerPodInformer(fakeK8s)
 
-	syncer := NewWorkerPoolSyncer(persistence, workerInformer)
+	objects := make([]runtime.Object, len(initPools))
+	for i, pool := range initPools {
+		objects[i] = pool
+	}
+	//nolint:staticcheck // NewSimpleClientset is the only available fake clientset for versioned CRDs.
+	fakeAte := atefake.NewSimpleClientset(objects...)
+	ateInformerFactory := externalversions.NewSharedInformerFactory(fakeAte, 0)
+	workerPoolLister := ateInformerFactory.Api().V1alpha1().WorkerPools().Lister()
+
+	syncer := NewWorkerPoolSyncer(persistence, workerInformer, workerPoolLister)
 	syncer.Start(ctx)
 
 	workerFactory.Start(ctx.Done())
-	workerFactory.WaitForCacheSync(ctx.Done())
+	ateInformerFactory.Start(ctx.Done())
 
-	return persistence, fakeK8s, cleanup
+	workerFactory.WaitForCacheSync(ctx.Done())
+	ateInformerFactory.WaitForCacheSync(ctx.Done())
+
+	return persistence, fakeK8s, fakeAte, cleanup
 }
 
 func TestSyncer_Lifecycle(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	persistence, fakeK8s, cleanup := setupSyncerTest(t, ctx)
-	defer cleanup()
-
 	ns := "ns-syncer-lifecycle"
 	podName := "worker-unit-1"
 	poolName := "pool1"
+
+	pool := &atev1alpha1.WorkerPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: ns,
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: atev1alpha1.WorkerPoolSpec{
+			SandboxClass: "gvisor",
+		},
+	}
+
+	persistence, fakeK8s, _, cleanup := setupSyncerTest(t, ctx, pool)
+	defer cleanup()
 
 	// 1. Verify no workers in Redis initially
 	workers, err := persistence.ListWorkers(context.Background())
@@ -127,7 +155,16 @@ func TestSyncer_Lifecycle(t *testing.T) {
 			}
 			return false, err
 		}
-		return w.Ip == "127.0.0.1", nil
+		if w.Ip != "127.0.0.1" {
+			return false, nil
+		}
+		if w.SandboxClass != "gvisor" {
+			return false, fmt.Errorf("expected SandboxClass gvisor, got %q", w.SandboxClass)
+		}
+		if !maps.Equal(w.Labels, map[string]string{"foo": "bar"}) {
+			return false, fmt.Errorf("expected labels map[foo:bar], got %v", w.Labels)
+		}
+		return true, nil
 	})
 	if err != nil {
 		t.Fatalf("Worker not found in Redis after update: %v", err)
@@ -159,10 +196,20 @@ func TestSyncer_DeleteBoundWorker_ClearsActor(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	persistence, fakeK8s, cleanup := setupSyncerTest(t, ctx)
-	defer cleanup()
-
 	ns, pool, pod, ip := "ns-orphan", "pool1", "worker-orphan", "10.0.0.1"
+	workerPool := &atev1alpha1.WorkerPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pool,
+			Namespace: ns,
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: atev1alpha1.WorkerPoolSpec{
+			SandboxClass: "gvisor",
+		},
+	}
+
+	persistence, fakeK8s, _, cleanup := setupSyncerTest(t, ctx, workerPool)
+	defer cleanup()
 	if _, err := fakeK8s.CoreV1().Pods(ns).Create(ctx,
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -238,5 +285,78 @@ func TestSyncer_DeleteBoundWorker_ClearsActor(t *testing.T) {
 	}
 	if got.GetLatestSnapshotInfo().GetExternal().SnapshotUriPrefix == "" {
 		t.Errorf("External SnapshotUriPrefix must be preserved")
+	}
+}
+
+func TestSyncer_OmittedFields(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ns := "ns-syncer-omitted"
+	podName := "worker-unit-1"
+	poolName := "pool1"
+
+	// Create a pool with omitted sandbox class and no labels
+	pool := &atev1alpha1.WorkerPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: ns,
+		},
+		Spec: atev1alpha1.WorkerPoolSpec{
+			// Spec has no SandboxClass and no Labels
+		},
+	}
+
+	persistence, fakeK8s, _, cleanup := setupSyncerTest(t, ctx, pool)
+	defer cleanup()
+
+	// Create a pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+			UID:       "08675309-4a65-6e6e-7973-6e756d626572",
+			Labels: map[string]string{
+				workerPodLabel: poolName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   "node1",
+			Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
+			PodIP:  "127.0.0.1",
+			PodIPs: []corev1.PodIP{{IP: "127.0.0.1"}},
+		},
+	}
+
+	_, err := fakeK8s.CoreV1().Pods(ns).Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	// Verify that it is created in Redis with empty SandboxClass and empty Labels
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		w, err := persistence.GetWorker(ctx, ns, poolName, podName)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return false, nil
+			}
+			return false, err
+		}
+		if w.Ip != "127.0.0.1" {
+			return false, nil
+		}
+		if w.SandboxClass != "" {
+			return false, fmt.Errorf("expected SandboxClass to be empty, got %q", w.SandboxClass)
+		}
+		if len(w.Labels) != 0 {
+			return false, fmt.Errorf("expected labels to be empty, got %v", w.Labels)
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("Worker state check failed: %v", err)
 	}
 }

--- a/cmd/ateapi/internal/controlapi/workflow.go
+++ b/cmd/ateapi/internal/controlapi/workflow.go
@@ -166,7 +166,7 @@ func (w *ActorWorkflow) ResumeActor(ctx context.Context, atespace, id string, bo
 
 	steps := []WorkflowStep[*ResumeInput, *ResumeState]{
 		&LoadActorForResumeStep{store: w.store, actorTemplateLister: w.actorTemplateLister},
-		&AssignWorkerStep{store: w.store, workerCache: w.workerCache, workerPoolLister: w.workerPoolLister},
+		&AssignWorkerStep{store: w.store, workerCache: w.workerCache},
 		&CallAteletRestoreStep{store: w.store, dialer: w.dialer, kubeClient: w.kubeClient, secretCache: w.secretCache, workerPoolLister: w.workerPoolLister, sandboxConfigLister: w.sandboxConfigLister},
 		&FinalizeRunningStep{store: w.store},
 	}

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
@@ -83,39 +82,32 @@ func (s *LoadActorForResumeStep) Execute(ctx context.Context, input *ResumeInput
 
 func (s *LoadActorForResumeStep) RetryBackoff() *wait.Backoff { return nil }
 
-func eligibleWorkerPools(pools []*atev1alpha1.WorkerPool, templateClass atev1alpha1.SandboxClass, templateSelector *metav1.LabelSelector, actorSelector *ateapipb.Selector) (map[types.NamespacedName]struct{}, error) {
+func isWorkerEligibleForActor(worker *ateapipb.Worker, templateClass atev1alpha1.SandboxClass, templateSelector *metav1.LabelSelector, actorSelector *ateapipb.Selector) (bool, error) {
+	// Snapshots are not portable across sandbox classes, so the worker's class
+	// must match the template's. Both classes are populated by the CRD default
+	// (gvisor), so we compare them directly.
+	if worker.GetSandboxClass() != string(templateClass) {
+		return false, nil
+	}
+
 	templateSel := labels.Everything()
 	if templateSelector != nil {
 		sel, err := metav1.LabelSelectorAsSelector(templateSelector)
 		if err != nil {
-			return nil, fmt.Errorf("invalid template worker selector: %w", err)
+			return false, fmt.Errorf("invalid template worker selector: %w", err)
 		}
 		templateSel = sel
 	}
 
 	actorSel := labels.SelectorFromSet(labels.Set(actorSelector.GetMatchLabels()))
 
-	eligible := make(map[types.NamespacedName]struct{})
-	for _, pool := range pools {
-		// Snapshots are not portable across sandbox classes, so the pool's class
-		// must match the template's. This is a hard gate AND'd with the label
-		// selectors below. Both classes are populated by the CRD default (gvisor),
-		// so we compare them directly.
-		if pool.Spec.SandboxClass != templateClass {
-			continue
-		}
-		set := labels.Set(pool.GetLabels())
-		if templateSel.Matches(set) && actorSel.Matches(set) {
-			eligible[types.NamespacedName{Namespace: pool.GetNamespace(), Name: pool.GetName()}] = struct{}{}
-		}
-	}
-	return eligible, nil
+	set := labels.Set(worker.GetLabels())
+	return templateSel.Matches(set) && actorSel.Matches(set), nil
 }
 
 type AssignWorkerStep struct {
-	store            store.Interface
-	workerCache      *workercache.Cache
-	workerPoolLister listersv1alpha1.WorkerPoolLister
+	store       store.Interface
+	workerCache *workercache.Cache
 }
 
 func (s *AssignWorkerStep) Name() string { return "AssignWorker" }
@@ -124,18 +116,6 @@ func (s *AssignWorkerStep) IsComplete(ctx context.Context, input *ResumeInput, s
 	return state.Actor.GetStatus() == ateapipb.Actor_STATUS_RUNNING, nil
 }
 func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, state *ResumeState) error {
-	pools, err := s.workerPoolLister.List(labels.Everything())
-	if err != nil {
-		return fmt.Errorf("while listing worker pools: %w", err)
-	}
-	eligible, err := eligibleWorkerPools(pools, state.ActorTemplate.Spec.SandboxClass, state.ActorTemplate.Spec.WorkerSelector, state.Actor.GetWorkerSelector())
-	if err != nil {
-		return fmt.Errorf("while computing eligible worker pools: %w", err)
-	}
-	if len(eligible) == 0 {
-		return status.Errorf(codes.FailedPrecondition, "no worker pool matches the template's sandboxClass and the template/actor selectors")
-	}
-
 	workers, err := s.workerCache.Workers()
 	if err != nil {
 		return fmt.Errorf("while listing workers: %w", err)
@@ -155,7 +135,11 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 		if worker.Assignment.Actor.Name != input.ActorID {
 			continue
 		}
-		if _, ok := eligible[types.NamespacedName{Namespace: worker.GetWorkerNamespace(), Name: worker.GetWorkerPool()}]; ok {
+		eligible, err := isWorkerEligibleForActor(worker, state.ActorTemplate.Spec.SandboxClass, state.ActorTemplate.Spec.WorkerSelector, state.Actor.GetWorkerSelector())
+		if err != nil {
+			return fmt.Errorf("while checking worker eligibility: %w", err)
+		}
+		if eligible {
 			assignedWorker = worker
 			break
 		}
@@ -170,7 +154,10 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 
 	// If not, find a free one using randomized shuffling
 	if assignedWorker == nil {
-		pickedWorker := s.findFreeWorker(workers, eligible, state.Actor.GetLatestSnapshotInfo().GetLocal().GetNodeVmsWithLocalSnapshots())
+		pickedWorker, err := s.findFreeWorker(workers, state.ActorTemplate.Spec.SandboxClass, state.ActorTemplate.Spec.WorkerSelector, state.Actor.GetWorkerSelector(), state.Actor.GetLatestSnapshotInfo().GetLocal().GetNodeVmsWithLocalSnapshots())
+		if err != nil {
+			return err
+		}
 		if pickedWorker == nil {
 			return status.Errorf(codes.FailedPrecondition, "no free workers available")
 		}
@@ -219,13 +206,23 @@ func (s *AssignWorkerStep) RetryBackoff() *wait.Backoff {
 	}
 }
 
-func (s *AssignWorkerStep) findFreeWorker(workers []*ateapipb.Worker, eligible map[types.NamespacedName]struct{}, nodesRestrictions []string) *ateapipb.Worker {
+func (s *AssignWorkerStep) findFreeWorker(
+	workers []*ateapipb.Worker,
+	templateClass atev1alpha1.SandboxClass,
+	templateSelector *metav1.LabelSelector,
+	actorSelector *ateapipb.Selector,
+	nodesRestrictions []string,
+) (*ateapipb.Worker, error) {
 	var freeWorkers []*ateapipb.Worker
 	for _, worker := range workers {
 		if worker.Assignment != nil {
 			continue
 		}
-		if _, ok := eligible[types.NamespacedName{Namespace: worker.GetWorkerNamespace(), Name: worker.GetWorkerPool()}]; !ok {
+		eligible, err := isWorkerEligibleForActor(worker, templateClass, templateSelector, actorSelector)
+		if err != nil {
+			return nil, err
+		}
+		if !eligible {
 			continue
 		}
 		if len(nodesRestrictions) == 0 || slices.Contains(nodesRestrictions, worker.GetNodeName()) {
@@ -237,9 +234,9 @@ func (s *AssignWorkerStep) findFreeWorker(workers []*ateapipb.Worker, eligible m
 		rand.Shuffle(len(freeWorkers), func(i, j int) {
 			freeWorkers[i], freeWorkers[j] = freeWorkers[j], freeWorkers[i]
 		})
-		return freeWorkers[0]
+		return freeWorkers[0], nil
 	}
-	return nil
+	return nil, nil
 }
 
 type CallAteletRestoreStep struct {

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -20,167 +20,144 @@ import (
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
-func pool(namespace, name string, labels map[string]string) *atev1alpha1.WorkerPool {
-	return &atev1alpha1.WorkerPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-			Labels:    labels,
-		},
-	}
-}
-
-func poolWithClass(namespace, name string, class atev1alpha1.SandboxClass, labels map[string]string) *atev1alpha1.WorkerPool {
-	p := pool(namespace, name, labels)
-	p.Spec.SandboxClass = class
-	return p
-}
-
-func TestEligibleWorkerPools(t *testing.T) {
+func TestIsWorkerEligibleForActor(t *testing.T) {
 	tests := []struct {
-		name              string
-		pools             []*atev1alpha1.WorkerPool
-		templateClass     atev1alpha1.SandboxClass
-		templateSelector  *metav1.LabelSelector
-		actorSelector     *ateapipb.Selector
-		wantEligibleNames []string // pool names expected in the result
+		name             string
+		worker           *ateapipb.Worker
+		templateClass    atev1alpha1.SandboxClass
+		templateSelector *metav1.LabelSelector
+		actorSelector    *ateapipb.Selector
+		wantEligible     bool
 	}{
 		{
 			name: "both nil matches everything",
-			pools: []*atev1alpha1.WorkerPool{
-				pool("ns", "a", map[string]string{"foo": "bar"}),
-				pool("ns", "b", nil),
+			worker: &ateapipb.Worker{
+				SandboxClass: "gvisor",
+				Labels:       map[string]string{"foo": "bar"},
 			},
-			templateSelector:  nil,
-			actorSelector:     nil,
-			wantEligibleNames: []string{"a", "b"},
+			templateClass:    atev1alpha1.SandboxClassGvisor,
+			templateSelector: nil,
+			actorSelector:    nil,
+			wantEligible:     true,
 		},
 		{
-			name: "template selector only",
-			pools: []*atev1alpha1.WorkerPool{
-				pool("ns", "match", map[string]string{"workload": "code-sandbox"}),
-				pool("ns", "nomatch", map[string]string{"workload": "browser-agent"}),
+			name: "template selector only match",
+			worker: &ateapipb.Worker{
+				SandboxClass: "gvisor",
+				Labels:       map[string]string{"workload": "code-sandbox"},
 			},
+			templateClass: atev1alpha1.SandboxClassGvisor,
 			templateSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"workload": "code-sandbox"},
 			},
-			actorSelector:     nil,
-			wantEligibleNames: []string{"match"},
+			actorSelector: nil,
+			wantEligible:  true,
 		},
 		{
-			name: "actor selector only",
-			pools: []*atev1alpha1.WorkerPool{
-				pool("ns", "match", map[string]string{"tier": "paid"}),
-				pool("ns", "nomatch", map[string]string{"tier": "free"}),
+			name: "template selector only no match",
+			worker: &ateapipb.Worker{
+				SandboxClass: "gvisor",
+				Labels:       map[string]string{"workload": "browser-agent"},
 			},
+			templateClass: atev1alpha1.SandboxClassGvisor,
+			templateSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"workload": "code-sandbox"},
+			},
+			actorSelector: nil,
+			wantEligible:  false,
+		},
+		{
+			name: "actor selector only match",
+			worker: &ateapipb.Worker{
+				SandboxClass: "gvisor",
+				Labels:       map[string]string{"tier": "paid"},
+			},
+			templateClass:    atev1alpha1.SandboxClassGvisor,
 			templateSelector: nil,
 			actorSelector: &ateapipb.Selector{
 				MatchLabels: map[string]string{"tier": "paid"},
 			},
-			wantEligibleNames: []string{"match"},
+			wantEligible: true,
 		},
 		{
-			name: "AND of two selectors on the same pool",
-			pools: []*atev1alpha1.WorkerPool{
-				pool("ns", "both", map[string]string{"workload": "code-sandbox", "tier": "paid"}),
-				pool("ns", "template-only", map[string]string{"workload": "code-sandbox", "tier": "free"}),
-				pool("ns", "actor-only", map[string]string{"workload": "browser-agent", "tier": "paid"}),
-				pool("ns", "neither", map[string]string{"workload": "browser-agent", "tier": "free"}),
+			name: "actor selector only no match",
+			worker: &ateapipb.Worker{
+				SandboxClass: "gvisor",
+				Labels:       map[string]string{"tier": "free"},
 			},
+			templateClass:    atev1alpha1.SandboxClassGvisor,
+			templateSelector: nil,
+			actorSelector: &ateapipb.Selector{
+				MatchLabels: map[string]string{"tier": "paid"},
+			},
+			wantEligible: false,
+		},
+		{
+			name: "AND of two selectors match",
+			worker: &ateapipb.Worker{
+				SandboxClass: "gvisor",
+				Labels:       map[string]string{"workload": "code-sandbox", "tier": "paid"},
+			},
+			templateClass: atev1alpha1.SandboxClassGvisor,
 			templateSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"workload": "code-sandbox"},
 			},
 			actorSelector: &ateapipb.Selector{
 				MatchLabels: map[string]string{"tier": "paid"},
 			},
-			wantEligibleNames: []string{"both"},
+			wantEligible: true,
 		},
 		{
-			name: "disjoint label keys: independent evaluation, not a merged map",
-			pools: []*atev1alpha1.WorkerPool{
-				// Has the template's key/value but not the actor's.
-				pool("ns", "template-key-only", map[string]string{"workload": "x"}),
-				// Has the actor's key/value but not the template's.
-				pool("ns", "actor-key-only", map[string]string{"zone": "y"}),
-				// Has both keys with matching values: must be the only eligible pool.
-				pool("ns", "both-keys", map[string]string{"workload": "x", "zone": "y"}),
+			name: "AND of two selectors one fails",
+			worker: &ateapipb.Worker{
+				SandboxClass: "gvisor",
+				Labels:       map[string]string{"workload": "code-sandbox", "tier": "free"},
 			},
+			templateClass: atev1alpha1.SandboxClassGvisor,
 			templateSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"workload": "x"},
+				MatchLabels: map[string]string{"workload": "code-sandbox"},
 			},
 			actorSelector: &ateapipb.Selector{
-				MatchLabels: map[string]string{"zone": "y"},
-			},
-			wantEligibleNames: []string{"both-keys"},
-		},
-		{
-			name: "no eligible pool",
-			pools: []*atev1alpha1.WorkerPool{
-				pool("ns", "a", map[string]string{"workload": "x"}),
-			},
-			templateSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"workload": "y"},
-			},
-			actorSelector:     nil,
-			wantEligibleNames: nil,
-		},
-		{
-			name: "microvm template matches only microvm pools",
-			pools: []*atev1alpha1.WorkerPool{
-				poolWithClass("ns", "micro", atev1alpha1.SandboxClassMicroVM, nil),
-				poolWithClass("ns", "gvisor", atev1alpha1.SandboxClassGvisor, nil),
-			},
-			templateClass:     atev1alpha1.SandboxClassMicroVM,
-			wantEligibleNames: []string{"micro"},
-		},
-		{
-			name: "gvisor template excludes microvm pools",
-			pools: []*atev1alpha1.WorkerPool{
-				poolWithClass("ns", "micro", atev1alpha1.SandboxClassMicroVM, nil),
-				poolWithClass("ns", "gvisor", atev1alpha1.SandboxClassGvisor, nil),
-			},
-			templateClass:     atev1alpha1.SandboxClassGvisor,
-			wantEligibleNames: []string{"gvisor"},
-		},
-		{
-			name: "class gate AND's with label selector",
-			pools: []*atev1alpha1.WorkerPool{
-				poolWithClass("ns", "match", atev1alpha1.SandboxClassMicroVM, map[string]string{"tier": "paid"}),
-				// Right class, wrong label.
-				poolWithClass("ns", "wrong-label", atev1alpha1.SandboxClassMicroVM, map[string]string{"tier": "free"}),
-				// Right label, wrong class.
-				poolWithClass("ns", "wrong-class", atev1alpha1.SandboxClassGvisor, map[string]string{"tier": "paid"}),
-			},
-			templateClass: atev1alpha1.SandboxClassMicroVM,
-			templateSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"tier": "paid"},
 			},
-			wantEligibleNames: []string{"match"},
+			wantEligible: false,
+		},
+		{
+			name: "microvm template matches only microvm worker",
+			worker: &ateapipb.Worker{
+				SandboxClass: "microvm",
+			},
+			templateClass: atev1alpha1.SandboxClassMicroVM,
+			wantEligible:  true,
+		},
+		{
+			name: "microvm template excludes gvisor worker",
+			worker: &ateapipb.Worker{
+				SandboxClass: "gvisor",
+			},
+			templateClass: atev1alpha1.SandboxClassMicroVM,
+			wantEligible:  false,
+		},
+		{
+			name: "gvisor template excludes microvm worker",
+			worker: &ateapipb.Worker{
+				SandboxClass: "microvm",
+			},
+			templateClass: atev1alpha1.SandboxClassGvisor,
+			wantEligible:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := eligibleWorkerPools(tt.pools, tt.templateClass, tt.templateSelector, tt.actorSelector)
+			got, err := isWorkerEligibleForActor(tt.worker, tt.templateClass, tt.templateSelector, tt.actorSelector)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			wantKeys := make(map[types.NamespacedName]struct{}, len(tt.wantEligibleNames))
-			for _, name := range tt.wantEligibleNames {
-				wantKeys[types.NamespacedName{Namespace: "ns", Name: name}] = struct{}{}
-			}
-
-			if len(got) != len(wantKeys) {
-				t.Fatalf("got %d eligible pools, want %d: got=%v want=%v", len(got), len(wantKeys), got, wantKeys)
-			}
-			for k := range wantKeys {
-				if _, ok := got[k]; !ok {
-					t.Errorf("expected pool %v to be eligible, but it was not: got=%v", k, got)
-				}
+			if got != tt.wantEligible {
+				t.Errorf("got eligible=%t, want %t", got, tt.wantEligible)
 			}
 		})
 	}

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -137,7 +137,7 @@ func main() {
 	workerPodInformerFactory, workerPodInformer := controlapi.WorkerPodInformer(clientset)
 	ateletPodInformerFactory, ateletPodInformer := controlapi.AteletInformer(clientset)
 
-	syncer := controlapi.NewWorkerPoolSyncer(redisPersistence, workerPodInformer)
+	syncer := controlapi.NewWorkerPoolSyncer(redisPersistence, workerPodInformer, workerPoolLister)
 	syncer.Start(ctx)
 
 	stopCh := make(chan struct{})

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -1794,6 +1794,8 @@ type Worker struct {
 	Version         int64                  `protobuf:"varint,6,opt,name=version,proto3" json:"version,omitempty"`
 	WorkerPodUid    string                 `protobuf:"bytes,7,opt,name=worker_pod_uid,json=workerPodUid,proto3" json:"worker_pod_uid,omitempty"`
 	NodeName        string                 `protobuf:"bytes,8,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
+	SandboxClass    string                 `protobuf:"bytes,9,opt,name=sandbox_class,json=sandboxClass,proto3" json:"sandbox_class,omitempty"`
+	Labels          map[string]string      `protobuf:"bytes,10,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1882,6 +1884,20 @@ func (x *Worker) GetNodeName() string {
 		return x.NodeName
 	}
 	return ""
+}
+
+func (x *Worker) GetSandboxClass() string {
+	if x != nil {
+		return x.SandboxClass
+	}
+	return ""
+}
+
+func (x *Worker) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
 }
 
 type Assignment struct {
@@ -2417,7 +2433,7 @@ const file_ateapi_proto_rawDesc = "" +
 	"\batespace\x18\x03 \x01(\tR\batespace\"c\n" +
 	"\x12ListActorsResponse\x12%\n" +
 	"\x06actors\x18\x01 \x03(\v2\r.ateapi.ActorR\x06actors\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x94\x02\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xa8\x03\n" +
 	"\x06Worker\x12)\n" +
 	"\x10worker_namespace\x18\x01 \x01(\tR\x0fworkerNamespace\x12\x1f\n" +
 	"\vworker_pool\x18\x02 \x01(\tR\n" +
@@ -2430,7 +2446,13 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x02ip\x18\x05 \x01(\tR\x02ip\x12\x18\n" +
 	"\aversion\x18\x06 \x01(\x03R\aversion\x12$\n" +
 	"\x0eworker_pod_uid\x18\a \x01(\tR\fworkerPodUid\x12\x1b\n" +
-	"\tnode_name\x18\b \x01(\tR\bnodeName\"|\n" +
+	"\tnode_name\x18\b \x01(\tR\bnodeName\x12#\n" +
+	"\rsandbox_class\x18\t \x01(\tR\fsandboxClass\x122\n" +
+	"\x06labels\x18\n" +
+	" \x03(\v2\x1a.ateapi.Worker.LabelsEntryR\x06labels\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"|\n" +
 	"\n" +
 	"Assignment\x12F\n" +
 	"\x0eactor_template\x18\x01 \x01(\v2\x1f.ateapi.KubeNamespacedObjectRefR\ractorTemplate\x12&\n" +
@@ -2492,7 +2514,7 @@ func file_ateapi_proto_rawDescGZIP() []byte {
 }
 
 var file_ateapi_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
 var file_ateapi_proto_goTypes = []any{
 	(Actor_Status)(0),               // 0: ateapi.Actor.Status
 	(*ExternalSnapshotInfo)(nil),    // 1: ateapi.ExternalSnapshotInfo
@@ -2538,6 +2560,7 @@ var file_ateapi_proto_goTypes = []any{
 	(*MintCertRequest)(nil),         // 41: ateapi.MintCertRequest
 	(*MintCertResponse)(nil),        // 42: ateapi.MintCertResponse
 	nil,                             // 43: ateapi.Selector.MatchLabelsEntry
+	nil,                             // 44: ateapi.Worker.LabelsEntry
 }
 var file_ateapi_proto_depIdxs = []int32{
 	1,  // 0: ateapi.SnapshotInfo.external:type_name -> ateapi.ExternalSnapshotInfo
@@ -2567,45 +2590,46 @@ var file_ateapi_proto_depIdxs = []int32{
 	34, // 24: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
 	5,  // 25: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
 	35, // 26: ateapi.Worker.assignment:type_name -> ateapi.Assignment
-	36, // 27: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	7,  // 28: ateapi.Assignment.actor:type_name -> ateapi.ActorRef
-	16, // 29: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	18, // 30: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	20, // 31: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	22, // 32: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	24, // 33: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	26, // 34: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	28, // 35: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	30, // 36: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	32, // 37: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	8,  // 38: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	10, // 39: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	12, // 40: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	14, // 41: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	37, // 42: ateapi.Control.DebugClear:input_type -> ateapi.DebugClearRequest
-	39, // 43: ateapi.SessionIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	41, // 44: ateapi.SessionIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	17, // 45: ateapi.Control.GetActor:output_type -> ateapi.GetActorResponse
-	19, // 46: ateapi.Control.CreateActor:output_type -> ateapi.CreateActorResponse
-	21, // 47: ateapi.Control.UpdateActor:output_type -> ateapi.UpdateActorResponse
-	23, // 48: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	25, // 49: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	27, // 50: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	29, // 51: ateapi.Control.DeleteActor:output_type -> ateapi.DeleteActorResponse
-	31, // 52: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	33, // 53: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	9,  // 54: ateapi.Control.CreateAtespace:output_type -> ateapi.CreateAtespaceResponse
-	11, // 55: ateapi.Control.GetAtespace:output_type -> ateapi.GetAtespaceResponse
-	13, // 56: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	15, // 57: ateapi.Control.DeleteAtespace:output_type -> ateapi.DeleteAtespaceResponse
-	38, // 58: ateapi.Control.DebugClear:output_type -> ateapi.DebugClearResponse
-	40, // 59: ateapi.SessionIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	42, // 60: ateapi.SessionIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	45, // [45:61] is the sub-list for method output_type
-	29, // [29:45] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	44, // 27: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
+	36, // 28: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
+	7,  // 29: ateapi.Assignment.actor:type_name -> ateapi.ActorRef
+	16, // 30: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	18, // 31: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	20, // 32: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	22, // 33: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	24, // 34: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	26, // 35: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	28, // 36: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	30, // 37: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	32, // 38: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	8,  // 39: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	10, // 40: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	12, // 41: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	14, // 42: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	37, // 43: ateapi.Control.DebugClear:input_type -> ateapi.DebugClearRequest
+	39, // 44: ateapi.SessionIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	41, // 45: ateapi.SessionIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	17, // 46: ateapi.Control.GetActor:output_type -> ateapi.GetActorResponse
+	19, // 47: ateapi.Control.CreateActor:output_type -> ateapi.CreateActorResponse
+	21, // 48: ateapi.Control.UpdateActor:output_type -> ateapi.UpdateActorResponse
+	23, // 49: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	25, // 50: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	27, // 51: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	29, // 52: ateapi.Control.DeleteActor:output_type -> ateapi.DeleteActorResponse
+	31, // 53: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	33, // 54: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	9,  // 55: ateapi.Control.CreateAtespace:output_type -> ateapi.CreateAtespaceResponse
+	11, // 56: ateapi.Control.GetAtespace:output_type -> ateapi.GetAtespaceResponse
+	13, // 57: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	15, // 58: ateapi.Control.DeleteAtespace:output_type -> ateapi.DeleteAtespaceResponse
+	38, // 59: ateapi.Control.DebugClear:output_type -> ateapi.DebugClearResponse
+	40, // 60: ateapi.SessionIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	42, // 61: ateapi.SessionIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	46, // [46:62] is the sub-list for method output_type
+	30, // [30:46] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }
@@ -2623,7 +2647,7 @@ func file_ateapi_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateapi_proto_rawDesc), len(file_ateapi_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   43,
+			NumMessages:   44,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -294,6 +294,8 @@ message Worker {
   int64  version         = 6;
   string worker_pod_uid  = 7;
   string node_name       = 8;
+  string sandbox_class   = 9;
+  map<string, string> labels = 10;
 }
 
 message Assignment {


### PR DESCRIPTION
Decouple the actor resumption scheduler from Kubernetes by avoiding direct queries to WorkerPool CRDs. Instead, cache the worker pool's labels and sandbox class on the Worker object in Redis during pod synchronization, and update the scheduler to evaluate worker eligibility using these cached fields.
