### PR TITLE
Rename nameentity to identity

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -647,15 +647,15 @@ func (s *AteomHerder) prepareOCIBundles(
 	spec *ateletpb.WorkloadSpec,
 	targetAteomUid string,
 ) error {
-	// Populate the per-actor nameentity directory that gets bind-mounted into
+	// Populate the per-actor identity directory that gets bind-mounted into
 	// the application containers. Regenerated on every resume, so it carries
 	// the correct per-actor name even when restoring from the golden snapshot.
 	identityDir := ateompath.ActorIdentityDirPath(atespace, actorName)
 	if err := os.MkdirAll(identityDir, 0o755); err != nil {
-		return fmt.Errorf("while creating actor nameentity dir: %w", err)
+		return fmt.Errorf("while creating actor identity dir: %w", err)
 	}
 	if err := writeFileAtomic(filepath.Join(identityDir, ActorIDFileName), []byte(actorName), 0o644); err != nil {
-		return fmt.Errorf("while writing actor nameentity file: %w", err)
+		return fmt.Errorf("while writing actor identity file: %w", err)
 	}
 
 	ddVolumes := make(map[string]bool)
@@ -698,7 +698,7 @@ func (s *AteomHerder) prepareOCIBundles(
 			nil,
 			annotations,
 			ateompath.AteomNetNSPath(targetAteomUid),
-			"", // pause is sandbox infra; it gets no actor nameentity mount.
+			"", // pause is sandbox infra; it gets no actor identity mount.
 			nil,
 		); err != nil {
 			return wrapFileSystemErr("while creating pause OCI bundle", err)
@@ -1044,10 +1044,10 @@ func resetActorDirs(atespace, actorName string) error {
 	// reads it through the gofer.
 	identityDir := ateompath.ActorIdentityDirPath(atespace, actorName)
 	if err := os.RemoveAll(identityDir); err != nil {
-		return wrapFileSystemErr("while deleting actor nameentity dir: %w", err)
+		return wrapFileSystemErr("while deleting actor identity dir: %w", err)
 	}
 	if err := os.MkdirAll(identityDir, 0o755); err != nil {
-		return wrapFileSystemErr("while creating actor nameentity dir: %w", err)
+		return wrapFileSystemErr("while creating actor identity dir: %w", err)
 	}
 
 	durableDirVolumesMountDir := ateompath.DurableDirVolumeMountsDir(atespace, actorName)

--- a/cmd/atelet/oci.go
+++ b/cmd/atelet/oci.go
@@ -82,7 +82,7 @@ func prepareOCIDirectory(ctx context.Context, pullCache *memorypullcache.MemoryP
 		return fmt.Errorf("in untar: %w", err)
 	}
 
-	// Bind-mount the per-actor nameentity directory so the workload can read its
+	// Bind-mount the per-actor identity directory so the workload can read its
 	// own ID at IdentityMountPath/ActorIDFileName. The bind target must exist
 	// in the rootfs for the mount to attach.
 	if identityDir != "" {

--- a/cmd/atelet/oci_test.go
+++ b/cmd/atelet/oci_test.go
@@ -103,7 +103,7 @@ func TestBuildActorOCISpec_IdentityMount(t *testing.T) {
 		}
 		found = true
 		if m.Source != "/host/actors/atespace:id/identity" {
-			t.Errorf("identity mount source = %q, want the per-actor nameentity dir", m.Source)
+			t.Errorf("identity mount source = %q, want the per-actor identity dir", m.Source)
 		}
 		if m.Type != "bind" {
 			t.Errorf("identity mount type = %q, want bind", m.Type)

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -101,9 +101,9 @@ Because a snapshot is not restorable across sandbox runtimes, `sandboxClass` is 
 Container environment variables support literal `value` entries and `valueFrom.secretKeyRef`. Secret references are resolved by `ate-api-server` from the `ActorTemplate` namespace when a workload spec is materialized. For the golden actor, the resolved values are captured in the golden snapshot and future actors inherit those values until the golden snapshot is recreated. For an actor that bypasses the golden snapshot and boots from the current template spec, the resolved values are sent to atelet but are not serialized into the public Actor API. Other Kubernetes `valueFrom` sources are not supported yet. Secret changes do not automatically restart actors or invalidate snapshots; rotating a Secret requires an explicit actor or template lifecycle action.
 
 ### Workload Connectivity (Uniform DNS)
-Substrate uses a **Uniform DNS Mesh**: every actor created from a template is automatically reachable through the **Substrate Router** via its atespace and ID:
+Substrate uses a **Uniform DNS Mesh**: every actor created from a template is automatically reachable through the **Substrate Router** via its atespace and name:
 
-**Format:** `<actor-id>.<atespace>.actors.resources.substrate.ate.dev`
+**Format:** `<actor-name>.<atespace>.actors.resources.substrate.ate.dev`
 
 ### Actor Identity
 Substrate bind-mounts a read-only, per-actor identity directory at **`/run/ate`** into each of the actor's containers. An actor can learn its own ID without parsing the `Host` header by reading the file **`/run/ate/actor-id`** inside it, which contains the raw actor ID with no trailing newline. Further identity and configuration data may appear in this directory over time.


### PR DESCRIPTION
nameentity seems to be a typo when renaming `id` to `name`