### PR TITLE
Release the worker and clear the actor's binding when crashing an actor.

### DIFF
--- a/cmd/ateapi/internal/controlapi/crash.go
+++ b/cmd/ateapi/internal/controlapi/crash.go
@@ -96,14 +96,14 @@ func releaseWorker(ctx context.Context, st store.Interface, actor *ateapipb.Acto
 	if err != nil {
 		return fmt.Errorf("while getting worker to release: %w", err)
 	}
-
 	wass := worker.GetAssignment()
 	if wass == nil {
 		slog.WarnContext(ctx, "Worker's assignment is already nil, skipping release", slog.String("worker", podUid))
 		return nil
 	}
+	// Only free it if it still belongs to us
 	if wass.GetActor().GetAtespace() != actor.GetMetadata().GetAtespace() || wass.GetActor().GetName() != actor.GetMetadata().GetName() {
-		// Worker is already assigned to a different actor; leave it alone.
+		slog.WarnContext(ctx, "Worker already assigned to another Actor", slog.String("worker", podUid))
 		return nil
 	}
 

--- a/cmd/ateapi/internal/controlapi/crash.go
+++ b/cmd/ateapi/internal/controlapi/crash.go
@@ -52,12 +52,11 @@ func crashActor(ctx context.Context, st store.Interface, atespace, actorName str
 	if err != nil {
 		return fmt.Errorf("while loading actor to crash: %w", err)
 	}
-	// Remember the binding before clearing it; releasing the worker
-	// below still needs it.
-	podNamespace := actor.GetAteomPodNamespace()
-	podName := actor.GetAteomPodName()
-	podUid := actor.GetAteomPodUid()
-	poolName := actor.GetWorkerPoolName()
+
+	var errCollected []error
+	if err := releaseWorker(ctx, st, actor); err != nil {
+		errCollected = append(errCollected, err)
+	}
 
 	actor.Status = ateapipb.Actor_STATUS_CRASHED
 
@@ -69,35 +68,48 @@ func crashActor(ctx context.Context, st store.Interface, atespace, actorName str
 	actor.AteomPodUid = ""
 	actor.WorkerPoolName = ""
 
-	var errCollected []error
 	if _, err := st.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion()); err != nil {
 		errCollected = append(errCollected, fmt.Errorf("while marking actor crashed: %w", err))
 	}
+	return errors.Join(errCollected...)
+}
+
+// releaseWorker clears the worker's assignment if it still points at the given
+// actor. A missing worker or an already-cleared assignment is not an error.
+func releaseWorker(ctx context.Context, st store.Interface, actor *ateapipb.Actor) error {
+	podNamespace := actor.GetAteomPodNamespace()
+	podName := actor.GetAteomPodName()
+	podUid := actor.GetAteomPodUid()
+	poolName := actor.GetWorkerPoolName()
 
 	if podNamespace == "" || podName == "" || poolName == "" {
 		slog.WarnContext(ctx, "Actor's worker assignment is already cleared")
-		return errors.Join(errCollected...)
+		return nil
 	}
 
-	// Free the worker assigned to this actor.
 	worker, err := st.GetWorker(ctx, podNamespace, poolName, podName)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			// No need to release if the worker is not found.
-			slog.WarnContext(ctx, "Worker already gone while crashing actor, skipping release", slog.String("worker", podUid))
-		} else {
-			errCollected = append(errCollected, fmt.Errorf("while getting worker to release: %w", err))
-		}
-		return errors.Join(errCollected...)
+	if errors.Is(err, store.ErrNotFound) {
+		// No need to release if the worker is not found.
+		slog.WarnContext(ctx, "Worker already gone while crashing actor, skipping release", slog.String("worker", podUid))
+		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("while getting worker to release: %w", err)
+	}
+
 	wass := worker.GetAssignment()
 	if wass == nil {
 		slog.WarnContext(ctx, "Worker's assignment is already nil, skipping release", slog.String("worker", podUid))
-	} else if wass.GetActor().GetAtespace() == atespace && wass.GetActor().GetName() == actorName {
-		worker.Assignment = nil
-		if err := st.UpdateWorker(ctx, worker, worker.GetVersion()); err != nil {
-			errCollected = append(errCollected, fmt.Errorf("while releasing worker: %w", err))
-		}
+		return nil
 	}
-	return errors.Join(errCollected...)
+	if wass.GetActor().GetAtespace() != actor.GetMetadata().GetAtespace() || wass.GetActor().GetName() != actor.GetMetadata().GetName() {
+		// Worker is already assigned to a different actor; leave it alone.
+		return nil
+	}
+
+	worker.Assignment = nil
+	if err := st.UpdateWorker(ctx, worker, worker.GetVersion()); err != nil {
+		return fmt.Errorf("while releasing worker: %w", err)
+	}
+	return nil
 }

--- a/cmd/ateapi/internal/controlapi/crash.go
+++ b/cmd/ateapi/internal/controlapi/crash.go
@@ -16,6 +16,7 @@ package controlapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -44,26 +45,59 @@ func maybeCrashActor(ctx context.Context, st store.Interface, atespace, actorNam
 	return fmt.Errorf("%s: %w", wrapMsg, err)
 }
 
-// crashActor moves the actor to CRASHED state.
+// crashActor moves the actor to CRASHED state and frees the worker it was
+// assigned to, if any, so the worker can host other actors.
 func crashActor(ctx context.Context, st store.Interface, atespace, actorName string) error {
 	actor, err := st.GetActor(ctx, atespace, actorName)
 	if err != nil {
 		return fmt.Errorf("while loading actor to crash: %w", err)
 	}
+	// Remember the binding before clearing it; releasing the worker
+	// below still needs it.
+	podNamespace := actor.GetAteomPodNamespace()
+	podName := actor.GetAteomPodName()
+	podUid := actor.GetAteomPodUid()
+	poolName := actor.GetWorkerPoolName()
+
 	actor.Status = ateapipb.Actor_STATUS_CRASHED
+
 	// InProgressSnapshot is kept for debugging; failed workflow
 	// steps must never promote it to LatestSnapshotInfo.
-	// TODO(zoezhao):
-	// 1. If the Actor crashed because the worker is unhealthy,
-	//    free the worker and mark it as unhealthy(or delete it)
-	//    to prevent other actors from being scheduled on it.
-	// 2. If the Actor crashed while resuming from a Paused state,
-	//    we must preserve the Actor's assigned node VM in order
-	//    to support `ate actor dump` command.
-	// (https://github.com/agent-substrate/substrate/issues/119)
+	actor.AteomPodNamespace = ""
+	actor.AteomPodName = ""
+	actor.AteomPodIp = ""
+	actor.AteomPodUid = ""
+	actor.WorkerPoolName = ""
+
+	var errCollected []error
 	if _, err := st.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion()); err != nil {
-		return fmt.Errorf("while marking actor crashed: %w", err)
+		errCollected = append(errCollected, fmt.Errorf("while marking actor crashed: %w", err))
 	}
 
-	return nil
+	if podNamespace == "" || podName == "" || poolName == "" {
+		slog.WarnContext(ctx, "Actor's worker assignment is already cleared")
+		return errors.Join(errCollected...)
+	}
+
+	// Free the worker assigned to this actor.
+	worker, err := st.GetWorker(ctx, podNamespace, poolName, podName)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// No need to release if the worker is not found.
+			slog.WarnContext(ctx, "Worker already gone while crashing actor, skipping release", slog.String("worker", podUid))
+		} else {
+			errCollected = append(errCollected, fmt.Errorf("while getting worker to release: %w", err))
+		}
+		return errors.Join(errCollected...)
+	}
+	wass := worker.GetAssignment()
+	if wass == nil {
+		slog.WarnContext(ctx, "Worker's assignment is already nil, skipping release", slog.String("worker", podUid))
+	} else if wass.GetActor().GetAtespace() == atespace && wass.GetActor().GetName() == actorName {
+		worker.Assignment = nil
+		if err := st.UpdateWorker(ctx, worker, worker.GetVersion()); err != nil {
+			errCollected = append(errCollected, fmt.Errorf("while releasing worker: %w", err))
+		}
+	}
+	return errors.Join(errCollected...)
 }

--- a/cmd/ateapi/internal/controlapi/crash_test.go
+++ b/cmd/ateapi/internal/controlapi/crash_test.go
@@ -46,7 +46,40 @@ func seedActor(t *testing.T, ctx context.Context, st store.Interface, atespace, 
 	}
 }
 
-// assertCrashed reloads the actor and verifies it is CRASHED.
+// seedWorker registers the worker referenced by seedActor's binding fields,
+// assigned to the given actor in atespace (unassigned if assignedActor is "").
+func seedWorker(t *testing.T, ctx context.Context, st store.Interface, atespace, assignedActor string) {
+	t.Helper()
+	worker := &ateapipb.Worker{
+		WorkerNamespace: "ns",
+		WorkerPool:      "pool",
+		WorkerPod:       "pod",
+	}
+	if assignedActor != "" {
+		worker.Assignment = &ateapipb.Assignment{
+			Actor: &ateapipb.ObjectRef{Atespace: atespace, Name: assignedActor},
+		}
+	}
+	if err := st.CreateWorker(ctx, worker); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+}
+
+// seedUnboundActor stores a running actor whose worker-binding fields were
+// already cleared, e.g. by a prior release.
+func seedUnboundActor(t *testing.T, ctx context.Context, st store.Interface, atespace, actorName string) {
+	t.Helper()
+	if _, err := st.CreateActor(ctx, &ateapipb.Actor{
+		Metadata:           &ateapipb.ResourceMetadata{Name: actorName, Atespace: atespace},
+		Status:             ateapipb.Actor_STATUS_RUNNING,
+		InProgressSnapshot: "gs://snapshots/actor-1/reserved",
+	}); err != nil {
+		t.Fatalf("seed unbound actor: %v", err)
+	}
+}
+
+// assertCrashed reloads the actor and verifies it is CRASHED with its worker
+// binding cleared.
 func assertCrashed(t *testing.T, ctx context.Context, st store.Interface, atespace, actorName string) {
 	t.Helper()
 	got, err := st.GetActor(ctx, atespace, actorName)
@@ -60,6 +93,17 @@ func assertCrashed(t *testing.T, ctx context.Context, st store.Interface, atespa
 	if got.GetInProgressSnapshot() == "" {
 		t.Error(`InProgressSnapshot = "", want preserved`)
 	}
+	for field, val := range map[string]string{
+		"AteomPodNamespace": got.GetAteomPodNamespace(),
+		"AteomPodName":      got.GetAteomPodName(),
+		"AteomPodIp":        got.GetAteomPodIp(),
+		"AteomPodUid":       got.GetAteomPodUid(),
+		"WorkerPoolName":    got.GetWorkerPoolName(),
+	} {
+		if val != "" {
+			t.Errorf("%s = %q, want cleared", field, val)
+		}
+	}
 }
 
 func TestCrashActor(t *testing.T) {
@@ -71,17 +115,83 @@ func TestCrashActor(t *testing.T) {
 	tests := []struct {
 		name string
 		seed bool
+		// setup runs after the actor is seeded, e.g. to register a worker.
+		setup func(t *testing.T, ctx context.Context, st store.Interface)
 		// check inspects the returned error; nil-safe.
 		check func(t *testing.T, ctx context.Context, st store.Interface, err error)
 	}{
 		{
-			name: "crashes running actor",
+			name: "crashes running actor with no registered worker",
 			seed: true,
 			check: func(t *testing.T, ctx context.Context, st store.Interface, err error) {
 				if err != nil {
 					t.Fatalf("crashActor() = %v, want nil", err)
 				}
 				assertCrashed(t, ctx, st, atespace, actorName)
+			},
+		},
+		{
+			name: "releases worker assigned to crashed actor",
+			seed: true,
+			setup: func(t *testing.T, ctx context.Context, st store.Interface) {
+				seedWorker(t, ctx, st, atespace, actorName)
+			},
+			check: func(t *testing.T, ctx context.Context, st store.Interface, err error) {
+				if err != nil {
+					t.Fatalf("crashActor() = %v, want nil", err)
+				}
+				assertCrashed(t, ctx, st, atespace, actorName)
+				worker, gerr := st.GetWorker(ctx, "ns", "pool", "pod")
+				if gerr != nil {
+					t.Fatalf("GetWorker() = %v, want nil", gerr)
+				}
+				if worker.GetAssignment() != nil {
+					t.Errorf("worker assignment = %v, want nil", worker.GetAssignment())
+				}
+			},
+		},
+		{
+			name: "keeps worker assigned to another actor",
+			seed: true,
+			setup: func(t *testing.T, ctx context.Context, st store.Interface) {
+				seedWorker(t, ctx, st, atespace, "actor-2")
+			},
+			check: func(t *testing.T, ctx context.Context, st store.Interface, err error) {
+				if err != nil {
+					t.Fatalf("crashActor() = %v, want nil", err)
+				}
+				assertCrashed(t, ctx, st, atespace, actorName)
+				worker, gerr := st.GetWorker(ctx, "ns", "pool", "pod")
+				if gerr != nil {
+					t.Fatalf("GetWorker() = %v, want nil", gerr)
+				}
+				if got := worker.GetAssignment().GetActor().GetName(); got != "actor-2" {
+					t.Errorf("worker assigned actor = %q, want %q", got, "actor-2")
+				}
+			},
+		},
+		{
+			name: "skips release for actor with no worker binding",
+			seed: false,
+			setup: func(t *testing.T, ctx context.Context, st store.Interface) {
+				seedUnboundActor(t, ctx, st, atespace, actorName)
+				seedWorker(t, ctx, st, atespace, actorName)
+			},
+			check: func(t *testing.T, ctx context.Context, st store.Interface, err error) {
+				if err != nil {
+					t.Fatalf("crashActor() = %v, want nil", err)
+				}
+				assertCrashed(t, ctx, st, atespace, actorName)
+				// Without a binding the worker cannot be looked up, so its
+				// assignment must be left untouched even though it names
+				// the crashed actor.
+				worker, gerr := st.GetWorker(ctx, "ns", "pool", "pod")
+				if gerr != nil {
+					t.Fatalf("GetWorker() = %v, want nil", gerr)
+				}
+				if worker.GetAssignment() == nil {
+					t.Error("worker assignment = nil, want untouched")
+				}
 			},
 		},
 		{
@@ -109,6 +219,9 @@ func TestCrashActor(t *testing.T) {
 
 			if tt.seed {
 				seedActor(t, ctx, st, atespace, actorName)
+			}
+			if tt.setup != nil {
+				tt.setup(t, ctx, st)
 			}
 
 			err := crashActor(ctx, st, atespace, actorName)

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -2608,6 +2608,47 @@ func TestDeleteActor_NotSuspended(t *testing.T) {
 	assertGrpcError(t, err, codes.FailedPrecondition, "Actor id1 is not suspended (status: STATUS_RUNNING)")
 }
 
+func TestDeleteActor_Crashed(t *testing.T) {
+	ns := namespaceForTest("ns-delete-crashed")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      "tmpl1",
+	}})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	actor, err := tc.persistence.GetActor(context.Background(), testAtespace, "id1")
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	actor.Status = ateapipb.Actor_STATUS_CRASHED
+	if _, err := tc.persistence.UpdateActor(context.Background(), actor, actor.GetMetadata().GetVersion()); err != nil {
+		t.Fatalf("UpdateActor failed: %v", err)
+	}
+
+	deleted, err := tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteActor of crashed actor failed: %v", err)
+	}
+	if got := deleted.GetStatus(); got != ateapipb.Actor_STATUS_CRASHED {
+		t.Errorf("deleted actor status = %v, want %v", got, ateapipb.Actor_STATUS_CRASHED)
+	}
+
+	_, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"},
+	})
+	assertGrpcError(t, err, codes.NotFound, "Actor id1 not found")
+}
+
 func TestDeleteActor_NotFound(t *testing.T) {
 	ns := namespaceForTest("ns-delete-notfound")
 	tc := setupTest(t, ns)


### PR DESCRIPTION
This will free up the worker to which the crashed actor was assigned, so it can be picked up by other actors.

Minor fix: 
* Added functional test to make sure a crashed actor can be deleted.