### PR TITLE
microvm: bump runtime assets to kata 4.0.0 + virtiofsd v1.14.0

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -20,7 +20,7 @@ on:
   schedule:
     # Weekly run on the default branch keeps the micro-VM asset cache warm (GitHub
     # evicts caches idle for 7 days). The push-to-main run populates the cache that
-    # PRs inherit; this refreshes it so PRs keep hitting it (no virtiofsd rebuild).
+    # PRs inherit; this refreshes it so PRs keep hitting it (no asset re-download).
     - cron: '37 4 * * 1'
 jobs:
   run-tests:
@@ -57,21 +57,13 @@ jobs:
       id: microvm-assets
       uses: actions/cache@v4
       with:
-        # Assembling the assets (download kata-static + cloud-hypervisor, build
-        # virtiofsd from source for the overlay rootfs) is the slow part and is fully
-        # pinned by assemble.sh, so key the cache on its hash. The push-to-main run
-        # populates the default-branch cache PRs inherit; the weekly schedule refreshes
-        # it. run-microvm-demo-kind.sh skips assembling when these are present.
+        # Assembling the assets (download kata-static + cloud-hypervisor + the
+        # prebuilt virtiofsd — all downloads on amd64) is fully pinned by assemble.sh,
+        # so key the cache on its hash. The push-to-main run populates the
+        # default-branch cache PRs inherit; the weekly schedule refreshes it.
+        # run-microvm-demo-kind.sh skips assembling when these are present.
         path: bin/microvm-assets/amd64
         key: microvm-assets-amd64-${{ hashFiles('hack/microvm-assets/assemble.sh') }}
-    - name: Install micro-VM asset build deps
-      # Only needed when (re)assembling (cache miss): building virtiofsd from source.
-      if: steps.microvm-assets.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libcap-ng-dev libseccomp-dev pkg-config
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
     - name: Enable KVM
       # Grant the runner access to /dev/kvm so create-kind-cluster.sh mounts it into
       # the node and labels it for the micro-VM sandbox class.

--- a/cmd/ateom-microvm/internal/third_party/kata/PROVENANCE.md
+++ b/cmd/ateom-microvm/internal/third_party/kata/PROVENANCE.md
@@ -5,8 +5,10 @@ and used by `cmd/ateom-microvm`. The upstream `LICENSE` in this directory covers
 everything under it.
 
 - **Upstream:** github.com/kata-containers/kata-containers
-- **Version:** tag `3.31.0` (matches the kata runtime assets the micro-VM demo fetches;
-  see `hack/microvm-assets/assemble.sh` `KATA_VER`)
+- **Version:** tag `3.31.0`. The micro-VM demo's runtime assets track a newer kata
+  (see `hack/microvm-assets/assemble.sh` `KATA_VER`, currently `4.0.0`); the four
+  vendored `.proto` files are byte-identical between `3.31.0` and `4.0.0` (verified
+  2026-07-22), so the generated Go needs no re-vendor.
 - **License:** Apache-2.0 — `./LICENSE` is the upstream license verbatim (mirrored to
   `LICENSES/third_party/kata/LICENSE` by `hack/update/licenses.sh`); the per-file
   copyright headers (HyperHQ, Ant Group, Intel, Databricks) are retained verbatim in

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -21,9 +21,9 @@
 # from the cluster object store bucket ${BUCKET_NAME} under kata-assets/ (rustfs on
 # kind, GCS on GKE) — NOT baked into the worker image. ateom boots cloud-hypervisor
 # itself and gives the actor an overlay rootfs (virtio-fs RO lower + guest-tmpfs
-# upper), so it fetches virtiofsd (built from upstream main — vhost 0.16; the
-# snapshot/restore fix is not in a release tag yet). The kata containerd shim is NOT
-# fetched (ateom drives the kata-agent directly). kata assets are 3.32.0.
+# upper), so it fetches virtiofsd (v1.14.0 — the first release with the vhost-0.16
+# snapshot/restore fix; the kata-bundled v1.13.3 hangs restore). The kata containerd
+# shim is NOT fetched (ateom drives the kata-agent directly). kata assets are 4.0.0.
 # The per-arch sha256 values below are the asset sets produced by
 # hack/microvm-assets/assemble.sh; atelet selects the block matching the node's
 # architecture, and each cluster's bucket holds that arch's binaries at these paths
@@ -47,42 +47,44 @@ spec:
       cloud-hypervisor:
         url: "gs://${BUCKET_NAME}/kata-assets/cloud-hypervisor"
         sha256: "bf004ddc1a148f47caa87ac49a783b8dbd6bf9bc27abe522ed197df7b982d3b1"
-      # virtiofsd serves the overlay RO lower (virtio-fs); built from a pinned source
-      # commit (vhost 0.16 — the snapshot/restore fix is not in a release tag yet).
+      # virtiofsd serves the overlay RO lower (virtio-fs); v1.14.0 carries the
+      # vhost-0.16 snapshot/restore fix the kata-bundled v1.13.3 lacks.
       virtiofsd:
         url: "gs://${BUCKET_NAME}/kata-assets/virtiofsd"
-        # virtiofsd is built from source (pinned commit in assemble.sh), so its binary
-        # is not byte-reproducible across toolchains/arches and can't carry a fixed pin.
-        # run-microvm-demo.sh computes this from the freshly-staged binary at deploy.
+        # Upstream publishes no arm64 prebuilt, so assemble.sh builds the v1.14.0 tag
+        # from source; the binary is not byte-reproducible across toolchains and can't
+        # carry a fixed pin. run-microvm-demo.sh computes this from the freshly-staged
+        # binary at deploy.
         sha256: "${VIRTIOFSD_SHA256}"
       kata-kernel:
         url: "gs://${BUCKET_NAME}/kata-assets/vmlinux"
-        sha256: "f437320bab94f19105d12b932aa29735f0d54d2588218872254367f312c1027c"
+        sha256: "4a8998a2e7ac12d6ad1f15b5e7d00571e4518ea9f33db1a1a568310373ca428d"
       kata-image:
         url: "gs://${BUCKET_NAME}/kata-assets/rootfs.img"
-        sha256: "31ffb41177571c5654d3a28a2728eaac9d6d3daed90bb993f64e0b4b3ca6b235"
+        sha256: "24d77700749846355f3be25b87974c1fdea9fd2a9534256b4e4bbdde5df23588"
       kata-config:
         url: "gs://${BUCKET_NAME}/kata-assets/configuration-clh.toml"
-        sha256: "8a09a40543a527dbdc3ff26d229bae0de9aebb655475c28d7e5482dbedefa030"
-    # amd64 assets are kata 3.32 + virtiofsd (assemble.sh ARCH=amd64), matching arm64.
+        sha256: "20f5de4f705423ddd1ee93318c784c6aede30c07c78dc6b311a771cc2f6859c7"
+    # amd64 assets are kata 4.0.0 + virtiofsd v1.14.0 (assemble.sh ARCH=amd64).
     amd64:
       cloud-hypervisor:
         url: "gs://${BUCKET_NAME}/kata-assets/cloud-hypervisor"
         sha256: "829af01ff075bb96c4f183905134c453a88d68cbabdc6b87df21098842581ee9"
       virtiofsd:
         url: "gs://${BUCKET_NAME}/kata-assets/virtiofsd"
-        # Built from source (see the arm64 note above); sha injected at deploy by
-        # run-microvm-demo.sh from the freshly-staged binary.
-        sha256: "${VIRTIOFSD_SHA256}"
+        # The x86_64-musl binary attached to the upstream v1.14.0 release (downloaded
+        # by assemble.sh, reproducible bytes), so it carries a fixed pin like the
+        # other downloaded assets.
+        sha256: "15b2e72a78cc08a9bd8a6943e89fb69c88cb3cbeb63069efceade835342ac7d4"
       kata-kernel:
         url: "gs://${BUCKET_NAME}/kata-assets/vmlinux"
-        sha256: "43701715ae2885f936bbe5c66a2de7c14dc51de7d19412d04833e4bbcf205bd0"
+        sha256: "6abc48fa83c58e3db314037105d04ec00c1bc80d85eb2dfb2e2854f414573bca"
       kata-image:
         url: "gs://${BUCKET_NAME}/kata-assets/rootfs.img"
-        sha256: "e9548ff64f51c120791d3a2d1a81ebfd275df2bf0737368bd3e6381a6e967855"
+        sha256: "fbbd40de605ab2f99dc82c777dc5b41f9a00dad3a0f699f2247c306ac9c1204d"
       kata-config:
         url: "gs://${BUCKET_NAME}/kata-assets/configuration-clh.toml"
-        sha256: "8cce580e5abf78c05c8e9b929c24a524b9a81fc47be4e2e4f38dcae5ef052be6"
+        sha256: "1e67eabdfb9d900bf95a00edb52cacc1efe64f23ea095f8b49ee81c7434bce90"
 
 ---
 

--- a/hack/microvm-assets/assemble.sh
+++ b/hack/microvm-assets/assemble.sh
@@ -20,20 +20,21 @@
 #
 # Produces, under $OUT, the five assets named as the SandboxConfig expects:
 #   cloud-hypervisor  virtiofsd  vmlinux  rootfs.img  configuration-clh.toml
-# The four DOWNLOADED assets are reproducible, so paste their sha256 sums into the
-# manifest (demos/counter/counter-microvm.yaml.tmpl). virtiofsd is built from source
+# The DOWNLOADED assets are reproducible, so paste their sha256 sums into the
+# manifest (demos/counter/counter-microvm.yaml.tmpl). That now includes virtiofsd on
+# amd64 (upstream prebuilt); on arm64 virtiofsd is still built from source
 # (non-reproducible bytes), so its sha is NOT pinned there — run-microvm-demo.sh
 # computes it from the staged binary and injects it at deploy.
 #
 # ateom drives the kata-agent directly (the kata containerd shim is NOT an asset). The
 # actor rootfs is overlay(virtio-fs RO lower + guest-tmpfs upper), so virtiofsd IS an
-# asset; it is built from source (pinned commit, see VIRTIOFSD_COMMIT below) because the
-# vhost-0.16 snapshot/restore fix (REPLY_ACK) is not in a release tag yet — the
-# kata-bundled v1.13.3 virtiofsd hangs CH's restore handshake. Tracking issue:
-# https://gitlab.com/virtio-fs/virtiofsd/-/work_items/236 — switch to a release once it
-# lands. Building it needs rust (rustup) + libcap-ng-dev libseccomp-dev pkg-config.
+# asset; kata-static (4.0.0 included) still bundles virtiofsd v1.13.3, whose old vhost
+# hangs CH's restore handshake, so we take virtiofsd v1.14.0 — the first release with
+# the vhost-0.16 / vhost-user-backend-0.22 snapshot-restore fix (REPLY_ACK). Upstream
+# publishes a prebuilt static binary for x86_64 only; arm64 builds from the release
+# tag, which needs rust (rustup) + libcap-ng-dev libseccomp-dev pkg-config.
 #
-# Env: ARCH (arm64|amd64, default arm64), KATA_VER (3.32.0), CH_VER (v52.0),
+# Env: ARCH (arm64|amd64, default arm64), KATA_VER (4.0.0), CH_VER (v52.0),
 #      OUT (default ./bin/microvm-assets/$ARCH, under the gitignored bin/).
 
 set -o errexit -o nounset -o pipefail
@@ -41,7 +42,7 @@ set -o errexit -o nounset -o pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 
 ARCH="${ARCH:-arm64}"
-KATA_VER="${KATA_VER:-3.32.0}"
+KATA_VER="${KATA_VER:-4.0.0}"
 CH_VER="${CH_VER:-v52.0}"
 OUT="${OUT:-${ROOT}/bin/microvm-assets/$ARCH}"
 WORK="$(mktemp -d)"
@@ -72,26 +73,42 @@ curl -fSL -o "${OUT}/cloud-hypervisor" \
   "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${CH_VER}/${CH_ASSET}"
 chmod +x "${OUT}/cloud-hypervisor"
 
-# virtiofsd pinned commit. The vhost-0.16 / vhost-user-backend-0.22 snapshot-restore
-# fix (REPLY_ACK) is upstream but not in a release tag yet (tracking issue
-# https://gitlab.com/virtio-fs/virtiofsd/-/work_items/236) — the kata-bundled v1.13.3
-# (old vhost) hangs CH's restore handshake. Pin a known-good commit until a release
-# carries the fix.
-VIRTIOFSD_COMMIT="acb3d506a9f1b256fff7327023df85570caf1e75"
-echo ">> Building virtiofsd @ ${VIRTIOFSD_COMMIT} (vhost 0.16)..."
-# Build deps (Debian): apt-get install -y git libcap-ng-dev libseccomp-dev pkg-config; rust via rustup.
-if ! command -v cargo >/dev/null 2>&1; then
-  echo "cargo not found; install rust (rustup) + libcap-ng-dev libseccomp-dev pkg-config" >&2
-  exit 1
+# virtiofsd v1.14.0: first release with the vhost-0.16 / vhost-user-backend-0.22
+# snapshot-restore fix (REPLY_ACK) — the kata-bundled v1.13.3 (old vhost) hangs CH's
+# restore handshake, so this stays a separately-sourced asset. Upstream attaches a
+# prebuilt static binary to the release for x86_64 only; other arches build from the
+# release tag.
+VIRTIOFSD_VER="v1.14.0"
+# The x86_64-musl binary attached to the v1.14.0 release notes
+# (https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.14.0). 21523468 is the
+# gitlab.com project id of virtio-fs/virtiofsd: the /-/project/<id>/uploads/ form
+# is the canonical unauthenticated upload URL (the /<path>/-/uploads/ form the
+# release notes link to 403s outside a browser session). The zip sha is pinned
+# because a bad URL yields a login page, which would otherwise only fail later
+# at unzip.
+VIRTIOFSD_ZIP_URL="https://gitlab.com/-/project/21523468/uploads/f505704014ae7a816e515f2a05a93d8b/virtiofsd-v1.14.0.zip"
+VIRTIOFSD_ZIP_SHA256="2e4fe9571f492b00baa34bc4e708e950039c5da05b830b31a8d179cb6ac8978e"
+if [ "$ARCH" = "amd64" ]; then
+  echo ">> Downloading prebuilt virtiofsd ${VIRTIOFSD_VER} (x86_64-musl)..."
+  curl -fSL -o virtiofsd.zip "${VIRTIOFSD_ZIP_URL}"
+  echo "${VIRTIOFSD_ZIP_SHA256}  virtiofsd.zip" | sha256sum -c -
+  unzip -q -o virtiofsd.zip
+  cp "target/x86_64-unknown-linux-musl/release/virtiofsd" "${OUT}/virtiofsd"
+else
+  echo ">> Building virtiofsd ${VIRTIOFSD_VER} (no upstream prebuilt for ${ARCH})..."
+  # Build deps (Debian): apt-get install -y git libcap-ng-dev libseccomp-dev pkg-config; rust via rustup.
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "cargo not found; install rust (rustup) + libcap-ng-dev libseccomp-dev pkg-config" >&2
+    exit 1
+  fi
+  git clone --depth 1 --branch "${VIRTIOFSD_VER}" https://gitlab.com/virtio-fs/virtiofsd.git
+  (
+    cd virtiofsd
+    grep -E '^(vhost|vhost-user-backend) =' Cargo.toml   # expect vhost 0.16 / backend 0.22
+    cargo build --release
+  )
+  cp "virtiofsd/target/release/virtiofsd" "${OUT}/virtiofsd"
 fi
-git clone https://gitlab.com/virtio-fs/virtiofsd.git
-(
-  cd virtiofsd
-  git checkout --quiet "${VIRTIOFSD_COMMIT}"
-  grep -E '^(vhost|vhost-user-backend) =' Cargo.toml   # expect vhost 0.16 / backend 0.22
-  cargo build --release
-)
-cp "virtiofsd/target/release/virtiofsd" "${OUT}/virtiofsd"
 chmod +x "${OUT}/virtiofsd"
 
 echo
@@ -102,6 +119,7 @@ for f in cloud-hypervisor virtiofsd vmlinux rootfs.img configuration-clh.toml; d
 done
 "${OUT}/virtiofsd" --version 2>/dev/null | head -1 || true
 echo
-echo ">> sha256 (paste the DOWNLOADED assets into counter-microvm.yaml.tmpl;"
-echo ">> virtiofsd's sha is injected at deploy by run-microvm-demo.sh, not pinned):"
+echo ">> sha256 (paste the DOWNLOADED assets into counter-microvm.yaml.tmpl; that"
+echo ">> includes virtiofsd on amd64 (prebuilt). The arm64 virtiofsd is built from"
+echo ">> source, so its sha is injected at deploy by run-microvm-demo.sh, not pinned):"
 sha256sum cloud-hypervisor virtiofsd vmlinux rootfs.img configuration-clh.toml

--- a/hack/run-microvm-demo.sh
+++ b/hack/run-microvm-demo.sh
@@ -114,11 +114,12 @@ fi
 # is used as-is — no override). Only ko apply/create/delete/run accept args after
 # `--`; thread --context there (mirrors the run_ko helper in hack/install-ate.sh).
 log "Applying the counter-microvm demo manifest..."
-# virtiofsd is built from source (pinned commit in assemble.sh), so its binary bytes
-# are not reproducible across toolchains/arches and its sha can't be a fixed pin in the
+# The arm64 virtiofsd is built from source (release tag in assemble.sh), so its binary
+# bytes are not reproducible across toolchains and its sha can't be a fixed pin in the
 # manifest. Compute it from the freshly-staged binary and inject it, so the deployed
 # SandboxConfig always matches whatever was staged. The downloaded assets
-# (cloud-hypervisor/kernel/rootfs/config) keep their committed, reproducible per-arch shas.
+# (cloud-hypervisor/kernel/rootfs/config, plus virtiofsd on amd64 where upstream
+# publishes a prebuilt) keep their committed, reproducible per-arch shas.
 VIRTIOFSD_SHA256="$(sha256sum "${OUT}/virtiofsd" | awk '{print $1}')"
 sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
     -e "s|\${VIRTIOFSD_SHA256}|${VIRTIOFSD_SHA256}|g" \


### PR DESCRIPTION
- We no longer need to compile virtiofsd when installing for amd64, we still need to for arm64 (no upstream release)
- Drop-in compatible, only updating the scripts that manage obtaining the binaries, and the versions / hashes in the config.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
