### PR TITLE
test: parse go test flags

### DIFF
--- a/internal/e2e/testmain.go
+++ b/internal/e2e/testmain.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	goflag "flag"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -41,6 +42,10 @@ func RunTestMain(m *testing.M) int {
 	bindFlags()
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	pflag.Parse()
+	if err := pflag.ParseSkippedFlags(os.Args[1:], goflag.CommandLine); err != nil {
+		fmt.Printf("Failed to parse Go test flags: %v\n", err)
+		return 1
+	}
 
 	if !RunE2E {
 		fmt.Println(Colorf(`


### PR DESCRIPTION
This enables parsing of flags like `-test.v` to pass into the Go test logic.


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
