### PR TITLE
Instrument ate-apiserver so that it can shutdown gracefully.

### DIFF
--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -24,7 +24,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/controlapi"
@@ -76,6 +78,9 @@ var (
 	podIdentityCACerts     = pflag.String("pod-identity-ca-certs", "", "The file that contains the pod-identity CA bundle, used both for verifying client certificates presented to the gRPC server and for verifying atelet serving certificates when dialing atelet. If empty, client-cert verification is disabled and atelet dials will fail.")
 	ateletClientCredBundle = pflag.String("atelet-client-cred-bundle", "", "Credential bundle presented as the client certificate when dialing atelet.")
 
+	drainDelay   = pflag.Duration("drain-delay", 13*time.Second, "How long to keep accepting new work after SIGTERM, before starting the gRPC drain.")
+	drainTimeout = pflag.Duration("drain-timeout", 15*time.Second, "Deadline for the graceful gRPC drain on shutdown. In-flight RPCs still running past it are forcefully cancelled.")
+
 	showVersion     = pflag.Bool("version", false, "Print version and exit.")
 	clientJWTCAFile = pflag.String("client-jwt-ca-cert", ateapiauth.DefaultServiceAccountCAFile, "CA cert file used to verify TLS when fetching the OIDC discovery document and JWKS for JWT authentication. Defaults to the in-cluster service account CA.")
 )
@@ -88,6 +93,12 @@ func main() {
 	}
 	ctx := context.Background()
 	serverboot.InitLogger()
+
+	// Kept separate from ctx so that in-progress work (clients, informers) is
+	// not cancelled the moment SIGTERM arrives. The drainOnShutdown
+	// function drives the shutdown process.
+	shutdownCtx, stopSignals := signal.NotifyContext(ctx, syscall.SIGTERM, os.Interrupt)
+	defer stopSignals()
 
 	tp, err := serverboot.InitTracing(ctx, serverboot.TracingOptions{
 		ServiceName: "ateapi",
@@ -198,14 +209,45 @@ func main() {
 	ateapipb.RegisterSessionIdentityServer(mux, sessionIdentitySrv)
 	ateapipb.RegisterDebugServer(mux, debugSrv)
 
+	readiness := &serverboot.Readiness{}
 	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{
-		Addr:         *metricsListenAddr,
-		EnableReadyz: true,
+		Addr:          *metricsListenAddr,
+		Readiness:     readiness,
+		EnableHealthz: true,
 	})
+
+	drainDone := drainOnShutdown(shutdownCtx, mux, readiness)
 
 	if err := mux.Serve(lis); err != nil {
 		serverboot.Fatal(ctx, "Failed to serve", err)
 	}
+	<-drainDone
+	slog.InfoContext(ctx, "Shutdown complete")
+}
+
+func drainOnShutdown(ctx context.Context, srv *grpc.Server, readiness *serverboot.Readiness) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		<-ctx.Done()
+		slog.InfoContext(ctx, "Shutdown signal received; draining")
+		readiness.MarkNotReady()
+		time.Sleep(*drainDelay)
+		slog.InfoContext(ctx, "Starting gRPC drain")
+		drainComplete := make(chan struct{})
+		go func() {
+			srv.GracefulStop()
+			close(drainComplete)
+		}()
+		select {
+		case <-drainComplete:
+			slog.InfoContext(ctx, "Drain completed within deadline")
+		case <-time.After(*drainTimeout):
+			slog.WarnContext(ctx, "Drain deadline exceeded; forcing stop")
+			srv.Stop()
+		}
+	}()
+	return done
 }
 
 // loadFlagsFromEnv resolves any flag whose value is the sentinel `@env`
@@ -245,6 +287,8 @@ func logFlagValues(ctx context.Context) {
 		slog.String("session-id-ca-pool", *sessionIDCAPoolFile),
 		slog.String("pod-identity-ca-certs", *podIdentityCACerts),
 		slog.String("atelet-client-cred-bundle", *ateletClientCredBundle),
+		slog.Duration("drain-delay", *drainDelay),
+		slog.Duration("drain-timeout", *drainTimeout),
 	)
 }
 

--- a/cmd/benchmarking/glutton/main.go
+++ b/cmd/benchmarking/glutton/main.go
@@ -108,8 +108,8 @@ func main() {
 	}
 
 	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{
-		Addr:         *metricsListenAddr,
-		EnableReadyz: true,
+		Addr:      *metricsListenAddr,
+		Readiness: &serverboot.Readiness{},
 	})
 
 	slog.InfoContext(ctx, "glutton starting",

--- a/internal/serverboot/serverboot.go
+++ b/internal/serverboot/serverboot.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sync/atomic"
 
 	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/google/uuid"
@@ -163,30 +164,63 @@ func ShutdownProvider(name string, shutdown func(context.Context) error) {
 	}
 }
 
+// Readiness is a predicate for process readiness. The zero value
+// reports ready. Calling MarkNotReady flips it permanently to not ready,
+// which causes /readyz to start returning "Service Unavailable" (503).
+type Readiness struct {
+	notReady atomic.Bool
+}
+
+// MarkNotReady makes /readyz return 503 from now on.
+func (r *Readiness) MarkNotReady() { r.notReady.Store(true) }
+
+// Ready reports whether /readyz returns 200.
+func (r *Readiness) Ready() bool { return !r.notReady.Load() }
+
 // MetricsServerOptions configures StartMetricsServer.
 type MetricsServerOptions struct {
 	// Addr is the TCP listen address (e.g. ":9090").
 	Addr string
-	// EnableReadyz adds a /readyz handler that returns 200 OK. Some
-	// binaries (ateapi) want it for Kubernetes readiness probes; others
-	// (atelet) historically didn't surface one.
-	EnableReadyz bool
+	// Readiness, if non-nil, enables a /readyz handler: 200 while
+	// Ready, 503 after MarkNotReady. A zero-value Readiness never
+	// flips, giving a static 200 for binaries with no drain sequence.
+	// Nil serves no /readyz at all.
+	Readiness *Readiness
+	// EnableHealthz adds an always-200 /healthz for liveness probes,
+	// which must keep succeeding while a draining server fails /readyz.
+	EnableHealthz bool
 }
 
 // StartMetricsServer runs an HTTP server exposing /metrics (Prometheus)
-// and optionally /readyz. Blocks until http.ListenAndServe returns;
-// designed to be `go`-launched.
+// and optionally /readyz and /healthz. Blocks until http.ListenAndServe
+// returns; designed to be `go`-launched.
 func StartMetricsServer(ctx context.Context, opts MetricsServerOptions) {
+	slog.InfoContext(ctx, "Starting metrics HTTP server", slog.String("addr", opts.Addr))
+	if err := http.ListenAndServe(opts.Addr, metricsMux(opts)); err != nil {
+		slog.Error("Failed to start prometheus metrics server", slog.Any("err", err))
+	}
+}
+
+// metricsMux builds the handler for StartMetricsServer; split out so
+// tests can exercise the endpoints without binding a port.
+func metricsMux(opts MetricsServerOptions) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
-	if opts.EnableReadyz {
+	if opts.Readiness != nil {
 		mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+			if !opts.Readiness.Ready() {
+				http.Error(w, "draining", http.StatusServiceUnavailable)
+				return
+			}
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		})
 	}
-	slog.InfoContext(ctx, fmt.Sprintf("Starting Prometheus metrics server on %s", opts.Addr))
-	if err := http.ListenAndServe(opts.Addr, mux); err != nil {
-		slog.Error("Failed to start prometheus metrics server", slog.Any("err", err))
+	if opts.EnableHealthz {
+		mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		})
 	}
+	return mux
 }

--- a/internal/serverboot/serverboot_test.go
+++ b/internal/serverboot/serverboot_test.go
@@ -16,6 +16,8 @@ package serverboot
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -58,4 +60,56 @@ func TestNewResourceEnvWins(t *testing.T) {
 	if got := attrs[string(semconv.ServiceInstanceIDKey)]; got != "fixed-id" {
 		t.Errorf("service.instance.id = %q, want fixed-id (OTEL_RESOURCE_ATTRIBUTES must win)", got)
 	}
+}
+
+func TestReadyzDrainsWhileHealthzStaysUp(t *testing.T) {
+	readiness := &Readiness{}
+	mux := metricsMux(MetricsServerOptions{
+		Readiness:     readiness,
+		EnableHealthz: true,
+	})
+
+	if got := getCode(t, mux, "/readyz"); got != http.StatusOK {
+		t.Errorf("/readyz before drain = %d, want %d", got, http.StatusOK)
+	}
+	if got := getCode(t, mux, "/healthz"); got != http.StatusOK {
+		t.Errorf("/healthz before drain = %d, want %d", got, http.StatusOK)
+	}
+
+	readiness.MarkNotReady()
+
+	if got := getCode(t, mux, "/readyz"); got != http.StatusServiceUnavailable {
+		t.Errorf("/readyz during drain = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+	if got := getCode(t, mux, "/healthz"); got != http.StatusOK {
+		t.Errorf("/healthz during drain = %d, want %d (liveness must not fail while draining)", got, http.StatusOK)
+	}
+}
+
+func TestReadyzStaticWithZeroValueReadiness(t *testing.T) {
+	mux := metricsMux(MetricsServerOptions{Readiness: &Readiness{}})
+	if got := getCode(t, mux, "/readyz"); got != http.StatusOK {
+		t.Errorf("/readyz with zero-value Readiness = %d, want %d", got, http.StatusOK)
+	}
+}
+
+func TestReadyzAbsentWithoutReadiness(t *testing.T) {
+	mux := metricsMux(MetricsServerOptions{})
+	if got := getCode(t, mux, "/readyz"); got != http.StatusNotFound {
+		t.Errorf("/readyz with nil Readiness = %d, want %d", got, http.StatusNotFound)
+	}
+}
+
+func TestHealthzAbsentUnlessEnabled(t *testing.T) {
+	mux := metricsMux(MetricsServerOptions{Readiness: &Readiness{}})
+	if got := getCode(t, mux, "/healthz"); got != http.StatusNotFound {
+		t.Errorf("/healthz without EnableHealthz = %d, want %d", got, http.StatusNotFound)
+	}
+}
+
+func getCode(t *testing.T, mux *http.ServeMux, path string) int {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec.Code
 }

--- a/manifests/ate-install/ate-api-server.yaml
+++ b/manifests/ate-install/ate-api-server.yaml
@@ -75,6 +75,10 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: ate-api-server
+      # Budget for the full shutdown sequence: --drain-delay (sized to cover
+      # the readinessProbe below reaching NotReady, plus propagation) +
+      # --drain-timeout.
+      terminationGracePeriodSeconds: 40
       containers:
       - name: ate-api-server
         image: ko://github.com/agent-substrate/substrate/cmd/ateapi
@@ -92,6 +96,9 @@ spec:
           - --session-id-ca-pool=/run/session-id-ca-pool/pool.json
           - --atelet-client-cred-bundle=/run/podidentity.podcert.ate.dev/credential-bundle.pem
           - --pod-identity-ca-certs=/run/podidentity.podcert.ate.dev/trust-bundle.pem
+          # Graceful shutdown knobs. The sum must fit within terminationGracePeriodSeconds.
+          - --drain-delay=13s
+          - --drain-timeout=15s
         env:
         - name: POD_NAME
           valueFrom:
@@ -145,6 +152,16 @@ spec:
             port: 9090
           initialDelaySeconds: 5
           periodSeconds: 2
+          failureThreshold: 3
+        # /healthz stays 200 while a terminating pod drains; /readyz
+        # turns 503, so liveness and readiness diverge correctly during
+        # shutdown.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 10
+          periodSeconds: 10
       volumes:
       - name: "servicedns"
         projected:


### PR DESCRIPTION
Make the server trap SIGTERM and initiate a graceful shutdown process. This involves reporting the Pod as not ready, and draining all in-flight gRPC requests so they can complete.

Part of #181 