### PR TITLE
Make sure valkey reload certs before the cached one expires

### DIFF
--- a/manifests/ate-install/valkey.yaml
+++ b/manifests/ate-install/valkey.yaml
@@ -30,8 +30,11 @@ data:
     tls-key-file /run/servicedns.podcert.ate.dev/credential-bundle.pem
     tls-ca-cert-file /etc/valkey-ca/ca.crt
     tls-auth-clients yes
-    # Reload the cert every 12h.
-    tls-auto-reload-interval 43200
+
+    # Reload every 10 minutes. 
+    # The interval should be less than the 30m headroom (notAfter - beginRefreshAt) 
+    # set by cmd/podcertcontroller/internal/servicednssigner/servicednssigner.go.
+    tls-auto-reload-interval 600
 
     # Enable cluster mode
     cluster-enabled yes


### PR DESCRIPTION
The new refresh interval is set to 10m, less than the 30m headroom set by https://github.com/agent-substrate/substrate/blob/73b824057a71c26f5593adf5ae46c50f6c6d65be/cmd/podcertcontroller/internal/servicednssigner/servicednssigner.go#L157