### PR TITLE
docs: fix kubectl ate logs examples and flag reference

### DIFF
--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -64,6 +64,7 @@ These flags can be appended to any command:
 | Flag | Short | Description | Default |
 |---|---|---|---|
 | `--kubeconfig` | | Path to your kubeconfig file | `~/.kube/config` |
+| `--context` | | Name of the kubeconfig context to use | current context |
 | `--endpoint` | | Manual gRPC endpoint override (e.g., `localhost:8080`) | |
 | `--output` | `-o` | Output format (`table`, `json`, `yaml`) | `table` |
 | `--trace` | | Enable on-demand tracing for the request | `false` |
@@ -169,9 +170,13 @@ kubectl ate delete actor my-actor -a <atespace>
 `kubectl ate logs` requires a resource-type subcommand; running `kubectl ate logs <actor-name>` on its own prints help. The only supported resource type is `actors`:
 
 ```bash
-# Stream logs for an actor (follows by default; aggregated across worker
-# reassignments so the same actor is queryable as it teleports between pods).
-kubectl ate logs actors my-actor
+# Print the logs an actor has produced on its current worker.
+# -a/--atespace is required, since an actor is addressed by (atespace, name).
+kubectl ate logs actors my-actor -a <atespace>
+
+# Follow the logs with -f. The stream is aggregated across worker
+# reassignments, so the same actor stays queryable as it teleports between pods.
+kubectl ate logs actors my-actor -a <atespace> -f
 ```
 
 Logs are streamable only while the actor is bound to a worker (i.e., `STATUS_RUNNING`). For history across worker migrations, route through a centralized log backend (Cloud Logging, Loki, etc.); see `docs/observability.md`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -26,8 +26,11 @@ Agent Substrate captures container standard output/error, wraps them into struct
 For quick, on-demand debugging of an active actor, use the Agent Substrate CLI:
 
 ```bash
-kubectl ate logs actors <actor-name> [--follow / -f]
+kubectl ate logs actors <actor-name> --atespace <atespace> [--follow / -f]
 ```
+
+`--atespace` (short form `-a`) is required: actor names are only unique within
+an atespace, so an actor is always addressed by `(atespace, name)`.
 
 > **Note:** By default, `kubectl ate logs` queries the Kubernetes API of the worker pod where the actor is *currently* running. It is designed for immediate inspection of active actors. To view historical logs across past worker pods and suspension cycles, use a centralized logging backend.
 
@@ -35,7 +38,7 @@ kubectl ate logs actors <actor-name> [--follow / -f]
 If an actor is suspended or not assigned to a worker pod, the CLI informs you immediately:
 
 ```bash
-$ kubectl ate logs actors test
+$ kubectl ate logs actors test -a demo
 Error: actor test is not currently running on any worker pod
 ```
 
@@ -43,7 +46,7 @@ Error: actor test is not currently running on any worker pod
 When an active actor is assigned to a worker pod, the CLI outputs clean, uniform JSON lines stripped of Substrate metadata, perfectly matching standard `kubectl logs` behavior:
 
 ```bash
-$ kubectl ate logs actors test
+$ kubectl ate logs actors test -a demo
 {"time":"2026-05-22T21:49:15.23700774Z","message":"Actor started"}
 {"time":"2026-05-22T21:49:15.23700774Z","level":"INFO","msg":"Starting counter server on port 80"}
 {"time":"2026-05-22T21:49:15.255765354Z","count":0,"fshash":"mCY7G4S318ztOUojPTF2NA/W+ZSmWyr+T5K3udFuP50","level":"INFO","msg":"Count"}
@@ -54,7 +57,7 @@ $ kubectl ate logs actors test
 To stream actor logs in real-time, append the `--follow` (or `-f`) flag. The CLI is fully actor-aware, automatically resuming the stream if the actor is suspended or migrates to a different worker pod:
 
 ```bash
-$ kubectl ate logs actors test -f
+$ kubectl ate logs actors test -a demo -f
 Actor is currently running on pod ate-demo-counter/counter-d8f99-m7d96
 {"time":"2026-05-22T21:49:15.255765354Z","count":0,"fshash":"mCY7...","level":"INFO","msg":"Count"}
 {"time":"2026-05-22T21:49:25.263744806Z","count":1,"fshash":"mCY7...","level":"INFO","msg":"Count"}


### PR DESCRIPTION
Doc-only fix, no issue filed — happy to open one if preferred.

`-a/--atespace` became a required flag on `kubectl ate logs actors` in #458, but the examples in the CLI README and `docs/observability.md` were never updated. Every documented invocation currently fails:

```
$ go run ./cmd/kubectl-ate logs actors my-actor
Error: required flag(s) "atespace" not set
```

While in those files, two smaller inaccuracies in `cmd/kubectl-ate/README.md`:

- The logs example says it "follows by default", but `--follow` defaults to `false`. Split into a one-shot and a `-f` example.
- The global flags table was missing `--context`.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR