### PR TITLE
Fix the issue that run-e2e.sh doesn't work on bash 3.2 macos.

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -103,5 +103,5 @@ if [[ -n "${KUBECTL_CONTEXT:-}" ]]; then
     extra_e2e_args+=("--kube-context" "${KUBECTL_CONTEXT}")
 fi
 
-exec go test -v "$target_path" "${go_test_args[@]}" -args --e2e "${extra_e2e_args[@]}" "${e2e_args[@]}"
+exec go test -v "$target_path" ${go_test_args[@]+"${go_test_args[@]}"} -args --e2e ${extra_e2e_args[@]+"${extra_e2e_args[@]}"} ${e2e_args[@]+"${e2e_args[@]}"}
 

--- a/hack/verify/python-licenses.sh
+++ b/hack/verify/python-licenses.sh
@@ -31,7 +31,10 @@ cd "${ROOT}"
 # that contains requirements.txt; its venv lives at <dir>/venv. Discovered
 # dynamically from tracked/untracked (but not ignored) requirements.txt files,
 # excluding vendored trees and the LICENSES/ directory.
-mapfile -t PROJECTS < <(
+PROJECTS=()
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  [[ -n "${line}" ]] && PROJECTS+=("${line}")
+done < <(
   git ls-files \
     -cmo \
     --exclude-standard \
@@ -94,7 +97,7 @@ check_project() {
 }
 
 fail=0
-for proj in "${PROJECTS[@]}"; do
+for proj in ${PROJECTS[@]+"${PROJECTS[@]}"}; do
   if ! check_project "${proj}"; then
     echo "ERROR: ${proj} contains disallowed Python license(s)" >&2
     fail=1


### PR DESCRIPTION
run-e2e.sh always fail on my mac with ` line 106: go_test_args[@]: unbound variable,exit`, asked Claude code and fix related Bash 3.2 problem in scripts.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
