### PR TITLE
Clear a never-written snapshot when suspending a dangling worker

### DIFF
--- a/cmd/ateapi/internal/controlapi/crash.go
+++ b/cmd/ateapi/internal/controlapi/crash.go
@@ -51,6 +51,8 @@ func crashActor(ctx context.Context, st store.Interface, atespace, actorName str
 		return fmt.Errorf("while loading actor to crash: %w", err)
 	}
 	actor.Status = ateapipb.Actor_STATUS_CRASHED
+	// InProgressSnapshot is kept for debugging; failed workflow
+	// steps must never promote it to LatestSnapshotInfo.
 	// TODO(zoezhao):
 	// 1. If the Actor crashed because the worker is unhealthy,
 	//    free the worker and mark it as unhealthy(or delete it)

--- a/cmd/ateapi/internal/controlapi/crash_test.go
+++ b/cmd/ateapi/internal/controlapi/crash_test.go
@@ -33,13 +33,14 @@ import (
 func seedActor(t *testing.T, ctx context.Context, st store.Interface, atespace, actorName string) {
 	t.Helper()
 	if _, err := st.CreateActor(ctx, &ateapipb.Actor{
-		Metadata:          &ateapipb.ResourceMetadata{Name: actorName, Atespace: atespace},
-		Status:            ateapipb.Actor_STATUS_RUNNING,
-		AteomPodNamespace: "ns",
-		AteomPodName:      "pod",
-		AteomPodIp:        "1.2.3.4",
-		AteomPodUid:       "uid",
-		WorkerPoolName:    "pool",
+		Metadata:           &ateapipb.ResourceMetadata{Name: actorName, Atespace: atespace},
+		Status:             ateapipb.Actor_STATUS_RUNNING,
+		AteomPodNamespace:  "ns",
+		AteomPodName:       "pod",
+		AteomPodIp:         "1.2.3.4",
+		AteomPodUid:        "uid",
+		WorkerPoolName:     "pool",
+		InProgressSnapshot: "gs://snapshots/actor-1/reserved",
 	}); err != nil {
 		t.Fatalf("seed actor: %v", err)
 	}
@@ -54,6 +55,10 @@ func assertCrashed(t *testing.T, ctx context.Context, st store.Interface, atespa
 	}
 	if got.GetStatus() != ateapipb.Actor_STATUS_CRASHED {
 		t.Errorf("status = %v, want %v", got.GetStatus(), ateapipb.Actor_STATUS_CRASHED)
+	}
+	// Keep the snapshot uri for debugging.
+	if got.GetInProgressSnapshot() == "" {
+		t.Error(`InProgressSnapshot = "", want preserved`)
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -119,8 +119,11 @@ func (s *CallAteletSuspendStep) Execute(ctx context.Context, input *SuspendInput
 	ateletConn, err := s.dialer.DialForWorker(state.Actor.GetAteomPodNamespace(), state.Actor.GetAteomPodName())
 	if err != nil {
 		if errors.Is(err, ErrWorkerPodNotFound) {
-			slog.Warn("Skipping suspend for dangling worker pod", "namespace", state.Actor.GetAteomPodNamespace(), "pod", state.Actor.GetAteomPodName())
-			return nil
+			slog.ErrorContext(ctx, "Worker pod gone before checkpoint, crashing actor", "namespace", state.Actor.GetAteomPodNamespace(), "pod", state.Actor.GetAteomPodName(), "in_progress_snapshot", state.Actor.GetInProgressSnapshot())
+			if err := crashActor(ctx, s.store, state.Actor.GetMetadata().GetAtespace(), state.Actor.GetMetadata().GetName()); err != nil {
+				slog.ErrorContext(ctx, "Failed to crash actor", slog.String("err", err.Error()))
+			}
+			return fmt.Errorf("actor is CRASHED because its worker pod is gone and no snapshot was written")
 		}
 		return fmt.Errorf("while getting atelet conn for worker pod: %w", err)
 	}

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -111,7 +111,7 @@ func (s *CallAteletSuspendStep) IsComplete(ctx context.Context, input *SuspendIn
 func (s *CallAteletSuspendStep) Execute(ctx context.Context, input *SuspendInput, state *SuspendState) error {
 	if state.Actor.GetAteomPodNamespace() == "" || state.Actor.GetAteomPodName() == "" {
 		if err := crashActor(ctx, s.store, state.Actor.GetMetadata().GetAtespace(), state.Actor.GetMetadata().GetName()); err != nil {
-			slog.Error("Failed to crash actor", slog.String("err", err.Error()))
+			slog.ErrorContext(ctx, "Failed to crash actor", slog.String("err", err.Error()))
 		}
 		return fmt.Errorf("actor is CRASHED because it was in SUSPENDING state but has no active worker")
 	}
@@ -184,7 +184,7 @@ func (s *FinalizeSuspendedStep) Execute(ctx context.Context, input *SuspendInput
 			if !errors.Is(err, store.ErrNotFound) {
 				return fmt.Errorf("while getting worker for release: %w", err)
 			}
-			slog.Warn("Worker already gone during finalize suspend, skipping release", "worker", workerPod)
+			slog.WarnContext(ctx, "Worker already gone during finalize suspend, skipping release", "worker", workerPod)
 		} else {
 			// Only free it if it still belongs to us
 			if wass := worker.Assignment; wass != nil {

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
+	"k8s.io/client-go/tools/cache"
 )
 
 // newTestPersistence returns a store backed by a throwaway miniredis.
@@ -36,6 +37,80 @@ func newTestPersistence(t *testing.T) store.Interface {
 	rdb := redis.NewClusterClient(&redis.ClusterOptions{Addrs: []string{mr.Addr()}})
 	t.Cleanup(func() { rdb.Close() }) //nolint:errcheck // test cleanup
 	return ateredis.NewPersistence(rdb)
+}
+
+// newDanglingDialer returns a dialer whose informer cache has no pods, so
+// DialForWorker returns ErrWorkerPodNotFound.
+func newDanglingDialer() *AteletDialer {
+	empty := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		byNamespaceAndName: func(obj any) ([]string, error) { return nil, nil },
+	})
+	return NewAteletDialer(empty, empty)
+}
+
+func TestCallAteletSuspendStep_DanglingWorkerDoesNotRecordPhantomSnapshot(t *testing.T) {
+	tests := []struct {
+		name         string
+		prevSnapshot *ateapipb.SnapshotInfo
+	}{
+		{
+			name: "keeps previous snapshot",
+			prevSnapshot: &ateapipb.SnapshotInfo{
+				Data: &ateapipb.SnapshotInfo_External{
+					External: &ateapipb.ExternalSnapshotInfo{SnapshotUriPrefix: "gs://snapshots/actor-1/prev"},
+				},
+			},
+		},
+		{
+			name:         "stays nil without previous snapshot",
+			prevSnapshot: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			persistence := newTestPersistence(t)
+
+			actor := &ateapipb.Actor{
+				Metadata:           &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "actor-1"},
+				Status:             ateapipb.Actor_STATUS_SUSPENDING,
+				AteomPodNamespace:  "worker-ns",
+				AteomPodName:       "pod-gone",
+				WorkerPoolName:     "pool",
+				InProgressSnapshot: "gs://snapshots/actor-1/never-written",
+				LatestSnapshotInfo: tt.prevSnapshot,
+			}
+			created, err := persistence.CreateActor(ctx, actor)
+			if err != nil {
+				t.Fatalf("CreateActor: %v", err)
+			}
+
+			step := &CallAteletSuspendStep{store: persistence, dialer: newDanglingDialer()}
+			input := &SuspendInput{ActorName: "actor-1", Atespace: "team-a"}
+			if err := step.Execute(ctx, input, &SuspendState{Actor: created}); err == nil {
+				t.Fatal("Execute: want error for dangling worker, got nil")
+			}
+
+			stored, err := persistence.GetActor(ctx, "team-a", "actor-1")
+			if err != nil {
+				t.Fatalf("GetActor: %v", err)
+			}
+			if stored.GetStatus() != ateapipb.Actor_STATUS_CRASHED {
+				t.Errorf("status = %v, want CRASHED", stored.GetStatus())
+			}
+			if got := stored.GetInProgressSnapshot(); got != "gs://snapshots/actor-1/never-written" {
+				t.Errorf("InProgressSnapshot = %q, want preserved for debugging", got)
+			}
+			if tt.prevSnapshot == nil {
+				if stored.GetLatestSnapshotInfo() != nil {
+					t.Errorf("LatestSnapshotInfo = %v, want nil", stored.GetLatestSnapshotInfo())
+				}
+			} else if got, want := stored.GetLatestSnapshotInfo().GetExternal().GetSnapshotUriPrefix(), tt.prevSnapshot.GetExternal().GetSnapshotUriPrefix(); got != want {
+				t.Errorf("LatestSnapshotInfo uri = %q, want %q", got, want)
+			}
+		})
+	}
 }
 
 func TestFinalizeSuspendedStep_ReleasesOnlyOwnWorker(t *testing.T) {


### PR DESCRIPTION
When the worker pod disappeared before Checkpoint was called, the suspend workflow skipped the atelet call but still let finalize promote the reserved InProgressSnapshot URI to LatestSnapshotInfo, overwriting the last good snapshot with one that was never written.  This could break the next resume call of this actor.

Now the dangling-worker path crashes the actor via `crashActor` too, and crashActor clears any reserved snapshot URI so `FinalizeSuspendedStep` won't overwrite the last good snapshot.


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
