### PR TITLE
docs: list the missing demos, guides, and core terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,12 +199,19 @@ We provide several sample applications demonstrating Agent Substrate's capabilit
 1. **[Counter Demo](demos/counter/README.md)**: A stateful Go HTTP server demonstrating state preservation across suspends/resumes, and dynamic CRD routing.
 2. **[Sandbox Demo (Antigravity)](demos/sandbox/README.md)**: A secure, sandboxed execution environment (running Alpine Linux) that allows arbitrary shell execution while preserving filesystem state across sessions.
 3. **[Claude Code Multiplex](demos/claude-code-multiplex/README.md)**: Demonstrates oversubscribing physical hardware by multiplexing multiple Claude Code agents onto a limited pool of workers.
+4. **[Multi-Template](demos/multi-template/README.md)**: Two `ActorTemplate`s running different binaries share one `WorkerPool`, across three namespaces.
+5. **[Request Parking](demos/parking/README.md)**: An oversubscribed pool where the router holds inbound requests until a worker frees up, instead of returning `503`.
+6. **[Autoscaled WorkerPool](demos/autoscaled-workerpool/README.md)**: Scales a `WorkerPool` on its assigned-worker count with an HPA fed by prometheus-adapter.
 
 ### Documentation & Guides
+* [Architecture](docs/architecture.md): How the control plane, node supervisor, and networking stack fit together.
 * [API Configuration Guide](docs/api-guide.md): Detailed reference for configuring WorkerPools, ActorTemplates, Secrets, and Volumes.
 * [Full CLI Documentation](cmd/kubectl-ate/README.md): Installation and usage for `kubectl-ate`.
-* [Glossary](docs/glossary.md): Core terms (Actor, ActorTemplate, WorkerPool, Worker, ate-api-server, atenet, atelet, ateom) and how they relate.
+* [Glossary](docs/glossary.md): Core terms (Actor, Atespace, ActorTemplate, WorkerPool, Worker, ate-api-server, atenet, atelet, ateom) and how they relate.
 * [Observability Guide](docs/observability.md): Guide to actor logging, metrics, and distributed tracing.
+* [Request Parking](docs/request-parking.md): How the router parks requests through transient worker-pool saturation.
+* [Threat Model](docs/threat-model.md): Trust boundaries, assumptions, and known risks.
+* [Roadmap](docs/roadmap.md): Current limitations and what is planned next.
 * [Benchmarking Guide](benchmarking/README.md): Locust-based load tests, monitoring stack, and the orchestrated benchmark harness.
 
 ## Tour
@@ -216,8 +223,10 @@ We provide several sample applications demonstrating Agent Substrate's capabilit
 * `cmd/atecontroller`: A Kubernetes controller that reconciles WorkerPool and ActorTemplate custom resources.
 * `cmd/atenet`: A combined networking controller providing DNS, Envoy routing, and proxy sidecars.
 * `cmd/ateom-gvisor`: An interior-pod helper running inside sandboxed worker pods to execute `runsc` checkpoint and restore commands.
+* `cmd/ateom-microvm`: The micro-VM peer of `ateom-gvisor`, running actors as cloud-hypervisor VMs through the Kata guest model.
 * `cmd/podcertcontroller`: A "polyfill" that provides Pod Certificate signers that
   will eventually ship in upstream Kubernetes (with different names).
 * `cmd/kubectl-ate`: A CLI tool for managing Agent Substrate resources. See its [README](cmd/kubectl-ate/README.md).
+* `cmd/benchmarking`: Synthetic workloads used by the load tests, including `glutton`, which consumes RAM, disk, and file descriptors on demand.
 * `tools/setup-gcp`: A provisioning utility to set up the necessary GCP infrastructure resources (GKE, GCS, IAM).
 * `demos/`: Sample applications demonstrating Agent Substrate capabilities.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ We provide several sample applications demonstrating Agent Substrate's capabilit
 * `cmd/atecontroller`: A Kubernetes controller that reconciles WorkerPool and ActorTemplate custom resources.
 * `cmd/atenet`: A combined networking controller providing DNS, Envoy routing, and proxy sidecars.
 * `cmd/ateom-gvisor`: An interior-pod helper running inside sandboxed worker pods to execute `runsc` checkpoint and restore commands.
-* `cmd/ateom-microvm`: The micro-VM peer of `ateom-gvisor`, running actors as cloud-hypervisor VMs through the Kata guest model.
+* `cmd/ateom-microvm`: The micro-VM peer of `ateom-gvisor`, running actors as cloud-hypervisor VMs.
 * `cmd/podcertcontroller`: A "polyfill" that provides Pod Certificate signers that
   will eventually ship in upstream Kubernetes (with different names).
 * `cmd/kubectl-ate`: A CLI tool for managing Agent Substrate resources. See its [README](cmd/kubectl-ate/README.md).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -17,10 +17,23 @@ For how the pieces fit together, see the [Architecture](architecture.md) and
   pods. It is reconciled into a Kubernetes `Deployment` by the
   [atecontroller](#components).
 
+- **SandboxConfig**: a cluster-scoped resource holding the sandbox binaries for
+  one runtime family (the gVisor `runsc` binary, or a micro-VM
+  kernel/firmware/config). A `WorkerPool` resolves its binaries from the config
+  it names, or from the cluster default for its class, so one config pins the
+  runtime version for many templates.
+
 ## Records (dynamic state, in the control-plane store)
 
 These are not Kubernetes objects; they live in the control-plane database
 because they change too frequently for etcd.
+
+- **Atespace**: the isolation boundary an Actor belongs to, and the first half
+  of its identity: an Actor is addressed by `(atespace, name)`, so the same
+  name can exist in two atespaces. Atespaces are global-scoped, not Kubernetes
+  namespaces, and are distinct from the namespace an `ActorTemplate` lives in.
+  One must exist before any Actor can be created in it, and it can only be
+  deleted once empty.
 
 - **Actor**: a single instance derived from an `ActorTemplate`, identified by a
   DNS-1123 name. It is the unit that is suspended and resumed, and it moves


### PR DESCRIPTION
The README lists 3 of the 6 demos and 5 of the 9 docs, and its command tour skips `cmd/ateom-microvm` and `cmd/benchmarking`. The glossary never defines Atespace, even though it is half of an actor's identity and has its own API, and it omits SandboxConfig.