### PR TITLE
Refactor ateom networking to shared internal/ateomnet package

### DIFF
--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -18,12 +18,10 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"os"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -31,6 +29,7 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"github.com/agent-substrate/substrate/internal/actorlog"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
+	"github.com/agent-substrate/substrate/internal/ateomnet"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/agent-substrate/substrate/internal/imagecache"
@@ -38,12 +37,8 @@ import (
 	"github.com/agent-substrate/substrate/internal/readyz"
 	"github.com/agent-substrate/substrate/internal/serverboot"
 	"github.com/agent-substrate/substrate/internal/version"
-	"github.com/google/nftables"
-	"github.com/google/nftables/binaryutil"
-	"github.com/google/nftables/expr"
 	"github.com/hashicorp/go-reap"
 	"github.com/spf13/pflag"
-	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -58,17 +53,6 @@ var (
 	showVersion = pflag.Bool("version", false, "Print version and exit.")
 
 	reapLock sync.RWMutex
-)
-
-const (
-	hostVethName      = "ateom0"
-	actorVethName     = "eth0"
-	actorVethTempName = "ateom1"
-	hostVethCIDR      = "169.254.17.1/30"
-	actorVethCIDR     = "169.254.17.2/30"
-	actorVethGateway  = "169.254.17.1"
-	actorVethIP       = "169.254.17.2"
-	actorNftTableName = "ateom_actor"
 )
 
 func main() {
@@ -139,7 +123,7 @@ func do(ctx context.Context) error {
 	// read the addresses and routes off of every link in the namespace, then
 	// remove all the addresses and handle injecting packets into the interfaces
 	// using AF_PACKET.
-	interiorNetNS, err := createNetNSWithoutSwitching(ctx, ateompath.AteomNetNSName(*podUID))
+	interiorNetNS, err := ateomnet.CreateNetNSWithoutSwitching(ateompath.AteomNetNSName(*podUID))
 	if err != nil {
 		return fmt.Errorf("while creating ateom-interior netns: %w", err)
 	}
@@ -196,7 +180,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	//   * Correct runsc version is downloaded and placed on disk.
 	//   * All OCI bundles are set up, including for "pause" container.
 
-	if err := s.setupActorNetwork(ctx); err != nil {
+	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{InteriorNetNS: s.interiorNetNS, DumpNetInfo: true}); err != nil {
 		return nil, fmt.Errorf("while setting up actor network: %w", err)
 	}
 	defer func() {
@@ -204,13 +188,14 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 			// Detach any bundle rootfs overlays a partially-completed setup
 			// mounted, mirroring the post-checkpoint cleanup — otherwise they
 			// linger in this namespace until atelet wipes the bundle dirs.
-			// Run before the network cleanup, which exits the process on
-			// failure and would skip this.
+			// Run before the network cleanup.
 			if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(req.GetActorUid())); err != nil {
 				slog.WarnContext(ctx, "Failed to unmount bundle rootfs overlays after Run failure",
 					"actorUID", req.GetActorUid(), "err", err)
 			}
-			s.cleanupActorNetworkOrExit(ctx, "Failed to clean up actor network after Run failure")
+			if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
+				slog.WarnContext(ctx, "Failed to clean up actor network after Run failure", slog.Any("err", err))
+			}
 		}
 	}()
 
@@ -254,7 +239,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	}
 
 	// Block until every readyz-enabled container reports 200.
-	if err := readyz.WaitAll(ctx, req.GetSpec().GetContainers(), actorVethIP); err != nil {
+	if err := readyz.WaitAll(ctx, req.GetSpec().GetContainers(), ateomnet.ActorVethIP); err != nil {
 		return nil, fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
@@ -329,7 +314,9 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 			"err", err)
 	}
 
-	s.cleanupActorNetworkOrExit(ctx, "Failed to clean up actor network after checkpoint")
+	if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
+		slog.WarnContext(ctx, "Failed to clean up actor network after checkpoint", slog.Any("err", err))
+	}
 
 	// Report exactly the files runsc wrote so atelet ships precisely this set
 	// (checkpoint.img plus any pages images), rather than a hardcoded list.
@@ -398,7 +385,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	//   * All OCI bundles are set up, including for "pause" container.
 	//   * Checkpoint downloaded and placed on disk
 
-	if err := s.setupActorNetwork(ctx); err != nil {
+	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{InteriorNetNS: s.interiorNetNS, DumpNetInfo: true}); err != nil {
 		return nil, fmt.Errorf("while setting up actor network: %w", err)
 	}
 	defer func() {
@@ -408,7 +395,9 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 				slog.WarnContext(ctx, "Failed to unmount bundle rootfs overlays after Restore failure",
 					"actorUID", req.GetActorUid(), "err", err)
 			}
-			s.cleanupActorNetworkOrExit(ctx, "Failed to clean up actor network after Restore failure")
+			if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
+				slog.WarnContext(ctx, "Failed to clean up actor network after Restore failure", slog.Any("err", err))
+			}
 		}
 	}()
 
@@ -479,263 +468,13 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	}
 
 	// Block until every readyz-enabled container reports 200.
-	if err := readyz.WaitAll(ctx, req.GetSpec().GetContainers(), actorVethIP); err != nil {
+	if err := readyz.WaitAll(ctx, req.GetSpec().GetContainers(), ateomnet.ActorVethIP); err != nil {
 		return nil, fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
 	s.actorLogger.EmitLifecycleLog("Actor restored", req.GetAtespace(), req.GetActorName(), req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
 	return &ateompb.RestoreWorkloadResponse{}, nil
-}
-
-func (s *AteomService) setupActorNetwork(ctx context.Context) (retErr error) {
-	// Build a fresh point-to-point network between the worker pod netns and the
-	// gVisor interior netns. The worker side keeps the pod's real eth0, creates
-	// ateom0 as the gateway, and moves only the veth peer into the actor netns.
-	// The actor side renames that peer to eth0 and installs a default route via
-	// the worker-side veth address. This replaces the old behavior of moving the
-	// Kubernetes-provided eth0 out of the worker pod.
-	//
-	// The nftables rules installed here are a compatibility bridge for the
-	// current router assumptions: actor egress is masqueraded behind the worker
-	// pod IP, and inbound traffic to the worker pod's HTTP port is DNAT'd to the
-	// actor veth IP.
-	//
-	// Clean up stale state from a failed prior activation before creating the
-	// next actor-side network. The worker currently runs one actor at a time.
-	s.cleanupActorNetworkOrExit(ctx, "Failed to clean up stale actor network before setup")
-	defer func() {
-		if retErr != nil {
-			s.cleanupActorNetworkOrExit(ctx, "Failed to clean up partially configured actor network")
-		}
-	}()
-
-	podIP, err := podIPv4()
-	if err != nil {
-		return fmt.Errorf("while resolving pod IPv4 address: %w", err)
-	}
-
-	hostAddr, err := parseAddr(hostVethCIDR)
-	if err != nil {
-		return err
-	}
-
-	veth := &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{
-			Name: hostVethName,
-		},
-		PeerName: actorVethTempName,
-	}
-	if err := netlink.LinkAdd(veth); err != nil {
-		return fmt.Errorf("while creating actor veth pair: %w", err)
-	}
-
-	hostLink, err := netlink.LinkByName(hostVethName)
-	if err != nil {
-		return fmt.Errorf("while getting host veth: %w", err)
-	}
-	if err := netlink.AddrReplace(hostLink, hostAddr); err != nil {
-		return fmt.Errorf("while assigning host veth address: %w", err)
-	}
-	if err := netlink.LinkSetUp(hostLink); err != nil {
-		return fmt.Errorf("while bringing up host veth: %w", err)
-	}
-
-	actorLink, err := netlink.LinkByName(actorVethTempName)
-	if err != nil {
-		return fmt.Errorf("while getting actor veth peer: %w", err)
-	}
-	if err := netlink.LinkSetNsFd(actorLink, int(s.interiorNetNS)); err != nil {
-		return fmt.Errorf("while moving actor veth peer into interior netns: %w", err)
-	}
-
-	if err := netNSDo(ctx, s.interiorNetNS, configureActorVeth); err != nil {
-		return fmt.Errorf("while configuring actor veth in interior netns: %w", err)
-	}
-
-	if err := enableIPv4Forwarding(); err != nil {
-		return err
-	}
-	if err := installActorNftablesRules(podIP); err != nil {
-		return err
-	}
-
-	if err := dumpNetInfo(ctx, "Pod NetNS "); err != nil {
-		return fmt.Errorf("while dumping pod netns links: %w", err)
-	}
-	if err := netNSDo(ctx, s.interiorNetNS, func(ctx context.Context) error {
-		return dumpNetInfo(ctx, "Interior NetNS ")
-	}); err != nil {
-		return fmt.Errorf("while dumping interior netns links: %w", err)
-	}
-
-	return nil
-}
-
-func configureActorVeth(ctx context.Context) error {
-	// Run inside the gVisor interior netns after setupActorNetwork moves the
-	// veth peer there. gVisor reads link names, addresses, and routes from this
-	// namespace when the workload starts, so the peer is deliberately renamed to
-	// eth0 and configured like a normal container interface:
-	//
-	//   * lo is brought up for localhost behavior.
-	//   * the temporary veth peer is renamed to eth0.
-	//   * eth0 receives the actor-side /30 address.
-	//   * the default route points to the worker-side veth gateway.
-	loLink, err := netlink.LinkByName("lo")
-	if err != nil {
-		return fmt.Errorf("while acquiring lo in interior netns: %w", err)
-	}
-	if err := netlink.LinkSetUp(loLink); err != nil {
-		return fmt.Errorf("while bringing up lo in interior netns: %w", err)
-	}
-
-	actorLink, err := netlink.LinkByName(actorVethTempName)
-	if err != nil {
-		return fmt.Errorf("while acquiring actor veth in interior netns: %w", err)
-	}
-	if err := netlink.LinkSetName(actorLink, actorVethName); err != nil {
-		return fmt.Errorf("while renaming actor veth to %q: %w", actorVethName, err)
-	}
-	actorLink, err = netlink.LinkByName(actorVethName)
-	if err != nil {
-		return fmt.Errorf("while reacquiring actor veth in interior netns: %w", err)
-	}
-
-	actorAddr, err := parseAddr(actorVethCIDR)
-	if err != nil {
-		return err
-	}
-	if err := netlink.AddrReplace(actorLink, actorAddr); err != nil {
-		return fmt.Errorf("while assigning actor veth address: %w", err)
-	}
-	if err := netlink.LinkSetUp(actorLink); err != nil {
-		return fmt.Errorf("while bringing up actor veth: %w", err)
-	}
-
-	gw := net.ParseIP(actorVethGateway).To4()
-	if gw == nil {
-		return fmt.Errorf("invalid actor veth gateway %q", actorVethGateway)
-	}
-	if err := netlink.RouteReplace(&netlink.Route{
-		LinkIndex: actorLink.Attrs().Index,
-		Gw:        gw,
-	}); err != nil {
-		return fmt.Errorf("while installing actor default route: %w", err)
-	}
-
-	return nil
-}
-
-func (s *AteomService) cleanupActorNetwork(ctx context.Context) error {
-	// Remove all per-activation network state owned by ateom. Deleting the
-	// worker-side veth also deletes its peer when the pair is still connected,
-	// but failed setup can leave the peer already moved into the actor netns.
-	// For that reason cleanup also enters the interior netns and deletes either
-	// the final actor interface name or the temporary peer name if present.
-	//
-	// This function is intentionally idempotent so it can run before setup, after
-	// checkpoint, and from setup failure cleanup without requiring the caller to
-	// know how far network initialization progressed.
-	if err := removeActorNftablesRules(); err != nil {
-		return err
-	}
-
-	var cleanupErr error
-	if link, err := netlink.LinkByName(hostVethName); err == nil {
-		if err := netlink.LinkDel(link); err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while deleting host veth: %w", err))
-			slog.WarnContext(ctx, "Failed to delete host veth; continuing actor netns cleanup", "err", err)
-		}
-	} else if _, ok := err.(netlink.LinkNotFoundError); !ok {
-		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while looking up host veth: %w", err))
-		slog.WarnContext(ctx, "Failed to look up host veth; continuing actor netns cleanup", "err", err)
-	}
-
-	if err := netNSDo(ctx, s.interiorNetNS, func(_ context.Context) error {
-		for _, name := range []string{actorVethName, actorVethTempName} {
-			link, err := netlink.LinkByName(name)
-			if err == nil {
-				if err := netlink.LinkDel(link); err != nil {
-					return fmt.Errorf("while deleting interior veth %q: %w", name, err)
-				}
-				continue
-			}
-			if _, ok := err.(netlink.LinkNotFoundError); !ok {
-				return fmt.Errorf("while looking up interior veth %q: %w", name, err)
-			}
-		}
-		return nil
-	}); err != nil {
-		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while cleaning interior netns links: %w", err))
-	}
-
-	return cleanupErr
-}
-
-func (s *AteomService) cleanupActorNetworkOrExit(ctx context.Context, msg string) {
-	if err := s.cleanupActorNetwork(ctx); err != nil {
-		serverboot.Fatal(ctx, msg, err)
-	}
-}
-
-func podIPv4() (net.IP, error) {
-	// Resolve the worker pod IPv4 address from the pod namespace's real eth0.
-	// Because eth0 now stays in the pod namespace, this IP remains available for
-	// both normal worker connectivity and the temporary inbound DNAT rule.
-	eth0Link, err := netlink.LinkByName("eth0")
-	if err != nil {
-		return nil, fmt.Errorf("while getting pod eth0: %w", err)
-	}
-	addrs, err := netlink.AddrList(eth0Link, netlink.FAMILY_V4)
-	if err != nil {
-		return nil, fmt.Errorf("while listing pod eth0 addresses: %w", err)
-	}
-	for _, addr := range addrs {
-		if addr.IP == nil {
-			continue
-		}
-		if ip := addr.IP.To4(); ip != nil {
-			return ip, nil
-		}
-	}
-	return nil, fmt.Errorf("pod eth0 has no IPv4 address")
-}
-
-func parseAddr(cidr string) (*netlink.Addr, error) {
-	addr, err := netlink.ParseAddr(cidr)
-	if err != nil {
-		return nil, fmt.Errorf("while parsing address %q: %w", cidr, err)
-	}
-	return addr, nil
-}
-
-func enableIPv4Forwarding() error {
-	// Forwarding is required because actor packets now enter the worker pod via
-	// the host-side veth and then leave through the pod's eth0. Without this, the
-	// kernel would not route traffic between those interfaces even though both
-	// live in the worker pod network namespace.
-	//
-	// Without privileged, the container runtime bind-mounts /proc/sys read-only.
-	// The worker holds CAP_SYS_ADMIN and uses no user namespace, so the ro flag
-	// is not locked: clear it, write the sysctl, restore ro.
-	const path = "/proc/sys/net/ipv4/ip_forward"
-	if b, err := os.ReadFile(path); err == nil && len(b) > 0 && b[0] == '1' {
-		return nil
-	}
-	if err := os.WriteFile(path, []byte("1\n"), 0o644); err == nil {
-		return nil
-	}
-	if err := unix.Mount("none", "/proc/sys", "", unix.MS_BIND|unix.MS_REMOUNT, ""); err != nil {
-		return fmt.Errorf("while remounting /proc/sys read-write to enable IPv4 forwarding: %w", err)
-	}
-	defer func() {
-		_ = unix.Mount("none", "/proc/sys", "", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY, "")
-	}()
-	if err := os.WriteFile(path, []byte("1\n"), 0o644); err != nil {
-		return fmt.Errorf("while enabling IPv4 forwarding in worker pod netns: %w", err)
-	}
-	return nil
 }
 
 // setupCgroupDelegation prepares the worker pod's cgroup so runsc can create a
@@ -857,253 +596,4 @@ func moveProcs(ctx context.Context, srcProcs, dstProcs string) error {
 		}
 	}
 	return fmt.Errorf("%q did not drain after 100 iterations", srcProcs)
-}
-
-func installActorNftablesRules(podIP net.IP) error {
-	// Install a dedicated nftables table for the active actor. Keeping all
-	// rules in an ateom-owned table makes cleanup simple and avoids mutating
-	// Kubernetes or CNI-managed chains directly.
-	//
-	// TODO: Add IPv6 veth addressing, forwarding, and nftables rules once actor
-	// networking supports dual-stack pods. The current compatibility path is
-	// IPv4-only.
-	//
-	// The temporary compatibility rules do three things:
-	//
-	//   * postrouting: masquerade actor egress from 169.254.17.2 behind the worker
-	//     pod IP so replies route back to the pod.
-	//   * prerouting: DNAT traffic sent to the worker pod IP on TCP/80 to the
-	//     actor veth IP on TCP/80, preserving existing inbound behavior.
-	//   * forward: accept forwarded packets between the actor veth and pod eth0.
-	//
-	// This is not the final egress policy path. The later AgentGateway phase
-	// should replace the broad masquerade path with transparent TCP capture and
-	// default-deny rules.
-	if err := removeActorNftablesRules(); err != nil {
-		return err
-	}
-
-	c := &nftables.Conn{}
-	table := &nftables.Table{
-		Family: nftables.TableFamilyIPv4,
-		Name:   actorNftTableName,
-	}
-	c.AddTable(table)
-
-	prerouting := c.AddChain(&nftables.Chain{
-		Name:     "prerouting",
-		Table:    table,
-		Type:     nftables.ChainTypeNAT,
-		Hooknum:  nftables.ChainHookPrerouting,
-		Priority: nftables.ChainPriorityNATDest,
-	})
-	// TODO: Support inbound UDP DNAT for actors that expose UDP protocols such
-	// as QUIC.
-	// TODO: Replace the hard-coded HTTP port with the actor's configured
-	// inbound ports, either by adding one rule per port or by matching a set.
-	preroutingExprs := append(ipDestinationEqual(podIP.String()), tcpDestinationPortEqual(80)...)
-	preroutingExprs = append(preroutingExprs,
-		&expr.Immediate{
-			Register: 1,
-			Data:     net.ParseIP(actorVethIP).To4(),
-		},
-		&expr.Immediate{
-			Register: 2,
-			Data:     binaryutil.BigEndian.PutUint16(80),
-		},
-		&expr.NAT{
-			Type:        expr.NATTypeDestNAT,
-			Family:      unix.NFPROTO_IPV4,
-			RegAddrMin:  1,
-			RegProtoMin: 2,
-		},
-	)
-	c.AddRule(&nftables.Rule{
-		Table: table,
-		Chain: prerouting,
-		Exprs: preroutingExprs,
-	})
-
-	postrouting := c.AddChain(&nftables.Chain{
-		Name:     "postrouting",
-		Table:    table,
-		Type:     nftables.ChainTypeNAT,
-		Hooknum:  nftables.ChainHookPostrouting,
-		Priority: nftables.ChainPriorityNATSource,
-	})
-	c.AddRule(&nftables.Rule{
-		Table: table,
-		Chain: postrouting,
-		Exprs: append(ipSourceEqual(actorVethIP), &expr.Masq{}),
-	})
-
-	acceptPolicy := nftables.ChainPolicyAccept
-	forward := c.AddChain(&nftables.Chain{
-		Name:     "forward",
-		Table:    table,
-		Type:     nftables.ChainTypeFilter,
-		Hooknum:  nftables.ChainHookForward,
-		Priority: nftables.ChainPriorityFilter,
-		Policy:   &acceptPolicy,
-	})
-	c.AddRule(&nftables.Rule{
-		Table: table,
-		Chain: forward,
-		Exprs: []expr.Any{
-			&expr.Verdict{Kind: expr.VerdictAccept},
-		},
-	})
-
-	if err := c.Flush(); err != nil {
-		return fmt.Errorf("while installing actor nftables rules: %w", err)
-	}
-	return nil
-}
-
-func removeActorNftablesRules() error {
-	// Delete the whole ateom nftables table if it exists. The table is
-	// per-worker and currently per-active-actor because this worker path runs at
-	// most one actor at a time. Missing tables are treated as already clean.
-	c := &nftables.Conn{}
-	tables, err := c.ListTablesOfFamily(nftables.TableFamilyIPv4)
-	if err != nil {
-		return fmt.Errorf("while listing nftables tables: %w", err)
-	}
-	for _, table := range tables {
-		if table.Name != actorNftTableName {
-			continue
-		}
-		c.DelTable(table)
-		if err := c.Flush(); err != nil {
-			return fmt.Errorf("while deleting actor nftables table: %w", err)
-		}
-		return nil
-	}
-	return nil
-}
-
-func ipSourceEqual(ip string) []expr.Any {
-	return ipPayloadEqual(12, ip)
-}
-
-func ipDestinationEqual(ip string) []expr.Any {
-	return ipPayloadEqual(16, ip)
-}
-
-func ipPayloadEqual(offset uint32, ip string) []expr.Any {
-	return []expr.Any{
-		&expr.Payload{
-			DestRegister: 1,
-			Base:         expr.PayloadBaseNetworkHeader,
-			Offset:       offset,
-			Len:          4,
-		},
-		&expr.Cmp{
-			Op:       expr.CmpOpEq,
-			Register: 1,
-			Data:     net.ParseIP(ip).To4(),
-		},
-	}
-}
-
-func tcpDestinationPortEqual(port uint16) []expr.Any {
-	return []expr.Any{
-		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
-		&expr.Cmp{
-			Op:       expr.CmpOpEq,
-			Register: 1,
-			Data:     []byte{unix.IPPROTO_TCP},
-		},
-		&expr.Payload{
-			DestRegister: 1,
-			Base:         expr.PayloadBaseTransportHeader,
-			Offset:       2,
-			Len:          2,
-		},
-		&expr.Cmp{
-			Op:       expr.CmpOpEq,
-			Register: 1,
-			Data:     binaryutil.BigEndian.PutUint16(port),
-		},
-	}
-}
-
-func createNetNSWithoutSwitching(ctx context.Context, name string) (netns.NsHandle, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	// We need to create the new NS, then switch back to the current netns.
-	curNetNS, err := netns.Get()
-	if err != nil {
-		return -1, fmt.Errorf("while getting current netns: %w", err)
-	}
-	defer func() {
-		if err := netns.Set(curNetNS); err != nil {
-			// Better to blow up the program than continue execution with
-			// one OS thread randomly in a different netns.
-			panic(fmt.Sprintf("Failed to restore original netns: %v", err))
-		}
-	}()
-
-	interiorNetNS, err := netns.NewNamed(name)
-	if err != nil {
-		return -1, fmt.Errorf("while creating interior network namespace for gVisor: %w", err)
-	}
-
-	return interiorNetNS, nil
-}
-
-func netNSDo(ctx context.Context, targetNS netns.NsHandle, do func(context.Context) error) error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	// We need to create the new NS, then switch back to the current netns.
-	curNetNS, err := netns.Get()
-	if err != nil {
-		return fmt.Errorf("while getting current netns: %w", err)
-	}
-	defer func() {
-		if err := netns.Set(curNetNS); err != nil {
-			// Better to blow up the program than continue execution with
-			// one OS thread randomly in a different netns.
-			panic(fmt.Sprintf("Failed to restore original netns: %v", err))
-		}
-	}()
-
-	if err := netns.Set(targetNS); err != nil {
-		return fmt.Errorf("setting target netns: %w", err)
-	}
-
-	if err := do(ctx); err != nil {
-		return fmt.Errorf("while executing function in target netns: %w", err)
-	}
-
-	return nil
-}
-
-func dumpNetInfo(ctx context.Context, prefix string) error {
-	links, err := netlink.LinkList()
-	if err != nil {
-		return fmt.Errorf("in netlink.LinkList(): %w", err)
-	}
-
-	for _, link := range links {
-		slog.InfoContext(ctx, prefix+"Link", slog.String("name", link.Attrs().Name), slog.String("type", link.Type()), slog.Any("attrs", link.Attrs()))
-
-		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
-		if err != nil {
-			return fmt.Errorf("while getting pod eth0 addresses: %w", err)
-		}
-		slog.InfoContext(ctx, prefix+"Link Addresses", slog.String("link", link.Attrs().Name), slog.Any("addrs", addrs))
-
-		rts, err := netlink.RouteList(link, netlink.FAMILY_V4)
-		if err != nil {
-			return fmt.Errorf("while getting routes off eth0: %w", err)
-		}
-		for _, rt := range rts {
-			slog.InfoContext(ctx, prefix+"Link Routes", slog.Any("link", link.Attrs().Name), slog.Any("route", rt), slog.Any("route-string", rt.String()))
-		}
-	}
-
-	return nil
 }

--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -25,6 +25,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/ateomnet"
+
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/ch"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
 	"github.com/agent-substrate/substrate/internal/ateompath"
@@ -150,7 +152,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	delete(s.running, actorUID)
 
 	// Tear down the per-activation actor network.
-	if err := s.cleanupActorNetwork(ctx); err != nil {
+	if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
 		slog.WarnContext(ctx, "Failed to clean up actor network after checkpoint", slog.Any("err", err))
 	}
 

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/reaper"
 	"github.com/agent-substrate/substrate/internal/actorlog"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
+	"github.com/agent-substrate/substrate/internal/ateomnet"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	"github.com/agent-substrate/substrate/internal/serverboot"
@@ -128,7 +129,7 @@ func do(ctx context.Context) error {
 
 	// Networking: create a named interior netns; each activation builds a fresh
 	// veth pair into it (see net.go) and points kata at it.
-	interiorNetNS, err := createNetNSWithoutSwitching(ateompath.AteomNetNSName(*podUID))
+	interiorNetNS, err := ateomnet.CreateNetNSWithoutSwitching(ateompath.AteomNetNSName(*podUID))
 	if err != nil {
 		return fmt.Errorf("while creating interior netns: %w", err)
 	}

--- a/cmd/ateom-microvm/net.go
+++ b/cmd/ateom-microvm/net.go
@@ -16,51 +16,19 @@
 
 package main
 
-// Actor networking mirrors cmd/ateom-gvisor's veth model: a fresh
-// point-to-point veth pair per activation, with the worker side (ateom0,
-// 169.254.17.1/30) staying in the pod netns next to the pod's real eth0, and
-// the peer moved into the interior netns, renamed eth0, and given the stable
-// actor address 169.254.17.2/30. nftables rules in the pod netns masquerade
-// actor egress behind the pod IP and DNAT inbound pod-IP:80 to the actor.
-//
-// kata consumes the interior netns exactly like a CNI-provisioned container
-// netns: its tcfilter network model builds a tap cross-connected to eth0 (the
-// veth peer) and gives the guest eth0's address. Because that address is a
-// CONSTANT, a restored guest's frozen network config stays valid on any pod —
-// no in-guest reconfiguration needed.
-//
-// (Copied with light adaptation from cmd/ateom-gvisor; expected to be
-// de-duplicated into a shared package later.)
-
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"os"
-	"runtime"
 
-	"github.com/google/nftables"
-	"github.com/google/nftables/binaryutil"
-	"github.com/google/nftables/expr"
 	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 
-	"github.com/agent-substrate/substrate/internal/serverboot"
+	"github.com/agent-substrate/substrate/internal/ateomnet"
 )
 
 const (
-	hostVethName      = "ateom0"
-	actorVethName     = "eth0"
-	actorVethTempName = "ateom1"
-	hostVethCIDR      = "169.254.17.1/30"
-	actorVethCIDR     = "169.254.17.2/30"
-	actorVethGateway  = "169.254.17.1"
-	actorVethIP       = "169.254.17.2"
-	actorNftTableName = "ateom_actor"
-
 	// hostVethMAC is deliberately FIXED (locally administered), unlike
 	// ateom-gvisor where the kernel's random veth MAC is fine. A CH snapshot
 	// freezes the guest kernel's ARP cache, including the entry for the
@@ -76,457 +44,11 @@ const (
 	// guest's frozen interface config stays valid across pods. Distinct from the
 	// gateway MAC (…:01).
 	actorGuestMAC = "02:a8:1e:00:00:02"
-
-	// actorVethSubnet is the point-to-point /30 the actor veth lives on; the guest
-	// needs the connected (scope-link) route to it so the gateway is reachable.
-	actorVethSubnet = "169.254.17.0/30"
 )
 
-// Parsed forms of the fixed network constants above, cooked once at package init
-// (a malformed constant is a programmer error, so these panic). Callers use them
-// directly instead of re-parsing on every activation.
 var (
-	hostVethAddr   = mustParseAddr(hostVethCIDR)
-	hostVethHWAddr = mustParseMAC(hostVethMAC)
-	actorVethAddr  = mustParseAddr(actorVethCIDR)
-	actorVethGwIP  = mustParseIP(actorVethGateway)
+	hostVethHWAddr = ateomnet.MustParseMAC(hostVethMAC)
 )
-
-func mustParseAddr(cidr string) *netlink.Addr {
-	a, err := parseAddr(cidr)
-	if err != nil {
-		panic(fmt.Sprintf("parsing constant CIDR %q: %v", cidr, err))
-	}
-	return a
-}
-
-func mustParseMAC(s string) net.HardwareAddr {
-	m, err := net.ParseMAC(s)
-	if err != nil {
-		panic(fmt.Sprintf("parsing constant MAC %q: %v", s, err))
-	}
-	return m
-}
-
-func mustParseIP(s string) net.IP {
-	ip := net.ParseIP(s).To4()
-	if ip == nil {
-		panic(fmt.Sprintf("parsing constant IPv4 %q", s))
-	}
-	return ip
-}
-
-// setupActorNetwork builds a fresh point-to-point network between the worker
-// pod netns and the kata interior netns (see the package comment). Idempotent
-// via cleanup-before-setup; also sweeps stale kata taps out of the interior
-// netns so the sandbox always builds on a clean slate.
-func (s *AteomService) setupActorNetwork(ctx context.Context) (retErr error) {
-	s.cleanupActorNetworkOrExit(ctx, "Failed to clean up stale actor network before setup")
-	defer func() {
-		if retErr != nil {
-			s.cleanupActorNetworkOrExit(ctx, "Failed to clean up partially configured actor network")
-		}
-	}()
-
-	podIP, err := podIPv4()
-	if err != nil {
-		return fmt.Errorf("while resolving pod IPv4 address: %w", err)
-	}
-
-	// Sweep leftover links (kata taps from torn-down runs, restore taps) from
-	// the persistent interior netns before the new veth peer arrives.
-	if err := netNSDo(ctx, s.interiorNetNS, func(ctx context.Context) error {
-		links, err := netlink.LinkList()
-		if err != nil {
-			return fmt.Errorf("while listing interior netns links: %w", err)
-		}
-		for _, l := range links {
-			if l.Attrs().Name == "lo" {
-				continue
-			}
-			if err := netlink.LinkDel(l); err != nil {
-				slog.WarnContext(ctx, "Failed to delete leftover interior link", slog.String("link", l.Attrs().Name), slog.Any("err", err))
-			}
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	veth := &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:         hostVethName,
-			HardwareAddr: hostVethHWAddr,
-		},
-		PeerName: actorVethTempName,
-	}
-	if err := netlink.LinkAdd(veth); err != nil {
-		return fmt.Errorf("while creating actor veth pair: %w", err)
-	}
-
-	hostLink, err := netlink.LinkByName(hostVethName)
-	if err != nil {
-		return fmt.Errorf("while getting host veth: %w", err)
-	}
-	if err := netlink.AddrReplace(hostLink, hostVethAddr); err != nil {
-		return fmt.Errorf("while assigning host veth address: %w", err)
-	}
-	if err := netlink.LinkSetUp(hostLink); err != nil {
-		return fmt.Errorf("while bringing up host veth: %w", err)
-	}
-
-	actorLink, err := netlink.LinkByName(actorVethTempName)
-	if err != nil {
-		return fmt.Errorf("while getting actor veth peer: %w", err)
-	}
-	if err := netlink.LinkSetNsFd(actorLink, int(s.interiorNetNS)); err != nil {
-		return fmt.Errorf("while moving actor veth peer into interior netns: %w", err)
-	}
-
-	if err := netNSDo(ctx, s.interiorNetNS, configureActorVeth); err != nil {
-		return fmt.Errorf("while configuring actor veth in interior netns: %w", err)
-	}
-
-	if err := enableIPv4Forwarding(); err != nil {
-		return err
-	}
-	if err := installActorNftablesRules(podIP); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func configureActorVeth(ctx context.Context) error {
-	// Run inside the interior netns after setupActorNetwork moves the veth peer
-	// there. kata reads link names, addresses, and routes from this namespace
-	// when the sandbox starts, so the peer is renamed to eth0 and configured
-	// like a normal container interface; the guest is configured identically by
-	// the kata agent.
-	loLink, err := netlink.LinkByName("lo")
-	if err != nil {
-		return fmt.Errorf("while acquiring lo in interior netns: %w", err)
-	}
-	if err := netlink.LinkSetUp(loLink); err != nil {
-		return fmt.Errorf("while bringing up lo in interior netns: %w", err)
-	}
-
-	actorLink, err := netlink.LinkByName(actorVethTempName)
-	if err != nil {
-		return fmt.Errorf("while acquiring actor veth in interior netns: %w", err)
-	}
-	if err := netlink.LinkSetName(actorLink, actorVethName); err != nil {
-		return fmt.Errorf("while renaming actor veth to %q: %w", actorVethName, err)
-	}
-	actorLink, err = netlink.LinkByName(actorVethName)
-	if err != nil {
-		return fmt.Errorf("while reacquiring actor veth in interior netns: %w", err)
-	}
-
-	if err := netlink.AddrReplace(actorLink, actorVethAddr); err != nil {
-		return fmt.Errorf("while assigning actor veth address: %w", err)
-	}
-	if err := netlink.LinkSetUp(actorLink); err != nil {
-		return fmt.Errorf("while bringing up actor veth: %w", err)
-	}
-
-	if err := netlink.RouteReplace(&netlink.Route{
-		LinkIndex: actorLink.Attrs().Index,
-		Gw:        actorVethGwIP,
-	}); err != nil {
-		return fmt.Errorf("while installing actor default route: %w", err)
-	}
-
-	return nil
-}
-
-// cleanupActorNetwork removes all per-activation network state owned by ateom.
-// Intentionally idempotent: runs before setup, after checkpoint, and from
-// setup-failure cleanup.
-func (s *AteomService) cleanupActorNetwork(ctx context.Context) error {
-	var cleanupErr error
-	if err := removeActorNftablesRules(); err != nil {
-		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while removing actor nftables rules: %w", err))
-		slog.WarnContext(ctx, "Failed to remove actor nftables rules; continuing actor netns cleanup", slog.Any("err", err))
-	}
-
-	if link, err := netlink.LinkByName(hostVethName); err == nil {
-		if err := netlink.LinkDel(link); err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while deleting host veth: %w", err))
-			slog.WarnContext(ctx, "Failed to delete host veth; continuing actor netns cleanup", slog.Any("err", err))
-		}
-	} else if _, ok := err.(netlink.LinkNotFoundError); !ok {
-		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while looking up host veth: %w", err))
-		slog.WarnContext(ctx, "Failed to look up host veth; continuing actor netns cleanup", slog.Any("err", err))
-	}
-
-	if err := netNSDo(ctx, s.interiorNetNS, func(_ context.Context) error {
-		for _, name := range []string{actorVethName, actorVethTempName} {
-			link, err := netlink.LinkByName(name)
-			if err == nil {
-				if err := netlink.LinkDel(link); err != nil {
-					return fmt.Errorf("while deleting interior veth %q: %w", name, err)
-				}
-				continue
-			}
-			if _, ok := err.(netlink.LinkNotFoundError); !ok {
-				return fmt.Errorf("while looking up interior veth %q: %w", name, err)
-			}
-		}
-		return nil
-	}); err != nil {
-		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while cleaning interior netns links: %w", err))
-	}
-
-	return cleanupErr
-}
-
-func (s *AteomService) cleanupActorNetworkOrExit(ctx context.Context, msg string) {
-	if err := s.cleanupActorNetwork(ctx); err != nil {
-		serverboot.Fatal(ctx, msg, err)
-	}
-}
-
-// podIPv4 resolves the worker pod IPv4 address from the pod namespace's real
-// eth0 (which stays in the pod namespace in the veth model).
-func podIPv4() (net.IP, error) {
-	eth0Link, err := netlink.LinkByName("eth0")
-	if err != nil {
-		return nil, fmt.Errorf("while getting pod eth0: %w", err)
-	}
-	addrs, err := netlink.AddrList(eth0Link, netlink.FAMILY_V4)
-	if err != nil {
-		return nil, fmt.Errorf("while listing pod eth0 addresses: %w", err)
-	}
-	for _, addr := range addrs {
-		if addr.IP == nil {
-			continue
-		}
-		if ip := addr.IP.To4(); ip != nil {
-			return ip, nil
-		}
-	}
-	return nil, fmt.Errorf("pod eth0 has no IPv4 address")
-}
-
-func parseAddr(cidr string) (*netlink.Addr, error) {
-	addr, err := netlink.ParseAddr(cidr)
-	if err != nil {
-		return nil, fmt.Errorf("while parsing address %q: %w", cidr, err)
-	}
-	return addr, nil
-}
-
-func enableIPv4Forwarding() error {
-	// Actor packets enter the worker pod via the host-side veth and leave
-	// through the pod's eth0; the kernel will not route between them otherwise.
-	// Open the existing sysctl O_WRONLY (not os.WriteFile, which would create a
-	// regular file if the knob were missing) so an absent knob is a clear error.
-	f, err := os.OpenFile("/proc/sys/net/ipv4/ip_forward", os.O_WRONLY, 0)
-	if err != nil {
-		return fmt.Errorf("while opening ip_forward sysctl: %w", err)
-	}
-	defer f.Close()
-	if _, err := f.Write([]byte("1\n")); err != nil {
-		return fmt.Errorf("while enabling IPv4 forwarding in worker pod netns: %w", err)
-	}
-	return nil
-}
-
-func installActorNftablesRules(podIP net.IP) error {
-	// Dedicated ateom-owned IPv4 table (cheap cleanup, no CNI chain mutation):
-	//   * postrouting: masquerade actor egress (169.254.17.2) behind the pod IP.
-	//   * prerouting: DNAT pod-IP:80/tcp to the actor veth IP.
-	//   * forward: accept forwarded packets between the actor veth and pod eth0.
-	// Mirrors cmd/ateom-gvisor (same compatibility-bridge caveats and TODOs).
-	if err := removeActorNftablesRules(); err != nil {
-		return err
-	}
-
-	c := &nftables.Conn{}
-	table := &nftables.Table{
-		Family: nftables.TableFamilyIPv4,
-		Name:   actorNftTableName,
-	}
-	c.AddTable(table)
-
-	prerouting := c.AddChain(&nftables.Chain{
-		Name:     "prerouting",
-		Table:    table,
-		Type:     nftables.ChainTypeNAT,
-		Hooknum:  nftables.ChainHookPrerouting,
-		Priority: nftables.ChainPriorityNATDest,
-	})
-	preroutingExprs := append(ipDestinationEqual(podIP.String()), tcpDestinationPortEqual(80)...)
-	preroutingExprs = append(preroutingExprs,
-		&expr.Immediate{
-			Register: 1,
-			Data:     net.ParseIP(actorVethIP).To4(),
-		},
-		&expr.Immediate{
-			Register: 2,
-			Data:     binaryutil.BigEndian.PutUint16(80),
-		},
-		&expr.NAT{
-			Type:        expr.NATTypeDestNAT,
-			Family:      unix.NFPROTO_IPV4,
-			RegAddrMin:  1,
-			RegProtoMin: 2,
-		},
-	)
-	c.AddRule(&nftables.Rule{
-		Table: table,
-		Chain: prerouting,
-		Exprs: preroutingExprs,
-	})
-
-	postrouting := c.AddChain(&nftables.Chain{
-		Name:     "postrouting",
-		Table:    table,
-		Type:     nftables.ChainTypeNAT,
-		Hooknum:  nftables.ChainHookPostrouting,
-		Priority: nftables.ChainPriorityNATSource,
-	})
-	c.AddRule(&nftables.Rule{
-		Table: table,
-		Chain: postrouting,
-		Exprs: append(ipSourceEqual(actorVethIP), &expr.Masq{}),
-	})
-
-	acceptPolicy := nftables.ChainPolicyAccept
-	forward := c.AddChain(&nftables.Chain{
-		Name:     "forward",
-		Table:    table,
-		Type:     nftables.ChainTypeFilter,
-		Hooknum:  nftables.ChainHookForward,
-		Priority: nftables.ChainPriorityFilter,
-		Policy:   &acceptPolicy,
-	})
-	c.AddRule(&nftables.Rule{
-		Table: table,
-		Chain: forward,
-		Exprs: []expr.Any{
-			&expr.Verdict{Kind: expr.VerdictAccept},
-		},
-	})
-
-	if err := c.Flush(); err != nil {
-		return fmt.Errorf("while installing actor nftables rules: %w", err)
-	}
-	return nil
-}
-
-func removeActorNftablesRules() error {
-	c := &nftables.Conn{}
-	tables, err := c.ListTablesOfFamily(nftables.TableFamilyIPv4)
-	if err != nil {
-		return fmt.Errorf("while listing nftables tables: %w", err)
-	}
-	for _, table := range tables {
-		if table.Name != actorNftTableName {
-			continue
-		}
-		c.DelTable(table)
-		if err := c.Flush(); err != nil {
-			return fmt.Errorf("while deleting actor nftables table: %w", err)
-		}
-		return nil
-	}
-	return nil
-}
-
-func ipSourceEqual(ip string) []expr.Any {
-	return ipPayloadEqual(12, ip)
-}
-
-func ipDestinationEqual(ip string) []expr.Any {
-	return ipPayloadEqual(16, ip)
-}
-
-func ipPayloadEqual(offset uint32, ip string) []expr.Any {
-	return []expr.Any{
-		&expr.Payload{
-			DestRegister: 1,
-			Base:         expr.PayloadBaseNetworkHeader,
-			Offset:       offset,
-			Len:          4,
-		},
-		&expr.Cmp{
-			Op:       expr.CmpOpEq,
-			Register: 1,
-			Data:     net.ParseIP(ip).To4(),
-		},
-	}
-}
-
-func tcpDestinationPortEqual(port uint16) []expr.Any {
-	return []expr.Any{
-		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
-		&expr.Cmp{
-			Op:       expr.CmpOpEq,
-			Register: 1,
-			Data:     []byte{unix.IPPROTO_TCP},
-		},
-		&expr.Payload{
-			DestRegister: 1,
-			Base:         expr.PayloadBaseTransportHeader,
-			Offset:       2,
-			Len:          2,
-		},
-		&expr.Cmp{
-			Op:       expr.CmpOpEq,
-			Register: 1,
-			Data:     binaryutil.BigEndian.PutUint16(port),
-		},
-	}
-}
-
-// createNetNSWithoutSwitching creates a named netns and returns its handle,
-// restoring the caller's current netns before returning.
-func createNetNSWithoutSwitching(name string) (netns.NsHandle, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	curNetNS, err := netns.Get()
-	if err != nil {
-		return -1, fmt.Errorf("while getting current netns: %w", err)
-	}
-	defer func() {
-		if err := netns.Set(curNetNS); err != nil {
-			panic(fmt.Sprintf("Failed to restore original netns: %v", err))
-		}
-	}()
-
-	interiorNetNS, err := netns.NewNamed(name)
-	if err != nil {
-		return -1, fmt.Errorf("while creating interior network namespace: %w", err)
-	}
-	return interiorNetNS, nil
-}
-
-// netNSDo runs do() with the OS thread switched into targetNS, then restores it.
-func netNSDo(ctx context.Context, targetNS netns.NsHandle, do func(context.Context) error) error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	curNetNS, err := netns.Get()
-	if err != nil {
-		return fmt.Errorf("while getting current netns: %w", err)
-	}
-	defer func() {
-		if err := netns.Set(curNetNS); err != nil {
-			panic(fmt.Sprintf("Failed to restore original netns: %v", err))
-		}
-	}()
-
-	if err := netns.Set(targetNS); err != nil {
-		return fmt.Errorf("setting target netns: %w", err)
-	}
-	if err := do(ctx); err != nil {
-		return fmt.Errorf("while executing function in target netns: %w", err)
-	}
-	return nil
-}
 
 // setupRestoreTap recreates, in the interior netns, the tap + TC-mirror wiring
 // kata's tcfilter network model builds at boot: a tap device cross-connected to
@@ -537,8 +59,8 @@ func netNSDo(ctx context.Context, targetNS netns.NsHandle, do func(context.Conte
 // setupActorNetwork.
 func (s *AteomService) setupRestoreTap(ctx context.Context, name string, queuePairs int) ([]*os.File, error) {
 	var fds []*os.File
-	err := netNSDo(ctx, s.interiorNetNS, func(ctx context.Context) error {
-		eth0, err := netlink.LinkByName(actorVethName)
+	err := ateomnet.NetNSDo(ctx, s.interiorNetNS, func(ctx context.Context) error {
+		eth0, err := netlink.LinkByName(ateomnet.ActorVethName)
 		if err != nil {
 			return fmt.Errorf("acquiring actor veth in interior netns: %w", err)
 		}
@@ -604,12 +126,12 @@ func (s *AteomService) setupRestoreTap(ctx context.Context, name string, queuePa
 // (UpdateInterface). Defaults to 1500 if the link can't be read.
 func (s *AteomService) actorVethMTU(ctx context.Context) int {
 	mtu := 1500
-	_ = netNSDo(ctx, s.interiorNetNS, func(ctx context.Context) error {
-		if l, err := netlink.LinkByName(actorVethName); err == nil {
+	_ = ateomnet.NetNSDo(ctx, s.interiorNetNS, func(ctx context.Context) error {
+		if l, err := netlink.LinkByName(ateomnet.ActorVethName); err == nil {
 			mtu = l.Attrs().MTU
 		} else {
 			slog.WarnContext(ctx, "Failed to read actor veth MTU; using default",
-				slog.String("link", actorVethName), slog.Int("default_mtu", mtu), slog.Any("err", err))
+				slog.String("link", ateomnet.ActorVethName), slog.Int("default_mtu", mtu), slog.Any("err", err))
 		}
 		return nil
 	})

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/ateomnet"
+
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/ch"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
 	"github.com/agent-substrate/substrate/internal/ateompath"
@@ -181,12 +183,16 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 
 	// Networking: rebuild the per-activation veth + tap; the snapshot's virtio-net
 	// is fd-backed, so CH needs fresh tap FDs (net_fds) on restore.
-	if err := s.setupActorNetwork(ctx); err != nil {
+	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+		InteriorNetNS:      s.interiorNetNS,
+		HostVethHWAddr:     hostVethHWAddr,
+		SweepInteriorLinks: true,
+	}); err != nil {
 		return fmt.Errorf("while setting up actor network: %w", err)
 	}
 	defer func() {
 		if retErr != nil {
-			if cleanupErr := s.cleanupActorNetwork(ctx); cleanupErr != nil {
+			if cleanupErr := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); cleanupErr != nil {
 				slog.WarnContext(ctx, "Failed to clean up actor network after Restore failure", slog.Any("err", cleanupErr))
 			}
 			// Detach any bundle rootfs overlays mounted by buildActorContainers
@@ -249,7 +255,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	}
 
 	// Block until every readyz-enabled container reports 200.
-	if err := readyz.WaitAll(ctx, containers, actorVethIP); err != nil {
+	if err := readyz.WaitAll(ctx, containers, ateomnet.ActorVethIP); err != nil {
 		return fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -26,6 +26,8 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/ateomnet"
+
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/ch"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/third_party/kata/agentpb"
@@ -259,12 +261,16 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 
 	// Networking (host side): per-activation veth into the interior netns. The
 	// tap + TC mirror is built below (after the VM exists) so its FDs are fresh.
-	if err := s.setupActorNetwork(ctx); err != nil {
+	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+		InteriorNetNS:      s.interiorNetNS,
+		HostVethHWAddr:     hostVethHWAddr,
+		SweepInteriorLinks: true,
+	}); err != nil {
 		return fmt.Errorf("while setting up actor network: %w", err)
 	}
 	defer func() {
 		if retErr != nil {
-			if cleanupErr := s.cleanupActorNetwork(ctx); cleanupErr != nil {
+			if cleanupErr := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); cleanupErr != nil {
 				slog.WarnContext(ctx, "Failed to clean up actor network after Run failure", slog.Any("err", cleanupErr))
 			}
 			// Detach any bundle rootfs overlays mounted by buildActorContainers
@@ -411,7 +417,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	}
 
 	// Block until every readyz-enabled container reports 200.
-	if err := readyz.WaitAll(ctx, containers, actorVethIP); err != nil {
+	if err := readyz.WaitAll(ctx, containers, ateomnet.ActorVethIP); err != nil {
 		return fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
@@ -699,25 +705,25 @@ func tailString(s string, n int) string {
 // neighbor entry stays valid).
 func (s *AteomService) configureGuestNetwork(ctx context.Context, ac *kata.AgentClient, mtu uint64) error {
 	if err := ac.UpdateInterface(ctx, &agentpb.Interface{
-		Device: actorVethName,
-		Name:   actorVethName,
+		Device: ateomnet.ActorVethName,
+		Name:   ateomnet.ActorVethName,
 		HwAddr: actorGuestMAC,
 		Mtu:    mtu,
 		IPAddresses: []*agentpb.IPAddress{
-			{Family: agentpb.IPFamily_v4, Address: actorVethIP, Mask: "30"},
+			{Family: agentpb.IPFamily_v4, Address: ateomnet.ActorVethIP, Mask: "30"},
 		},
 	}); err != nil {
 		return err
 	}
 	if err := ac.UpdateRoutes(ctx, []*agentpb.Route{
-		{Dest: actorVethSubnet, Device: actorVethName, Scope: uint32(unix.RT_SCOPE_LINK), Family: agentpb.IPFamily_v4},
-		{Dest: "", Gateway: actorVethGateway, Device: actorVethName, Family: agentpb.IPFamily_v4},
+		{Dest: ateomnet.ActorVethSubnet, Device: ateomnet.ActorVethName, Scope: uint32(unix.RT_SCOPE_LINK), Family: agentpb.IPFamily_v4},
+		{Dest: "", Gateway: ateomnet.ActorVethGateway, Device: ateomnet.ActorVethName, Family: agentpb.IPFamily_v4},
 	}); err != nil {
 		return err
 	}
 	return ac.AddARPNeighbors(ctx, []*agentpb.ARPNeighbor{{
-		ToIPAddress: &agentpb.IPAddress{Family: agentpb.IPFamily_v4, Address: actorVethGateway},
-		Device:      actorVethName,
+		ToIPAddress: &agentpb.IPAddress{Family: agentpb.IPFamily_v4, Address: ateomnet.ActorVethGateway},
+		Device:      ateomnet.ActorVethName,
 		Lladdr:      hostVethMAC,
 		State:       0x80, // NUD_PERMANENT
 	}})

--- a/internal/ateomnet/net.go
+++ b/internal/ateomnet/net.go
@@ -1,0 +1,613 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ateomnet provides shared networking configuration logic for Substrate runtime agents.
+package ateomnet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"runtime"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/binaryutil"
+	"github.com/google/nftables/expr"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	HostVethName      = "ateom0"
+	ActorVethName     = "eth0"
+	ActorVethTempName = "ateom1"
+	HostVethCIDR      = "169.254.17.1/30"
+	ActorVethCIDR     = "169.254.17.2/30"
+	ActorVethGateway  = "169.254.17.1"
+	ActorVethIP       = "169.254.17.2"
+	ActorNftTableName = "ateom_actor"
+
+	// ActorVethSubnet is the point-to-point /30 the actor veth lives on.
+	ActorVethSubnet = "169.254.17.0/30"
+)
+
+var (
+	HostVethAddr  = MustParseAddr(HostVethCIDR)
+	ActorVethAddr = MustParseAddr(ActorVethCIDR)
+	ActorVethGwIP = MustParseIP(ActorVethGateway)
+)
+
+// MustParseAddr parses a CIDR string into a netlink.Addr, panicking on error.
+func MustParseAddr(cidr string) *netlink.Addr {
+	a, err := netlink.ParseAddr(cidr)
+	if err != nil {
+		panic(fmt.Sprintf("parsing constant CIDR %q: %v", cidr, err))
+	}
+	return a
+}
+
+// MustParseIP parses an IPv4 string into a net.IP, panicking on error.
+func MustParseIP(s string) net.IP {
+	ip := net.ParseIP(s).To4()
+	if ip == nil {
+		panic(fmt.Sprintf("parsing constant IPv4 %q", s))
+	}
+	return ip
+}
+
+// MustParseMAC parses a MAC address string into a net.HardwareAddr, panicking on error.
+func MustParseMAC(s string) net.HardwareAddr {
+	m, err := net.ParseMAC(s)
+	if err != nil {
+		panic(fmt.Sprintf("parsing constant MAC %q: %v", s, err))
+	}
+	return m
+}
+
+// ConfigureActorVeth configures the actor veth inside the interior netns.
+// It assumes it is already running inside the target network namespace.
+func ConfigureActorVeth(ctx context.Context) error {
+	// Run inside the gVisor interior netns after setupActorNetwork moves the
+	// veth peer there. gVisor reads link names, addresses, and routes from this
+	// namespace when the workload starts, so the peer is deliberately renamed to
+	// eth0 and configured like a normal container interface:
+	//
+	//   * lo is brought up for localhost behavior.
+	//   * the temporary veth peer is renamed to eth0.
+	//   * eth0 receives the actor-side /30 address.
+	//   * the default route points to the worker-side veth gateway.
+	loLink, err := netlink.LinkByName("lo")
+	if err != nil {
+		return fmt.Errorf("while acquiring lo in interior netns: %w", err)
+	}
+	if err := netlink.LinkSetUp(loLink); err != nil {
+		return fmt.Errorf("while bringing up lo in interior netns: %w", err)
+	}
+
+	actorLink, err := netlink.LinkByName(ActorVethTempName)
+	if err != nil {
+		return fmt.Errorf("while acquiring actor veth in interior netns: %w", err)
+	}
+	if err := netlink.LinkSetName(actorLink, ActorVethName); err != nil {
+		return fmt.Errorf("while renaming actor veth to %q: %w", ActorVethName, err)
+	}
+	actorLink, err = netlink.LinkByName(ActorVethName)
+	if err != nil {
+		return fmt.Errorf("while reacquiring actor veth in interior netns: %w", err)
+	}
+
+	if err := netlink.AddrReplace(actorLink, ActorVethAddr); err != nil {
+		return fmt.Errorf("while assigning actor veth address: %w", err)
+	}
+	if err := netlink.LinkSetUp(actorLink); err != nil {
+		return fmt.Errorf("while bringing up actor veth: %w", err)
+	}
+
+	if err := netlink.RouteReplace(&netlink.Route{
+		LinkIndex: actorLink.Attrs().Index,
+		Gw:        ActorVethGwIP,
+	}); err != nil {
+		return fmt.Errorf("while installing actor default route: %w", err)
+	}
+
+	return nil
+}
+
+// CleanupActorNetwork removes all per-activation network state owned by ateom.
+// Intentionally idempotent.
+func CleanupActorNetwork(ctx context.Context, interiorNetNS netns.NsHandle) error {
+	// Remove all per-activation network state owned by ateom. Deleting the
+	// worker-side veth also deletes its peer when the pair is still connected,
+	// but failed setup can leave the peer already moved into the actor netns.
+	// For that reason cleanup also enters the interior netns and deletes either
+	// the final actor interface name or the temporary peer name if present.
+	//
+	// This function is intentionally idempotent so it can run before setup, after
+	// checkpoint, and from setup failure cleanup without requiring the caller to
+	// know how far network initialization progressed.
+	var cleanupErr error
+	if err := RemoveActorNftablesRules(); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while removing actor nftables rules: %w", err))
+		slog.WarnContext(ctx, "Failed to remove actor nftables rules; continuing actor netns cleanup", "err", err)
+	}
+
+	if link, err := netlink.LinkByName(HostVethName); err == nil {
+		if err := netlink.LinkDel(link); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while deleting host veth: %w", err))
+			slog.WarnContext(ctx, "Failed to delete host veth; continuing actor netns cleanup", "err", err)
+		}
+	} else if _, ok := err.(netlink.LinkNotFoundError); !ok {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while looking up host veth: %w", err))
+		slog.WarnContext(ctx, "Failed to look up host veth; continuing actor netns cleanup", "err", err)
+	}
+
+	if err := NetNSDo(ctx, interiorNetNS, func(_ context.Context) error {
+		for _, name := range []string{ActorVethName, ActorVethTempName} {
+			link, err := netlink.LinkByName(name)
+			if err == nil {
+				if err := netlink.LinkDel(link); err != nil {
+					return fmt.Errorf("while deleting interior veth %q: %w", name, err)
+				}
+				continue
+			}
+			if _, ok := err.(netlink.LinkNotFoundError); !ok {
+				return fmt.Errorf("while looking up interior veth %q: %w", name, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while cleaning interior netns links: %w", err))
+	}
+
+	return cleanupErr
+}
+
+// PodIPv4 resolves the worker pod IPv4 address from the pod namespace's real eth0.
+func PodIPv4() (net.IP, error) {
+	// Resolve the worker pod IPv4 address from the pod namespace's real eth0.
+	// Because eth0 now stays in the pod namespace, this IP remains available for
+	// both normal worker connectivity and the temporary inbound DNAT rule.
+	eth0Link, err := netlink.LinkByName("eth0")
+	if err != nil {
+		return nil, fmt.Errorf("while getting pod eth0: %w", err)
+	}
+	addrs, err := netlink.AddrList(eth0Link, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, fmt.Errorf("while listing pod eth0 addresses: %w", err)
+	}
+	for _, addr := range addrs {
+		if addr.IP == nil {
+			continue
+		}
+		if ip := addr.IP.To4(); ip != nil {
+			return ip, nil
+		}
+	}
+	return nil, fmt.Errorf("pod eth0 has no IPv4 address")
+}
+
+// EnableIPv4Forwarding enables IPv4 forwarding in the current network namespace.
+func EnableIPv4Forwarding() error {
+	// Forwarding is required because actor packets now enter the worker pod via
+	// the host-side veth and then leave through the pod's eth0. Without this, the
+	// kernel would not route traffic between those interfaces even though both
+	// live in the worker pod network namespace.
+	//
+	// Without privileged, the container runtime bind-mounts /proc/sys read-only.
+	// The worker holds CAP_SYS_ADMIN and uses no user namespace, so the ro flag
+	// is not locked: clear it, write the sysctl, restore ro.
+	const path = "/proc/sys/net/ipv4/ip_forward"
+	if b, err := os.ReadFile(path); err == nil && len(b) > 0 && b[0] == '1' {
+		return nil
+	}
+	if err := os.WriteFile(path, []byte("1\n"), 0o644); err == nil {
+		return nil
+	}
+	if err := unix.Mount("none", "/proc/sys", "", unix.MS_BIND|unix.MS_REMOUNT, ""); err != nil {
+		return fmt.Errorf("while remounting /proc/sys read-write to enable IPv4 forwarding: %w", err)
+	}
+	defer func() {
+		_ = unix.Mount("none", "/proc/sys", "", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY, "")
+	}()
+	if err := os.WriteFile(path, []byte("1\n"), 0o644); err != nil {
+		return fmt.Errorf("while enabling IPv4 forwarding in worker pod netns: %w", err)
+	}
+	return nil
+}
+
+// InstallActorNftablesRules configures the NAT and filtering rules for the actor.
+func InstallActorNftablesRules(podIP net.IP) error {
+	// Install a dedicated nftables table for the active actor. Keeping all
+	// rules in an ateom-owned table makes cleanup simple and avoids mutating
+	// Kubernetes or CNI-managed chains directly.
+	//
+	// TODO: Add IPv6 veth addressing, forwarding, and nftables rules once actor
+	// networking supports dual-stack pods. The current compatibility path is
+	// IPv4-only.
+	//
+	// The temporary compatibility rules do three things:
+	//
+	//   * postrouting: masquerade actor egress from 169.254.17.2 behind the worker
+	//     pod IP so replies route back to the pod.
+	//   * prerouting: DNAT traffic sent to the worker pod IP on TCP/80 to the
+	//     actor veth IP on TCP/80, preserving existing inbound behavior.
+	//   * forward: accept forwarded packets between the actor veth and pod eth0.
+	//
+	// This is not the final egress policy path. The later AgentGateway phase
+	// should replace the broad masquerade path with transparent TCP capture and
+	// default-deny rules.
+	if err := RemoveActorNftablesRules(); err != nil {
+		return err
+	}
+
+	c := &nftables.Conn{}
+	table := &nftables.Table{
+		Family: nftables.TableFamilyIPv4,
+		Name:   ActorNftTableName,
+	}
+	c.AddTable(table)
+
+	prerouting := c.AddChain(&nftables.Chain{
+		Name:     "prerouting",
+		Table:    table,
+		Type:     nftables.ChainTypeNAT,
+		Hooknum:  nftables.ChainHookPrerouting,
+		Priority: nftables.ChainPriorityNATDest,
+	})
+	// TODO: Support inbound UDP DNAT for actors that expose UDP protocols such
+	// as QUIC.
+	// TODO: Replace the hard-coded HTTP port with the actor's configured
+	// inbound ports, either by adding one rule per port or by matching a set.
+	preroutingExprs := append(IPDestinationEqual(podIP.String()), TCPDestinationPortEqual(80)...)
+	preroutingExprs = append(preroutingExprs,
+		&expr.Immediate{
+			Register: 1,
+			Data:     net.ParseIP(ActorVethIP).To4(),
+		},
+		&expr.Immediate{
+			Register: 2,
+			Data:     binaryutil.BigEndian.PutUint16(80),
+		},
+		&expr.NAT{
+			Type:        expr.NATTypeDestNAT,
+			Family:      unix.NFPROTO_IPV4,
+			RegAddrMin:  1,
+			RegProtoMin: 2,
+		},
+	)
+	c.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: prerouting,
+		Exprs: preroutingExprs,
+	})
+
+	postrouting := c.AddChain(&nftables.Chain{
+		Name:     "postrouting",
+		Table:    table,
+		Type:     nftables.ChainTypeNAT,
+		Hooknum:  nftables.ChainHookPostrouting,
+		Priority: nftables.ChainPriorityNATSource,
+	})
+	c.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: postrouting,
+		Exprs: append(IPSourceEqual(ActorVethIP), &expr.Masq{}),
+	})
+
+	acceptPolicy := nftables.ChainPolicyAccept
+	forward := c.AddChain(&nftables.Chain{
+		Name:     "forward",
+		Table:    table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookForward,
+		Priority: nftables.ChainPriorityFilter,
+		Policy:   &acceptPolicy,
+	})
+	c.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: forward,
+		Exprs: []expr.Any{
+			&expr.Verdict{Kind: expr.VerdictAccept},
+		},
+	})
+
+	if err := c.Flush(); err != nil {
+		return fmt.Errorf("while installing actor nftables rules: %w", err)
+	}
+	return nil
+}
+
+// RemoveActorNftablesRules removes the ateom nftables table.
+func RemoveActorNftablesRules() error {
+	// Delete the whole ateom nftables table if it exists. The table is
+	// per-worker and currently per-active-actor because this worker path runs at
+	// most one actor at a time. Missing tables are treated as already clean.
+	c := &nftables.Conn{}
+	tables, err := c.ListTablesOfFamily(nftables.TableFamilyIPv4)
+	if err != nil {
+		return fmt.Errorf("while listing nftables tables: %w", err)
+	}
+	for _, table := range tables {
+		if table.Name != ActorNftTableName {
+			continue
+		}
+		c.DelTable(table)
+		if err := c.Flush(); err != nil {
+			return fmt.Errorf("while deleting actor nftables table: %w", err)
+		}
+		return nil
+	}
+	return nil
+}
+
+func IPSourceEqual(ip string) []expr.Any {
+	return IPPayloadEqual(12, ip)
+}
+
+func IPDestinationEqual(ip string) []expr.Any {
+	return IPPayloadEqual(16, ip)
+}
+
+func IPPayloadEqual(offset uint32, ip string) []expr.Any {
+	return []expr.Any{
+		&expr.Payload{
+			DestRegister: 1,
+			Base:         expr.PayloadBaseNetworkHeader,
+			Offset:       offset,
+			Len:          4,
+		},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     net.ParseIP(ip).To4(),
+		},
+	}
+}
+
+func TCPDestinationPortEqual(port uint16) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     []byte{unix.IPPROTO_TCP},
+		},
+		&expr.Payload{
+			DestRegister: 1,
+			Base:         expr.PayloadBaseTransportHeader,
+			Offset:       2,
+			Len:          2,
+		},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     binaryutil.BigEndian.PutUint16(port),
+		},
+	}
+}
+
+// CreateNetNSWithoutSwitching creates a named netns and returns its handle,
+// restoring the caller's current netns before returning.
+func CreateNetNSWithoutSwitching(name string) (netns.NsHandle, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// We need to create the new NS, then switch back to the current netns.
+	curNetNS, err := netns.Get()
+	if err != nil {
+		return -1, fmt.Errorf("while getting current netns: %w", err)
+	}
+	defer func() {
+		if err := netns.Set(curNetNS); err != nil {
+			// Better to blow up the program than continue execution with
+			// one OS thread randomly in a different netns.
+			panic(fmt.Sprintf("Failed to restore original netns: %v", err))
+		}
+	}()
+
+	interiorNetNS, err := netns.NewNamed(name)
+	if err != nil {
+		return -1, fmt.Errorf("while creating interior network namespace: %w", err)
+	}
+	return interiorNetNS, nil
+}
+
+// NetNSDo runs do() with the OS thread switched into targetNS, then restores it.
+func NetNSDo(ctx context.Context, targetNS netns.NsHandle, do func(context.Context) error) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// We need to create the new NS, then switch back to the current netns.
+	curNetNS, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("while getting current netns: %w", err)
+	}
+	defer func() {
+		if err := netns.Set(curNetNS); err != nil {
+			// Better to blow up the program than continue execution with
+			// one OS thread randomly in a different netns.
+			panic(fmt.Sprintf("Failed to restore original netns: %v", err))
+		}
+	}()
+
+	if err := netns.Set(targetNS); err != nil {
+		return fmt.Errorf("setting target netns: %w", err)
+	}
+	if err := do(ctx); err != nil {
+		return fmt.Errorf("while executing function in target netns: %w", err)
+	}
+	return nil
+}
+
+// DumpNetInfo dumps link and route information for debugging.
+func DumpNetInfo(ctx context.Context, prefix string) error {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("in netlink.LinkList(): %w", err)
+	}
+
+	for _, link := range links {
+		slog.InfoContext(ctx, prefix+"Link", slog.String("name", link.Attrs().Name), slog.String("type", link.Type()), slog.Any("attrs", link.Attrs()))
+
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		if err != nil {
+			return fmt.Errorf("while getting pod eth0 addresses: %w", err)
+		}
+		slog.InfoContext(ctx, prefix+"Link Addresses", slog.String("link", link.Attrs().Name), slog.Any("addrs", addrs))
+
+		rts, err := netlink.RouteList(link, netlink.FAMILY_V4)
+		if err != nil {
+			return fmt.Errorf("while getting routes off eth0: %w", err)
+		}
+		for _, rt := range rts {
+			slog.InfoContext(ctx, prefix+"Link Routes", slog.Any("link", link.Attrs().Name), slog.Any("route", rt), slog.Any("route-string", rt.String()))
+		}
+	}
+
+	return nil
+}
+
+type NetworkConfig struct {
+	// InteriorNetNS is the target network namespace for the actor's veth pair peer.
+	// Used by: Both gVisor and MicroVM.
+	InteriorNetNS netns.NsHandle
+
+	// HostVethHWAddr is the hardware address to assign to the host veth interface.
+	// Used by: MicroVM (to ensure consistent MAC addresses across snapshot/restore).
+	HostVethHWAddr net.HardwareAddr
+	// SweepInteriorLinks indicates whether to delete existing links in the interior netns (excluding loopback).
+	// Used by: MicroVM (to clean up stale tap devices).
+	SweepInteriorLinks bool
+
+	// DumpNetInfo indicates whether to dump network information to the logs for debugging purposes.
+	// Used by: gVisor.
+	DumpNetInfo bool
+}
+
+// SetupActorNetwork builds a fresh point-to-point network between the worker
+// pod netns and the interior netns.
+func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
+	// Build a fresh point-to-point network between the worker pod netns and the
+	// gVisor interior netns. The worker side keeps the pod's real eth0, creates
+	// ateom0 as the gateway, and moves only the veth peer into the actor netns.
+	// The actor side renames that peer to eth0 and installs a default route via
+	// the worker-side veth address. This replaces the old behavior of moving the
+	// Kubernetes-provided eth0 out of the worker pod.
+	//
+	// The nftables rules installed here are a compatibility bridge for the
+	// current router assumptions: actor egress is masqueraded behind the worker
+	// pod IP, and inbound traffic to the worker pod's HTTP port is DNAT'd to the
+	// actor veth IP.
+	//
+	// Clean up stale state from a failed prior activation before creating the
+	// next actor-side network. The worker currently runs one actor at a time.
+	if err := CleanupActorNetwork(ctx, cfg.InteriorNetNS); err != nil {
+		return fmt.Errorf("failed to clean up stale actor network before setup: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			if err := CleanupActorNetwork(ctx, cfg.InteriorNetNS); err != nil {
+				slog.WarnContext(ctx, "Failed to clean up partially configured actor network", slog.Any("err", err))
+			}
+		}
+	}()
+
+	podIP, err := PodIPv4()
+	if err != nil {
+		return fmt.Errorf("while resolving pod IPv4 address: %w", err)
+	}
+
+	if cfg.SweepInteriorLinks {
+		if err := NetNSDo(ctx, cfg.InteriorNetNS, func(ctx context.Context) error {
+			links, err := netlink.LinkList()
+			if err != nil {
+				return fmt.Errorf("while listing interior netns links: %w", err)
+			}
+			for _, l := range links {
+				if l.Attrs().Name == "lo" {
+					continue
+				}
+				if err := netlink.LinkDel(l); err != nil {
+					slog.WarnContext(ctx, "Failed to delete leftover interior link", slog.String("link", l.Attrs().Name), slog.Any("err", err))
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
+	veth := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: HostVethName,
+		},
+		PeerName: ActorVethTempName,
+	}
+	if len(cfg.HostVethHWAddr) > 0 {
+		veth.LinkAttrs.HardwareAddr = cfg.HostVethHWAddr
+	}
+
+	if err := netlink.LinkAdd(veth); err != nil {
+		return fmt.Errorf("while creating actor veth pair: %w", err)
+	}
+
+	hostLink, err := netlink.LinkByName(HostVethName)
+	if err != nil {
+		return fmt.Errorf("while getting host veth: %w", err)
+	}
+	if err := netlink.AddrReplace(hostLink, HostVethAddr); err != nil {
+		return fmt.Errorf("while assigning host veth address: %w", err)
+	}
+	if err := netlink.LinkSetUp(hostLink); err != nil {
+		return fmt.Errorf("while bringing up host veth: %w", err)
+	}
+
+	actorLink, err := netlink.LinkByName(ActorVethTempName)
+	if err != nil {
+		return fmt.Errorf("while getting actor veth peer: %w", err)
+	}
+	if err := netlink.LinkSetNsFd(actorLink, int(cfg.InteriorNetNS)); err != nil {
+		return fmt.Errorf("while moving actor veth peer into interior netns: %w", err)
+	}
+
+	if err := NetNSDo(ctx, cfg.InteriorNetNS, ConfigureActorVeth); err != nil {
+		return fmt.Errorf("while configuring actor veth in interior netns: %w", err)
+	}
+
+	if err := EnableIPv4Forwarding(); err != nil {
+		return err
+	}
+	if err := InstallActorNftablesRules(podIP); err != nil {
+		return err
+	}
+
+	if cfg.DumpNetInfo {
+		if err := DumpNetInfo(ctx, "Pod NetNS "); err != nil {
+			return fmt.Errorf("while dumping pod netns links: %w", err)
+		}
+		if err := NetNSDo(ctx, cfg.InteriorNetNS, func(ctx context.Context) error {
+			return DumpNetInfo(ctx, "Interior NetNS ")
+		}); err != nil {
+			return fmt.Errorf("while dumping interior netns links: %w", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
1. Extracts duplicated networking logic from ateom-gvisor and ateom-microvm into internal/ateomnet.

2. Updates gVisor CleanupActorNetwork behavior so that an error from RemoveActorNftablesRules logs a warning and continues cleanup rather than failing fast.


This is a prep PR for https://github.com/agent-substrate/substrate/issues/175. 
