### PR TITLE
atelet: return destination Close error from copyFile

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -664,9 +664,8 @@ func copyFile(src, dst string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer destination.Close()
 	nBytes, err := io.Copy(destination, source)
-	return nBytes, err
+	return nBytes, errors.Join(err, destination.Close())
 }
 
 func (s *AteomHerder) downloadExternalCheckpoint(ctx context.Context, snapshotUriPrefix string, dstDir string, files []string) error {

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -644,6 +644,8 @@ func (s *AteomHerder) copyLocalCheckpoint(ctx context.Context, snapshotPrefix st
 	return nil
 }
 
+var createDestFile = func(name string) (io.WriteCloser, error) { return os.Create(name) }
+
 func copyFile(src, dst string) (int64, error) {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
@@ -660,7 +662,7 @@ func copyFile(src, dst string) (int64, error) {
 	}
 	defer source.Close()
 
-	destination, err := os.Create(dst)
+	destination, err := createDestFile(dst)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -86,6 +86,63 @@ func TestWriteFileAtomic(t *testing.T) {
 	})
 }
 
+func TestCopyFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	want := []byte("checkpoint pages")
+	if err := os.WriteFile(src, want, 0o600); err != nil {
+		t.Fatalf("seeding src: %v", err)
+	}
+
+	dst := filepath.Join(dir, "dst")
+	n, err := copyFile(src, dst)
+	if err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	if n != int64(len(want)) {
+		t.Errorf("copied %d bytes, want %d", n, len(want))
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading dst: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("dst content = %q, want %q", got, want)
+	}
+
+	if _, err := copyFile(dir, filepath.Join(dir, "dst2")); err == nil {
+		t.Error("copyFile(directory, ...) succeeded, want error")
+	}
+}
+
+type failingCloseFile struct{ *os.File }
+
+func (f failingCloseFile) Close() error {
+	_ = f.File.Close()
+	return errors.New("deferred flush failed")
+}
+
+func TestCopyFile_CloseError(t *testing.T) {
+	orig := createDestFile
+	createDestFile = func(name string) (io.WriteCloser, error) {
+		f, err := os.Create(name)
+		if err != nil {
+			return nil, err
+		}
+		return failingCloseFile{f}, nil
+	}
+	t.Cleanup(func() { createDestFile = orig })
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.WriteFile(src, []byte("checkpoint pages"), 0o600); err != nil {
+		t.Fatalf("seeding src: %v", err)
+	}
+	if _, err := copyFile(src, filepath.Join(dir, "dst")); err == nil {
+		t.Error("copyFile with failing destination Close = nil, want error")
+	}
+}
+
 // validRunRequest, validCheckpointRequest, and validRestoreRequest build
 // requests whose every field passes validation; the per-request tests below
 // break one field per case.


### PR DESCRIPTION
Otherwise if the deferred `Close()` failed the caller will still received a successful response from `copyFile()`.

Fixes #611.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
