### PR TITLE
Rework Get / Delete methods to align with API style guide

### DIFF
--- a/cmd/ateapi/internal/controlapi/create_actor.go
+++ b/cmd/ateapi/internal/controlapi/create_actor.go
@@ -42,18 +42,18 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 	}
 
 	// The atespace must already exist.
-	exists, err := s.persistence.AtespaceExists(ctx, req.GetActorRef().GetAtespace())
+	exists, err := s.persistence.AtespaceExists(ctx, req.GetActor().GetAtespace())
 	if err != nil {
 		return nil, fmt.Errorf("while checking atespace: %w", err)
 	}
 	if !exists {
-		return nil, status.Errorf(codes.FailedPrecondition, "Atespace %s not found", req.GetActorRef().GetAtespace())
+		return nil, status.Errorf(codes.FailedPrecondition, "Atespace %s not found", req.GetActor().GetAtespace())
 	}
 
-	name := req.GetActorRef().GetName()
+	name := req.GetActor().GetName()
 	actor := &ateapipb.Actor{
 		Metadata: &ateapipb.ResourceMetadata{
-			Atespace: req.GetActorRef().GetAtespace(),
+			Atespace: req.GetActor().GetAtespace(),
 			Name:     name,
 		},
 		Status:                 ateapipb.Actor_STATUS_SUSPENDED,
@@ -94,10 +94,10 @@ func validateCreateActorRequest(req *ateapipb.CreateActorRequest) error {
 		}
 	}
 
-	if val, fldPath := req.ActorRef, fldPath.Child("actor_ref"); val == nil {
+	if val, fldPath := req.Actor, fldPath.Child("actor"); val == nil {
 		errs = append(errs, field.Required(fldPath, ""))
 	} else {
-		errs = append(errs, resources.ValidateActorRef(val, fldPath)...)
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
 	if val := req.WorkerSelector; val != nil {

--- a/cmd/ateapi/internal/controlapi/delete_actor.go
+++ b/cmd/ateapi/internal/controlapi/delete_actor.go
@@ -32,16 +32,16 @@ func (s *Service) DeleteActor(ctx context.Context, req *ateapipb.DeleteActorRequ
 		return nil, err
 	}
 
-	if err := s.persistence.DeleteActor(ctx, req.GetActorRef().GetAtespace(), req.GetActorRef().GetName()); err != nil {
+	if err := s.persistence.DeleteActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName()); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActorRef().GetName())
+			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActor().GetName())
 		}
 		if errors.Is(err, store.ErrFailedPrecondition) {
-			actor, getErr := s.persistence.GetActor(ctx, req.GetActorRef().GetAtespace(), req.GetActorRef().GetName())
+			actor, getErr := s.persistence.GetActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName())
 			if getErr == nil {
-				return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not suspended (status: %v)", req.GetActorRef().GetName(), actor.GetStatus())
+				return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not suspended (status: %v)", req.GetActor().GetName(), actor.GetStatus())
 			}
-			return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not suspended", req.GetActorRef().GetName())
+			return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not suspended", req.GetActor().GetName())
 		}
 		if errors.Is(err, store.ErrPersistenceRetry) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
@@ -56,10 +56,10 @@ func validateDeleteActorRequest(req *ateapipb.DeleteActorRequest) error {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
-	if val, fldPath := req.ActorRef, fldPath.Child("actor_ref"); val == nil {
+	if val, fldPath := req.Actor, fldPath.Child("actor"); val == nil {
 		errs = append(errs, field.Required(fldPath, ""))
 	} else {
-		errs = append(errs, resources.ValidateActorRef(val, fldPath)...)
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
 	if len(errs) > 0 {

--- a/cmd/ateapi/internal/controlapi/delete_actor.go
+++ b/cmd/ateapi/internal/controlapi/delete_actor.go
@@ -27,19 +27,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func (s *Service) DeleteActor(ctx context.Context, req *ateapipb.DeleteActorRequest) (*ateapipb.DeleteActorResponse, error) {
+func (s *Service) DeleteActor(ctx context.Context, req *ateapipb.DeleteActorRequest) (*ateapipb.Actor, error) {
 	if err := validateDeleteActorRequest(req); err != nil {
 		return nil, err
 	}
 
-	if err := s.persistence.DeleteActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName()); err != nil {
+	deleted, err := s.persistence.DeleteActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName())
+	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActor().GetName())
 		}
 		if errors.Is(err, store.ErrFailedPrecondition) {
-			actor, getErr := s.persistence.GetActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName())
+			current, getErr := s.persistence.GetActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName())
 			if getErr == nil {
-				return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not suspended (status: %v)", req.GetActor().GetName(), actor.GetStatus())
+				return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not suspended (status: %v)", req.GetActor().GetName(), current.GetStatus())
 			}
 			return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not suspended", req.GetActor().GetName())
 		}
@@ -49,7 +50,7 @@ func (s *Service) DeleteActor(ctx context.Context, req *ateapipb.DeleteActorRequ
 		return nil, fmt.Errorf("while deleting actor from DB: %w", err)
 	}
 
-	return &ateapipb.DeleteActorResponse{}, nil
+	return deleted, nil
 }
 
 func validateDeleteActorRequest(req *ateapipb.DeleteActorRequest) error {

--- a/cmd/ateapi/internal/controlapi/delete_atespace.go
+++ b/cmd/ateapi/internal/controlapi/delete_atespace.go
@@ -24,32 +24,41 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func (s *Service) DeleteAtespace(ctx context.Context, req *ateapipb.DeleteAtespaceRequest) (*ateapipb.DeleteAtespaceResponse, error) {
+func (s *Service) DeleteAtespace(ctx context.Context, req *ateapipb.DeleteAtespaceRequest) (*ateapipb.Atespace, error) {
 	if err := validateDeleteAtespaceRequest(req); err != nil {
 		return nil, err
 	}
 
-	if err := s.persistence.DeleteAtespace(ctx, req.GetName()); err != nil {
+	name := req.GetAtespace().GetName()
+	deleted, err := s.persistence.DeleteAtespace(ctx, name)
+	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Errorf(codes.NotFound, "Atespace %s not found", req.GetName())
+			return nil, status.Errorf(codes.NotFound, "Atespace %s not found", name)
 		}
 		if errors.Is(err, store.ErrFailedPrecondition) {
-			return nil, status.Errorf(codes.FailedPrecondition, "Atespace %s is not empty", req.GetName())
+			return nil, status.Errorf(codes.FailedPrecondition, "Atespace %s is not empty", name)
 		}
 		return nil, fmt.Errorf("while deleting atespace from DB: %w", err)
 	}
 
-	return &ateapipb.DeleteAtespaceResponse{}, nil
+	return deleted, nil
 }
 
 func validateDeleteAtespaceRequest(req *ateapipb.DeleteAtespaceRequest) error {
-	if req.GetName() == "" {
-		return status.Error(codes.InvalidArgument, "name is required")
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.Atespace, fldPath.Child("atespace"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateGlobalObjectRef(val, fldPath)...)
 	}
-	if err := resources.ValidateAtespace(req.GetName()); err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
+
+	if len(errs) > 0 {
+		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
 	}
 	return nil
 }

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -698,7 +698,7 @@ func TestCreateActor_Success(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	createResp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 		WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}},
@@ -742,7 +742,7 @@ func TestCreateActor_TemplateNotFound(t *testing.T) {
 	defer tc.cleanup()
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "non-existent",
 	})
@@ -758,7 +758,7 @@ func TestCreateActor_Duplicate(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -767,7 +767,7 @@ func TestCreateActor_Duplicate(t *testing.T) {
 	}
 
 	_, err = tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -785,7 +785,7 @@ func TestGetActor_Found(t *testing.T) {
 	name := "id1"
 
 	createResp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -794,7 +794,7 @@ func TestGetActor_Found(t *testing.T) {
 	}
 
 	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
@@ -819,7 +819,7 @@ func TestGetActor_NotFound(t *testing.T) {
 	defer tc.cleanup()
 
 	_, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "non-existent"},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "non-existent"},
 	})
 	assertGrpcError(t, err, codes.NotFound, "Actor non-existent not found")
 }
@@ -838,7 +838,7 @@ func TestListActors(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	resp1, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -846,7 +846,7 @@ func TestListActors(t *testing.T) {
 		t.Fatalf("CreateActor 1 failed: %v", err)
 	}
 	resp2, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id2"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id2"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -894,7 +894,7 @@ func TestListActors_ByAtespace(t *testing.T) {
 
 	create := func(atespace, name string) *ateapipb.Actor {
 		resp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-			ActorRef:               &ateapipb.ActorRef{Atespace: atespace, Name: name},
+			Actor:                  &ateapipb.ObjectRef{Atespace: atespace, Name: name},
 			ActorTemplateNamespace: ns,
 			ActorTemplateName:      "tmpl1",
 		})
@@ -931,10 +931,10 @@ func TestListActors_ByAtespace(t *testing.T) {
 	}
 
 	// Get is scoped: the right atespace hits, the empty atespace misses (deny-across by key).
-	if _, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: "team-a", Name: "id1"}}); err != nil {
+	if _, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "team-a", Name: "id1"}}); err != nil {
 		t.Errorf("GetActor(id1, team-a) failed: %v", err)
 	}
-	_, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"}})
+	_, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}})
 	assertGrpcError(t, err, codes.NotFound, "Actor id1 not found")
 }
 
@@ -951,7 +951,7 @@ func TestListActors_AllAtespaces(t *testing.T) {
 
 	create := func(atespace, name string) {
 		if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-			ActorRef:               &ateapipb.ActorRef{Atespace: atespace, Name: name},
+			Actor:                  &ateapipb.ObjectRef{Atespace: atespace, Name: name},
 			ActorTemplateNamespace: ns,
 			ActorTemplateName:      "tmpl1",
 		}); err != nil {
@@ -989,7 +989,7 @@ func TestListActors_Pagination(t *testing.T) {
 	var want []*ateapipb.Actor
 	for i := 0; i < 5; i++ {
 		resp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-			ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: fmt.Sprintf("name%d", i)},
+			Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: fmt.Sprintf("name%d", i)},
 			ActorTemplateNamespace: ns,
 			ActorTemplateName:      "tmpl1",
 		})
@@ -1125,7 +1125,7 @@ func TestResumeActor(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -1134,7 +1134,7 @@ func TestResumeActor(t *testing.T) {
 	}
 
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("ResumeActor failed: %v", err)
@@ -1145,7 +1145,7 @@ func TestResumeActor(t *testing.T) {
 	}
 
 	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
@@ -1191,7 +1191,7 @@ func TestResumeActor(t *testing.T) {
 				Namespace: ns,
 				Name:      "tmpl1",
 			},
-			Actor: &ateapipb.ActorRef{
+			Actor: &ateapipb.ObjectRef{
 				Name:     name,
 				Atespace: testAtespace,
 			},
@@ -1250,7 +1250,7 @@ func TestResumeActorResolvesValueFromEnv(t *testing.T) {
 	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
 
 	_, err = tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -1258,7 +1258,7 @@ func TestResumeActorResolvesValueFromEnv(t *testing.T) {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 	})
 	if err != nil {
 		t.Fatalf("ResumeActor failed: %v", err)
@@ -1304,7 +1304,7 @@ func TestResumeActor_NoWorkers(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	createResp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -1315,7 +1315,7 @@ func TestResumeActor_NoWorkers(t *testing.T) {
 	name := createResp.GetActor().GetMetadata().GetName()
 
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	assertGrpcError(t, err, codes.FailedPrecondition, "no free workers available")
 }
@@ -1338,7 +1338,7 @@ func TestResumeActor_MultiPoolSelector(t *testing.T) {
 	createWorkerPod(t, tc, ns, "worker-b", "node1", "pool-b")
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 		WorkerSelector: &ateapipb.Selector{
@@ -1349,12 +1349,12 @@ func TestResumeActor_MultiPoolSelector(t *testing.T) {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
 
-	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"}})
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}})
 	if err != nil {
 		t.Fatalf("ResumeActor failed: %v", err)
 	}
 
-	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"}})
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
@@ -1389,7 +1389,7 @@ func TestResumeActor_RequiresBothSelectorsToMatch(t *testing.T) {
 	createWorkerPod(t, tc, ns, "worker-actor-only", "node1", "pool-actor-only")
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 		WorkerSelector: &ateapipb.Selector{
@@ -1400,11 +1400,11 @@ func TestResumeActor_RequiresBothSelectorsToMatch(t *testing.T) {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
 
-	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"}}); err != nil {
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}}); err != nil {
 		t.Fatalf("ResumeActor failed: %v", err)
 	}
 
-	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"}})
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
@@ -1435,7 +1435,7 @@ func TestResumeActor_Reentrancy(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -1447,7 +1447,7 @@ func TestResumeActor_Reentrancy(t *testing.T) {
 	tc.fakeAtelet.FailRestore = fmt.Errorf("mock atelet failure")
 
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err == nil {
 		t.Fatalf("expected ResumeActor to fail due to atelet error")
@@ -1467,7 +1467,7 @@ func TestResumeActor_Reentrancy(t *testing.T) {
 	tc.fakeAtelet.RestoreCalled = false // reset for verification
 
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("ResumeActor failed on retry: %v", err)
@@ -1508,7 +1508,7 @@ func TestSuspendActor(t *testing.T) {
 	name := "id1"
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -1518,7 +1518,7 @@ func TestSuspendActor(t *testing.T) {
 
 	// Resume first to make it running
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("ResumeActor failed: %v", err)
@@ -1526,7 +1526,7 @@ func TestSuspendActor(t *testing.T) {
 
 	// Suspend
 	_, err = tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("SuspendActor failed: %v", err)
@@ -1537,7 +1537,7 @@ func TestSuspendActor(t *testing.T) {
 	}
 
 	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
@@ -1593,7 +1593,7 @@ func TestPauseActor(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -1603,7 +1603,7 @@ func TestPauseActor(t *testing.T) {
 
 	// Resume first to make it running
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("ResumeActor failed: %v", err)
@@ -1611,7 +1611,7 @@ func TestPauseActor(t *testing.T) {
 
 	// Pause
 	_, err = tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("PauseActor failed: %v", err)
@@ -1622,7 +1622,7 @@ func TestPauseActor(t *testing.T) {
 	}
 
 	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
@@ -1668,7 +1668,7 @@ func TestUpdateActor_Success(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 		WorkerSelector: &ateapipb.Selector{
@@ -1680,7 +1680,7 @@ func TestUpdateActor_Success(t *testing.T) {
 	}
 
 	updateResp, err := tc.client.UpdateActor(context.Background(), &ateapipb.UpdateActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		WorkerSelector: &ateapipb.Selector{
 			MatchLabels: map[string]string{"tier": "paid"},
 		},
@@ -1703,7 +1703,7 @@ func TestUpdateActor_Success(t *testing.T) {
 		t.Errorf("UpdateActor response mismatch (-want +got):\n%s", diff)
 	}
 
-	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"}})
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
@@ -1718,7 +1718,7 @@ func TestUpdateActor_NotFound(t *testing.T) {
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
 
-	_, err := tc.client.UpdateActor(context.Background(), &ateapipb.UpdateActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "does-not-exist"}})
+	_, err := tc.client.UpdateActor(context.Background(), &ateapipb.UpdateActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "does-not-exist"}})
 	assertGrpcError(t, err, codes.NotFound, "Actor does-not-exist not found")
 }
 
@@ -1751,7 +1751,7 @@ func TestResumeActor_ReleasesStaleWorkerWhenPoolBecomesIneligible(t *testing.T) 
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 		WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "a"}},
@@ -1761,24 +1761,24 @@ func TestResumeActor_ReleasesStaleWorkerWhenPoolBecomesIneligible(t *testing.T) 
 	}
 
 	tc.fakeAtelet.FailRun = fmt.Errorf("mock atelet failure")
-	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name}})
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}})
 	if err == nil {
 		t.Fatalf("expected first ResumeActor (onto worker-a) to fail")
 	}
 	tc.fakeAtelet.FailRun = nil
 
 	if _, err := tc.client.UpdateActor(context.Background(), &ateapipb.UpdateActorRequest{
-		ActorRef:       &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:          &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "b"}},
 	}); err != nil {
 		t.Fatalf("UpdateActor failed: %v", err)
 	}
 
-	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name}}); err != nil {
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}}); err != nil {
 		t.Fatalf("second ResumeActor failed: %v", err)
 	}
 
-	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name}})
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
@@ -1851,7 +1851,7 @@ func TestUpdateActor_ReassignsPoolAcrossSuspendResume(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 		WorkerSelector: &ateapipb.Selector{
@@ -1862,11 +1862,11 @@ func TestUpdateActor_ReassignsPoolAcrossSuspendResume(t *testing.T) {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
 
-	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name}}); err != nil {
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}}); err != nil {
 		t.Fatalf("first ResumeActor failed: %v", err)
 	}
 
-	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name}})
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
@@ -1878,7 +1878,7 @@ func TestUpdateActor_ReassignsPoolAcrossSuspendResume(t *testing.T) {
 	}
 
 	if _, err := tc.client.UpdateActor(context.Background(), &ateapipb.UpdateActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		WorkerSelector: &ateapipb.Selector{
 			MatchLabels: map[string]string{"tier": "b"},
 		},
@@ -1886,14 +1886,14 @@ func TestUpdateActor_ReassignsPoolAcrossSuspendResume(t *testing.T) {
 		t.Fatalf("UpdateActor failed: %v", err)
 	}
 
-	if _, err := tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name}}); err != nil {
+	if _, err := tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}}); err != nil {
 		t.Fatalf("SuspendActor failed: %v", err)
 	}
-	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name}}); err != nil {
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}}); err != nil {
 		t.Fatalf("second ResumeActor failed: %v", err)
 	}
 
-	getResp, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name}})
+	getResp, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
@@ -1925,68 +1925,68 @@ func TestValidation(t *testing.T) {
 			wantMsg string
 		}{{
 			"missing actor_template_namespace",
-			&ateapipb.CreateActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"}, ActorTemplateName: "tmpl1"},
+			&ateapipb.CreateActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}, ActorTemplateName: "tmpl1"},
 			"actor_template_namespace: Required value",
 		}, {
 			"invalid actor_template_namespace",
 			&ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"},
+				Actor:                  &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
 				ActorTemplateNamespace: "invalid value",
 				ActorTemplateName:      "tmpl1",
 			},
 			"actor_template_namespace: Invalid value",
 		}, {
 			"missing actor_template_name",
-			&ateapipb.CreateActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"}, ActorTemplateNamespace: "ns1"},
+			&ateapipb.CreateActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}, ActorTemplateNamespace: "ns1"},
 			"actor_template_name: Required value",
 		}, {
 			"invalid actor_template_name",
 			&ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"},
+				Actor:                  &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
 				ActorTemplateNamespace: "ns1",
 				ActorTemplateName:      "invalid value",
 			},
 			"actor_template_name: Invalid value",
 		}, {
-			"missing actor_ref",
+			"missing actor",
 			&ateapipb.CreateActorRequest{ActorTemplateNamespace: "ns1", ActorTemplateName: "tmpl1"},
-			"actor_ref: Required value",
+			"actor: Required value",
 		}, {
-			"missing actor_ref.atespace",
+			"missing actor.atespace",
 			&ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Name: "id1"},
+				Actor:                  &ateapipb.ObjectRef{Name: "id1"},
 				ActorTemplateNamespace: "ns1",
 				ActorTemplateName:      "tmpl1",
 			},
-			"actor_ref.atespace: Required value",
+			"actor.atespace: Required value",
 		}, {
-			"invalid actor_ref.atespace",
+			"invalid actor.atespace",
 			&ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Atespace: "NS1", Name: "id1"},
+				Actor:                  &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
 				ActorTemplateNamespace: "ns1",
 				ActorTemplateName:      "tmpl1",
 			},
-			"actor_ref.atespace: Invalid value",
+			"actor.atespace: Invalid value",
 		}, {
-			"missing actor_ref.name",
+			"missing actor.name",
 			&ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Atespace: "ns1"},
+				Actor:                  &ateapipb.ObjectRef{Atespace: "ns1"},
 				ActorTemplateNamespace: "ns1",
 				ActorTemplateName:      "tmpl1",
 			},
-			"actor_ref.name: Required value",
+			"actor.name: Required value",
 		}, {
-			"invalid actor_ref.name",
+			"invalid actor.name",
 			&ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Atespace: "ns1", Name: "ID1"},
+				Actor:                  &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
 				ActorTemplateNamespace: "ns1",
 				ActorTemplateName:      "tmpl1",
 			},
-			"actor_ref.name: Invalid value",
+			"actor.name: Invalid value",
 		}, {
 			"invalid worker_selector label key",
 			&ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"},
+				Actor:                  &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
 				ActorTemplateNamespace: "ns1",
 				ActorTemplateName:      "tmpl1",
 				WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"bad key!": "x"}},
@@ -1995,7 +1995,7 @@ func TestValidation(t *testing.T) {
 		}, {
 			"invalid worker_selector label value",
 			&ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"},
+				Actor:                  &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
 				ActorTemplateNamespace: "ns1",
 				ActorTemplateName:      "tmpl1",
 				WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "not valid!"}},
@@ -2004,7 +2004,7 @@ func TestValidation(t *testing.T) {
 		}, {
 			"too many worker_selector.match_labels",
 			&ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"},
+				Actor:                  &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
 				ActorTemplateNamespace: "ns1",
 				ActorTemplateName:      "tmpl1",
 				WorkerSelector:         &ateapipb.Selector{MatchLabels: selectorLabelsOfSize(11)}},
@@ -2024,33 +2024,33 @@ func TestValidation(t *testing.T) {
 			req     *ateapipb.GetActorRequest
 			wantMsg string
 		}{{
-			"missing actor_ref",
+			"missing actor",
 			&ateapipb.GetActorRequest{},
-			"actor_ref: Required value",
+			"actor: Required value",
 		}, {
-			"missing actor_ref.atespace",
+			"missing actor.atespace",
 			&ateapipb.GetActorRequest{
-				ActorRef: &ateapipb.ActorRef{Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Name: "id1"},
 			},
-			"actor_ref.atespace: Required value",
+			"actor.atespace: Required value",
 		}, {
-			"invalid actor_ref.atespace",
+			"invalid actor.atespace",
 			&ateapipb.GetActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "NS1", Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
 			},
-			"actor_ref.atespace: Invalid value",
+			"actor.atespace: Invalid value",
 		}, {
-			"missing actor_ref.name",
+			"missing actor.name",
 			&ateapipb.GetActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
 			},
-			"actor_ref.name: Required value",
+			"actor.name: Required value",
 		}, {
-			"invalid actor_ref.name",
+			"invalid actor.name",
 			&ateapipb.GetActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1", Name: "ID1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
 			},
-			"actor_ref.name: Invalid value",
+			"actor.name: Invalid value",
 		}}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -2066,33 +2066,33 @@ func TestValidation(t *testing.T) {
 			req     *ateapipb.ResumeActorRequest
 			wantMsg string
 		}{{
-			"missing actor_ref",
+			"missing actor",
 			&ateapipb.ResumeActorRequest{},
-			"actor_ref: Required value",
+			"actor: Required value",
 		}, {
-			"missing actor_ref.atespace",
+			"missing actor.atespace",
 			&ateapipb.ResumeActorRequest{
-				ActorRef: &ateapipb.ActorRef{Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Name: "id1"},
 			},
-			"actor_ref.atespace: Required value",
+			"actor.atespace: Required value",
 		}, {
-			"invalid actor_ref.atespace",
+			"invalid actor.atespace",
 			&ateapipb.ResumeActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "NS1", Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
 			},
-			"actor_ref.atespace: Invalid value",
+			"actor.atespace: Invalid value",
 		}, {
-			"missing actor_ref.name",
+			"missing actor.name",
 			&ateapipb.ResumeActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
 			},
-			"actor_ref.name: Required value",
+			"actor.name: Required value",
 		}, {
-			"invalid actor_ref.name",
+			"invalid actor.name",
 			&ateapipb.ResumeActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1", Name: "ID1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
 			},
-			"actor_ref.name: Invalid value",
+			"actor.name: Invalid value",
 		}}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -2108,33 +2108,33 @@ func TestValidation(t *testing.T) {
 			req     *ateapipb.PauseActorRequest
 			wantMsg string
 		}{{
-			"missing actor_ref",
+			"missing actor",
 			&ateapipb.PauseActorRequest{},
-			"actor_ref: Required value",
+			"actor: Required value",
 		}, {
-			"missing actor_ref.atespace",
+			"missing actor.atespace",
 			&ateapipb.PauseActorRequest{
-				ActorRef: &ateapipb.ActorRef{Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Name: "id1"},
 			},
-			"actor_ref.atespace: Required value",
+			"actor.atespace: Required value",
 		}, {
-			"invalid actor_ref.atespace",
+			"invalid actor.atespace",
 			&ateapipb.PauseActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "NS1", Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
 			},
-			"actor_ref.atespace: Invalid value",
+			"actor.atespace: Invalid value",
 		}, {
-			"missing actor_ref.name",
+			"missing actor.name",
 			&ateapipb.PauseActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
 			},
-			"actor_ref.name: Required value",
+			"actor.name: Required value",
 		}, {
-			"invalid actor_ref.name",
+			"invalid actor.name",
 			&ateapipb.PauseActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1", Name: "ID1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
 			},
-			"actor_ref.name: Invalid value",
+			"actor.name: Invalid value",
 		}}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -2150,33 +2150,33 @@ func TestValidation(t *testing.T) {
 			req     *ateapipb.SuspendActorRequest
 			wantMsg string
 		}{{
-			"missing actor_ref",
+			"missing actor",
 			&ateapipb.SuspendActorRequest{},
-			"actor_ref: Required value",
+			"actor: Required value",
 		}, {
-			"missing actor_ref.atespace",
+			"missing actor.atespace",
 			&ateapipb.SuspendActorRequest{
-				ActorRef: &ateapipb.ActorRef{Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Name: "id1"},
 			},
-			"actor_ref.atespace: Required value",
+			"actor.atespace: Required value",
 		}, {
-			"invalid actor_ref.atespace",
+			"invalid actor.atespace",
 			&ateapipb.SuspendActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "NS1", Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
 			},
-			"actor_ref.atespace: Invalid value",
+			"actor.atespace: Invalid value",
 		}, {
-			"missing actor_ref.name",
+			"missing actor.name",
 			&ateapipb.SuspendActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
 			},
-			"actor_ref.name: Required value",
+			"actor.name: Required value",
 		}, {
-			"invalid actor_ref.name",
+			"invalid actor.name",
 			&ateapipb.SuspendActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1", Name: "ID1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
 			},
-			"actor_ref.name: Invalid value",
+			"actor.name: Invalid value",
 		}}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -2192,51 +2192,51 @@ func TestValidation(t *testing.T) {
 			req     *ateapipb.UpdateActorRequest
 			wantMsg string
 		}{{
-			"missing actor_ref",
+			"missing actor",
 			&ateapipb.UpdateActorRequest{},
-			"actor_ref: Required value",
+			"actor: Required value",
 		}, {
-			"missing actor_ref.atespace",
+			"missing actor.atespace",
 			&ateapipb.UpdateActorRequest{
-				ActorRef: &ateapipb.ActorRef{Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Name: "id1"},
 			},
-			"actor_ref.atespace: Required value",
+			"actor.atespace: Required value",
 		}, {
-			"invalid actor_ref.atespace",
+			"invalid actor.atespace",
 			&ateapipb.UpdateActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "NS1", Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
 			},
-			"actor_ref.atespace: Invalid value",
+			"actor.atespace: Invalid value",
 		}, {
-			"missing actor_ref.name",
+			"missing actor.name",
 			&ateapipb.UpdateActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
 			},
-			"actor_ref.name: Required value",
+			"actor.name: Required value",
 		}, {
-			"invalid actor_ref.name",
+			"invalid actor.name",
 			&ateapipb.UpdateActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1", Name: "ID1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
 			},
-			"actor_ref.name: Invalid value",
+			"actor.name: Invalid value",
 		}, {
 			"invalid worker_selector label key",
 			&ateapipb.UpdateActorRequest{
-				ActorRef:       &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"},
+				Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
 				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"bad key!": "x"}},
 			},
 			`worker_selector.match_labels\[bad key!\]: Invalid value`,
 		}, {
 			"invalid worker_selector label value",
 			&ateapipb.UpdateActorRequest{
-				ActorRef:       &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"},
+				Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
 				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "not valid!"}},
 			},
 			`worker_selector.match_labels\[tier\]: Invalid value`,
 		}, {
 			"too many worker_selector.match_labels",
 			&ateapipb.UpdateActorRequest{
-				ActorRef:       &ateapipb.ActorRef{Atespace: "ns1", Name: "id1"},
+				Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
 				WorkerSelector: &ateapipb.Selector{MatchLabels: selectorLabelsOfSize(11)}},
 			"worker_selector.match_labels: Too many",
 		}}
@@ -2254,33 +2254,33 @@ func TestValidation(t *testing.T) {
 			req     *ateapipb.DeleteActorRequest
 			wantMsg string
 		}{{
-			"missing actor_ref",
+			"missing actor",
 			&ateapipb.DeleteActorRequest{},
-			"actor_ref: Required value",
+			"actor: Required value",
 		}, {
-			"missing actor_ref.atespace",
+			"missing actor.atespace",
 			&ateapipb.DeleteActorRequest{
-				ActorRef: &ateapipb.ActorRef{Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Name: "id1"},
 			},
-			"actor_ref.atespace: Required value",
+			"actor.atespace: Required value",
 		}, {
-			"invalid actor_ref.atespace",
+			"invalid actor.atespace",
 			&ateapipb.DeleteActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "NS1", Name: "id1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
 			},
-			"actor_ref.atespace: Invalid value",
+			"actor.atespace: Invalid value",
 		}, {
-			"missing actor_ref.name",
+			"missing actor.name",
 			&ateapipb.DeleteActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
 			},
-			"actor_ref.name: Required value",
+			"actor.name: Required value",
 		}, {
-			"invalid actor_ref.name",
+			"invalid actor.name",
 			&ateapipb.DeleteActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: "ns1", Name: "ID1"},
+				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
 			},
-			"actor_ref.name: Invalid value",
+			"actor.name: Invalid value",
 		}}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -2302,7 +2302,7 @@ func TestResumeActor_LockConflict(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -2317,7 +2317,7 @@ func TestResumeActor_LockConflict(t *testing.T) {
 	errChan := make(chan error, 1)
 	go func() {
 		_, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-			ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+			Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		})
 		errChan <- err
 	}()
@@ -2327,7 +2327,7 @@ func TestResumeActor_LockConflict(t *testing.T) {
 
 	// Launch Request B (should fail due to lock conflict)
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	assertGrpcError(t, err, codes.Aborted, "another operation is in progress for this actor")
 
@@ -2349,7 +2349,7 @@ func TestResumeActor_DanglingWorker(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -2362,7 +2362,7 @@ func TestResumeActor_DanglingWorker(t *testing.T) {
 
 	// 3. Call ResumeActor -> Expect failure
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err == nil {
 		t.Fatalf("expected ResumeActor to fail due to atelet error")
@@ -2370,7 +2370,7 @@ func TestResumeActor_DanglingWorker(t *testing.T) {
 
 	// Verify actor state is RESUMING with worker A assigned
 	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
@@ -2394,7 +2394,7 @@ func TestResumeActor_DanglingWorker(t *testing.T) {
 
 	// 8. Call ResumeActor again -> Expect success and picking Worker B!
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("ResumeActor failed on retry: %v", err)
@@ -2429,7 +2429,7 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -2439,7 +2439,7 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 
 	// Resume first to make it running
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("ResumeActor failed: %v", err)
@@ -2455,7 +2455,7 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 	}
 
 	_, err = tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("SuspendActor failed: %v", err)
@@ -2463,7 +2463,7 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 
 	// 4. Verify it becomes SUSPENDED in Redis
 	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: name},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
@@ -2484,7 +2484,7 @@ func TestDeleteActor_Success(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -2493,14 +2493,14 @@ func TestDeleteActor_Success(t *testing.T) {
 	}
 
 	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 	})
 	if err != nil {
 		t.Fatalf("DeleteActor failed: %v", err)
 	}
 
 	_, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 	})
 	assertGrpcError(t, err, codes.NotFound, "Actor id1 not found")
 }
@@ -2514,7 +2514,7 @@ func TestDeleteActor_NotSuspended(t *testing.T) {
 	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -2523,14 +2523,14 @@ func TestDeleteActor_NotSuspended(t *testing.T) {
 	}
 
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 	})
 	if err != nil {
 		t.Fatalf("ResumeActor failed: %v", err)
 	}
 
 	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "id1"},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 	})
 	assertGrpcError(t, err, codes.FailedPrecondition, "Actor id1 is not suspended (status: STATUS_RUNNING)")
 }
@@ -2541,7 +2541,7 @@ func TestDeleteActor_NotFound(t *testing.T) {
 	defer tc.cleanup()
 
 	_, err := tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: testAtespace, Name: "non-existent"},
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "non-existent"},
 	})
 	assertGrpcError(t, err, codes.NotFound, "Actor non-existent not found")
 }
@@ -2592,7 +2592,7 @@ func TestCreateActor_AtespaceNotFound(t *testing.T) {
 	// The template exists, but "missing-as" was never created. The template
 	// check fires first, so reaching this error proves the atespace check ran.
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: "missing-as", Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: "missing-as", Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	})
@@ -2616,7 +2616,7 @@ func TestCreateAtespace_Success(t *testing.T) {
 
 	// An actor can now be created into the new atespace.
 	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: "team-a", Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: "team-a", Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	}); err != nil {
@@ -2732,7 +2732,7 @@ func TestDeleteAtespace_NonEmpty_Rejected(t *testing.T) {
 		t.Fatalf("CreateAtespace failed: %v", err)
 	}
 	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: "team-a", Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: "team-a", Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	}); err != nil {
@@ -2759,7 +2759,7 @@ func TestDeleteAtespace_ScopedToTargetAtespace(t *testing.T) {
 
 	// Actor only in team-b.
 	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: "team-b", Name: "id1"},
+		Actor:                  &ateapipb.ObjectRef{Atespace: "team-b", Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
 	}); err != nil {

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -800,9 +800,7 @@ func TestGetActor_Found(t *testing.T) {
 		t.Fatalf("GetActor failed: %v", err)
 	}
 
-	want := &ateapipb.GetActorResponse{
-		Actor: createResp.GetActor(),
-	}
+	want := createResp.GetActor()
 
 	if diff := cmp.Diff(want, getResp, protocmp.Transform()); diff != "" {
 		t.Errorf("GetActor response mismatch (-want +got):\n%s", diff)
@@ -1150,17 +1148,15 @@ func TestResumeActor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	want := &ateapipb.GetActorResponse{
-		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
-			Status:                 ateapipb.Actor_STATUS_RUNNING,
-			AteomPodNamespace:      ns,
-			AteomPodName:           "worker-1",
-			AteomPodIp:             "127.0.0.1",
-			WorkerPoolName:         "pool1",
-		},
+	want := &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      "tmpl1",
+		Status:                 ateapipb.Actor_STATUS_RUNNING,
+		AteomPodNamespace:      ns,
+		AteomPodName:           "worker-1",
+		AteomPodIp:             "127.0.0.1",
+		WorkerPoolName:         "pool1",
 	}
 	if diff := cmp.Diff(want, getResp, protocmp.Transform(), ignoreUID, ignoreVersion, ignoreTimestamps, protocmp.IgnoreFields(&ateapipb.Actor{}, "ateom_pod_uid")); diff != "" {
 		t.Errorf("GetActor response mismatch (-want +got):\n%s", diff)
@@ -1358,10 +1354,10 @@ func TestResumeActor_MultiPoolSelector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	if got := getResp.GetActor().GetAteomPodName(); got != "worker-b" {
+	if got := getResp.GetAteomPodName(); got != "worker-b" {
 		t.Errorf("expected actor to be assigned to worker-b (pool-b, matching narrowed selector), got %q", got)
 	}
-	if got := getResp.GetActor().GetWorkerPoolName(); got != "pool-b" {
+	if got := getResp.GetWorkerPoolName(); got != "pool-b" {
 		t.Errorf("expected actor's worker_pool_name to be pool-b, got %q", got)
 	}
 }
@@ -1408,7 +1404,7 @@ func TestResumeActor_RequiresBothSelectorsToMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	if got := getResp.GetActor().GetWorkerPoolName(); got != "pool-both" {
+	if got := getResp.GetWorkerPoolName(); got != "pool-both" {
 		t.Errorf("expected actor to be assigned to pool-both (the only pool matching both selectors), got worker_pool_name=%q", got)
 	}
 }
@@ -1542,17 +1538,15 @@ func TestSuspendActor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	want := &ateapipb.GetActorResponse{
-		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
-			Status:                 ateapipb.Actor_STATUS_SUSPENDED,
-			LatestSnapshotInfo: &ateapipb.SnapshotInfo{
-				Data: &ateapipb.SnapshotInfo_External{
-					External: &ateapipb.ExternalSnapshotInfo{
-						SnapshotUriPrefix: fmt.Sprintf("gs://fake-fake-fake/%s/", name),
-					},
+	want := &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      "tmpl1",
+		Status:                 ateapipb.Actor_STATUS_SUSPENDED,
+		LatestSnapshotInfo: &ateapipb.SnapshotInfo{
+			Data: &ateapipb.SnapshotInfo_External{
+				External: &ateapipb.ExternalSnapshotInfo{
+					SnapshotUriPrefix: fmt.Sprintf("gs://fake-fake-fake/%s/", name),
 				},
 			},
 		},
@@ -1627,18 +1621,16 @@ func TestPauseActor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	want := &ateapipb.GetActorResponse{
-		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
-			Status:                 ateapipb.Actor_STATUS_PAUSED,
-			LatestSnapshotInfo: &ateapipb.SnapshotInfo{
-				Data: &ateapipb.SnapshotInfo_Local{
-					Local: &ateapipb.LocalSnapshotInfo{
-						SnapshotPrefix:            name,
-						NodeVmsWithLocalSnapshots: []string{"node1"},
-					},
+	want := &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      "tmpl1",
+		Status:                 ateapipb.Actor_STATUS_PAUSED,
+		LatestSnapshotInfo: &ateapipb.SnapshotInfo{
+			Data: &ateapipb.SnapshotInfo_Local{
+				Local: &ateapipb.LocalSnapshotInfo{
+					SnapshotPrefix:            name,
+					NodeVmsWithLocalSnapshots: []string{"node1"},
 				},
 			},
 		},
@@ -1707,7 +1699,7 @@ func TestUpdateActor_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	wantGetResp := &ateapipb.GetActorResponse{Actor: wantActor}
+	wantGetResp := wantActor
 	if diff := cmp.Diff(wantGetResp, getResp, protocmp.Transform(), ignoreUID, ignoreTimestamps); diff != "" {
 		t.Errorf("GetActor response mismatch after UpdateActor (-want +got):\n%s", diff)
 	}
@@ -1782,10 +1774,10 @@ func TestResumeActor_ReleasesStaleWorkerWhenPoolBecomesIneligible(t *testing.T) 
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	if got := getResp.GetActor().GetWorkerPoolName(); got != "pool-b" {
+	if got := getResp.GetWorkerPoolName(); got != "pool-b" {
 		t.Errorf("expected actor to land on pool-b, got worker_pool_name=%q", got)
 	}
-	if got := getResp.GetActor().GetStatus(); got != ateapipb.Actor_STATUS_RUNNING {
+	if got := getResp.GetStatus(); got != ateapipb.Actor_STATUS_RUNNING {
 		t.Errorf("expected actor status RUNNING, got %v", got)
 	}
 
@@ -1870,10 +1862,10 @@ func TestUpdateActor_ReassignsPoolAcrossSuspendResume(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	if got := getResp.GetActor().GetWorkerPoolName(); got != "pool-a" {
+	if got := getResp.GetWorkerPoolName(); got != "pool-a" {
 		t.Fatalf("expected actor to first resume onto pool-a, got worker_pool_name=%q", got)
 	}
-	if got := getResp.GetActor().GetAteomPodName(); got != "worker-a" {
+	if got := getResp.GetAteomPodName(); got != "worker-a" {
 		t.Fatalf("expected actor to first resume onto worker-a, got ateom_pod_name=%q", got)
 	}
 
@@ -1897,13 +1889,13 @@ func TestUpdateActor_ReassignsPoolAcrossSuspendResume(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	if got := getResp.GetActor().GetWorkerPoolName(); got != "pool-b" {
+	if got := getResp.GetWorkerPoolName(); got != "pool-b" {
 		t.Errorf("expected actor to resume onto pool-b after selector update, got worker_pool_name=%q", got)
 	}
-	if got := getResp.GetActor().GetAteomPodName(); got != "worker-b" {
+	if got := getResp.GetAteomPodName(); got != "worker-b" {
 		t.Errorf("expected actor to resume onto worker-b after selector update, got ateom_pod_name=%q", got)
 	}
-	if got := getResp.GetActor().GetStatus(); got != ateapipb.Actor_STATUS_RUNNING {
+	if got := getResp.GetStatus(); got != ateapipb.Actor_STATUS_RUNNING {
 		t.Errorf("expected actor status RUNNING after second resume, got %v", got)
 	}
 }
@@ -2375,7 +2367,7 @@ func TestResumeActor_DanglingWorker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	actor := getResp.GetActor()
+	actor := getResp
 	if actor.GetStatus() != ateapipb.Actor_STATUS_RESUMING {
 		t.Fatalf("expected status RESUMING, got %v", actor.GetStatus())
 	}
@@ -2468,11 +2460,11 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
-	if getResp.GetActor().GetStatus() != ateapipb.Actor_STATUS_SUSPENDED {
-		t.Errorf("expected status SUSPENDED, got %v", getResp.GetActor().GetStatus())
+	if getResp.GetStatus() != ateapipb.Actor_STATUS_SUSPENDED {
+		t.Errorf("expected status SUSPENDED, got %v", getResp.GetStatus())
 	}
-	if getResp.GetActor().GetAteomPodNamespace() != "" {
-		t.Errorf("expected ateom_pod_namespace to be empty, got %v", getResp.GetActor().GetAteomPodNamespace())
+	if getResp.GetAteomPodNamespace() != "" {
+		t.Errorf("expected ateom_pod_namespace to be empty, got %v", getResp.GetAteomPodNamespace())
 	}
 }
 
@@ -2663,11 +2655,11 @@ func TestGetAtespace_Found(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAtespace failed: %v", err)
 	}
-	resp, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Name: "team-a"})
+	resp, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}})
 	if err != nil {
 		t.Fatalf("GetAtespace failed: %v", err)
 	}
-	if diff := cmp.Diff(created.GetAtespace(), resp.GetAtespace(), protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(created.GetAtespace(), resp, protocmp.Transform()); diff != "" {
 		t.Errorf("GetAtespace mismatch (-created +got):\n%s", diff)
 	}
 }
@@ -2677,7 +2669,7 @@ func TestGetAtespace_NotFound(t *testing.T) {
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
 
-	_, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Name: "nope"})
+	_, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "nope"}})
 	assertGrpcError(t, err, codes.NotFound, "Atespace nope not found")
 }
 
@@ -2718,7 +2710,7 @@ func TestDeleteAtespace_Empty_Success(t *testing.T) {
 	if _, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Name: "team-a"}); err != nil {
 		t.Fatalf("DeleteAtespace failed: %v", err)
 	}
-	_, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Name: "team-a"})
+	_, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}})
 	assertGrpcError(t, err, codes.NotFound, "Atespace team-a not found")
 }
 
@@ -2741,7 +2733,7 @@ func TestDeleteAtespace_NonEmpty_Rejected(t *testing.T) {
 	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Name: "team-a"})
 	assertGrpcError(t, err, codes.FailedPrecondition, "Atespace team-a is not empty")
 	// The atespace must survive a rejected delete.
-	if _, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Name: "team-a"}); err != nil {
+	if _, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}}); err != nil {
 		t.Errorf("atespace should survive a rejected delete, got %v", err)
 	}
 }

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -2484,11 +2484,18 @@ func TestDeleteActor_Success(t *testing.T) {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
 
-	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+	deleted, err := tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
 	})
 	if err != nil {
 		t.Fatalf("DeleteActor failed: %v", err)
+	}
+	// DeleteActor returns the deleted resource.
+	if got := deleted.GetMetadata().GetName(); got != "id1" {
+		t.Errorf("deleted actor name = %q, want id1", got)
+	}
+	if got := deleted.GetMetadata().GetAtespace(); got != testAtespace {
+		t.Errorf("deleted actor atespace = %q, want %q", got, testAtespace)
 	}
 
 	_, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
@@ -2707,10 +2714,16 @@ func TestDeleteAtespace_Empty_Success(t *testing.T) {
 	if _, err := tc.client.CreateAtespace(context.Background(), &ateapipb.CreateAtespaceRequest{Name: "team-a"}); err != nil {
 		t.Fatalf("CreateAtespace failed: %v", err)
 	}
-	if _, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Name: "team-a"}); err != nil {
+	deleted, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}})
+	if err != nil {
 		t.Fatalf("DeleteAtespace failed: %v", err)
 	}
-	_, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}})
+	// DeleteAtespace returns the deleted resource.
+	if got := deleted.GetMetadata().GetName(); got != "team-a" {
+		t.Errorf("deleted atespace name = %q, want team-a", got)
+	}
+
+	_, err = tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}})
 	assertGrpcError(t, err, codes.NotFound, "Atespace team-a not found")
 }
 
@@ -2730,7 +2743,7 @@ func TestDeleteAtespace_NonEmpty_Rejected(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
-	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Name: "team-a"})
+	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}})
 	assertGrpcError(t, err, codes.FailedPrecondition, "Atespace team-a is not empty")
 	// The atespace must survive a rejected delete.
 	if _, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}}); err != nil {
@@ -2759,11 +2772,11 @@ func TestDeleteAtespace_ScopedToTargetAtespace(t *testing.T) {
 	}
 
 	// Empty team-a deletes fine despite team-b holding an actor.
-	if _, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Name: "team-a"}); err != nil {
+	if _, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}}); err != nil {
 		t.Errorf("DeleteAtespace(team-a, empty) failed: %v", err)
 	}
 	// team-b is still non-empty → rejected.
-	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Name: "team-b"})
+	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-b"}})
 	assertGrpcError(t, err, codes.FailedPrecondition, "Atespace team-b is not empty")
 }
 
@@ -2772,7 +2785,7 @@ func TestDeleteAtespace_NotFound(t *testing.T) {
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
 
-	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Name: "nope"})
+	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "nope"}})
 	assertGrpcError(t, err, codes.NotFound, "Atespace nope not found")
 }
 
@@ -2781,12 +2794,12 @@ func TestDeleteAtespace_Validation(t *testing.T) {
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
 
-	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Name: ""})
-	assertGrpcError(t, err, codes.InvalidArgument, "name is required")
+	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: ""}})
+	assertGrpcError(t, err, codes.InvalidArgument, "atespace.name: Required value")
 
 	// Metacharacter names are rejected before the emptiness glob scan ever runs.
 	for _, bad := range []string{"a*", "a:b"} {
-		_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Name: bad})
+		_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: bad}})
 		if status.Code(err) != codes.InvalidArgument {
 			t.Errorf("DeleteAtespace(%q): got code %v, want InvalidArgument", bad, status.Code(err))
 		}

--- a/cmd/ateapi/internal/controlapi/get_actor.go
+++ b/cmd/ateapi/internal/controlapi/get_actor.go
@@ -31,9 +31,9 @@ func (s *Service) GetActor(ctx context.Context, req *ateapipb.GetActorRequest) (
 	if err := validateGetActorRequest(req); err != nil {
 		return nil, err
 	}
-	actor, err := s.persistence.GetActor(ctx, req.GetActorRef().GetAtespace(), req.GetActorRef().GetName())
+	actor, err := s.persistence.GetActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName())
 	if errors.Is(err, store.ErrNotFound) {
-		return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActorRef().GetName())
+		return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActor().GetName())
 	} else if err != nil {
 		return nil, fmt.Errorf("while getting actor from DB: %w", err)
 	}
@@ -46,10 +46,10 @@ func validateGetActorRequest(req *ateapipb.GetActorRequest) error {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
-	if val, fldPath := req.ActorRef, fldPath.Child("actor_ref"); val == nil {
+	if val, fldPath := req.Actor, fldPath.Child("actor"); val == nil {
 		errs = append(errs, field.Required(fldPath, ""))
 	} else {
-		errs = append(errs, resources.ValidateActorRef(val, fldPath)...)
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
 	if len(errs) > 0 {

--- a/cmd/ateapi/internal/controlapi/get_actor.go
+++ b/cmd/ateapi/internal/controlapi/get_actor.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func (s *Service) GetActor(ctx context.Context, req *ateapipb.GetActorRequest) (*ateapipb.GetActorResponse, error) {
+func (s *Service) GetActor(ctx context.Context, req *ateapipb.GetActorRequest) (*ateapipb.Actor, error) {
 	if err := validateGetActorRequest(req); err != nil {
 		return nil, err
 	}
@@ -37,9 +37,7 @@ func (s *Service) GetActor(ctx context.Context, req *ateapipb.GetActorRequest) (
 	} else if err != nil {
 		return nil, fmt.Errorf("while getting actor from DB: %w", err)
 	}
-	return &ateapipb.GetActorResponse{
-		Actor: actor,
-	}, nil
+	return actor, nil
 }
 
 func validateGetActorRequest(req *ateapipb.GetActorRequest) error {

--- a/cmd/ateapi/internal/controlapi/get_atespace.go
+++ b/cmd/ateapi/internal/controlapi/get_atespace.go
@@ -24,29 +24,37 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func (s *Service) GetAtespace(ctx context.Context, req *ateapipb.GetAtespaceRequest) (*ateapipb.GetAtespaceResponse, error) {
+func (s *Service) GetAtespace(ctx context.Context, req *ateapipb.GetAtespaceRequest) (*ateapipb.Atespace, error) {
 	if err := validateGetAtespaceRequest(req); err != nil {
 		return nil, err
 	}
 
-	atespace, err := s.persistence.GetAtespace(ctx, req.GetName())
+	name := req.GetAtespace().GetName()
+	atespace, err := s.persistence.GetAtespace(ctx, name)
 	if errors.Is(err, store.ErrNotFound) {
-		return nil, status.Errorf(codes.NotFound, "Atespace %s not found", req.GetName())
+		return nil, status.Errorf(codes.NotFound, "Atespace %s not found", name)
 	} else if err != nil {
 		return nil, fmt.Errorf("while getting atespace from DB: %w", err)
 	}
 
-	return &ateapipb.GetAtespaceResponse{Atespace: atespace}, nil
+	return atespace, nil
 }
 
 func validateGetAtespaceRequest(req *ateapipb.GetAtespaceRequest) error {
-	if req.GetName() == "" {
-		return status.Error(codes.InvalidArgument, "name is required")
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.Atespace, fldPath.Child("atespace"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateGlobalObjectRef(val, fldPath)...)
 	}
-	if err := resources.ValidateAtespace(req.GetName()); err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
+
+	if len(errs) > 0 {
+		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
 	}
 	return nil
 }

--- a/cmd/ateapi/internal/controlapi/pause_actor.go
+++ b/cmd/ateapi/internal/controlapi/pause_actor.go
@@ -31,13 +31,13 @@ func (s *Service) PauseActor(ctx context.Context, req *ateapipb.PauseActorReques
 		return nil, err
 	}
 
-	actor, err := s.actorWorkflow.PauseActor(ctx, req.GetActorRef().GetAtespace(), req.GetActorRef().GetName())
+	actor, err := s.actorWorkflow.PauseActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName())
 	if err != nil {
 		if errors.Is(err, store.ErrPersistenceRetry) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
 		}
 		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActorRef().GetName())
+			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActor().GetName())
 		}
 		return nil, err
 	}
@@ -49,10 +49,10 @@ func validatePauseActorRequest(req *ateapipb.PauseActorRequest) error {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
-	if val, fldPath := req.ActorRef, fldPath.Child("actor_ref"); val == nil {
+	if val, fldPath := req.Actor, fldPath.Child("actor"); val == nil {
 		errs = append(errs, field.Required(fldPath, ""))
 	} else {
-		errs = append(errs, resources.ValidateActorRef(val, fldPath)...)
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
 	if len(errs) > 0 {

--- a/cmd/ateapi/internal/controlapi/resume_actor.go
+++ b/cmd/ateapi/internal/controlapi/resume_actor.go
@@ -31,13 +31,13 @@ func (s *Service) ResumeActor(ctx context.Context, req *ateapipb.ResumeActorRequ
 		return nil, err
 	}
 
-	actor, err := s.actorWorkflow.ResumeActor(ctx, req.GetActorRef().GetAtespace(), req.GetActorRef().GetName(), req.GetBoot())
+	actor, err := s.actorWorkflow.ResumeActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName(), req.GetBoot())
 	if err != nil {
 		if errors.Is(err, store.ErrPersistenceRetry) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
 		}
 		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActorRef().GetName())
+			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActor().GetName())
 		}
 		return nil, err
 	}
@@ -49,10 +49,10 @@ func validateResumeActorRequest(req *ateapipb.ResumeActorRequest) error {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
-	if val, fldPath := req.ActorRef, fldPath.Child("actor_ref"); val == nil {
+	if val, fldPath := req.Actor, fldPath.Child("actor"); val == nil {
 		errs = append(errs, field.Required(fldPath, ""))
 	} else {
-		errs = append(errs, resources.ValidateActorRef(val, fldPath)...)
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
 	if len(errs) > 0 {

--- a/cmd/ateapi/internal/controlapi/suspend_actor.go
+++ b/cmd/ateapi/internal/controlapi/suspend_actor.go
@@ -31,13 +31,13 @@ func (s *Service) SuspendActor(ctx context.Context, req *ateapipb.SuspendActorRe
 		return nil, err
 	}
 
-	actor, err := s.actorWorkflow.SuspendActor(ctx, req.GetActorRef().GetAtespace(), req.GetActorRef().GetName())
+	actor, err := s.actorWorkflow.SuspendActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName())
 	if err != nil {
 		if errors.Is(err, store.ErrPersistenceRetry) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
 		}
 		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActorRef().GetName())
+			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActor().GetName())
 		}
 		return nil, err
 	}
@@ -49,10 +49,10 @@ func validateSuspendActorRequest(req *ateapipb.SuspendActorRequest) error {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
-	if val, fldPath := req.ActorRef, fldPath.Child("actor_ref"); val == nil {
+	if val, fldPath := req.Actor, fldPath.Child("actor"); val == nil {
 		errs = append(errs, field.Required(fldPath, ""))
 	} else {
-		errs = append(errs, resources.ValidateActorRef(val, fldPath)...)
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
 	if len(errs) > 0 {

--- a/cmd/ateapi/internal/controlapi/syncer_test.go
+++ b/cmd/ateapi/internal/controlapi/syncer_test.go
@@ -257,7 +257,7 @@ func TestSyncer_DeleteBoundWorker_ClearsActor(t *testing.T) {
 			Namespace: ns,
 			Name:      "tmpl",
 		},
-		Actor: &ateapipb.ActorRef{
+		Actor: &ateapipb.ObjectRef{
 			Name:     actorName,
 			Atespace: "team-orphan",
 		},

--- a/cmd/ateapi/internal/controlapi/update_actor.go
+++ b/cmd/ateapi/internal/controlapi/update_actor.go
@@ -32,10 +32,10 @@ func (s *Service) UpdateActor(ctx context.Context, req *ateapipb.UpdateActorRequ
 		return nil, err
 	}
 
-	actor, err := s.persistence.GetActor(ctx, req.GetActorRef().GetAtespace(), req.GetActorRef().GetName())
+	actor, err := s.persistence.GetActor(ctx, req.GetActor().GetAtespace(), req.GetActor().GetName())
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActorRef().GetName())
+			return nil, status.Errorf(codes.NotFound, "Actor %s not found", req.GetActor().GetName())
 		}
 		return nil, fmt.Errorf("while getting actor: %w", err)
 	}
@@ -56,10 +56,10 @@ func validateUpdateActorRequest(req *ateapipb.UpdateActorRequest) error {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
-	if val, fldPath := req.ActorRef, fldPath.Child("actor_ref"); val == nil {
+	if val, fldPath := req.Actor, fldPath.Child("actor"); val == nil {
 		errs = append(errs, field.Required(fldPath, ""))
 	} else {
-		errs = append(errs, resources.ValidateActorRef(val, fldPath)...)
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
 	if val := req.WorkerSelector; val != nil {

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -174,7 +174,7 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 			Namespace: state.Actor.GetActorTemplateNamespace(),
 			Name:      state.Actor.GetActorTemplateName(),
 		},
-		Actor: &ateapipb.ActorRef{
+		Actor: &ateapipb.ObjectRef{
 			Name:     input.ActorName,
 			Atespace: state.Actor.GetMetadata().GetAtespace(),
 		},

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -180,7 +180,7 @@ func TestAssignWorkerStep_SkipsWorkerAssignedInOtherAtespace(t *testing.T) {
 		WorkerPod:       "pod-1",
 		SandboxClass:    "gvisor",
 		Assignment: &ateapipb.Assignment{
-			Actor: &ateapipb.ActorRef{Atespace: "team-b", Name: "shared"},
+			Actor: &ateapipb.ObjectRef{Atespace: "team-b", Name: "shared"},
 		},
 	}
 	if err := persistence.CreateWorker(ctx, worker); err != nil {

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -66,7 +66,7 @@ func TestFinalizeSuspendedStep_ReleasesOnlyOwnWorker(t *testing.T) {
 				WorkerPool:      "pool",
 				WorkerPod:       "pod-1",
 				Assignment: &ateapipb.Assignment{
-					Actor: &ateapipb.ActorRef{Atespace: tt.assignmentAtespace, Name: "shared"},
+					Actor: &ateapipb.ObjectRef{Atespace: tt.assignmentAtespace, Name: "shared"},
 				},
 			}
 			if err := persistence.CreateWorker(ctx, worker); err != nil {

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -190,31 +190,37 @@ func (s *Persistence) ListAtespaces(ctx context.Context) ([]*ateapipb.Atespace, 
 // DeleteAtespace deletes an empty atespace. Returns store.ErrNotFound if the
 // atespace does not exist, or store.ErrFailedPrecondition if any actor still
 // lives in it.
-func (s *Persistence) DeleteAtespace(ctx context.Context, name string) error {
+func (s *Persistence) DeleteAtespace(ctx context.Context, name string) (*ateapipb.Atespace, error) {
 	dbKey := atespaceDBKey(name)
 
-	// Existence first, so a missing atespace returns NotFound, not a silent no-op.
-	exists, err := s.rdb.Exists(ctx, dbKey).Result()
+	// Read first, so a missing atespace returns NotFound (not a silent no-op) and
+	// so we can return the deleted resource.
+	currentVal, err := s.rdb.Get(ctx, dbKey).Bytes()
 	if err != nil {
-		return fmt.Errorf("while checking atespace key %q: %w", dbKey, err)
+		if errors.Is(err, redis.Nil) {
+			return nil, store.ErrNotFound
+		}
+		return nil, fmt.Errorf("while getting atespace key %q: %w", dbKey, err)
 	}
-	if exists == 0 {
-		return store.ErrNotFound
+
+	deleted := &ateapipb.Atespace{}
+	if err := protojson.Unmarshal(currentVal, deleted); err != nil {
+		return nil, fmt.Errorf("in protojson.Unmarshal: %w", err)
 	}
 
 	// Reject a non-empty atespace.
 	actors, _, err := s.ListActors(ctx, name, 1, "")
 	if err != nil {
-		return fmt.Errorf("while checking atespace emptiness: %w", err)
+		return nil, fmt.Errorf("while checking atespace emptiness: %w", err)
 	}
 	if len(actors) > 0 {
-		return store.ErrFailedPrecondition
+		return nil, store.ErrFailedPrecondition
 	}
 
 	if err := s.rdb.Del(ctx, dbKey).Err(); err != nil {
-		return fmt.Errorf("while deleting atespace key %q: %w", dbKey, err)
+		return nil, fmt.Errorf("while deleting atespace key %q: %w", dbKey, err)
 	}
-	return nil
+	return deleted, nil
 }
 
 func workerDBKey(namespace, poolName, podName string) string {
@@ -488,8 +494,9 @@ func (s *Persistence) DeleteWorker(ctx context.Context, namespace, pool, pod str
 	return nil
 }
 
-func (s *Persistence) DeleteActor(ctx context.Context, atespace, name string) error {
+func (s *Persistence) DeleteActor(ctx context.Context, atespace, name string) (*ateapipb.Actor, error) {
 	dbKey := actorDBKey(atespace, name)
+	var deleted *ateapipb.Actor
 	err := s.rdb.Watch(ctx, func(tx *redis.Tx) error {
 		currentVal, err := tx.Get(ctx, dbKey).Bytes()
 		if err != nil {
@@ -509,21 +516,24 @@ func (s *Persistence) DeleteActor(ctx context.Context, atespace, name string) er
 			return store.ErrFailedPrecondition
 		}
 
-		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		if _, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 			pipe.Del(ctx, dbKey)
 			return nil
-		})
-		return err
+		}); err != nil {
+			return err
+		}
+		deleted = currentActor
+		return nil
 	}, dbKey)
 
 	if err != nil {
 		if errors.Is(err, redis.TxFailedErr) {
-			return store.ErrPersistenceRetry
+			return nil, store.ErrPersistenceRetry
 		}
-		return err
+		return nil, err
 	}
 
-	return nil
+	return deleted, nil
 }
 
 func (s *Persistence) UpdateActor(ctx context.Context, actor *ateapipb.Actor, expectedVersion int64) (*ateapipb.Actor, error) {

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -315,7 +315,7 @@ func TestUpdateWorker_Success(t *testing.T) {
 			Namespace: "default",
 			Name:      "test-template",
 		},
-		Actor: &ateapipb.ActorRef{
+		Actor: &ateapipb.ObjectRef{
 			Name: "session-1",
 		},
 	}
@@ -578,14 +578,14 @@ func TestUpdateWorker_Conflict(t *testing.T) {
 	}
 
 	// Update instance 1
-	worker1.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ActorRef{Name: "session-1"}}
+	worker1.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ObjectRef{Name: "session-1"}}
 	err = s.UpdateWorker(ctx, worker1, worker1.Version)
 	if err != nil {
 		t.Fatalf("UpdateWorker failed: %v", err)
 	}
 
 	// Try to update instance 2
-	worker2.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ActorRef{Name: "session-2"}}
+	worker2.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ObjectRef{Name: "session-2"}}
 	err = s.UpdateWorker(ctx, worker2, worker2.Version)
 	if !errors.Is(err, store.ErrPersistenceRetry) {
 		t.Errorf("expected ErrPersistenceRetry, got %v", err)

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -414,7 +414,7 @@ func TestDeleteActor(t *testing.T) {
 				t.Fatalf("CreateActor failed: %v", err)
 			}
 
-			err := s.DeleteActor(ctx, testAtespace, "session-1")
+			deleted, err := s.DeleteActor(ctx, testAtespace, "session-1")
 			if tt.wantErr != nil {
 				if !errors.Is(err, tt.wantErr) {
 					t.Errorf("DeleteActor: expected %v, got %v", tt.wantErr, err)
@@ -423,6 +423,10 @@ func TestDeleteActor(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("DeleteActor failed: %v", err)
+			}
+			// DeleteActor returns the deleted resource.
+			if got := deleted.GetMetadata().GetName(); got != "session-1" {
+				t.Errorf("deleted actor name = %q, want session-1", got)
 			}
 
 			if _, err := s.GetActor(ctx, testAtespace, "session-1"); !errors.Is(err, store.ErrNotFound) {
@@ -436,7 +440,7 @@ func TestDeleteActor_NotFound(t *testing.T) {
 	mr, s, ctx := setupTest(t)
 	defer mr.Close()
 
-	err := s.DeleteActor(ctx, testAtespace, "non-existent")
+	_, err := s.DeleteActor(ctx, testAtespace, "non-existent")
 	if !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("expected ErrNotFound deleting non-existent actor, got %v", err)
 	}
@@ -1072,8 +1076,13 @@ func TestDeleteAtespace_Empty(t *testing.T) {
 	if _, err := s.CreateAtespace(ctx, newTestAtespace("team-a")); err != nil {
 		t.Fatalf("CreateAtespace failed: %v", err)
 	}
-	if err := s.DeleteAtespace(ctx, "team-a"); err != nil {
+	deleted, err := s.DeleteAtespace(ctx, "team-a")
+	if err != nil {
 		t.Fatalf("DeleteAtespace failed: %v", err)
+	}
+	// DeleteAtespace returns the deleted resource.
+	if got := deleted.GetMetadata().GetName(); got != "team-a" {
+		t.Errorf("deleted atespace name = %q, want team-a", got)
 	}
 	if _, err := s.GetAtespace(ctx, "team-a"); !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("after delete, GetAtespace = %v, want ErrNotFound", err)
@@ -1084,7 +1093,7 @@ func TestDeleteAtespace_NotFound(t *testing.T) {
 	mr, s, ctx := setupTest(t)
 	defer mr.Close()
 
-	if err := s.DeleteAtespace(ctx, "nope"); !errors.Is(err, store.ErrNotFound) {
+	if _, err := s.DeleteAtespace(ctx, "nope"); !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
@@ -1099,7 +1108,7 @@ func TestDeleteAtespace_NonEmpty_Rejected(t *testing.T) {
 	if _, err := s.CreateActor(ctx, &ateapipb.Actor{Metadata: &ateapipb.ResourceMetadata{Name: "id1", Atespace: "team-a"}, Status: ateapipb.Actor_STATUS_SUSPENDED}); err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
-	if err := s.DeleteAtespace(ctx, "team-a"); !errors.Is(err, store.ErrFailedPrecondition) {
+	if _, err := s.DeleteAtespace(ctx, "team-a"); !errors.Is(err, store.ErrFailedPrecondition) {
 		t.Errorf("DeleteAtespace on non-empty = %v, want ErrFailedPrecondition", err)
 	}
 	// The atespace must survive a rejected delete.
@@ -1118,13 +1127,13 @@ func TestDeleteAtespace_EmptyAfterActorsRemoved(t *testing.T) {
 	if _, err := s.CreateActor(ctx, &ateapipb.Actor{Metadata: &ateapipb.ResourceMetadata{Name: "id1", Atespace: "team-a"}, Status: ateapipb.Actor_STATUS_SUSPENDED}); err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
-	if err := s.DeleteAtespace(ctx, "team-a"); !errors.Is(err, store.ErrFailedPrecondition) {
+	if _, err := s.DeleteAtespace(ctx, "team-a"); !errors.Is(err, store.ErrFailedPrecondition) {
 		t.Fatalf("expected rejection while non-empty, got %v", err)
 	}
-	if err := s.DeleteActor(ctx, "team-a", "id1"); err != nil {
+	if _, err := s.DeleteActor(ctx, "team-a", "id1"); err != nil {
 		t.Fatalf("DeleteActor failed: %v", err)
 	}
-	if err := s.DeleteAtespace(ctx, "team-a"); err != nil {
+	if _, err := s.DeleteAtespace(ctx, "team-a"); err != nil {
 		t.Errorf("DeleteAtespace after actor removed = %v, want nil (re-scan should find it empty)", err)
 	}
 }
@@ -1145,14 +1154,14 @@ func TestDeleteAtespace_EmptyWhileOtherAtespaceNonEmpty(t *testing.T) {
 	}
 
 	// team-a is empty → delete must succeed.
-	if err := s.DeleteAtespace(ctx, "team-a"); err != nil {
+	if _, err := s.DeleteAtespace(ctx, "team-a"); err != nil {
 		t.Errorf("DeleteAtespace(team-a, empty) = %v, want nil (must not be blocked by team-b's actor)", err)
 	}
 	if _, err := s.GetAtespace(ctx, "team-a"); !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("after delete, GetAtespace(team-a) = %v, want ErrNotFound", err)
 	}
 	// team-b is still non-empty → still rejected.
-	if err := s.DeleteAtespace(ctx, "team-b"); !errors.Is(err, store.ErrFailedPrecondition) {
+	if _, err := s.DeleteAtespace(ctx, "team-b"); !errors.Is(err, store.ErrFailedPrecondition) {
 		t.Errorf("DeleteAtespace(team-b, non-empty) = %v, want ErrFailedPrecondition", err)
 	}
 }

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -52,8 +52,9 @@ type Interface interface {
 	// mutated. Returns ErrNotFound if missing, or ErrPersistenceRetry on version mismatch.
 	UpdateActor(ctx context.Context, actor *ateapipb.Actor, expectedVersion int64) (*ateapipb.Actor, error)
 
-	// Removes an actor. Returns ErrNotFound if missing, or ErrFailedPrecondition if not suspended.
-	DeleteActor(ctx context.Context, atespace, name string) error
+	// Removes an actor and returns the deleted resource. Returns ErrNotFound if
+	// missing, or ErrFailedPrecondition if not suspended.
+	DeleteActor(ctx context.Context, atespace, name string) (*ateapipb.Actor, error)
 
 	// Lists actors in the given atespace (scoped scan), or across ALL atespaces if atespace is
 	// empty. Returns a page of actors and a next page token.
@@ -73,9 +74,10 @@ type Interface interface {
 	// AtespaceExists reports whether the atespace object exists.
 	AtespaceExists(ctx context.Context, name string) (bool, error)
 
-	// Removes an empty atespace. Returns ErrNotFound if missing, or
-	// ErrFailedPrecondition if any actor:<name>:* key still exists.
-	DeleteAtespace(ctx context.Context, name string) error
+	// Removes an empty atespace and returns the deleted resource. Returns
+	// ErrNotFound if missing, or ErrFailedPrecondition if the atespace is not empty
+	// (e.g. there are actors in it).
+	DeleteAtespace(ctx context.Context, name string) (*ateapipb.Atespace, error)
 
 	// Fetches worker state by namespace, pool, and pod name. Returns ErrNotFound if missing.
 	GetWorker(ctx context.Context, namespace, pool, pod string) (*ateapipb.Worker, error)

--- a/cmd/ateapi/internal/workercache/workercache_test.go
+++ b/cmd/ateapi/internal/workercache/workercache_test.go
@@ -92,7 +92,7 @@ func TestCache_UpdatedEvent_NewerVersionApplied(t *testing.T) {
 	}
 
 	updated := makeWorker("ns", "pod1", 2)
-	updated.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ActorRef{Name: "actor-1"}}
+	updated.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ObjectRef{Name: "actor-1"}}
 	fs.send(store.WorkerEvent{Type: store.WorkerEventUpdated, Worker: updated})
 
 	eventually(t, func() bool {
@@ -122,7 +122,7 @@ func TestCache_UpdatedEvent_OlderVersionIgnored(t *testing.T) {
 
 	// Send a stale update followed by a sentinel we can detect.
 	stale := makeWorker("ns", "pod1", 3)
-	stale.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ActorRef{Name: "stale-actor"}}
+	stale.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ObjectRef{Name: "stale-actor"}}
 	fs.send(store.WorkerEvent{Type: store.WorkerEventUpdated, Worker: stale})
 
 	sentinel := makeWorker("ns", "pod2", 1)

--- a/cmd/atecontroller/internal/controllers/actortemplate_controller.go
+++ b/cmd/atecontroller/internal/controllers/actortemplate_controller.go
@@ -89,7 +89,7 @@ func (r *ActorTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		createReq := &ateapipb.CreateActorRequest{
-			ActorRef:               &ateapipb.ActorRef{Atespace: resources.GoldenActorAtespace, Name: actorID},
+			Actor:                  &ateapipb.ObjectRef{Atespace: resources.GoldenActorAtespace, Name: actorID},
 			ActorTemplateNamespace: at.ObjectMeta.Namespace,
 			ActorTemplateName:      at.ObjectMeta.Name,
 		}
@@ -118,7 +118,7 @@ func (r *ActorTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// TODO: Maybe this should go through a different RPC dedicated to
 		// booting an actor from scratch.
 		resumeReq := &ateapipb.ResumeActorRequest{
-			ActorRef: &ateapipb.ActorRef{Atespace: resources.GoldenActorAtespace, Name: at.Status.GoldenActorID},
+			Actor: &ateapipb.ObjectRef{Atespace: resources.GoldenActorAtespace, Name: at.Status.GoldenActorID},
 		}
 		_, err := r.AteClient.ResumeActor(ctx, resumeReq)
 		if err != nil {
@@ -144,7 +144,7 @@ func (r *ActorTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// from it.
 
 		req := &ateapipb.SuspendActorRequest{
-			ActorRef: &ateapipb.ActorRef{Atespace: resources.GoldenActorAtespace, Name: at.Status.GoldenActorID},
+			Actor: &ateapipb.ObjectRef{Atespace: resources.GoldenActorAtespace, Name: at.Status.GoldenActorID},
 		}
 		resp, err := r.AteClient.SuspendActor(ctx, req)
 		if err != nil {

--- a/cmd/atenet/internal/router/extproc_test.go
+++ b/cmd/atenet/internal/router/extproc_test.go
@@ -179,8 +179,8 @@ func TestExtProcHeadersEvaluation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			clientMock := &mockClient{
 				resumeFn: func(ctx context.Context, in *ateapipb.ResumeActorRequest, opts ...grpc.CallOption) (*ateapipb.ResumeActorResponse, error) {
-					if in.GetActorRef().GetName() != testUUID {
-						t.Errorf("unexpected identifier parsed in test context: %s", in.GetActorRef().GetName())
+					if in.GetActor().GetName() != testUUID {
+						t.Errorf("unexpected identifier parsed in test context: %s", in.GetActor().GetName())
 					}
 					if tc.resumeErr != nil {
 						return nil, tc.resumeErr

--- a/cmd/atenet/internal/router/resumer.go
+++ b/cmd/atenet/internal/router/resumer.go
@@ -70,7 +70,7 @@ func (r *ActorResumer) ResumeActor(ctx context.Context, atespace, actorID string
 		err := wait.ExponentialBackoffWithContext(bgCtx, backoff, func(ctx context.Context) (bool, error) {
 			var err error
 			resumeResp, err = r.apiClient.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: atespace, Name: actorID},
+				Actor: &ateapipb.ObjectRef{Atespace: atespace, Name: actorID},
 			})
 			if err == nil {
 				return true, nil

--- a/cmd/kubectl-ate/internal/cmd/create_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/create_actor.go
@@ -48,7 +48,7 @@ var createActorCmd = &cobra.Command{
 		resp, err := apiClient.CreateActor(ctx, &ateapipb.CreateActorRequest{
 			ActorTemplateNamespace: parts[0],
 			ActorTemplateName:      parts[1],
-			ActorRef:               &ateapipb.ActorRef{Atespace: atespaceFlag, Name: actorID},
+			Actor:                  &ateapipb.ObjectRef{Atespace: atespaceFlag, Name: actorID},
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create actor: %w", err)

--- a/cmd/kubectl-ate/internal/cmd/delete_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/delete_actor.go
@@ -38,7 +38,7 @@ var deleteActorCmd = &cobra.Command{
 
 		id := args[0]
 		_, err = c.ControlClient.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
-			ActorRef: &ateapipb.ActorRef{Atespace: deleteAtespaceFlag, Name: id},
+			Actor: &ateapipb.ObjectRef{Atespace: deleteAtespaceFlag, Name: id},
 		})
 		if err != nil {
 			return err

--- a/cmd/kubectl-ate/internal/cmd/delete_atespace.go
+++ b/cmd/kubectl-ate/internal/cmd/delete_atespace.go
@@ -35,7 +35,7 @@ var deleteAtespaceCmd = &cobra.Command{
 		defer apiClient.Close()
 
 		name := args[0]
-		if _, err := apiClient.DeleteAtespace(ctx, &ateapipb.DeleteAtespaceRequest{Name: name}); err != nil {
+		if _, err := apiClient.DeleteAtespace(ctx, &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: name}}); err != nil {
 			return fmt.Errorf("failed to delete atespace: %w", err)
 		}
 

--- a/cmd/kubectl-ate/internal/cmd/get_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/get_actors.go
@@ -52,7 +52,7 @@ var getActorsCmd = &cobra.Command{
 			if getActorsAtespaceFlag == "" {
 				return fmt.Errorf("--atespace is required when getting a specific actor")
 			}
-			resp, err := apiClient.GetActor(ctx, &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: getActorsAtespaceFlag, Name: args[0]}})
+			resp, err := apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: getActorsAtespaceFlag, Name: args[0]}})
 			if err != nil {
 				return fmt.Errorf("failed to get actor: %w", err)
 			}

--- a/cmd/kubectl-ate/internal/cmd/get_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/get_actors.go
@@ -56,7 +56,7 @@ var getActorsCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to get actor: %w", err)
 			}
-			return printer.PrintActor(resp.GetActor(), outputFmt)
+			return printer.PrintActor(resp, outputFmt)
 		}
 
 		// Listing requires exactly one of --atespace (one atespace) or -A (all

--- a/cmd/kubectl-ate/internal/cmd/get_atespaces.go
+++ b/cmd/kubectl-ate/internal/cmd/get_atespaces.go
@@ -36,11 +36,11 @@ var getAtespacesCmd = &cobra.Command{
 		defer apiClient.Close()
 
 		if len(args) > 0 {
-			resp, err := apiClient.GetAtespace(ctx, &ateapipb.GetAtespaceRequest{Name: args[0]})
+			resp, err := apiClient.GetAtespace(ctx, &ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: args[0]}})
 			if err != nil {
 				return fmt.Errorf("failed to get atespace: %w", err)
 			}
-			return printer.PrintAtespace(resp.GetAtespace(), outputFmt)
+			return printer.PrintAtespace(resp, outputFmt)
 		}
 
 		resp, err := apiClient.ListAtespaces(ctx, &ateapipb.ListAtespacesRequest{})

--- a/cmd/kubectl-ate/internal/cmd/logs_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors.go
@@ -109,7 +109,7 @@ func (r *LogsActorRunner) Run(ctx context.Context, actorID string) error {
 }
 
 func (r *LogsActorRunner) runOneShot(ctx context.Context, actorID string) error {
-	actorResp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: r.atespace, Name: actorID}})
+	actorResp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
 	if err != nil {
 		return fmt.Errorf("failed to get actor: %w", err)
 	}
@@ -156,7 +156,7 @@ func (r *LogsActorRunner) runFollow(ctx context.Context, actorID string) error {
 		default:
 		}
 
-		actorResp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: r.atespace, Name: actorID}})
+		actorResp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
 		if err != nil {
 			if status.Code(err) == codes.NotFound {
 				return fmt.Errorf("actor %s not found: %w", actorID, err)
@@ -264,7 +264,7 @@ func (r *LogsActorRunner) startMigrationMonitor(
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				resp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: r.atespace, Name: actorID}})
+				resp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
 				if err == nil {
 					act := resp.GetActor()
 					if act.GetStatus() != ateapipb.Actor_STATUS_RUNNING || act.GetAteomPodName() != currentPod {

--- a/cmd/kubectl-ate/internal/cmd/logs_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors.go
@@ -58,7 +58,7 @@ func init() {
 
 // AteAPIClient abstracts the gRPC client calls.
 type AteAPIClient interface {
-	GetActor(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error)
+	GetActor(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error)
 	Close()
 }
 
@@ -109,12 +109,11 @@ func (r *LogsActorRunner) Run(ctx context.Context, actorID string) error {
 }
 
 func (r *LogsActorRunner) runOneShot(ctx context.Context, actorID string) error {
-	actorResp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
+	actor, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
 	if err != nil {
 		return fmt.Errorf("failed to get actor: %w", err)
 	}
 
-	actor := actorResp.GetActor()
 	podName := actor.GetAteomPodName()
 	namespace := actor.GetAteomPodNamespace()
 
@@ -156,7 +155,7 @@ func (r *LogsActorRunner) runFollow(ctx context.Context, actorID string) error {
 		default:
 		}
 
-		actorResp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
+		actor, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
 		if err != nil {
 			if status.Code(err) == codes.NotFound {
 				return fmt.Errorf("actor %s not found: %w", actorID, err)
@@ -169,7 +168,6 @@ func (r *LogsActorRunner) runFollow(ctx context.Context, actorID string) error {
 			}
 		}
 
-		actor := actorResp.GetActor()
 		podName := actor.GetAteomPodName()
 		namespace := actor.GetAteomPodNamespace()
 
@@ -266,7 +264,7 @@ func (r *LogsActorRunner) startMigrationMonitor(
 			case <-ticker.C:
 				resp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
 				if err == nil {
-					act := resp.GetActor()
+					act := resp
 					if act.GetStatus() != ateapipb.Actor_STATUS_RUNNING || act.GetAteomPodName() != currentPod {
 						// Actor suspended or migrated! Cancel stream context to reconnect.
 						cancel()

--- a/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
@@ -187,8 +187,8 @@ func TestLogsActorRunner_Run_OneShotSuccess(t *testing.T) {
 
 	mockAPI := &mockAteAPIClient{
 		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
-			if in.GetActorRef().GetName() != actorID {
-				return nil, fmt.Errorf("unexpected actor ID: %s", in.GetActorRef().GetName())
+			if in.GetActor().GetName() != actorID {
+				return nil, fmt.Errorf("unexpected actor ID: %s", in.GetActor().GetName())
 			}
 			return &ateapipb.GetActorResponse{
 				Actor: &ateapipb.Actor{

--- a/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
@@ -154,11 +154,11 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 }
 
 type mockAteAPIClient struct {
-	GetActorFunc func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error)
+	GetActorFunc func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error)
 	CloseCalls   int
 }
 
-func (m *mockAteAPIClient) GetActor(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+func (m *mockAteAPIClient) GetActor(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
 	if m.GetActorFunc != nil {
 		return m.GetActorFunc(ctx, in, opts...)
 	}
@@ -186,17 +186,15 @@ func TestLogsActorRunner_Run_OneShotSuccess(t *testing.T) {
 	namespace := "ns-abc"
 
 	mockAPI := &mockAteAPIClient{
-		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
 			if in.GetActor().GetName() != actorID {
 				return nil, fmt.Errorf("unexpected actor ID: %s", in.GetActor().GetName())
 			}
-			return &ateapipb.GetActorResponse{
-				Actor: &ateapipb.Actor{
-					Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
-					AteomPodName:      podName,
-					AteomPodNamespace: namespace,
-					Status:            ateapipb.Actor_STATUS_RUNNING,
-				},
+			return &ateapipb.Actor{
+				Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+				AteomPodName:      podName,
+				AteomPodNamespace: namespace,
+				Status:            ateapipb.Actor_STATUS_RUNNING,
 			}, nil
 		},
 	}
@@ -243,12 +241,10 @@ func TestLogsActorRunner_Run_OneShot_ActorNotRunning(t *testing.T) {
 	actorID := "act-123"
 
 	mockAPI := &mockAteAPIClient{
-		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
-			return &ateapipb.GetActorResponse{
-				Actor: &ateapipb.Actor{
-					Metadata: &ateapipb.ResourceMetadata{Name: actorID},
-					Status:   ateapipb.Actor_STATUS_SUSPENDED, // not running
-				},
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
+			return &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: actorID},
+				Status:   ateapipb.Actor_STATUS_SUSPENDED, // not running
 			}, nil
 		},
 	}
@@ -292,29 +288,25 @@ func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
 	var getActorMu sync.Mutex
 
 	mockAPI := &mockAteAPIClient{
-		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
 			getActorMu.Lock()
 			defer getActorMu.Unlock()
 			getActorCalls++
 
 			if getActorCalls == 1 {
 				// First call: suspended
-				return &ateapipb.GetActorResponse{
-					Actor: &ateapipb.Actor{
-						Metadata: &ateapipb.ResourceMetadata{Name: actorID},
-						Status:   ateapipb.Actor_STATUS_SUSPENDED,
-					},
+				return &ateapipb.Actor{
+					Metadata: &ateapipb.ResourceMetadata{Name: actorID},
+					Status:   ateapipb.Actor_STATUS_SUSPENDED,
 				}, nil
 			}
 
 			// Subsequent calls: running
-			return &ateapipb.GetActorResponse{
-				Actor: &ateapipb.Actor{
-					Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
-					AteomPodName:      podName,
-					AteomPodNamespace: namespace,
-					Status:            ateapipb.Actor_STATUS_RUNNING,
-				},
+			return &ateapipb.Actor{
+				Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+				AteomPodName:      podName,
+				AteomPodNamespace: namespace,
+				Status:            ateapipb.Actor_STATUS_RUNNING,
 			}, nil
 		},
 	}
@@ -385,7 +377,7 @@ func TestLogsActorRunner_Run_Follow_NotFoundActor(t *testing.T) {
 	actorID := "act-notfound"
 
 	mockAPI := &mockAteAPIClient{
-		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
 			return nil, status.Error(codes.NotFound, "actor not found")
 		},
 	}
@@ -428,20 +420,18 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 	lineRead := make(chan struct{})
 
 	mockAPI := &mockAteAPIClient{
-		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
 			getActorMu.Lock()
 			defer getActorMu.Unlock()
 			getActorCalls++
 
 			if getActorCalls == 1 {
 				// 1. Initial call for stream 1: pod-1
-				return &ateapipb.GetActorResponse{
-					Actor: &ateapipb.Actor{
-						Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
-						AteomPodName:      "pod-1",
-						AteomPodNamespace: "ns",
-						Status:            ateapipb.Actor_STATUS_RUNNING,
-					},
+				return &ateapipb.Actor{
+					Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+					AteomPodName:      "pod-1",
+					AteomPodNamespace: "ns",
+					Status:            ateapipb.Actor_STATUS_RUNNING,
 				}, nil
 			}
 
@@ -453,13 +443,11 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 				return nil, ctx.Err()
 			}
 
-			return &ateapipb.GetActorResponse{
-				Actor: &ateapipb.Actor{
-					Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
-					AteomPodName:      "pod-2",
-					AteomPodNamespace: "ns",
-					Status:            ateapipb.Actor_STATUS_RUNNING,
-				},
+			return &ateapipb.Actor{
+				Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+				AteomPodName:      "pod-2",
+				AteomPodNamespace: "ns",
+				Status:            ateapipb.Actor_STATUS_RUNNING,
 			}, nil
 		},
 	}
@@ -541,20 +529,18 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 	lineRead := make(chan struct{})
 
 	mockAPI := &mockAteAPIClient{
-		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.GetActorResponse, error) {
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
 			getActorMu.Lock()
 			defer getActorMu.Unlock()
 			getActorCalls++
 
 			// 1. Initial call: running on pod-1
 			if getActorCalls == 1 {
-				return &ateapipb.GetActorResponse{
-					Actor: &ateapipb.Actor{
-						Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
-						AteomPodName:      "pod-1",
-						AteomPodNamespace: "ns",
-						Status:            ateapipb.Actor_STATUS_RUNNING,
-					},
+				return &ateapipb.Actor{
+					Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+					AteomPodName:      "pod-1",
+					AteomPodNamespace: "ns",
+					Status:            ateapipb.Actor_STATUS_RUNNING,
 				}, nil
 			}
 
@@ -566,32 +552,26 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 				case <-ctx.Done():
 					return nil, ctx.Err()
 				}
-				return &ateapipb.GetActorResponse{
-					Actor: &ateapipb.Actor{
-						Metadata: &ateapipb.ResourceMetadata{Name: actorID},
-						Status:   ateapipb.Actor_STATUS_SUSPENDED,
-					},
+				return &ateapipb.Actor{
+					Metadata: &ateapipb.ResourceMetadata{Name: actorID},
+					Status:   ateapipb.Actor_STATUS_SUSPENDED,
 				}, nil
 			}
 
 			// 3. Loop reconnection call: suspended (still suspended, so it will wait)
 			if getActorCalls == 3 {
-				return &ateapipb.GetActorResponse{
-					Actor: &ateapipb.Actor{
-						Metadata: &ateapipb.ResourceMetadata{Name: actorID},
-						Status:   ateapipb.Actor_STATUS_SUSPENDED,
-					},
+				return &ateapipb.Actor{
+					Metadata: &ateapipb.ResourceMetadata{Name: actorID},
+					Status:   ateapipb.Actor_STATUS_SUSPENDED,
 				}, nil
 			}
 
 			// 4. Subsequent loop reconnection call: running again on pod-1
-			return &ateapipb.GetActorResponse{
-				Actor: &ateapipb.Actor{
-					Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
-					AteomPodName:      "pod-1",
-					AteomPodNamespace: "ns",
-					Status:            ateapipb.Actor_STATUS_RUNNING,
-				},
+			return &ateapipb.Actor{
+				Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+				AteomPodName:      "pod-1",
+				AteomPodNamespace: "ns",
+				Status:            ateapipb.Actor_STATUS_RUNNING,
 			}, nil
 		},
 	}

--- a/cmd/kubectl-ate/internal/cmd/pause_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/pause_actor.go
@@ -38,7 +38,7 @@ var pauseActorCmd = &cobra.Command{
 		defer apiClient.Close()
 
 		resp, err := apiClient.PauseActor(ctx, &ateapipb.PauseActorRequest{
-			ActorRef: &ateapipb.ActorRef{Atespace: pauseAtespaceFlag, Name: args[0]},
+			Actor: &ateapipb.ObjectRef{Atespace: pauseAtespaceFlag, Name: args[0]},
 		})
 		if err != nil {
 			return fmt.Errorf("failed to pause actor: %w", err)

--- a/cmd/kubectl-ate/internal/cmd/resume_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/resume_actor.go
@@ -39,8 +39,8 @@ var resumeActorCmd = &cobra.Command{
 		defer apiClient.Close()
 
 		resp, err := apiClient.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-			ActorRef: &ateapipb.ActorRef{Atespace: resumeAtespaceFlag, Name: args[0]},
-			Boot:     bootFlag,
+			Actor: &ateapipb.ObjectRef{Atespace: resumeAtespaceFlag, Name: args[0]},
+			Boot:  bootFlag,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to resume actor: %w", err)

--- a/cmd/kubectl-ate/internal/cmd/suspend_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/suspend_actor.go
@@ -38,7 +38,7 @@ var suspendActorCmd = &cobra.Command{
 		defer apiClient.Close()
 
 		resp, err := apiClient.SuspendActor(ctx, &ateapipb.SuspendActorRequest{
-			ActorRef: &ateapipb.ActorRef{Atespace: suspendAtespaceFlag, Name: args[0]},
+			Actor: &ateapipb.ObjectRef{Atespace: suspendAtespaceFlag, Name: args[0]},
 		})
 		if err != nil {
 			return fmt.Errorf("failed to suspend actor: %w", err)

--- a/cmd/kubectl-ate/internal/printer/printer_test.go
+++ b/cmd/kubectl-ate/internal/printer/printer_test.go
@@ -159,7 +159,7 @@ func TestPrintWorkersTo_Table(t *testing.T) {
 					Namespace: "default",
 					Name:      "template-1",
 				},
-				Actor: &ateapipb.ActorRef{
+				Actor: &ateapipb.ObjectRef{
 					Name: "id-1",
 				},
 			},

--- a/demos/agent-secret/main.go
+++ b/demos/agent-secret/main.go
@@ -130,7 +130,7 @@ func suspendSelf(id string) {
 	client := ateapipb.NewControlClient(conn)
 
 	log.Printf("Yielding compute. Requesting self-suspension for actor %s...", id)
-	_, err = client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{ActorRef: &ateapipb.ActorRef{Name: id}})
+	_, err = client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{Actor: &ateapipb.ObjectRef{Name: id}})
 	if err != nil {
 		log.Printf("Failed to self-suspend: %v", err)
 	}

--- a/demos/sandbox/client/main.go
+++ b/demos/sandbox/client/main.go
@@ -94,7 +94,7 @@ func main() {
 	defer conn.Close()
 
 	log.Printf("Resuming actor %s...", *actorID)
-	_, err = cli.ResumeActor(ctx, &ateapipb.ResumeActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: *atespace, Name: *actorID}})
+	_, err = cli.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: *atespace, Name: *actorID}})
 	if err != nil {
 		log.Fatalf("Failed to resume actor: %v", err)
 	}
@@ -104,7 +104,7 @@ func main() {
 	defer func() {
 		log.Printf("Suspending actor %s...", *actorID)
 		suspendCtx := context.Background()
-		_, err := cli.SuspendActor(suspendCtx, &ateapipb.SuspendActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: *atespace, Name: *actorID}})
+		_, err := cli.SuspendActor(suspendCtx, &ateapipb.SuspendActorRequest{Actor: &ateapipb.ObjectRef{Atespace: *atespace, Name: *actorID}})
 		if err != nil {
 			log.Printf("Failed to suspend actor: %v", err)
 		} else {

--- a/internal/benchmarking/boomer/glutton/lifecycle.go
+++ b/internal/benchmarking/boomer/glutton/lifecycle.go
@@ -175,8 +175,8 @@ type gluttonUser struct {
 	actorRunning bool
 }
 
-func (u *gluttonUser) ref() *ateapipb.ActorRef {
-	return &ateapipb.ActorRef{Atespace: u.cfg.Atespace, Name: u.actorID}
+func (u *gluttonUser) ref() *ateapipb.ObjectRef {
+	return &ateapipb.ObjectRef{Atespace: u.cfg.Atespace, Name: u.actorID}
 }
 
 // ensureAtespace creates the configured atespace, swallowing AlreadyExists
@@ -201,7 +201,7 @@ func (u *gluttonUser) ensureAtespace(ctx context.Context) error {
 func (u *gluttonUser) create(ctx context.Context) error {
 	return u.tracedCall(ctx, "CreateActor", func(callCtx context.Context, tr *metadata.MD) error {
 		_, err := u.cfg.APIStub.CreateActor(callCtx, &ateapipb.CreateActorRequest{
-			ActorRef:               u.ref(),
+			Actor:                  u.ref(),
 			ActorTemplateNamespace: templateNS,
 			ActorTemplateName:      templateName,
 		}, grpc.Trailer(tr))
@@ -216,8 +216,8 @@ func (u *gluttonUser) resume(ctx context.Context) bool {
 	}
 	err := u.tracedCall(ctx, metricName, func(callCtx context.Context, tr *metadata.MD) error {
 		_, err := u.cfg.APIStub.ResumeActor(callCtx, &ateapipb.ResumeActorRequest{
-			ActorRef: u.ref(),
-			Boot:     u.firstResume,
+			Actor: u.ref(),
+			Boot:  u.firstResume,
 		}, grpc.Trailer(tr))
 		return err
 	})
@@ -232,7 +232,7 @@ func (u *gluttonUser) resume(ctx context.Context) bool {
 func (u *gluttonUser) suspend(ctx context.Context) {
 	_ = u.tracedCall(ctx, "SuspendActor", func(callCtx context.Context, tr *metadata.MD) error {
 		_, err := u.cfg.APIStub.SuspendActor(callCtx, &ateapipb.SuspendActorRequest{
-			ActorRef: u.ref(),
+			Actor: u.ref(),
 		}, grpc.Trailer(tr))
 		return err
 	})
@@ -242,7 +242,7 @@ func (u *gluttonUser) suspend(ctx context.Context) {
 func (u *gluttonUser) delete(ctx context.Context) {
 	_ = u.tracedCall(ctx, "DeleteActor", func(callCtx context.Context, tr *metadata.MD) error {
 		_, err := u.cfg.APIStub.DeleteActor(callCtx, &ateapipb.DeleteActorRequest{
-			ActorRef: u.ref(),
+			Actor: u.ref(),
 		}, grpc.Trailer(tr))
 		return err
 	})

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -157,7 +157,7 @@ func TestDurableDirLifecycle(t *testing.T) {
 
 			t.Logf("Creating Actor %q using Substrate API...", actorID)
 			createResp, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{
-				ActorRef:               &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+				Actor:                  &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 				ActorTemplateNamespace: nsObj.Name,
 				ActorTemplateName:      at.Name,
 			})
@@ -167,14 +167,14 @@ func TestDurableDirLifecycle(t *testing.T) {
 			t.Logf("Successfully created Actor: %s", createResp.GetActor().GetMetadata().GetName())
 			defer func() {
 				clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
-					ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+					Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 				})
 			}()
 
 			// Resuming the actor
 			t.Logf("Resuming Actor %q...", actorID)
 			if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+				Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 			}); err != nil {
 				t.Fatalf("failed to resume Actor: %v", err)
 			}
@@ -191,7 +191,7 @@ func TestDurableDirLifecycle(t *testing.T) {
 			//
 			t.Logf("Pausing Actor %q...", actorID)
 			if _, err := clients.SubstrateAPI.PauseActor(ctx, &ateapipb.PauseActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+				Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 			}); err != nil {
 				t.Fatalf("failed to pause Actor: %v", err)
 			}
@@ -200,7 +200,7 @@ func TestDurableDirLifecycle(t *testing.T) {
 			// Resuming the actor
 			t.Logf("Resuming Actor %q again...", actorID)
 			if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+				Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 			}); err != nil {
 				t.Fatalf("failed to resume Actor again: %v", err)
 			}
@@ -217,7 +217,7 @@ func TestDurableDirLifecycle(t *testing.T) {
 			//
 			t.Logf("Suspending Actor %q...", actorID)
 			if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+				Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 			}); err != nil {
 				t.Fatalf("failed to suspend Actor: %v", err)
 			}
@@ -226,7 +226,7 @@ func TestDurableDirLifecycle(t *testing.T) {
 			// Resuming the actor
 			t.Logf("Resuming Actor %q again...", actorID)
 			if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-				ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+				Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 			}); err != nil {
 				t.Fatalf("failed to resume Actor again: %v", err)
 			}
@@ -259,7 +259,7 @@ func createActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj 
 
 	t.Logf("Creating Actor %q using Substrate API...", actorID)
 	createResp, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor:                  &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 		ActorTemplateNamespace: nsObj.Name,
 		ActorTemplateName:      at.Name,
 	})
@@ -269,7 +269,7 @@ func createActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj 
 	t.Logf("Successfully created Actor: %s", createResp.GetActor().GetMetadata().GetName())
 	defer func() {
 		clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
-			ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+			Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 		})
 	}()
 
@@ -313,7 +313,7 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 	// Creating an actor
 	t.Logf("Creating Actor %q...", actorID)
 	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor:                  &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 		ActorTemplateNamespace: nsObj.Name,
 		ActorTemplateName:      at.Name,
 	}); err != nil {
@@ -324,7 +324,7 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 	// Resuming the actor
 	t.Logf("Resuming Actor %q...", actorID)
 	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
 	}
@@ -344,7 +344,7 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 	// Pausing the actor
 	t.Logf("Pausing Actor %q...", actorID)
 	if _, err := clients.SubstrateAPI.PauseActor(ctx, &ateapipb.PauseActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to pause Actor: %v", err)
 	}
@@ -353,7 +353,7 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 	// Resuming the actor again
 	t.Logf("Resuming Actor %q again...", actorID)
 	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor again: %v", err)
 	}
@@ -372,7 +372,7 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 	// Suspending the actor before deletion
 	t.Logf("Suspending Actor %q before deletion...", actorID)
 	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to suspend Actor: %v", err)
 	}
@@ -381,13 +381,13 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 	// Deleting the actor
 	t.Logf("Deleting Actor %q...", actorID)
 	if _, err := clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to delete Actor: %v", err)
 	}
 	// Verify deletion
 	if _, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err == nil {
 		t.Fatalf("expected actor %q to be deleted, but it still exists", actorID)
 	}
@@ -401,7 +401,7 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 	// Creating an actor
 	t.Logf("Creating Actor %q...", actorID)
 	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor:                  &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 		ActorTemplateNamespace: nsObj.Name,
 		ActorTemplateName:      at.Name,
 	}); err != nil {
@@ -412,7 +412,7 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 	// Resuming the actor
 	t.Logf("Resuming Actor %q...", actorID)
 	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
 	}
@@ -431,7 +431,7 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 	// Suspending the actor
 	t.Logf("Suspending Actor %q...", actorID)
 	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to suspend Actor: %v", err)
 	}
@@ -440,7 +440,7 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 	// Resuming the actor again
 	t.Logf("Resuming Actor %q again...", actorID)
 	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor again: %v", err)
 	}
@@ -459,7 +459,7 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 	// Suspending the actor before deletion
 	t.Logf("Suspending Actor %q before deletion...", actorID)
 	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to suspend Actor: %v", err)
 	}
@@ -468,13 +468,13 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 	// Deleting the actor
 	t.Logf("Deleting Actor %q...", actorID)
 	if _, err := clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to delete Actor: %v", err)
 	}
 	// Verify deletion
 	if _, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
-		ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err == nil {
 		t.Fatalf("expected actor %q to be deleted, but it still exists", actorID)
 	}
@@ -606,7 +606,7 @@ func waitForActorStatus(ctx context.Context, t *testing.T, clients *e2e.Clients,
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		resp, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
-			ActorRef: &ateapipb.ActorRef{Atespace: demoAtespace, Name: actorID},
+			Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 		})
 		if err == nil {
 			if resp.GetActor().GetStatus() == expectedStatus {

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -609,7 +609,7 @@ func waitForActorStatus(ctx context.Context, t *testing.T, clients *e2e.Clients,
 			Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 		})
 		if err == nil {
-			if resp.GetActor().GetStatus() == expectedStatus {
+			if resp.GetStatus() == expectedStatus {
 				t.Logf("Actor %q reached status %v", actorID, expectedStatus)
 				return
 			}

--- a/internal/e2e/suites/identity/identity_test.go
+++ b/internal/e2e/suites/identity/identity_test.go
@@ -162,7 +162,7 @@ func createAndResumeActor(t *testing.T, ctx context.Context, clients *e2e.Client
 	// CreateActor requires the atespace to exist first.
 	_, _ = clients.SubstrateAPI.CreateAtespace(ctx, &ateapipb.CreateAtespaceRequest{Name: probeNamespace})
 	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{
-		ActorRef:               &ateapipb.ActorRef{Atespace: probeNamespace, Name: id},
+		Actor:                  &ateapipb.ObjectRef{Atespace: probeNamespace, Name: id},
 		ActorTemplateNamespace: probeNamespace,
 		ActorTemplateName:      probeTemplate,
 	}); err != nil {
@@ -170,12 +170,12 @@ func createAndResumeActor(t *testing.T, ctx context.Context, clients *e2e.Client
 	}
 	t.Cleanup(func() {
 		// DeleteActor requires the actor to be suspended.
-		_, _ = clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: probeNamespace, Name: id}})
-		_, _ = clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: probeNamespace, Name: id}})
+		_, _ = clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: &ateapipb.ObjectRef{Atespace: probeNamespace, Name: id}})
+		_, _ = clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{Actor: &ateapipb.ObjectRef{Atespace: probeNamespace, Name: id}})
 	})
 
 	// Resume from the golden snapshot (the restore path, not --boot).
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{ActorRef: &ateapipb.ActorRef{Atespace: probeNamespace, Name: id}}); err != nil {
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: probeNamespace, Name: id}}); err != nil {
 		t.Fatalf("ResumeActor %q: %v", id, err)
 	}
 }

--- a/internal/resources/validate.go
+++ b/internal/resources/validate.go
@@ -38,10 +38,9 @@ func ValidateResourceName(name string, fldPath *field.Path) field.ErrorList {
 	return errs
 }
 
-// ValidateActorRef checks that the actor reference is well-formed and that
-// each of its components is a valid resource name. It does not check that the
-// referenced actor actually exists.
-func ValidateActorRef(ref *ateapipb.ActorRef, fldPath *field.Path) field.ErrorList {
+// ValidateObjectRef checks that the object reference is well-formed and that
+// each of its components is a valid resource name.
+func ValidateObjectRef(ref *ateapipb.ObjectRef, fldPath *field.Path) field.ErrorList {
 	if ref == nil {
 		return nil
 	}

--- a/internal/resources/validate.go
+++ b/internal/resources/validate.go
@@ -62,6 +62,30 @@ func ValidateObjectRef(ref *ateapipb.ObjectRef, fldPath *field.Path) field.Error
 	return errs
 }
 
+// ValidateGlobalObjectRef checks that a reference to a global-scoped resource is
+// well-formed: its atespace must be empty (global resources do not belong to an
+// atespace) and its name must be a valid resource name. It does not check that
+// the referenced resource actually exists.
+func ValidateGlobalObjectRef(ref *ateapipb.ObjectRef, fldPath *field.Path) field.ErrorList {
+	if ref == nil {
+		return nil
+	}
+
+	var errs field.ErrorList
+
+	if val, fldPath := ref.Atespace, fldPath.Child("atespace"); val != "" {
+		errs = append(errs, field.Invalid(fldPath, val, "must be empty for a global-scoped resource"))
+	}
+
+	if val, fldPath := ref.Name, fldPath.Child("name"); val == "" {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, ValidateResourceName(val, fldPath)...)
+	}
+
+	return errs
+}
+
 // ValidateAteomUID rejects a target ateom pod UID that could escape the host
 // paths built from it: the netns path (/run/netns/ateom:<uid>) and the ateom
 // control socket (.../ateoms/<uid>/ateom.sock). Kubernetes pod UIDs are UUIDs,

--- a/internal/resources/validate_test.go
+++ b/internal/resources/validate_test.go
@@ -23,31 +23,31 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func TestValidateActorRef(t *testing.T) {
+func TestValidateObjectRef(t *testing.T) {
 	tests := []struct {
 		name    string
-		input   *ateapipb.ActorRef
+		input   *ateapipb.ObjectRef
 		wantMsg string
 	}{{
 		"missing atespace",
-		&ateapipb.ActorRef{Name: "id1"},
+		&ateapipb.ObjectRef{Name: "id1"},
 		"atespace: Required value",
 	}, {
 		"invalid atespace",
-		&ateapipb.ActorRef{Atespace: "NS1", Name: "id1"},
+		&ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
 		"atespace: Invalid value",
 	}, {
 		"missing name",
-		&ateapipb.ActorRef{Atespace: "ns1"},
+		&ateapipb.ObjectRef{Atespace: "ns1"},
 		"name: Required value",
 	}, {
 		"invalid name",
-		&ateapipb.ActorRef{Atespace: "ns1", Name: "ID1"},
+		&ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
 		"name: Invalid value",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := ValidateActorRef(tt.input, field.NewPath("path"))
+			errs := ValidateObjectRef(tt.input, field.NewPath("path"))
 			if len(errs) == 0 {
 				t.Fatalf("expected 1 error, got 0")
 			}
@@ -196,7 +196,7 @@ func TestValidateWorker(t *testing.T) {
 					Namespace: "actor-ns",
 					Name:      "actor-template",
 				},
-				Actor: &ateapipb.ActorRef{
+				Actor: &ateapipb.ObjectRef{
 					Name:     "actor-id",
 					Atespace: "actor-atespace",
 				},
@@ -213,7 +213,7 @@ func TestValidateWorker(t *testing.T) {
 			WorkerPool:      "pool-1",
 			WorkerPod:       "pod-1",
 			Assignment: &ateapipb.Assignment{
-				Actor: &ateapipb.ActorRef{
+				Actor: &ateapipb.ObjectRef{
 					Name:     "actor-id",
 					Atespace: "actor-atespace",
 				},
@@ -233,7 +233,7 @@ func TestValidateWorker(t *testing.T) {
 				ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
 					Name: "actor-template",
 				},
-				Actor: &ateapipb.ActorRef{
+				Actor: &ateapipb.ObjectRef{
 					Name:     "actor-id",
 					Atespace: "actor-atespace",
 				},
@@ -253,7 +253,7 @@ func TestValidateWorker(t *testing.T) {
 				ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
 					Namespace: "actor-ns",
 				},
-				Actor: &ateapipb.ActorRef{
+				Actor: &ateapipb.ObjectRef{
 					Name:     "actor-id",
 					Atespace: "actor-atespace",
 				},
@@ -291,7 +291,7 @@ func TestValidateWorker(t *testing.T) {
 					Name:      "actor-template",
 					Namespace: "actor-ns",
 				},
-				Actor: &ateapipb.ActorRef{
+				Actor: &ateapipb.ObjectRef{
 					Atespace: "actor-atespace",
 				},
 			},
@@ -311,7 +311,7 @@ func TestValidateWorker(t *testing.T) {
 					Name:      "actor-template",
 					Namespace: "actor-ns",
 				},
-				Actor: &ateapipb.ActorRef{
+				Actor: &ateapipb.ObjectRef{
 					Name: "actor-id",
 				},
 			},

--- a/internal/resources/validate_test.go
+++ b/internal/resources/validate_test.go
@@ -65,6 +65,50 @@ func TestValidateObjectRef(t *testing.T) {
 	}
 }
 
+func TestValidateGlobalObjectRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *ateapipb.ObjectRef
+		wantMsg string // empty means no error is expected
+	}{{
+		"valid global ref",
+		&ateapipb.ObjectRef{Name: "team-a"},
+		"",
+	}, {
+		"atespace must be empty",
+		&ateapipb.ObjectRef{Atespace: "ns1", Name: "team-a"},
+		"atespace: Invalid value",
+	}, {
+		"missing name",
+		&ateapipb.ObjectRef{},
+		"name: Required value",
+	}, {
+		"invalid name",
+		&ateapipb.ObjectRef{Name: "TEAM-A"},
+		"name: Invalid value",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateGlobalObjectRef(tt.input, field.NewPath("path"))
+			if tt.wantMsg == "" {
+				if len(errs) != 0 {
+					t.Fatalf("expected no errors, got %v", errs)
+				}
+				return
+			}
+			if len(errs) != 1 {
+				t.Fatalf("expected 1 error, got %v", errs)
+			}
+			got := errs[0].Error()
+			if matched, matchErr := regexp.MatchString(tt.wantMsg, got); matchErr != nil {
+				t.Fatalf("failed to compile regex %q: %v", tt.wantMsg, matchErr)
+			} else if !matched {
+				t.Errorf("expected message %q, got %q", tt.wantMsg, got)
+			}
+		})
+	}
+}
+
 func TestValidateAteomUID(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -611,29 +611,32 @@ func (x *Atespace) GetMetadata() *ResourceMetadata {
 	return nil
 }
 
-// ActorRef identifies an actor: a name is only unique within its atespace.
-type ActorRef struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Atespace      string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+// ObjectRef references a Substrate resource by its (atespace, name) identity.
+type ObjectRef struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The atespace where the resource lives. Empty if the resource is global-scoped.
+	Atespace string `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	// The name of the resource. Required. Unique within an atespace, or globally
+	// unique if the resource is global-scoped.
+	Name          string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ActorRef) Reset() {
-	*x = ActorRef{}
+func (x *ObjectRef) Reset() {
+	*x = ObjectRef{}
 	mi := &file_ateapi_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ActorRef) String() string {
+func (x *ObjectRef) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ActorRef) ProtoMessage() {}
+func (*ObjectRef) ProtoMessage() {}
 
-func (x *ActorRef) ProtoReflect() protoreflect.Message {
+func (x *ObjectRef) ProtoReflect() protoreflect.Message {
 	mi := &file_ateapi_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -645,19 +648,19 @@ func (x *ActorRef) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ActorRef.ProtoReflect.Descriptor instead.
-func (*ActorRef) Descriptor() ([]byte, []int) {
+// Deprecated: Use ObjectRef.ProtoReflect.Descriptor instead.
+func (*ObjectRef) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *ActorRef) GetAtespace() string {
+func (x *ObjectRef) GetAtespace() string {
 	if x != nil {
 		return x.Atespace
 	}
 	return ""
 }
 
-func (x *ActorRef) GetName() string {
+func (x *ObjectRef) GetName() string {
 	if x != nil {
 		return x.Name
 	}
@@ -1002,7 +1005,7 @@ func (*DeleteAtespaceResponse) Descriptor() ([]byte, []int) {
 
 type GetActorRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	ActorRef      *ActorRef              `protobuf:"bytes,1,opt,name=actor_ref,json=actorRef,proto3" json:"actor_ref,omitempty"`
+	Actor         *ObjectRef             `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1037,9 +1040,9 @@ func (*GetActorRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{16}
 }
 
-func (x *GetActorRequest) GetActorRef() *ActorRef {
+func (x *GetActorRequest) GetActor() *ObjectRef {
 	if x != nil {
-		return x.ActorRef
+		return x.Actor
 	}
 	return nil
 }
@@ -1092,7 +1095,7 @@ func (x *GetActorResponse) GetActor() *Actor {
 type CreateActorRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The new actor's atespace and actor_id (actor_id must be a valid DNS-1123 label).
-	ActorRef *ActorRef `protobuf:"bytes,1,opt,name=actor_ref,json=actorRef,proto3" json:"actor_ref,omitempty"`
+	Actor *ObjectRef `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
 	// The namespace of the ActorTemplate to derive from.
 	ActorTemplateNamespace string `protobuf:"bytes,2,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
 	// The name of the ActorTemplate to derive from.
@@ -1134,9 +1137,9 @@ func (*CreateActorRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{18}
 }
 
-func (x *CreateActorRequest) GetActorRef() *ActorRef {
+func (x *CreateActorRequest) GetActor() *ObjectRef {
 	if x != nil {
-		return x.ActorRef
+		return x.Actor
 	}
 	return nil
 }
@@ -1210,8 +1213,8 @@ func (x *CreateActorResponse) GetActor() *Actor {
 // May be called regardless of the actor's current status.
 // Changes take effect on the next ResumeActor call.
 type UpdateActorRequest struct {
-	state    protoimpl.MessageState `protogen:"open.v1"`
-	ActorRef *ActorRef              `protobuf:"bytes,1,opt,name=actor_ref,json=actorRef,proto3" json:"actor_ref,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Actor *ObjectRef             `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
 	// worker_selector replaces the actor's current placement constraint.
 	// Takes effect on the next ResumeActor call.
 	WorkerSelector *Selector `protobuf:"bytes,2,opt,name=worker_selector,json=workerSelector,proto3" json:"worker_selector,omitempty"`
@@ -1249,9 +1252,9 @@ func (*UpdateActorRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{20}
 }
 
-func (x *UpdateActorRequest) GetActorRef() *ActorRef {
+func (x *UpdateActorRequest) GetActor() *ObjectRef {
 	if x != nil {
-		return x.ActorRef
+		return x.Actor
 	}
 	return nil
 }
@@ -1309,7 +1312,7 @@ func (x *UpdateActorResponse) GetActor() *Actor {
 
 type SuspendActorRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	ActorRef      *ActorRef              `protobuf:"bytes,1,opt,name=actor_ref,json=actorRef,proto3" json:"actor_ref,omitempty"`
+	Actor         *ObjectRef             `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1344,9 +1347,9 @@ func (*SuspendActorRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{22}
 }
 
-func (x *SuspendActorRequest) GetActorRef() *ActorRef {
+func (x *SuspendActorRequest) GetActor() *ObjectRef {
 	if x != nil {
-		return x.ActorRef
+		return x.Actor
 	}
 	return nil
 }
@@ -1397,7 +1400,7 @@ func (x *SuspendActorResponse) GetActor() *Actor {
 
 type PauseActorRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	ActorRef      *ActorRef              `protobuf:"bytes,1,opt,name=actor_ref,json=actorRef,proto3" json:"actor_ref,omitempty"`
+	Actor         *ObjectRef             `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1432,9 +1435,9 @@ func (*PauseActorRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{24}
 }
 
-func (x *PauseActorRequest) GetActorRef() *ActorRef {
+func (x *PauseActorRequest) GetActor() *ObjectRef {
 	if x != nil {
-		return x.ActorRef
+		return x.Actor
 	}
 	return nil
 }
@@ -1484,8 +1487,8 @@ func (x *PauseActorResponse) GetActor() *Actor {
 }
 
 type ResumeActorRequest struct {
-	state    protoimpl.MessageState `protogen:"open.v1"`
-	ActorRef *ActorRef              `protobuf:"bytes,1,opt,name=actor_ref,json=actorRef,proto3" json:"actor_ref,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Actor *ObjectRef             `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
 	// If true, skip golden snapshot and boot the workload from scratch.
 	Boot          bool `protobuf:"varint,2,opt,name=boot,proto3" json:"boot,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -1522,9 +1525,9 @@ func (*ResumeActorRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{26}
 }
 
-func (x *ResumeActorRequest) GetActorRef() *ActorRef {
+func (x *ResumeActorRequest) GetActor() *ObjectRef {
 	if x != nil {
-		return x.ActorRef
+		return x.Actor
 	}
 	return nil
 }
@@ -1582,7 +1585,7 @@ func (x *ResumeActorResponse) GetActor() *Actor {
 
 type DeleteActorRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	ActorRef      *ActorRef              `protobuf:"bytes,1,opt,name=actor_ref,json=actorRef,proto3" json:"actor_ref,omitempty"`
+	Actor         *ObjectRef             `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1617,9 +1620,9 @@ func (*DeleteActorRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{28}
 }
 
-func (x *DeleteActorRequest) GetActorRef() *ActorRef {
+func (x *DeleteActorRequest) GetActor() *ObjectRef {
 	if x != nil {
-		return x.ActorRef
+		return x.Actor
 	}
 	return nil
 }
@@ -1983,7 +1986,7 @@ func (x *Worker) GetLabels() map[string]string {
 type Assignment struct {
 	state         protoimpl.MessageState   `protogen:"open.v1"`
 	ActorTemplate *KubeNamespacedObjectRef `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
-	Actor         *ActorRef                `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
+	Actor         *ObjectRef               `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2025,7 +2028,7 @@ func (x *Assignment) GetActorTemplate() *KubeNamespacedObjectRef {
 	return nil
 }
 
-func (x *Assignment) GetActor() *ActorRef {
+func (x *Assignment) GetActor() *ObjectRef {
 	if x != nil {
 		return x.Actor
 	}
@@ -2459,8 +2462,8 @@ const file_ateapi_proto_rawDesc = "" +
 	"\rSTATUS_PAUSED\x10\x06\x12\x12\n" +
 	"\x0eSTATUS_CRASHED\x10\a\"@\n" +
 	"\bAtespace\x124\n" +
-	"\bmetadata\x18\x01 \x01(\v2\x18.ateapi.ResourceMetadataR\bmetadata\":\n" +
-	"\bActorRef\x12\x1a\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x18.ateapi.ResourceMetadataR\bmetadata\";\n" +
+	"\tObjectRef\x12\x1a\n" +
 	"\batespace\x18\x01 \x01(\tR\batespace\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\"+\n" +
 	"\x15CreateAtespaceRequest\x12\x12\n" +
@@ -2476,38 +2479,38 @@ const file_ateapi_proto_rawDesc = "" +
 	"\tatespaces\x18\x01 \x03(\v2\x10.ateapi.AtespaceR\tatespaces\"+\n" +
 	"\x15DeleteAtespaceRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"\x18\n" +
-	"\x16DeleteAtespaceResponse\"@\n" +
-	"\x0fGetActorRequest\x12-\n" +
-	"\tactor_ref\x18\x01 \x01(\v2\x10.ateapi.ActorRefR\bactorRef\"7\n" +
+	"\x16DeleteAtespaceResponse\":\n" +
+	"\x0fGetActorRequest\x12'\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"7\n" +
 	"\x10GetActorResponse\x12#\n" +
-	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"\xe8\x01\n" +
-	"\x12CreateActorRequest\x12-\n" +
-	"\tactor_ref\x18\x01 \x01(\v2\x10.ateapi.ActorRefR\bactorRef\x128\n" +
+	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"\xe2\x01\n" +
+	"\x12CreateActorRequest\x12'\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\x128\n" +
 	"\x18actor_template_namespace\x18\x02 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
 	"\x13actor_template_name\x18\x03 \x01(\tR\x11actorTemplateName\x129\n" +
 	"\x0fworker_selector\x18\x04 \x01(\v2\x10.ateapi.SelectorR\x0eworkerSelector\":\n" +
 	"\x13CreateActorResponse\x12#\n" +
-	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"~\n" +
-	"\x12UpdateActorRequest\x12-\n" +
-	"\tactor_ref\x18\x01 \x01(\v2\x10.ateapi.ActorRefR\bactorRef\x129\n" +
+	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"x\n" +
+	"\x12UpdateActorRequest\x12'\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\x129\n" +
 	"\x0fworker_selector\x18\x02 \x01(\v2\x10.ateapi.SelectorR\x0eworkerSelector\":\n" +
 	"\x13UpdateActorResponse\x12#\n" +
-	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"D\n" +
-	"\x13SuspendActorRequest\x12-\n" +
-	"\tactor_ref\x18\x01 \x01(\v2\x10.ateapi.ActorRefR\bactorRef\";\n" +
+	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\">\n" +
+	"\x13SuspendActorRequest\x12'\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\";\n" +
 	"\x14SuspendActorResponse\x12#\n" +
-	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"B\n" +
-	"\x11PauseActorRequest\x12-\n" +
-	"\tactor_ref\x18\x01 \x01(\v2\x10.ateapi.ActorRefR\bactorRef\"9\n" +
+	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"<\n" +
+	"\x11PauseActorRequest\x12'\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"9\n" +
 	"\x12PauseActorResponse\x12#\n" +
-	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"W\n" +
-	"\x12ResumeActorRequest\x12-\n" +
-	"\tactor_ref\x18\x01 \x01(\v2\x10.ateapi.ActorRefR\bactorRef\x12\x12\n" +
+	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"Q\n" +
+	"\x12ResumeActorRequest\x12'\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\x12\x12\n" +
 	"\x04boot\x18\x02 \x01(\bR\x04boot\":\n" +
 	"\x13ResumeActorResponse\x12#\n" +
-	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"C\n" +
-	"\x12DeleteActorRequest\x12-\n" +
-	"\tactor_ref\x18\x01 \x01(\v2\x10.ateapi.ActorRefR\bactorRef\"\x15\n" +
+	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"=\n" +
+	"\x12DeleteActorRequest\x12'\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"\x15\n" +
 	"\x13DeleteActorResponse\"\x14\n" +
 	"\x12ListWorkersRequest\"?\n" +
 	"\x13ListWorkersResponse\x12(\n" +
@@ -2538,11 +2541,11 @@ const file_ateapi_proto_rawDesc = "" +
 	" \x03(\v2\x1a.ateapi.Worker.LabelsEntryR\x06labels\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"|\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"}\n" +
 	"\n" +
 	"Assignment\x12F\n" +
-	"\x0eactor_template\x18\x01 \x01(\v2\x1f.ateapi.KubeNamespacedObjectRefR\ractorTemplate\x12&\n" +
-	"\x05actor\x18\x02 \x01(\v2\x10.ateapi.ActorRefR\x05actor\"K\n" +
+	"\x0eactor_template\x18\x01 \x01(\v2\x1f.ateapi.KubeNamespacedObjectRefR\ractorTemplate\x12'\n" +
+	"\x05actor\x18\x02 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"K\n" +
 	"\x17KubeNamespacedObjectRef\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\"\x13\n" +
@@ -2610,7 +2613,7 @@ var file_ateapi_proto_goTypes = []any{
 	(*ResourceMetadata)(nil),        // 5: ateapi.ResourceMetadata
 	(*Actor)(nil),                   // 6: ateapi.Actor
 	(*Atespace)(nil),                // 7: ateapi.Atespace
-	(*ActorRef)(nil),                // 8: ateapi.ActorRef
+	(*ObjectRef)(nil),               // 8: ateapi.ObjectRef
 	(*CreateAtespaceRequest)(nil),   // 9: ateapi.CreateAtespaceRequest
 	(*CreateAtespaceResponse)(nil),  // 10: ateapi.CreateAtespaceResponse
 	(*GetAtespaceRequest)(nil),      // 11: ateapi.GetAtespaceRequest
@@ -2664,27 +2667,27 @@ var file_ateapi_proto_depIdxs = []int32{
 	7,  // 10: ateapi.CreateAtespaceResponse.atespace:type_name -> ateapi.Atespace
 	7,  // 11: ateapi.GetAtespaceResponse.atespace:type_name -> ateapi.Atespace
 	7,  // 12: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
-	8,  // 13: ateapi.GetActorRequest.actor_ref:type_name -> ateapi.ActorRef
+	8,  // 13: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
 	6,  // 14: ateapi.GetActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 15: ateapi.CreateActorRequest.actor_ref:type_name -> ateapi.ActorRef
+	8,  // 15: ateapi.CreateActorRequest.actor:type_name -> ateapi.ObjectRef
 	4,  // 16: ateapi.CreateActorRequest.worker_selector:type_name -> ateapi.Selector
 	6,  // 17: ateapi.CreateActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 18: ateapi.UpdateActorRequest.actor_ref:type_name -> ateapi.ActorRef
+	8,  // 18: ateapi.UpdateActorRequest.actor:type_name -> ateapi.ObjectRef
 	4,  // 19: ateapi.UpdateActorRequest.worker_selector:type_name -> ateapi.Selector
 	6,  // 20: ateapi.UpdateActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 21: ateapi.SuspendActorRequest.actor_ref:type_name -> ateapi.ActorRef
+	8,  // 21: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
 	6,  // 22: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 23: ateapi.PauseActorRequest.actor_ref:type_name -> ateapi.ActorRef
+	8,  // 23: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
 	6,  // 24: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 25: ateapi.ResumeActorRequest.actor_ref:type_name -> ateapi.ActorRef
+	8,  // 25: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
 	6,  // 26: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 27: ateapi.DeleteActorRequest.actor_ref:type_name -> ateapi.ActorRef
+	8,  // 27: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
 	35, // 28: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
 	6,  // 29: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
 	36, // 30: ateapi.Worker.assignment:type_name -> ateapi.Assignment
 	45, // 31: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
 	37, // 32: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	8,  // 33: ateapi.Assignment.actor:type_name -> ateapi.ActorRef
+	8,  // 33: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
 	17, // 34: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
 	19, // 35: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
 	21, // 36: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -757,7 +757,7 @@ func (x *CreateAtespaceResponse) GetAtespace() *Atespace {
 
 type GetAtespaceRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Atespace      *ObjectRef             `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -792,51 +792,7 @@ func (*GetAtespaceRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *GetAtespaceRequest) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
-type GetAtespaceResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Atespace      *Atespace              `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *GetAtespaceResponse) Reset() {
-	*x = GetAtespaceResponse{}
-	mi := &file_ateapi_proto_msgTypes[11]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *GetAtespaceResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*GetAtespaceResponse) ProtoMessage() {}
-
-func (x *GetAtespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[11]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use GetAtespaceResponse.ProtoReflect.Descriptor instead.
-func (*GetAtespaceResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{11}
-}
-
-func (x *GetAtespaceResponse) GetAtespace() *Atespace {
+func (x *GetAtespaceRequest) GetAtespace() *ObjectRef {
 	if x != nil {
 		return x.Atespace
 	}
@@ -851,7 +807,7 @@ type ListAtespacesRequest struct {
 
 func (x *ListAtespacesRequest) Reset() {
 	*x = ListAtespacesRequest{}
-	mi := &file_ateapi_proto_msgTypes[12]
+	mi := &file_ateapi_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -863,7 +819,7 @@ func (x *ListAtespacesRequest) String() string {
 func (*ListAtespacesRequest) ProtoMessage() {}
 
 func (x *ListAtespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[12]
+	mi := &file_ateapi_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -876,7 +832,7 @@ func (x *ListAtespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAtespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListAtespacesRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{12}
+	return file_ateapi_proto_rawDescGZIP(), []int{11}
 }
 
 type ListAtespacesResponse struct {
@@ -888,7 +844,7 @@ type ListAtespacesResponse struct {
 
 func (x *ListAtespacesResponse) Reset() {
 	*x = ListAtespacesResponse{}
-	mi := &file_ateapi_proto_msgTypes[13]
+	mi := &file_ateapi_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -900,7 +856,7 @@ func (x *ListAtespacesResponse) String() string {
 func (*ListAtespacesResponse) ProtoMessage() {}
 
 func (x *ListAtespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[13]
+	mi := &file_ateapi_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -913,7 +869,7 @@ func (x *ListAtespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAtespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListAtespacesResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{13}
+	return file_ateapi_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ListAtespacesResponse) GetAtespaces() []*Atespace {
@@ -932,7 +888,7 @@ type DeleteAtespaceRequest struct {
 
 func (x *DeleteAtespaceRequest) Reset() {
 	*x = DeleteAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[14]
+	mi := &file_ateapi_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -944,7 +900,7 @@ func (x *DeleteAtespaceRequest) String() string {
 func (*DeleteAtespaceRequest) ProtoMessage() {}
 
 func (x *DeleteAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[14]
+	mi := &file_ateapi_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -957,7 +913,7 @@ func (x *DeleteAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{14}
+	return file_ateapi_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DeleteAtespaceRequest) GetName() string {
@@ -975,7 +931,7 @@ type DeleteAtespaceResponse struct {
 
 func (x *DeleteAtespaceResponse) Reset() {
 	*x = DeleteAtespaceResponse{}
-	mi := &file_ateapi_proto_msgTypes[15]
+	mi := &file_ateapi_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -987,7 +943,7 @@ func (x *DeleteAtespaceResponse) String() string {
 func (*DeleteAtespaceResponse) ProtoMessage() {}
 
 func (x *DeleteAtespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[15]
+	mi := &file_ateapi_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1000,7 +956,7 @@ func (x *DeleteAtespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAtespaceResponse.ProtoReflect.Descriptor instead.
 func (*DeleteAtespaceResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{15}
+	return file_ateapi_proto_rawDescGZIP(), []int{14}
 }
 
 type GetActorRequest struct {
@@ -1012,7 +968,7 @@ type GetActorRequest struct {
 
 func (x *GetActorRequest) Reset() {
 	*x = GetActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[16]
+	mi := &file_ateapi_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1024,7 +980,7 @@ func (x *GetActorRequest) String() string {
 func (*GetActorRequest) ProtoMessage() {}
 
 func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[16]
+	mi := &file_ateapi_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1037,54 +993,10 @@ func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorRequest.ProtoReflect.Descriptor instead.
 func (*GetActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{16}
+	return file_ateapi_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetActorRequest) GetActor() *ObjectRef {
-	if x != nil {
-		return x.Actor
-	}
-	return nil
-}
-
-type GetActorResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Actor         *Actor                 `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *GetActorResponse) Reset() {
-	*x = GetActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[17]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *GetActorResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*GetActorResponse) ProtoMessage() {}
-
-func (x *GetActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[17]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use GetActorResponse.ProtoReflect.Descriptor instead.
-func (*GetActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{17}
-}
-
-func (x *GetActorResponse) GetActor() *Actor {
 	if x != nil {
 		return x.Actor
 	}
@@ -1109,7 +1021,7 @@ type CreateActorRequest struct {
 
 func (x *CreateActorRequest) Reset() {
 	*x = CreateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[18]
+	mi := &file_ateapi_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1121,7 +1033,7 @@ func (x *CreateActorRequest) String() string {
 func (*CreateActorRequest) ProtoMessage() {}
 
 func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[18]
+	mi := &file_ateapi_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1134,7 +1046,7 @@ func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateActorRequest.ProtoReflect.Descriptor instead.
 func (*CreateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{18}
+	return file_ateapi_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CreateActorRequest) GetActor() *ObjectRef {
@@ -1174,7 +1086,7 @@ type CreateActorResponse struct {
 
 func (x *CreateActorResponse) Reset() {
 	*x = CreateActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[19]
+	mi := &file_ateapi_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1186,7 +1098,7 @@ func (x *CreateActorResponse) String() string {
 func (*CreateActorResponse) ProtoMessage() {}
 
 func (x *CreateActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[19]
+	mi := &file_ateapi_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1199,7 +1111,7 @@ func (x *CreateActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateActorResponse.ProtoReflect.Descriptor instead.
 func (*CreateActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{19}
+	return file_ateapi_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CreateActorResponse) GetActor() *Actor {
@@ -1224,7 +1136,7 @@ type UpdateActorRequest struct {
 
 func (x *UpdateActorRequest) Reset() {
 	*x = UpdateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[20]
+	mi := &file_ateapi_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1236,7 +1148,7 @@ func (x *UpdateActorRequest) String() string {
 func (*UpdateActorRequest) ProtoMessage() {}
 
 func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[20]
+	mi := &file_ateapi_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1249,7 +1161,7 @@ func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorRequest.ProtoReflect.Descriptor instead.
 func (*UpdateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{20}
+	return file_ateapi_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UpdateActorRequest) GetActor() *ObjectRef {
@@ -1275,7 +1187,7 @@ type UpdateActorResponse struct {
 
 func (x *UpdateActorResponse) Reset() {
 	*x = UpdateActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[21]
+	mi := &file_ateapi_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1287,7 +1199,7 @@ func (x *UpdateActorResponse) String() string {
 func (*UpdateActorResponse) ProtoMessage() {}
 
 func (x *UpdateActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[21]
+	mi := &file_ateapi_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1300,7 +1212,7 @@ func (x *UpdateActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorResponse.ProtoReflect.Descriptor instead.
 func (*UpdateActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{21}
+	return file_ateapi_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *UpdateActorResponse) GetActor() *Actor {
@@ -1319,7 +1231,7 @@ type SuspendActorRequest struct {
 
 func (x *SuspendActorRequest) Reset() {
 	*x = SuspendActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1331,7 +1243,7 @@ func (x *SuspendActorRequest) String() string {
 func (*SuspendActorRequest) ProtoMessage() {}
 
 func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1344,7 +1256,7 @@ func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorRequest.ProtoReflect.Descriptor instead.
 func (*SuspendActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{22}
+	return file_ateapi_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SuspendActorRequest) GetActor() *ObjectRef {
@@ -1363,7 +1275,7 @@ type SuspendActorResponse struct {
 
 func (x *SuspendActorResponse) Reset() {
 	*x = SuspendActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1375,7 +1287,7 @@ func (x *SuspendActorResponse) String() string {
 func (*SuspendActorResponse) ProtoMessage() {}
 
 func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1388,7 +1300,7 @@ func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorResponse.ProtoReflect.Descriptor instead.
 func (*SuspendActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{23}
+	return file_ateapi_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SuspendActorResponse) GetActor() *Actor {
@@ -1407,7 +1319,7 @@ type PauseActorRequest struct {
 
 func (x *PauseActorRequest) Reset() {
 	*x = PauseActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1419,7 +1331,7 @@ func (x *PauseActorRequest) String() string {
 func (*PauseActorRequest) ProtoMessage() {}
 
 func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1432,7 +1344,7 @@ func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorRequest.ProtoReflect.Descriptor instead.
 func (*PauseActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{24}
+	return file_ateapi_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *PauseActorRequest) GetActor() *ObjectRef {
@@ -1451,7 +1363,7 @@ type PauseActorResponse struct {
 
 func (x *PauseActorResponse) Reset() {
 	*x = PauseActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1463,7 +1375,7 @@ func (x *PauseActorResponse) String() string {
 func (*PauseActorResponse) ProtoMessage() {}
 
 func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1476,7 +1388,7 @@ func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorResponse.ProtoReflect.Descriptor instead.
 func (*PauseActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{25}
+	return file_ateapi_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *PauseActorResponse) GetActor() *Actor {
@@ -1497,7 +1409,7 @@ type ResumeActorRequest struct {
 
 func (x *ResumeActorRequest) Reset() {
 	*x = ResumeActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1509,7 +1421,7 @@ func (x *ResumeActorRequest) String() string {
 func (*ResumeActorRequest) ProtoMessage() {}
 
 func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1522,7 +1434,7 @@ func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorRequest.ProtoReflect.Descriptor instead.
 func (*ResumeActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{26}
+	return file_ateapi_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ResumeActorRequest) GetActor() *ObjectRef {
@@ -1548,7 +1460,7 @@ type ResumeActorResponse struct {
 
 func (x *ResumeActorResponse) Reset() {
 	*x = ResumeActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[27]
+	mi := &file_ateapi_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1560,7 +1472,7 @@ func (x *ResumeActorResponse) String() string {
 func (*ResumeActorResponse) ProtoMessage() {}
 
 func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[27]
+	mi := &file_ateapi_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1573,7 +1485,7 @@ func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorResponse.ProtoReflect.Descriptor instead.
 func (*ResumeActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{27}
+	return file_ateapi_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ResumeActorResponse) GetActor() *Actor {
@@ -1592,7 +1504,7 @@ type DeleteActorRequest struct {
 
 func (x *DeleteActorRequest) Reset() {
 	*x = DeleteActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1604,7 +1516,7 @@ func (x *DeleteActorRequest) String() string {
 func (*DeleteActorRequest) ProtoMessage() {}
 
 func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1617,7 +1529,7 @@ func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorRequest.ProtoReflect.Descriptor instead.
 func (*DeleteActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{28}
+	return file_ateapi_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *DeleteActorRequest) GetActor() *ObjectRef {
@@ -1635,7 +1547,7 @@ type DeleteActorResponse struct {
 
 func (x *DeleteActorResponse) Reset() {
 	*x = DeleteActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1647,7 +1559,7 @@ func (x *DeleteActorResponse) String() string {
 func (*DeleteActorResponse) ProtoMessage() {}
 
 func (x *DeleteActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1660,7 +1572,7 @@ func (x *DeleteActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorResponse.ProtoReflect.Descriptor instead.
 func (*DeleteActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{29}
+	return file_ateapi_proto_rawDescGZIP(), []int{27}
 }
 
 type ListWorkersRequest struct {
@@ -1671,7 +1583,7 @@ type ListWorkersRequest struct {
 
 func (x *ListWorkersRequest) Reset() {
 	*x = ListWorkersRequest{}
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1683,7 +1595,7 @@ func (x *ListWorkersRequest) String() string {
 func (*ListWorkersRequest) ProtoMessage() {}
 
 func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1696,7 +1608,7 @@ func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkersRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{30}
+	return file_ateapi_proto_rawDescGZIP(), []int{28}
 }
 
 type ListWorkersResponse struct {
@@ -1708,7 +1620,7 @@ type ListWorkersResponse struct {
 
 func (x *ListWorkersResponse) Reset() {
 	*x = ListWorkersResponse{}
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1720,7 +1632,7 @@ func (x *ListWorkersResponse) String() string {
 func (*ListWorkersResponse) ProtoMessage() {}
 
 func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1733,7 +1645,7 @@ func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkersResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{31}
+	return file_ateapi_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListWorkersResponse) GetWorkers() []*Worker {
@@ -1762,7 +1674,7 @@ type ListActorsRequest struct {
 
 func (x *ListActorsRequest) Reset() {
 	*x = ListActorsRequest{}
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1774,7 +1686,7 @@ func (x *ListActorsRequest) String() string {
 func (*ListActorsRequest) ProtoMessage() {}
 
 func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1787,7 +1699,7 @@ func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsRequest.ProtoReflect.Descriptor instead.
 func (*ListActorsRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{32}
+	return file_ateapi_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ListActorsRequest) GetPageSize() int32 {
@@ -1825,7 +1737,7 @@ type ListActorsResponse struct {
 
 func (x *ListActorsResponse) Reset() {
 	*x = ListActorsResponse{}
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1837,7 +1749,7 @@ func (x *ListActorsResponse) String() string {
 func (*ListActorsResponse) ProtoMessage() {}
 
 func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1850,7 +1762,7 @@ func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsResponse.ProtoReflect.Descriptor instead.
 func (*ListActorsResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{33}
+	return file_ateapi_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListActorsResponse) GetActors() []*Actor {
@@ -1885,7 +1797,7 @@ type Worker struct {
 
 func (x *Worker) Reset() {
 	*x = Worker{}
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1897,7 +1809,7 @@ func (x *Worker) String() string {
 func (*Worker) ProtoMessage() {}
 
 func (x *Worker) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1910,7 +1822,7 @@ func (x *Worker) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Worker.ProtoReflect.Descriptor instead.
 func (*Worker) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{34}
+	return file_ateapi_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *Worker) GetWorkerNamespace() string {
@@ -1993,7 +1905,7 @@ type Assignment struct {
 
 func (x *Assignment) Reset() {
 	*x = Assignment{}
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2005,7 +1917,7 @@ func (x *Assignment) String() string {
 func (*Assignment) ProtoMessage() {}
 
 func (x *Assignment) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2018,7 +1930,7 @@ func (x *Assignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Assignment.ProtoReflect.Descriptor instead.
 func (*Assignment) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{35}
+	return file_ateapi_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Assignment) GetActorTemplate() *KubeNamespacedObjectRef {
@@ -2045,7 +1957,7 @@ type KubeNamespacedObjectRef struct {
 
 func (x *KubeNamespacedObjectRef) Reset() {
 	*x = KubeNamespacedObjectRef{}
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2057,7 +1969,7 @@ func (x *KubeNamespacedObjectRef) String() string {
 func (*KubeNamespacedObjectRef) ProtoMessage() {}
 
 func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2070,7 +1982,7 @@ func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeNamespacedObjectRef.ProtoReflect.Descriptor instead.
 func (*KubeNamespacedObjectRef) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{36}
+	return file_ateapi_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *KubeNamespacedObjectRef) GetNamespace() string {
@@ -2095,7 +2007,7 @@ type DebugClearRequest struct {
 
 func (x *DebugClearRequest) Reset() {
 	*x = DebugClearRequest{}
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2107,7 +2019,7 @@ func (x *DebugClearRequest) String() string {
 func (*DebugClearRequest) ProtoMessage() {}
 
 func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2120,7 +2032,7 @@ func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearRequest.ProtoReflect.Descriptor instead.
 func (*DebugClearRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{37}
+	return file_ateapi_proto_rawDescGZIP(), []int{35}
 }
 
 type DebugClearResponse struct {
@@ -2131,7 +2043,7 @@ type DebugClearResponse struct {
 
 func (x *DebugClearResponse) Reset() {
 	*x = DebugClearResponse{}
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2143,7 +2055,7 @@ func (x *DebugClearResponse) String() string {
 func (*DebugClearResponse) ProtoMessage() {}
 
 func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2156,7 +2068,7 @@ func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearResponse.ProtoReflect.Descriptor instead.
 func (*DebugClearResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{38}
+	return file_ateapi_proto_rawDescGZIP(), []int{36}
 }
 
 type MintJWTRequest struct {
@@ -2171,7 +2083,7 @@ type MintJWTRequest struct {
 
 func (x *MintJWTRequest) Reset() {
 	*x = MintJWTRequest{}
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2183,7 +2095,7 @@ func (x *MintJWTRequest) String() string {
 func (*MintJWTRequest) ProtoMessage() {}
 
 func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2196,7 +2108,7 @@ func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTRequest.ProtoReflect.Descriptor instead.
 func (*MintJWTRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{39}
+	return file_ateapi_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *MintJWTRequest) GetAudience() []string {
@@ -2256,7 +2168,7 @@ type MintJWTResponse struct {
 
 func (x *MintJWTResponse) Reset() {
 	*x = MintJWTResponse{}
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2268,7 +2180,7 @@ func (x *MintJWTResponse) String() string {
 func (*MintJWTResponse) ProtoMessage() {}
 
 func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2281,7 +2193,7 @@ func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTResponse.ProtoReflect.Descriptor instead.
 func (*MintJWTResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{40}
+	return file_ateapi_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *MintJWTResponse) GetSessionJwt() string {
@@ -2306,7 +2218,7 @@ type MintCertRequest struct {
 
 func (x *MintCertRequest) Reset() {
 	*x = MintCertRequest{}
-	mi := &file_ateapi_proto_msgTypes[41]
+	mi := &file_ateapi_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2318,7 +2230,7 @@ func (x *MintCertRequest) String() string {
 func (*MintCertRequest) ProtoMessage() {}
 
 func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[41]
+	mi := &file_ateapi_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2331,7 +2243,7 @@ func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertRequest.ProtoReflect.Descriptor instead.
 func (*MintCertRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{41}
+	return file_ateapi_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *MintCertRequest) GetAppId() string {
@@ -2374,7 +2286,7 @@ type MintCertResponse struct {
 
 func (x *MintCertResponse) Reset() {
 	*x = MintCertResponse{}
-	mi := &file_ateapi_proto_msgTypes[42]
+	mi := &file_ateapi_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2386,7 +2298,7 @@ func (x *MintCertResponse) String() string {
 func (*MintCertResponse) ProtoMessage() {}
 
 func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[42]
+	mi := &file_ateapi_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2399,7 +2311,7 @@ func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertResponse.ProtoReflect.Descriptor instead.
 func (*MintCertResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{42}
+	return file_ateapi_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *MintCertResponse) GetSessionCertificates() [][]byte {
@@ -2469,11 +2381,9 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x15CreateAtespaceRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"F\n" +
 	"\x16CreateAtespaceResponse\x12,\n" +
-	"\batespace\x18\x01 \x01(\v2\x10.ateapi.AtespaceR\batespace\"(\n" +
-	"\x12GetAtespaceRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"C\n" +
-	"\x13GetAtespaceResponse\x12,\n" +
-	"\batespace\x18\x01 \x01(\v2\x10.ateapi.AtespaceR\batespace\"\x16\n" +
+	"\batespace\x18\x01 \x01(\v2\x10.ateapi.AtespaceR\batespace\"C\n" +
+	"\x12GetAtespaceRequest\x12-\n" +
+	"\batespace\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\batespace\"\x16\n" +
 	"\x14ListAtespacesRequest\"G\n" +
 	"\x15ListAtespacesResponse\x12.\n" +
 	"\tatespaces\x18\x01 \x03(\v2\x10.ateapi.AtespaceR\tatespaces\"+\n" +
@@ -2481,9 +2391,7 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"\x18\n" +
 	"\x16DeleteAtespaceResponse\":\n" +
 	"\x0fGetActorRequest\x12'\n" +
-	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"7\n" +
-	"\x10GetActorResponse\x12#\n" +
-	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"\xe2\x01\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"\xe2\x01\n" +
 	"\x12CreateActorRequest\x12'\n" +
 	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\x128\n" +
 	"\x18actor_template_namespace\x18\x02 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
@@ -2567,9 +2475,9 @@ const file_ateapi_proto_rawDesc = "" +
 	"session_id\x18\x03 \x01(\tR\tsessionId\x12>\n" +
 	"\x1bcertificate_signing_request\x18\x04 \x01(\fR\x19certificateSigningRequest\"E\n" +
 	"\x10MintCertResponse\x121\n" +
-	"\x14session_certificates\x18\x01 \x03(\fR\x13sessionCertificates2\x9e\b\n" +
-	"\aControl\x12?\n" +
-	"\bGetActor\x12\x17.ateapi.GetActorRequest\x1a\x18.ateapi.GetActorResponse\"\x00\x12H\n" +
+	"\x14session_certificates\x18\x01 \x03(\fR\x13sessionCertificates2\x88\b\n" +
+	"\aControl\x124\n" +
+	"\bGetActor\x12\x17.ateapi.GetActorRequest\x1a\r.ateapi.Actor\"\x00\x12H\n" +
 	"\vCreateActor\x12\x1a.ateapi.CreateActorRequest\x1a\x1b.ateapi.CreateActorResponse\"\x00\x12H\n" +
 	"\vUpdateActor\x12\x1a.ateapi.UpdateActorRequest\x1a\x1b.ateapi.UpdateActorResponse\"\x00\x12K\n" +
 	"\fSuspendActor\x12\x1b.ateapi.SuspendActorRequest\x1a\x1c.ateapi.SuspendActorResponse\"\x00\x12E\n" +
@@ -2580,8 +2488,8 @@ const file_ateapi_proto_rawDesc = "" +
 	"\vListWorkers\x12\x1a.ateapi.ListWorkersRequest\x1a\x1b.ateapi.ListWorkersResponse\"\x00\x12E\n" +
 	"\n" +
 	"ListActors\x12\x19.ateapi.ListActorsRequest\x1a\x1a.ateapi.ListActorsResponse\"\x00\x12Q\n" +
-	"\x0eCreateAtespace\x12\x1d.ateapi.CreateAtespaceRequest\x1a\x1e.ateapi.CreateAtespaceResponse\"\x00\x12H\n" +
-	"\vGetAtespace\x12\x1a.ateapi.GetAtespaceRequest\x1a\x1b.ateapi.GetAtespaceResponse\"\x00\x12N\n" +
+	"\x0eCreateAtespace\x12\x1d.ateapi.CreateAtespaceRequest\x1a\x1e.ateapi.CreateAtespaceResponse\"\x00\x12=\n" +
+	"\vGetAtespace\x12\x1a.ateapi.GetAtespaceRequest\x1a\x10.ateapi.Atespace\"\x00\x12N\n" +
 	"\rListAtespaces\x12\x1c.ateapi.ListAtespacesRequest\x1a\x1d.ateapi.ListAtespacesResponse\"\x00\x12Q\n" +
 	"\x0eDeleteAtespace\x12\x1d.ateapi.DeleteAtespaceRequest\x1a\x1e.ateapi.DeleteAtespaceResponse\"\x00\x12E\n" +
 	"\n" +
@@ -2603,7 +2511,7 @@ func file_ateapi_proto_rawDescGZIP() []byte {
 }
 
 var file_ateapi_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
+var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
 var file_ateapi_proto_goTypes = []any{
 	(Actor_Status)(0),               // 0: ateapi.Actor.Status
 	(*ExternalSnapshotInfo)(nil),    // 1: ateapi.ExternalSnapshotInfo
@@ -2617,114 +2525,111 @@ var file_ateapi_proto_goTypes = []any{
 	(*CreateAtespaceRequest)(nil),   // 9: ateapi.CreateAtespaceRequest
 	(*CreateAtespaceResponse)(nil),  // 10: ateapi.CreateAtespaceResponse
 	(*GetAtespaceRequest)(nil),      // 11: ateapi.GetAtespaceRequest
-	(*GetAtespaceResponse)(nil),     // 12: ateapi.GetAtespaceResponse
-	(*ListAtespacesRequest)(nil),    // 13: ateapi.ListAtespacesRequest
-	(*ListAtespacesResponse)(nil),   // 14: ateapi.ListAtespacesResponse
-	(*DeleteAtespaceRequest)(nil),   // 15: ateapi.DeleteAtespaceRequest
-	(*DeleteAtespaceResponse)(nil),  // 16: ateapi.DeleteAtespaceResponse
-	(*GetActorRequest)(nil),         // 17: ateapi.GetActorRequest
-	(*GetActorResponse)(nil),        // 18: ateapi.GetActorResponse
-	(*CreateActorRequest)(nil),      // 19: ateapi.CreateActorRequest
-	(*CreateActorResponse)(nil),     // 20: ateapi.CreateActorResponse
-	(*UpdateActorRequest)(nil),      // 21: ateapi.UpdateActorRequest
-	(*UpdateActorResponse)(nil),     // 22: ateapi.UpdateActorResponse
-	(*SuspendActorRequest)(nil),     // 23: ateapi.SuspendActorRequest
-	(*SuspendActorResponse)(nil),    // 24: ateapi.SuspendActorResponse
-	(*PauseActorRequest)(nil),       // 25: ateapi.PauseActorRequest
-	(*PauseActorResponse)(nil),      // 26: ateapi.PauseActorResponse
-	(*ResumeActorRequest)(nil),      // 27: ateapi.ResumeActorRequest
-	(*ResumeActorResponse)(nil),     // 28: ateapi.ResumeActorResponse
-	(*DeleteActorRequest)(nil),      // 29: ateapi.DeleteActorRequest
-	(*DeleteActorResponse)(nil),     // 30: ateapi.DeleteActorResponse
-	(*ListWorkersRequest)(nil),      // 31: ateapi.ListWorkersRequest
-	(*ListWorkersResponse)(nil),     // 32: ateapi.ListWorkersResponse
-	(*ListActorsRequest)(nil),       // 33: ateapi.ListActorsRequest
-	(*ListActorsResponse)(nil),      // 34: ateapi.ListActorsResponse
-	(*Worker)(nil),                  // 35: ateapi.Worker
-	(*Assignment)(nil),              // 36: ateapi.Assignment
-	(*KubeNamespacedObjectRef)(nil), // 37: ateapi.KubeNamespacedObjectRef
-	(*DebugClearRequest)(nil),       // 38: ateapi.DebugClearRequest
-	(*DebugClearResponse)(nil),      // 39: ateapi.DebugClearResponse
-	(*MintJWTRequest)(nil),          // 40: ateapi.MintJWTRequest
-	(*MintJWTResponse)(nil),         // 41: ateapi.MintJWTResponse
-	(*MintCertRequest)(nil),         // 42: ateapi.MintCertRequest
-	(*MintCertResponse)(nil),        // 43: ateapi.MintCertResponse
-	nil,                             // 44: ateapi.Selector.MatchLabelsEntry
-	nil,                             // 45: ateapi.Worker.LabelsEntry
-	(*timestamppb.Timestamp)(nil),   // 46: google.protobuf.Timestamp
+	(*ListAtespacesRequest)(nil),    // 12: ateapi.ListAtespacesRequest
+	(*ListAtespacesResponse)(nil),   // 13: ateapi.ListAtespacesResponse
+	(*DeleteAtespaceRequest)(nil),   // 14: ateapi.DeleteAtespaceRequest
+	(*DeleteAtespaceResponse)(nil),  // 15: ateapi.DeleteAtespaceResponse
+	(*GetActorRequest)(nil),         // 16: ateapi.GetActorRequest
+	(*CreateActorRequest)(nil),      // 17: ateapi.CreateActorRequest
+	(*CreateActorResponse)(nil),     // 18: ateapi.CreateActorResponse
+	(*UpdateActorRequest)(nil),      // 19: ateapi.UpdateActorRequest
+	(*UpdateActorResponse)(nil),     // 20: ateapi.UpdateActorResponse
+	(*SuspendActorRequest)(nil),     // 21: ateapi.SuspendActorRequest
+	(*SuspendActorResponse)(nil),    // 22: ateapi.SuspendActorResponse
+	(*PauseActorRequest)(nil),       // 23: ateapi.PauseActorRequest
+	(*PauseActorResponse)(nil),      // 24: ateapi.PauseActorResponse
+	(*ResumeActorRequest)(nil),      // 25: ateapi.ResumeActorRequest
+	(*ResumeActorResponse)(nil),     // 26: ateapi.ResumeActorResponse
+	(*DeleteActorRequest)(nil),      // 27: ateapi.DeleteActorRequest
+	(*DeleteActorResponse)(nil),     // 28: ateapi.DeleteActorResponse
+	(*ListWorkersRequest)(nil),      // 29: ateapi.ListWorkersRequest
+	(*ListWorkersResponse)(nil),     // 30: ateapi.ListWorkersResponse
+	(*ListActorsRequest)(nil),       // 31: ateapi.ListActorsRequest
+	(*ListActorsResponse)(nil),      // 32: ateapi.ListActorsResponse
+	(*Worker)(nil),                  // 33: ateapi.Worker
+	(*Assignment)(nil),              // 34: ateapi.Assignment
+	(*KubeNamespacedObjectRef)(nil), // 35: ateapi.KubeNamespacedObjectRef
+	(*DebugClearRequest)(nil),       // 36: ateapi.DebugClearRequest
+	(*DebugClearResponse)(nil),      // 37: ateapi.DebugClearResponse
+	(*MintJWTRequest)(nil),          // 38: ateapi.MintJWTRequest
+	(*MintJWTResponse)(nil),         // 39: ateapi.MintJWTResponse
+	(*MintCertRequest)(nil),         // 40: ateapi.MintCertRequest
+	(*MintCertResponse)(nil),        // 41: ateapi.MintCertResponse
+	nil,                             // 42: ateapi.Selector.MatchLabelsEntry
+	nil,                             // 43: ateapi.Worker.LabelsEntry
+	(*timestamppb.Timestamp)(nil),   // 44: google.protobuf.Timestamp
 }
 var file_ateapi_proto_depIdxs = []int32{
 	1,  // 0: ateapi.SnapshotInfo.external:type_name -> ateapi.ExternalSnapshotInfo
 	2,  // 1: ateapi.SnapshotInfo.local:type_name -> ateapi.LocalSnapshotInfo
-	44, // 2: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
-	46, // 3: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
-	46, // 4: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
+	42, // 2: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
+	44, // 3: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
+	44, // 4: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
 	5,  // 5: ateapi.Actor.metadata:type_name -> ateapi.ResourceMetadata
 	0,  // 6: ateapi.Actor.status:type_name -> ateapi.Actor.Status
 	3,  // 7: ateapi.Actor.latest_snapshot_info:type_name -> ateapi.SnapshotInfo
 	4,  // 8: ateapi.Actor.worker_selector:type_name -> ateapi.Selector
 	5,  // 9: ateapi.Atespace.metadata:type_name -> ateapi.ResourceMetadata
 	7,  // 10: ateapi.CreateAtespaceResponse.atespace:type_name -> ateapi.Atespace
-	7,  // 11: ateapi.GetAtespaceResponse.atespace:type_name -> ateapi.Atespace
+	8,  // 11: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
 	7,  // 12: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
 	8,  // 13: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
-	6,  // 14: ateapi.GetActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 15: ateapi.CreateActorRequest.actor:type_name -> ateapi.ObjectRef
-	4,  // 16: ateapi.CreateActorRequest.worker_selector:type_name -> ateapi.Selector
-	6,  // 17: ateapi.CreateActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 18: ateapi.UpdateActorRequest.actor:type_name -> ateapi.ObjectRef
-	4,  // 19: ateapi.UpdateActorRequest.worker_selector:type_name -> ateapi.Selector
-	6,  // 20: ateapi.UpdateActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 21: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
-	6,  // 22: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 23: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
-	6,  // 24: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 25: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
-	6,  // 26: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 27: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
-	35, // 28: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
-	6,  // 29: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
-	36, // 30: ateapi.Worker.assignment:type_name -> ateapi.Assignment
-	45, // 31: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
-	37, // 32: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	8,  // 33: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
-	17, // 34: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	19, // 35: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	21, // 36: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	23, // 37: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	25, // 38: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	27, // 39: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	29, // 40: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	31, // 41: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	33, // 42: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	9,  // 43: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	11, // 44: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	13, // 45: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	15, // 46: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	38, // 47: ateapi.Control.DebugClear:input_type -> ateapi.DebugClearRequest
-	40, // 48: ateapi.SessionIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	42, // 49: ateapi.SessionIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	18, // 50: ateapi.Control.GetActor:output_type -> ateapi.GetActorResponse
-	20, // 51: ateapi.Control.CreateActor:output_type -> ateapi.CreateActorResponse
-	22, // 52: ateapi.Control.UpdateActor:output_type -> ateapi.UpdateActorResponse
-	24, // 53: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	26, // 54: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	28, // 55: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	30, // 56: ateapi.Control.DeleteActor:output_type -> ateapi.DeleteActorResponse
-	32, // 57: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	34, // 58: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	10, // 59: ateapi.Control.CreateAtespace:output_type -> ateapi.CreateAtespaceResponse
-	12, // 60: ateapi.Control.GetAtespace:output_type -> ateapi.GetAtespaceResponse
-	14, // 61: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	16, // 62: ateapi.Control.DeleteAtespace:output_type -> ateapi.DeleteAtespaceResponse
-	39, // 63: ateapi.Control.DebugClear:output_type -> ateapi.DebugClearResponse
-	41, // 64: ateapi.SessionIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	43, // 65: ateapi.SessionIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	50, // [50:66] is the sub-list for method output_type
-	34, // [34:50] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	8,  // 14: ateapi.CreateActorRequest.actor:type_name -> ateapi.ObjectRef
+	4,  // 15: ateapi.CreateActorRequest.worker_selector:type_name -> ateapi.Selector
+	6,  // 16: ateapi.CreateActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 17: ateapi.UpdateActorRequest.actor:type_name -> ateapi.ObjectRef
+	4,  // 18: ateapi.UpdateActorRequest.worker_selector:type_name -> ateapi.Selector
+	6,  // 19: ateapi.UpdateActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 20: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
+	6,  // 21: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 22: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
+	6,  // 23: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 24: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
+	6,  // 25: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 26: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
+	33, // 27: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
+	6,  // 28: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
+	34, // 29: ateapi.Worker.assignment:type_name -> ateapi.Assignment
+	43, // 30: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
+	35, // 31: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
+	8,  // 32: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
+	16, // 33: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	17, // 34: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	19, // 35: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	21, // 36: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	23, // 37: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	25, // 38: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	27, // 39: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	29, // 40: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	31, // 41: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	9,  // 42: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	11, // 43: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	12, // 44: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	14, // 45: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	36, // 46: ateapi.Control.DebugClear:input_type -> ateapi.DebugClearRequest
+	38, // 47: ateapi.SessionIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	40, // 48: ateapi.SessionIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	6,  // 49: ateapi.Control.GetActor:output_type -> ateapi.Actor
+	18, // 50: ateapi.Control.CreateActor:output_type -> ateapi.CreateActorResponse
+	20, // 51: ateapi.Control.UpdateActor:output_type -> ateapi.UpdateActorResponse
+	22, // 52: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	24, // 53: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	26, // 54: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	28, // 55: ateapi.Control.DeleteActor:output_type -> ateapi.DeleteActorResponse
+	30, // 56: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	32, // 57: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	10, // 58: ateapi.Control.CreateAtespace:output_type -> ateapi.CreateAtespaceResponse
+	7,  // 59: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
+	13, // 60: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	15, // 61: ateapi.Control.DeleteAtespace:output_type -> ateapi.DeleteAtespaceResponse
+	37, // 62: ateapi.Control.DebugClear:output_type -> ateapi.DebugClearResponse
+	39, // 63: ateapi.SessionIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	41, // 64: ateapi.SessionIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	49, // [49:65] is the sub-list for method output_type
+	33, // [33:49] is the sub-list for method input_type
+	33, // [33:33] is the sub-list for extension type_name
+	33, // [33:33] is the sub-list for extension extendee
+	0,  // [0:33] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }
@@ -2742,7 +2647,7 @@ func file_ateapi_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateapi_proto_rawDesc), len(file_ateapi_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   45,
+			NumMessages:   43,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -881,7 +881,7 @@ func (x *ListAtespacesResponse) GetAtespaces() []*Atespace {
 
 type DeleteAtespaceRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Atespace      *ObjectRef             `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -916,47 +916,11 @@ func (*DeleteAtespaceRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{13}
 }
 
-func (x *DeleteAtespaceRequest) GetName() string {
+func (x *DeleteAtespaceRequest) GetAtespace() *ObjectRef {
 	if x != nil {
-		return x.Name
+		return x.Atespace
 	}
-	return ""
-}
-
-type DeleteAtespaceResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *DeleteAtespaceResponse) Reset() {
-	*x = DeleteAtespaceResponse{}
-	mi := &file_ateapi_proto_msgTypes[14]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *DeleteAtespaceResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*DeleteAtespaceResponse) ProtoMessage() {}
-
-func (x *DeleteAtespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[14]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use DeleteAtespaceResponse.ProtoReflect.Descriptor instead.
-func (*DeleteAtespaceResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{14}
+	return nil
 }
 
 type GetActorRequest struct {
@@ -968,7 +932,7 @@ type GetActorRequest struct {
 
 func (x *GetActorRequest) Reset() {
 	*x = GetActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[15]
+	mi := &file_ateapi_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -980,7 +944,7 @@ func (x *GetActorRequest) String() string {
 func (*GetActorRequest) ProtoMessage() {}
 
 func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[15]
+	mi := &file_ateapi_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -993,7 +957,7 @@ func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorRequest.ProtoReflect.Descriptor instead.
 func (*GetActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{15}
+	return file_ateapi_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetActorRequest) GetActor() *ObjectRef {
@@ -1021,7 +985,7 @@ type CreateActorRequest struct {
 
 func (x *CreateActorRequest) Reset() {
 	*x = CreateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[16]
+	mi := &file_ateapi_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1033,7 +997,7 @@ func (x *CreateActorRequest) String() string {
 func (*CreateActorRequest) ProtoMessage() {}
 
 func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[16]
+	mi := &file_ateapi_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1046,7 +1010,7 @@ func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateActorRequest.ProtoReflect.Descriptor instead.
 func (*CreateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{16}
+	return file_ateapi_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *CreateActorRequest) GetActor() *ObjectRef {
@@ -1086,7 +1050,7 @@ type CreateActorResponse struct {
 
 func (x *CreateActorResponse) Reset() {
 	*x = CreateActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[17]
+	mi := &file_ateapi_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1098,7 +1062,7 @@ func (x *CreateActorResponse) String() string {
 func (*CreateActorResponse) ProtoMessage() {}
 
 func (x *CreateActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[17]
+	mi := &file_ateapi_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1111,7 +1075,7 @@ func (x *CreateActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateActorResponse.ProtoReflect.Descriptor instead.
 func (*CreateActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{17}
+	return file_ateapi_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CreateActorResponse) GetActor() *Actor {
@@ -1136,7 +1100,7 @@ type UpdateActorRequest struct {
 
 func (x *UpdateActorRequest) Reset() {
 	*x = UpdateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[18]
+	mi := &file_ateapi_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1148,7 +1112,7 @@ func (x *UpdateActorRequest) String() string {
 func (*UpdateActorRequest) ProtoMessage() {}
 
 func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[18]
+	mi := &file_ateapi_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1161,7 +1125,7 @@ func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorRequest.ProtoReflect.Descriptor instead.
 func (*UpdateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{18}
+	return file_ateapi_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *UpdateActorRequest) GetActor() *ObjectRef {
@@ -1187,7 +1151,7 @@ type UpdateActorResponse struct {
 
 func (x *UpdateActorResponse) Reset() {
 	*x = UpdateActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[19]
+	mi := &file_ateapi_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1199,7 +1163,7 @@ func (x *UpdateActorResponse) String() string {
 func (*UpdateActorResponse) ProtoMessage() {}
 
 func (x *UpdateActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[19]
+	mi := &file_ateapi_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1212,7 +1176,7 @@ func (x *UpdateActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorResponse.ProtoReflect.Descriptor instead.
 func (*UpdateActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{19}
+	return file_ateapi_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UpdateActorResponse) GetActor() *Actor {
@@ -1231,7 +1195,7 @@ type SuspendActorRequest struct {
 
 func (x *SuspendActorRequest) Reset() {
 	*x = SuspendActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[20]
+	mi := &file_ateapi_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1243,7 +1207,7 @@ func (x *SuspendActorRequest) String() string {
 func (*SuspendActorRequest) ProtoMessage() {}
 
 func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[20]
+	mi := &file_ateapi_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1256,7 +1220,7 @@ func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorRequest.ProtoReflect.Descriptor instead.
 func (*SuspendActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{20}
+	return file_ateapi_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SuspendActorRequest) GetActor() *ObjectRef {
@@ -1275,7 +1239,7 @@ type SuspendActorResponse struct {
 
 func (x *SuspendActorResponse) Reset() {
 	*x = SuspendActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[21]
+	mi := &file_ateapi_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1287,7 +1251,7 @@ func (x *SuspendActorResponse) String() string {
 func (*SuspendActorResponse) ProtoMessage() {}
 
 func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[21]
+	mi := &file_ateapi_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1300,7 +1264,7 @@ func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorResponse.ProtoReflect.Descriptor instead.
 func (*SuspendActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{21}
+	return file_ateapi_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SuspendActorResponse) GetActor() *Actor {
@@ -1319,7 +1283,7 @@ type PauseActorRequest struct {
 
 func (x *PauseActorRequest) Reset() {
 	*x = PauseActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1331,7 +1295,7 @@ func (x *PauseActorRequest) String() string {
 func (*PauseActorRequest) ProtoMessage() {}
 
 func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1344,7 +1308,7 @@ func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorRequest.ProtoReflect.Descriptor instead.
 func (*PauseActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{22}
+	return file_ateapi_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *PauseActorRequest) GetActor() *ObjectRef {
@@ -1363,7 +1327,7 @@ type PauseActorResponse struct {
 
 func (x *PauseActorResponse) Reset() {
 	*x = PauseActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1375,7 +1339,7 @@ func (x *PauseActorResponse) String() string {
 func (*PauseActorResponse) ProtoMessage() {}
 
 func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1388,7 +1352,7 @@ func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorResponse.ProtoReflect.Descriptor instead.
 func (*PauseActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{23}
+	return file_ateapi_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *PauseActorResponse) GetActor() *Actor {
@@ -1409,7 +1373,7 @@ type ResumeActorRequest struct {
 
 func (x *ResumeActorRequest) Reset() {
 	*x = ResumeActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1421,7 +1385,7 @@ func (x *ResumeActorRequest) String() string {
 func (*ResumeActorRequest) ProtoMessage() {}
 
 func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1434,7 +1398,7 @@ func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorRequest.ProtoReflect.Descriptor instead.
 func (*ResumeActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{24}
+	return file_ateapi_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ResumeActorRequest) GetActor() *ObjectRef {
@@ -1460,7 +1424,7 @@ type ResumeActorResponse struct {
 
 func (x *ResumeActorResponse) Reset() {
 	*x = ResumeActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1472,7 +1436,7 @@ func (x *ResumeActorResponse) String() string {
 func (*ResumeActorResponse) ProtoMessage() {}
 
 func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1485,7 +1449,7 @@ func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorResponse.ProtoReflect.Descriptor instead.
 func (*ResumeActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{25}
+	return file_ateapi_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ResumeActorResponse) GetActor() *Actor {
@@ -1504,7 +1468,7 @@ type DeleteActorRequest struct {
 
 func (x *DeleteActorRequest) Reset() {
 	*x = DeleteActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1516,7 +1480,7 @@ func (x *DeleteActorRequest) String() string {
 func (*DeleteActorRequest) ProtoMessage() {}
 
 func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1529,7 +1493,7 @@ func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorRequest.ProtoReflect.Descriptor instead.
 func (*DeleteActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{26}
+	return file_ateapi_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *DeleteActorRequest) GetActor() *ObjectRef {
@@ -1537,42 +1501,6 @@ func (x *DeleteActorRequest) GetActor() *ObjectRef {
 		return x.Actor
 	}
 	return nil
-}
-
-type DeleteActorResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *DeleteActorResponse) Reset() {
-	*x = DeleteActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[27]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *DeleteActorResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*DeleteActorResponse) ProtoMessage() {}
-
-func (x *DeleteActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[27]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use DeleteActorResponse.ProtoReflect.Descriptor instead.
-func (*DeleteActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{27}
 }
 
 type ListWorkersRequest struct {
@@ -1583,7 +1511,7 @@ type ListWorkersRequest struct {
 
 func (x *ListWorkersRequest) Reset() {
 	*x = ListWorkersRequest{}
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1595,7 +1523,7 @@ func (x *ListWorkersRequest) String() string {
 func (*ListWorkersRequest) ProtoMessage() {}
 
 func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1608,7 +1536,7 @@ func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkersRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{28}
+	return file_ateapi_proto_rawDescGZIP(), []int{26}
 }
 
 type ListWorkersResponse struct {
@@ -1620,7 +1548,7 @@ type ListWorkersResponse struct {
 
 func (x *ListWorkersResponse) Reset() {
 	*x = ListWorkersResponse{}
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1632,7 +1560,7 @@ func (x *ListWorkersResponse) String() string {
 func (*ListWorkersResponse) ProtoMessage() {}
 
 func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1645,7 +1573,7 @@ func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkersResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{29}
+	return file_ateapi_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListWorkersResponse) GetWorkers() []*Worker {
@@ -1674,7 +1602,7 @@ type ListActorsRequest struct {
 
 func (x *ListActorsRequest) Reset() {
 	*x = ListActorsRequest{}
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1686,7 +1614,7 @@ func (x *ListActorsRequest) String() string {
 func (*ListActorsRequest) ProtoMessage() {}
 
 func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1699,7 +1627,7 @@ func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsRequest.ProtoReflect.Descriptor instead.
 func (*ListActorsRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{30}
+	return file_ateapi_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ListActorsRequest) GetPageSize() int32 {
@@ -1737,7 +1665,7 @@ type ListActorsResponse struct {
 
 func (x *ListActorsResponse) Reset() {
 	*x = ListActorsResponse{}
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1749,7 +1677,7 @@ func (x *ListActorsResponse) String() string {
 func (*ListActorsResponse) ProtoMessage() {}
 
 func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1762,7 +1690,7 @@ func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsResponse.ProtoReflect.Descriptor instead.
 func (*ListActorsResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{31}
+	return file_ateapi_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListActorsResponse) GetActors() []*Actor {
@@ -1797,7 +1725,7 @@ type Worker struct {
 
 func (x *Worker) Reset() {
 	*x = Worker{}
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1809,7 +1737,7 @@ func (x *Worker) String() string {
 func (*Worker) ProtoMessage() {}
 
 func (x *Worker) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1822,7 +1750,7 @@ func (x *Worker) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Worker.ProtoReflect.Descriptor instead.
 func (*Worker) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{32}
+	return file_ateapi_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *Worker) GetWorkerNamespace() string {
@@ -1905,7 +1833,7 @@ type Assignment struct {
 
 func (x *Assignment) Reset() {
 	*x = Assignment{}
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1917,7 +1845,7 @@ func (x *Assignment) String() string {
 func (*Assignment) ProtoMessage() {}
 
 func (x *Assignment) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1930,7 +1858,7 @@ func (x *Assignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Assignment.ProtoReflect.Descriptor instead.
 func (*Assignment) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{33}
+	return file_ateapi_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *Assignment) GetActorTemplate() *KubeNamespacedObjectRef {
@@ -1957,7 +1885,7 @@ type KubeNamespacedObjectRef struct {
 
 func (x *KubeNamespacedObjectRef) Reset() {
 	*x = KubeNamespacedObjectRef{}
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1969,7 +1897,7 @@ func (x *KubeNamespacedObjectRef) String() string {
 func (*KubeNamespacedObjectRef) ProtoMessage() {}
 
 func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1982,7 +1910,7 @@ func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeNamespacedObjectRef.ProtoReflect.Descriptor instead.
 func (*KubeNamespacedObjectRef) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{34}
+	return file_ateapi_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *KubeNamespacedObjectRef) GetNamespace() string {
@@ -2007,7 +1935,7 @@ type DebugClearRequest struct {
 
 func (x *DebugClearRequest) Reset() {
 	*x = DebugClearRequest{}
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2019,7 +1947,7 @@ func (x *DebugClearRequest) String() string {
 func (*DebugClearRequest) ProtoMessage() {}
 
 func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2032,7 +1960,7 @@ func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearRequest.ProtoReflect.Descriptor instead.
 func (*DebugClearRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{35}
+	return file_ateapi_proto_rawDescGZIP(), []int{33}
 }
 
 type DebugClearResponse struct {
@@ -2043,7 +1971,7 @@ type DebugClearResponse struct {
 
 func (x *DebugClearResponse) Reset() {
 	*x = DebugClearResponse{}
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2055,7 +1983,7 @@ func (x *DebugClearResponse) String() string {
 func (*DebugClearResponse) ProtoMessage() {}
 
 func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2068,7 +1996,7 @@ func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearResponse.ProtoReflect.Descriptor instead.
 func (*DebugClearResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{36}
+	return file_ateapi_proto_rawDescGZIP(), []int{34}
 }
 
 type MintJWTRequest struct {
@@ -2083,7 +2011,7 @@ type MintJWTRequest struct {
 
 func (x *MintJWTRequest) Reset() {
 	*x = MintJWTRequest{}
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2095,7 +2023,7 @@ func (x *MintJWTRequest) String() string {
 func (*MintJWTRequest) ProtoMessage() {}
 
 func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2108,7 +2036,7 @@ func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTRequest.ProtoReflect.Descriptor instead.
 func (*MintJWTRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{37}
+	return file_ateapi_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *MintJWTRequest) GetAudience() []string {
@@ -2168,7 +2096,7 @@ type MintJWTResponse struct {
 
 func (x *MintJWTResponse) Reset() {
 	*x = MintJWTResponse{}
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2180,7 +2108,7 @@ func (x *MintJWTResponse) String() string {
 func (*MintJWTResponse) ProtoMessage() {}
 
 func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2193,7 +2121,7 @@ func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTResponse.ProtoReflect.Descriptor instead.
 func (*MintJWTResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{38}
+	return file_ateapi_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *MintJWTResponse) GetSessionJwt() string {
@@ -2218,7 +2146,7 @@ type MintCertRequest struct {
 
 func (x *MintCertRequest) Reset() {
 	*x = MintCertRequest{}
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2230,7 +2158,7 @@ func (x *MintCertRequest) String() string {
 func (*MintCertRequest) ProtoMessage() {}
 
 func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2243,7 +2171,7 @@ func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertRequest.ProtoReflect.Descriptor instead.
 func (*MintCertRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{39}
+	return file_ateapi_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *MintCertRequest) GetAppId() string {
@@ -2286,7 +2214,7 @@ type MintCertResponse struct {
 
 func (x *MintCertResponse) Reset() {
 	*x = MintCertResponse{}
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2298,7 +2226,7 @@ func (x *MintCertResponse) String() string {
 func (*MintCertResponse) ProtoMessage() {}
 
 func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2311,7 +2239,7 @@ func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertResponse.ProtoReflect.Descriptor instead.
 func (*MintCertResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{40}
+	return file_ateapi_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *MintCertResponse) GetSessionCertificates() [][]byte {
@@ -2386,10 +2314,9 @@ const file_ateapi_proto_rawDesc = "" +
 	"\batespace\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\batespace\"\x16\n" +
 	"\x14ListAtespacesRequest\"G\n" +
 	"\x15ListAtespacesResponse\x12.\n" +
-	"\tatespaces\x18\x01 \x03(\v2\x10.ateapi.AtespaceR\tatespaces\"+\n" +
-	"\x15DeleteAtespaceRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"\x18\n" +
-	"\x16DeleteAtespaceResponse\":\n" +
+	"\tatespaces\x18\x01 \x03(\v2\x10.ateapi.AtespaceR\tatespaces\"F\n" +
+	"\x15DeleteAtespaceRequest\x12-\n" +
+	"\batespace\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\batespace\":\n" +
 	"\x0fGetActorRequest\x12'\n" +
 	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"\xe2\x01\n" +
 	"\x12CreateActorRequest\x12'\n" +
@@ -2418,8 +2345,7 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x13ResumeActorResponse\x12#\n" +
 	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"=\n" +
 	"\x12DeleteActorRequest\x12'\n" +
-	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"\x15\n" +
-	"\x13DeleteActorResponse\"\x14\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"\x14\n" +
 	"\x12ListWorkersRequest\"?\n" +
 	"\x13ListWorkersResponse\x12(\n" +
 	"\aworkers\x18\x01 \x03(\v2\x0e.ateapi.WorkerR\aworkers\"k\n" +
@@ -2475,7 +2401,7 @@ const file_ateapi_proto_rawDesc = "" +
 	"session_id\x18\x03 \x01(\tR\tsessionId\x12>\n" +
 	"\x1bcertificate_signing_request\x18\x04 \x01(\fR\x19certificateSigningRequest\"E\n" +
 	"\x10MintCertResponse\x121\n" +
-	"\x14session_certificates\x18\x01 \x03(\fR\x13sessionCertificates2\x88\b\n" +
+	"\x14session_certificates\x18\x01 \x03(\fR\x13sessionCertificates2\xec\a\n" +
 	"\aControl\x124\n" +
 	"\bGetActor\x12\x17.ateapi.GetActorRequest\x1a\r.ateapi.Actor\"\x00\x12H\n" +
 	"\vCreateActor\x12\x1a.ateapi.CreateActorRequest\x1a\x1b.ateapi.CreateActorResponse\"\x00\x12H\n" +
@@ -2483,15 +2409,15 @@ const file_ateapi_proto_rawDesc = "" +
 	"\fSuspendActor\x12\x1b.ateapi.SuspendActorRequest\x1a\x1c.ateapi.SuspendActorResponse\"\x00\x12E\n" +
 	"\n" +
 	"PauseActor\x12\x19.ateapi.PauseActorRequest\x1a\x1a.ateapi.PauseActorResponse\"\x00\x12H\n" +
-	"\vResumeActor\x12\x1a.ateapi.ResumeActorRequest\x1a\x1b.ateapi.ResumeActorResponse\"\x00\x12H\n" +
-	"\vDeleteActor\x12\x1a.ateapi.DeleteActorRequest\x1a\x1b.ateapi.DeleteActorResponse\"\x00\x12H\n" +
+	"\vResumeActor\x12\x1a.ateapi.ResumeActorRequest\x1a\x1b.ateapi.ResumeActorResponse\"\x00\x12:\n" +
+	"\vDeleteActor\x12\x1a.ateapi.DeleteActorRequest\x1a\r.ateapi.Actor\"\x00\x12H\n" +
 	"\vListWorkers\x12\x1a.ateapi.ListWorkersRequest\x1a\x1b.ateapi.ListWorkersResponse\"\x00\x12E\n" +
 	"\n" +
 	"ListActors\x12\x19.ateapi.ListActorsRequest\x1a\x1a.ateapi.ListActorsResponse\"\x00\x12Q\n" +
 	"\x0eCreateAtespace\x12\x1d.ateapi.CreateAtespaceRequest\x1a\x1e.ateapi.CreateAtespaceResponse\"\x00\x12=\n" +
 	"\vGetAtespace\x12\x1a.ateapi.GetAtespaceRequest\x1a\x10.ateapi.Atespace\"\x00\x12N\n" +
-	"\rListAtespaces\x12\x1c.ateapi.ListAtespacesRequest\x1a\x1d.ateapi.ListAtespacesResponse\"\x00\x12Q\n" +
-	"\x0eDeleteAtespace\x12\x1d.ateapi.DeleteAtespaceRequest\x1a\x1e.ateapi.DeleteAtespaceResponse\"\x00\x12E\n" +
+	"\rListAtespaces\x12\x1c.ateapi.ListAtespacesRequest\x1a\x1d.ateapi.ListAtespacesResponse\"\x00\x12C\n" +
+	"\x0eDeleteAtespace\x12\x1d.ateapi.DeleteAtespaceRequest\x1a\x10.ateapi.Atespace\"\x00\x12E\n" +
 	"\n" +
 	"DebugClear\x12\x19.ateapi.DebugClearRequest\x1a\x1a.ateapi.DebugClearResponse\"\x002\x8c\x01\n" +
 	"\x0fSessionIdentity\x12:\n" +
@@ -2511,7 +2437,7 @@ func file_ateapi_proto_rawDescGZIP() []byte {
 }
 
 var file_ateapi_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_ateapi_proto_goTypes = []any{
 	(Actor_Status)(0),               // 0: ateapi.Actor.Status
 	(*ExternalSnapshotInfo)(nil),    // 1: ateapi.ExternalSnapshotInfo
@@ -2528,43 +2454,41 @@ var file_ateapi_proto_goTypes = []any{
 	(*ListAtespacesRequest)(nil),    // 12: ateapi.ListAtespacesRequest
 	(*ListAtespacesResponse)(nil),   // 13: ateapi.ListAtespacesResponse
 	(*DeleteAtespaceRequest)(nil),   // 14: ateapi.DeleteAtespaceRequest
-	(*DeleteAtespaceResponse)(nil),  // 15: ateapi.DeleteAtespaceResponse
-	(*GetActorRequest)(nil),         // 16: ateapi.GetActorRequest
-	(*CreateActorRequest)(nil),      // 17: ateapi.CreateActorRequest
-	(*CreateActorResponse)(nil),     // 18: ateapi.CreateActorResponse
-	(*UpdateActorRequest)(nil),      // 19: ateapi.UpdateActorRequest
-	(*UpdateActorResponse)(nil),     // 20: ateapi.UpdateActorResponse
-	(*SuspendActorRequest)(nil),     // 21: ateapi.SuspendActorRequest
-	(*SuspendActorResponse)(nil),    // 22: ateapi.SuspendActorResponse
-	(*PauseActorRequest)(nil),       // 23: ateapi.PauseActorRequest
-	(*PauseActorResponse)(nil),      // 24: ateapi.PauseActorResponse
-	(*ResumeActorRequest)(nil),      // 25: ateapi.ResumeActorRequest
-	(*ResumeActorResponse)(nil),     // 26: ateapi.ResumeActorResponse
-	(*DeleteActorRequest)(nil),      // 27: ateapi.DeleteActorRequest
-	(*DeleteActorResponse)(nil),     // 28: ateapi.DeleteActorResponse
-	(*ListWorkersRequest)(nil),      // 29: ateapi.ListWorkersRequest
-	(*ListWorkersResponse)(nil),     // 30: ateapi.ListWorkersResponse
-	(*ListActorsRequest)(nil),       // 31: ateapi.ListActorsRequest
-	(*ListActorsResponse)(nil),      // 32: ateapi.ListActorsResponse
-	(*Worker)(nil),                  // 33: ateapi.Worker
-	(*Assignment)(nil),              // 34: ateapi.Assignment
-	(*KubeNamespacedObjectRef)(nil), // 35: ateapi.KubeNamespacedObjectRef
-	(*DebugClearRequest)(nil),       // 36: ateapi.DebugClearRequest
-	(*DebugClearResponse)(nil),      // 37: ateapi.DebugClearResponse
-	(*MintJWTRequest)(nil),          // 38: ateapi.MintJWTRequest
-	(*MintJWTResponse)(nil),         // 39: ateapi.MintJWTResponse
-	(*MintCertRequest)(nil),         // 40: ateapi.MintCertRequest
-	(*MintCertResponse)(nil),        // 41: ateapi.MintCertResponse
-	nil,                             // 42: ateapi.Selector.MatchLabelsEntry
-	nil,                             // 43: ateapi.Worker.LabelsEntry
-	(*timestamppb.Timestamp)(nil),   // 44: google.protobuf.Timestamp
+	(*GetActorRequest)(nil),         // 15: ateapi.GetActorRequest
+	(*CreateActorRequest)(nil),      // 16: ateapi.CreateActorRequest
+	(*CreateActorResponse)(nil),     // 17: ateapi.CreateActorResponse
+	(*UpdateActorRequest)(nil),      // 18: ateapi.UpdateActorRequest
+	(*UpdateActorResponse)(nil),     // 19: ateapi.UpdateActorResponse
+	(*SuspendActorRequest)(nil),     // 20: ateapi.SuspendActorRequest
+	(*SuspendActorResponse)(nil),    // 21: ateapi.SuspendActorResponse
+	(*PauseActorRequest)(nil),       // 22: ateapi.PauseActorRequest
+	(*PauseActorResponse)(nil),      // 23: ateapi.PauseActorResponse
+	(*ResumeActorRequest)(nil),      // 24: ateapi.ResumeActorRequest
+	(*ResumeActorResponse)(nil),     // 25: ateapi.ResumeActorResponse
+	(*DeleteActorRequest)(nil),      // 26: ateapi.DeleteActorRequest
+	(*ListWorkersRequest)(nil),      // 27: ateapi.ListWorkersRequest
+	(*ListWorkersResponse)(nil),     // 28: ateapi.ListWorkersResponse
+	(*ListActorsRequest)(nil),       // 29: ateapi.ListActorsRequest
+	(*ListActorsResponse)(nil),      // 30: ateapi.ListActorsResponse
+	(*Worker)(nil),                  // 31: ateapi.Worker
+	(*Assignment)(nil),              // 32: ateapi.Assignment
+	(*KubeNamespacedObjectRef)(nil), // 33: ateapi.KubeNamespacedObjectRef
+	(*DebugClearRequest)(nil),       // 34: ateapi.DebugClearRequest
+	(*DebugClearResponse)(nil),      // 35: ateapi.DebugClearResponse
+	(*MintJWTRequest)(nil),          // 36: ateapi.MintJWTRequest
+	(*MintJWTResponse)(nil),         // 37: ateapi.MintJWTResponse
+	(*MintCertRequest)(nil),         // 38: ateapi.MintCertRequest
+	(*MintCertResponse)(nil),        // 39: ateapi.MintCertResponse
+	nil,                             // 40: ateapi.Selector.MatchLabelsEntry
+	nil,                             // 41: ateapi.Worker.LabelsEntry
+	(*timestamppb.Timestamp)(nil),   // 42: google.protobuf.Timestamp
 }
 var file_ateapi_proto_depIdxs = []int32{
 	1,  // 0: ateapi.SnapshotInfo.external:type_name -> ateapi.ExternalSnapshotInfo
 	2,  // 1: ateapi.SnapshotInfo.local:type_name -> ateapi.LocalSnapshotInfo
-	42, // 2: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
-	44, // 3: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
-	44, // 4: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
+	40, // 2: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
+	42, // 3: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
+	42, // 4: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
 	5,  // 5: ateapi.Actor.metadata:type_name -> ateapi.ResourceMetadata
 	0,  // 6: ateapi.Actor.status:type_name -> ateapi.Actor.Status
 	3,  // 7: ateapi.Actor.latest_snapshot_info:type_name -> ateapi.SnapshotInfo
@@ -2573,63 +2497,64 @@ var file_ateapi_proto_depIdxs = []int32{
 	7,  // 10: ateapi.CreateAtespaceResponse.atespace:type_name -> ateapi.Atespace
 	8,  // 11: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
 	7,  // 12: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
-	8,  // 13: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
-	8,  // 14: ateapi.CreateActorRequest.actor:type_name -> ateapi.ObjectRef
-	4,  // 15: ateapi.CreateActorRequest.worker_selector:type_name -> ateapi.Selector
-	6,  // 16: ateapi.CreateActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 17: ateapi.UpdateActorRequest.actor:type_name -> ateapi.ObjectRef
-	4,  // 18: ateapi.UpdateActorRequest.worker_selector:type_name -> ateapi.Selector
-	6,  // 19: ateapi.UpdateActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 20: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
-	6,  // 21: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 22: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
-	6,  // 23: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 24: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
-	6,  // 25: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
-	8,  // 26: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
-	33, // 27: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
-	6,  // 28: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
-	34, // 29: ateapi.Worker.assignment:type_name -> ateapi.Assignment
-	43, // 30: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
-	35, // 31: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	8,  // 32: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
-	16, // 33: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	17, // 34: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	19, // 35: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	21, // 36: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	23, // 37: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	25, // 38: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	27, // 39: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	29, // 40: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	31, // 41: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	9,  // 42: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	11, // 43: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	12, // 44: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	14, // 45: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	36, // 46: ateapi.Control.DebugClear:input_type -> ateapi.DebugClearRequest
-	38, // 47: ateapi.SessionIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	40, // 48: ateapi.SessionIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	6,  // 49: ateapi.Control.GetActor:output_type -> ateapi.Actor
-	18, // 50: ateapi.Control.CreateActor:output_type -> ateapi.CreateActorResponse
-	20, // 51: ateapi.Control.UpdateActor:output_type -> ateapi.UpdateActorResponse
-	22, // 52: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	24, // 53: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	26, // 54: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	28, // 55: ateapi.Control.DeleteActor:output_type -> ateapi.DeleteActorResponse
-	30, // 56: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	32, // 57: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	10, // 58: ateapi.Control.CreateAtespace:output_type -> ateapi.CreateAtespaceResponse
-	7,  // 59: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
-	13, // 60: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	15, // 61: ateapi.Control.DeleteAtespace:output_type -> ateapi.DeleteAtespaceResponse
-	37, // 62: ateapi.Control.DebugClear:output_type -> ateapi.DebugClearResponse
-	39, // 63: ateapi.SessionIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	41, // 64: ateapi.SessionIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	49, // [49:65] is the sub-list for method output_type
-	33, // [33:49] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	8,  // 13: ateapi.DeleteAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
+	8,  // 14: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
+	8,  // 15: ateapi.CreateActorRequest.actor:type_name -> ateapi.ObjectRef
+	4,  // 16: ateapi.CreateActorRequest.worker_selector:type_name -> ateapi.Selector
+	6,  // 17: ateapi.CreateActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 18: ateapi.UpdateActorRequest.actor:type_name -> ateapi.ObjectRef
+	4,  // 19: ateapi.UpdateActorRequest.worker_selector:type_name -> ateapi.Selector
+	6,  // 20: ateapi.UpdateActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 21: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
+	6,  // 22: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 23: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
+	6,  // 24: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 25: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
+	6,  // 26: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
+	8,  // 27: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
+	31, // 28: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
+	6,  // 29: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
+	32, // 30: ateapi.Worker.assignment:type_name -> ateapi.Assignment
+	41, // 31: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
+	33, // 32: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
+	8,  // 33: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
+	15, // 34: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	16, // 35: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	18, // 36: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	20, // 37: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	22, // 38: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	24, // 39: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	26, // 40: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	27, // 41: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	29, // 42: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	9,  // 43: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	11, // 44: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	12, // 45: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	14, // 46: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	34, // 47: ateapi.Control.DebugClear:input_type -> ateapi.DebugClearRequest
+	36, // 48: ateapi.SessionIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	38, // 49: ateapi.SessionIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	6,  // 50: ateapi.Control.GetActor:output_type -> ateapi.Actor
+	17, // 51: ateapi.Control.CreateActor:output_type -> ateapi.CreateActorResponse
+	19, // 52: ateapi.Control.UpdateActor:output_type -> ateapi.UpdateActorResponse
+	21, // 53: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	23, // 54: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	25, // 55: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	6,  // 56: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
+	28, // 57: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	30, // 58: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	10, // 59: ateapi.Control.CreateAtespace:output_type -> ateapi.CreateAtespaceResponse
+	7,  // 60: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
+	13, // 61: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	7,  // 62: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
+	35, // 63: ateapi.Control.DebugClear:output_type -> ateapi.DebugClearResponse
+	37, // 64: ateapi.SessionIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	39, // 65: ateapi.SessionIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	50, // [50:66] is the sub-list for method output_type
+	34, // [34:50] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }
@@ -2647,7 +2572,7 @@ func file_ateapi_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateapi_proto_rawDesc), len(file_ateapi_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   43,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -167,9 +167,12 @@ message Atespace {
   ResourceMetadata metadata = 1;
 }
 
-// ActorRef identifies an actor: a name is only unique within its atespace.
-message ActorRef {
+// ObjectRef references a Substrate resource by its (atespace, name) identity.
+message ObjectRef {
+  // The atespace where the resource lives. Empty if the resource is global-scoped.
   string atespace = 1;
+  // The name of the resource. Required. Unique within an atespace, or globally
+  // unique if the resource is global-scoped.
   string name     = 2;
 }
 
@@ -198,7 +201,7 @@ message DeleteAtespaceRequest {
 message DeleteAtespaceResponse {}
 
 message GetActorRequest {
-  ActorRef actor_ref = 1;
+  ObjectRef actor = 1;
 }
 
 message GetActorResponse {
@@ -208,7 +211,7 @@ message GetActorResponse {
 // Request to create a new Actor.
 message CreateActorRequest {
   // The new actor's atespace and actor_id (actor_id must be a valid DNS-1123 label).
-  ActorRef actor_ref = 1;
+  ObjectRef actor = 1;
 
   // The namespace of the ActorTemplate to derive from.
   string actor_template_namespace = 2;
@@ -229,7 +232,7 @@ message CreateActorResponse {
 // May be called regardless of the actor's current status.
 // Changes take effect on the next ResumeActor call.
 message UpdateActorRequest {
-  ActorRef actor_ref = 1;
+  ObjectRef actor = 1;
 
   // worker_selector replaces the actor's current placement constraint.
   // Takes effect on the next ResumeActor call.
@@ -241,7 +244,7 @@ message UpdateActorResponse {
 }
 
 message SuspendActorRequest {
-  ActorRef actor_ref = 1;
+  ObjectRef actor = 1;
 }
 
 message SuspendActorResponse {
@@ -249,7 +252,7 @@ message SuspendActorResponse {
 }
 
 message PauseActorRequest {
-  ActorRef actor_ref = 1;
+  ObjectRef actor = 1;
 }
 
 message PauseActorResponse {
@@ -257,7 +260,7 @@ message PauseActorResponse {
 }
 
 message ResumeActorRequest {
-  ActorRef actor_ref = 1;
+  ObjectRef actor = 1;
 
   // If true, skip golden snapshot and boot the workload from scratch.
   bool boot = 2;
@@ -268,7 +271,7 @@ message ResumeActorResponse {
 }
 
 message DeleteActorRequest {
-  ActorRef actor_ref = 1;
+  ObjectRef actor = 1;
 }
 
 message DeleteActorResponse {}
@@ -322,7 +325,7 @@ message Worker {
 
 message Assignment {
   KubeNamespacedObjectRef actor_template = 1;
-  ActorRef actor = 2;
+  ObjectRef actor = 2;
 }
 
 message KubeNamespacedObjectRef {

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -44,7 +44,7 @@ service Control {
   rpc ResumeActor(ResumeActorRequest) returns (ResumeActorResponse) {}
 
   // Delete an actor. Only suspended actors can be deleted.
-  rpc DeleteActor(DeleteActorRequest) returns (DeleteActorResponse) {}
+  rpc DeleteActor(DeleteActorRequest) returns (Actor) {}
 
   // List all workers currently reflected in redis.
   rpc ListWorkers(ListWorkersRequest) returns (ListWorkersResponse) {}
@@ -62,7 +62,7 @@ service Control {
   rpc ListAtespaces(ListAtespacesRequest) returns (ListAtespacesResponse) {}
 
   // Delete an empty Atespace. Rejects (FailedPrecondition) if any actors remain.
-  rpc DeleteAtespace(DeleteAtespaceRequest) returns (DeleteAtespaceResponse) {}
+  rpc DeleteAtespace(DeleteAtespaceRequest) returns (Atespace) {}
 
   // Debugging: drop all data from the ate database.
   rpc DebugClear(DebugClearRequest) returns (DebugClearResponse) {}
@@ -193,9 +193,8 @@ message ListAtespacesResponse {
 }
 
 message DeleteAtespaceRequest {
-  string name = 1;
+  ObjectRef atespace = 1;
 }
-message DeleteAtespaceResponse {}
 
 message GetActorRequest {
   ObjectRef actor = 1;
@@ -266,8 +265,6 @@ message ResumeActorResponse {
 message DeleteActorRequest {
   ObjectRef actor = 1;
 }
-
-message DeleteActorResponse {}
 
 message ListWorkersRequest {}
 

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -26,7 +26,7 @@ option go_package = "github.com/agent-substrate/substrate/pkg/proto/ateapipb";
 // Control is the primary RPC interface for Agentic Substrate.
 service Control {
   // Get an Actor.
-  rpc GetActor(GetActorRequest) returns (GetActorResponse) {}
+  rpc GetActor(GetActorRequest) returns (Actor) {}
 
   // Create a new Actor deriving from a given ActorTemplate.
   rpc CreateActor(CreateActorRequest) returns (CreateActorResponse) {}
@@ -56,7 +56,7 @@ service Control {
   rpc CreateAtespace(CreateAtespaceRequest) returns (CreateAtespaceResponse) {}
 
   // Get an Atespace by name.
-  rpc GetAtespace(GetAtespaceRequest) returns (GetAtespaceResponse) {}
+  rpc GetAtespace(GetAtespaceRequest) returns (Atespace) {}
 
   // List all Atespaces.
   rpc ListAtespaces(ListAtespacesRequest) returns (ListAtespacesResponse) {}
@@ -184,10 +184,7 @@ message CreateAtespaceResponse {
 }
 
 message GetAtespaceRequest {
-  string name = 1;
-}
-message GetAtespaceResponse {
-  Atespace atespace = 1;
+  ObjectRef atespace = 1;
 }
 
 message ListAtespacesRequest {}
@@ -202,10 +199,6 @@ message DeleteAtespaceResponse {}
 
 message GetActorRequest {
   ObjectRef actor = 1;
-}
-
-message GetActorResponse {
-  Actor actor = 1;
 }
 
 // Request to create a new Actor.

--- a/pkg/proto/ateapipb/ateapi_grpc.pb.go
+++ b/pkg/proto/ateapipb/ateapi_grpc.pb.go
@@ -70,7 +70,7 @@ type ControlClient interface {
 	// Resume an actor from its latest snapshot.
 	ResumeActor(ctx context.Context, in *ResumeActorRequest, opts ...grpc.CallOption) (*ResumeActorResponse, error)
 	// Delete an actor. Only suspended actors can be deleted.
-	DeleteActor(ctx context.Context, in *DeleteActorRequest, opts ...grpc.CallOption) (*DeleteActorResponse, error)
+	DeleteActor(ctx context.Context, in *DeleteActorRequest, opts ...grpc.CallOption) (*Actor, error)
 	// List all workers currently reflected in redis.
 	ListWorkers(ctx context.Context, in *ListWorkersRequest, opts ...grpc.CallOption) (*ListWorkersResponse, error)
 	// List all actors currently reflected in redis.
@@ -82,7 +82,7 @@ type ControlClient interface {
 	// List all Atespaces.
 	ListAtespaces(ctx context.Context, in *ListAtespacesRequest, opts ...grpc.CallOption) (*ListAtespacesResponse, error)
 	// Delete an empty Atespace. Rejects (FailedPrecondition) if any actors remain.
-	DeleteAtespace(ctx context.Context, in *DeleteAtespaceRequest, opts ...grpc.CallOption) (*DeleteAtespaceResponse, error)
+	DeleteAtespace(ctx context.Context, in *DeleteAtespaceRequest, opts ...grpc.CallOption) (*Atespace, error)
 	// Debugging: drop all data from the ate database.
 	DebugClear(ctx context.Context, in *DebugClearRequest, opts ...grpc.CallOption) (*DebugClearResponse, error)
 }
@@ -155,9 +155,9 @@ func (c *controlClient) ResumeActor(ctx context.Context, in *ResumeActorRequest,
 	return out, nil
 }
 
-func (c *controlClient) DeleteActor(ctx context.Context, in *DeleteActorRequest, opts ...grpc.CallOption) (*DeleteActorResponse, error) {
+func (c *controlClient) DeleteActor(ctx context.Context, in *DeleteActorRequest, opts ...grpc.CallOption) (*Actor, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(DeleteActorResponse)
+	out := new(Actor)
 	err := c.cc.Invoke(ctx, Control_DeleteActor_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
@@ -215,9 +215,9 @@ func (c *controlClient) ListAtespaces(ctx context.Context, in *ListAtespacesRequ
 	return out, nil
 }
 
-func (c *controlClient) DeleteAtespace(ctx context.Context, in *DeleteAtespaceRequest, opts ...grpc.CallOption) (*DeleteAtespaceResponse, error) {
+func (c *controlClient) DeleteAtespace(ctx context.Context, in *DeleteAtespaceRequest, opts ...grpc.CallOption) (*Atespace, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(DeleteAtespaceResponse)
+	out := new(Atespace)
 	err := c.cc.Invoke(ctx, Control_DeleteAtespace_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
@@ -254,7 +254,7 @@ type ControlServer interface {
 	// Resume an actor from its latest snapshot.
 	ResumeActor(context.Context, *ResumeActorRequest) (*ResumeActorResponse, error)
 	// Delete an actor. Only suspended actors can be deleted.
-	DeleteActor(context.Context, *DeleteActorRequest) (*DeleteActorResponse, error)
+	DeleteActor(context.Context, *DeleteActorRequest) (*Actor, error)
 	// List all workers currently reflected in redis.
 	ListWorkers(context.Context, *ListWorkersRequest) (*ListWorkersResponse, error)
 	// List all actors currently reflected in redis.
@@ -266,7 +266,7 @@ type ControlServer interface {
 	// List all Atespaces.
 	ListAtespaces(context.Context, *ListAtespacesRequest) (*ListAtespacesResponse, error)
 	// Delete an empty Atespace. Rejects (FailedPrecondition) if any actors remain.
-	DeleteAtespace(context.Context, *DeleteAtespaceRequest) (*DeleteAtespaceResponse, error)
+	DeleteAtespace(context.Context, *DeleteAtespaceRequest) (*Atespace, error)
 	// Debugging: drop all data from the ate database.
 	DebugClear(context.Context, *DebugClearRequest) (*DebugClearResponse, error)
 	mustEmbedUnimplementedControlServer()
@@ -297,7 +297,7 @@ func (UnimplementedControlServer) PauseActor(context.Context, *PauseActorRequest
 func (UnimplementedControlServer) ResumeActor(context.Context, *ResumeActorRequest) (*ResumeActorResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ResumeActor not implemented")
 }
-func (UnimplementedControlServer) DeleteActor(context.Context, *DeleteActorRequest) (*DeleteActorResponse, error) {
+func (UnimplementedControlServer) DeleteActor(context.Context, *DeleteActorRequest) (*Actor, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteActor not implemented")
 }
 func (UnimplementedControlServer) ListWorkers(context.Context, *ListWorkersRequest) (*ListWorkersResponse, error) {
@@ -315,7 +315,7 @@ func (UnimplementedControlServer) GetAtespace(context.Context, *GetAtespaceReque
 func (UnimplementedControlServer) ListAtespaces(context.Context, *ListAtespacesRequest) (*ListAtespacesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListAtespaces not implemented")
 }
-func (UnimplementedControlServer) DeleteAtespace(context.Context, *DeleteAtespaceRequest) (*DeleteAtespaceResponse, error) {
+func (UnimplementedControlServer) DeleteAtespace(context.Context, *DeleteAtespaceRequest) (*Atespace, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteAtespace not implemented")
 }
 func (UnimplementedControlServer) DebugClear(context.Context, *DebugClearRequest) (*DebugClearResponse, error) {

--- a/pkg/proto/ateapipb/ateapi_grpc.pb.go
+++ b/pkg/proto/ateapipb/ateapi_grpc.pb.go
@@ -58,7 +58,7 @@ const (
 // Control is the primary RPC interface for Agentic Substrate.
 type ControlClient interface {
 	// Get an Actor.
-	GetActor(ctx context.Context, in *GetActorRequest, opts ...grpc.CallOption) (*GetActorResponse, error)
+	GetActor(ctx context.Context, in *GetActorRequest, opts ...grpc.CallOption) (*Actor, error)
 	// Create a new Actor deriving from a given ActorTemplate.
 	CreateActor(ctx context.Context, in *CreateActorRequest, opts ...grpc.CallOption) (*CreateActorResponse, error)
 	// Update mutable fields on an existing Actor.
@@ -78,7 +78,7 @@ type ControlClient interface {
 	// Create a new Atespace. Substrate-native, stored in Redis.
 	CreateAtespace(ctx context.Context, in *CreateAtespaceRequest, opts ...grpc.CallOption) (*CreateAtespaceResponse, error)
 	// Get an Atespace by name.
-	GetAtespace(ctx context.Context, in *GetAtespaceRequest, opts ...grpc.CallOption) (*GetAtespaceResponse, error)
+	GetAtespace(ctx context.Context, in *GetAtespaceRequest, opts ...grpc.CallOption) (*Atespace, error)
 	// List all Atespaces.
 	ListAtespaces(ctx context.Context, in *ListAtespacesRequest, opts ...grpc.CallOption) (*ListAtespacesResponse, error)
 	// Delete an empty Atespace. Rejects (FailedPrecondition) if any actors remain.
@@ -95,9 +95,9 @@ func NewControlClient(cc grpc.ClientConnInterface) ControlClient {
 	return &controlClient{cc}
 }
 
-func (c *controlClient) GetActor(ctx context.Context, in *GetActorRequest, opts ...grpc.CallOption) (*GetActorResponse, error) {
+func (c *controlClient) GetActor(ctx context.Context, in *GetActorRequest, opts ...grpc.CallOption) (*Actor, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(GetActorResponse)
+	out := new(Actor)
 	err := c.cc.Invoke(ctx, Control_GetActor_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
@@ -195,9 +195,9 @@ func (c *controlClient) CreateAtespace(ctx context.Context, in *CreateAtespaceRe
 	return out, nil
 }
 
-func (c *controlClient) GetAtespace(ctx context.Context, in *GetAtespaceRequest, opts ...grpc.CallOption) (*GetAtespaceResponse, error) {
+func (c *controlClient) GetAtespace(ctx context.Context, in *GetAtespaceRequest, opts ...grpc.CallOption) (*Atespace, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(GetAtespaceResponse)
+	out := new(Atespace)
 	err := c.cc.Invoke(ctx, Control_GetAtespace_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
@@ -242,7 +242,7 @@ func (c *controlClient) DebugClear(ctx context.Context, in *DebugClearRequest, o
 // Control is the primary RPC interface for Agentic Substrate.
 type ControlServer interface {
 	// Get an Actor.
-	GetActor(context.Context, *GetActorRequest) (*GetActorResponse, error)
+	GetActor(context.Context, *GetActorRequest) (*Actor, error)
 	// Create a new Actor deriving from a given ActorTemplate.
 	CreateActor(context.Context, *CreateActorRequest) (*CreateActorResponse, error)
 	// Update mutable fields on an existing Actor.
@@ -262,7 +262,7 @@ type ControlServer interface {
 	// Create a new Atespace. Substrate-native, stored in Redis.
 	CreateAtespace(context.Context, *CreateAtespaceRequest) (*CreateAtespaceResponse, error)
 	// Get an Atespace by name.
-	GetAtespace(context.Context, *GetAtespaceRequest) (*GetAtespaceResponse, error)
+	GetAtespace(context.Context, *GetAtespaceRequest) (*Atespace, error)
 	// List all Atespaces.
 	ListAtespaces(context.Context, *ListAtespacesRequest) (*ListAtespacesResponse, error)
 	// Delete an empty Atespace. Rejects (FailedPrecondition) if any actors remain.
@@ -279,7 +279,7 @@ type ControlServer interface {
 // pointer dereference when methods are called.
 type UnimplementedControlServer struct{}
 
-func (UnimplementedControlServer) GetActor(context.Context, *GetActorRequest) (*GetActorResponse, error) {
+func (UnimplementedControlServer) GetActor(context.Context, *GetActorRequest) (*Actor, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetActor not implemented")
 }
 func (UnimplementedControlServer) CreateActor(context.Context, *CreateActorRequest) (*CreateActorResponse, error) {
@@ -309,7 +309,7 @@ func (UnimplementedControlServer) ListActors(context.Context, *ListActorsRequest
 func (UnimplementedControlServer) CreateAtespace(context.Context, *CreateAtespaceRequest) (*CreateAtespaceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateAtespace not implemented")
 }
-func (UnimplementedControlServer) GetAtespace(context.Context, *GetAtespaceRequest) (*GetAtespaceResponse, error) {
+func (UnimplementedControlServer) GetAtespace(context.Context, *GetAtespaceRequest) (*Atespace, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAtespace not implemented")
 }
 func (UnimplementedControlServer) ListAtespaces(context.Context, *ListAtespacesRequest) (*ListAtespacesResponse, error) {


### PR DESCRIPTION
More changes related to #149. Update `Get`/`Delete` methods as well as replace `ActorRef` with generic `ObjectRef`.