### PR TITLE
(otel): onboard ateom to the OTLP metrics path

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -24,10 +24,15 @@ import (
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 )
 
+// ateomOTelResourceAttributes mirrors atelet.yaml; service.instance.id is the pod
+// uid so each worker pod is a distinct telemetry source.
+const ateomOTelResourceAttributes = "k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),service.instance.id=$(POD_UID)"
+
 // buildDeploymentApplyConfig constructs the SSA apply configuration for the
 // Deployment managed by a WorkerPool. Only fields owned by this controller
-// are declared here.
-func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.DeploymentApplyConfiguration {
+// are declared here. otelEndpoint, when non-empty, is propagated to the ateom
+// container so it pushes telemetry to that collector.
+func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otelEndpoint string) *appsv1ac.DeploymentApplyConfiguration {
 	containerAC := corev1ac.Container().
 		WithName("ateom").
 		WithImage(wp.Spec.AteomImage).
@@ -35,13 +40,7 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.Deployment
 			"--pod-uid=$(POD_UID)",
 		).
 		WithSecurityContext(ateomSecurityContext(wp.Spec.SandboxClass)).
-		WithEnv(
-			corev1ac.EnvVar().
-				WithName("POD_UID").
-				WithValueFrom(corev1ac.EnvVarSource().
-					WithFieldRef(corev1ac.ObjectFieldSelector().
-						WithFieldPath("metadata.uid"))),
-		).
+		WithEnv(ateomContainerEnv(otelEndpoint)...).
 		WithVolumeMounts(corev1ac.VolumeMount().
 			WithName("run-ateom").
 			WithMountPath(ateompath.BasePath).
@@ -78,6 +77,32 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool) *appsv1ac.Deployment
 					"ate.dev/worker-pool": wp.Name,
 				}).
 				WithSpec(podSpecAC)))
+}
+
+// ateomContainerEnv adds the OTLP endpoint and resource identity only when
+// telemetry is configured. POD_* refs precede OTEL_RESOURCE_ATTRIBUTES so its
+// $(POD_*) substitutions resolve.
+func ateomContainerEnv(otelEndpoint string) []*corev1ac.EnvVarApplyConfiguration {
+	envs := []*corev1ac.EnvVarApplyConfiguration{
+		fieldRefEnv("POD_UID", "metadata.uid"),
+	}
+	if otelEndpoint == "" {
+		return envs
+	}
+	return append(envs,
+		fieldRefEnv("POD_NAME", "metadata.name"),
+		fieldRefEnv("POD_NAMESPACE", "metadata.namespace"),
+		corev1ac.EnvVar().WithName("OTEL_EXPORTER_OTLP_ENDPOINT").WithValue(otelEndpoint),
+		corev1ac.EnvVar().WithName("OTEL_RESOURCE_ATTRIBUTES").WithValue(ateomOTelResourceAttributes),
+	)
+}
+
+func fieldRefEnv(name, fieldPath string) *corev1ac.EnvVarApplyConfiguration {
+	return corev1ac.EnvVar().
+		WithName(name).
+		WithValueFrom(corev1ac.EnvVarSource().
+			WithFieldRef(corev1ac.ObjectFieldSelector().
+				WithFieldPath(fieldPath)))
 }
 
 // ateomGvisorCapabilities is the capability set an unprivileged gVisor worker

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -201,7 +201,7 @@ func TestBuildDeploymentApplyConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildDeploymentApplyConfig(tt.wp)
+			got := buildDeploymentApplyConfig(tt.wp, "")
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("buildDeploymentApplyConfig() mismatch (-want +got):\n%s", diff)
 			}
@@ -226,7 +226,7 @@ func TestMicroVMPodShape(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wp := testWorkerPoolApplyConfig(nil)
 			wp.Spec.SandboxClass = tt.class
-			ps := buildDeploymentApplyConfig(wp).Spec.Template.Spec
+			ps := buildDeploymentApplyConfig(wp, "").Spec.Template.Spec
 
 			hasVol := false
 			for _, v := range ps.Volumes {
@@ -307,6 +307,78 @@ func TestAteomSecurityContextByClass(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildDeploymentApplyConfigOTelEndpoint asserts the OTLP endpoint and the
+// pod-scoped resource identity are set on the ateom container only when an endpoint
+// is configured, and that the $(POD_*) refs precede OTEL_RESOURCE_ATTRIBUTES.
+func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
+	const endpoint = "http://collector.otel-system.svc:4317"
+	tests := []struct {
+		name          string
+		endpoint      string
+		wantTelemetry bool
+	}{
+		{"endpoint empty", "", false},
+		{"endpoint set", endpoint, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.endpoint).
+				Spec.Template.Spec.Containers[0]
+			env := envByName(c.Env)
+
+			if _, ok := env["POD_UID"]; !ok {
+				t.Error("POD_UID must always be set")
+			}
+
+			if !tt.wantTelemetry {
+				for _, k := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES", "POD_NAME", "POD_NAMESPACE"} {
+					if _, ok := env[k]; ok {
+						t.Errorf("%s must be absent without an OTLP endpoint", k)
+					}
+				}
+				return
+			}
+
+			if got := env["OTEL_EXPORTER_OTLP_ENDPOINT"].value; got != endpoint {
+				t.Errorf("OTEL_EXPORTER_OTLP_ENDPOINT = %q, want %q", got, endpoint)
+			}
+			if got := env["OTEL_RESOURCE_ATTRIBUTES"].value; got != ateomOTelResourceAttributes {
+				t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want %q", got, ateomOTelResourceAttributes)
+			}
+			raIdx := env["OTEL_RESOURCE_ATTRIBUTES"].index
+			for _, ref := range []string{"POD_UID", "POD_NAME", "POD_NAMESPACE"} {
+				if _, ok := env[ref]; !ok {
+					t.Errorf("%s must be set for OTEL_RESOURCE_ATTRIBUTES substitution", ref)
+					continue
+				}
+				if env[ref].index > raIdx {
+					t.Errorf("%s (index %d) must precede OTEL_RESOURCE_ATTRIBUTES (index %d)", ref, env[ref].index, raIdx)
+				}
+			}
+		})
+	}
+}
+
+type envInfo struct {
+	index int
+	value string
+}
+
+func envByName(env []corev1ac.EnvVarApplyConfiguration) map[string]envInfo {
+	m := make(map[string]envInfo, len(env))
+	for i, e := range env {
+		if e.Name == nil {
+			continue
+		}
+		info := envInfo{index: i}
+		if e.Value != nil {
+			info.value = *e.Value
+		}
+		m[*e.Name] = info
+	}
+	return m
 }
 
 func testWorkerPoolApplyConfig(tmpl *atev1alpha1.WorkerPoolPodTemplate) *atev1alpha1.WorkerPool {

--- a/cmd/atecontroller/internal/controllers/workerpool_controller.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller.go
@@ -35,7 +35,8 @@ const workerPoolFieldOwner = "workerpool-controller"
 
 type WorkerPoolReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme       *runtime.Scheme
+	OTelEndpoint string
 }
 
 //+kubebuilder:rbac:groups=ate.dev,resources=workerpools,verbs=get;list;watch;create;update;patch;delete
@@ -91,7 +92,7 @@ func (r *WorkerPoolReconciler) reconcileWorkerPool(ctx context.Context, wp *atev
 }
 
 func (r *WorkerPoolReconciler) applyDeployment(ctx context.Context, wp *atev1alpha1.WorkerPool) error {
-	depAC := buildDeploymentApplyConfig(wp)
+	depAC := buildDeploymentApplyConfig(wp, r.OTelEndpoint)
 	if err := r.Apply(ctx, depAC, client.FieldOwner(workerPoolFieldOwner), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply Deployment: %w", err)
 	}

--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -39,6 +39,9 @@ var (
 
 	ateAPIConnSpec = pflag.String("ateapi-conn-spec", "dns:///api.ate-system.svc:443", "")
 
+	otelEndpoint = pflag.String("otel-exporter-otlp-endpoint", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+		"OTLP endpoint set on ateom worker pods so they push telemetry. Defaults to the controller's own OTEL_EXPORTER_OTLP_ENDPOINT.")
+
 	ateapiCAFile     = pflag.String("ateapi-ca-file", ateapiauth.DefaultServiceAccountCAFile, "PEM file with CAs trusted to verify the ateapi server cert.")
 	ateapiServerName = pflag.String("ateapi-server-name", "", "SNI / hostname expected on the ateapi server cert. Optional.")
 	ateapiTokenAuth  = pflag.Bool("ateapi-use-token-auth", false, "Authenticate to ateapi with the Bearer token from --ateapi-token-file instead of the client certificate from --ateapi-client-cert.")
@@ -84,8 +87,9 @@ func main() {
 	}
 
 	if err = (&controllers.WorkerPoolReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
+		OTelEndpoint: *otelEndpoint,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkerPool")
 		os.Exit(1)

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -96,14 +96,21 @@ func do(ctx context.Context) error {
 
 	slog.InfoContext(ctx, "ateom booting")
 
+	const serviceName = "ateom-gvisor"
 	tp, err := serverboot.InitTracing(ctx, serverboot.TracingOptions{
-		ServiceName: "ateom-gvisor",
+		ServiceName: serviceName,
 		Sampler:     sdktrace.ParentBased(sdktrace.NeverSample()),
 	})
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
 	}
 	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+
+	mp, err := serverboot.InitMetricsPushOnly(ctx, serviceName)
+	if err != nil {
+		serverboot.Fatal(ctx, "Failed to initialize metrics", err)
+	}
+	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
 
 	// Create ateom dir
 	ateomDir := ateompath.AteomPath(*podUID)

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -81,14 +81,21 @@ func do(ctx context.Context) error {
 	serverboot.InitLoggerWithWriter(logWriter)
 	slog.InfoContext(ctx, "ateom-microvm booting", slog.String("version", version.String()))
 
+	const serviceName = "ateom-microvm"
 	tp, err := serverboot.InitTracing(ctx, serverboot.TracingOptions{
-		ServiceName: "ateom-microvm",
+		ServiceName: serviceName,
 		Sampler:     sdktrace.ParentBased(sdktrace.NeverSample()),
 	})
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to initialize tracing", err)
 	}
 	defer serverboot.ShutdownProvider("TracerProvider", tp.Shutdown)
+
+	mp, err := serverboot.InitMetricsPushOnly(ctx, serviceName)
+	if err != nil {
+		serverboot.Fatal(ctx, "Failed to initialize metrics", err)
+	}
+	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
 
 	// Create ateom dir.
 	ateomDir := ateompath.AteomPath(*podUID)

--- a/internal/e2e/collector_metrics.go
+++ b/internal/e2e/collector_metrics.go
@@ -110,6 +110,20 @@ func MissingPlatformMetrics(scrape string, prefixes []string) []string {
 	return missing
 }
 
+// CollectorHasService reports whether any named service has pushed telemetry to
+// the collector. Its prometheus exporter surfaces each pushed resource as a
+// target_info series and stamps the service.name as the job label, so a service
+// that has exported anything shows up under either.
+func CollectorHasService(scrape string, services ...string) bool {
+	for _, svc := range services {
+		if strings.Contains(scrape, `service_name="`+svc+`"`) ||
+			strings.Contains(scrape, `job="`+svc+`"`) {
+			return true
+		}
+	}
+	return false
+}
+
 // metricNameFromLine extracts the metric name from one exposition line, handling
 // the "# HELP name ...", "# TYPE name type", and "name{labels} value" forms.
 // It returns "" for blank lines and other comments.

--- a/internal/e2e/suites/metrics/metrics_test.go
+++ b/internal/e2e/suites/metrics/metrics_test.go
@@ -73,17 +73,20 @@ func TestPlatformMetricsEmitted(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Minute)
 	var missing []string
+	var ateomSeen bool
 	for time.Now().Before(deadline) {
 		scrape, err := e2e.ScrapeCollectorMetrics(ctx)
 		if err != nil {
 			t.Fatalf("ScrapeCollectorMetrics: %v", err)
 		}
-		if missing = e2e.MissingPlatformMetrics(scrape, e2e.PlatformMetricPrefixes); len(missing) == 0 {
+		missing = e2e.MissingPlatformMetrics(scrape, e2e.PlatformMetricPrefixes)
+		ateomSeen = e2e.CollectorHasService(scrape, "ateom-gvisor", "ateom-microvm")
+		if len(missing) == 0 && ateomSeen {
 			return
 		}
 		time.Sleep(3 * time.Second)
 	}
-	t.Fatalf("platform metrics never reached the collector: missing %v", missing)
+	t.Fatalf("platform telemetry never reached the collector: missing metrics %v, ateom pushed=%v", missing, ateomSeen)
 }
 
 func resume(t *testing.T, ctx context.Context, clients *e2e.Clients, actorID string) {

--- a/internal/serverboot/serverboot.go
+++ b/internal/serverboot/serverboot.go
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // Package serverboot collects the startup boilerplate shared by the
-// long-running substrate server binaries (ateapi, atelet, ateom-gvisor):
-// slog wiring, OTel tracer + meter providers, a Prometheus + /readyz
-// HTTP surface, and a couple of small helpers for startup fail-fast.
+// long-running substrate server binaries (ateapi, atelet, ateom-gvisor,
+// ateom-microvm): slog wiring, OTel tracer + meter providers, a Prometheus +
+// /readyz HTTP surface, and a couple of small helpers for startup fail-fast.
 package serverboot
 
 import (
@@ -123,12 +123,23 @@ func InitTracing(ctx context.Context, opts TracingOptions) (*sdktrace.TracerProv
 // reader (exposed via StartMetricsServer's /metrics handler) and an
 // OTLP periodic reader.
 func InitMetrics(ctx context.Context, serviceName string) (*sdkmetric.MeterProvider, error) {
-	if serviceName == "" {
-		return nil, fmt.Errorf("serviceName is required")
-	}
 	promExporter, err := prometheus.New()
 	if err != nil {
 		return nil, fmt.Errorf("create Prometheus metric exporter: %w", err)
+	}
+	return newMeterProvider(ctx, serviceName, promExporter)
+}
+
+// InitMetricsPushOnly is InitMetrics without the Prometheus reader, for binaries
+// that run no metrics HTTP server (ateom): a pull reader would collect into a
+// registry nothing serves.
+func InitMetricsPushOnly(ctx context.Context, serviceName string) (*sdkmetric.MeterProvider, error) {
+	return newMeterProvider(ctx, serviceName)
+}
+
+func newMeterProvider(ctx context.Context, serviceName string, extraReaders ...sdkmetric.Reader) (*sdkmetric.MeterProvider, error) {
+	if serviceName == "" {
+		return nil, fmt.Errorf("serviceName is required")
 	}
 	otlpExporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithInsecure())
 	if err != nil {
@@ -138,11 +149,14 @@ func InitMetrics(ctx context.Context, serviceName string) (*sdkmetric.MeterProvi
 	if err != nil {
 		return nil, fmt.Errorf("create metric resource: %w", err)
 	}
-	mp := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(promExporter),
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(otlpExporter)),
+	opts := []sdkmetric.Option{
 		sdkmetric.WithResource(res),
-	)
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(otlpExporter)),
+	}
+	for _, r := range extraReaders {
+		opts = append(opts, sdkmetric.WithReader(r))
+	}
+	mp := sdkmetric.NewMeterProvider(opts...)
 	otel.SetMeterProvider(mp)
 	return mp, nil
 }

--- a/internal/serverboot/serverboot.go
+++ b/internal/serverboot/serverboot.go
@@ -123,6 +123,9 @@ func InitTracing(ctx context.Context, opts TracingOptions) (*sdktrace.TracerProv
 // reader (exposed via StartMetricsServer's /metrics handler) and an
 // OTLP periodic reader.
 func InitMetrics(ctx context.Context, serviceName string) (*sdkmetric.MeterProvider, error) {
+	if serviceName == "" {
+		return nil, fmt.Errorf("serviceName is required")
+	}
 	promExporter, err := prometheus.New()
 	if err != nil {
 		return nil, fmt.Errorf("create Prometheus metric exporter: %w", err)

--- a/internal/serverboot/serverboot_test.go
+++ b/internal/serverboot/serverboot_test.go
@@ -144,6 +144,12 @@ func TestInitMetricsPushOnlyRequiresServiceName(t *testing.T) {
 	}
 }
 
+func TestInitMetricsRequiresServiceName(t *testing.T) {
+	if _, err := InitMetrics(context.Background(), ""); err == nil {
+		t.Error("InitMetrics(\"\") must return an error")
+	}
+}
+
 func getCode(t *testing.T, mux *http.ServeMux, path string) int {
 	t.Helper()
 	rec := httptest.NewRecorder()

--- a/internal/serverboot/serverboot_test.go
+++ b/internal/serverboot/serverboot_test.go
@@ -18,8 +18,11 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
@@ -104,6 +107,40 @@ func TestHealthzAbsentUnlessEnabled(t *testing.T) {
 	mux := metricsMux(MetricsServerOptions{Readiness: &Readiness{}})
 	if got := getCode(t, mux, "/healthz"); got != http.StatusNotFound {
 		t.Errorf("/healthz without EnableHealthz = %d, want %d", got, http.StatusNotFound)
+	}
+}
+
+func TestInitMetricsPushOnlyHasNoPrometheusSurface(t *testing.T) {
+	mp, err := InitMetricsPushOnly(context.Background(), "test-pushonly")
+	if err != nil {
+		t.Fatalf("InitMetricsPushOnly: %v", err)
+	}
+	// Bound shutdown: the periodic reader would otherwise block flushing to the
+	// unreachable default OTLP endpoint until the export timeout.
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = mp.Shutdown(ctx)
+	})
+
+	ctr, err := mp.Meter("test").Int64Counter("ate.test.pushonly.count")
+	if err != nil {
+		t.Fatalf("create counter: %v", err)
+	}
+	ctr.Add(context.Background(), 1)
+
+	// A push-only provider registers no Prometheus reader, so what it records must
+	// not surface on the default registry StartMetricsServer's /metrics serves.
+	rec := httptest.NewRecorder()
+	promhttp.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if strings.Contains(rec.Body.String(), "ate_test_pushonly") {
+		t.Error("push-only MeterProvider must not expose a Prometheus pull surface")
+	}
+}
+
+func TestInitMetricsPushOnlyRequiresServiceName(t *testing.T) {
+	if _, err := InitMetricsPushOnly(context.Background(), ""); err == nil {
+		t.Error("InitMetricsPushOnly(\"\") must return an error")
 	}
 }
 

--- a/manifests/ate-install/ate-controller.yaml
+++ b/manifests/ate-install/ate-controller.yaml
@@ -91,6 +91,9 @@ spec:
         args:
         - --ateapi-ca-file=/run/servicedns-ca/trust-bundle.pem
         - --ateapi-client-cert=/run/podidentity.podcert.ate.dev/credential-bundle.pem
+        env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
         ports:
         - name: metrics
           containerPort: 8080

--- a/manifests/ate-install/kind/kustomization.yaml
+++ b/manifests/ate-install/kind/kustomization.yaml
@@ -56,3 +56,17 @@ patches:
               env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ate-controller
+        namespace: ate-system
+      spec:
+        template:
+          spec:
+            containers:
+            - name: ate-controller
+              env:
+              - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                value: http://opentelemetry-collector.otel-system.svc:4317


### PR DESCRIPTION
This PR wires `ateom` into the OTLP push path so it can emit metrics, and unblock unblocking https://github.com/agent-substrate/substrate/issues/550

- serverboot: new InitMetricsPushOnly (OTLP periodic reader, no Prometheus pull surface) for binaries that run no metrics HTTP server
- ateom-gvisor + ateom-microvm call it, so the existing otelgrpc server handler now feeds `rpc.server.*` to the collector
- atecontroller propagates its `OTEL_EXPORTER_OTLP_ENDPOINT` + `OTEL_RESOURCE_ATTRIBUTES` into the ateom worker pods
- fixes ateom telemetry not reaching the collector 
- e2e: metrics suite asserts an `ateom` service reaches the collector

cc. @git286 

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
