### PR TITLE
fix(atenet): propagate trace context through router and namespace span/metric attrs

### DIFF
--- a/cmd/atenet/internal/router/extproc.go
+++ b/cmd/atenet/internal/router/extproc.go
@@ -147,6 +147,10 @@ func (s *ExtProcServer) handleRequestHeaders(
 		// Host is invalid, respond with 404.
 		return nil, metadata, "", "", "", invalidHostErr(metadata.host, err)
 	}
+	span.SetAttributes(
+		attribute.String("ate.atespace", atespace),
+		attribute.String("ate.actor_name", actorName),
+	)
 
 	slog.InfoContext(ctx, "ResumeActor", slog.String("atespace", atespace), slog.String("actor", actorName))
 	actor, err := s.resumer.ResumeActor(ctx, atespace, actorName)
@@ -176,9 +180,17 @@ func (s *ExtProcServer) handleRequestHeaders(
 
 	slog.InfoContext(ctx, "Route ok", slog.String("actor", actorName), slog.String("targetAddr", targetAddr))
 
-	// Route by rewriting the :authority header.
+	span.SetAttributes(
+		attribute.String("ate.target_addr", targetAddr),
+		attribute.String("ate.actor_template_namespace", tmplNs),
+		attribute.String("ate.actor_template_name", tmplName),
+	)
+
+	// Route by rewriting the :authority header and injecting trace context
+	// so the upstream worker receives the same trace as the ingress path.
 	mutation := &extprocv3.HeaderMutation{}
 	addAuthorityMutation(targetAddr, mutation)
+	injectTraceContext(ctx, mutation)
 
 	return &extprocv3.HeadersResponse{
 		Response: &extprocv3.CommonResponse{
@@ -192,9 +204,9 @@ func (s *ExtProcServer) recordRouteDuration(ctx context.Context, d time.Duration
 		return
 	}
 	s.routeDuration.Record(ctx, d.Seconds(), metric.WithAttributes(
-		attribute.String("actor_template_namespace", tmplNs),
-		attribute.String("actor_template_name", tmplName),
-		attribute.String("outcome", outcome),
+		attribute.String("ate.actor_template_namespace", tmplNs),
+		attribute.String("ate.actor_template_name", tmplName),
+		attribute.String("ate.outcome", outcome),
 	))
 }
 

--- a/cmd/atenet/internal/router/extproc_out.go
+++ b/cmd/atenet/internal/router/extproc_out.go
@@ -18,6 +18,8 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // reqError carries an HTTP-mappable status code and a client-safe message.
@@ -41,6 +43,22 @@ func addAuthorityMutation(auth string, mut *extproc.HeaderMutation) {
 			},
 		},
 	)
+}
+
+// injectTraceContext injects the trace context from ctx into the header mutation,
+// so that Envoy forwards traceparent/tracestate to the upstream worker and spans
+// are connected across the full request path.
+func injectTraceContext(ctx context.Context, mutation *extproc.HeaderMutation) {
+	headers := make(map[string]string)
+	otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(headers))
+	for k, v := range headers {
+		mutation.SetHeaders = append(mutation.SetHeaders, &corev3.HeaderValueOption{
+			Header: &corev3.HeaderValue{
+				Key:   k,
+				Value: v,
+			},
+		})
+	}
 }
 
 func immediateResponse(statusCode envoy_type.StatusCode, message string) *extproc.ProcessingResponse {

--- a/cmd/atenet/internal/router/extproc_test.go
+++ b/cmd/atenet/internal/router/extproc_test.go
@@ -230,17 +230,19 @@ func TestExtProcHeadersEvaluation(t *testing.T) {
 			}
 
 			mutation := res.Response.GetHeaderMutation()
-			if len(mutation.GetSetHeaders()) != 1 {
-				t.Fatalf("expected exactly one Header option set, found: %v", mutation.GetSetHeaders())
+			headers := mutation.GetSetHeaders()
+			var found bool
+			for _, h := range headers {
+				if strings.ToLower(h.Header.Key) == ":authority" {
+					found = true
+					if string(h.Header.RawValue) != tc.expectedTarget {
+						t.Errorf("invalid destination mapping found: %s, expected: %s", h.Header.RawValue, tc.expectedTarget)
+					}
+					break
+				}
 			}
-
-			headerOption := mutation.GetSetHeaders()[0]
-			if strings.ToLower(headerOption.Header.Key) != ":authority" {
-				t.Errorf("invalid resulting dynamic parameter key: %s", headerOption.Header.Key)
-			}
-
-			if string(headerOption.Header.RawValue) != tc.expectedTarget {
-				t.Errorf("invalid destination mapping found: %s, expected: %s", headerOption.Header.RawValue, tc.expectedTarget)
+			if !found {
+				t.Errorf(":authority header not found in mutation, got: %v", headers)
 			}
 
 			// Confirm that query logs recorded metric trace details

--- a/cmd/atenet/internal/router/resumer.go
+++ b/cmd/atenet/internal/router/resumer.go
@@ -46,8 +46,8 @@ func NewActorResumer(apiClient ateapipb.ControlClient) *ActorResumer {
 func (r *ActorResumer) ResumeActor(ctx context.Context, atespace, actorName string) (*ateapipb.Actor, error) {
 	ctx, span := otel.Tracer(routerServiceName).Start(ctx, "ResumeActor",
 		trace.WithAttributes(
-			attribute.String("atespace", atespace),
-			attribute.String("actor", actorName),
+			attribute.String("ate.atespace", atespace),
+			attribute.String("ate.actor_name", actorName),
 		))
 	defer span.End()
 
@@ -57,6 +57,9 @@ func (r *ActorResumer) ResumeActor(ctx context.Context, atespace, actorName stri
 		// resume operation continues running for Caller 2 and Caller 3 without failing.
 		bgCtx, bgCancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer bgCancel()
+		// Propagate the caller's span context so the gRPC spans are children
+		// of ResumeActor rather than appearing as a separate trace.
+		bgCtx = trace.ContextWithSpanContext(bgCtx, trace.SpanContextFromContext(ctx))
 
 		backoff := wait.Backoff{
 			Steps:    7,


### PR DESCRIPTION
Fixes #427

## Root cause

Two bugs broke the trace chain through the router, creating two separate traces instead of one connected trace for each ResumeActor request:

### 1. Singleflight detaches trace context (primary)

resumer.go:58 uses context.Background() inside singleflight.DoChan(). The otelgrpc client handler reads the trace context from the context passed to the gRPC call, so the ateapi handler spans ended up in a separate trace from the router's ResumeActor span.

Fix: Propagate the caller's span context into the background context via trace.ContextWithSpanContext. The caller's lifecycle detachment is preserved (background context parent), but the trace chain is maintained.

### 2. No traceparent injected into upstream request (secondary)

extproc.go:179-187 only rewrote the :authority header in the HeadersResponse mutation. When Envoy tracing is not configured (no OTLP collector), Envoy does not inject traceparent into upstream requests, so the worker pod receives no trace context.

Fix: After building the header mutation, call injectTraceContext(ctx, mutation) which uses otel.GetTextMapPropagator().Inject() to write traceparent/tracestate into the mutation set headers.

### 3. Non-namespaced attribute keys

Span and metric attributes used bare keys (atespace, actor, actor_template_namespace, etc.) instead of the ate.* namespaced convention established in #412.

Fix: Renamed attributes across extproc.go and resumer.go:
- atespace -> ate.atespace
- actor -> ate.actor_name
- target_addr (new) -> ate.target_addr
- actor_template_namespace -> ate.actor_template_namespace
- actor_template_name -> ate.actor_template_name
- outcome -> ate.outcome

Also added missing ate.atespace and ate.actor_name attributes to the ExtProc.RequestHeaders span (previously had zero custom attributes).

## Testing

- Existing TestExtProcHeadersEvaluation updated to handle additional trace headers in the mutation (searches for :authority among SetHeaders instead of asserting exactly one entry).
- TestHandleRequestHeadersDoesNotLogSensitiveData unaffected (no mutation assertion).
- TestActorResumer_ResumeActor unaffected (tests the resumed actor, not span internals).

```release-note
fix(atenet): connect router traces across ateapi, atelet, and worker by propagating span context through singleflight and injecting traceparent into ext_proc mutations; namespace all span and metric attributes to ate.*
```