### PR TITLE
Build the locust image for the cluster's architecture

### DIFF
--- a/benchmarking/locust/build_and_push.sh
+++ b/benchmarking/locust/build_and_push.sh
@@ -31,10 +31,13 @@ fi
 
 IMAGE="us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest"
 
-echo "Building Docker image: $IMAGE"
+# Target platform must match the cluster's nodes, not the build host.
+PLATFORM="${LOCUST_IMAGE_PLATFORM:-linux/amd64}"
+
+echo "Building Docker image: $IMAGE (platform: $PLATFORM)"
 # Build context is the monorepo root because the Dockerfile compiles the
 # boomer-glutton Go binary alongside the Python install (see Dockerfile).
-docker build -t "$IMAGE" -f benchmarking/locust/Dockerfile .
+docker build --platform "$PLATFORM" -t "$IMAGE" -f benchmarking/locust/Dockerfile .
 
 echo "Pushing Docker image..."
 docker push "$IMAGE"


### PR DESCRIPTION
## Problem

`build_and_push.sh` ran `docker build` with no `--platform`, so an arm64
workstation produced an arm64 image while GKE nodes (c3-standard-4) are
amd64. The push succeeds and nothing fails until the kubelet pulls, two
steps later:

    no match for platform in manifest: not found

## Solution

Default to `linux/amd64`, overridable via `LOCUST_IMAGE_PLATFORM` for arm64
node pools (T2A, Axion).

## Notes

Verified: pushed manifest reports `linux/amd64` and the locust pod reaches
3/3 Running.
