### PR TITLE
Build the locust image for the cluster's architecture

### DIFF
--- a/benchmarking/locust/build_and_push.sh
+++ b/benchmarking/locust/build_and_push.sh
@@ -31,10 +31,17 @@ fi
 
 IMAGE="us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest"
 
-echo "Building Docker image: $IMAGE"
+# Target platform must match the cluster's nodes, not the build host. Without
+# this, an arm64 workstation (Apple Silicon) pushes an arm64 image, the push
+# succeeds, and the failure only surfaces two steps later when the kubelet on an
+# amd64 node reports "no match for platform in manifest". Override for arm64
+# node pools (T2A, Axion).
+PLATFORM="${LOCUST_IMAGE_PLATFORM:-linux/amd64}"
+
+echo "Building Docker image: $IMAGE (platform: $PLATFORM)"
 # Build context is the monorepo root because the Dockerfile compiles the
 # boomer-glutton Go binary alongside the Python install (see Dockerfile).
-docker build -t "$IMAGE" -f benchmarking/locust/Dockerfile .
+docker build --platform "$PLATFORM" -t "$IMAGE" -f benchmarking/locust/Dockerfile .
 
 echo "Pushing Docker image..."
 docker push "$IMAGE"

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -391,7 +391,10 @@ deploy_atenet() {
   run_ko apply -f manifests/ate-install/atenet-router.yaml
   run_ko apply -f manifests/ate-install/atenet-dns.yaml
   run_kubectl rollout status deployment/atenet-router -n ate-system --timeout=120s
-  run_kubectl rollout status deployment/atenet-dns -n ate-system --timeout=120s
+  # The Deployment in atenet-dns.yaml is named "dns"; every other resource in
+  # that file is "atenet-dns". Waiting on the filename rather than the actual
+  # Deployment made this step fail with NotFound on every successful deploy.
+  run_kubectl rollout status deployment/dns -n ate-system --timeout=120s
 }
 
 # get_actor_status echoes the actor's status enum (e.g. STATUS_SUSPENDED).


### PR DESCRIPTION
`build_and_push.sh` ran `docker build` with no `--platform`, so an arm64
workstation produced an arm64 image while GKE nodes (c3-standard-4) are
amd64. The push succeeds and nothing fails until the kubelet pulls, two
steps later:

    no match for platform in manifest: not found

Default to linux/amd64, overridable via LOCUST_IMAGE_PLATFORM for arm64
node pools (T2A, Axion).

Verified: pushed manifest reports linux/amd64 and the locust pod reaches
3/3 Running.


Stacked on #542.