### PR TITLE
Extract scheduling logic into its own package.

### DIFF
--- a/cmd/ateapi/internal/controlapi/workflow.go
+++ b/cmd/ateapi/internal/controlapi/workflow.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/scheduling"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
@@ -130,6 +131,7 @@ func runStep[Params any, Context any](ctx context.Context, params Params, wCtx C
 type ActorWorkflow struct {
 	store               store.Interface
 	workerCache         *workercache.Cache
+	scheduler           scheduling.Scheduler
 	dialer              *AteletDialer
 	actorTemplateLister listersv1alpha1.ActorTemplateLister
 	workerPoolLister    listersv1alpha1.WorkerPoolLister
@@ -151,6 +153,7 @@ func NewActorWorkflow(
 	return &ActorWorkflow{
 		store:               store,
 		workerCache:         workerCache,
+		scheduler:           scheduling.New(workerCache),
 		dialer:              dialer,
 		actorTemplateLister: actorTemplateLister,
 		workerPoolLister:    workerPoolLister,
@@ -177,9 +180,9 @@ func (w *ActorWorkflow) ResumeActor(ctx context.Context, atespace, name string, 
 
 	steps := []WorkflowStep[*ResumeInput, *ResumeState]{
 		&LoadActorForResumeStep{store: w.store, actorTemplateLister: w.actorTemplateLister},
-		&AssignWorkerStep{store: w.store, workerCache: w.workerCache},
+		&AssignWorkerStep{store: w.store, workerCache: w.workerCache, scheduler: w.scheduler},
 		&AttachVolumesStep{store: w.store},
-		&CallAteletRestoreStep{store: w.store, dialer: w.dialer, kubeClient: w.kubeClient, secretCache: w.secretCache, workerPoolLister: w.workerPoolLister, sandboxConfigLister: w.sandboxConfigLister},
+		&CallAteletRestoreStep{store: w.store, dialer: w.dialer, kubeClient: w.kubeClient, secretCache: w.secretCache, workerPoolLister: w.workerPoolLister, sandboxConfigLister: w.sandboxConfigLister, scheduler: w.scheduler},
 		&FinalizeRunningStep{store: w.store},
 	}
 

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -258,7 +258,7 @@ func (s *FinalizePausedStep) Execute(ctx context.Context, input *PauseInput, sta
 		latestActor.Status = ateapipb.Actor_STATUS_PAUSED
 		if nodeName == "" {
 			// Without a node name we cannot record where the local snapshot lives,
-			// so the actor can never be resumed (findFreeWorker would search for a
+			// so the actor can never be resumed (the scheduler would search for a
 			// worker on an unknown node forever). Crash it instead of leaving it
 			// stuck in PAUSED.
 			slog.ErrorContext(ctx, "Node name not found during finalize pause, crashing actor", "actor", input.ActorName)

--- a/cmd/ateapi/internal/controlapi/workflow_pause_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause_test.go
@@ -28,9 +28,9 @@ import (
 // disappears from the DB during pause finalization, so the node it ran on is
 // unknown.
 //
-// Old behavior: NodeVmsWithLocalSnapshots = []string{""}, which made
-// findFreeWorker search for a worker with node name "", never found, a
-// permanent "no free workers available" on resume.
+// Old behavior: NodeVmsWithLocalSnapshots = []string{""}, which made the
+// scheduler's node restriction search for a worker with node name "", never
+// found, a permanent "no free workers available" on resume.
 //
 // Current behavior: NodeVmsWithLocalSnapshots is left nil, and the actor is
 // crashed instead of left PAUSED, since a local snapshot with an unknown node
@@ -72,7 +72,7 @@ func TestFinalizePausedStep_WorkerGone(t *testing.T) {
 	}
 	for _, n := range got.GetLatestSnapshotInfo().GetLocal().GetNodeVmsWithLocalSnapshots() {
 		if n == "" {
-			t.Errorf("BUG: empty string in NodeVmsWithLocalSnapshots, findFreeWorker would never match")
+			t.Errorf("BUG: empty string in NodeVmsWithLocalSnapshots, the scheduler's node restriction would never match a real worker")
 		}
 	}
 
@@ -83,37 +83,6 @@ func TestFinalizePausedStep_WorkerGone(t *testing.T) {
 	}
 	if !done {
 		t.Error("IsComplete = false, want true once the actor is CRASHED and the worker is freed")
-	}
-}
-
-// TestFindFreeWorker_EmptyNodeRestriction shows the root symptom the fix
-// avoids: old code wrote []string{""} into NodeVmsWithLocalSnapshots when the
-// node name was unknown, and findFreeWorker required worker.NodeName == "",
-// which never matches a real worker.
-func TestFindFreeWorker_EmptyNodeRestriction(t *testing.T) {
-	workers := []*ateapipb.Worker{
-		{WorkerNamespace: "default", WorkerPool: "pool1", WorkerPod: "w1", NodeName: "node1"},
-		{WorkerNamespace: "default", WorkerPool: "pool1", WorkerPod: "w2", NodeName: "node2"},
-	}
-
-	s := &AssignWorkerStep{}
-
-	// Old behavior: []string{""}, no worker has NodeName == "", returns nil.
-	got, err := s.findFreeWorker(workers, "", nil, nil, []string{""})
-	if err != nil {
-		t.Fatalf("findFreeWorker: %v", err)
-	}
-	if got != nil {
-		t.Errorf("expected nil with old buggy input, got %v", got)
-	}
-
-	// Fixed behavior: nil restrictions, any free worker matches.
-	got, err = s.findFreeWorker(workers, "", nil, nil, nil)
-	if err != nil {
-		t.Fatalf("findFreeWorker: %v", err)
-	}
-	if got == nil {
-		t.Error("expected a worker with nil restrictions, got nil")
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -19,10 +19,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math/rand"
-	"slices"
 	"time"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/scheduling"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
@@ -116,32 +115,10 @@ func (s *LoadActorForResumeStep) Execute(ctx context.Context, input *ResumeInput
 
 func (s *LoadActorForResumeStep) RetryBackoff() *wait.Backoff { return nil }
 
-func isWorkerEligibleForActor(worker *ateapipb.Worker, templateClass atev1alpha1.SandboxClass, templateSelector *metav1.LabelSelector, actorSelector *ateapipb.Selector) (bool, error) {
-	// Snapshots are not portable across sandbox classes, so the worker's class
-	// must match the template's. Both classes are populated by the CRD default
-	// (gvisor), so we compare them directly.
-	if worker.GetSandboxClass() != string(templateClass) {
-		return false, nil
-	}
-
-	templateSel := labels.Everything()
-	if templateSelector != nil {
-		sel, err := metav1.LabelSelectorAsSelector(templateSelector)
-		if err != nil {
-			return false, fmt.Errorf("invalid template worker selector: %w", err)
-		}
-		templateSel = sel
-	}
-
-	actorSel := labels.SelectorFromSet(labels.Set(actorSelector.GetMatchLabels()))
-
-	set := labels.Set(worker.GetLabels())
-	return templateSel.Matches(set) && actorSel.Matches(set), nil
-}
-
 type AssignWorkerStep struct {
 	store       store.Interface
 	workerCache *workercache.Cache
+	scheduler   scheduling.Scheduler
 }
 
 func (s *AssignWorkerStep) Name() string { return "AssignWorker" }
@@ -166,6 +143,11 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 		return fmt.Errorf("while listing workers: %w", err)
 	}
 
+	constraints, err := schedulingConstraints(state.Actor, state.ActorTemplate)
+	if err != nil {
+		return err
+	}
+
 	var assignedWorker *ateapipb.Worker
 
 	// Check if we already have a worker assigned from a previous failed attempt.
@@ -178,11 +160,7 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 		if worker.Assignment.Actor.Atespace != input.Atespace || worker.Assignment.Actor.Name != input.ActorName {
 			continue
 		}
-		eligible, err := isWorkerEligibleForActor(worker, state.ActorTemplate.Spec.SandboxClass, state.ActorTemplate.Spec.WorkerSelector, state.Actor.GetWorkerSelector())
-		if err != nil {
-			return fmt.Errorf("while checking worker eligibility: %w", err)
-		}
-		if eligible {
+		if s.scheduler.Applies(worker, constraints) {
 			assignedWorker = worker
 			break
 		}
@@ -205,12 +183,12 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 		}(releaseWorker)
 	}
 	if assignedWorker == nil {
-		pickedWorker, err := s.findFreeWorker(workers, state.ActorTemplate.Spec.SandboxClass, state.ActorTemplate.Spec.WorkerSelector, state.Actor.GetWorkerSelector(), state.Actor.GetLatestSnapshotInfo().GetLocal().GetNodeVmsWithLocalSnapshots())
+		pickedWorker, err := s.scheduler.Schedule(ctx, constraints)
 		if err != nil {
+			if errors.Is(err, scheduling.ErrNoCapacity) {
+				return status.Errorf(codes.FailedPrecondition, "no free workers available")
+			}
 			return err
-		}
-		if pickedWorker == nil {
-			return status.Errorf(codes.FailedPrecondition, "no free workers available")
 		}
 
 		assignedWorker = pickedWorker
@@ -249,6 +227,22 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 	state.Actor = updatedActor
 	state.Worker = assignedWorker
 	return nil
+}
+
+func schedulingConstraints(actor *ateapipb.Actor, tmpl *atev1alpha1.ActorTemplate) (scheduling.Constraints, error) {
+	c := scheduling.Constraints{
+		SandboxClass:  string(tmpl.Spec.SandboxClass),
+		ActorSelector: labels.SelectorFromSet(labels.Set(actor.GetWorkerSelector().GetMatchLabels())),
+		RequiredNodes: actor.GetLatestSnapshotInfo().GetLocal().GetNodeVmsWithLocalSnapshots(),
+	}
+	if tmpl.Spec.WorkerSelector != nil {
+		sel, err := metav1.LabelSelectorAsSelector(tmpl.Spec.WorkerSelector)
+		if err != nil {
+			return scheduling.Constraints{}, fmt.Errorf("invalid template worker selector: %w", err)
+		}
+		c.TemplateSelector = sel
+	}
+	return c, nil
 }
 
 func (s *AssignWorkerStep) RetryBackoff() *wait.Backoff {
@@ -303,39 +297,6 @@ func (s *AttachVolumesStep) Execute(ctx context.Context, input *ResumeInput, sta
 
 func (s *AttachVolumesStep) RetryBackoff() *wait.Backoff { return nil }
 
-func (s *AssignWorkerStep) findFreeWorker(
-	workers []*ateapipb.Worker,
-	templateClass atev1alpha1.SandboxClass,
-	templateSelector *metav1.LabelSelector,
-	actorSelector *ateapipb.Selector,
-	nodesRestrictions []string,
-) (*ateapipb.Worker, error) {
-	var freeWorkers []*ateapipb.Worker
-	for _, worker := range workers {
-		if worker.Assignment != nil {
-			continue
-		}
-		eligible, err := isWorkerEligibleForActor(worker, templateClass, templateSelector, actorSelector)
-		if err != nil {
-			return nil, err
-		}
-		if !eligible {
-			continue
-		}
-		if len(nodesRestrictions) == 0 || slices.Contains(nodesRestrictions, worker.GetNodeName()) {
-			freeWorkers = append(freeWorkers, worker)
-		}
-	}
-
-	if len(freeWorkers) > 0 {
-		rand.Shuffle(len(freeWorkers), func(i, j int) {
-			freeWorkers[i], freeWorkers[j] = freeWorkers[j], freeWorkers[i]
-		})
-		return freeWorkers[0], nil
-	}
-	return nil, nil
-}
-
 type CallAteletRestoreStep struct {
 	store               store.Interface
 	dialer              *AteletDialer
@@ -343,6 +304,7 @@ type CallAteletRestoreStep struct {
 	secretCache         *envSecretCache
 	workerPoolLister    listersv1alpha1.WorkerPoolLister
 	sandboxConfigLister listersv1alpha1.SandboxConfigLister
+	scheduler           scheduling.Scheduler
 }
 
 func (s *CallAteletRestoreStep) Name() string { return "CallAteletRestore" }
@@ -367,11 +329,11 @@ func (s *CallAteletRestoreStep) CheckPrerequisite(ctx context.Context, input *Re
 		}
 		return status.Errorf(codes.Aborted, "actor %s crashed", input.ActorName)
 	}
-	eligible, err := isWorkerEligibleForActor(state.Worker, state.ActorTemplate.Spec.SandboxClass, state.ActorTemplate.Spec.WorkerSelector, state.Actor.GetWorkerSelector())
+	constraints, err := schedulingConstraints(state.Actor, state.ActorTemplate)
 	if err != nil {
-		return fmt.Errorf("while calling isWorkerEligbleForActor :%w", err)
+		return err
 	}
-	if !eligible {
+	if !s.scheduler.Applies(state.Worker, constraints) {
 		slog.ErrorContext(ctx, "crashing actor because previously assigned worker is not eligible anymore")
 		release := proto.Clone(state.Worker).(*ateapipb.Worker)
 		release.Assignment = nil

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/scheduling"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
@@ -26,149 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func TestIsWorkerEligibleForActor(t *testing.T) {
-	tests := []struct {
-		name             string
-		worker           *ateapipb.Worker
-		templateClass    atev1alpha1.SandboxClass
-		templateSelector *metav1.LabelSelector
-		actorSelector    *ateapipb.Selector
-		wantEligible     bool
-	}{
-		{
-			name: "both nil matches everything",
-			worker: &ateapipb.Worker{
-				SandboxClass: "gvisor",
-				Labels:       map[string]string{"foo": "bar"},
-			},
-			templateClass:    atev1alpha1.SandboxClassGvisor,
-			templateSelector: nil,
-			actorSelector:    nil,
-			wantEligible:     true,
-		},
-		{
-			name: "template selector only match",
-			worker: &ateapipb.Worker{
-				SandboxClass: "gvisor",
-				Labels:       map[string]string{"workload": "code-sandbox"},
-			},
-			templateClass: atev1alpha1.SandboxClassGvisor,
-			templateSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"workload": "code-sandbox"},
-			},
-			actorSelector: nil,
-			wantEligible:  true,
-		},
-		{
-			name: "template selector only no match",
-			worker: &ateapipb.Worker{
-				SandboxClass: "gvisor",
-				Labels:       map[string]string{"workload": "browser-agent"},
-			},
-			templateClass: atev1alpha1.SandboxClassGvisor,
-			templateSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"workload": "code-sandbox"},
-			},
-			actorSelector: nil,
-			wantEligible:  false,
-		},
-		{
-			name: "actor selector only match",
-			worker: &ateapipb.Worker{
-				SandboxClass: "gvisor",
-				Labels:       map[string]string{"tier": "paid"},
-			},
-			templateClass:    atev1alpha1.SandboxClassGvisor,
-			templateSelector: nil,
-			actorSelector: &ateapipb.Selector{
-				MatchLabels: map[string]string{"tier": "paid"},
-			},
-			wantEligible: true,
-		},
-		{
-			name: "actor selector only no match",
-			worker: &ateapipb.Worker{
-				SandboxClass: "gvisor",
-				Labels:       map[string]string{"tier": "free"},
-			},
-			templateClass:    atev1alpha1.SandboxClassGvisor,
-			templateSelector: nil,
-			actorSelector: &ateapipb.Selector{
-				MatchLabels: map[string]string{"tier": "paid"},
-			},
-			wantEligible: false,
-		},
-		{
-			name: "AND of two selectors match",
-			worker: &ateapipb.Worker{
-				SandboxClass: "gvisor",
-				Labels:       map[string]string{"workload": "code-sandbox", "tier": "paid"},
-			},
-			templateClass: atev1alpha1.SandboxClassGvisor,
-			templateSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"workload": "code-sandbox"},
-			},
-			actorSelector: &ateapipb.Selector{
-				MatchLabels: map[string]string{"tier": "paid"},
-			},
-			wantEligible: true,
-		},
-		{
-			name: "AND of two selectors one fails",
-			worker: &ateapipb.Worker{
-				SandboxClass: "gvisor",
-				Labels:       map[string]string{"workload": "code-sandbox", "tier": "free"},
-			},
-			templateClass: atev1alpha1.SandboxClassGvisor,
-			templateSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"workload": "code-sandbox"},
-			},
-			actorSelector: &ateapipb.Selector{
-				MatchLabels: map[string]string{"tier": "paid"},
-			},
-			wantEligible: false,
-		},
-		{
-			name: "microvm template matches only microvm worker",
-			worker: &ateapipb.Worker{
-				SandboxClass: "microvm",
-			},
-			templateClass: atev1alpha1.SandboxClassMicroVM,
-			wantEligible:  true,
-		},
-		{
-			name: "microvm template excludes gvisor worker",
-			worker: &ateapipb.Worker{
-				SandboxClass: "gvisor",
-			},
-			templateClass: atev1alpha1.SandboxClassMicroVM,
-			wantEligible:  false,
-		},
-		{
-			name: "gvisor template excludes microvm worker",
-			worker: &ateapipb.Worker{
-				SandboxClass: "microvm",
-			},
-			templateClass: atev1alpha1.SandboxClassGvisor,
-			wantEligible:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := isWorkerEligibleForActor(tt.worker, tt.templateClass, tt.templateSelector, tt.actorSelector)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tt.wantEligible {
-				t.Errorf("got eligible=%t, want %t", got, tt.wantEligible)
-			}
-		})
-	}
-}
 
 func TestAssignWorkerStep_SkipsWorkerAssignedInOtherAtespace(t *testing.T) {
 	ctx := context.Background()
@@ -196,7 +55,7 @@ func TestAssignWorkerStep_SkipsWorkerAssignedInOtherAtespace(t *testing.T) {
 		t.Fatalf("workercache.Start: %v", err)
 	}
 
-	step := &AssignWorkerStep{store: persistence, workerCache: wc}
+	step := &AssignWorkerStep{store: persistence, workerCache: wc, scheduler: scheduling.New(wc)}
 	state := &ResumeState{
 		Actor: &ateapipb.Actor{
 			Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "shared"},
@@ -265,7 +124,7 @@ func TestAssignWorkerStep_ReleasesIneligibleStaleWorkerInBackground(t *testing.T
 		t.Fatalf("workercache.Start: %v", err)
 	}
 
-	step := &AssignWorkerStep{store: persistence, workerCache: wc}
+	step := &AssignWorkerStep{store: persistence, workerCache: wc, scheduler: scheduling.New(wc)}
 	state := &ResumeState{
 		Actor: actor,
 		ActorTemplate: &atev1alpha1.ActorTemplate{
@@ -362,7 +221,7 @@ func TestAssignWorkerStep_RetryAfterConflictPicksFreshWorker(t *testing.T) {
 	stale.Assignment = &ateapipb.Assignment{
 		Actor: &ateapipb.ObjectRef{Atespace: "team-a", Name: "id1"},
 	}
-	step := &AssignWorkerStep{store: persistence, workerCache: wc}
+	step := &AssignWorkerStep{store: persistence, workerCache: wc, scheduler: scheduling.New(wc)}
 	state := &ResumeState{
 		Actor:  actor,
 		Worker: stale,
@@ -504,7 +363,7 @@ func TestResumeSteps_CheckPrerequisite(t *testing.T) {
 			// The restore call is allowed only from RESUMING (RUNNING is
 			// fast-forwarded by IsComplete).
 			name: "CallAteletRestoreStep",
-			step: &CallAteletRestoreStep{},
+			step: &CallAteletRestoreStep{scheduler: scheduling.New(nil)},
 			allowed: map[ateapipb.Actor_Status]bool{
 				ateapipb.Actor_STATUS_RESUMING: true,
 			},
@@ -653,7 +512,7 @@ func TestCallAteletRestoreStep_CheckPrerequisite_WorkerOwnership(t *testing.T) {
 
 			seedWorkflowActor(t, ctx, persistence, "team-a", "shared", "ns", "tmpl1", ateapipb.Actor_STATUS_RESUMING)
 
-			step := &CallAteletRestoreStep{store: persistence}
+			step := &CallAteletRestoreStep{store: persistence, scheduler: scheduling.New(nil)}
 			state := &ResumeState{
 				Actor: &ateapipb.Actor{
 					Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "shared"},

--- a/cmd/ateapi/internal/scheduling/scheduling.go
+++ b/cmd/ateapi/internal/scheduling/scheduling.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package scheduling decides which worker should host an actor.
+package scheduling
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"slices"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Constraints describes what a worker must satisfy to host an actor.
+type Constraints struct {
+	// SandboxClass must equal the worker's sandbox class. Snapshots are not
+	// portable across sandbox classes, so this is never relaxed.
+	SandboxClass string
+
+	// TemplateSelector and ActorSelector must both match the worker's labels.
+	TemplateSelector labels.Selector
+	ActorSelector    labels.Selector
+
+	// RequiredNodes, when non-empty, restricts placement to workers running
+	// on one of these nodes. Used when the actor's latest snapshot is local
+	// to specific node VMs.
+	RequiredNodes []string
+}
+
+// ErrNoCapacity is returned by Schedule when no free worker satisfies the
+// constraints.
+var ErrNoCapacity = errors.New("no free workers satisfy the constraints")
+
+// Scheduler answers placement questions against the current worker fleet.
+type Scheduler interface {
+	// Schedule returns a free worker satisfying constraints.
+	// Returns ErrNoCapacity when no free worker satisfies the requested constraints.
+	Schedule(ctx context.Context, constraints Constraints) (*ateapipb.Worker, error)
+
+	// Applies reports whether worker satisfies constraints.
+	Applies(worker *ateapipb.Worker, constraints Constraints) bool
+}
+
+// WorkerSource provides the whole fleet of workers.
+type WorkerSource interface {
+	Workers() ([]*ateapipb.Worker, error)
+}
+
+type scheduler struct {
+	source WorkerSource
+	// intn returns a uniformly distributed random value in [0,n).
+	// Defaults to the global math/rand source
+	intn func(n int) int
+}
+
+// Option configures the Scheduler returned by New.
+type Option func(*scheduler)
+
+// WithIntn overrides the random source used to pick among equally suitable
+// workers. n is always >= 1.
+func WithIntn(intn func(n int) int) Option {
+	return func(s *scheduler) { s.intn = intn }
+}
+
+// New returns a Scheduler placing onto workers reported by source.
+func New(source WorkerSource, opts ...Option) Scheduler {
+	s := &scheduler{source: source, intn: rand.Intn}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func (s *scheduler) Schedule(ctx context.Context, constraints Constraints) (*ateapipb.Worker, error) {
+	workers, err := s.source.Workers()
+	if err != nil {
+		return nil, fmt.Errorf("while listing workers: %w", err)
+	}
+
+	var candidates []*ateapipb.Worker
+	for _, worker := range workers {
+		if worker.GetAssignment() == nil && s.Applies(worker, constraints) {
+			candidates = append(candidates, worker)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil, ErrNoCapacity
+	}
+	return candidates[s.intn(len(candidates))], nil
+}
+
+func (s *scheduler) Applies(worker *ateapipb.Worker, constraints Constraints) bool {
+	if worker.GetSandboxClass() != constraints.SandboxClass {
+		return false
+	}
+
+	set := labels.Set(worker.GetLabels())
+	if constraints.TemplateSelector != nil && !constraints.TemplateSelector.Matches(set) {
+		return false
+	}
+	if constraints.ActorSelector != nil && !constraints.ActorSelector.Matches(set) {
+		return false
+	}
+
+	return len(constraints.RequiredNodes) == 0 || slices.Contains(constraints.RequiredNodes, worker.GetNodeName())
+}

--- a/cmd/ateapi/internal/scheduling/scheduling_test.go
+++ b/cmd/ateapi/internal/scheduling/scheduling_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduling
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestSchedule(t *testing.T) {
+	tierOne := map[string]string{"tier": "1"}
+	tierTwo := map[string]string{"tier": "2"}
+
+	tests := []struct {
+		name        string
+		fleet       fleet
+		constraints Constraints
+		wantPod     string // "" means ErrNoCapacity expected
+	}{
+		{
+			name: "picks the only eligible free worker",
+			fleet: fleet{
+				worker("w-busy", "gvisor", "node-a", tierTwo, assigned("demo", "other")),
+				worker("w-free", "gvisor", "node-a", tierTwo),
+			},
+			constraints: Constraints{SandboxClass: "gvisor"},
+			wantPod:     "w-free",
+		},
+		{
+			name: "sandbox class is a hard constraint",
+			fleet: fleet{
+				worker("w-vm", "microvm", "node-a", tierTwo),
+			},
+			constraints: Constraints{SandboxClass: "gvisor"},
+		},
+		{
+			name: "template selector filters",
+			fleet: fleet{
+				worker("w-1", "gvisor", "node-a", tierTwo),
+				worker("w-2", "gvisor", "node-a", tierOne),
+			},
+			constraints: Constraints{SandboxClass: "gvisor",
+				TemplateSelector: labels.SelectorFromSet(labels.Set{"tier": "1"})},
+			wantPod: "w-2",
+		},
+		{
+			name: "actor selector filters on top of template selector",
+			fleet: fleet{
+				worker("w-1", "gvisor", "node-a", map[string]string{"tier": "1", "worload": "a"}),
+				worker("w-2", "gvisor", "node-b", map[string]string{"tier": "1", "workload": "b"}),
+			},
+			constraints: Constraints{SandboxClass: "gvisor",
+				TemplateSelector: labels.SelectorFromSet(labels.Set{"tier": "1"}),
+				ActorSelector:    labels.SelectorFromSet(labels.Set{"workload": "b"})},
+			wantPod: "w-2",
+		},
+		{
+			name: "node restriction is a hard constraint",
+			fleet: fleet{
+				worker("w-a", "gvisor", "node-a", tierTwo),
+				worker("w-b", "gvisor", "node-b", tierTwo),
+			},
+			constraints: Constraints{SandboxClass: "gvisor", RequiredNodes: []string{"node-b"}},
+			wantPod:     "w-b",
+		},
+		{
+			name: "nil selectors match everything",
+			fleet: fleet{
+				worker("w-1", "gvisor", "node-a", nil),
+			},
+			constraints: Constraints{SandboxClass: "gvisor"},
+			wantPod:     "w-1",
+		},
+		{
+			name: "busy workers never scheduled even if eligible",
+			fleet: fleet{
+				worker("w-busy", "gvisor", "node-a", tierTwo, assigned("demo", "a")),
+			},
+			constraints: Constraints{SandboxClass: "gvisor"},
+		},
+		{
+			name:        "empty fleet",
+			fleet:       fleet{},
+			constraints: Constraints{SandboxClass: "gvisor"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New(tc.fleet, WithIntn(firstIntn))
+			got, err := s.Schedule(context.Background(), tc.constraints)
+
+			if tc.wantPod != "" {
+				if err != nil {
+					t.Fatalf("Schedule() error = %v, want worker %q", err, tc.wantPod)
+				}
+				if got.GetWorkerPod() != tc.wantPod {
+					t.Fatalf("Schedule() = %q, want %q", got.GetWorkerPod(), tc.wantPod)
+				}
+				return
+			}
+
+			if !errors.Is(err, ErrNoCapacity) {
+				t.Fatalf("Schedule() error = %v, want ErrNoCapacity", err)
+			}
+		})
+	}
+}
+
+func TestApplies(t *testing.T) {
+	tierSel := labels.SelectorFromSet(labels.Set{"tier": "1"})
+	workloadSel := labels.SelectorFromSet(labels.Set{"workload": "a"})
+
+	tests := []struct {
+		name        string
+		worker      *ateapipb.Worker
+		constraints Constraints
+		want        bool
+	}{
+		{
+			name:   "satisfies all constraints",
+			worker: worker("w", "gvisor", "node-a", map[string]string{"tier": "1", "workload": "a"}),
+			constraints: Constraints{SandboxClass: "gvisor", TemplateSelector: tierSel, RequiredNodes: []string{"node-a"},
+				ActorSelector: workloadSel},
+			want: true,
+		},
+		{
+			name:        "assignment is ignored",
+			worker:      worker("w", "gvisor", "node-a", nil, assigned("demo", "someone-else")),
+			constraints: Constraints{SandboxClass: "gvisor"},
+			want:        true,
+		},
+		{
+			name:        "class mismatch",
+			worker:      worker("w", "microvm", "node-a", nil),
+			constraints: Constraints{SandboxClass: "gvisor"},
+			want:        false,
+		},
+		{
+			name:        "template selector mismatch",
+			worker:      worker("w", "gvisor", "node-a", map[string]string{"tier": "2"}),
+			constraints: Constraints{SandboxClass: "gvisor", TemplateSelector: tierSel},
+			want:        false,
+		},
+		{
+			name:        "actor selector mismatch",
+			worker:      worker("w", "gvisor", "node-a", map[string]string{"workload": "b"}),
+			constraints: Constraints{SandboxClass: "gvisor", ActorSelector: workloadSel},
+			want:        false,
+		},
+		{
+			name:        "node restriction excludes",
+			worker:      worker("w", "gvisor", "node-b", nil),
+			constraints: Constraints{SandboxClass: "gvisor", RequiredNodes: []string{"node-a"}},
+			want:        false,
+		},
+		{
+			name:   "AND of template and actor selectors match",
+			worker: worker("w", "gvisor", "node-a", map[string]string{"tier": "1", "workload": "a"}),
+			constraints: Constraints{SandboxClass: "gvisor",
+				TemplateSelector: tierSel,
+				ActorSelector:    workloadSel},
+			want: true,
+		},
+		{
+			name:   "AND of two selectors, one fails",
+			worker: worker("w", "gvisor", "node-a", map[string]string{"tier": "1", "workload": "b"}),
+			constraints: Constraints{SandboxClass: "gvisor",
+				TemplateSelector: tierSel,
+				ActorSelector:    workloadSel},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New(fleet{})
+			if got := s.Applies(tc.worker, tc.constraints); got != tc.want {
+				t.Fatalf("Applies() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type fleet []*ateapipb.Worker
+
+func (f fleet) Workers() ([]*ateapipb.Worker, error) { return f, nil }
+
+func worker(pod, class, node string, lbls map[string]string, opts ...func(*ateapipb.Worker)) *ateapipb.Worker {
+	w := &ateapipb.Worker{
+		WorkerPod:    pod,
+		SandboxClass: class,
+		NodeName:     node,
+		Labels:       lbls,
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w
+}
+
+func assigned(atespace, name string) func(*ateapipb.Worker) {
+	return func(w *ateapipb.Worker) {
+		w.Assignment = &ateapipb.Assignment{
+			Actor: &ateapipb.ObjectRef{Atespace: atespace, Name: name},
+		}
+	}
+}
+
+// firstIntn always picks the first candidate, making Schedule deterministic.
+func firstIntn(int) int { return 0 }


### PR DESCRIPTION
The scheduling logic is all mixed up with the resume/suspend/pause workflows. Move it into a dedicated package, behind an interface and add tests.
