### PR TITLE
chore(otel): bump semconv v1.21.0 -> v1.40.0 and pin schema_url

### DIFF
--- a/internal/ateclient/builder.go
+++ b/internal/ateclient/builder.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
@@ -308,6 +308,7 @@ func (c bearerTokenCreds) RequireTransportSecurity() bool { return true }
 
 func initTracing(ctx context.Context, enabled bool) (*sdktrace.TracerProvider, error) {
 	res, err := resource.New(ctx,
+		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithAttributes(
 			semconv.UserAgentOriginal("kubectl-ate"),
 		),

--- a/internal/benchmarking/boomer/trace/trace.go
+++ b/internal/benchmarking/boomer/trace/trace.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 // UpdatableSampler wraps a TraceIDRatioBased sampler whose probability can
@@ -70,6 +70,7 @@ func Init(ctx context.Context, serviceName string, sampler sdktrace.Sampler) (*s
 	}
 	res, err := resource.New(ctx,
 		resource.WithTelemetrySDK(),
+		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithAttributes(
 			semconv.ServiceName(serviceName),
 			semconv.ServiceInstanceID(uuid.NewString()),

--- a/internal/serverboot/serverboot.go
+++ b/internal/serverboot/serverboot.go
@@ -38,7 +38,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 // InitLogger sets the global slog logger to a JSON handler wrapped in
@@ -62,6 +62,9 @@ var serviceInstanceID = uuid.NewString()
 func newResource(ctx context.Context, serviceName string) (*resource.Resource, error) {
 	res, err := resource.New(ctx,
 		resource.WithTelemetrySDK(),
+		// Must track the schema version the SDK's own detectors emit, else the
+		// merge drops the schema URL with ErrSchemaURLConflict (tolerated below).
+		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithAttributes(
 			semconv.ServiceName(serviceName),
 			semconv.ServiceInstanceID(serviceInstanceID),


### PR DESCRIPTION
This PR bumps the imported OpenTelemetry semantic conventions from `v1.21.0` to `v1.40.0`, and explicitly pins `schema_url`.

### Rationale

The current semconv (v1.21.0) predates every GenAI conventions (and a lot more beside that), so this is a required change to set the foundation for any additional GenAI telemetry work coming next.

### No functional changes

The only semconv attributes in use are `ServiceName`, `ServiceInstanceID`, and `UserAgentOriginal` all stable and unchanged between the two versions and since v1.40.0 was already vendored, no go.mod changes.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
