### PR TITLE
demo(counter): capture process memory on suspend (onCommit: Full)

### DIFF
--- a/demos/counter/counter.yaml.tmpl
+++ b/demos/counter/counter.yaml.tmpl
@@ -54,7 +54,7 @@ spec:
       workload: counter
   snapshotsConfig:
     onPause: Full
-    onCommit: Data
+    onCommit: Full
     location: gs://${BUCKET_NAME}/ate-demo-counter/
   volumes:
   - name: data


### PR DESCRIPTION
Fixes #519

The counter demo promises state preservation across suspend/resume, but shipped `onCommit: Data` - so suspend checkpoints took the `runsc fscheckpoint` branch (filesystem only) and process memory was never captured. On resume, actors cold-booted with only the DurableDir restored: the demo's own `preserved memory count` reset to 1 on every suspend.

With `onCommit: Full`, suspend captures a full `runsc checkpoint` (memory + fs) and resume restores it via `runsc restore`.

Verified end-to-end on kind (`create-kind-cluster.sh` + `install-ate-kind.sh`): 3 POSTs (memory 3, file 3) -> suspend -> resume POST now returns `preserved memory count: 4 | preserved file counter: 4` (previously memory reset to 1 while file continued to 4).

- [x] Tests pass (no new code paths; this aligns the shipped demo with the `onCommit:Full, onPause:Full` case already covered by `TestDurableDirLifecycle`, plus manual end-to-end verification above)
- [x] Appropriate changes to documentation are included in the PR (none needed - the demo README already promises this behavior)