### PR TITLE
Fix retry AssignWorkerStep: only save the assigned worker after having picked and persisted worker assignment

### DIFF
--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -166,6 +166,8 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 		return fmt.Errorf("while listing workers: %w", err)
 	}
 
+	var assignedWorker *ateapipb.Worker
+
 	// Check if we already have a worker assigned from a previous failed attempt.
 	// This can happen if ateapi crashed after updating worker with actor assignment,
 	// but has not yet updated the actor.
@@ -181,7 +183,7 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 			return fmt.Errorf("while checking worker eligibility: %w", err)
 		}
 		if eligible {
-			state.Worker = worker
+			assignedWorker = worker
 			break
 		}
 		// Workers() returns pointers directly from the cache so we need to clone before
@@ -202,7 +204,7 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 			}
 		}(releaseWorker)
 	}
-	if state.Worker == nil {
+	if assignedWorker == nil {
 		pickedWorker, err := s.findFreeWorker(workers, state.ActorTemplate.Spec.SandboxClass, state.ActorTemplate.Spec.WorkerSelector, state.Actor.GetWorkerSelector(), state.Actor.GetLatestSnapshotInfo().GetLocal().GetNodeVmsWithLocalSnapshots())
 		if err != nil {
 			return err
@@ -211,14 +213,14 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 			return status.Errorf(codes.FailedPrecondition, "no free workers available")
 		}
 
-		state.Worker = pickedWorker
+		assignedWorker = pickedWorker
 		slog.InfoContext(ctx, "Picked worker", slog.Any("worker", pickedWorker.String()))
 	}
 
 	// Workers() returns pointers directly from the cache so we need to clone before
 	// mutating so that the cache is not corrupted if UpdateWorker fails.
-	state.Worker = proto.Clone(state.Worker).(*ateapipb.Worker)
-	state.Worker.Assignment = &ateapipb.Assignment{
+	assignedWorker = proto.Clone(assignedWorker).(*ateapipb.Worker)
+	assignedWorker.Assignment = &ateapipb.Assignment{
 		ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
 			Namespace: state.Actor.GetActorTemplateNamespace(),
 			Name:      state.Actor.GetActorTemplateName(),
@@ -229,22 +231,23 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 		},
 	}
 
-	if err := s.store.UpdateWorker(ctx, state.Worker, state.Worker.Version); err != nil {
+	if err := s.store.UpdateWorker(ctx, assignedWorker, assignedWorker.Version); err != nil {
 		return err
 	}
 
 	state.Actor.Status = ateapipb.Actor_STATUS_RESUMING
-	state.Actor.AteomPodNamespace = state.Worker.GetWorkerNamespace()
-	state.Actor.AteomPodName = state.Worker.GetWorkerPod()
-	state.Actor.AteomPodIp = state.Worker.GetIp()
-	state.Actor.AteomPodUid = state.Worker.GetWorkerPodUid()
-	state.Actor.WorkerPoolName = state.Worker.GetWorkerPool()
+	state.Actor.AteomPodNamespace = assignedWorker.GetWorkerNamespace()
+	state.Actor.AteomPodName = assignedWorker.GetWorkerPod()
+	state.Actor.AteomPodIp = assignedWorker.GetIp()
+	state.Actor.AteomPodUid = assignedWorker.GetWorkerPodUid()
+	state.Actor.WorkerPoolName = assignedWorker.GetWorkerPool()
 
 	updatedActor, err := s.store.UpdateActor(ctx, state.Actor, state.Actor.GetMetadata().GetVersion())
 	if err != nil {
 		return err
 	}
 	state.Actor = updatedActor
+	state.Worker = assignedWorker
 	return nil
 }
 

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -298,6 +298,112 @@ func TestAssignWorkerStep_ReleasesIneligibleStaleWorkerInBackground(t *testing.T
 	}
 }
 
+// TestAssignWorkerStep_RetryAfterConflictPicksFreshWorker verifies Execute is
+// reentrant across runStep's persistence-conflict retries: when a concurrent
+// resume wins the picked worker, the loser's retry must drop the stale pick
+// left in state.Worker and re-select from the cache, instead of re-submitting
+// the same stale version until the backoff is exhausted.
+func TestAssignWorkerStep_RetryAfterConflictPicksFreshWorker(t *testing.T) {
+	ctx := context.Background()
+	persistence := newTestPersistence(t)
+
+	contested := &ateapipb.Worker{
+		WorkerNamespace: "worker-ns",
+		WorkerPool:      "pool",
+		WorkerPod:       "contested-pod",
+		SandboxClass:    "gvisor",
+	}
+	fallback := &ateapipb.Worker{
+		WorkerNamespace: "worker-ns",
+		WorkerPool:      "pool",
+		WorkerPod:       "fallback-pod",
+		SandboxClass:    "gvisor",
+	}
+	for _, w := range []*ateapipb.Worker{contested, fallback} {
+		if err := persistence.CreateWorker(ctx, w); err != nil {
+			t.Fatalf("CreateWorker(%s): %v", w.GetWorkerPod(), err)
+		}
+	}
+
+	// Snapshot the contested worker at the version the failed attempt saw.
+	beforeClaim, err := persistence.GetWorker(ctx, "worker-ns", "pool", "contested-pod")
+	if err != nil {
+		t.Fatalf("GetWorker: %v", err)
+	}
+
+	// A concurrent resume of another actor wins the contested worker, bumping
+	// its stored version past the failed attempt's snapshot.
+	claimed := proto.Clone(beforeClaim).(*ateapipb.Worker)
+	claimed.Assignment = &ateapipb.Assignment{
+		Actor: &ateapipb.ObjectRef{Atespace: "team-a", Name: "other"},
+	}
+	if err := persistence.UpdateWorker(ctx, claimed, claimed.GetVersion()); err != nil {
+		t.Fatalf("UpdateWorker (concurrent claim): %v", err)
+	}
+
+	actor, err := persistence.CreateActor(ctx, &ateapipb.Actor{
+		Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "id1"},
+		Status:   ateapipb.Actor_STATUS_SUSPENDED,
+	})
+	if err != nil {
+		t.Fatalf("CreateActor: %v", err)
+	}
+
+	cacheCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	wc := workercache.New(persistence, time.Minute)
+	if err := wc.Start(cacheCtx); err != nil {
+		t.Fatalf("workercache.Start: %v", err)
+	}
+
+	// state.Worker is exactly what the conflicted attempt left behind: the
+	// contested worker mutated with our assignment, at the pre-claim version.
+	stale := proto.Clone(beforeClaim).(*ateapipb.Worker)
+	stale.Assignment = &ateapipb.Assignment{
+		Actor: &ateapipb.ObjectRef{Atespace: "team-a", Name: "id1"},
+	}
+	step := &AssignWorkerStep{store: persistence, workerCache: wc}
+	state := &ResumeState{
+		Actor:  actor,
+		Worker: stale,
+		ActorTemplate: &atev1alpha1.ActorTemplate{
+			Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor},
+		},
+	}
+	if err := step.Execute(ctx, &ResumeInput{ActorName: "id1", Atespace: "team-a"}, state); err != nil {
+		t.Fatalf("Execute() on retry = %v, want nil (must re-pick a free worker)", err)
+	}
+	if got := state.Worker.GetWorkerPod(); got != "fallback-pod" {
+		t.Errorf("assigned worker = %q, want %q", got, "fallback-pod")
+	}
+
+	storedContested, err := persistence.GetWorker(ctx, "worker-ns", "pool", "contested-pod")
+	if err != nil {
+		t.Fatalf("GetWorker(contested-pod): %v", err)
+	}
+	if got := storedContested.GetAssignment().GetActor().GetName(); got != "other" {
+		t.Errorf("contested worker assignment = %v, want to remain with actor %q", storedContested.GetAssignment(), "other")
+	}
+	storedFallback, err := persistence.GetWorker(ctx, "worker-ns", "pool", "fallback-pod")
+	if err != nil {
+		t.Fatalf("GetWorker(fallback-pod): %v", err)
+	}
+	if got := storedFallback.GetAssignment().GetActor().GetName(); got != "id1" {
+		t.Errorf("fallback worker assignment = %v, want actor %q", storedFallback.GetAssignment(), "id1")
+	}
+
+	storedActor, err := persistence.GetActor(ctx, "team-a", "id1")
+	if err != nil {
+		t.Fatalf("GetActor: %v", err)
+	}
+	if storedActor.GetStatus() != ateapipb.Actor_STATUS_RESUMING {
+		t.Errorf("stored actor status = %v, want %v", storedActor.GetStatus(), ateapipb.Actor_STATUS_RESUMING)
+	}
+	if got := storedActor.GetAteomPodName(); got != "fallback-pod" {
+		t.Errorf("stored actor AteomPodName = %q, want %q", got, "fallback-pod")
+	}
+}
+
 // TestResumeActorWorkflow_RejectedAndIdempotentPaths covers the two
 // short-circuit paths of the resume workflow: rejection by AssignWorkerStep's
 // CheckPrerequisite and the IsComplete idempotent fast-forward.


### PR DESCRIPTION
Fixed flakey integration test at head.

Broken test in https://github.com/agent-substrate/substrate/actions/runs/29795626928/job/88526261507 was because, once a old version of worker has been picked and saved in state.worker, retrying no longer picked a new, usable worker. 

Updated the implementation to only update state.worker after having successfully picked and persisted the worker.