### PR TITLE
Add unit tests for request validators in ate-apiserver.

### DIFF
--- a/cmd/ateapi/internal/controlapi/create_actor.go
+++ b/cmd/ateapi/internal/controlapi/create_actor.go
@@ -30,8 +30,8 @@ import (
 )
 
 func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequest) (*ateapipb.Actor, error) {
-	if err := validateCreateActorRequest(req); err != nil {
-		return nil, err
+	if errs := validateCreateActorRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	in := req.GetActor()
 	templateNamespace := in.GetActorTemplateNamespace()
@@ -94,7 +94,7 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 	return stored, nil
 }
 
-func validateCreateActorRequest(req *ateapipb.CreateActorRequest) error {
+func validateCreateActorRequest(req *ateapipb.CreateActorRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -102,7 +102,7 @@ func validateCreateActorRequest(req *ateapipb.CreateActorRequest) error {
 	actorPath := fldPath.Child("actor")
 	if actor == nil {
 		errs = append(errs, field.Required(actorPath, ""))
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+		return errs
 	}
 
 	metaPath := actorPath.Child("metadata")
@@ -136,10 +136,7 @@ func validateCreateActorRequest(req *ateapipb.CreateActorRequest) error {
 		errs = append(errs, validateSelector(val, actorPath.Child("worker_selector"))...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }
 
 func validateSelector(sel *ateapipb.Selector, fldPath *field.Path) field.ErrorList {

--- a/cmd/ateapi/internal/controlapi/create_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/create_actor_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // CreateActor is the only lifecycle op with the full identity (incl. version)
@@ -55,5 +56,104 @@ func TestCreateActor_StampsFullSpanIdentity(t *testing.T) {
 	}
 	if v, ok := attrs[ateattr.ActorVersionKey]; !ok || v.Type() != attribute.INT64 || v.AsInt64() != 1 {
 		t.Errorf("%s = %v, want int64 1", ateattr.ActorVersionKey, v.Emit())
+	}
+}
+
+func TestValidateCreateActorRequest(t *testing.T) {
+	validActor := func(mutate func(*ateapipb.Actor)) *ateapipb.CreateActorRequest {
+		a := &ateapipb.Actor{
+			Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"},
+			ActorTemplateNamespace: "ns1",
+			ActorTemplateName:      "tmpl1",
+		}
+		if mutate != nil {
+			mutate(a)
+		}
+		return &ateapipb.CreateActorRequest{Actor: a}
+	}
+
+	tests := []struct {
+		name string
+		req  *ateapipb.CreateActorRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		validActor(nil),
+		nil,
+	}, {
+		"missing actor",
+		&ateapipb.CreateActorRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor"), "")},
+	}, {
+		"missing actor.metadata.atespace",
+		validActor(func(a *ateapipb.Actor) { a.Metadata.Atespace = "" }),
+		field.ErrorList{field.Required(field.NewPath("actor", "metadata", "atespace"), "")},
+	}, {
+		"invalid actor.metadata.atespace",
+		validActor(func(a *ateapipb.Actor) { a.Metadata.Atespace = "NS1" }),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "metadata", "atespace"), "NS1", "")},
+	}, {
+		"missing actor.metadata.name",
+		validActor(func(a *ateapipb.Actor) { a.Metadata.Name = "" }),
+		field.ErrorList{field.Required(field.NewPath("actor", "metadata", "name"), "")},
+	}, {
+		"invalid actor.metadata.name",
+		validActor(func(a *ateapipb.Actor) { a.Metadata.Name = "ID1" }),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "metadata", "name"), "ID1", "")},
+	}, {
+		"missing actor_template_namespace",
+		validActor(func(a *ateapipb.Actor) { a.ActorTemplateNamespace = "" }),
+		field.ErrorList{field.Required(field.NewPath("actor", "actor_template_namespace"), "")},
+	}, {
+		"invalid actor_template_namespace",
+		validActor(func(a *ateapipb.Actor) { a.ActorTemplateNamespace = "invalid value" }),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template_namespace"), "invalid value", "")},
+	}, {
+		"missing actor_template_name",
+		validActor(func(a *ateapipb.Actor) { a.ActorTemplateName = "" }),
+		field.ErrorList{field.Required(field.NewPath("actor", "actor_template_name"), "")},
+	}, {
+		"invalid actor_template_name",
+		validActor(func(a *ateapipb.Actor) { a.ActorTemplateName = "invalid value" }),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template_name"), "invalid value", "")},
+	}, {
+		"worker_selector with nil match_labels",
+		validActor(func(a *ateapipb.Actor) { a.WorkerSelector = &ateapipb.Selector{} }),
+		nil,
+	}, {
+		"worker_selector with empty match_labels",
+		validActor(func(a *ateapipb.Actor) { a.WorkerSelector = &ateapipb.Selector{MatchLabels: map[string]string{}} }),
+		nil,
+	}, {
+		"valid worker_selector",
+		validActor(func(a *ateapipb.Actor) {
+			a.WorkerSelector = &ateapipb.Selector{MatchLabels: map[string]string{"tier": "1"}}
+		}),
+		nil,
+	}, {
+		"worker_selector with exactly max match_labels",
+		validActor(func(a *ateapipb.Actor) { a.WorkerSelector = &ateapipb.Selector{MatchLabels: selectorLabelsOfSize(10)} }),
+		nil,
+	}, {
+		"invalid worker_selector label key",
+		validActor(func(a *ateapipb.Actor) {
+			a.WorkerSelector = &ateapipb.Selector{MatchLabels: map[string]string{"bad key!": "1"}}
+		}),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "worker_selector", "match_labels").Key("bad key!"), "bad key!", "")},
+	}, {
+		"invalid worker_selector label value",
+		validActor(func(a *ateapipb.Actor) {
+			a.WorkerSelector = &ateapipb.Selector{MatchLabels: map[string]string{"tier": "not valid!"}}
+		}),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "worker_selector", "match_labels").Key("tier"), "not valid!", "")},
+	}, {
+		"too many worker_selector.match_labels",
+		validActor(func(a *ateapipb.Actor) { a.WorkerSelector = &ateapipb.Selector{MatchLabels: selectorLabelsOfSize(11)} }),
+		field.ErrorList{field.TooMany(field.NewPath("actor", "worker_selector", "match_labels"), 11, 10)},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateCreateActorRequest(tt.req), tt.want)
+		})
 	}
 }

--- a/cmd/ateapi/internal/controlapi/create_atespace.go
+++ b/cmd/ateapi/internal/controlapi/create_atespace.go
@@ -28,8 +28,8 @@ import (
 )
 
 func (s *Service) CreateAtespace(ctx context.Context, req *ateapipb.CreateAtespaceRequest) (*ateapipb.Atespace, error) {
-	if err := validateCreateAtespaceRequest(req); err != nil {
-		return nil, err
+	if errs := validateCreateAtespaceRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 
 	name := req.GetAtespace().GetMetadata().GetName()
@@ -49,7 +49,7 @@ func (s *Service) CreateAtespace(ctx context.Context, req *ateapipb.CreateAtespa
 	return stored, nil
 }
 
-func validateCreateAtespaceRequest(req *ateapipb.CreateAtespaceRequest) error {
+func validateCreateAtespaceRequest(req *ateapipb.CreateAtespaceRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -57,7 +57,7 @@ func validateCreateAtespaceRequest(req *ateapipb.CreateAtespaceRequest) error {
 	atespacePath := fldPath.Child("atespace")
 	if atespace == nil {
 		errs = append(errs, field.Required(atespacePath, ""))
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+		return errs
 	}
 
 	// Atespace is global-scoped: metadata.atespace must be empty, name required + valid.
@@ -71,8 +71,5 @@ func validateCreateAtespaceRequest(req *ateapipb.CreateAtespaceRequest) error {
 		errs = append(errs, resources.ValidateResourceName(val, p)...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/create_atespace_test.go
+++ b/cmd/ateapi/internal/controlapi/create_atespace_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateCreateAtespaceRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.CreateAtespaceRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.CreateAtespaceRequest{Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: "team-a"}}},
+		nil,
+	}, {
+		"missing atespace",
+		&ateapipb.CreateAtespaceRequest{},
+		field.ErrorList{field.Required(field.NewPath("atespace"), "")},
+	}, {
+		"metadata.atespace must be empty",
+		&ateapipb.CreateAtespaceRequest{Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "team-a"}}},
+		field.ErrorList{field.Invalid(field.NewPath("atespace", "metadata", "atespace"), "ns1", "")},
+	}, {
+		"missing metadata.name",
+		&ateapipb.CreateAtespaceRequest{Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: ""}}},
+		field.ErrorList{field.Required(field.NewPath("atespace", "metadata", "name"), "")},
+	}, {
+		"invalid metadata.name",
+		&ateapipb.CreateAtespaceRequest{Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: "Team_A"}}},
+		field.ErrorList{field.Invalid(field.NewPath("atespace", "metadata", "name"), "Team_A", "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateCreateAtespaceRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/delete_actor.go
+++ b/cmd/ateapi/internal/controlapi/delete_actor.go
@@ -28,8 +28,8 @@ import (
 )
 
 func (s *Service) DeleteActor(ctx context.Context, req *ateapipb.DeleteActorRequest) (*ateapipb.Actor, error) {
-	if err := validateDeleteActorRequest(req); err != nil {
-		return nil, err
+	if errs := validateDeleteActorRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	actorRef := resources.ActorRefFromObjectRef(req.GetActor())
 	setSpanActorRefAttributes(ctx, actorRef)
@@ -68,7 +68,7 @@ func (s *Service) DeleteActor(ctx context.Context, req *ateapipb.DeleteActorRequ
 	return deleted, nil
 }
 
-func validateDeleteActorRequest(req *ateapipb.DeleteActorRequest) error {
+func validateDeleteActorRequest(req *ateapipb.DeleteActorRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -78,8 +78,5 @@ func validateDeleteActorRequest(req *ateapipb.DeleteActorRequest) error {
 		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/delete_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/delete_actor_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // Delete addresses the actor by ref (atespace + id) and does not resolve the
@@ -49,4 +50,41 @@ func TestDeleteActor_StampsRefSpanIdentity(t *testing.T) {
 
 	assertSpanStr(t, attrs, ateattr.AtespaceKey, testAtespace)
 	assertSpanStr(t, attrs, ateattr.ActorNameKey, testActorID)
+}
+
+func TestValidateDeleteActorRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.DeleteActorRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.DeleteActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}},
+		nil,
+	}, {
+		"missing actor",
+		&ateapipb.DeleteActorRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor"), "")},
+	}, {
+		"missing actor.atespace",
+		&ateapipb.DeleteActorRequest{Actor: &ateapipb.ObjectRef{Name: "id1"}},
+		field.ErrorList{field.Required(field.NewPath("actor", "atespace"), "")},
+	}, {
+		"invalid actor.atespace",
+		&ateapipb.DeleteActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor", "atespace"), "NS1", "")},
+	}, {
+		"missing actor.name",
+		&ateapipb.DeleteActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1"}},
+		field.ErrorList{field.Required(field.NewPath("actor", "name"), "")},
+	}, {
+		"invalid actor.name",
+		&ateapipb.DeleteActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor", "name"), "ID1", "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateDeleteActorRequest(tt.req), tt.want)
+		})
+	}
 }

--- a/cmd/ateapi/internal/controlapi/delete_atespace.go
+++ b/cmd/ateapi/internal/controlapi/delete_atespace.go
@@ -28,8 +28,8 @@ import (
 )
 
 func (s *Service) DeleteAtespace(ctx context.Context, req *ateapipb.DeleteAtespaceRequest) (*ateapipb.Atespace, error) {
-	if err := validateDeleteAtespaceRequest(req); err != nil {
-		return nil, err
+	if errs := validateDeleteAtespaceRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 
 	name := req.GetAtespace().GetName()
@@ -47,7 +47,7 @@ func (s *Service) DeleteAtespace(ctx context.Context, req *ateapipb.DeleteAtespa
 	return deleted, nil
 }
 
-func validateDeleteAtespaceRequest(req *ateapipb.DeleteAtespaceRequest) error {
+func validateDeleteAtespaceRequest(req *ateapipb.DeleteAtespaceRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -57,8 +57,5 @@ func validateDeleteAtespaceRequest(req *ateapipb.DeleteAtespaceRequest) error {
 		errs = append(errs, resources.ValidateGlobalObjectRef(val, fldPath)...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/delete_atespace_test.go
+++ b/cmd/ateapi/internal/controlapi/delete_atespace_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateDeleteAtespaceRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.DeleteAtespaceRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}},
+		nil,
+	}, {
+		"missing atespace",
+		&ateapipb.DeleteAtespaceRequest{},
+		field.ErrorList{field.Required(field.NewPath("atespace"), "")},
+	}, {
+		"atespace.atespace must be empty",
+		&ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Atespace: "ns1", Name: "team-a"}},
+		field.ErrorList{field.Invalid(field.NewPath("atespace", "atespace"), "ns1", "")},
+	}, {
+		"missing atespace.name",
+		&ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{}},
+		field.ErrorList{field.Required(field.NewPath("atespace", "name"), "")},
+	}, {
+		"invalid atespace.name",
+		&ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "TEAM-A"}},
+		field.ErrorList{field.Invalid(field.NewPath("atespace", "name"), "TEAM-A", "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateDeleteAtespaceRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -52,6 +52,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -1058,29 +1059,6 @@ func TestListActors_Pagination(t *testing.T) {
 	}
 }
 
-func TestListActors_PageSizeValidation(t *testing.T) {
-	ns := namespaceForTest("ns-list-actors-validation")
-	tc := setupTest(t, ns)
-	defer tc.cleanup()
-
-	// 1. Negative page size
-	_, err := tc.client.ListActors(context.Background(), &ateapipb.ListActorsRequest{
-		Atespace: testAtespace,
-		PageSize: -1,
-	})
-	if status.Code(err) != codes.InvalidArgument {
-		t.Errorf("expected InvalidArgument error for negative page_size, got: %v", err)
-	}
-
-	// 2. Page size exceeding maxPageSize (1000) is coerced silently.
-	if _, err := tc.client.ListActors(context.Background(), &ateapipb.ListActorsRequest{
-		Atespace: testAtespace,
-		PageSize: 1001,
-	}); err != nil {
-		t.Errorf("expected page_size > 1000 to be coerced, got error: %v", err)
-	}
-}
-
 // TestListWorkers tests that workers mirrored to Redis are listed.
 // Workflow:
 // 1. Creates a mock WorkerPool in Kubernetes.
@@ -1919,444 +1897,74 @@ func TestUpdateActor_ReassignsPoolAcrossSuspendResume(t *testing.T) {
 	}
 }
 
-// TestValidation tests the negative validation cases for all gRPC methods.
-// Workflow:
-// 1. Uses table-driven tests for each RPC method (CreateActor, GetActor, ResumeActor, SuspendActor).
-// 2. Passes invalid requests (missing required fields).
-// 3. Verifies that all requests fail with an error.
 func TestValidation(t *testing.T) {
 	ns := namespaceForTest("ns-validation")
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
 
 	t.Run("CreateActor", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.CreateActorRequest
-			wantMsg string
-		}{{
-			"missing actor_template_namespace",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"}, ActorTemplateName: "tmpl1"}},
-			"actor.actor_template_namespace: Required value",
-		}, {
-			"invalid actor_template_namespace",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"},
-				ActorTemplateNamespace: "invalid value",
-				ActorTemplateName:      "tmpl1",
-			}},
-			"actor.actor_template_namespace: Invalid value",
-		}, {
-			"missing actor_template_name",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"}, ActorTemplateNamespace: "ns1"}},
-			"actor.actor_template_name: Required value",
-		}, {
-			"invalid actor_template_name",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"},
-				ActorTemplateNamespace: "ns1",
-				ActorTemplateName:      "invalid value",
-			}},
-			"actor.actor_template_name: Invalid value",
-		}, {
-			"missing actor",
-			&ateapipb.CreateActorRequest{},
-			"actor: Required value",
-		}, {
-			"missing actor.atespace",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Name: "id1"},
-				ActorTemplateNamespace: "ns1",
-				ActorTemplateName:      "tmpl1",
-			}},
-			"actor.metadata.atespace: Required value",
-		}, {
-			"invalid actor.atespace",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: "NS1", Name: "id1"},
-				ActorTemplateNamespace: "ns1",
-				ActorTemplateName:      "tmpl1",
-			}},
-			"actor.metadata.atespace: Invalid value",
-		}, {
-			"missing actor.name",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1"},
-				ActorTemplateNamespace: "ns1",
-				ActorTemplateName:      "tmpl1",
-			}},
-			"actor.metadata.name: Required value",
-		}, {
-			"invalid actor.name",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "ID1"},
-				ActorTemplateNamespace: "ns1",
-				ActorTemplateName:      "tmpl1",
-			}},
-			"actor.metadata.name: Invalid value",
-		}, {
-			"invalid worker_selector label key",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"},
-				ActorTemplateNamespace: "ns1",
-				ActorTemplateName:      "tmpl1",
-				WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"bad key!": "x"}},
-			}},
-			`actor.worker_selector.match_labels\[bad key!\]: Invalid value`,
-		}, {
-			"invalid worker_selector label value",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"},
-				ActorTemplateNamespace: "ns1",
-				ActorTemplateName:      "tmpl1",
-				WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "not valid!"}},
-			}},
-			`actor.worker_selector.match_labels\[tier\]: Invalid value`,
-		}, {
-			"too many worker_selector.match_labels",
-			&ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"},
-				ActorTemplateNamespace: "ns1",
-				ActorTemplateName:      "tmpl1",
-				WorkerSelector:         &ateapipb.Selector{MatchLabels: selectorLabelsOfSize(11)}}},
-			"actor.worker_selector.match_labels: Too many",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.CreateActor(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "actor: Required value")
 	})
 
 	t.Run("GetActor", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.GetActorRequest
-			wantMsg string
-		}{{
-			"missing actor",
-			&ateapipb.GetActorRequest{},
-			"actor: Required value",
-		}, {
-			"missing actor.atespace",
-			&ateapipb.GetActorRequest{
-				Actor: &ateapipb.ObjectRef{Name: "id1"},
-			},
-			"actor.atespace: Required value",
-		}, {
-			"invalid actor.atespace",
-			&ateapipb.GetActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
-			},
-			"actor.atespace: Invalid value",
-		}, {
-			"missing actor.name",
-			&ateapipb.GetActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
-			},
-			"actor.name: Required value",
-		}, {
-			"invalid actor.name",
-			&ateapipb.GetActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
-			},
-			"actor.name: Invalid value",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.GetActor(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "actor: Required value")
 	})
 
 	t.Run("ResumeActor", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.ResumeActorRequest
-			wantMsg string
-		}{{
-			"missing actor",
-			&ateapipb.ResumeActorRequest{},
-			"actor: Required value",
-		}, {
-			"missing actor.atespace",
-			&ateapipb.ResumeActorRequest{
-				Actor: &ateapipb.ObjectRef{Name: "id1"},
-			},
-			"actor.atespace: Required value",
-		}, {
-			"invalid actor.atespace",
-			&ateapipb.ResumeActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
-			},
-			"actor.atespace: Invalid value",
-		}, {
-			"missing actor.name",
-			&ateapipb.ResumeActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
-			},
-			"actor.name: Required value",
-		}, {
-			"invalid actor.name",
-			&ateapipb.ResumeActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
-			},
-			"actor.name: Invalid value",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.ResumeActor(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "actor: Required value")
 	})
 
 	t.Run("PauseActor", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.PauseActorRequest
-			wantMsg string
-		}{{
-			"missing actor",
-			&ateapipb.PauseActorRequest{},
-			"actor: Required value",
-		}, {
-			"missing actor.atespace",
-			&ateapipb.PauseActorRequest{
-				Actor: &ateapipb.ObjectRef{Name: "id1"},
-			},
-			"actor.atespace: Required value",
-		}, {
-			"invalid actor.atespace",
-			&ateapipb.PauseActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
-			},
-			"actor.atespace: Invalid value",
-		}, {
-			"missing actor.name",
-			&ateapipb.PauseActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
-			},
-			"actor.name: Required value",
-		}, {
-			"invalid actor.name",
-			&ateapipb.PauseActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
-			},
-			"actor.name: Invalid value",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.PauseActor(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "actor: Required value")
 	})
 
 	t.Run("SuspendActor", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.SuspendActorRequest
-			wantMsg string
-		}{{
-			"missing actor",
-			&ateapipb.SuspendActorRequest{},
-			"actor: Required value",
-		}, {
-			"missing actor.atespace",
-			&ateapipb.SuspendActorRequest{
-				Actor: &ateapipb.ObjectRef{Name: "id1"},
-			},
-			"actor.atespace: Required value",
-		}, {
-			"invalid actor.atespace",
-			&ateapipb.SuspendActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
-			},
-			"actor.atespace: Invalid value",
-		}, {
-			"missing actor.name",
-			&ateapipb.SuspendActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
-			},
-			"actor.name: Required value",
-		}, {
-			"invalid actor.name",
-			&ateapipb.SuspendActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
-			},
-			"actor.name: Invalid value",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.SuspendActor(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "actor: Required value")
 	})
 
 	t.Run("UpdateActor", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.UpdateActorRequest
-			wantMsg string
-		}{{
-			"missing actor",
-			&ateapipb.UpdateActorRequest{},
-			"actor: Required value",
-		}, {
-			"missing actor.atespace",
-			&ateapipb.UpdateActorRequest{
-				Actor: &ateapipb.ObjectRef{Name: "id1"},
-			},
-			"actor.atespace: Required value",
-		}, {
-			"invalid actor.atespace",
-			&ateapipb.UpdateActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
-			},
-			"actor.atespace: Invalid value",
-		}, {
-			"missing actor.name",
-			&ateapipb.UpdateActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
-			},
-			"actor.name: Required value",
-		}, {
-			"invalid actor.name",
-			&ateapipb.UpdateActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
-			},
-			"actor.name: Invalid value",
-		}, {
-			"invalid worker_selector label key",
-			&ateapipb.UpdateActorRequest{
-				Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
-				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"bad key!": "x"}},
-			},
-			`worker_selector.match_labels\[bad key!\]: Invalid value`,
-		}, {
-			"invalid worker_selector label value",
-			&ateapipb.UpdateActorRequest{
-				Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
-				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "not valid!"}},
-			},
-			`worker_selector.match_labels\[tier\]: Invalid value`,
-		}, {
-			"too many worker_selector.match_labels",
-			&ateapipb.UpdateActorRequest{
-				Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
-				WorkerSelector: &ateapipb.Selector{MatchLabels: selectorLabelsOfSize(11)}},
-			"worker_selector.match_labels: Too many",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.UpdateActor(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.UpdateActor(context.Background(), &ateapipb.UpdateActorRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "actor: Required value")
 	})
 
 	t.Run("DeleteActor", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.DeleteActorRequest
-			wantMsg string
-		}{{
-			"missing actor",
-			&ateapipb.DeleteActorRequest{},
-			"actor: Required value",
-		}, {
-			"missing actor.atespace",
-			&ateapipb.DeleteActorRequest{
-				Actor: &ateapipb.ObjectRef{Name: "id1"},
-			},
-			"actor.atespace: Required value",
-		}, {
-			"invalid actor.atespace",
-			&ateapipb.DeleteActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"},
-			},
-			"actor.atespace: Invalid value",
-		}, {
-			"missing actor.name",
-			&ateapipb.DeleteActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1"},
-			},
-			"actor.name: Required value",
-		}, {
-			"invalid actor.name",
-			&ateapipb.DeleteActorRequest{
-				Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"},
-			},
-			"actor.name: Invalid value",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.DeleteActor(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "actor: Required value")
 	})
 
 	t.Run("ListActors", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.ListActorsRequest
-			wantMsg string
-		}{{
-			"invalid atespace",
-			&ateapipb.ListActorsRequest{Atespace: "NS1"},
-			"atespace: Invalid value",
-		}, {
-			"negative page_size",
-			&ateapipb.ListActorsRequest{Atespace: "ns1", PageSize: -1},
-			"page_size: Invalid value",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.ListActors(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.ListActors(context.Background(), &ateapipb.ListActorsRequest{PageSize: -1})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "page_size: Invalid value")
 	})
 
 	t.Run("ListWorkers", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.ListWorkersRequest
-			wantMsg string
-		}{{
-			"negative page_size",
-			&ateapipb.ListWorkersRequest{PageSize: -1},
-			"page_size: Invalid value",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.ListWorkers(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.ListWorkers(context.Background(), &ateapipb.ListWorkersRequest{PageSize: -1})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "page_size: Invalid value")
 	})
 
 	t.Run("ListAtespaces", func(t *testing.T) {
-		tests := []struct {
-			name    string
-			req     *ateapipb.ListAtespacesRequest
-			wantMsg string
-		}{{
-			"negative page_size",
-			&ateapipb.ListAtespacesRequest{PageSize: -1},
-			"page_size: Invalid value",
-		}}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := tc.client.ListAtespaces(context.Background(), tt.req)
-				assertGrpcErrorRegex(t, err, codes.InvalidArgument, tt.wantMsg)
-			})
-		}
+		_, err := tc.client.ListAtespaces(context.Background(), &ateapipb.ListAtespacesRequest{PageSize: -1})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "page_size: Invalid value")
+	})
+
+	t.Run("CreateAtespace", func(t *testing.T) {
+		_, err := tc.client.CreateAtespace(context.Background(), &ateapipb.CreateAtespaceRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "atespace: Required value")
+	})
+
+	t.Run("GetAtespace", func(t *testing.T) {
+		_, err := tc.client.GetAtespace(context.Background(), &ateapipb.GetAtespaceRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "atespace: Required value")
+	})
+
+	t.Run("DeleteAtespace", func(t *testing.T) {
+		_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{})
+		assertGrpcErrorRegex(t, err, codes.InvalidArgument, "atespace: Required value")
 	})
 }
 
@@ -2774,24 +2382,6 @@ func TestCreateAtespace_AlreadyExists(t *testing.T) {
 	assertGrpcError(t, err, codes.AlreadyExists, "Atespace team-a already exists")
 }
 
-func TestCreateAtespace_Validation(t *testing.T) {
-	ns := namespaceForTest("ns-create-atespace-validation")
-	tc := setupTest(t, ns)
-	defer tc.cleanup()
-
-	_, err := tc.client.CreateAtespace(context.Background(), &ateapipb.CreateAtespaceRequest{Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: ""}}})
-	assertGrpcError(t, err, codes.InvalidArgument, "atespace.metadata.name: Required value")
-
-	// Invalid names — uppercase/underscore plus Redis-key/SCAN metacharacters —
-	// are rejected by ValidateAtespace before any key is built (injection guard).
-	for _, bad := range []string{"Team_A", "a*", "a:b", "a/b"} {
-		_, err := tc.client.CreateAtespace(context.Background(), &ateapipb.CreateAtespaceRequest{Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: bad}}})
-		if status.Code(err) != codes.InvalidArgument {
-			t.Errorf("CreateAtespace(%q): got code %v, want InvalidArgument (err=%v)", bad, status.Code(err), err)
-		}
-	}
-}
-
 func TestGetAtespace_Found(t *testing.T) {
 	ns := namespaceForTest("ns-get-atespace")
 	tc := setupTest(t, ns)
@@ -2928,19 +2518,7 @@ func TestDeleteAtespace_NotFound(t *testing.T) {
 	assertGrpcError(t, err, codes.NotFound, "Atespace nope not found")
 }
 
-func TestDeleteAtespace_Validation(t *testing.T) {
-	ns := namespaceForTest("ns-delete-atespace-validation")
-	tc := setupTest(t, ns)
-	defer tc.cleanup()
-
-	_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: ""}})
-	assertGrpcError(t, err, codes.InvalidArgument, "atespace.name: Required value")
-
-	// Metacharacter names are rejected before the emptiness glob scan ever runs.
-	for _, bad := range []string{"a*", "a:b"} {
-		_, err := tc.client.DeleteAtespace(context.Background(), &ateapipb.DeleteAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: bad}})
-		if status.Code(err) != codes.InvalidArgument {
-			t.Errorf("DeleteAtespace(%q): got code %v, want InvalidArgument", bad, status.Code(err))
-		}
-	}
+func assertValidateErr(t *testing.T, got field.ErrorList, want field.ErrorList) {
+	t.Helper()
+	field.ErrorMatcher{}.ByType().ByField().ByValue().Test(t, want, got)
 }

--- a/cmd/ateapi/internal/controlapi/get_actor.go
+++ b/cmd/ateapi/internal/controlapi/get_actor.go
@@ -28,8 +28,8 @@ import (
 )
 
 func (s *Service) GetActor(ctx context.Context, req *ateapipb.GetActorRequest) (*ateapipb.Actor, error) {
-	if err := validateGetActorRequest(req); err != nil {
-		return nil, err
+	if errs := validateGetActorRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	actorRef := resources.ActorRefFromObjectRef(req.GetActor())
 	actor, err := s.persistence.GetActor(ctx, actorRef)
@@ -41,7 +41,7 @@ func (s *Service) GetActor(ctx context.Context, req *ateapipb.GetActorRequest) (
 	return actor, nil
 }
 
-func validateGetActorRequest(req *ateapipb.GetActorRequest) error {
+func validateGetActorRequest(req *ateapipb.GetActorRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -51,8 +51,5 @@ func validateGetActorRequest(req *ateapipb.GetActorRequest) error {
 		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/get_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/get_actor_test.go
@@ -15,66 +15,45 @@
 package controlapi
 
 import (
-	"context"
 	"testing"
 
-	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// The early ref stamp must land on the span even when the op fails, so a failed
-// resume is still attributable to who/where.
-func TestResumeActor_ErrorStillStampsRefSpanIdentity(t *testing.T) {
-	ns := namespaceForTest("ns-span-resume-err")
-	tc := setupTest(t, ns)
-	defer tc.cleanup()
-
-	attrs := recordRootSpanAttrs(t, func(ctx context.Context) {
-		if _, err := tc.service.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-			Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "missing"},
-		}); err == nil {
-			t.Fatal("expected error resuming missing actor")
-		}
-	})
-
-	assertSpanStr(t, attrs, ateattr.AtespaceKey, testAtespace)
-	assertSpanStr(t, attrs, ateattr.ActorNameKey, "missing")
-}
-
-func TestValidateResumeActorRequest(t *testing.T) {
+func TestValidateGetActorRequest(t *testing.T) {
 	tests := []struct {
 		name string
-		req  *ateapipb.ResumeActorRequest
+		req  *ateapipb.GetActorRequest
 		want field.ErrorList
 	}{{
 		"valid",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}},
+		&ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}},
 		nil,
 	}, {
 		"missing actor",
-		&ateapipb.ResumeActorRequest{},
+		&ateapipb.GetActorRequest{},
 		field.ErrorList{field.Required(field.NewPath("actor"), "")},
 	}, {
 		"missing actor.atespace",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Name: "id1"}},
+		&ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Name: "id1"}},
 		field.ErrorList{field.Required(field.NewPath("actor", "atespace"), "")},
 	}, {
 		"invalid actor.atespace",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"}},
+		&ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"}},
 		field.ErrorList{field.Invalid(field.NewPath("actor", "atespace"), "NS1", "")},
 	}, {
 		"missing actor.name",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1"}},
+		&ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1"}},
 		field.ErrorList{field.Required(field.NewPath("actor", "name"), "")},
 	}, {
 		"invalid actor.name",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"}},
+		&ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"}},
 		field.ErrorList{field.Invalid(field.NewPath("actor", "name"), "ID1", "")},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assertValidateErr(t, validateResumeActorRequest(tt.req), tt.want)
+			assertValidateErr(t, validateGetActorRequest(tt.req), tt.want)
 		})
 	}
 }

--- a/cmd/ateapi/internal/controlapi/get_atespace.go
+++ b/cmd/ateapi/internal/controlapi/get_atespace.go
@@ -28,8 +28,8 @@ import (
 )
 
 func (s *Service) GetAtespace(ctx context.Context, req *ateapipb.GetAtespaceRequest) (*ateapipb.Atespace, error) {
-	if err := validateGetAtespaceRequest(req); err != nil {
-		return nil, err
+	if errs := validateGetAtespaceRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 
 	name := req.GetAtespace().GetName()
@@ -43,7 +43,7 @@ func (s *Service) GetAtespace(ctx context.Context, req *ateapipb.GetAtespaceRequ
 	return atespace, nil
 }
 
-func validateGetAtespaceRequest(req *ateapipb.GetAtespaceRequest) error {
+func validateGetAtespaceRequest(req *ateapipb.GetAtespaceRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -53,8 +53,5 @@ func validateGetAtespaceRequest(req *ateapipb.GetAtespaceRequest) error {
 		errs = append(errs, resources.ValidateGlobalObjectRef(val, fldPath)...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/get_atespace_test.go
+++ b/cmd/ateapi/internal/controlapi/get_atespace_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateGetAtespaceRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.GetAtespaceRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "team-a"}},
+		nil,
+	}, {
+		"missing atespace",
+		&ateapipb.GetAtespaceRequest{},
+		field.ErrorList{field.Required(field.NewPath("atespace"), "")},
+	}, {
+		"atespace.atespace must be empty",
+		&ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Atespace: "ns1", Name: "team-a"}},
+		field.ErrorList{field.Invalid(field.NewPath("atespace", "atespace"), "ns1", "")},
+	}, {
+		"missing atespace.name",
+		&ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{}},
+		field.ErrorList{field.Required(field.NewPath("atespace", "name"), "")},
+	}, {
+		"invalid atespace.name",
+		&ateapipb.GetAtespaceRequest{Atespace: &ateapipb.ObjectRef{Name: "TEAM-A"}},
+		field.ErrorList{field.Invalid(field.NewPath("atespace", "name"), "TEAM-A", "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateGetAtespaceRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/list_actors.go
+++ b/cmd/ateapi/internal/controlapi/list_actors.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -37,8 +35,8 @@ func effectivePageSize(requested int32) int32 {
 }
 
 func (s *Service) ListActors(ctx context.Context, req *ateapipb.ListActorsRequest) (*ateapipb.ListActorsResponse, error) {
-	if err := validateListActorsRequest(req); err != nil {
-		return nil, err
+	if errs := validateListActorsRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 
 	actors, nextToken, err := s.persistence.ListActors(ctx, req.GetAtespace(), effectivePageSize(req.GetPageSize()), req.GetPageToken())
@@ -51,13 +49,11 @@ func (s *Service) ListActors(ctx context.Context, req *ateapipb.ListActorsReques
 	}, nil
 }
 
-func validateListActorsRequest(req *ateapipb.ListActorsRequest) error {
+func validateListActorsRequest(req *ateapipb.ListActorsRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
-	// An empty atespace is allowed here and means "all atespaces" (used by
-	// `kubectl ate get actors -A`). A non-empty atespace is validated and
-	// scopes the listing to that atespace.
+	// An empty atespace is allowed here and means "all atespaces".
 	if val, fldPath := req.Atespace, fldPath.Child("atespace"); val != "" {
 		errs = append(errs, resources.ValidateResourceName(val, fldPath)...)
 	}
@@ -66,8 +62,5 @@ func validateListActorsRequest(req *ateapipb.ListActorsRequest) error {
 		errs = append(errs, field.Invalid(fldPath, val, "must be greater than or equal to 0"))
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/list_actors_test.go
+++ b/cmd/ateapi/internal/controlapi/list_actors_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateListActorsRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.ListActorsRequest
+		want field.ErrorList
+	}{{
+		"valid, atespace scoped",
+		&ateapipb.ListActorsRequest{Atespace: "ns1"},
+		nil,
+	}, {
+		// Empty atespace means "all atespaces" (kubectl ate get actors -A).
+		"valid, empty atespace means all atespaces",
+		&ateapipb.ListActorsRequest{},
+		nil,
+	}, {
+		"invalid atespace",
+		&ateapipb.ListActorsRequest{Atespace: "NS1"},
+		field.ErrorList{field.Invalid(field.NewPath("atespace"), "NS1", "")},
+	}, {
+		"valid, positive page_size",
+		&ateapipb.ListActorsRequest{Atespace: "ns1", PageSize: 10},
+		nil,
+	}, {
+		"negative page_size",
+		&ateapipb.ListActorsRequest{Atespace: "ns1", PageSize: -1},
+		field.ErrorList{field.Invalid(field.NewPath("page_size"), int32(-1), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateListActorsRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/list_atespaces.go
+++ b/cmd/ateapi/internal/controlapi/list_atespaces.go
@@ -19,14 +19,12 @@ import (
 	"fmt"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func (s *Service) ListAtespaces(ctx context.Context, req *ateapipb.ListAtespacesRequest) (*ateapipb.ListAtespacesResponse, error) {
-	if err := validateListAtespacesRequest(req); err != nil {
-		return nil, err
+	if errs := validateListAtespacesRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 
 	atespaces, nextToken, err := s.persistence.ListAtespaces(ctx, effectivePageSize(req.GetPageSize()), req.GetPageToken())
@@ -39,7 +37,7 @@ func (s *Service) ListAtespaces(ctx context.Context, req *ateapipb.ListAtespaces
 	}, nil
 }
 
-func validateListAtespacesRequest(req *ateapipb.ListAtespacesRequest) error {
+func validateListAtespacesRequest(req *ateapipb.ListAtespacesRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -47,8 +45,5 @@ func validateListAtespacesRequest(req *ateapipb.ListAtespacesRequest) error {
 		errs = append(errs, field.Invalid(fldPath, val, "must be greater than or equal to 0"))
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/list_atespaces_test.go
+++ b/cmd/ateapi/internal/controlapi/list_atespaces_test.go
@@ -12,28 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package debugapi
+package controlapi
 
 import (
-	"context"
-	"fmt"
+	"testing"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func (s *Service) DebugClear(ctx context.Context, req *ateapipb.DebugClearRequest) (*ateapipb.DebugClearResponse, error) {
-	if errs := validateDebugClearRequest(req); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+func TestValidateListAtespacesRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.ListAtespacesRequest
+		want field.ErrorList
+	}{{
+		"valid, no page_size",
+		&ateapipb.ListAtespacesRequest{},
+		nil,
+	}, {
+		"valid, positive page_size",
+		&ateapipb.ListAtespacesRequest{PageSize: 10},
+		nil,
+	}, {
+		"negative page_size",
+		&ateapipb.ListAtespacesRequest{PageSize: -1},
+		field.ErrorList{field.Invalid(field.NewPath("page_size"), int32(-1), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateListAtespacesRequest(tt.req), tt.want)
+		})
 	}
-	if err := s.persistence.DebugClearAll(ctx); err != nil {
-		return nil, fmt.Errorf("while running DebugClearAll: %w", err)
-	}
-	return &ateapipb.DebugClearResponse{}, nil
-}
-
-func validateDebugClearRequest(req *ateapipb.DebugClearRequest) field.ErrorList {
-	return nil
 }

--- a/cmd/ateapi/internal/controlapi/list_workers.go
+++ b/cmd/ateapi/internal/controlapi/list_workers.go
@@ -19,14 +19,12 @@ import (
 	"fmt"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func (s *Service) ListWorkers(ctx context.Context, req *ateapipb.ListWorkersRequest) (*ateapipb.ListWorkersResponse, error) {
-	if err := validateListWorkersRequest(req); err != nil {
-		return nil, err
+	if errs := validateListWorkersRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 
 	workers, nextToken, err := s.persistence.ListWorkers(ctx, effectivePageSize(req.GetPageSize()), req.GetPageToken())
@@ -39,7 +37,7 @@ func (s *Service) ListWorkers(ctx context.Context, req *ateapipb.ListWorkersRequ
 	}, nil
 }
 
-func validateListWorkersRequest(req *ateapipb.ListWorkersRequest) error {
+func validateListWorkersRequest(req *ateapipb.ListWorkersRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -47,8 +45,5 @@ func validateListWorkersRequest(req *ateapipb.ListWorkersRequest) error {
 		errs = append(errs, field.Invalid(fldPath, val, "must be greater than or equal to 0"))
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/list_workers_test.go
+++ b/cmd/ateapi/internal/controlapi/list_workers_test.go
@@ -12,28 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package debugapi
+package controlapi
 
 import (
-	"context"
-	"fmt"
+	"testing"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func (s *Service) DebugClear(ctx context.Context, req *ateapipb.DebugClearRequest) (*ateapipb.DebugClearResponse, error) {
-	if errs := validateDebugClearRequest(req); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+func TestValidateListWorkersRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.ListWorkersRequest
+		want field.ErrorList
+	}{{
+		"valid, no page_size",
+		&ateapipb.ListWorkersRequest{},
+		nil,
+	}, {
+		"valid, positive page_size",
+		&ateapipb.ListWorkersRequest{PageSize: 10},
+		nil,
+	}, {
+		"negative page_size",
+		&ateapipb.ListWorkersRequest{PageSize: -1},
+		field.ErrorList{field.Invalid(field.NewPath("page_size"), int32(-1), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateListWorkersRequest(tt.req), tt.want)
+		})
 	}
-	if err := s.persistence.DebugClearAll(ctx); err != nil {
-		return nil, fmt.Errorf("while running DebugClearAll: %w", err)
-	}
-	return &ateapipb.DebugClearResponse{}, nil
-}
-
-func validateDebugClearRequest(req *ateapipb.DebugClearRequest) field.ErrorList {
-	return nil
 }

--- a/cmd/ateapi/internal/controlapi/pause_actor.go
+++ b/cmd/ateapi/internal/controlapi/pause_actor.go
@@ -27,8 +27,8 @@ import (
 )
 
 func (s *Service) PauseActor(ctx context.Context, req *ateapipb.PauseActorRequest) (*ateapipb.PauseActorResponse, error) {
-	if err := validatePauseActorRequest(req); err != nil {
-		return nil, err
+	if errs := validatePauseActorRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	actorRef := resources.ActorRefFromObjectRef(req.GetActor())
 	setSpanActorRefAttributes(ctx, actorRef)
@@ -48,7 +48,7 @@ func (s *Service) PauseActor(ctx context.Context, req *ateapipb.PauseActorReques
 	return &ateapipb.PauseActorResponse{Actor: actor}, nil
 }
 
-func validatePauseActorRequest(req *ateapipb.PauseActorRequest) error {
+func validatePauseActorRequest(req *ateapipb.PauseActorRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -58,8 +58,5 @@ func validatePauseActorRequest(req *ateapipb.PauseActorRequest) error {
 		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/pause_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/pause_actor_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // Pause stamps the ref identity before resolving the Actor record, so a failed
@@ -48,5 +49,42 @@ func TestPauseActor_FailedLookupStampsRefIdentityOnly(t *testing.T) {
 		if _, ok := attrs[k]; ok {
 			t.Errorf("unexpected %s on failed-pause span", k)
 		}
+	}
+}
+
+func TestValidatePauseActorRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.PauseActorRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.PauseActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}},
+		nil,
+	}, {
+		"missing actor",
+		&ateapipb.PauseActorRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor"), "")},
+	}, {
+		"missing actor.atespace",
+		&ateapipb.PauseActorRequest{Actor: &ateapipb.ObjectRef{Name: "id1"}},
+		field.ErrorList{field.Required(field.NewPath("actor", "atespace"), "")},
+	}, {
+		"invalid actor.atespace",
+		&ateapipb.PauseActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor", "atespace"), "NS1", "")},
+	}, {
+		"missing actor.name",
+		&ateapipb.PauseActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1"}},
+		field.ErrorList{field.Required(field.NewPath("actor", "name"), "")},
+	}, {
+		"invalid actor.name",
+		&ateapipb.PauseActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor", "name"), "ID1", "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validatePauseActorRequest(tt.req), tt.want)
+		})
 	}
 }

--- a/cmd/ateapi/internal/controlapi/resume_actor.go
+++ b/cmd/ateapi/internal/controlapi/resume_actor.go
@@ -27,8 +27,8 @@ import (
 )
 
 func (s *Service) ResumeActor(ctx context.Context, req *ateapipb.ResumeActorRequest) (*ateapipb.ResumeActorResponse, error) {
-	if err := validateResumeActorRequest(req); err != nil {
-		return nil, err
+	if errs := validateResumeActorRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	actorRef := resources.ActorRefFromObjectRef(req.GetActor())
 	setSpanActorRefAttributes(ctx, actorRef)
@@ -48,7 +48,7 @@ func (s *Service) ResumeActor(ctx context.Context, req *ateapipb.ResumeActorRequ
 	return &ateapipb.ResumeActorResponse{Actor: actor}, nil
 }
 
-func validateResumeActorRequest(req *ateapipb.ResumeActorRequest) error {
+func validateResumeActorRequest(req *ateapipb.ResumeActorRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -58,8 +58,5 @@ func validateResumeActorRequest(req *ateapipb.ResumeActorRequest) error {
 		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/suspend_actor.go
+++ b/cmd/ateapi/internal/controlapi/suspend_actor.go
@@ -27,8 +27,8 @@ import (
 )
 
 func (s *Service) SuspendActor(ctx context.Context, req *ateapipb.SuspendActorRequest) (*ateapipb.SuspendActorResponse, error) {
-	if err := validateSuspendActorRequest(req); err != nil {
-		return nil, err
+	if errs := validateSuspendActorRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	actorRef := resources.ActorRefFromObjectRef(req.GetActor())
 	setSpanActorRefAttributes(ctx, actorRef)
@@ -48,7 +48,7 @@ func (s *Service) SuspendActor(ctx context.Context, req *ateapipb.SuspendActorRe
 	return &ateapipb.SuspendActorResponse{Actor: actor}, nil
 }
 
-func validateSuspendActorRequest(req *ateapipb.SuspendActorRequest) error {
+func validateSuspendActorRequest(req *ateapipb.SuspendActorRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -58,8 +58,5 @@ func validateSuspendActorRequest(req *ateapipb.SuspendActorRequest) error {
 		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/suspend_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/suspend_actor_test.go
@@ -15,66 +15,45 @@
 package controlapi
 
 import (
-	"context"
 	"testing"
 
-	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// The early ref stamp must land on the span even when the op fails, so a failed
-// resume is still attributable to who/where.
-func TestResumeActor_ErrorStillStampsRefSpanIdentity(t *testing.T) {
-	ns := namespaceForTest("ns-span-resume-err")
-	tc := setupTest(t, ns)
-	defer tc.cleanup()
-
-	attrs := recordRootSpanAttrs(t, func(ctx context.Context) {
-		if _, err := tc.service.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-			Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "missing"},
-		}); err == nil {
-			t.Fatal("expected error resuming missing actor")
-		}
-	})
-
-	assertSpanStr(t, attrs, ateattr.AtespaceKey, testAtespace)
-	assertSpanStr(t, attrs, ateattr.ActorNameKey, "missing")
-}
-
-func TestValidateResumeActorRequest(t *testing.T) {
+func TestValidateSuspendActorRequest(t *testing.T) {
 	tests := []struct {
 		name string
-		req  *ateapipb.ResumeActorRequest
+		req  *ateapipb.SuspendActorRequest
 		want field.ErrorList
 	}{{
 		"valid",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}},
+		&ateapipb.SuspendActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}},
 		nil,
 	}, {
 		"missing actor",
-		&ateapipb.ResumeActorRequest{},
+		&ateapipb.SuspendActorRequest{},
 		field.ErrorList{field.Required(field.NewPath("actor"), "")},
 	}, {
 		"missing actor.atespace",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Name: "id1"}},
+		&ateapipb.SuspendActorRequest{Actor: &ateapipb.ObjectRef{Name: "id1"}},
 		field.ErrorList{field.Required(field.NewPath("actor", "atespace"), "")},
 	}, {
 		"invalid actor.atespace",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"}},
+		&ateapipb.SuspendActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"}},
 		field.ErrorList{field.Invalid(field.NewPath("actor", "atespace"), "NS1", "")},
 	}, {
 		"missing actor.name",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1"}},
+		&ateapipb.SuspendActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1"}},
 		field.ErrorList{field.Required(field.NewPath("actor", "name"), "")},
 	}, {
 		"invalid actor.name",
-		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"}},
+		&ateapipb.SuspendActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"}},
 		field.ErrorList{field.Invalid(field.NewPath("actor", "name"), "ID1", "")},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assertValidateErr(t, validateResumeActorRequest(tt.req), tt.want)
+			assertValidateErr(t, validateSuspendActorRequest(tt.req), tt.want)
 		})
 	}
 }

--- a/cmd/ateapi/internal/controlapi/update_actor.go
+++ b/cmd/ateapi/internal/controlapi/update_actor.go
@@ -28,8 +28,8 @@ import (
 )
 
 func (s *Service) UpdateActor(ctx context.Context, req *ateapipb.UpdateActorRequest) (*ateapipb.UpdateActorResponse, error) {
-	if err := validateUpdateActorRequest(req); err != nil {
-		return nil, err
+	if errs := validateUpdateActorRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	actorRef := resources.ActorRefFromObjectRef(req.GetActor())
 
@@ -53,7 +53,7 @@ func (s *Service) UpdateActor(ctx context.Context, req *ateapipb.UpdateActorRequ
 	return &ateapipb.UpdateActorResponse{Actor: updated}, nil
 }
 
-func validateUpdateActorRequest(req *ateapipb.UpdateActorRequest) error {
+func validateUpdateActorRequest(req *ateapipb.UpdateActorRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
 
@@ -67,8 +67,5 @@ func validateUpdateActorRequest(req *ateapipb.UpdateActorRequest) error {
 		errs = append(errs, validateSelector(val, fldPath.Child("worker_selector"))...)
 	}
 
-	if len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+	return errs
 }

--- a/cmd/ateapi/internal/controlapi/update_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/update_actor_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateUpdateActorRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.UpdateActorRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.UpdateActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}},
+		nil,
+	}, {
+		"missing actor",
+		&ateapipb.UpdateActorRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor"), "")},
+	}, {
+		"missing actor.atespace",
+		&ateapipb.UpdateActorRequest{Actor: &ateapipb.ObjectRef{Name: "id1"}},
+		field.ErrorList{field.Required(field.NewPath("actor", "atespace"), "")},
+	}, {
+		"invalid actor.atespace",
+		&ateapipb.UpdateActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "NS1", Name: "id1"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor", "atespace"), "NS1", "")},
+	}, {
+		"missing actor.name",
+		&ateapipb.UpdateActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1"}},
+		field.ErrorList{field.Required(field.NewPath("actor", "name"), "")},
+	}, {
+		"invalid actor.name",
+		&ateapipb.UpdateActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor", "name"), "ID1", "")},
+	}, {
+		"nil worker_selector",
+		&ateapipb.UpdateActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"}, WorkerSelector: nil},
+		nil,
+	}, {
+		"valid worker_selector",
+		&ateapipb.UpdateActorRequest{
+			Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
+			WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "1"}},
+		},
+		nil,
+	}, {
+		"invalid worker_selector label key",
+		&ateapipb.UpdateActorRequest{
+			Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
+			WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"bad key!": "1"}},
+		},
+		field.ErrorList{field.Invalid(field.NewPath("worker_selector", "match_labels").Key("bad key!"), "bad key!", "")},
+	}, {
+		"invalid worker_selector label value",
+		&ateapipb.UpdateActorRequest{
+			Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
+			WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "not valid!"}},
+		},
+		field.ErrorList{field.Invalid(field.NewPath("worker_selector", "match_labels").Key("tier"), "not valid!", "")},
+	}, {
+		"too many worker_selector.match_labels",
+		&ateapipb.UpdateActorRequest{
+			Actor:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
+			WorkerSelector: &ateapipb.Selector{MatchLabels: selectorLabelsOfSize(11)},
+		},
+		field.ErrorList{field.TooMany(field.NewPath("worker_selector", "match_labels"), 11, 10)},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateUpdateActorRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/validate.go
+++ b/cmd/ateapi/internal/controlapi/validate.go
@@ -12,28 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package debugapi
+package controlapi
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func (s *Service) DebugClear(ctx context.Context, req *ateapipb.DebugClearRequest) (*ateapipb.DebugClearResponse, error) {
-	if errs := validateDebugClearRequest(req); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	if err := s.persistence.DebugClearAll(ctx); err != nil {
-		return nil, fmt.Errorf("while running DebugClearAll: %w", err)
-	}
-	return &ateapipb.DebugClearResponse{}, nil
-}
-
-func validateDebugClearRequest(req *ateapipb.DebugClearRequest) field.ErrorList {
-	return nil
+func toGRPCStatusError(errs field.ErrorList) error {
+	return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
 }


### PR DESCRIPTION
Add unit tests that exercise all the validation cases and assert on the k8s `ErrorMatcher` instead of comparing raw error strings.

Moved most validations from functional tests to unit tests, and kept one validation for each gRPC method to validate that handlers properly map Go errors to gRPC statuses.

