### PR TITLE
Use the full snapshot scope by default for the counter demo

### DIFF
--- a/demos/counter/counter.yaml.tmpl
+++ b/demos/counter/counter.yaml.tmpl
@@ -54,7 +54,7 @@ spec:
       workload: counter
   snapshotsConfig:
     onPause: Full
-    onCommit: Data
+    onCommit: Full
     location: gs://${BUCKET_NAME}/ate-demo-counter/
   volumes:
   - name: data


### PR DESCRIPTION
The Data snapshot scope is meant to restore state from DurableDir volumes and does not persist the process memory. For this demo, it makes more sense to default to the Full snapshot scope so that users can play around with incrementing a counter, pausing/resuming with the previous value still intact, and continue incrementing the counter.

Fixes #519

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
