### PR TITLE
Authenticate the benchmark's ateapi clients

### DIFF
--- a/benchmarking/locust/common/ateapi_channel.py
+++ b/benchmarking/locust/common/ateapi_channel.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Authenticated gRPC channel to ateapi, shared by every locust user class.
+
+ateapi rejects calls that carry no credential: its interceptor takes identity
+from an mTLS client certificate, or failing that from an `authorization:
+Bearer <jwt>` header. We present the certificate, which is what the base
+install gives ate-controller and atenet-router.
+
+Both files are projected in by the Deployment
+(benchmarking/locust/manifests/locust.yaml).
+"""
+
+import re
+
+import grpc
+
+CA_FILE = "/run/servicedns-ca/ca.crt"
+CRED_BUNDLE = "/run/podidentity.podcert.ate.dev/credential-bundle.pem"
+
+# The DNS SAN on the apiserver's serving cert, which is shorter than the
+# endpoint the user classes dial.
+SERVER_NAME = "api.ate-system.svc"
+
+_PEM_BLOCK = re.compile(
+    rb"-----BEGIN (?P<kind>[A-Z ]+)-----.*?-----END (?P=kind)-----\n?",
+    re.DOTALL,
+)
+
+
+def _split_cred_bundle(bundle: bytes):
+    """Split a Kubernetes pod-certificate bundle into (key, chain).
+
+    The bundle is one file holding a PRIVATE KEY block followed by
+    CERTIFICATE blocks in leaf-to-root order. grpc wants the two halves
+    separately, so pull the PEM blocks apart by armor rather than parsing
+    the DER — no crypto library needed, and nothing here has to understand
+    the key type.
+    """
+    key, chain = None, []
+    for m in _PEM_BLOCK.finditer(bundle):
+        if m.group("kind") == b"PRIVATE KEY":
+            key = m.group(0)
+        else:
+            chain.append(m.group(0))
+    if key is None:
+        raise ValueError(f"{CRED_BUNDLE}: no PRIVATE KEY block")
+    if not chain:
+        raise ValueError(f"{CRED_BUNDLE}: no CERTIFICATE block")
+    return key, b"".join(chain)
+
+
+def ateapi_channel(host: str, options=None) -> grpc.Channel:
+    """Open an mTLS channel to ateapi that authenticates as this pod.
+
+    The certificate is read once, when the channel is built. Python's gRPC
+    has no per-handshake reload hook, unlike the Go client's
+    credbundle.ClientLoader. That is fine in practice: each locust User
+    builds its own channel in on_start, so a respawn picks up a rotated
+    certificate, and an already-established connection is unaffected by the
+    old one expiring.
+    """
+    target = host.replace("http://", "").replace("https://", "")
+    with open(CA_FILE, "rb") as f:
+        ca_cert = f.read()
+    with open(CRED_BUNDLE, "rb") as f:
+        private_key, cert_chain = _split_cred_bundle(f.read())
+
+    creds = grpc.ssl_channel_credentials(
+        root_certificates=ca_cert,
+        private_key=private_key,
+        certificate_chain=cert_chain,
+    )
+    channel_options = [("grpc.ssl_target_name_override", SERVER_NAME)]
+    if options:
+        channel_options.extend(options)
+    return grpc.secure_channel(target, creds, options=channel_options)

--- a/benchmarking/locust/manifests/locust.yaml
+++ b/benchmarking/locust/manifests/locust.yaml
@@ -73,6 +73,9 @@ spec:
         - name: servicedns-ca
           mountPath: /run/servicedns-ca
           readOnly: true
+        - name: podidentity
+          mountPath: /run/podidentity.podcert.ate.dev
+          readOnly: true
         resources:
           requests:
             cpu: "500m"
@@ -98,6 +101,9 @@ spec:
         volumeMounts:
         - name: servicedns-ca
           mountPath: /run/servicedns-ca
+          readOnly: true
+        - name: podidentity
+          mountPath: /run/podidentity.podcert.ate.dev
           readOnly: true
         resources:
           requests:
@@ -125,6 +131,13 @@ spec:
         - name: boomer-prom
           containerPort: 8001
           protocol: TCP
+        volumeMounts:
+        - name: servicedns-ca
+          mountPath: /run/servicedns-ca
+          readOnly: true
+        - name: podidentity
+          mountPath: /run/podidentity.podcert.ate.dev
+          readOnly: true
         resources:
           requests:
             cpu: "500m"
@@ -140,6 +153,19 @@ spec:
                 matchLabels:
                   podcert.ate.dev/canarying: live
               path: ca.crt
+      # The benchmark's own client identity, presented to ateapi. Its
+      # interceptor rejects calls carrying no credential, taking identity from
+      # an mTLS client cert or, failing that, a Bearer token. Use the cert:
+      # that is what the base install gives ate-controller and atenet-router
+      # (the token path is the opt-in ATE_ATEAPI_CLIENT_AUTH=token overlay),
+      # and it yields a SPIFFE ID rather than an opaque JWT subject.
+      - name: podidentity
+        projected:
+          sources:
+          - podCertificate:
+              signerName: podidentity.podcert.ate.dev/identity
+              keyType: ECDSAP256
+              credentialBundlePath: credential-bundle.pem
 ---
 apiVersion: v1
 kind: Service

--- a/benchmarking/locust/tests/ate_api.py
+++ b/benchmarking/locust/tests/ate_api.py
@@ -19,6 +19,7 @@ import uuid
 import grpc
 from common import ateapi_pb2
 from common import ateapi_pb2_grpc
+from common.ateapi_channel import ateapi_channel
 from common.atespace import ATESPACE, ensure_atespace
 from common.grpc_tracing import traced_grpc
 from common.metrics import init_metrics, update_user_count
@@ -48,11 +49,7 @@ class AteAPIUser(User):
 
         # Setup gRPC
         # Strip protocol prefix if present
-        target = self.host.replace("http://", "").replace("https://", "")
-        with open("/run/servicedns-ca/ca.crt", "rb") as f:
-            ca_cert = f.read()
-        options = [('grpc.ssl_target_name_override', 'api.ate-system.svc')]
-        self.channel = grpc.secure_channel(target, grpc.ssl_channel_credentials(root_certificates=ca_cert), options=options)
+        self.channel = ateapi_channel(self.host)
         self.stub = ateapi_pb2_grpc.ControlStub(self.channel)
 
         try:

--- a/benchmarking/locust/tests/counter_demo.py
+++ b/benchmarking/locust/tests/counter_demo.py
@@ -25,6 +25,7 @@ import grpc
 import requests
 from common import ateapi_pb2
 from common import ateapi_pb2_grpc
+from common.ateapi_channel import ateapi_channel
 from common.atespace import ATESPACE, ensure_atespace
 from common.grpc_tracing import traced_grpc
 
@@ -68,11 +69,7 @@ class CounterUser(User):
         update_user_count(1, self.__class__.__name__)
 
         # Setup gRPC
-        target = self.api_host.replace("http://", "").replace("https://", "")
-        with open("/run/servicedns-ca/ca.crt", "rb") as f:
-            ca_cert = f.read()
-        options = [('grpc.ssl_target_name_override', 'api.ate-system.svc')]
-        self.channel = grpc.secure_channel(target, grpc.ssl_channel_credentials(root_certificates=ca_cert), options=options)
+        self.channel = ateapi_channel(self.api_host)
         self.stub = ateapi_pb2_grpc.ControlStub(self.channel)
 
         try:

--- a/benchmarking/locust/tests/kernelmem.py
+++ b/benchmarking/locust/tests/kernelmem.py
@@ -19,6 +19,7 @@ import uuid
 import grpc
 from common import ateapi_pb2
 from common import ateapi_pb2_grpc
+from common.ateapi_channel import ateapi_channel
 from common.atespace import ATESPACE, ensure_atespace
 from common.grpc_tracing import traced_grpc
 from common.metrics import init_metrics, update_user_count
@@ -42,11 +43,7 @@ class KernelMemUser(User):
         update_user_count(1, self.__class__.__name__)
 
         # Setup gRPC
-        target = self.host.replace("http://", "").replace("https://", "")
-        with open("/run/servicedns-ca/ca.crt", "rb") as f:
-            ca_cert = f.read()
-        options = [('grpc.ssl_target_name_override', 'api.ate-system.svc')]
-        self.channel = grpc.secure_channel(target, grpc.ssl_channel_credentials(root_certificates=ca_cert), options=options)
+        self.channel = ateapi_channel(self.host)
         self.stub = ateapi_pb2_grpc.ControlStub(self.channel)
 
         try:

--- a/benchmarking/locust/tests/sleep.py
+++ b/benchmarking/locust/tests/sleep.py
@@ -19,6 +19,7 @@ import uuid
 import grpc
 from common import ateapi_pb2
 from common import ateapi_pb2_grpc
+from common.ateapi_channel import ateapi_channel
 from common.atespace import ATESPACE, ensure_atespace
 from common.grpc_tracing import traced_grpc
 from common.metrics import init_metrics, update_user_count
@@ -42,11 +43,7 @@ class SleepUser(User):
         update_user_count(1, self.__class__.__name__)
 
         # Setup gRPC
-        target = self.host.replace("http://", "").replace("https://", "")
-        with open("/run/servicedns-ca/ca.crt", "rb") as f:
-            ca_cert = f.read()
-        options = [('grpc.ssl_target_name_override', 'api.ate-system.svc')]
-        self.channel = grpc.secure_channel(target, grpc.ssl_channel_credentials(root_certificates=ca_cert), options=options)
+        self.channel = ateapi_channel(self.host)
         self.stub = ateapi_pb2_grpc.ControlStub(self.channel)
 
         try:

--- a/benchmarking/locust/tests/usermem.py
+++ b/benchmarking/locust/tests/usermem.py
@@ -19,6 +19,7 @@ import uuid
 import grpc
 from common import ateapi_pb2
 from common import ateapi_pb2_grpc
+from common.ateapi_channel import ateapi_channel
 from common.atespace import ATESPACE, ensure_atespace
 from common.grpc_tracing import traced_grpc
 from common.metrics import init_metrics, update_user_count
@@ -42,11 +43,7 @@ class UserMemUser(User):
         update_user_count(1, self.__class__.__name__)
 
         # Setup gRPC
-        target = self.host.replace("http://", "").replace("https://", "")
-        with open("/run/servicedns-ca/ca.crt", "rb") as f:
-            ca_cert = f.read()
-        options = [('grpc.ssl_target_name_override', 'api.ate-system.svc')]
-        self.channel = grpc.secure_channel(target, grpc.ssl_channel_credentials(root_certificates=ca_cert), options=options)
+        self.channel = ateapi_channel(self.host)
         self.stub = ateapi_pb2_grpc.ControlStub(self.channel)
 
         try:

--- a/internal/benchmarking/boomer/glutton/grpcclient.go
+++ b/internal/benchmarking/boomer/glutton/grpcclient.go
@@ -15,25 +15,44 @@
 package glutton
 
 import (
-	"crypto/tls"
 	"fmt"
 
+	"github.com/agent-substrate/substrate/internal/ateapiauth"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
-// DialControl opens a TLS gRPC connection to ateapi. Matches the dial
-// pattern in internal/ateclient/builder.go: TLS for transport encryption,
-// hostname verification skipped (intra-cluster; the in-cluster cert often
-// lacks the SAN entries Go's strict verifier requires).
+const (
+	// ateapiCAFile verifies ateapi's servicedns serving cert;
+	// ateapiCredBundle is the benchmark's own pod certificate. Both are
+	// projected in by benchmarking/locust/manifests/locust.yaml.
+	ateapiCAFile     = "/run/servicedns-ca/ca.crt"
+	ateapiCredBundle = "/run/podidentity.podcert.ate.dev/credential-bundle.pem"
+
+	// ateapiServerName is the DNS SAN on the apiserver's serving cert, which
+	// is shorter than the endpoint the benchmark dials.
+	ateapiServerName = "api.ate-system.svc"
+)
+
+// DialControl opens an authenticated gRPC connection to ateapi.
+//
+// ateapi rejects calls that carry no credential, so present the pod
+// certificate — the same client auth the base install gives ate-controller
+// and atenet-router. ClientCredBundle re-reads the bundle on every handshake,
+// so rotations are picked up without a restart.
 func DialControl(endpoint string) (*grpc.ClientConn, ateapipb.ControlClient, error) {
-	creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
-	conn, err := grpc.NewClient(endpoint,
-		grpc.WithTransportCredentials(creds),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-	)
+	dialOpts, err := ateapiauth.DialOptions(ateapiauth.ClientConfig{
+		CAFile:           ateapiCAFile,
+		ClientCredBundle: ateapiCredBundle,
+		ServerName:       ateapiServerName,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("ateapi dial options: %w", err)
+	}
+	dialOpts = append(dialOpts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
+
+	conn, err := grpc.NewClient(endpoint, dialOpts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("dial %s: %w", endpoint, err)
 	}


### PR DESCRIPTION
The benchmark has been unrunnable on `main` since #237 landed. Every ateapi
call fails with:

```
rpc error: code = Unauthenticated desc = missing bearer token
```

`ateapiauth`'s interceptor takes identity from an mTLS client certificate, or
failing that an `authorization: Bearer <jwt>` header, and rejects anything
else. The benchmark's clients still dialed with server-side TLS only.

#237 gave the ate-system components a pod certificate and the flags to present
it. The benchmark has its own Deployment, outside `manifests/ate-install/`, so
it was missed.

## What this does

- Projects a `podidentity.podcert.ate.dev/identity` certificate into the locust
  pod, mounted in all three containers.
- Go boomer: `DialControl` now builds its options through
  `ateapiauth.DialOptions` with `ClientCredBundle`, so `credbundle.ClientLoader`
  re-reads the bundle on every handshake and rotations need no restart. This
  also drops the `InsecureSkipVerify` it was using — the servicedns trust bundle
  was already mounted and nothing was reading it.
- Python user classes: a new `common/ateapi_channel.py` replaces the five-line
  channel setup duplicated across all five of them.

Certificate rather than token because that is what the base install gives the
other components — the token path is the opt-in `ATE_ATEAPI_CLIENT_AUTH=token`
overlay — and because it yields a SPIFFE ID rather than an opaque JWT subject
for a future authz layer to key on.

One asymmetry worth knowing about: Python's gRPC has no per-handshake reload
hook, so it reads the bundle once per channel. Each locust `User` builds its own
channel in `on_start`, so a respawn picks up a rotated certificate, and an
established connection is unaffected by the old one expiring.

## Verification

Deployed to a GKE cluster running `main`. Before: every call rejected, boomer
retrying `on_start` in a loop. After: every call authenticated as
`spiffe://cluster.local/ns/benchmarking/sa/default`, and no `Unauthenticated`
in the api-server log.

The SPIFFE ID is the part that matters. Only `mtlsPeerIdentity` logs
`Authentication successful`; the JWT branch is silent. So an absence of errors
alone would not distinguish the certificate being accepted from a token falling
through behind it — seeing the SPIFFE ID does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
