### PR TITLE
docs: fix broken file references and a typo

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,7 +11,7 @@ In particular, all of the following currently apply:
 - There is no bug bounty.
 - There is no security mailing list for announcements.
 - There are no SLOs on fix timeline.
-- There are no embargos.
+- There are no embargoes.
 - Though we do wait to publish advisories until fixes have been merged,
   details may appear in PRs prior to publishing.
 

--- a/cmd/atenet/internal/router/README.md
+++ b/cmd/atenet/internal/router/README.md
@@ -15,7 +15,7 @@ Router has several responsibilities:
 * Parks requests whose actor cannot be served immediately due to transient
   worker-pool saturation, retrying the resume until the actor is routable or a
   bounded wait elapses, instead of failing fast. See
-  [docs/request-parking.md](../../../../../docs/request-parking.md).
+  [docs/request-parking.md](../../../../docs/request-parking.md).
 * Drains gracefully on SIGTERM: flips `/readyz` so the Service stops sending
   new connections, waits out endpoint propagation (`--drain-delay`), drains the
   dataplane's established connections (Envoy only — driven over its admin API;

--- a/demos/autoscaled-workerpool/README.md
+++ b/demos/autoscaled-workerpool/README.md
@@ -33,7 +33,7 @@ currently assigned, using a Kubernetes HorizontalPodAutoscaler (HPA) fed by the
 ate-api-server :9090/metrics          (ate_workerpool_workers, OTel -> Prometheus gauge)
         │  scrape (prometheus.io/scrape annotation, 15s)
         ▼
-Prometheus                            manifests/ate-install/monitoring/prometheus.yaml
+Prometheus                            manifests/ate-install/kind/prometheus.yaml
         │  PromQL
         ▼
 prometheus-adapter                    demos/autoscaled-workerpool/prometheus-adapter.yaml


### PR DESCRIPTION
Three doc references point at paths that do not exist. The router README link to `docs/request-parking.md` has one `../` too many, and the autoscaled-workerpool README points Prometheus at `manifests/ate-install/monitoring/prometheus.yaml` instead of the real `manifests/ate-install/kind/prometheus.yaml`. Also fixes "embargos" to "embargoes" in SECURITY.md.