### PR TITLE
Rework the Lock API so that locks can be auto-renewed.

### DIFF
--- a/cmd/ateapi/internal/controlapi/workflow.go
+++ b/cmd/ateapi/internal/controlapi/workflow.go
@@ -18,13 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
-	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	grpcCodes "google.golang.org/grpc/codes"
@@ -156,13 +154,11 @@ func (w *ActorWorkflow) ResumeActor(ctx context.Context, atespace, name string, 
 	}
 	state := &ResumeState{}
 
-	// Acquire lock and get the timeout context for the workflow
-	// Lock TTL is 30 seconds, with 2 seconds padding for workflow timeout
-	ctx, releaseLock, err := w.acquireActorLock(ctx, atespace, name, 30*time.Second, 2*time.Second)
+	ctx, lock, err := w.acquireActorLock(ctx, atespace, name)
 	if err != nil {
 		return nil, err
 	}
-	defer releaseLock()
+	defer lock.Close()
 
 	steps := []WorkflowStep[*ResumeInput, *ResumeState]{
 		&LoadActorForResumeStep{store: w.store, actorTemplateLister: w.actorTemplateLister},
@@ -186,13 +182,11 @@ func (w *ActorWorkflow) SuspendActor(ctx context.Context, atespace, name string)
 	}
 	state := &SuspendState{}
 
-	// Acquire lock and get the timeout context for the workflow
-	// Lock TTL is 30 seconds, with 2 seconds padding for workflow timeout
-	ctx, releaseLock, err := w.acquireActorLock(ctx, atespace, name, 30*time.Second, 2*time.Second)
+	ctx, lock, err := w.acquireActorLock(ctx, atespace, name)
 	if err != nil {
 		return nil, err
 	}
-	defer releaseLock()
+	defer lock.Close()
 
 	steps := []WorkflowStep[*SuspendInput, *SuspendState]{
 		&LoadActorForSuspendStep{store: w.store, actorTemplateLister: w.actorTemplateLister},
@@ -216,13 +210,11 @@ func (w *ActorWorkflow) PauseActor(ctx context.Context, atespace, name string) (
 	}
 	state := &PauseState{}
 
-	// Acquire lock and get the timeout context for the workflow
-	// Lock TTL is 30 seconds, with 2 seconds padding for workflow timeout
-	ctx, releaseLock, err := w.acquireActorLock(ctx, atespace, name, 30*time.Second, 2*time.Second)
+	ctx, lock, err := w.acquireActorLock(ctx, atespace, name)
 	if err != nil {
 		return nil, err
 	}
-	defer releaseLock()
+	defer lock.Close()
 
 	steps := []WorkflowStep[*PauseInput, *PauseState]{
 		&LoadActorForPauseStep{store: w.store, actorTemplateLister: w.actorTemplateLister},
@@ -238,27 +230,16 @@ func (w *ActorWorkflow) PauseActor(ctx context.Context, atespace, name string) (
 	return state.Actor, nil
 }
 
-func (w *ActorWorkflow) acquireActorLock(ctx context.Context, atespace, name string, ttl time.Duration, padding time.Duration) (context.Context, func(), error) {
+func (w *ActorWorkflow) acquireActorLock(ctx context.Context, atespace, name string) (context.Context, *store.Lock, error) {
 	lockKey := "lock:actor:" + atespace + ":" + name
-	lockValue := uuid.New().String()
 
-	// Create a child context for the workflow that expires BEFORE the lock
-	workflowTimeout := ttl - padding
-	workflowCtx, cancel := context.WithTimeout(ctx, workflowTimeout)
-
-	acquired, err := w.store.AcquireLock(workflowCtx, lockKey, lockValue, ttl)
+	lock, err := w.store.AcquireLock(ctx, lockKey)
 	if err != nil {
-		cancel()
+		if errors.Is(err, store.ErrLockConflict) {
+			return nil, nil, status.Error(grpcCodes.Aborted, "another operation is in progress for this actor")
+		}
 		return nil, nil, fmt.Errorf("while acquiring lock: %w", err)
 	}
-	if !acquired {
-		cancel()
-		return nil, nil, status.Error(grpcCodes.Aborted, "another operation is in progress for this actor")
-	}
 
-	return workflowCtx, func() {
-		cancel()
-		// Use context.Background() to ensure the lock is released even if the workflow context was canceled.
-		w.store.ReleaseLock(context.Background(), lockKey, lockValue) //nolint:errcheck // best-effort release; the lock TTL is the safety net.
-	}, nil
+	return lock.Context(), lock, nil
 }

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -75,7 +75,8 @@ type redisClient interface {
 
 // Persistence is a service that stores information about applications in Redis.
 type Persistence struct {
-	rdb redisClient
+	rdb     redisClient
+	lockTTL time.Duration
 }
 
 var _ store.Interface = (*Persistence)(nil)
@@ -83,7 +84,8 @@ var _ store.Interface = (*Persistence)(nil)
 // NewPersistence creates a new Persistence.
 func NewPersistence(redisClient *redis.ClusterClient) *Persistence {
 	return &Persistence{
-		rdb: redisClient,
+		rdb:     redisClient,
+		lockTTL: defaultLockTTL,
 	}
 }
 
@@ -767,24 +769,153 @@ func fetchProtos[M proto.Message](ctx context.Context, master *redis.Client, key
 	return out, nil
 }
 
-func (s *Persistence) AcquireLock(ctx context.Context, key string, value string, ttl time.Duration) (bool, error) {
+// lockRenewScript extends key's TTL only if it is still owned by ARGV[1],
+// atomically. Returns 1 if renewed, 0 if the lock was lost (expired and
+// possibly reacquired by someone else, or otherwise deleted).
+var lockRenewScript = redis.NewScript(`
+	if redis.call("get", KEYS[1]) == ARGV[1] then
+		return redis.call("pexpire", KEYS[1], ARGV[2])
+	else
+		return 0
+	end
+`)
+
+// lockReleaseScript deletes key only if it is still owned by ARGV[1],
+// atomically, so a caller can never release a lock it no longer holds.
+var lockReleaseScript = redis.NewScript(`
+	if redis.call("get", KEYS[1]) == ARGV[1] then
+		return redis.call("del", KEYS[1])
+	else
+		return 0
+	end
+`)
+
+// defaultLockTTL is how long a lock may go unrenewed before another client
+// can reclaim it.
+const defaultLockTTL = 30 * time.Second
+
+func (s *Persistence) AcquireLock(ctx context.Context, key string) (*store.Lock, error) {
+	ttl := s.lockTTL
+	value := uuid.New().String()
+
 	ok, err := s.rdb.SetNX(ctx, key, value, ttl).Result()
 	if err != nil {
-		return false, fmt.Errorf("while acquiring lock for %q: %w", key, err)
+		return nil, fmt.Errorf("while acquiring lock for %q: %w", key, err)
 	}
-	return ok, nil
+	if !ok {
+		return nil, store.ErrLockConflict
+	}
+
+	// leaseCtx is cancelled either by Close, or by the renewal loop below if it
+	// ever stops without Close having been called (i.e. the lease was lost).
+	leaseCtx, cancel := context.WithCancel(ctx)
+	renewalDone := make(chan struct{})
+
+	go func() {
+		defer close(renewalDone)
+		defer cancel()
+		s.renewLockLoop(leaseCtx, key, value, ttl)
+	}()
+
+	closeFn := func() {
+		cancel()
+		<-renewalDone // wait for the renewal loop to stop before releasing.
+
+		releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer releaseCancel()
+		if err := s.releaseLock(releaseCtx, key, value); err != nil {
+			slog.WarnContext(releaseCtx, "failed to release lock, relying on TTL to reclaim it", "key", key, "error", err)
+		}
+	}
+
+	return store.NewLock(leaseCtx, closeFn), nil
 }
 
-func (s *Persistence) ReleaseLock(ctx context.Context, key string, value string) error {
-	var luaRelease = redis.NewScript(`
-		if redis.call("get", KEYS[1]) == ARGV[1] then
-			return redis.call("del", KEYS[1])
-		else
-			return 0
-		end
-	`)
+const (
+	// renewIntervalDivisor and renewRetryPeriodDivisor set the renewal loop's
+	// steady-state cadence and in-failure retry spacing as fractions of ttl:
+	// interval = ttl/renewIntervalDivisor, retryPeriod = ttl/renewRetryPeriodDivisor.
+	renewIntervalDivisor    = 3
+	renewRetryPeriodDivisor = 10
+	// renewDeadlineFraction bounds how much of the lock's TTL the renewal loop
+	// may spend retrying after its last successful renewal before conceding the
+	// lease as lost.
+	renewDeadlineFraction = 2.0 / 3.0
+)
 
-	_, err := luaRelease.Run(ctx, s.rdb, []string{key}, value).Result()
+func (s *Persistence) renewLockLoop(ctx context.Context, key, value string, ttl time.Duration) {
+	interval := ttl / renewIntervalDivisor
+	renewDeadline := time.Duration(float64(ttl) * renewDeadlineFraction)
+
+	lastRenewed := time.Now()
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			renewCtx, cancel := context.WithDeadline(ctx, lastRenewed.Add(renewDeadline))
+			renewed := s.tryRenewLock(renewCtx, key, value, ttl)
+			cancel()
+			if !renewed {
+				return
+			}
+			lastRenewed = time.Now()
+			timer.Reset(interval)
+		}
+	}
+}
+
+func (s *Persistence) tryRenewLock(ctx context.Context, key, value string, ttl time.Duration) bool {
+	retryPeriod := ttl / renewRetryPeriodDivisor
+
+	retry := time.NewTimer(0) // first attempt fires immediately.
+	defer retry.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				slog.WarnContext(ctx, "failed to renew lock and its renew deadline has elapsed, treating lease as lost", "key", key)
+			}
+			return false
+
+		case <-retry.C:
+			renewed, err := s.renewLock(ctx, key, value, ttl)
+
+			if ctx.Err() != nil {
+				return false // deadline elapsed or Close raced with this attempt.
+			}
+
+			switch {
+			case err == nil && renewed:
+				return true
+
+			case err == nil && !renewed:
+				slog.WarnContext(ctx, "lock renewal found lease no longer owned", "key", key)
+				return false
+
+			default:
+				slog.WarnContext(ctx, "failed to renew lock, retrying before its renew deadline elapses", "key", key, "error", err)
+				retry.Reset(retryPeriod)
+			}
+		}
+	}
+}
+
+func (s *Persistence) renewLock(ctx context.Context, key, value string, ttl time.Duration) (bool, error) {
+	res, err := lockRenewScript.Run(ctx, s.rdb, []string{key}, value, ttl.Milliseconds()).Result()
+	if err != nil {
+		return false, fmt.Errorf("while renewing lock for %q: %w", key, err)
+	}
+	renewed, _ := res.(int64)
+	return renewed == 1, nil
+}
+
+func (s *Persistence) releaseLock(ctx context.Context, key, value string) error {
+	_, err := lockReleaseScript.Run(ctx, s.rdb, []string{key}, value).Result()
 	if err != nil {
 		return fmt.Errorf("while releasing lock for %q with value %q: %w", key, value, err)
 	}

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
@@ -38,13 +39,14 @@ func setupTest(t *testing.T) (*miniredis.Miniredis, *Persistence, context.Contex
 	if err != nil {
 		t.Fatalf("failed to start miniredis: %v", err)
 	}
+	t.Cleanup(mr.Close)
 	// Miniredis runs as a single node, but ClusterClient can work with it
 	// if we don't use cluster-specific commands that miniredis doesn't support.
 	// Miniredis supports most standard commands.
 	rdb := redis.NewClusterClient(&redis.ClusterOptions{
 		Addrs: []string{mr.Addr()},
 	})
-	return mr, &Persistence{rdb: rdb}, context.Background()
+	return mr, NewPersistence(rdb), t.Context()
 }
 
 // testAtespace is the atespace used by tests that create a single actor. Actors
@@ -61,8 +63,7 @@ var (
 )
 
 func TestGetActor_NotFound(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	_, err := s.GetActor(ctx, testAtespace, "non-existent")
 	if !errors.Is(err, store.ErrNotFound) {
@@ -71,8 +72,7 @@ func TestGetActor_NotFound(t *testing.T) {
 }
 
 func TestCreateActor_Success(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	actor := &ateapipb.Actor{
 		Metadata:               &ateapipb.ResourceMetadata{Name: "session-1", Atespace: testAtespace},
@@ -120,8 +120,7 @@ func TestCreateActor_Success(t *testing.T) {
 }
 
 func TestCreateActor_AlreadyExists(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	actor := &ateapipb.Actor{
 		Metadata:               &ateapipb.ResourceMetadata{Name: "session-1", Atespace: testAtespace},
@@ -142,8 +141,7 @@ func TestCreateActor_AlreadyExists(t *testing.T) {
 }
 
 func TestUpdateActor_Success(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	actor := &ateapipb.Actor{
 		Metadata:               &ateapipb.ResourceMetadata{Name: "session-1", Atespace: testAtespace},
@@ -195,8 +193,7 @@ func TestUpdateActor_Success(t *testing.T) {
 }
 
 func TestUpdateActor_Conflict(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	actor := &ateapipb.Actor{
 		Metadata:               &ateapipb.ResourceMetadata{Name: "session-1", Atespace: testAtespace},
@@ -238,8 +235,7 @@ func TestUpdateActor_Conflict(t *testing.T) {
 }
 
 func TestGetWorker_NotFound(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	_, err := s.GetWorker(ctx, "default", "pool-1", "non-existent")
 	if !errors.Is(err, store.ErrNotFound) {
@@ -248,8 +244,7 @@ func TestGetWorker_NotFound(t *testing.T) {
 }
 
 func TestCreateWorker_Success(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	watch, err := s.WatchWorkers(ctx)
 	if err != nil {
@@ -291,8 +286,7 @@ func TestCreateWorker_Success(t *testing.T) {
 }
 
 func TestUpdateWorker_Success(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	worker := &ateapipb.Worker{
 		WorkerNamespace: "default",
@@ -348,8 +342,7 @@ func TestUpdateWorker_Success(t *testing.T) {
 }
 
 func TestDeleteWorker(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	worker := &ateapipb.Worker{
 		WorkerNamespace: "default",
@@ -400,8 +393,7 @@ func TestDeleteActor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mr, s, ctx := setupTest(t)
-			defer mr.Close()
+			_, s, ctx := setupTest(t)
 
 			actor := &ateapipb.Actor{
 				Metadata:               &ateapipb.ResourceMetadata{Name: "session-1", Atespace: testAtespace},
@@ -437,8 +429,7 @@ func TestDeleteActor(t *testing.T) {
 }
 
 func TestDeleteActor_NotFound(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	_, err := s.DeleteActor(ctx, testAtespace, "non-existent")
 	if !errors.Is(err, store.ErrNotFound) {
@@ -447,8 +438,7 @@ func TestDeleteActor_NotFound(t *testing.T) {
 }
 
 func TestListWorkers(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	worker1 := &ateapipb.Worker{
 		WorkerNamespace: "ns1",
@@ -492,8 +482,7 @@ func TestListWorkers(t *testing.T) {
 }
 
 func TestListActors(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	actor1 := &ateapipb.Actor{
 
@@ -555,8 +544,7 @@ func TestListActors(t *testing.T) {
 }
 
 func TestUpdateWorker_Conflict(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	worker := &ateapipb.Worker{
 		WorkerNamespace: "default",
@@ -597,8 +585,7 @@ func TestUpdateWorker_Conflict(t *testing.T) {
 }
 
 func TestCreateWorker_AlreadyExists(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	worker := &ateapipb.Worker{
 		WorkerNamespace: "default",
@@ -618,8 +605,7 @@ func TestCreateWorker_AlreadyExists(t *testing.T) {
 }
 
 func TestListWorkers_Empty(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	workers, _, err := s.ListWorkers(ctx, 1000, "")
 	if err != nil {
@@ -632,8 +618,7 @@ func TestListWorkers_Empty(t *testing.T) {
 }
 
 func TestListWorkers_Pagination(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	for i := 0; i < 5; i++ {
 		worker := &ateapipb.Worker{
@@ -676,8 +661,7 @@ func TestListWorkers_Pagination(t *testing.T) {
 }
 
 func TestListAtespaces_Pagination(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	for i := 0; i < 5; i++ {
 		if _, err := s.CreateAtespace(ctx, newTestAtespace(fmt.Sprintf("team-%d", i))); err != nil {
@@ -715,8 +699,7 @@ func TestListAtespaces_Pagination(t *testing.T) {
 }
 
 func TestListActors_Empty(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	actors, _, err := s.ListActors(ctx, "", 1000, "")
 	if err != nil {
@@ -729,8 +712,7 @@ func TestListActors_Empty(t *testing.T) {
 }
 
 func TestListActors_Pagination(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	for i := 0; i < 5; i++ {
 		actor := &ateapipb.Actor{
@@ -775,158 +757,343 @@ func TestListActors_Pagination(t *testing.T) {
 
 func TestAcquireLock_Success(t *testing.T) {
 	mr, s, ctx := setupTest(t)
-	defer mr.Close()
 
 	key := "test-lock"
-	value := "token-1"
-	wrongValue := "token-2"
-	newValue := "token-3"
-	ttl := 10 * time.Second
 
-	// 1. Acquire lock
-	acquired, err := s.AcquireLock(ctx, key, value, ttl)
+	lock, err := s.AcquireLock(ctx, key)
 	if err != nil {
 		t.Fatalf("AcquireLock failed: %v", err)
 	}
-	if !acquired {
-		t.Errorf("expected lock to be acquired")
-	}
+	defer lock.Close()
 
-	// 2. Try to release with WRONG value
-	err = s.ReleaseLock(ctx, key, wrongValue)
-	if err != nil {
-		t.Fatalf("ReleaseLock failed: %v", err)
-	}
-
-	// Verify it is STILL THERE by trying to acquire it again
-	acquired, err = s.AcquireLock(ctx, key, newValue, ttl)
-	if err != nil {
-		t.Fatalf("AcquireLock failed: %v", err)
-	}
-	if acquired {
-		t.Errorf("expected lock to still be held by token-1, but token-3 successfully acquired it!")
-	}
-
-	// 3. Try to release with CORRECT value
-	err = s.ReleaseLock(ctx, key, value)
-	if err != nil {
-		t.Fatalf("ReleaseLock failed: %v", err)
-	}
-
-	// Verify it is GONE by trying to acquire it again!
-	acquired, err = s.AcquireLock(ctx, key, newValue, ttl)
-	if err != nil {
-		t.Fatalf("AcquireLock failed: %v", err)
-	}
-	if !acquired {
-		t.Errorf("expected lock to be free, but it could not be acquired!")
+	if !mr.Exists(key) {
+		t.Errorf("expected lock key to exist after AcquireLock")
 	}
 }
 
 func TestAcquireLock_Conflict(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	key := "test-lock"
-	value1 := "token-1"
-	value2 := "token-2"
-	ttl := 10 * time.Second
 
-	acquired, err := s.AcquireLock(ctx, key, value1, ttl)
+	lock, err := s.AcquireLock(ctx, key)
 	if err != nil {
 		t.Fatalf("first AcquireLock failed: %v", err)
 	}
-	if !acquired {
-		t.Fatalf("expected first lock to be acquired")
-	}
+	defer lock.Close()
 
-	acquired, err = s.AcquireLock(ctx, key, value2, ttl)
-	if err != nil {
-		t.Fatalf("second AcquireLock failed: %v", err)
-	}
-	if acquired {
-		t.Errorf("expected second lock to fail (conflict)")
+	_, err = s.AcquireLock(ctx, key)
+	if !errors.Is(err, store.ErrLockConflict) {
+		t.Errorf("second AcquireLock error = %v, want ErrLockConflict", err)
 	}
 }
 
-func TestReleaseLock_Success(t *testing.T) {
+func TestLock_Close_ReleasesLockImmediately(t *testing.T) {
 	mr, s, ctx := setupTest(t)
-	defer mr.Close()
 
 	key := "test-lock"
-	value := "token-1"
-	ttl := 10 * time.Second
 
-	s.AcquireLock(ctx, key, value, ttl)
-
-	err := s.ReleaseLock(ctx, key, value)
+	lock, err := s.AcquireLock(ctx, key)
 	if err != nil {
-		t.Fatalf("ReleaseLock failed: %v", err)
+		t.Fatalf("AcquireLock failed: %v", err)
 	}
 
-	// Verify it's gone
+	lock.Close()
+
+	// Close should release the key immediately rather than making the next
+	// caller wait out the rest of the TTL.
 	if mr.Exists(key) {
-		t.Errorf("expected lock to be deleted")
+		t.Errorf("expected lock to be deleted after Close")
+	}
+
+	next, err := s.AcquireLock(ctx, key)
+	if err != nil {
+		t.Fatalf("AcquireLock after Close failed: %v", err)
+	}
+	next.Close()
+}
+
+func TestLock_Close_CancelsContext(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	lock, err := s.AcquireLock(ctx, "test-lock")
+	if err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+
+	lock.Close()
+
+	select {
+	case <-lock.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("expected lock.Context() to be cancelled after Close")
 	}
 }
 
-func TestReleaseLock_Unsafe(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+func TestLock_Close_ReleasesEvenAfterParentContextCancelled(t *testing.T) {
+	mr, s, _ := setupTest(t)
 
 	key := "test-lock"
-	value1 := "token-1"
-	value2 := "token-2"
-	value3 := "token-3"
-	ttl := 10 * time.Second
+	parentCtx, parentCancel := context.WithCancel(context.Background())
 
-	s.AcquireLock(ctx, key, value1, ttl)
-
-	// Try to release with WRONG token
-	err := s.ReleaseLock(ctx, key, value2)
-	if err != nil {
-		t.Fatalf("ReleaseLock failed: %v", err)
-	}
-
-	// Verify it is STILL THERE by trying to acquire it again!
-	acquired, err := s.AcquireLock(ctx, key, value3, ttl)
+	lock, err := s.AcquireLock(parentCtx, key)
 	if err != nil {
 		t.Fatalf("AcquireLock failed: %v", err)
 	}
-	if acquired {
-		t.Errorf("expected lock to still be held by token-1, but token-3 successfully acquired it!")
+
+	// Simulate the caller's own context dying independently of Close, e.g. an
+	// upstream RPC deadline. The renewal loop should stop as a result.
+	parentCancel()
+
+	select {
+	case <-lock.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("expected lock.Context() to be cancelled once the parent context is cancelled")
+	}
+
+	// A real caller's `defer lock.Close()` still runs after this. Close must
+	// still release the key even though the context it was acquired with is
+	// already dead, since it releases via context.Background() internally.
+	lock.Close()
+
+	if mr.Exists(key) {
+		t.Errorf("expected Close to release the lock even though the parent context was already cancelled")
 	}
 }
 
-func TestAcquireLock_TTLExpiration(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+func TestAcquireLock_ExpiresAndIsReacquirableAfterHolderCrashes(t *testing.T) {
+	mr, s, _ := setupTest(t)
 
 	key := "test-lock"
-	value1 := "token-1"
-	value2 := "token-2"
-	ttl := 5 * time.Second
+	ttl := 300 * time.Millisecond
+	s.lockTTL = ttl
 
-	// 1. Acquire lock
-	acquired, err := s.AcquireLock(ctx, key, value1, ttl)
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	lock, err := s.AcquireLock(parentCtx, key)
 	if err != nil {
 		t.Fatalf("AcquireLock failed: %v", err)
 	}
-	if !acquired {
-		t.Fatalf("expected lock to be acquired")
+
+	// Simulate a hard crash: the holder disappears without ever calling
+	// Close (e.g. the process is killed), so the key is never explicitly
+	// released and is left to expire on its own TTL. Canceling the parent
+	// context stops the renewal loop the same way process death would,
+	// without releasing the key the way Close does.
+	parentCancel()
+	select {
+	case <-lock.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("expected lock.Context() to be cancelled once the parent context is cancelled")
 	}
 
-	// 2. Fast-forward time past TTL
-	mr.FastForward(6 * time.Second)
+	if !mr.Exists(key) {
+		t.Fatal("expected the key to still exist right after the crash; only Close deletes it")
+	}
+	if _, err := s.AcquireLock(context.Background(), key); !errors.Is(err, store.ErrLockConflict) {
+		t.Errorf("AcquireLock before TTL expiry: err = %v, want ErrLockConflict", err)
+	}
 
-	// 3. Try to acquire again with different token
-	acquired, err = s.AcquireLock(ctx, key, value2, ttl)
+	// Simulate real time passing with no renewer left alive, until the key's
+	// actual Redis TTL elapses. miniredis's TTLs are purely virtual --
+	// stored durations decremented only by FastForward, never by wall-clock
+	// time -- so a real time.Sleep here would not expire the key at all.
+	mr.FastForward(ttl + time.Second)
+
+	if mr.Exists(key) {
+		t.Fatal("expected the key to have expired in Redis once its TTL elapsed")
+	}
+
+	newOwner, err := s.AcquireLock(context.Background(), key)
+	if err != nil {
+		t.Fatalf("AcquireLock after crash + TTL expiry failed: %v", err)
+	}
+	defer newOwner.Close()
+}
+
+func TestLock_Close_DoesNotStealALockReacquiredAfterLeaseLoss(t *testing.T) {
+	mr, s, ctx := setupTest(t)
+
+	key := "test-lock"
+	ttl := 300 * time.Millisecond
+	s.lockTTL = ttl
+
+	lock, err := s.AcquireLock(ctx, key)
 	if err != nil {
 		t.Fatalf("AcquireLock failed: %v", err)
 	}
-	if !acquired {
-		t.Errorf("expected lock to be acquired by token-2 after TTL expiration")
+
+	// Lose the lease out from under the renewal loop.
+	mr.Del(key)
+	select {
+	case <-lock.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("expected lock.Context() to be cancelled once the lease is lost")
 	}
+
+	// A different holder acquires the same key once it's free.
+	newOwner, err := s.AcquireLock(ctx, key)
+	if err != nil {
+		t.Fatalf("AcquireLock by new owner failed: %v", err)
+	}
+	defer newOwner.Close()
+
+	// The original Lock no longer owns the key; Close must be a safe no-op
+	// rather than deleting the new owner's lock out from under it.
+	lock.Close()
+
+	if !mr.Exists(key) {
+		t.Errorf("expected the new owner's lock to survive the old Lock's Close, but the key was deleted")
+	}
+}
+
+func TestLock_Close_Idempotent(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	lock, err := s.AcquireLock(ctx, "test-lock")
+	if err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+
+	lock.Close()
+	lock.Close() // must not panic or double-release.
+}
+
+func TestRenewDeadlineFractionLeavesRetryHeadroom(t *testing.T) {
+	const minRetries = 2
+
+	intervalFraction := 1.0 / renewIntervalDivisor
+	retryPeriodFraction := 1.0 / renewRetryPeriodDivisor
+	floor := intervalFraction + minRetries*retryPeriodFraction
+
+	if renewDeadlineFraction <= floor {
+		t.Fatalf("renewDeadlineFraction (%v) must exceed intervalFraction + %d*retryPeriodFraction (%v) to leave room for %d retries; "+
+			"at or below intervalFraction (%v) alone, the very first renewal attempt would already find the deadline elapsed",
+			renewDeadlineFraction, minRetries, floor, minRetries, intervalFraction)
+	}
+}
+
+func TestAcquireLock_RenewsUntilClosed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mock := &mockRedisClient{SetNXFunc: acquires, EvalShaFunc: renews}
+		s := &Persistence{rdb: mock, lockTTL: defaultLockTTL}
+
+		lock, err := s.AcquireLock(t.Context(), "test-lock")
+		if err != nil {
+			t.Fatalf("AcquireLock failed: %v", err)
+		}
+		defer lock.Close()
+
+		time.Sleep(3 * defaultLockTTL)
+		synctest.Wait()
+
+		if err := lock.Context().Err(); err != nil {
+			t.Errorf("lock.Context().Err() = %v, want nil (lease still held)", err)
+		}
+	})
+}
+
+func TestLock_ContextCancelled_OnLeaseLost(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mock := &mockRedisClient{SetNXFunc: acquires, EvalShaFunc: leaseLost}
+		s := &Persistence{rdb: mock, lockTTL: defaultLockTTL}
+
+		lock, err := s.AcquireLock(t.Context(), "test-lock")
+		if err != nil {
+			t.Fatalf("AcquireLock failed: %v", err)
+		}
+		defer lock.Close()
+
+		time.Sleep(defaultLockTTL)
+		synctest.Wait()
+
+		if err := lock.Context().Err(); err == nil {
+			t.Error("expected lock.Context() to be cancelled once renewal detects the lease is lost")
+		}
+	})
+}
+
+func TestAcquireLock_RenewalRecoversFromTransientError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Clears with margin to spare before the renew deadline, after a
+		// couple of retryPeriod-spaced attempts.
+		renewDeadline := time.Duration(float64(defaultLockTTL) * renewDeadlineFraction)
+		retryPeriod := defaultLockTTL / renewRetryPeriodDivisor
+		errorClearsAt := time.Now().Add(renewDeadline - 2*retryPeriod)
+
+		mock := &mockRedisClient{SetNXFunc: acquires, EvalShaFunc: failsUntil(errorClearsAt, errors.New("connection refused"))}
+		s := &Persistence{rdb: mock, lockTTL: defaultLockTTL}
+
+		lock, err := s.AcquireLock(t.Context(), "test-lock")
+		if err != nil {
+			t.Fatalf("AcquireLock failed: %v", err)
+		}
+		defer lock.Close()
+
+		time.Sleep(2 * defaultLockTTL)
+		synctest.Wait()
+
+		if err := lock.Context().Err(); err != nil {
+			t.Errorf("lock.Context().Err() = %v, want nil (renewal should have recovered from the transient error)", err)
+		}
+	})
+}
+
+func TestAcquireLock_RenewalGivesUpOncePersistentErrorOutlastsTTL(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mock := &mockRedisClient{SetNXFunc: acquires, EvalShaFunc: failsWith(errors.New("connection refused"))}
+		s := &Persistence{rdb: mock, lockTTL: defaultLockTTL}
+
+		lock, err := s.AcquireLock(t.Context(), "test-lock")
+		if err != nil {
+			t.Fatalf("AcquireLock failed: %v", err)
+		}
+		defer lock.Close()
+
+		time.Sleep(defaultLockTTL) // past the renew deadline (renewDeadlineFraction * defaultLockTTL)
+		synctest.Wait()
+
+		if err := lock.Context().Err(); err == nil {
+			t.Error("expected lock.Context() to be cancelled once the persistent error outlasts the renew deadline")
+		}
+	})
+}
+
+func TestAcquireLock_RenewalGivesUpWhenRedisHangsUntilDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mock := &mockRedisClient{SetNXFunc: acquires, EvalShaFunc: hangs}
+		s := &Persistence{rdb: mock, lockTTL: defaultLockTTL}
+
+		lock, err := s.AcquireLock(t.Context(), "test-lock")
+		if err != nil {
+			t.Fatalf("AcquireLock failed: %v", err)
+		}
+
+		time.Sleep(defaultLockTTL)
+		synctest.Wait()
+
+		if err := lock.Context().Err(); err == nil {
+			t.Error("expected lock.Context() to be cancelled once every renewal attempt hangs past the renew deadline")
+		}
+	})
+}
+
+func TestAcquireLock_RenewalGivesUpAfterMixOfFastFailuresThenHang(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mock := &mockRedisClient{SetNXFunc: acquires, EvalShaFunc: failsNTimesThenHangs(2, errors.New("connection refused"))}
+		s := &Persistence{rdb: mock, lockTTL: defaultLockTTL}
+
+		lock, err := s.AcquireLock(t.Context(), "test-lock")
+		if err != nil {
+			t.Fatalf("AcquireLock failed: %v", err)
+		}
+
+		time.Sleep(defaultLockTTL)
+		synctest.Wait()
+
+		if err := lock.Context().Err(); err == nil {
+			t.Error("expected lock.Context() to be cancelled once the renew deadline elapses, whether attempts fail fast or hang")
+		}
+	})
 }
 
 func receiveEvent(t *testing.T, ch <-chan store.WorkerEvent) store.WorkerEvent {
@@ -943,36 +1110,8 @@ func receiveEvent(t *testing.T, ch <-chan store.WorkerEvent) store.WorkerEvent {
 	}
 }
 
-func TestAcquireLock_NonReentry(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
-
-	key := "test-lock"
-	value := "token-1"
-	ttl := 10 * time.Second
-
-	// 1. Acquire lock first time
-	acquired, err := s.AcquireLock(ctx, key, value, ttl)
-	if err != nil {
-		t.Fatalf("first AcquireLock failed: %v", err)
-	}
-	if !acquired {
-		t.Fatalf("expected first lock to be acquired")
-	}
-
-	// 2. Try to acquire lock again with SAME token
-	acquired, err = s.AcquireLock(ctx, key, value, ttl)
-	if err != nil {
-		t.Fatalf("second AcquireLock failed: %v", err)
-	}
-	if acquired {
-		t.Errorf("expected second lock acquisition to fail (non-reentrant)")
-	}
-}
-
 func TestListActors_ScopedByAtespace(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	mkActor := func(atespace, name string) *ateapipb.Actor {
 		return &ateapipb.Actor{
@@ -1043,8 +1182,7 @@ func newTestAtespace(name string) *ateapipb.Atespace {
 }
 
 func TestCreateAtespace_Success(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	want := newTestAtespace("team-a")
 	created, err := s.CreateAtespace(ctx, want)
@@ -1076,8 +1214,7 @@ func TestCreateAtespace_Success(t *testing.T) {
 }
 
 func TestCreateAtespace_AlreadyExists(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	if _, err := s.CreateAtespace(ctx, newTestAtespace("team-a")); err != nil {
 		t.Fatalf("first CreateAtespace failed: %v", err)
@@ -1088,8 +1225,7 @@ func TestCreateAtespace_AlreadyExists(t *testing.T) {
 }
 
 func TestGetAtespace_NotFound(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	if _, err := s.GetAtespace(ctx, "nope"); !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
@@ -1097,8 +1233,7 @@ func TestGetAtespace_NotFound(t *testing.T) {
 }
 
 func TestAtespaceExists(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	if ok, err := s.AtespaceExists(ctx, "team-a"); err != nil || ok {
 		t.Fatalf("AtespaceExists before create = (%v, %v), want (false, nil)", ok, err)
@@ -1112,8 +1247,7 @@ func TestAtespaceExists(t *testing.T) {
 }
 
 func TestListAtespaces(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	names := []string{"team-a", "team-b", "team-c"}
 	for _, n := range names {
@@ -1140,8 +1274,7 @@ func TestListAtespaces(t *testing.T) {
 }
 
 func TestListAtespaces_Empty(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	got, _, err := s.ListAtespaces(ctx, 1000, "")
 	if err != nil {
@@ -1153,8 +1286,7 @@ func TestListAtespaces_Empty(t *testing.T) {
 }
 
 func TestDeleteAtespace_Empty(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	if _, err := s.CreateAtespace(ctx, newTestAtespace("team-a")); err != nil {
 		t.Fatalf("CreateAtespace failed: %v", err)
@@ -1173,8 +1305,7 @@ func TestDeleteAtespace_Empty(t *testing.T) {
 }
 
 func TestDeleteAtespace_NotFound(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	if _, err := s.DeleteAtespace(ctx, "nope"); !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
@@ -1182,8 +1313,7 @@ func TestDeleteAtespace_NotFound(t *testing.T) {
 }
 
 func TestDeleteAtespace_NonEmpty_Rejected(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	if _, err := s.CreateAtespace(ctx, newTestAtespace("team-a")); err != nil {
 		t.Fatalf("CreateAtespace failed: %v", err)
@@ -1201,8 +1331,7 @@ func TestDeleteAtespace_NonEmpty_Rejected(t *testing.T) {
 }
 
 func TestDeleteAtespace_EmptyAfterActorsRemoved(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	if _, err := s.CreateAtespace(ctx, newTestAtespace("team-a")); err != nil {
 		t.Fatalf("CreateAtespace failed: %v", err)
@@ -1222,8 +1351,7 @@ func TestDeleteAtespace_EmptyAfterActorsRemoved(t *testing.T) {
 }
 
 func TestDeleteAtespace_EmptyWhileOtherAtespaceNonEmpty(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
+	_, s, ctx := setupTest(t)
 
 	if _, err := s.CreateAtespace(ctx, newTestAtespace("team-a")); err != nil {
 		t.Fatalf("CreateAtespace(team-a) failed: %v", err)
@@ -1330,7 +1458,6 @@ func TestListActors_MultiMaster_Pagination(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to start miniredis %d: %v", i, err)
 		}
-		defer mr.Close()
 
 		client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 		clusterClient := redis.NewClusterClient(&redis.ClusterOptions{Addrs: []string{mr.Addr()}})
@@ -1526,5 +1653,103 @@ func TestListAtespaces_MultiMaster_Pagination(t *testing.T) {
 				t.Fatalf("expected %d atespaces across %d shards, got %d", numShards*3, numShards, len(seen))
 			}
 		})
+	}
+}
+
+type setNXFunc func(ctx context.Context, key string, value interface{}, ttl time.Duration) *redis.BoolCmd
+
+type evalFunc func(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd
+
+type mockRedisClient struct {
+	redisClient
+
+	SetNXFunc   setNXFunc
+	EvalShaFunc evalFunc
+}
+
+func (m *mockRedisClient) SetNX(ctx context.Context, key string, value interface{}, ttl time.Duration) *redis.BoolCmd {
+	return m.SetNXFunc(ctx, key, value, ttl)
+}
+
+func (m *mockRedisClient) EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd {
+	return m.EvalShaFunc(ctx, sha1, keys, args...)
+}
+
+// intCmd and errCmd build the two possible shapes of a script-eval result:
+// intCmd for the CAS script's 1 (applied) / 0 (not owned) return value, and
+// errCmd for a failed call.
+func intCmd(ctx context.Context, v int64) *redis.Cmd {
+	cmd := redis.NewCmd(ctx)
+	cmd.SetVal(v)
+	return cmd
+}
+
+func errCmd(ctx context.Context, err error) *redis.Cmd {
+	cmd := redis.NewCmd(ctx)
+	cmd.SetErr(err)
+	return cmd
+}
+
+// acquires is a setNXFunc reporting the lock was acquired.
+func acquires(ctx context.Context, key string, value interface{}, ttl time.Duration) *redis.BoolCmd {
+	cmd := redis.NewBoolCmd(ctx)
+	cmd.SetVal(true)
+	return cmd
+}
+
+// renews is an evalFunc reporting a successful renewal.
+func renews(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd {
+	return intCmd(ctx, 1)
+}
+
+// leaseLost is an evalFunc reporting that the CAS check found we no longer
+// own the key (someone else took over, or it was deleted) -- Mode 6: an
+// authoritative "you don't hold this anymore," not a retryable failure.
+func leaseLost(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd {
+	return intCmd(ctx, 0)
+}
+
+// failsWith returns an evalFunc that always fails fast with err.
+func failsWith(err error) evalFunc {
+	return func(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd {
+		return errCmd(ctx, err)
+	}
+}
+
+// hangs is an evalFunc that blocks until ctx is done, simulating an
+// unresponsive Redis.
+func hangs(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd {
+	<-ctx.Done()
+	return errCmd(ctx, ctx.Err())
+}
+
+// failsUntil returns an evalFunc that fails fast with err until t, then
+// reports a successful renewal.
+func failsUntil(t time.Time, err error) evalFunc {
+	return func(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd {
+		if time.Now().Before(t) {
+			return errCmd(ctx, err)
+		}
+		return intCmd(ctx, 1)
+	}
+}
+
+// failsNTimesThenHangs returns an evalFunc that fails fast with err for its
+// first n calls, then hangs (as hangs does) on every call after that.
+func failsNTimesThenHangs(n int, err error) evalFunc {
+	var mu sync.Mutex
+	left := n
+	return func(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd {
+		mu.Lock()
+		fail := left > 0
+		if fail {
+			left--
+		}
+		mu.Unlock()
+
+		if fail {
+			return errCmd(ctx, err)
+		}
+		return hangs(ctx, sha1, keys, args...)
 	}
 }

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -18,7 +18,7 @@ package store
 import (
 	"context"
 	"errors"
-	"time"
+	"sync"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 )
@@ -35,6 +35,9 @@ var (
 
 	// ErrFailedPrecondition indicates the object is not in the required state for the operation.
 	ErrFailedPrecondition = errors.New("persistence: failed precondition")
+
+	// ErrLockConflict indicates that a distributed lock is already held by another client.
+	ErrLockConflict = errors.New("persistence: lock conflict")
 )
 
 // Interface defines the contract for the persistence layer storing actor state.
@@ -101,17 +104,10 @@ type Interface interface {
 	// must Close the watch to release its subscription.
 	WatchWorkers(ctx context.Context) (*WorkerWatch, error)
 
-	// AcquireLock attempts to acquire a distributed lock with a TTL.
-	// Returns true if the lock was successfully acquired.
-	// Returns false if the lock is already held by another client (conflict).
-	// Returns an error only on database failure.
-	// The value must be a unique token (e.g., UUID) to ensure safe release.
-	AcquireLock(ctx context.Context, key string, value string, ttl time.Duration) (bool, error)
-
-	// ReleaseLock releases a distributed lock if the stored value matches the passed value.
-	// Returns nil if the lock was successfully released or if the lock was not held by this value.
-	// Returns an error only on database failure.
-	ReleaseLock(ctx context.Context, key string, value string) error
+	// AcquireLock attempts to acquire a distributed lock for key. The lock is
+	// held and renewed automatically until the returned Lock is closed.
+	// Returns ErrLockConflict if the lock is already held by another client.
+	AcquireLock(ctx context.Context, key string) (*Lock, error)
 
 	// DebugClearAll drop all data from the database. Useful for debugging / local testing/
 	DebugClearAll(ctx context.Context) error
@@ -152,3 +148,28 @@ func NewWorkerWatch(events <-chan WorkerEvent, stop context.CancelFunc) *WorkerW
 
 // Close releases the subscription. Safe to call multiple times.
 func (w *WorkerWatch) Close() { w.stop() }
+
+// Lock represents a held distributed lock that is renewed automatically until
+// Close is called. If renewal cannot keep the lease alive, the context
+// returned by Context is cancelled so the caller can detect it may no
+// longer have exclusive access.
+type Lock struct {
+	ctx     context.Context
+	closeFn func()
+	once    sync.Once
+}
+
+// NewLock builds a Lock from its lease context (cancelled on loss or Close)
+// and the func that stops lease renewal and releases the lock.
+func NewLock(ctx context.Context, closeFn func()) *Lock {
+	return &Lock{ctx: ctx, closeFn: closeFn}
+}
+
+// Context returns a context derived from the context AcquireLock was called
+// with. It is cancelled when Close is called, or earlier if the lease is
+// lost.
+func (l *Lock) Context() context.Context { return l.ctx }
+
+// Close stops lease renewal and releases the lock. Safe to call multiple
+// times.
+func (l *Lock) Close() { l.once.Do(l.closeFn) }

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -53,6 +53,9 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// maxRPCDeadline is the max deadline for all RPC methods exposed by this server.
+const maxRPCDeadline = 10 * time.Minute
+
 var (
 	listenAddr           = pflag.String("grpc-listen-addr", ":443", "Address and port the gRPC server should listen on.")
 	metricsListenAddr    = pflag.String("metrics-listen-addr", ":9090", "Address and port the prometheus metrics server should listen on.")
@@ -184,6 +187,7 @@ func main() {
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainUnaryInterceptor(
 			ateapiauth.UnaryServerInterceptor(authCfg),
+			ateinterceptors.MaxDeadlineUnaryInterceptor(maxRPCDeadline),
 			ateinterceptors.ServerUnaryInterceptor,
 		),
 		grpc.ChainStreamInterceptor(

--- a/internal/ateinterceptors/ateinterceptors.go
+++ b/internal/ateinterceptors/ateinterceptors.go
@@ -71,6 +71,15 @@ func ServerUnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServer
 	return resp, err
 }
 
+// MaxDeadlineUnaryInterceptor returns an interceptor that caps the request context at maxDeadline.
+func MaxDeadlineUnaryInterceptor(maxDeadline time.Duration) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		ctx, cancel := context.WithTimeout(ctx, maxDeadline)
+		defer cancel()
+		return handler(ctx, req)
+	}
+}
+
 // InternalServerUnaryInterceptor is for internal services to return full gRPC errors with specific error codes and debugging details.
 func InternalServerUnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	startTime := time.Now()

--- a/internal/ateinterceptors/ateinterceptors_test.go
+++ b/internal/ateinterceptors/ateinterceptors_test.go
@@ -219,6 +219,77 @@ func TestServerUnaryInterceptorEmitsElapsedTrailer(t *testing.T) {
 	}
 }
 
+func TestMaxDeadlineUnaryInterceptor_MaxDeadlineIsEnforced(t *testing.T) {
+	const ceiling = 50 * time.Millisecond
+
+	tests := []struct {
+		name      string
+		callerCtx func() (context.Context, context.CancelFunc)
+	}{
+		{
+			name: "no caller deadline",
+			callerCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+		},
+		{
+			name: "caller deadline longer than ceiling",
+			callerCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), time.Hour)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interceptor := MaxDeadlineUnaryInterceptor(ceiling)
+
+			callerCtx, cancel := tt.callerCtx()
+			defer cancel()
+
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				gotDeadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatalf("expected the ceiling deadline to be present")
+				}
+				if until := time.Until(gotDeadline); until > ceiling {
+					t.Errorf("time until deadline = %v, want at most the %v ceiling", until, ceiling)
+				}
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}
+
+			_, err := interceptor(callerCtx, "request", &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, handler)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("err = %v, want context.DeadlineExceeded (should not have waited out the caller's own deadline)", err)
+			}
+		})
+	}
+}
+
+func TestMaxDeadlineUnaryInterceptor_ShorterDeadlineIsPreserved(t *testing.T) {
+	interceptor := MaxDeadlineUnaryInterceptor(time.Hour)
+
+	callerCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	callerDeadline, _ := callerCtx.Deadline()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		gotDeadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatalf("expected the caller's shorter deadline to be preserved")
+		}
+		if !gotDeadline.Equal(callerDeadline) {
+			t.Errorf("deadline = %v, want caller's deadline %v (a ceiling above the caller's own deadline must not override it)", gotDeadline, callerDeadline)
+		}
+		return "response", nil
+	}
+
+	if _, err := interceptor(callerCtx, "request", &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, handler); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestServerUnaryInterceptorRedactsEnvFromProtoRequestLogs(t *testing.T) {
 	var log bytes.Buffer
 	origLogger := slog.Default()


### PR DESCRIPTION
Instead of requiring callers to specify a fixed deadline for the lock, let the store return a `Lock` object that performs auto-renewal in background.

This fixes an issue when a workflow takes longer than the hard-coded TTL, most commonly when atelet takes long times to initialize an actor (e.g. pulling / untaring large OCI images).

Leases are taken for 30 seconds, but renewed every 10 seconds (TTL/3).

Removing that implicit TTL-based limit means a caller that sets no deadline of its own (e.g. kubectl-ate) could otherwise hang a Resume/Suspend/Pause indefinitely. MaxDeadlineUnaryInterceptor adds a 10-minute ceiling on every RPC as a hang-prevention backstop.
