### PR TITLE
Cache parsed credential bundles in credbundle loaders

### DIFF
--- a/internal/credbundle/credbundle.go
+++ b/internal/credbundle/credbundle.go
@@ -89,7 +89,7 @@ func (c *certCache) get() (*tls.Certificate, error) {
 
 	fi, err := os.Stat(c.path)
 	if err != nil {
-		return nil, fmt.Errorf("while examining credential bundle: %w", err)
+		return nil, fmt.Errorf("while getting file info for credential bundle %q: %w", c.path, err)
 	}
 	if c.cert != nil && os.SameFile(c.fi, fi) && fi.ModTime().Equal(c.fi.ModTime()) && fi.Size() == c.fi.Size() {
 		return c.cert, nil

--- a/internal/credbundle/credbundle.go
+++ b/internal/credbundle/credbundle.go
@@ -25,28 +25,82 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"sync"
 )
 
 // Loader reads a private key and certificate chain from a credential bundle file as written by the
 // Kubernetes Pod Certificates mechanism.
 //
-// Returns a function that can be used as GetCertificate in a tls.Config
+// Returns a function that can be used as GetCertificate in a tls.Config. The parsed bundle is
+// cached: each handshake stats the file and re-reads it only when the file has changed, so
+// pod-certificate rotations are picked up on the next handshake without paying the read and
+// parse cost when nothing changed.
 func Loader(path string) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	// TODO: Introduce caching.
+	c := &certCache{path: path}
 	return func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-		return Parse(path)
+		return c.get()
 	}
 }
 
 // ClientLoader is the client-side counterpart to Loader. It returns a function
-// suitable for use as GetClientCertificate in a tls.Config, re-reading the
-// bundle on each handshake so that in-place pod-certificate rotations are
-// picked up.
+// suitable for use as GetClientCertificate in a tls.Config, caching the parsed
+// bundle in the same way so that pod-certificate rotations are picked up on
+// the next handshake.
 func ClientLoader(path string) func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	// TODO: Introduce caching.
+	c := &certCache{path: path}
 	return func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-		return Parse(path)
+		return c.get()
 	}
+}
+
+// certCache holds the parse of a credential bundle file together with the stat
+// of the file it was parsed from, so unchanged files are not re-parsed on
+// every TLS handshake.
+type certCache struct {
+	path string
+
+	mu sync.Mutex
+	// fi is the stat of path taken just before cert was parsed; nil until the
+	// first successful parse. cert is served while a fresh stat of path still
+	// matches it.
+	fi   os.FileInfo
+	cert *tls.Certificate
+}
+
+// get returns the parsed bundle, re-reading the file only when it has changed
+// since the last successful parse.
+//
+// A change is any difference in file identity (os.SameFile: device and inode
+// on Unix), modification time, or size. The kubelet rotates projected volume
+// contents, including pod certificates, by writing a fresh timestamped
+// directory and atomically swapping a symlink to it, so a rotation always
+// surfaces here as a change of file identity; mtime and size additionally
+// cover in-place rewrites, whose mid-write states a reader may also observe.
+//
+// The file can still change between the stat and the read below. The parse of
+// the newer content is then stored against the older stat, so the next call
+// sees a stat mismatch and re-reads; the cache never lags a rotation by more
+// than one handshake. Errors leave the previous entry in place and are
+// returned to the caller: handshakes fail exactly as they would without
+// caching, and every later call retries until a parse succeeds.
+func (c *certCache) get() (*tls.Certificate, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	fi, err := os.Stat(c.path)
+	if err != nil {
+		return nil, fmt.Errorf("while examining credential bundle: %w", err)
+	}
+	if c.cert != nil && os.SameFile(c.fi, fi) && fi.ModTime().Equal(c.fi.ModTime()) && fi.Size() == c.fi.Size() {
+		return c.cert, nil
+	}
+
+	cert, err := Parse(c.path)
+	if err != nil {
+		return nil, err
+	}
+	c.fi, c.cert = fi, cert
+	return cert, nil
 }
 
 // Parse reads a private key and certificate chain from a credential bundle file as written by the

--- a/internal/credbundle/credbundle_test.go
+++ b/internal/credbundle/credbundle_test.go
@@ -22,9 +22,13 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -97,8 +101,8 @@ func TestLoaderServesCachedParseWhileFileUnchanged(t *testing.T) {
 	}
 }
 
-func TestLoaderPicksUpAtomicRotation(t *testing.T) {
-	path := writeBundle(t, makeBundle(t, 1))
+func TestLoaderPicksUpProjectedVolumeRotation(t *testing.T) {
+	path := writeProjectedBundle(t, makeBundle(t, 1))
 	getCert := Loader(path)
 
 	cert, err := getCert(nil)
@@ -109,14 +113,8 @@ func TestLoaderPicksUpAtomicRotation(t *testing.T) {
 		t.Fatalf("Loader() leaf serial = %d, want 1", got)
 	}
 
-	// Rotate the way the kubelet does: write the new bundle to a fresh file
-	// and atomically rename it over the old path, giving it a new inode.
-	next := path + ".next"
-	if err := os.WriteFile(next, makeBundle(t, 2), 0o600); err != nil {
-		t.Fatalf("write rotated bundle: %v", err)
-	}
-	if err := os.Rename(next, path); err != nil {
-		t.Fatalf("rename rotated bundle: %v", err)
+	if err := rotateProjectedBundle(path, makeBundle(t, 2)); err != nil {
+		t.Fatalf("rotate bundle: %v", err)
 	}
 
 	cert, err = getCert(nil)
@@ -194,7 +192,7 @@ func TestLoaderRecoversAfterError(t *testing.T) {
 }
 
 func TestClientLoaderCachesAndReloads(t *testing.T) {
-	path := writeBundle(t, makeBundle(t, 1))
+	path := writeProjectedBundle(t, makeBundle(t, 1))
 	getCert := ClientLoader(path)
 
 	cert, err := getCert(nil)
@@ -205,12 +203,8 @@ func TestClientLoaderCachesAndReloads(t *testing.T) {
 		t.Fatalf("ClientLoader() leaf serial = %d, want 1", got)
 	}
 
-	next := path + ".next"
-	if err := os.WriteFile(next, makeBundle(t, 2), 0o600); err != nil {
-		t.Fatalf("write rotated bundle: %v", err)
-	}
-	if err := os.Rename(next, path); err != nil {
-		t.Fatalf("rename rotated bundle: %v", err)
+	if err := rotateProjectedBundle(path, makeBundle(t, 2)); err != nil {
+		t.Fatalf("rotate bundle: %v", err)
 	}
 
 	cert, err = getCert(nil)
@@ -224,7 +218,7 @@ func TestClientLoaderCachesAndReloads(t *testing.T) {
 
 func TestLoaderConcurrentHandshakes(t *testing.T) {
 	bundles := [][]byte{makeBundle(t, 1), makeBundle(t, 2)}
-	path := writeBundle(t, bundles[0])
+	path := writeProjectedBundle(t, bundles[0])
 	getCert := Loader(path)
 
 	var wg sync.WaitGroup
@@ -232,14 +226,8 @@ func TestLoaderConcurrentHandshakes(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 25; i++ {
-			// Atomic-rename rotation, so readers never observe a torn file.
-			next := path + ".next"
-			if err := os.WriteFile(next, bundles[i%2], 0o600); err != nil {
-				t.Errorf("write rotated bundle: %v", err)
-				return
-			}
-			if err := os.Rename(next, path); err != nil {
-				t.Errorf("rename rotated bundle: %v", err)
+			if err := rotateProjectedBundle(path, bundles[i%2]); err != nil {
+				t.Errorf("rotate bundle: %v", err)
 				return
 			}
 		}
@@ -251,6 +239,14 @@ func TestLoaderConcurrentHandshakes(t *testing.T) {
 			for i := 0; i < 100; i++ {
 				cert, err := getCert(nil)
 				if err != nil {
+					// macOS rename(2) is not atomic with respect to
+					// concurrent path resolution through the swapped
+					// symlink and can surface a transient EINVAL from
+					// stat. Linux, where this runs in production and CI,
+					// guarantees resolution sees the old or new target.
+					if errors.Is(err, syscall.EINVAL) {
+						continue
+					}
 					t.Errorf("Loader() error = %v", err)
 					return
 				}
@@ -268,7 +264,7 @@ func TestLoaderConcurrentHandshakes(t *testing.T) {
 	wg.Wait()
 }
 
-func generateRSAKey(t testing.TB) *rsa.PrivateKey {
+func generateRSAKey(t *testing.T) *rsa.PrivateKey {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -277,7 +273,7 @@ func generateRSAKey(t testing.TB) *rsa.PrivateKey {
 	return key
 }
 
-func generateCertificate(t testing.TB, serial int64) []byte {
+func generateCertificate(t *testing.T, serial int64) []byte {
 	t.Helper()
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(serial),
@@ -294,7 +290,7 @@ func generateCertificate(t testing.TB, serial int64) []byte {
 	return der
 }
 
-func writeBundle(t testing.TB, bundle []byte) string {
+func writeBundle(t *testing.T, bundle []byte) string {
 	t.Helper()
 	path := t.TempDir() + "/bundle.pem"
 	if err := os.WriteFile(path, bundle, 0o600); err != nil {
@@ -306,7 +302,7 @@ func writeBundle(t testing.TB, bundle []byte) string {
 // makeBundle returns a PEM credential bundle whose leaf certificate carries
 // the given serial number, so tests can tell which bundle a parsed
 // certificate came from.
-func makeBundle(t testing.TB, serial int64) []byte {
+func makeBundle(t *testing.T, serial int64) []byte {
 	t.Helper()
 	keyDER, err := x509.MarshalPKCS8PrivateKey(generateRSAKey(t))
 	if err != nil {
@@ -326,26 +322,61 @@ func leafSerial(t *testing.T, cert *tls.Certificate) int64 {
 	return cert.Leaf.SerialNumber.Int64()
 }
 
-func BenchmarkLoaderCached(b *testing.B) {
-	getCert := Loader(writeBundle(b, makeBundle(b, 1)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if _, err := getCert(nil); err != nil {
-			b.Fatalf("Loader() error = %v", err)
-		}
+// writeProjectedBundle lays a bundle out the way the kubelet's atomic writer
+// (k8s.io/kubernetes/pkg/volume/util/atomic_writer.go) materializes projected
+// volumes:
+//
+//	<dir>/bundle.pem -> ..data/bundle.pem
+//	<dir>/..data     -> ..payload-<unique>/  (kubelet uses a timestamped name)
+//	<dir>/..payload-<unique>/bundle.pem
+//
+// and returns the visible <dir>/bundle.pem path.
+func writeProjectedBundle(t *testing.T, bundle []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	payload, err := os.MkdirTemp(dir, "..payload-")
+	if err != nil {
+		t.Fatalf("create payload dir: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(payload, "bundle.pem"), bundle, 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	if err := os.Symlink(filepath.Base(payload), filepath.Join(dir, "..data")); err != nil {
+		t.Fatalf("symlink ..data: %v", err)
+	}
+	if err := os.Symlink(filepath.Join("..data", "bundle.pem"), filepath.Join(dir, "bundle.pem")); err != nil {
+		t.Fatalf("symlink bundle.pem: %v", err)
+	}
+	return filepath.Join(dir, "bundle.pem")
 }
 
-// BenchmarkParseUncached is the per-handshake cost before caching: a full
-// read and parse of the bundle on every call.
-func BenchmarkParseUncached(b *testing.B) {
-	path := writeBundle(b, makeBundle(b, 1))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if _, err := Parse(path); err != nil {
-			b.Fatalf("Parse() error = %v", err)
-		}
+// rotateProjectedBundle rotates the bundle behind a writeProjectedBundle path
+// the way the kubelet's atomic writer does: write the new payload into a
+// fresh directory, point a ..data_tmp symlink at it, atomically rename that
+// over ..data, and remove the old payload directory. The visible path is
+// untouched throughout; only what it resolves to changes.
+func rotateProjectedBundle(path string, bundle []byte) error {
+	dir, name := filepath.Dir(path), filepath.Base(path)
+	oldPayload, err := os.Readlink(filepath.Join(dir, "..data"))
+	if err != nil {
+		return fmt.Errorf("readlink ..data: %w", err)
 	}
+	payload, err := os.MkdirTemp(dir, "..payload-")
+	if err != nil {
+		return fmt.Errorf("create payload dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(payload, name), bundle, 0o600); err != nil {
+		return fmt.Errorf("write payload: %w", err)
+	}
+	tmpLink := filepath.Join(dir, "..data_tmp")
+	if err := os.Symlink(filepath.Base(payload), tmpLink); err != nil {
+		return fmt.Errorf("symlink ..data_tmp: %w", err)
+	}
+	if err := os.Rename(tmpLink, filepath.Join(dir, "..data")); err != nil {
+		return fmt.Errorf("swap ..data: %w", err)
+	}
+	if err := os.RemoveAll(filepath.Join(dir, oldPayload)); err != nil {
+		return fmt.Errorf("remove old payload dir: %w", err)
+	}
+	return nil
 }

--- a/internal/credbundle/credbundle_test.go
+++ b/internal/credbundle/credbundle_test.go
@@ -15,13 +15,16 @@
 package credbundle
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
 	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -32,7 +35,7 @@ func TestParsePKCS8PrivateKeyBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal PKCS8 key: %v", err)
 	}
-	certDER := generateCertificate(t)
+	certDER := generateCertificate(t, 1)
 	bundle := append(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})...)
 
 	bundlePath := writeBundle(t, bundle)
@@ -52,7 +55,7 @@ func TestParsePKCS8PrivateKeyBlock(t *testing.T) {
 }
 
 func TestParseRejectsNonPKCS8PrivateKeyBlock(t *testing.T) {
-	certDER := generateCertificate(t)
+	certDER := generateCertificate(t, 1)
 	bundle := append(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(generateRSAKey(t))})...)
 
 	bundlePath := writeBundle(t, bundle)
@@ -61,7 +64,211 @@ func TestParseRejectsNonPKCS8PrivateKeyBlock(t *testing.T) {
 	}
 }
 
-func generateRSAKey(t *testing.T) *rsa.PrivateKey {
+func TestLoaderServesCachedParseWhileFileUnchanged(t *testing.T) {
+	bundle := makeBundle(t, 7)
+	path := writeBundle(t, bundle)
+	getCert := Loader(path)
+
+	if _, err := getCert(nil); err != nil {
+		t.Fatalf("Loader() first call error = %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat bundle: %v", err)
+	}
+	// Replace the content with same-length garbage and restore the mtime, so
+	// file identity (inode), size, and mtime all still match the cached stat.
+	// The cached parse must be served; any re-read would fail loudly on the
+	// garbage.
+	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), len(bundle)), 0o600); err != nil {
+		t.Fatalf("overwrite bundle: %v", err)
+	}
+	if err := os.Chtimes(path, fi.ModTime(), fi.ModTime()); err != nil {
+		t.Fatalf("restore mtime: %v", err)
+	}
+
+	cert, err := getCert(nil)
+	if err != nil {
+		t.Fatalf("Loader() with unchanged stat error = %v", err)
+	}
+	if got := leafSerial(t, cert); got != 7 {
+		t.Fatalf("Loader() leaf serial = %d, want cached 7", got)
+	}
+}
+
+func TestLoaderPicksUpAtomicRotation(t *testing.T) {
+	path := writeBundle(t, makeBundle(t, 1))
+	getCert := Loader(path)
+
+	cert, err := getCert(nil)
+	if err != nil {
+		t.Fatalf("Loader() first call error = %v", err)
+	}
+	if got := leafSerial(t, cert); got != 1 {
+		t.Fatalf("Loader() leaf serial = %d, want 1", got)
+	}
+
+	// Rotate the way the kubelet does: write the new bundle to a fresh file
+	// and atomically rename it over the old path, giving it a new inode.
+	next := path + ".next"
+	if err := os.WriteFile(next, makeBundle(t, 2), 0o600); err != nil {
+		t.Fatalf("write rotated bundle: %v", err)
+	}
+	if err := os.Rename(next, path); err != nil {
+		t.Fatalf("rename rotated bundle: %v", err)
+	}
+
+	cert, err = getCert(nil)
+	if err != nil {
+		t.Fatalf("Loader() after rotation error = %v", err)
+	}
+	if got := leafSerial(t, cert); got != 2 {
+		t.Fatalf("Loader() leaf serial after rotation = %d, want 2", got)
+	}
+}
+
+func TestLoaderPicksUpInPlaceRewrite(t *testing.T) {
+	path := writeBundle(t, makeBundle(t, 1))
+	getCert := Loader(path)
+
+	if _, err := getCert(nil); err != nil {
+		t.Fatalf("Loader() first call error = %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat bundle: %v", err)
+	}
+	// Rewrite the file in place (same inode) and push the mtime forward so
+	// the change is visible even on filesystems with coarse timestamps.
+	if err := os.WriteFile(path, makeBundle(t, 2), 0o600); err != nil {
+		t.Fatalf("rewrite bundle: %v", err)
+	}
+	bumped := fi.ModTime().Add(time.Second)
+	if err := os.Chtimes(path, bumped, bumped); err != nil {
+		t.Fatalf("bump mtime: %v", err)
+	}
+
+	cert, err := getCert(nil)
+	if err != nil {
+		t.Fatalf("Loader() after rewrite error = %v", err)
+	}
+	if got := leafSerial(t, cert); got != 2 {
+		t.Fatalf("Loader() leaf serial after rewrite = %d, want 2", got)
+	}
+}
+
+func TestLoaderErrorWhenBundleMissing(t *testing.T) {
+	getCert := Loader(t.TempDir() + "/absent.pem")
+	if _, err := getCert(nil); err == nil {
+		t.Fatalf("Loader() error = nil, want missing-file error")
+	}
+}
+
+func TestLoaderRecoversAfterError(t *testing.T) {
+	bundle := makeBundle(t, 3)
+	path := writeBundle(t, bundle)
+	getCert := Loader(path)
+
+	if _, err := getCert(nil); err != nil {
+		t.Fatalf("Loader() first call error = %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove bundle: %v", err)
+	}
+	if _, err := getCert(nil); err == nil {
+		t.Fatalf("Loader() error = nil after bundle removed, want error")
+	}
+	if err := os.WriteFile(path, bundle, 0o600); err != nil {
+		t.Fatalf("restore bundle: %v", err)
+	}
+
+	cert, err := getCert(nil)
+	if err != nil {
+		t.Fatalf("Loader() after restore error = %v", err)
+	}
+	if got := leafSerial(t, cert); got != 3 {
+		t.Fatalf("Loader() leaf serial after restore = %d, want 3", got)
+	}
+}
+
+func TestClientLoaderCachesAndReloads(t *testing.T) {
+	path := writeBundle(t, makeBundle(t, 1))
+	getCert := ClientLoader(path)
+
+	cert, err := getCert(nil)
+	if err != nil {
+		t.Fatalf("ClientLoader() first call error = %v", err)
+	}
+	if got := leafSerial(t, cert); got != 1 {
+		t.Fatalf("ClientLoader() leaf serial = %d, want 1", got)
+	}
+
+	next := path + ".next"
+	if err := os.WriteFile(next, makeBundle(t, 2), 0o600); err != nil {
+		t.Fatalf("write rotated bundle: %v", err)
+	}
+	if err := os.Rename(next, path); err != nil {
+		t.Fatalf("rename rotated bundle: %v", err)
+	}
+
+	cert, err = getCert(nil)
+	if err != nil {
+		t.Fatalf("ClientLoader() after rotation error = %v", err)
+	}
+	if got := leafSerial(t, cert); got != 2 {
+		t.Fatalf("ClientLoader() leaf serial after rotation = %d, want 2", got)
+	}
+}
+
+func TestLoaderConcurrentHandshakes(t *testing.T) {
+	bundles := [][]byte{makeBundle(t, 1), makeBundle(t, 2)}
+	path := writeBundle(t, bundles[0])
+	getCert := Loader(path)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 25; i++ {
+			// Atomic-rename rotation, so readers never observe a torn file.
+			next := path + ".next"
+			if err := os.WriteFile(next, bundles[i%2], 0o600); err != nil {
+				t.Errorf("write rotated bundle: %v", err)
+				return
+			}
+			if err := os.Rename(next, path); err != nil {
+				t.Errorf("rename rotated bundle: %v", err)
+				return
+			}
+		}
+	}()
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				cert, err := getCert(nil)
+				if err != nil {
+					t.Errorf("Loader() error = %v", err)
+					return
+				}
+				if cert.Leaf == nil {
+					t.Errorf("Loader() returned certificate with nil leaf")
+					return
+				}
+				if s := cert.Leaf.SerialNumber.Int64(); s != 1 && s != 2 {
+					t.Errorf("Loader() leaf serial = %d, want 1 or 2", s)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func generateRSAKey(t testing.TB) *rsa.PrivateKey {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -70,10 +277,10 @@ func generateRSAKey(t *testing.T) *rsa.PrivateKey {
 	return key
 }
 
-func generateCertificate(t *testing.T) []byte {
+func generateCertificate(t testing.TB, serial int64) []byte {
 	t.Helper()
 	template := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: big.NewInt(serial),
 		Subject:      pkix.Name{CommonName: "api.ate-system.svc"},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
@@ -87,11 +294,58 @@ func generateCertificate(t *testing.T) []byte {
 	return der
 }
 
-func writeBundle(t *testing.T, bundle []byte) string {
+func writeBundle(t testing.TB, bundle []byte) string {
 	t.Helper()
 	path := t.TempDir() + "/bundle.pem"
 	if err := os.WriteFile(path, bundle, 0o600); err != nil {
 		t.Fatalf("write bundle: %v", err)
 	}
 	return path
+}
+
+// makeBundle returns a PEM credential bundle whose leaf certificate carries
+// the given serial number, so tests can tell which bundle a parsed
+// certificate came from.
+func makeBundle(t testing.TB, serial int64) []byte {
+	t.Helper()
+	keyDER, err := x509.MarshalPKCS8PrivateKey(generateRSAKey(t))
+	if err != nil {
+		t.Fatalf("marshal PKCS8 key: %v", err)
+	}
+	return append(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: generateCertificate(t, serial)}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})...,
+	)
+}
+
+func leafSerial(t *testing.T, cert *tls.Certificate) int64 {
+	t.Helper()
+	if cert == nil || cert.Leaf == nil {
+		t.Fatalf("parsed bundle has no leaf certificate")
+	}
+	return cert.Leaf.SerialNumber.Int64()
+}
+
+func BenchmarkLoaderCached(b *testing.B) {
+	getCert := Loader(writeBundle(b, makeBundle(b, 1)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := getCert(nil); err != nil {
+			b.Fatalf("Loader() error = %v", err)
+		}
+	}
+}
+
+// BenchmarkParseUncached is the per-handshake cost before caching: a full
+// read and parse of the bundle on every call.
+func BenchmarkParseUncached(b *testing.B) {
+	path := writeBundle(b, makeBundle(b, 1))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Parse(path); err != nil {
+			b.Fatalf("Parse() error = %v", err)
+		}
+	}
 }


### PR DESCRIPTION
Resolves the `TODO: Introduce caching.` on `credbundle.Loader` / `credbundle.ClientLoader`. The TODO dates back to the package's introduction; since #237 established mTLS between all ate system components, every inter-component handshake is on this path.

## Problem

`Loader`/`ClientLoader` re-read and re-parse the credential bundle from disk on every TLS handshake so that pod-certificate rotations get picked up. That costs ~125µs and ~120 allocations per handshake (RSA bundle) for a file that almost never changes.

## Approach: stat-validated cache

Each loader keeps the last successful parse together with the `os.FileInfo` taken just before that parse. A handshake stats the file (~1µs) and serves the cached certificate while file identity (`os.SameFile`, i.e. device+inode on Unix), mtime, and size all match; any mismatch re-reads and re-parses.

Invalidation and eviction:

- The kubelet rotates projected-volume contents (including pod certificates) by writing a fresh timestamped directory and atomically swapping a symlink, so a rotation always surfaces as a change of file identity and is picked up on the **next handshake** — no staleness window. mtime and size additionally cover in-place rewrites.
- **No TTL**: freshness is derived from the file, never from time, so an unchanged bundle is never re-parsed and a changed one is never served. (A refresh-interval floor to throttle stats was considered and rejected: it would introduce a staleness window to save a ~1µs syscall that only runs at connection-establishment rate. fsnotify was also considered and rejected: watching through symlink swaps is error-prone and adds watcher lifecycle for no latency benefit over the stat.)
- **Memory**: exactly one parsed certificate per loader (one loader per `tls.Config`), replaced on rotation — nothing unbounded to evict.
- **Failure semantics unchanged**: stat/read/parse errors are returned to the caller (never a stale certificate), the previous entry stays in place, and every later handshake retries until a parse succeeds — exactly the uncached behavior.
- The file can change between the stat and the read; the parse is then stored against the older stat, so the next handshake detects the mismatch and re-reads. The cache never lags a rotation by more than one handshake.

## Benchmarks

Apple M5 Pro, RSA-2048 bundle:

| | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `BenchmarkLoaderCached` | 1,001 | 304 | 2 |
| `BenchmarkParseUncached` | 124,843 | 19,544 | 120 |

`Parse` stays exported and uncached; `Loader`/`ClientLoader` signatures are unchanged, so no call sites move.

- [x] Tests pass (`go test ./internal/credbundle/ -race`: cache-hit proof via unchanged-stat corruption, atomic-rename rotation, in-place rewrite, missing-file error, error recovery, concurrent handshakes under the race detector)
- [x] Appropriate changes to documentation are included in the PR (doc comments on `Loader`/`ClientLoader`/`certCache` describe the caching, rotation, and failure semantics)