### PR TITLE
Update `kubectl-ate` to use actor name instead of id.

### DIFF
--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -83,14 +83,14 @@ kubectl ate get actors -a <atespace>
 # List actors across all atespaces
 kubectl ate get actors -A
 
-# Get a specific actor by ID and output as raw YAML
-kubectl ate get actor <actor-id> --atespace <atespace> -o yaml
+# Get a specific actor by name and output as raw YAML
+kubectl ate get actor <actor-name> --atespace <atespace> -o yaml
 
 # List all physical workers and see which actors are assigned to them
 kubectl ate get workers
 ```
 
-> **Note:** `get actors` requires either `--atespace <name>` / `-a <name>` (one atespace) or `-A`/`--all-atespaces` (all atespaces) — there is no default atespace. Getting a single actor always requires `--atespace`/`-a`, since an actor is addressed by `(atespace, id)`. `-a` (lower-case) scopes to one atespace; `-A` (upper-case) spans all.
+> **Note:** `get actors` requires either `--atespace <name>` / `-a <name>` (one atespace) or `-A`/`--all-atespaces` (all atespaces) — there is no default atespace. Getting a single actor always requires `--atespace`/`-a`, since an actor is addressed by `(atespace, name)`. `-a` (lower-case) scopes to one atespace; `-A` (upper-case) spans all.
 
 > **Note:** Actors and workers are not Kubernetes CRDs — they live in the Substrate control plane (valkey/redis), not `etcd`. `kubectl get actor` and `kubectl get worker` will not return anything; only `kubectl ate get …` queries the control plane. `kubectl get actortemplate` and `kubectl get workerpool` *do* work, because those are CRDs.
 
@@ -98,14 +98,14 @@ kubectl ate get workers
 
 | Column | Meaning |
 |---|---|
-| `ATESPACE` | The atespace the actor belongs to. Part of the actor's identity; folded into the storage key as `actor:<atespace>:<id>`. |
-| `TEMPLATE NS` | The namespace of the `ActorTemplate` the actor was created from (distinct from `ATESPACE`). |
-| `TEMPLATE` | The `ActorTemplate` name. |
-| `ID` | Actor ID. User-provided for application actors; UUID for the golden actor that each template materialises during `ResumeGoldenActor`. |
+| `ATESPACE` | The atespace the actor belongs to. Part of the actor's identity; folded into the storage key as `actor:<atespace>:<name>`. |
+| `NAME` | The actor's name. User-provided for application actors; UUID for the golden actor that each template materialises during `ResumeGoldenActor`. |
+| `TEMPLATE` | The `ActorTemplate` the actor was created from, as `<namespace>/<name>` (the template namespace is distinct from `ATESPACE`). |
 | `STATUS` | One of `STATUS_RESUMING`, `STATUS_RUNNING`, `STATUS_SUSPENDING`, `STATUS_SUSPENDED`. |
 | `ATEOM POD` | The worker pod (namespace/name) currently hosting the actor. Empty while suspended. |
 | `ATEOM IP` | The pod IP of that worker. Empty while suspended. |
 | `VERSION` | Monotonic integer that increments on every state transition (resume / suspend / checkpoint). Useful for distinguishing snapshots. |
+| `AGE` | Time elapsed since the actor was created. |
 
 #### `kubectl ate get worker` output columns
 
@@ -115,7 +115,7 @@ kubectl ate get workers
 | `POOL` | The `WorkerPool` name. |
 | `POD` | The worker pod name. |
 | `STATUS` | `FREE` (idle, ready to receive an actor) or `ASSIGNED` (currently hosting an actor). |
-| `ASSIGNED ACTOR` | If `STATUS=ASSIGNED`, the actor reference `<namespace>/<template>/<actor-id>`. |
+| `ASSIGNED ACTOR` | If `STATUS=ASSIGNED`, the actor reference `<namespace>/<template>/<actor-name>`. |
 
 ### Atespaces
 
@@ -137,9 +137,16 @@ kubectl ate delete atespace <atespace>
 
 > **Note:** `create actor … -a <atespace>` requires the atespace to already exist, otherwise it fails with `FailedPrecondition`. `delete atespace` only removes an **empty** atespace; delete its actors first (cascade delete is not yet supported).
 
+#### `kubectl ate get atespace` output columns
+
+| Column | Meaning |
+|---|---|
+| `NAME` | The atespace name. Globally unique — atespaces are global-scoped. |
+| `AGE` | Time elapsed since the atespace was created. |
+
 ### Actor Lifecycle
 Manage the execution state of your workloads.
-*(Note: Actors are identified by a user-provided ID, which must be a valid DNS-1123 label)*
+*(Note: Actors are identified by a user-provided name, which must be a valid DNS-1123 label)*
 
 ```bash
 # Create a new actor deriving from a specific ActorTemplate.
@@ -159,7 +166,7 @@ kubectl ate delete actor my-actor -a <atespace>
 
 ### Logs
 
-`kubectl ate logs` requires a resource-type subcommand; running `kubectl ate logs <id>` on its own prints help. The only supported resource type is `actors`:
+`kubectl ate logs` requires a resource-type subcommand; running `kubectl ate logs <actor-name>` on its own prints help. The only supported resource type is `actors`:
 
 ```bash
 # Stream logs for an actor (follows by default; aggregated across worker

--- a/cmd/kubectl-ate/internal/cmd/create_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/create_actor.go
@@ -28,7 +28,7 @@ var templateFlag string
 var atespaceFlag string
 
 var createActorCmd = &cobra.Command{
-	Use:   "actor [actor-id]",
+	Use:   "actor <actor-name>",
 	Short: "Create an actor",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -39,7 +39,7 @@ var createActorCmd = &cobra.Command{
 		}
 		defer apiClient.Close()
 
-		actorID := args[0]
+		actorName := args[0]
 		parts := strings.Split(templateFlag, "/")
 		if len(parts) != 2 {
 			return fmt.Errorf("malformed --template: %s (expected <namespace>/<name>)", templateFlag)
@@ -49,7 +49,7 @@ var createActorCmd = &cobra.Command{
 			Actor: &ateapipb.Actor{
 				Metadata: &ateapipb.ResourceMetadata{
 					Atespace: atespaceFlag,
-					Name:     actorID,
+					Name:     actorName,
 				},
 				ActorTemplateNamespace: parts[0],
 				ActorTemplateName:      parts[1],

--- a/cmd/kubectl-ate/internal/cmd/delete_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/delete_actor.go
@@ -25,7 +25,7 @@ import (
 var deleteAtespaceFlag string
 
 var deleteActorCmd = &cobra.Command{
-	Use:   "actor [actor-id]",
+	Use:   "actor <actor-name>",
 	Short: "Delete an actor",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -36,15 +36,15 @@ var deleteActorCmd = &cobra.Command{
 		}
 		defer c.Close()
 
-		id := args[0]
+		name := args[0]
 		_, err = c.ControlClient.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
-			Actor: &ateapipb.ObjectRef{Atespace: deleteAtespaceFlag, Name: id},
+			Actor: &ateapipb.ObjectRef{Atespace: deleteAtespaceFlag, Name: name},
 		})
 		if err != nil {
 			return err
 		}
 
-		fmt.Printf("actor %q deleted\n", id)
+		fmt.Printf("actor %q deleted\n", name)
 		return nil
 	},
 }

--- a/cmd/kubectl-ate/internal/cmd/get_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/get_actors.go
@@ -29,7 +29,7 @@ var (
 )
 
 var getActorsCmd = &cobra.Command{
-	Use:     "actors [actor-id]",
+	Use:     "actors <actor-name>",
 	Aliases: []string{"actor"},
 	Short:   "List all actors or get a specific actor",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -44,7 +44,7 @@ var getActorsCmd = &cobra.Command{
 
 		// 2. Handle Get Single Actor
 		if len(args) > 0 {
-			// A single actor is addressed by (atespace, id), so the atespace is
+			// A single actor is addressed by (atespace, name), so the atespace is
 			// mandatory and "all atespaces" is meaningless here.
 			if getActorsAllAtespaces {
 				return fmt.Errorf("-A/--all-atespaces cannot be used when getting a specific actor; pass --atespace")

--- a/cmd/kubectl-ate/internal/cmd/logs_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors.go
@@ -42,7 +42,7 @@ var followLogs bool
 var logsAtespaceFlag string
 
 var logsActorsCmd = &cobra.Command{
-	Use:     "actors <actor-id>",
+	Use:     "actors <actor-name>",
 	Aliases: []string{"actor"},
 	Short:   "Stream logs for a specific actor",
 	Args:    cobra.ExactArgs(1),
@@ -90,7 +90,7 @@ type LogsActorRunner struct {
 }
 
 // Run executes the logs command.
-func (r *LogsActorRunner) Run(ctx context.Context, actorID string) error {
+func (r *LogsActorRunner) Run(ctx context.Context, actorName string) error {
 	if r.pollInterval <= 0 {
 		r.pollInterval = 2 * time.Second
 	}
@@ -103,13 +103,13 @@ func (r *LogsActorRunner) Run(ctx context.Context, actorID string) error {
 
 	defer r.apiClient.Close()
 	if r.follow {
-		return r.runFollow(ctx, actorID)
+		return r.runFollow(ctx, actorName)
 	}
-	return r.runOneShot(ctx, actorID)
+	return r.runOneShot(ctx, actorName)
 }
 
-func (r *LogsActorRunner) runOneShot(ctx context.Context, actorID string) error {
-	actor, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
+func (r *LogsActorRunner) runOneShot(ctx context.Context, actorName string) error {
+	actor, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorName}})
 	if err != nil {
 		return fmt.Errorf("failed to get actor: %w", err)
 	}
@@ -118,7 +118,7 @@ func (r *LogsActorRunner) runOneShot(ctx context.Context, actorID string) error 
 	namespace := actor.GetAteomPodNamespace()
 
 	if podName == "" || namespace == "" || actor.GetStatus() != ateapipb.Actor_STATUS_RUNNING {
-		return fmt.Errorf("actor %s is not currently running on any worker pod", actorID)
+		return fmt.Errorf("actor %s is not currently running on any worker pod", actorName)
 	}
 
 	opts := &corev1.PodLogOptions{
@@ -136,7 +136,7 @@ func (r *LogsActorRunner) runOneShot(ctx context.Context, actorID string) error 
 	scanner.Buffer(buf, 1024*1024) // Support up to 1MB lines
 	for scanner.Scan() {
 		line := scanner.Text()
-		filterAndDisplayLogLine(line, actorID, r.stdout)
+		filterAndDisplayLogLine(line, actorName, r.stdout)
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("error reading log stream: %w", err)
@@ -144,7 +144,7 @@ func (r *LogsActorRunner) runOneShot(ctx context.Context, actorID string) error 
 	return nil
 }
 
-func (r *LogsActorRunner) runFollow(ctx context.Context, actorID string) error {
+func (r *LogsActorRunner) runFollow(ctx context.Context, actorName string) error {
 	var lastWorkerPod string
 	var lastSeenTime time.Time
 
@@ -155,10 +155,10 @@ func (r *LogsActorRunner) runFollow(ctx context.Context, actorID string) error {
 		default:
 		}
 
-		actor, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
+		actor, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorName}})
 		if err != nil {
 			if status.Code(err) == codes.NotFound {
-				return fmt.Errorf("actor %s not found: %w", actorID, err)
+				return fmt.Errorf("actor %s not found: %w", actorName, err)
 			}
 			select {
 			case <-ctx.Done():
@@ -206,14 +206,14 @@ func (r *LogsActorRunner) runFollow(ctx context.Context, actorID string) error {
 		}
 
 		var wg sync.WaitGroup
-		r.startMigrationMonitor(streamCtx, streamCancel, &wg, actorID, podName)
+		r.startMigrationMonitor(streamCtx, streamCancel, &wg, actorName, podName)
 
 		scanner := bufio.NewScanner(stream)
 		buf := make([]byte, 0, 64*1024)
 		scanner.Buffer(buf, 1024*1024) // Support up to 1MB lines
 		for scanner.Scan() {
 			line := scanner.Text()
-			logTime, _ := filterAndDisplayLogLine(line, actorID, r.stdout)
+			logTime, _ := filterAndDisplayLogLine(line, actorName, r.stdout)
 			if !logTime.IsZero() {
 				lastSeenTime = logTime
 			}
@@ -249,7 +249,7 @@ func (r *LogsActorRunner) startMigrationMonitor(
 	ctx context.Context,
 	cancel context.CancelFunc,
 	wg *sync.WaitGroup,
-	actorID string,
+	actorName string,
 	currentPod string,
 ) {
 	wg.Add(1)
@@ -262,7 +262,7 @@ func (r *LogsActorRunner) startMigrationMonitor(
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				resp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorID}})
+				resp, err := r.apiClient.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: r.atespace, Name: actorName}})
 				if err == nil {
 					act := resp
 					if act.GetStatus() != ateapipb.Actor_STATUS_RUNNING || act.GetAteomPodName() != currentPod {
@@ -278,7 +278,7 @@ func (r *LogsActorRunner) startMigrationMonitor(
 
 func runLogsActor(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	actorID := args[0]
+	actorName := args[0]
 
 	apiClient, err := ateclient.NewClient(ctx, kubeconfig, k8sContext, endpoint, traceEnabled)
 	if err != nil {
@@ -303,10 +303,10 @@ func runLogsActor(cmd *cobra.Command, args []string) error {
 		tickerInterval:    2 * time.Second,
 	}
 
-	return runner.Run(ctx, actorID)
+	return runner.Run(ctx, actorName)
 }
 
-func filterAndDisplayLogLine(line, targetActorID string, w io.Writer) (time.Time, bool) {
+func filterAndDisplayLogLine(line, targetActorName string, w io.Writer) (time.Time, bool) {
 	var m map[string]any
 	dec := json.NewDecoder(strings.NewReader(line))
 	dec.UseNumber()
@@ -323,19 +323,19 @@ func filterAndDisplayLogLine(line, targetActorID string, w io.Writer) (time.Time
 		}
 	}
 
-	var actorID string
+	var actorName string
 	for _, labelKey := range []string{"logging.googleapis.com/labels", "labels"} {
 		if labelsAny, ok := m[labelKey]; ok {
 			if labels, ok := labelsAny.(map[string]any); ok {
-				if id, ok := labels["ate.dev/actor_id"].(string); ok && id != "" {
-					actorID = id
+				if name, ok := labels["ate.dev/actor_name"].(string); ok && name != "" {
+					actorName = name
 					break
 				}
 			}
 		}
 	}
 
-	matched := (actorID != "" && actorID == targetActorID)
+	matched := (actorName != "" && actorName == targetActorName)
 
 	if !matched {
 		return logTime, false

--- a/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
@@ -33,99 +33,99 @@ import (
 
 func TestFilterAndDisplayLogLine(t *testing.T) {
 	tests := []struct {
-		name          string
-		line          string
-		targetActorID string
-		wantMatched   bool
-		wantTime      string
-		wantOutput    string
+		name            string
+		line            string
+		targetActorName string
+		wantMatched     bool
+		wantTime        string
+		wantOutput      string
 	}{
 		{
-			name:          "matching actor, JSON log with RFC3339Nano",
-			line:          `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"}}`,
-			targetActorID: "act-1",
-			wantMatched:   true,
-			wantTime:      "2026-05-16T01:03:38.602878302Z",
-			wantOutput:    `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count"}`,
+			name:            "matching actor, JSON log with RFC3339Nano",
+			line:            `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-1"}}`,
+			targetActorName: "act-1",
+			wantMatched:     true,
+			wantTime:        "2026-05-16T01:03:38.602878302Z",
+			wantOutput:      `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count"}`,
 		},
 		{
-			name:          "matching actor, plain text log",
-			line:          `{"time":"2026-05-16T01:03:38Z","message":"Hello","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"}}`,
-			targetActorID: "act-1",
-			wantMatched:   true,
-			wantTime:      "2026-05-16T01:03:38Z",
-			wantOutput:    `{"time":"2026-05-16T01:03:38Z","message":"Hello"}`,
+			name:            "matching actor, plain text log",
+			line:            `{"time":"2026-05-16T01:03:38Z","message":"Hello","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-1"}}`,
+			targetActorName: "act-1",
+			wantMatched:     true,
+			wantTime:        "2026-05-16T01:03:38Z",
+			wantOutput:      `{"time":"2026-05-16T01:03:38Z","message":"Hello"}`,
 		},
 		{
-			name:          "matching actor, JSON log with no timestamp fallback",
-			line:          `{"level":"error","msg":"Failed","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"}}`,
-			targetActorID: "act-1",
-			wantMatched:   true,
-			wantTime:      "",
-			wantOutput:    `{"level":"error","msg":"Failed"}`,
+			name:            "matching actor, JSON log with no timestamp fallback",
+			line:            `{"level":"error","msg":"Failed","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-1"}}`,
+			targetActorName: "act-1",
+			wantMatched:     true,
+			wantTime:        "",
+			wantOutput:      `{"level":"error","msg":"Failed"}`,
 		},
 		{
-			name:          "matching actor, fallback to standard labels key",
-			line:          `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count","labels":{"ate.dev/actor_id":"act-1"}}`,
-			targetActorID: "act-1",
-			wantMatched:   true,
-			wantTime:      "2026-05-16T01:03:38.602878302Z",
-			wantOutput:    `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count"}`,
+			name:            "matching actor, fallback to standard labels key",
+			line:            `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count","labels":{"ate.dev/actor_name":"act-1"}}`,
+			targetActorName: "act-1",
+			wantMatched:     true,
+			wantTime:        "2026-05-16T01:03:38.602878302Z",
+			wantOutput:      `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count"}`,
 		},
 		{
-			name:          "non-matching actor",
-			line:          `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-2"}}`,
-			targetActorID: "act-1",
-			wantMatched:   false,
-			wantTime:      "2026-05-16T01:03:38Z",
-			wantOutput:    "",
+			name:            "non-matching actor",
+			line:            `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-2"}}`,
+			targetActorName: "act-1",
+			wantMatched:     false,
+			wantTime:        "2026-05-16T01:03:38Z",
+			wantOutput:      "",
 		},
 		{
-			name:          "invalid json line",
-			line:          "not a json line",
-			targetActorID: "act-1",
-			wantMatched:   false,
-			wantTime:      "",
-			wantOutput:    "",
+			name:            "invalid json line",
+			line:            "not a json line",
+			targetActorName: "act-1",
+			wantMatched:     false,
+			wantTime:        "",
+			wantOutput:      "",
 		},
 		{
-			name:          "matching actor, flat JSON log",
-			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello","traceID":"abc-123","err":"timeout","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"}}`,
-			targetActorID: "act-1",
-			wantMatched:   true,
-			wantTime:      "2026-05-16T01:03:38Z",
-			wantOutput:    `{"time":"2026-05-16T01:03:38Z","err":"timeout","level":"info","msg":"Hello","traceID":"abc-123"}`,
+			name:            "matching actor, flat JSON log",
+			line:            `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello","traceID":"abc-123","err":"timeout","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-1"}}`,
+			targetActorName: "act-1",
+			wantMatched:     true,
+			wantTime:        "2026-05-16T01:03:38Z",
+			wantOutput:      `{"time":"2026-05-16T01:03:38Z","err":"timeout","level":"info","msg":"Hello","traceID":"abc-123"}`,
 		},
 		{
-			name:          "matching actor, severity and message keys",
-			line:          `{"time":"2026-05-16T01:03:38Z","severity":"error","message":"Disk full","custom_tag":"alert","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"}}`,
-			targetActorID: "act-1",
-			wantMatched:   true,
-			wantTime:      "2026-05-16T01:03:38Z",
-			wantOutput:    `{"time":"2026-05-16T01:03:38Z","custom_tag":"alert","message":"Disk full","severity":"error"}`,
+			name:            "matching actor, severity and message keys",
+			line:            `{"time":"2026-05-16T01:03:38Z","severity":"error","message":"Disk full","custom_tag":"alert","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-1"}}`,
+			targetActorName: "act-1",
+			wantMatched:     true,
+			wantTime:        "2026-05-16T01:03:38Z",
+			wantOutput:      `{"time":"2026-05-16T01:03:38Z","custom_tag":"alert","message":"Disk full","severity":"error"}`,
 		},
 		{
-			name:          "matching actor, 2-field structured log without time",
-			line:          `{"message":"login failed","code":401,"logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1"}}`,
-			targetActorID: "act-1",
-			wantMatched:   true,
-			wantTime:      "",
-			wantOutput:    `{"code":401,"message":"login failed"}`,
+			name:            "matching actor, 2-field structured log without time",
+			line:            `{"message":"login failed","code":401,"logging.googleapis.com/labels":{"ate.dev/actor_name":"act-1"}}`,
+			targetActorName: "act-1",
+			wantMatched:     true,
+			wantTime:        "",
+			wantOutput:      `{"code":401,"message":"login failed"}`,
 		},
 		{
-			name:          "matching actor, JSON log with custom application labels",
-			line:          `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-1","app":"my-app"}}`,
-			targetActorID: "act-1",
-			wantMatched:   true,
-			wantTime:      "2026-05-16T01:03:38Z",
-			wantOutput:    `{"time":"2026-05-16T01:03:38Z","level":"info","logging.googleapis.com/labels":{"app":"my-app"},"msg":"Hello"}`,
+			name:            "matching actor, JSON log with custom application labels",
+			line:            `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-1","app":"my-app"}}`,
+			targetActorName: "act-1",
+			wantMatched:     true,
+			wantTime:        "2026-05-16T01:03:38Z",
+			wantOutput:      `{"time":"2026-05-16T01:03:38Z","level":"info","logging.googleapis.com/labels":{"app":"my-app"},"msg":"Hello"}`,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			logTime, matched := filterAndDisplayLogLine(tc.line, tc.targetActorID, &buf)
+			logTime, matched := filterAndDisplayLogLine(tc.line, tc.targetActorName, &buf)
 
 			if matched != tc.wantMatched {
 				t.Errorf("got matched = %v, want %v", matched, tc.wantMatched)
@@ -181,17 +181,17 @@ func (m *mockPodLogsStreamer) StreamLogs(ctx context.Context, namespace, podName
 }
 
 func TestLogsActorRunner_Run_OneShotSuccess(t *testing.T) {
-	actorID := "act-123"
+	actorName := "act-123"
 	podName := "pod-xyz"
 	namespace := "ns-abc"
 
 	mockAPI := &mockAteAPIClient{
 		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
-			if in.GetActor().GetName() != actorID {
-				return nil, fmt.Errorf("unexpected actor ID: %s", in.GetActor().GetName())
+			if in.GetActor().GetName() != actorName {
+				return nil, fmt.Errorf("unexpected actor name: %s", in.GetActor().GetName())
 			}
 			return &ateapipb.Actor{
-				Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+				Metadata:          &ateapipb.ResourceMetadata{Name: actorName},
 				AteomPodName:      podName,
 				AteomPodNamespace: namespace,
 				Status:            ateapipb.Actor_STATUS_RUNNING,
@@ -199,7 +199,7 @@ func TestLogsActorRunner_Run_OneShotSuccess(t *testing.T) {
 		},
 	}
 
-	logLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123"}}`
+	logLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-123"}}`
 	mockStreamer := &mockPodLogsStreamer{
 		StreamLogsFunc: func(ctx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
 			if ns != namespace || name != podName {
@@ -221,7 +221,7 @@ func TestLogsActorRunner_Run_OneShotSuccess(t *testing.T) {
 		follow:    false,
 	}
 
-	err := runner.Run(context.Background(), actorID)
+	err := runner.Run(context.Background(), actorName)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -238,12 +238,12 @@ func TestLogsActorRunner_Run_OneShotSuccess(t *testing.T) {
 }
 
 func TestLogsActorRunner_Run_OneShot_ActorNotRunning(t *testing.T) {
-	actorID := "act-123"
+	actorName := "act-123"
 
 	mockAPI := &mockAteAPIClient{
 		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
 			return &ateapipb.Actor{
-				Metadata: &ateapipb.ResourceMetadata{Name: actorID},
+				Metadata: &ateapipb.ResourceMetadata{Name: actorName},
 				Status:   ateapipb.Actor_STATUS_SUSPENDED, // not running
 			}, nil
 		},
@@ -264,7 +264,7 @@ func TestLogsActorRunner_Run_OneShot_ActorNotRunning(t *testing.T) {
 		follow:    false,
 	}
 
-	err := runner.Run(context.Background(), actorID)
+	err := runner.Run(context.Background(), actorName)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -280,7 +280,7 @@ func TestLogsActorRunner_Run_OneShot_ActorNotRunning(t *testing.T) {
 }
 
 func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
-	actorID := "act-123"
+	actorName := "act-123"
 	podName := "pod-xyz"
 	namespace := "ns-abc"
 
@@ -296,14 +296,14 @@ func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
 			if getActorCalls == 1 {
 				// First call: suspended
 				return &ateapipb.Actor{
-					Metadata: &ateapipb.ResourceMetadata{Name: actorID},
+					Metadata: &ateapipb.ResourceMetadata{Name: actorName},
 					Status:   ateapipb.Actor_STATUS_SUSPENDED,
 				}, nil
 			}
 
 			// Subsequent calls: running
 			return &ateapipb.Actor{
-				Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+				Metadata:          &ateapipb.ResourceMetadata{Name: actorName},
 				AteomPodName:      podName,
 				AteomPodNamespace: namespace,
 				Status:            ateapipb.Actor_STATUS_RUNNING,
@@ -311,7 +311,7 @@ func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
 		},
 	}
 
-	logLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Follow hello","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-123"}}`
+	logLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Follow hello","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-123"}}`
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -351,7 +351,7 @@ func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
 		tickerInterval:    1 * time.Millisecond,
 	}
 
-	err := runner.Run(ctx, actorID)
+	err := runner.Run(ctx, actorName)
 	if err != nil && err != context.Canceled {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -374,7 +374,7 @@ func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
 }
 
 func TestLogsActorRunner_Run_Follow_NotFoundActor(t *testing.T) {
-	actorID := "act-notfound"
+	actorName := "act-notfound"
 
 	mockAPI := &mockAteAPIClient{
 		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
@@ -400,7 +400,7 @@ func TestLogsActorRunner_Run_Follow_NotFoundActor(t *testing.T) {
 		tickerInterval:    1 * time.Millisecond,
 	}
 
-	err := runner.Run(context.Background(), actorID)
+	err := runner.Run(context.Background(), actorName)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -412,7 +412,7 @@ func TestLogsActorRunner_Run_Follow_NotFoundActor(t *testing.T) {
 }
 
 func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
-	actorID := "act-migrate"
+	actorName := "act-migrate"
 
 	var getActorCalls int
 	var getActorMu sync.Mutex
@@ -428,7 +428,7 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 			if getActorCalls == 1 {
 				// 1. Initial call for stream 1: pod-1
 				return &ateapipb.Actor{
-					Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+					Metadata:          &ateapipb.ResourceMetadata{Name: actorName},
 					AteomPodName:      "pod-1",
 					AteomPodNamespace: "ns",
 					Status:            ateapipb.Actor_STATUS_RUNNING,
@@ -444,7 +444,7 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 			}
 
 			return &ateapipb.Actor{
-				Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+				Metadata:          &ateapipb.ResourceMetadata{Name: actorName},
 				AteomPodName:      "pod-2",
 				AteomPodNamespace: "ns",
 				Status:            ateapipb.Actor_STATUS_RUNNING,
@@ -473,7 +473,7 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 				pr, pw := io.Pipe()
 				go func() {
 					// write one line and then keep it open
-					fmt.Fprintln(pw, `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"line 1 from pod-1","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-migrate"}}`)
+					fmt.Fprintln(pw, `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"line 1 from pod-1","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-migrate"}}`)
 					close(lineRead) // guaranteed to have been read because io.Pipe is unbuffered!
 					// wait until context is cancelled
 					<-streamCtx.Done()
@@ -490,7 +490,7 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 			// Now we can cancel the main context to exit the follow loop
 			cancel()
 
-			return io.NopCloser(strings.NewReader(`{"time":"2026-05-16T01:03:39Z","level":"info","msg":"line 1 from pod-2","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-migrate"}}` + "\n")), nil
+			return io.NopCloser(strings.NewReader(`{"time":"2026-05-16T01:03:39Z","level":"info","msg":"line 1 from pod-2","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-migrate"}}` + "\n")), nil
 		},
 	}
 
@@ -506,7 +506,7 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 		tickerInterval:    1 * time.Millisecond,
 	}
 
-	err := runner.Run(ctx, actorID)
+	err := runner.Run(ctx, actorName)
 	if err != nil && err != context.Canceled {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -521,7 +521,7 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 }
 
 func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
-	actorID := "act-suspended-mid"
+	actorName := "act-suspended-mid"
 
 	var getActorCalls int
 	var getActorMu sync.Mutex
@@ -537,7 +537,7 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 			// 1. Initial call: running on pod-1
 			if getActorCalls == 1 {
 				return &ateapipb.Actor{
-					Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+					Metadata:          &ateapipb.ResourceMetadata{Name: actorName},
 					AteomPodName:      "pod-1",
 					AteomPodNamespace: "ns",
 					Status:            ateapipb.Actor_STATUS_RUNNING,
@@ -553,7 +553,7 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 					return nil, ctx.Err()
 				}
 				return &ateapipb.Actor{
-					Metadata: &ateapipb.ResourceMetadata{Name: actorID},
+					Metadata: &ateapipb.ResourceMetadata{Name: actorName},
 					Status:   ateapipb.Actor_STATUS_SUSPENDED,
 				}, nil
 			}
@@ -561,14 +561,14 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 			// 3. Loop reconnection call: suspended (still suspended, so it will wait)
 			if getActorCalls == 3 {
 				return &ateapipb.Actor{
-					Metadata: &ateapipb.ResourceMetadata{Name: actorID},
+					Metadata: &ateapipb.ResourceMetadata{Name: actorName},
 					Status:   ateapipb.Actor_STATUS_SUSPENDED,
 				}, nil
 			}
 
 			// 4. Subsequent loop reconnection call: running again on pod-1
 			return &ateapipb.Actor{
-				Metadata:          &ateapipb.ResourceMetadata{Name: actorID},
+				Metadata:          &ateapipb.ResourceMetadata{Name: actorName},
 				AteomPodName:      "pod-1",
 				AteomPodNamespace: "ns",
 				Status:            ateapipb.Actor_STATUS_RUNNING,
@@ -591,7 +591,7 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 			if streamCalls == 1 {
 				pr, pw := io.Pipe()
 				go func() {
-					fmt.Fprintln(pw, `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"before suspend","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-suspended-mid"}}`)
+					fmt.Fprintln(pw, `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"before suspend","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-suspended-mid"}}`)
 					close(lineRead) // guaranteed to have been read!
 					<-streamCtx.Done()
 					pw.Close()
@@ -602,7 +602,7 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 			// Second stream (after resuming): cancel context to stop test
 			cancel()
 
-			return io.NopCloser(strings.NewReader(`{"time":"2026-05-16T01:03:40Z","level":"info","msg":"after resume","logging.googleapis.com/labels":{"ate.dev/actor_id":"act-suspended-mid"}}` + "\n")), nil
+			return io.NopCloser(strings.NewReader(`{"time":"2026-05-16T01:03:40Z","level":"info","msg":"after resume","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-suspended-mid"}}` + "\n")), nil
 		},
 	}
 
@@ -618,7 +618,7 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 		tickerInterval:    1 * time.Millisecond,
 	}
 
-	err := runner.Run(ctx, actorID)
+	err := runner.Run(ctx, actorName)
 	if err != nil && err != context.Canceled {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/kubectl-ate/internal/cmd/pause_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/pause_actor.go
@@ -26,7 +26,7 @@ import (
 var pauseAtespaceFlag string
 
 var pauseActorCmd = &cobra.Command{
-	Use:   "actor [actor-id]",
+	Use:   "actor <actor-name>",
 	Short: "Pause an actor",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kubectl-ate/internal/cmd/resume_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/resume_actor.go
@@ -27,7 +27,7 @@ var bootFlag bool
 var resumeAtespaceFlag string
 
 var resumeActorCmd = &cobra.Command{
-	Use:   "actor [actor-id]",
+	Use:   "actor <actor-name>",
 	Short: "Resume an actor",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kubectl-ate/internal/cmd/suspend_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/suspend_actor.go
@@ -26,7 +26,7 @@ import (
 var suspendAtespaceFlag string
 
 var suspendActorCmd = &cobra.Command{
-	Use:   "actor [actor-id]",
+	Use:   "actor <actor-name>",
 	Short: "Suspend an actor",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kubectl-ate/internal/printer/printer.go
+++ b/cmd/kubectl-ate/internal/printer/printer.go
@@ -22,12 +22,25 @@ import (
 	"os"
 	"slices"
 	"text/tabwriter"
+	"time"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"k8s.io/apimachinery/pkg/util/duration"
 	"sigs.k8s.io/yaml"
 )
+
+// timeNow returns the current time. It is a package variable so tests can pin
+// it and make age rendering deterministic.
+var timeNow = time.Now
+
+// formatAge renders a resource's age from its creation timestamp, kubectl-style
+// (e.g. "5m", "3h", "2d").
+func formatAge(ts *timestamppb.Timestamp) string {
+	return duration.HumanDuration(timeNow().Sub(ts.AsTime()))
+}
 
 // PrintActors prints a slice of actors to stdout in the requested format.
 func PrintActors(actors []*ateapipb.Actor, format string) error {
@@ -57,12 +70,11 @@ func PrintActorsTo(out io.Writer, actors []*ateapipb.Actor, format string) error
 		return printProto(out, &ateapipb.ListActorsResponse{Actors: actors}, format)
 	case "table":
 		w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
-		fmt.Fprintln(w, "ATESPACE\tTEMPLATE NS\tTEMPLATE\tID\tSTATUS\tATEOM POD\tATEOM IP\tVERSION")
+		fmt.Fprintln(w, "ATESPACE\tNAME\tTEMPLATE\tSTATUS\tATEOM POD\tATEOM IP\tVERSION\tAGE")
 		for _, actor := range actors {
 			atespace := actor.GetMetadata().GetAtespace()
-			ns := actor.GetActorTemplateNamespace()
-			tmpl := actor.GetActorTemplateName()
-			id := actor.GetMetadata().GetName()
+			name := actor.GetMetadata().GetName()
+			template := actor.GetActorTemplateNamespace() + "/" + actor.GetActorTemplateName()
 			status := actor.GetStatus().String()
 
 			worker := "<none>"
@@ -71,7 +83,8 @@ func PrintActorsTo(out io.Writer, actors []*ateapipb.Actor, format string) error
 			}
 
 			version := actor.GetMetadata().GetVersion()
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\n", atespace, ns, tmpl, id, status, worker, actor.GetAteomPodIp(), version)
+			age := formatAge(actor.GetMetadata().GetCreateTime())
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n", atespace, name, template, status, worker, actor.GetAteomPodIp(), version, age)
 		}
 		return w.Flush()
 	default:
@@ -150,9 +163,9 @@ func PrintAtespacesTo(out io.Writer, atespaces []*ateapipb.Atespace, format stri
 		return printProto(out, &ateapipb.ListAtespacesResponse{Atespaces: atespaces}, format)
 	case "table":
 		w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
-		fmt.Fprintln(w, "NAME")
+		fmt.Fprintln(w, "NAME\tAGE")
 		for _, a := range atespaces {
-			fmt.Fprintf(w, "%s\n", a.GetMetadata().GetName())
+			fmt.Fprintf(w, "%s\t%s\n", a.GetMetadata().GetName(), formatAge(a.GetMetadata().GetCreateTime()))
 		}
 		return w.Flush()
 	default:

--- a/cmd/kubectl-ate/internal/printer/printer_test.go
+++ b/cmd/kubectl-ate/internal/printer/printer_test.go
@@ -17,16 +17,55 @@ package printer
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// pinNow overrides the printer's clock for the duration of a test so that
+// age rendering is deterministic, restoring it on cleanup.
+func pinNow(t *testing.T, now time.Time) {
+	t.Helper()
+	prev := timeNow
+	timeNow = func() time.Time { return now }
+	t.Cleanup(func() { timeNow = prev })
+}
+
+func TestFormatAge(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
+	cases := []struct {
+		ago  time.Duration
+		want string
+	}{
+		{5 * time.Minute, "5m"},
+		{5 * time.Hour, "5h"},
+		{72 * time.Hour, "3d"},
+	}
+	for _, c := range cases {
+		ts := timestamppb.New(now.Add(-c.ago))
+		if got := formatAge(ts); got != c.want {
+			t.Errorf("formatAge(%s ago) = %q, want %q", c.ago, got, c.want)
+		}
+	}
+}
+
 func TestPrintActorsTo_Table(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
 	var buf bytes.Buffer
 	actors := []*ateapipb.Actor{
 		{
-			Metadata:               &ateapipb.ResourceMetadata{Name: "id-1", Atespace: "team-a", Version: 2},
+			Metadata: &ateapipb.ResourceMetadata{
+				Name:       "id-1",
+				Atespace:   "team-a",
+				Version:    2,
+				CreateTime: timestamppb.New(now.Add(-5 * time.Minute)),
+			},
 			ActorTemplateNamespace: "default",
 			ActorTemplateName:      "template-1",
 			Status:                 ateapipb.Actor_STATUS_RUNNING,
@@ -41,8 +80,8 @@ func TestPrintActorsTo_Table(t *testing.T) {
 	}
 	output := buf.String()
 
-	expected := `ATESPACE   TEMPLATE NS   TEMPLATE     ID     STATUS           ATEOM POD         ATEOM IP   VERSION
-team-a     default       template-1   id-1   STATUS_RUNNING   worker-ns/pod-1   1.2.3.4    2
+	expected := `ATESPACE   NAME   TEMPLATE             STATUS           ATEOM POD         ATEOM IP   VERSION   AGE
+team-a     id-1   default/template-1   STATUS_RUNNING   worker-ns/pod-1   1.2.3.4    2         5m
 `
 	if diff := cmp.Diff(expected, output); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -102,22 +141,37 @@ func TestPrintActorsTo_YAML(t *testing.T) {
 }
 
 func TestPrintActorsTo_Table_Sorted(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
 	var buf bytes.Buffer
 	actors := []*ateapipb.Actor{
 		{
-			Metadata:               &ateapipb.ResourceMetadata{Name: "zebra", Atespace: "team-b"},
+			Metadata: &ateapipb.ResourceMetadata{
+				Name:       "zebra",
+				Atespace:   "team-b",
+				CreateTime: timestamppb.New(now.Add(-72 * time.Hour)),
+			},
 			ActorTemplateNamespace: "default",
 			ActorTemplateName:      "template-1",
 			Status:                 ateapipb.Actor_STATUS_SUSPENDED,
 		},
 		{
-			Metadata:               &ateapipb.ResourceMetadata{Name: "alpha", Atespace: "team-a"},
+			Metadata: &ateapipb.ResourceMetadata{
+				Name:       "alpha",
+				Atespace:   "team-a",
+				CreateTime: timestamppb.New(now.Add(-5 * time.Minute)),
+			},
 			ActorTemplateNamespace: "default",
 			ActorTemplateName:      "template-1",
 			Status:                 ateapipb.Actor_STATUS_RUNNING,
 		},
 		{
-			Metadata:               &ateapipb.ResourceMetadata{Name: "beta", Atespace: "team-a"},
+			Metadata: &ateapipb.ResourceMetadata{
+				Name:       "beta",
+				Atespace:   "team-a",
+				CreateTime: timestamppb.New(now.Add(-5 * time.Hour)),
+			},
 			ActorTemplateNamespace: "other",
 			ActorTemplateName:      "template-2",
 			Status:                 ateapipb.Actor_STATUS_SUSPENDED,
@@ -128,11 +182,11 @@ func TestPrintActorsTo_Table_Sorted(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Sorted by atespace first, then template namespace, template name, id.
-	expected := `ATESPACE   TEMPLATE NS   TEMPLATE     ID      STATUS             ATEOM POD   ATEOM IP   VERSION
-team-a     default       template-1   alpha   STATUS_RUNNING     <none>                 0
-team-a     other         template-2   beta    STATUS_SUSPENDED   <none>                 0
-team-b     default       template-1   zebra   STATUS_SUSPENDED   <none>                 0
+	// Sorted by atespace first, then template namespace, template name, name.
+	expected := `ATESPACE   NAME    TEMPLATE             STATUS             ATEOM POD   ATEOM IP   VERSION   AGE
+team-a     alpha   default/template-1   STATUS_RUNNING     <none>                 0         5m
+team-a     beta    other/template-2     STATUS_SUSPENDED   <none>                 0         5h
+team-b     zebra   default/template-1   STATUS_SUSPENDED   <none>                 0         3d
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -245,17 +299,23 @@ func TestPrintWorkersTo_Invalid(t *testing.T) {
 }
 
 func TestPrintAtespacesTo_Table(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
 	var buf bytes.Buffer
 	atespaces := []*ateapipb.Atespace{
-		{Metadata: &ateapipb.ResourceMetadata{Name: "team-a"}},
+		{Metadata: &ateapipb.ResourceMetadata{
+			Name:       "team-a",
+			CreateTime: timestamppb.New(now.Add(-5 * time.Minute)),
+		}},
 	}
 
 	if err := PrintAtespacesTo(&buf, atespaces, "table"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := `NAME
-team-a
+	expected := `NAME     AGE
+team-a   5m
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -307,11 +367,14 @@ func TestPrintAtespacesTo_YAML(t *testing.T) {
 }
 
 func TestPrintAtespacesTo_Table_Sorted(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
 	var buf bytes.Buffer
 	atespaces := []*ateapipb.Atespace{
-		{Metadata: &ateapipb.ResourceMetadata{Name: "team-c"}},
-		{Metadata: &ateapipb.ResourceMetadata{Name: "team-a"}},
-		{Metadata: &ateapipb.ResourceMetadata{Name: "team-b"}},
+		{Metadata: &ateapipb.ResourceMetadata{Name: "team-c", CreateTime: timestamppb.New(now.Add(-72 * time.Hour))}},
+		{Metadata: &ateapipb.ResourceMetadata{Name: "team-a", CreateTime: timestamppb.New(now.Add(-5 * time.Minute))}},
+		{Metadata: &ateapipb.ResourceMetadata{Name: "team-b", CreateTime: timestamppb.New(now.Add(-5 * time.Hour))}},
 	}
 
 	if err := PrintAtespacesTo(&buf, atespaces, "table"); err != nil {
@@ -319,10 +382,10 @@ func TestPrintAtespacesTo_Table_Sorted(t *testing.T) {
 	}
 
 	// Sorted by name.
-	expected := `NAME
-team-a
-team-b
-team-c
+	expected := `NAME     AGE
+team-a   5m
+team-b   5h
+team-c   3d
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)

--- a/internal/actorlog/logger.go
+++ b/internal/actorlog/logger.go
@@ -66,13 +66,13 @@ func NewActorLogger(w io.Writer, isOnGCE bool) *ActorLogger {
 }
 
 // EmitLifecycleLog logs a synthetic actor lifecycle event.
-func (al *ActorLogger) EmitLifecycleLog(msg, atespace, actorID, actorTemplateNamespace, actorTemplateName string) {
+func (al *ActorLogger) EmitLifecycleLog(msg, atespace, actorName, actorTemplateNamespace, actorTemplateName string) {
 	envelope := map[string]any{
 		"time":    time.Now().Format(time.RFC3339Nano),
 		"message": msg,
 		al.labelsKey: map[string]string{
 			"ate.dev/actor_atespace":           atespace,
-			"ate.dev/actor_id":                 actorID,
+			"ate.dev/actor_name":               actorName,
 			"ate.dev/actor_template_namespace": actorTemplateNamespace,
 			"ate.dev/actor_template_name":      actorTemplateName,
 		},
@@ -87,13 +87,13 @@ func (al *ActorLogger) EmitLifecycleLog(msg, atespace, actorID, actorTemplateNam
 // through the logger. containerName tags every line with the originating container;
 // callers that multiplex multiple containers should give each its own pipe so the
 // tag is meaningful.
-func (al *ActorLogger) StartJSONLogPipe(atespace, actorID, actorTemplateNamespace, actorTemplateName, containerName string) (io.WriteCloser, error) {
+func (al *ActorLogger) StartJSONLogPipe(atespace, actorName, actorTemplateNamespace, actorTemplateName, containerName string) (io.WriteCloser, error) {
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
 	go func() {
-		al.WrapContainerLogs(pr, atespace, actorID, actorTemplateNamespace, actorTemplateName, containerName)
+		al.WrapContainerLogs(pr, atespace, actorName, actorTemplateNamespace, actorTemplateName, containerName)
 		pr.Close()
 	}()
 	return pw, nil
@@ -102,7 +102,7 @@ func (al *ActorLogger) StartJSONLogPipe(atespace, actorID, actorTemplateNamespac
 // WrapContainerLogs reads log lines from r, parses them, and logs them in a unified
 // structured format. containerName is added as the ate.dev/container_name label so
 // multi-container actors can be demultiplexed.
-func (al *ActorLogger) WrapContainerLogs(r io.Reader, atespace, actorID, actorTemplateNamespace, actorTemplateName, containerName string) {
+func (al *ActorLogger) WrapContainerLogs(r io.Reader, atespace, actorName, actorTemplateNamespace, actorTemplateName, containerName string) {
 	rdr := bufio.NewReader(r)
 	for {
 		lineBytes, err := rdr.ReadBytes('\n')
@@ -130,7 +130,7 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, atespace, actorID, actorTe
 			if unmarshalErr != nil {
 				labels := map[string]string{
 					"ate.dev/actor_atespace":           atespace,
-					"ate.dev/actor_id":                 actorID,
+					"ate.dev/actor_name":               actorName,
 					"ate.dev/actor_template_namespace": actorTemplateNamespace,
 					"ate.dev/actor_template_name":      actorTemplateName,
 					"ate.dev/container_name":           containerName,
@@ -150,7 +150,7 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, atespace, actorID, actorTe
 					m[al.labelsKey] = labels
 				}
 				labels["ate.dev/actor_atespace"] = atespace
-				labels["ate.dev/actor_id"] = actorID
+				labels["ate.dev/actor_name"] = actorName
 				labels["ate.dev/actor_template_namespace"] = actorTemplateNamespace
 				labels["ate.dev/actor_template_name"] = actorTemplateName
 				labels["ate.dev/container_name"] = containerName

--- a/internal/actorlog/logger_test.go
+++ b/internal/actorlog/logger_test.go
@@ -54,8 +54,8 @@ func TestWrapContainerLogs(t *testing.T) {
 		t.Fatal("labels group is not a map")
 	}
 
-	if labels["ate.dev/actor_id"] != "act-1" {
-		t.Errorf("got actor_id = %v, want 'act-1'", labels["ate.dev/actor_id"])
+	if labels["ate.dev/actor_name"] != "act-1" {
+		t.Errorf("got actor_name = %v, want 'act-1'", labels["ate.dev/actor_name"])
 	}
 	if labels["ate.dev/actor_atespace"] != "default" {
 		t.Errorf("got actor_atespace = %v, want 'default'", labels["ate.dev/actor_atespace"])
@@ -115,8 +115,8 @@ func TestWrapContainerLogs_JSONInput(t *testing.T) {
 		t.Fatal("labels group is not a map")
 	}
 
-	if labels["ate.dev/actor_id"] != "act-1" {
-		t.Errorf("got actor_id = %v, want 'act-1'", labels["ate.dev/actor_id"])
+	if labels["ate.dev/actor_name"] != "act-1" {
+		t.Errorf("got actor_name = %v, want 'act-1'", labels["ate.dev/actor_name"])
 	}
 	if labels["ate.dev/actor_template_namespace"] != "tmpl-ns" {
 		t.Errorf("got actor_template_namespace = %v, want 'tmpl-ns'", labels["ate.dev/actor_template_namespace"])
@@ -195,8 +195,8 @@ func TestWrapContainerLogs_MergeLabels(t *testing.T) {
 	if labels["version"] != "v1" {
 		t.Errorf("got version = %v, want 'v1'", labels["version"])
 	}
-	if labels["ate.dev/actor_id"] != "act-1" {
-		t.Errorf("got actor_id = %v, want 'act-1'", labels["ate.dev/actor_id"])
+	if labels["ate.dev/actor_name"] != "act-1" {
+		t.Errorf("got actor_name = %v, want 'act-1'", labels["ate.dev/actor_name"])
 	}
 	if labels["ate.dev/container_name"] != "ctr-1" {
 		t.Errorf("got container_name = %v, want 'ctr-1'", labels["ate.dev/container_name"])
@@ -204,7 +204,7 @@ func TestWrapContainerLogs_MergeLabels(t *testing.T) {
 }
 
 func TestWrapContainerLogs_LabelCollision(t *testing.T) {
-	input := `{"level":"info","msg":"App log","labels":{"ate.dev/actor_id":"malicious-id","app":"my-app"}}` + "\n"
+	input := `{"level":"info","msg":"App log","labels":{"ate.dev/actor_name":"malicious-id","app":"my-app"}}` + "\n"
 	rdr := strings.NewReader(input)
 
 	var buf bytes.Buffer
@@ -228,8 +228,8 @@ func TestWrapContainerLogs_LabelCollision(t *testing.T) {
 	if labels["app"] != "my-app" {
 		t.Errorf("got app = %v, want 'my-app'", labels["app"])
 	}
-	if labels["ate.dev/actor_id"] != "act-1" {
-		t.Errorf("got actor_id = %v, want 'act-1' (Substrate metadata should take precedence)", labels["ate.dev/actor_id"])
+	if labels["ate.dev/actor_name"] != "act-1" {
+		t.Errorf("got actor_name = %v, want 'act-1' (Substrate metadata should take precedence)", labels["ate.dev/actor_name"])
 	}
 }
 
@@ -259,7 +259,7 @@ func TestWrapContainerLogs_TrailingGarbage(t *testing.T) {
 		t.Fatal("labels group is not a map")
 	}
 
-	if labels["ate.dev/actor_id"] != "act-1" {
-		t.Errorf("got actor_id = %v, want 'act-1'", labels["ate.dev/actor_id"])
+	if labels["ate.dev/actor_name"] != "act-1" {
+		t.Errorf("got actor_name = %v, want 'act-1'", labels["ate.dev/actor_name"])
 	}
 }

--- a/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duration
+
+import (
+	"fmt"
+	"time"
+)
+
+// ShortHumanDuration returns a succinct representation of the provided duration
+// with limited precision for consumption by humans.
+func ShortHumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return "<invalid>"
+	} else if seconds < 0 {
+		return "0s"
+	} else if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	} else if minutes := int(d.Minutes()); minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	} else if hours := int(d.Hours()); hours < 24 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*365 {
+		return fmt.Sprintf("%dd", hours/24)
+	}
+	return fmt.Sprintf("%dy", int(d.Hours()/24/365))
+}
+
+// HumanDuration returns a succinct representation of the provided duration
+// with limited precision for consumption by humans. It provides ~2-3 significant
+// figures of duration.
+func HumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return "<invalid>"
+	} else if seconds < 0 {
+		return "0s"
+	} else if seconds < 60*2 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := int(d / time.Minute)
+	if minutes < 10 {
+		s := int(d/time.Second) % 60
+		if s == 0 {
+			return fmt.Sprintf("%dm", minutes)
+		}
+		return fmt.Sprintf("%dm%ds", minutes, s)
+	} else if minutes < 60*3 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	hours := int(d / time.Hour)
+	if hours < 8 {
+		m := int(d/time.Minute) % 60
+		if m == 0 {
+			return fmt.Sprintf("%dh", hours)
+		}
+		return fmt.Sprintf("%dh%dm", hours, m)
+	} else if hours < 48 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*8 {
+		h := hours % 24
+		if h == 0 {
+			return fmt.Sprintf("%dd", hours/24)
+		}
+		return fmt.Sprintf("%dd%dh", hours/24, h)
+	} else if hours < 24*365*2 {
+		return fmt.Sprintf("%dd", hours/24)
+	} else if hours < 24*365*8 {
+		dy := int(hours/24) % 365
+		if dy == 0 {
+			return fmt.Sprintf("%dy", hours/24/365)
+		}
+		return fmt.Sprintf("%dy%dd", hours/24/365, dy)
+	}
+	return fmt.Sprintf("%dy", int(hours/24/365))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1309,6 +1309,7 @@ k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/cache
 k8s.io/apimachinery/pkg/util/diff
+k8s.io/apimachinery/pkg/util/duration
 k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/pkg/util/httpstream


### PR DESCRIPTION
This is a follow up of the API refactor. Now the CLI shows some common fields (e.g. `create_timestamp`) but also shows actor *name* instead of *id*.

