### PR TITLE
Replace the global testCtx with per-test context. Run tests in parallel.

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
@@ -43,11 +43,9 @@ import (
 )
 
 var (
-	testEnv    *envtest.Environment
-	cfg        *rest.Config
-	k8sClient  client.Client
-	testCtx    context.Context
-	testCancel context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
 )
 
 func TestMain(m *testing.M) {
@@ -96,14 +94,14 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	testCtx, testCancel = context.WithCancel(context.Background())
+	mgrCtx, mgrCancel := context.WithCancel(context.Background())
 	go func() {
-		_ = mgr.Start(testCtx)
+		_ = mgr.Start(mgrCtx)
 	}()
 
 	code := m.Run()
 
-	testCancel()
+	mgrCancel()
 	_ = testEnv.Stop()
 	os.Exit(code)
 }
@@ -111,11 +109,13 @@ func TestMain(m *testing.M) {
 // TestWorkerPoolCreatesDeployment verifies that creating a WorkerPool causes
 // the controller to create a correctly-configured Deployment.
 func TestWorkerPoolCreatesDeployment(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-create", "default", 3, "ateom:v1")
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		dep, err := getDeployment(ctx, wp)
@@ -146,18 +146,20 @@ func TestWorkerPoolCreatesDeployment(t *testing.T) {
 // TestWorkerPoolReplicasUpdate verifies that changing spec.replicas on a
 // WorkerPool propagates to the managed Deployment.
 func TestWorkerPoolReplicasUpdate(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-replicas", "default", 2, "ateom:v1")
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		_, err := getDeployment(ctx, wp)
 		return err == nil, nil
 	})
 
-	updateWorkerPoolSpec(t, wp, "update WorkerPool replicas", func(current *atev1alpha1.WorkerPool) {
+	updateWorkerPoolSpec(t, ctx, wp, "update WorkerPool replicas", func(current *atev1alpha1.WorkerPool) {
 		current.Spec.Replicas = 5
 	})
 
@@ -173,18 +175,20 @@ func TestWorkerPoolReplicasUpdate(t *testing.T) {
 // TestWorkerPoolImageUpdate verifies that changing spec.ateomImage on a
 // WorkerPool propagates to the managed Deployment.
 func TestWorkerPoolImageUpdate(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-image", "default", 1, "ateom:v1")
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		_, err := getDeployment(ctx, wp)
 		return err == nil, nil
 	})
 
-	updateWorkerPoolSpec(t, wp, "update WorkerPool image", func(current *atev1alpha1.WorkerPool) {
+	updateWorkerPoolSpec(t, ctx, wp, "update WorkerPool image", func(current *atev1alpha1.WorkerPool) {
 		current.Spec.AteomImage = "ateom:v2"
 	})
 
@@ -200,11 +204,13 @@ func TestWorkerPoolImageUpdate(t *testing.T) {
 // TestSSAPreservesUnownedFields verifies that SSA leaves fields set by other
 // field managers untouched during reconciliation.
 func TestSSAPreservesUnownedFields(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-ssa-unowned", "default", 2, "ateom:v1")
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		_, err := getDeployment(ctx, wp)
@@ -214,7 +220,7 @@ func TestSSAPreservesUnownedFields(t *testing.T) {
 	// An external manager sets revisionHistoryLimit — a field the controller
 	// never declares in its apply config.
 	revisionHistoryLimit := int32(7)
-	updateDeploymentSpec(t, wp, "set revisionHistoryLimit", func(dep *appsv1.Deployment) {
+	updateDeploymentSpec(t, ctx, wp, "set revisionHistoryLimit", func(dep *appsv1.Deployment) {
 		dep.Spec.RevisionHistoryLimit = &revisionHistoryLimit
 	})
 
@@ -234,11 +240,13 @@ func TestSSAPreservesUnownedFields(t *testing.T) {
 // owned by the workerpool-controller (e.g. replicas on the Deployment), the
 // controller reverts it on the next reconcile.
 func TestSSARevertsOwnedFields(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-ssa-owned", "default", 2, "ateom:v1")
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		dep, err := getDeployment(ctx, wp)
@@ -246,7 +254,7 @@ func TestSSARevertsOwnedFields(t *testing.T) {
 	})
 
 	rogueReplicas := int32(99)
-	updateDeploymentSpec(t, wp, "rogue update", func(dep *appsv1.Deployment) {
+	updateDeploymentSpec(t, ctx, wp, "rogue update", func(dep *appsv1.Deployment) {
 		dep.Spec.Replicas = &rogueReplicas
 	})
 
@@ -263,22 +271,24 @@ func TestSSARevertsOwnedFields(t *testing.T) {
 // TestDeletedDeploymentRecreated verifies that if the managed Deployment is
 // deleted externally, the controller recreates it.
 func TestDeletedDeploymentRecreated(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-recreate", "default", 2, "ateom:v1")
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		_, err := getDeployment(ctx, wp)
 		return err == nil, nil
 	})
 
-	dep, err := getDeployment(testCtx, wp)
+	dep, err := getDeployment(ctx, wp)
 	if err != nil {
 		t.Fatalf("get Deployment: %v", err)
 	}
-	if err := k8sClient.Delete(testCtx, dep); err != nil {
+	if err := k8sClient.Delete(ctx, dep); err != nil {
 		t.Fatalf("delete Deployment: %v", err)
 	}
 
@@ -292,11 +302,13 @@ func TestDeletedDeploymentRecreated(t *testing.T) {
 // Deployment's status.replicas into WorkerPool.status.replicas, and publishes
 // the Deployment's pod selector as WorkerPool.status.selector.
 func TestStatusReplicasPropagation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-status", "default", 3, "ateom:v1")
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		_, err := getDeployment(ctx, wp)
@@ -304,7 +316,7 @@ func TestStatusReplicasPropagation(t *testing.T) {
 	})
 
 	// Simulate the deployment controller reporting 3 running pods.
-	updateDeploymentStatus(t, wp, "patch Deployment status", func(dep *appsv1.Deployment) {
+	updateDeploymentStatus(t, ctx, wp, "patch Deployment status", func(dep *appsv1.Deployment) {
 		dep.Status.Replicas = 3
 	})
 
@@ -358,12 +370,14 @@ func sampleWorkerPoolPodTemplate() *atev1alpha1.WorkerPoolPodTemplate {
 // TestWorkerPoolPodTemplatePropagation verifies that template fields propagate
 // to the managed Deployment pod template.
 func TestWorkerPoolPodTemplatePropagation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-template-propagate", "default", 1, "ateom:v1")
 	wp.Spec.Template = sampleWorkerPoolPodTemplate()
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		dep, err := getDeployment(ctx, wp)
@@ -395,23 +409,25 @@ func TestWorkerPoolPodTemplatePropagation(t *testing.T) {
 // TestWorkerPoolPodTemplateUpdate verifies that changing template fields on a
 // WorkerPool propagates to the managed Deployment.
 func TestWorkerPoolPodTemplateUpdate(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-template-update", "default", 1, "ateom:v1")
 	wp.Spec.Template = sampleWorkerPoolPodTemplate()
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		dep, err := getDeployment(ctx, wp)
 		return err == nil && dep.Spec.Template.Spec.NodeSelector["workload"] == "substrate", nil
 	})
 
-	if err := k8sClient.Get(testCtx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, wp); err != nil {
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, wp); err != nil {
 		t.Fatalf("re-fetch WorkerPool: %v", err)
 	}
 	wp.Spec.Template.NodeSelector = map[string]string{"workload": "updated"}
-	if err := k8sClient.Update(testCtx, wp); err != nil {
+	if err := k8sClient.Update(ctx, wp); err != nil {
 		t.Fatalf("update WorkerPool template: %v", err)
 	}
 
@@ -429,19 +445,21 @@ func TestWorkerPoolPodTemplateUpdate(t *testing.T) {
 // TestWorkerPoolPodTemplateClear verifies that clearing template.nodeSelector
 // removes it from the managed Deployment.
 func TestWorkerPoolPodTemplateClear(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-template-clear", "default", 1, "ateom:v1")
 	wp.Spec.Template = sampleWorkerPoolPodTemplate()
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		dep, err := getDeployment(ctx, wp)
 		return err == nil && dep.Spec.Template.Spec.NodeSelector["workload"] == "substrate", nil
 	})
 
-	updateWorkerPoolSpec(t, wp, "clear WorkerPool nodeSelector", func(current *atev1alpha1.WorkerPool) {
+	updateWorkerPoolSpec(t, ctx, wp, "clear WorkerPool nodeSelector", func(current *atev1alpha1.WorkerPool) {
 		current.Spec.Template.NodeSelector = nil
 	})
 
@@ -457,12 +475,14 @@ func TestWorkerPoolPodTemplateClear(t *testing.T) {
 // TestWorkerPoolPodTemplateClearAll verifies that removing spec.template clears
 // all pod template fields owned by the workerpool-controller.
 func TestWorkerPoolPodTemplateClearAll(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-template-clear-all", "default", 1, "ateom:v1")
 	wp.Spec.Template = sampleWorkerPoolPodTemplate()
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		dep, err := getDeployment(ctx, wp)
@@ -479,7 +499,7 @@ func TestWorkerPoolPodTemplateClearAll(t *testing.T) {
 			container.Resources.Requests.Cpu().String() == "500m", nil
 	})
 
-	updateWorkerPoolSpec(t, wp, "clear WorkerPool template", func(current *atev1alpha1.WorkerPool) {
+	updateWorkerPoolSpec(t, ctx, wp, "clear WorkerPool template", func(current *atev1alpha1.WorkerPool) {
 		current.Spec.Template = nil
 	})
 
@@ -503,19 +523,21 @@ func TestWorkerPoolPodTemplateClearAll(t *testing.T) {
 // changes pod template fields owned by the workerpool-controller, the
 // controller reverts them on the next reconcile.
 func TestSSARevertsOwnedPodTemplateFields(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-ssa-template", "default", 1, "ateom:v1")
 	wp.Spec.Template = sampleWorkerPoolPodTemplate()
-	if err := k8sClient.Create(testCtx, wp); err != nil {
+	if err := k8sClient.Create(ctx, wp); err != nil {
 		t.Fatalf("create WorkerPool: %v", err)
 	}
-	t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+	deleteOnCleanup(t, wp)
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		dep, err := getDeployment(ctx, wp)
 		return err == nil && dep.Spec.Template.Spec.NodeSelector["workload"] == "substrate", nil
 	})
 
-	updateDeploymentSpec(t, wp, "rogue update", func(dep *appsv1.Deployment) {
+	updateDeploymentSpec(t, ctx, wp, "rogue update", func(dep *appsv1.Deployment) {
 		dep.Spec.Template.Spec.NodeSelector = map[string]string{"workload": "rogue"}
 	})
 
@@ -531,10 +553,12 @@ func TestSSARevertsOwnedPodTemplateFields(t *testing.T) {
 // TestReplicasValidationRejectsNegative verifies that the API server rejects a
 // WorkerPool whose spec.replicas is negative.
 func TestReplicasValidationRejectsNegative(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
 	wp := makeWorkerPool("test-neg-replicas", "default", -1, "ateom:v1")
-	err := k8sClient.Create(testCtx, wp)
+	err := k8sClient.Create(ctx, wp)
 	if err == nil {
-		t.Cleanup(func() { k8sClient.Delete(testCtx, wp) }) //nolint:errcheck
+		deleteOnCleanup(t, wp)
 		t.Fatal("expected creation with negative replicas to fail, but it succeeded")
 	}
 	if !k8errors.IsInvalid(err) {
@@ -554,6 +578,19 @@ func makeWorkerPool(name, ns string, replicas int32, image string) *atev1alpha1.
 	}
 }
 
+// deleteOnCleanup registers a cleanup that deletes obj. It uses its own
+// context because t.Context() is already canceled when cleanups run.
+func deleteOnCleanup(t *testing.T, obj client.Object) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := client.IgnoreNotFound(k8sClient.Delete(ctx, obj)); err != nil {
+			t.Errorf("cleanup: delete %s: %v", obj.GetName(), err)
+		}
+	})
+}
+
 func getDeployment(ctx context.Context, wp *atev1alpha1.WorkerPool) (*appsv1.Deployment, error) {
 	dep := &appsv1.Deployment{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
@@ -568,10 +605,10 @@ func getDeployment(ctx context.Context, wp *atev1alpha1.WorkerPool) (*appsv1.Dep
 // controller reconciles the Deployment concurrently (bumping its
 // resourceVersion on every SSA apply), so a plain get-then-update flakes with
 // "the object has been modified" under load.
-func updateDeployment(t *testing.T, wp *atev1alpha1.WorkerPool, action string, mutate func(*appsv1.Deployment), update func(*appsv1.Deployment) error) {
+func updateDeployment(t *testing.T, ctx context.Context, wp *atev1alpha1.WorkerPool, action string, mutate func(*appsv1.Deployment), update func(*appsv1.Deployment) error) {
 	t.Helper()
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		dep, err := getDeployment(testCtx, wp)
+		dep, err := getDeployment(ctx, wp)
 		if err != nil {
 			return err
 		}
@@ -583,30 +620,30 @@ func updateDeployment(t *testing.T, wp *atev1alpha1.WorkerPool, action string, m
 	}
 }
 
-func updateDeploymentSpec(t *testing.T, wp *atev1alpha1.WorkerPool, action string, mutate func(*appsv1.Deployment)) {
+func updateDeploymentSpec(t *testing.T, ctx context.Context, wp *atev1alpha1.WorkerPool, action string, mutate func(*appsv1.Deployment)) {
 	t.Helper()
-	updateDeployment(t, wp, action, mutate, func(dep *appsv1.Deployment) error {
-		return k8sClient.Update(testCtx, dep)
+	updateDeployment(t, ctx, wp, action, mutate, func(dep *appsv1.Deployment) error {
+		return k8sClient.Update(ctx, dep)
 	})
 }
 
 // updateDeploymentStatus is updateDeploymentSpec for the status subresource.
-func updateDeploymentStatus(t *testing.T, wp *atev1alpha1.WorkerPool, action string, mutate func(*appsv1.Deployment)) {
+func updateDeploymentStatus(t *testing.T, ctx context.Context, wp *atev1alpha1.WorkerPool, action string, mutate func(*appsv1.Deployment)) {
 	t.Helper()
-	updateDeployment(t, wp, action, mutate, func(dep *appsv1.Deployment) error {
-		return k8sClient.Status().Update(testCtx, dep)
+	updateDeployment(t, ctx, wp, action, mutate, func(dep *appsv1.Deployment) error {
+		return k8sClient.Status().Update(ctx, dep)
 	})
 }
 
-func updateWorkerPoolSpec(t *testing.T, wp *atev1alpha1.WorkerPool, action string, mutate func(*atev1alpha1.WorkerPool)) {
+func updateWorkerPoolSpec(t *testing.T, ctx context.Context, wp *atev1alpha1.WorkerPool, action string, mutate func(*atev1alpha1.WorkerPool)) {
 	t.Helper()
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		current := &atev1alpha1.WorkerPool{}
-		if err := k8sClient.Get(testCtx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, current); err != nil {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, current); err != nil {
 			return err
 		}
 		mutate(current)
-		return k8sClient.Update(testCtx, current)
+		return k8sClient.Update(ctx, current)
 	})
 	if err != nil {
 		t.Fatalf("%s: %v", action, err)
@@ -616,7 +653,7 @@ func updateWorkerPoolSpec(t *testing.T, wp *atev1alpha1.WorkerPool, action strin
 // eventually polls condition every 100ms until it returns true or 15s elapses.
 func eventually(t *testing.T, condition func(ctx context.Context) (bool, error)) {
 	t.Helper()
-	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 15*time.Second, true, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, 15*time.Second, true, condition); err != nil {
 		t.Fatalf("condition not met within timeout: %v", err)
 	}
 }


### PR DESCRIPTION
- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
