### PR TITLE
Add a readyz probe to the benchmark glutton actor

### DIFF
--- a/benchmarking/workloads/manifests/workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/workloads.yaml.tmpl
@@ -70,6 +70,11 @@ spec:
     - "--metrics-listen-addr=:9090"
     - "--data-dir=/tmp/glutton"
     - "--mode=http"
+    # Hold ResumeActor open until port 80 actually answers.
+    readyz:
+      httpGet:
+        path: /readyz
+        port: 80
   workerSelector:
     matchLabels:
       workload: benchmark-ateom

--- a/cmd/benchmarking/glutton/main.go
+++ b/cmd/benchmarking/glutton/main.go
@@ -136,6 +136,11 @@ func main() {
 		// (re-exposable as additional routes if/when needed).
 		mux := http.NewServeMux()
 		mux.HandleFunc("/ping", httpPingHandler(svc))
+		// ateom blocks RestoreWorkload until this returns 200, so ResumeActor
+		// cannot report success before /ping is reachable.
+		mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
 		// otelhttp at the mux level + per-handler span follows
 		// docs/dev/best-practices/tracing.md: extract incoming context,
 		// then name the span after the operation in each handler.

--- a/cmd/benchmarking/glutton/main.go
+++ b/cmd/benchmarking/glutton/main.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -119,6 +120,15 @@ func main() {
 		slog.String("mode", *mode),
 	)
 
+	// ateom blocks RestoreWorkload until /readyz returns 200, so ResumeActor
+	// cannot report success before this listener is reachable. The probe is
+	// an HTTP GET, so both modes must serve it.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	var handler http.Handler
 	switch *mode {
 	case "grpc":
 		srv := grpc.NewServer(
@@ -126,31 +136,45 @@ func main() {
 		)
 		glutton.RegisterGluttonServer(srv, svc)
 		reflection.Register(srv)
-		if err := srv.Serve(lis); err != nil {
-			serverboot.Fatal(ctx, "Failed to serve", err)
-		}
+		handler = splitGRPC(srv, mux)
 	case "http":
 		// HTTP/1.1 mode: a single /ping route that consumes
 		// proto.Marshal(PingRequest) and returns proto.Marshal(PingResponse).
 		// Only Ping is exposed in HTTP mode; the other RPCs remain gRPC-only
 		// (re-exposable as additional routes if/when needed).
-		mux := http.NewServeMux()
 		mux.HandleFunc("/ping", httpPingHandler(svc))
-		// ateom blocks RestoreWorkload until this returns 200, so ResumeActor
-		// cannot report success before /ping is reachable.
-		mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
 		// otelhttp at the mux level + per-handler span follows
 		// docs/dev/best-practices/tracing.md: extract incoming context,
 		// then name the span after the operation in each handler.
-		httpSrv := &http.Server{Handler: otelhttp.NewHandler(mux, "/")}
-		if err := httpSrv.Serve(lis); err != nil {
-			serverboot.Fatal(ctx, "Failed to serve", err)
-		}
+		handler = otelhttp.NewHandler(mux, "/")
 	default:
 		serverboot.Fatal(ctx, "Invalid --mode", fmt.Errorf("must be grpc or http: %q", *mode))
 	}
+	if err := newServer(handler).Serve(lis); err != nil {
+		serverboot.Fatal(ctx, "Failed to serve", err)
+	}
+}
+
+// newServer enables unencrypted HTTP/2 so gRPC works on the plaintext
+// listener, alongside HTTP/1.1 for the readyz probe.
+func newServer(handler http.Handler) *http.Server {
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	return &http.Server{Handler: handler, Protocols: protocols}
+}
+
+// splitGRPC serves gRPC and plain HTTP on one listener: requests with a
+// gRPC content-type go to grpcSrv, everything else to rest. All glutton
+// RPCs are unary, which is what grpc.Server.ServeHTTP supports.
+func splitGRPC(grpcSrv, rest http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcSrv.ServeHTTP(w, r)
+			return
+		}
+		rest.ServeHTTP(w, r)
+	})
 }
 
 // httpPingHandler accepts a POST whose body is proto.Marshal(PingRequest) and

--- a/cmd/benchmarking/glutton/main_test.go
+++ b/cmd/benchmarking/glutton/main_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/agent-substrate/substrate/internal/proto/glutton"
+)
+
+// TestSplitGRPCServesReadyzAndGRPCOnOneListener starts the grpc-mode handler
+// on a real listener and exercises both protocols against it: the readyz
+// probe is a plain HTTP GET, and it must not stop gRPC from being served.
+func TestSplitGRPCServesReadyzAndGRPCOnOneListener(t *testing.T) {
+	svc, err := newGluttonService(t.TempDir())
+	if err != nil {
+		t.Fatalf("newGluttonService: %v", err)
+	}
+	defer svc.Close()
+
+	grpcSrv := grpc.NewServer()
+	glutton.RegisterGluttonServer(grpcSrv, svc)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := newServer(splitGRPC(grpcSrv, mux))
+	go srv.Serve(lis)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := http.Get("http://" + lis.Addr().String() + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /readyz = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer conn.Close()
+
+	pong, err := glutton.NewGluttonClient(conn).Ping(ctx, &glutton.PingRequest{Message: "hi"})
+	if err != nil {
+		t.Fatalf("Ping over gRPC: %v", err)
+	}
+	if pong.GetMessage() != "hi" {
+		t.Errorf("Ping = %q, want %q", pong.GetMessage(), "hi")
+	}
+}
+
+// TestSplitGRPCRoutesOnContentType pins the routing rule itself: an HTTP/2
+// request is not enough to reach the gRPC server, the content type is what
+// decides.
+func TestSplitGRPCRoutesOnContentType(t *testing.T) {
+	grpcHit := false
+	handler := splitGRPC(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { grpcHit = true }),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),
+	)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := newServer(handler)
+	go srv.Serve(lis)
+	defer srv.Close()
+
+	resp, err := http.Get("http://" + lis.Addr().String() + "/anything")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusTeapot {
+		t.Errorf("HTTP/1.1 GET = %d, want %d (the non-gRPC handler)", resp.StatusCode, http.StatusTeapot)
+	}
+	if grpcHit {
+		t.Error("HTTP/1.1 GET reached the gRPC handler")
+	}
+}


### PR DESCRIPTION
## Problem

ResumeActor returned as soon as the resume workflow finished, not when glutton's port 80 listener was accepting connections. A ping issued right after resume could land in that gap, get ECONNREFUSED, and come back from the router as a 503.

ateom already has a gate for exactly this: `internal/readyz.WaitAll` blocks `RestoreWorkload` and `RunWorkload` until every container that declares a readyz probe returns 200. But containers without a probe are skipped entirely, and glutton declared none, so nothing waited on it.

## Solution

Add `/readyz` to glutton's HTTP mux and point the ActorTemplate at it.

The route goes on the same listener as `/ping` rather than the metrics port: the metrics server starts independently, so a 200 there would say nothing about whether `/ping` is reachable yet.

## Notes

`ActorTemplate.spec` is immutable, so picking this up needs a delete and recreate of the template, not an apply.
