### PR TITLE
Same crashing for workflow_pause.go when pod is gone

### DIFF
--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -120,7 +120,7 @@ func (s *CallAteletPauseStep) CheckPrerequisite(ctx context.Context, input *Paus
 	}
 	if state.Actor.GetAteomPodNamespace() == "" || state.Actor.GetAteomPodName() == "" {
 		if err := crashActor(ctx, s.store, state.Actor.GetMetadata().GetAtespace(), state.Actor.GetMetadata().GetName()); err != nil {
-			slog.Error("Failed to crash actor", slog.String("err", err.Error()))
+			slog.ErrorContext(ctx, "Failed to crash actor", slog.String("err", err.Error()))
 		}
 		return status.Errorf(codes.FailedPrecondition, "CallAteletPauseStep prerequisite not met for Actor: %s. AteomPodNamespace: %s, GetAteomPodName %s", input.ActorName, state.Actor.GetAteomPodNamespace(), state.Actor.GetAteomPodName())
 	}
@@ -131,8 +131,11 @@ func (s *CallAteletPauseStep) Execute(ctx context.Context, input *PauseInput, st
 	ateletConn, err := s.dialer.DialForWorker(state.Actor.GetAteomPodNamespace(), state.Actor.GetAteomPodName())
 	if err != nil {
 		if errors.Is(err, ErrWorkerPodNotFound) {
-			slog.Warn("Skipping pause for dangling worker pod", "namespace", state.Actor.GetAteomPodNamespace(), "pod", state.Actor.GetAteomPodName())
-			return nil
+			slog.ErrorContext(ctx, "Worker pod gone before checkpoint, crashing actor", "namespace", state.Actor.GetAteomPodNamespace(), "pod", state.Actor.GetAteomPodName(), "in_progress_snapshot", state.Actor.GetInProgressSnapshot())
+			if err := crashActor(ctx, s.store, state.Actor.GetMetadata().GetAtespace(), state.Actor.GetMetadata().GetName()); err != nil {
+				slog.ErrorContext(ctx, "Failed to crash actor", slog.String("err", err.Error()))
+			}
+			return fmt.Errorf("actor is CRASHED because its worker pod is gone and no snapshot was written")
 		}
 		return fmt.Errorf("while getting atelet conn for worker pod: %w", err)
 	}

--- a/cmd/ateapi/internal/controlapi/workflow_pause_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause_test.go
@@ -238,6 +238,71 @@ func TestPauseSteps_CheckPrerequisite(t *testing.T) {
 	}
 }
 
+func TestCallAteletPauseStep_DanglingWorkerDoesNotRecordPhantomSnapshot(t *testing.T) {
+	tests := []struct {
+		name         string
+		prevSnapshot *ateapipb.SnapshotInfo
+	}{
+		{
+			name: "keeps previous snapshot",
+			prevSnapshot: &ateapipb.SnapshotInfo{
+				Data: &ateapipb.SnapshotInfo_External{
+					External: &ateapipb.ExternalSnapshotInfo{SnapshotUriPrefix: "gs://snapshots/actor-1/prev"},
+				},
+			},
+		},
+		{
+			name:         "stays nil without previous snapshot",
+			prevSnapshot: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			persistence := newTestPersistence(t)
+
+			actor := &ateapipb.Actor{
+				Metadata:           &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "actor-1"},
+				Status:             ateapipb.Actor_STATUS_PAUSING,
+				AteomPodNamespace:  "worker-ns",
+				AteomPodName:       "pod-gone",
+				WorkerPoolName:     "pool",
+				InProgressSnapshot: "actor-1-never-written",
+				LatestSnapshotInfo: tt.prevSnapshot,
+			}
+			created, err := persistence.CreateActor(ctx, actor)
+			if err != nil {
+				t.Fatalf("CreateActor: %v", err)
+			}
+
+			step := &CallAteletPauseStep{store: persistence, dialer: newDanglingDialer()}
+			input := &PauseInput{ActorName: "actor-1", Atespace: "team-a"}
+			if err := step.Execute(ctx, input, &PauseState{Actor: created}); err == nil {
+				t.Fatal("Execute: want error for dangling worker, got nil")
+			}
+
+			stored, err := persistence.GetActor(ctx, "team-a", "actor-1")
+			if err != nil {
+				t.Fatalf("GetActor: %v", err)
+			}
+			if stored.GetStatus() != ateapipb.Actor_STATUS_CRASHED {
+				t.Errorf("status = %v, want CRASHED", stored.GetStatus())
+			}
+			if got := stored.GetInProgressSnapshot(); got != "actor-1-never-written" {
+				t.Errorf("InProgressSnapshot = %q, want preserved for debugging", got)
+			}
+			if tt.prevSnapshot == nil {
+				if stored.GetLatestSnapshotInfo() != nil {
+					t.Errorf("LatestSnapshotInfo = %v, want nil", stored.GetLatestSnapshotInfo())
+				}
+			} else if got, want := stored.GetLatestSnapshotInfo().GetExternal().GetSnapshotUriPrefix(), tt.prevSnapshot.GetExternal().GetSnapshotUriPrefix(); got != want {
+				t.Errorf("LatestSnapshotInfo uri = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 // TestPauseActor_CrashesWhenPausingActorMissingWorkerPod verifies that a
 // PAUSING actor with no worker pod recorded is moved to CRASHED by
 // CallAteletPauseStep's prerequisite check and the pause fails with

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -101,7 +101,7 @@ func (s *LoadActorForResumeStep) Execute(ctx context.Context, input *ResumeInput
 		wk, err := s.store.GetWorker(ctx, actor.AteomPodNamespace, actor.WorkerPoolName, actor.AteomPodName)
 		if err != nil {
 			// Crash the actor if it was assigned to a deleted pod.
-			if errors.Is(err, ErrWorkerPodNotFound) {
+			if errors.Is(err, store.ErrNotFound) {
 				if cerr := crashActor(ctx, s.store, input.Atespace, input.ActorName); cerr != nil {
 					return cerr
 				}


### PR DESCRIPTION
Should found it when writing #474..
And also correct an error in `workflow_resume.go`.


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
