### PR TITLE
Generalize rootful test execution via internal/roottest discovery

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -33,11 +33,11 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - run: go test -v ./...
-    # The imagecache consumer half (overlay mounts, whiteout mknod, trusted.*
-    # xattrs) is guarded by root-only tests that skip for the unprivileged
-    # runner user above; run that one package again as root so they execute.
-    - name: imagecache privileged tests
-      run: sudo -E env "PATH=$PATH" go test -v -count=1 ./internal/imagecache/
+    # Root-gated tests (overlay mounts, whiteout mknod, trusted.* xattrs, ...)
+    # skip for the unprivileged runner user above; rerun the packages that
+    # contain them (any test importing internal/roottest) under sudo.
+    - name: root-gated tests
+      run: hack/run-root-tests.sh -v
     - name: verify
       run: hack/verify-all.sh
   # One kind cluster exercises BOTH runtimes. Free x86-64 ubuntu-latest runners

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,19 @@ for this purpose.
 All code changes should be accompanied by tests. We will not merge code that
 does not have tests, and we will not merge code that causes tests to fail.
 
+### Root-gated tests
+
+Tests that need root (overlay mounts, mknod, `trusted.*` xattrs, ...) call
+`roottest.Require(t, ...)` from [internal/roottest](internal/roottest) as
+their first statement. They skip in a plain `go test ./...`; CI reruns every
+package whose tests import that package under `sudo`. To run them locally:
+
+```sh
+hack/run-root-tests.sh
+```
+
+New privileged tests only need the `roottest.Require` call — no CI changes.
+
 ### Copyright Headers
 
 Every file containing source code must include copyright and license

--- a/hack/run-root-tests.sh
+++ b/hack/run-root-tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs every root-gated test package under sudo. A package is root-gated when
+# its tests import internal/roottest (the tests self-skip unless run as root),
+# so adding privileged tests anywhere picks them up here with no CI change.
+# Extra arguments are passed through to `go test` (e.g. -v, -run).
+
+set -o errexit -o nounset -o pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "${ROOT}"
+
+MARKER="github.com/agent-substrate/substrate/internal/roottest"
+
+# Look for the marker in both in-package (TestImports) and external _test
+# package (XTestImports) test files.
+PKGS="$(go list \
+  -f '{{range .TestImports}}{{if eq . "'"${MARKER}"'"}}{{println $.ImportPath}}{{end}}{{end}}{{range .XTestImports}}{{if eq . "'"${MARKER}"'"}}{{println $.ImportPath}}{{end}}{{end}}' \
+  ./... | sort -u)"
+
+if [[ -z "${PKGS}" ]]; then
+  echo "No root-gated test packages found (nothing imports ${MARKER})."
+  exit 0
+fi
+
+echo "Root-gated test packages:"
+echo "${PKGS}"
+
+# -count=1: the Go test cache does not key on euid, so without it a rerun as
+# root replays the unprivileged run's cached skips.
+# shellcheck disable=SC2086 # intentional word splitting of the package list
+if [[ "$(id -u)" -eq 0 ]]; then
+  exec go test -count=1 "$@" ${PKGS}
+fi
+# -E / env PATH: keep the invoking user's Go toolchain and module caches.
+# shellcheck disable=SC2086
+exec sudo -E env "PATH=${PATH}" go test -count=1 "$@" ${PKGS}

--- a/internal/imagecache/README.md
+++ b/internal/imagecache/README.md
@@ -190,8 +190,9 @@ untar backend later without restructuring.
   the real `mknod`/xattr materialization and a full mount → write-isolation
   → unmount round trip (the write-isolation assertion — actor writes land in
   the bundle upper, never in the shared pool — is the key safety property).
-  CI runs the package twice: once unprivileged, once under `sudo` so the
-  root-gated tests execute (see `.github/workflows/pr-workflow.yaml`).
+  The root-gated ones self-skip via `roottest.Require`; CI (and
+  `hack/run-root-tests.sh` locally) reruns the package under `sudo` so they
+  execute.
 - `tools/validate-image-cache` batch-validates that arbitrary registry
   images can be pulled, parsed, and unpacked by the store half — useful for
   sweeping large image corpora before relying on them in production.

--- a/internal/imagecache/bundle_linux_test.go
+++ b/internal/imagecache/bundle_linux_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/agent-substrate/substrate/internal/roottest"
 )
 
 // writeLayer builds a layer dir (fs/ tree + whiteouts.json) as the store's
@@ -59,9 +61,7 @@ func writeLayer(t *testing.T, dir string, files map[string]string, wh *whiteoutS
 // xattrs (trusted.*, CAP_SYS_ADMIN); only root has those in a plain test
 // environment. Runs in privileged CI / root shells, skips elsewhere.
 func TestFinalizeLayer_MaterializesWhiteouts(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("needs root (CAP_MKNOD + CAP_SYS_ADMIN for trusted.* xattrs)")
-	}
+	roottest.Require(t, "CAP_MKNOD + CAP_SYS_ADMIN for trusted.* xattrs")
 	dir := t.TempDir()
 	writeLayer(t, dir,
 		map[string]string{"kept.txt": "kept"},
@@ -173,9 +173,7 @@ func TestSetupBundleRootfs_ZeroLayers(t *testing.T) {
 // after compose the merged view must show 0700 — copied up into the
 // bundle's upper, with the shared layer trees untouched. Needs root.
 func TestSetupBundleRootfs_ImplicitDirMetadataRepair(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("needs root (mount/unmount)")
-	}
+	roottest.Require(t, "mount/unmount")
 	base := t.TempDir()
 	writeLayer(t, base, map[string]string{"secret/keep.txt": "k"}, nil)
 	if err := os.Chmod(filepath.Join(base, layerFSDirName, "secret"), 0o700); err != nil {
@@ -211,9 +209,7 @@ func TestSetupBundleRootfs_ImplicitDirMetadataRepair(t *testing.T) {
 
 // Full overlay mount + UnmountAllUnder round trip; needs CAP_SYS_ADMIN.
 func TestSetupBundleRootfs_MountAndUnmount(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("needs root (mount/unmount)")
-	}
+	roottest.Require(t, "mount/unmount")
 	layer := t.TempDir()
 	writeLayer(t, layer, map[string]string{"from-layer.txt": "hello"}, nil)
 
@@ -256,9 +252,7 @@ func TestSetupBundleRootfs_MountAndUnmount(t *testing.T) {
 // to fail with a bare EINVAL. The fsconfig lowerdir+ path has no aggregate
 // limit. Needs CAP_SYS_ADMIN.
 func TestSetupBundleRootfs_ManyLayers(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("needs root (mount/unmount)")
-	}
+	roottest.Require(t, "mount/unmount")
 	// Digest-length dir names so each path matches production length (~114
 	// bytes); 64 of them comfortably exceed the page that motivated this.
 	pool := filepath.Join(t.TempDir(), "sha256")

--- a/internal/roottest/roottest.go
+++ b/internal/roottest/roottest.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package roottest gates tests that need root privileges (mounts, mknod,
+// trusted.* xattrs, ...). Tests call [Require] up top and skip when
+// unprivileged; importing this package is also the marker
+// hack/run-root-tests.sh uses to discover which packages to rerun as root.
+package roottest
+
+import (
+	"os"
+	"testing"
+)
+
+// Require skips the test unless it is running as root. reason names the
+// privileged operation the test needs.
+func Require(tb testing.TB, reason string) {
+	tb.Helper()
+	if os.Geteuid() != 0 {
+		tb.Skipf("needs root: %s (run hack/run-root-tests.sh to execute under sudo)", reason)
+	}
+}

--- a/internal/roottest/roottest_test.go
+++ b/internal/roottest/roottest_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roottest
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRequire(t *testing.T) {
+	reached := false
+	t.Run("gate", func(t *testing.T) {
+		Require(t, "gate probe")
+		reached = true
+	})
+	if want := os.Geteuid() == 0; reached != want {
+		t.Errorf("gated code ran = %v, want %v (euid %d)", reached, want, os.Geteuid())
+	}
+}


### PR DESCRIPTION
Fix #501

Tests that need root (overlay mounts, mknod, `trusted.*` xattrs, ...) call `roottest.Require(t, ...)` from [internal/roottest](internal/roottest) as their first statement. They skip in a plain `go test ./...`; CI reruns every package whose tests import that package under `sudo`.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
