### PR TITLE
Avoid redundant object naming suffixes

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -63,7 +63,7 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.Deployment
 	maybeApplyMicroVMPodShape(podSpecAC, containerAC, wp.Spec.SandboxClass)
 	podSpecAC.WithContainers(containerAC)
 
-	return appsv1ac.Deployment(deploymentName(wp.Name), wp.Namespace).
+	return appsv1ac.Deployment(wp.Name, wp.Namespace).
 		WithOwnerReferences(metav1ac.OwnerReference().
 			WithAPIVersion(atev1alpha1.GroupVersion.String()).
 			WithKind("WorkerPool").

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -310,7 +310,7 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 		mutatePodSpec(podSpecAC)
 	}
 
-	return appsv1ac.Deployment(deploymentName(wp.Name), wp.Namespace).
+	return appsv1ac.Deployment(wp.Name, wp.Namespace).
 		WithOwnerReferences(metav1ac.OwnerReference().
 			WithAPIVersion(atev1alpha1.GroupVersion.String()).
 			WithKind("WorkerPool").

--- a/cmd/atecontroller/internal/controllers/workerpool_controller.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller.go
@@ -79,7 +79,7 @@ func (r *WorkerPoolReconciler) reconcileWorkerPool(ctx context.Context, wp *atev
 	}
 
 	dep := &appsv1.Deployment{}
-	if err := r.Get(ctx, types.NamespacedName{Name: deploymentName(wp.Name), Namespace: wp.Namespace}, dep); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, dep); err != nil {
 		if k8errors.IsNotFound(err) {
 			return nil
 		}
@@ -117,8 +117,4 @@ func (r *WorkerPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&atev1alpha1.WorkerPool{}).
 		Owns(&appsv1.Deployment{}).
 		Complete(r)
-}
-
-func deploymentName(wpName string) string {
-	return wpName + "-deployment"
 }

--- a/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
@@ -569,7 +569,7 @@ func makeWorkerPool(name, ns string, replicas int32, image string) *atev1alpha1.
 func getDeployment(ctx context.Context, wp *atev1alpha1.WorkerPool) (*appsv1.Deployment, error) {
 	dep := &appsv1.Deployment{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
-		Name:      deploymentName(wp.Name),
+		Name:      wp.Name,
 		Namespace: wp.Namespace,
 	}, dep)
 	return dep, err

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -54,10 +54,10 @@ To stream actor logs in real-time, append the `--follow` (or `-f`) flag. The CLI
 
 ```bash
 $ kubectl ate logs actors test -f
-Actor is currently running on pod ate-demo-counter/counter-deployment-d8f99-m7d96
+Actor is currently running on pod ate-demo-counter/counter-d8f99-m7d96
 {"time":"2026-05-22T21:49:15.255765354Z","count":0,"fshash":"mCY7...","level":"INFO","msg":"Count"}
 {"time":"2026-05-22T21:49:25.263744806Z","count":1,"fshash":"mCY7...","level":"INFO","msg":"Count"}
-Actor is currently running on pod ate-demo-counter/counter-deployment-ab123-x4y5z
+Actor is currently running on pod ate-demo-counter/counter-ab123-x4y5z
 {"time":"2026-05-22T21:50:02.123456789Z","count":2,"fshash":"mCY7...","level":"INFO","msg":"Count"}
 ```
 
@@ -94,7 +94,7 @@ labels.actor_template_name="counter"
 To inspect the physical worker pod's aggregate stream and see all co-located actors multiplexed together (useful for investigating pod-level resource exhaustion or noisy neighbor issues):
 
 ```text
-resource.labels.pod_name="counter-deployment-c995fdf4c-m7d96"
+resource.labels.pod_name="counter-c995fdf4c-m7d96"
 ```
 
 ---

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -303,7 +303,7 @@ deploy_ate_system() {
   echo "${manifests}" | run_kubectl apply -f -
 
   log_step "Waiting for ATE system components to be ready..."
-  run_kubectl rollout status deployment/ate-api-server-deployment -n ate-system --timeout=120s
+  run_kubectl rollout status deployment/ate-api-server -n ate-system --timeout=120s
   run_kubectl rollout status deployment/ate-controller -n ate-system --timeout=120s
   run_kubectl rollout status deployment/atenet-router -n ate-system --timeout=120s
   run_kubectl rollout status statefulset/valkey-cluster -n ate-system --timeout=120s
@@ -337,7 +337,7 @@ deploy_ate_apiserver() {
   ensure_apiserver_prerequisites
 
   run_ko apply -f manifests/ate-install/ate-api-server.yaml
-  run_kubectl rollout status deployment/ate-api-server-deployment -n ate-system --timeout=120s
+  run_kubectl rollout status deployment/ate-api-server -n ate-system --timeout=120s
 }
 
 deploy_atelet() {
@@ -440,7 +440,7 @@ delete_demo_actors() {
     return 1
   fi
 
-  if ! run_kubectl get deployment/ate-api-server-deployment -n ate-system >/dev/null 2>&1; then
+  if ! run_kubectl get deployment/ate-api-server -n ate-system >/dev/null 2>&1; then
     log_step "ate-api-server not found; skipping actor cleanup"
     return 0
   fi

--- a/hack/install-demo-counter.sh
+++ b/hack/install-demo-counter.sh
@@ -42,7 +42,7 @@ demo-counter_deploy() {
   # with a tight readiness deadline -- run against an already-warm node instead
   # of racing that cold-start work.
   log_step "Waiting for counter demo to be ready..."
-  run_kubectl rollout status deployment/counter-deployment -n ate-demo-counter --timeout=300s
+  run_kubectl rollout status deployment/counter -n ate-demo-counter --timeout=300s
   run_kubectl wait --for=condition=Ready actortemplate/counter -n ate-demo-counter --timeout=300s
 }
 

--- a/hack/install-demo-multi-template.sh
+++ b/hack/install-demo-multi-template.sh
@@ -37,7 +37,7 @@ demo-multi-template_deploy() {
 
   # Wait for both ActorTemplates to be ready before returning.
   log_step "Waiting for multi-template demo to be ready..."
-  run_kubectl rollout status deployment/shared-pool-deployment -n ate-demo-multi-template-pool --timeout=300s
+  run_kubectl rollout status deployment/shared-pool -n ate-demo-multi-template-pool --timeout=300s
   run_kubectl wait --for=condition=Ready actortemplate/counter -n ate-demo-multi-template-counter --timeout=300s
   run_kubectl wait --for=condition=Ready actortemplate/fspersist -n ate-demo-multi-template-fspersist --timeout=300s
 }

--- a/internal/ateclient/builder.go
+++ b/internal/ateclient/builder.go
@@ -267,7 +267,7 @@ func jwtDialOptions(ctx context.Context, clientset *kubernetes.Clientset) ([]grp
 func isJWTMode(ctx context.Context, clientset *kubernetes.Clientset) (bool, error) {
 	// TODO: Replace deployment introspection with an explicit client-readable
 	// config file once ateapi auth mode is part of install/runtime config.
-	deployment, err := clientset.AppsV1().Deployments("ate-system").Get(ctx, "ate-api-server-deployment", metav1.GetOptions{})
+	deployment, err := clientset.AppsV1().Deployments("ate-system").Get(ctx, "ate-api-server", metav1.GetOptions{})
 	if err != nil {
 		return false, fmt.Errorf("failed to get ate-api-server deployment: %w", err)
 	}

--- a/internal/e2e/preflight.go
+++ b/internal/e2e/preflight.go
@@ -39,7 +39,7 @@ func PreflightChecks() error {
 	// Check deployments.
 	deployments := []string{
 		"ate-controller",
-		"ate-api-server-deployment",
+		"ate-api-server",
 	}
 	namespace := "ate-system"
 	for _, depName := range deployments {

--- a/manifests/ate-install/ate-api-server.yaml
+++ b/manifests/ate-install/ate-api-server.yaml
@@ -17,7 +17,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ate-api-server-role
+  name: ate-api-server
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -45,21 +45,21 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ate-api-server-binding
+  name: ate-api-server
 subjects:
 - kind: ServiceAccount
   name: ate-api-server
   namespace: ate-system
 roleRef:
   kind: ClusterRole
-  name: ate-api-server-role
+  name: ate-api-server
   apiGroup: rbac.authorization.k8s.io
 ---
 # 5. Deploy the API Server
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ate-api-server-deployment
+  name: ate-api-server
   namespace: ate-system
 spec:
   replicas: 1

--- a/manifests/ate-install/atelet.yaml
+++ b/manifests/ate-install/atelet.yaml
@@ -23,7 +23,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: atelet-role
+  name: atelet
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -33,14 +33,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: atelet-binding
+  name: atelet
 subjects:
 - kind: ServiceAccount
   name: atelet
   namespace: ate-system
 roleRef:
   kind: ClusterRole
-  name: atelet-role
+  name: atelet
   apiGroup: rbac.authorization.k8s.io
 ---
 # 4. Create DaemonSet

--- a/manifests/ate-install/jwt/kustomization.yaml
+++ b/manifests/ate-install/jwt/kustomization.yaml
@@ -30,7 +30,7 @@ patches:
       group: apps
       version: v1
       kind: Deployment
-      name: ate-api-server-deployment
+      name: ate-api-server
       namespace: ate-system
     patch: |-
       - op: add

--- a/manifests/ate-install/kind-jwt/kustomization.yaml
+++ b/manifests/ate-install/kind-jwt/kustomization.yaml
@@ -24,7 +24,7 @@ patches:
       group: apps
       version: v1
       kind: Deployment
-      name: ate-api-server-deployment
+      name: ate-api-server
       namespace: ate-system
     patch: |-
       - op: add

--- a/manifests/ate-install/kind/kustomization.yaml
+++ b/manifests/ate-install/kind/kustomization.yaml
@@ -32,7 +32,7 @@ patches:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: ate-api-server-deployment
+        name: ate-api-server
         namespace: ate-system
       spec:
         template:
@@ -56,4 +56,3 @@ patches:
               env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
-

--- a/tools/setup-gcp/dashboards/ate-e2e-latency-dashboard.json
+++ b/tools/setup-gcp/dashboards/ate-e2e-latency-dashboard.json
@@ -67,7 +67,7 @@
               },
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=\"ate-api-server-deployment\", \"rpc.method\"=\"ateapi.Control/ResumeActor\"}[5m])))",
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=\"ate-api-server\", \"rpc.method\"=\"ateapi.Control/ResumeActor\"}[5m])))",
                   "unitOverride": "s"
                 },
                 "plotType": "LINE",

--- a/tools/setup-gcp/dashboards/ate-grpc-dashboard.json
+++ b/tools/setup-gcp/dashboards/ate-grpc-dashboard.json
@@ -14,7 +14,7 @@
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "histogram_quantile(0.99, sum by (le, \"rpc.method\") (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=\"ate-api-server-deployment\"}[5m])))",
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le, \"rpc.method\") (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=\"ate-api-server\"}[5m])))",
                   "unitOverride": "s"
                 },
                 "plotType": "LINE",
@@ -39,7 +39,7 @@
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (\"rpc.method\") (rate({\"rpc.server.call.duration_count\", top_level_controller_name=\"ate-api-server-deployment\"}[5m]))",
+                  "prometheusQuery": "sum by (\"rpc.method\") (rate({\"rpc.server.call.duration_count\", top_level_controller_name=\"ate-api-server\"}[5m]))",
                   "unitOverride": "1/s"
                 },
                 "plotType": "LINE",
@@ -64,7 +64,7 @@
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (\"rpc.response.status_code\") (rate({\"rpc.server.call.duration_count\", top_level_controller_name=\"ate-api-server-deployment\", \"rpc.response.status_code\"!=\"OK\"}[5m]))",
+                  "prometheusQuery": "sum by (\"rpc.response.status_code\") (rate({\"rpc.server.call.duration_count\", top_level_controller_name=\"ate-api-server\", \"rpc.response.status_code\"!=\"OK\"}[5m]))",
                   "unitOverride": "1/s"
                 },
                 "plotType": "LINE",


### PR DESCRIPTION
Best practices is not to put a -deployment deployment, -role role, etc; the kind already declares the kind we don't need it in the name as well. Additionally we did not do it consistently anyways.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
