### PR TITLE
Support multiple durable-dir volumes on the micro-VM runtime

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -726,7 +726,12 @@ func (s *AteomHerder) prepareOCIBundles(
 			"io.kubernetes.cri.container-type": "sandbox",
 			"io.kubernetes.cri.container-name": "pause",
 		}
-		// add annotation for every durable-dir volume
+		// Declare the durable-dir volume to gVisor. The annotation key holds a
+		// single mount ("durabledir"), so this can express exactly ONE volume —
+		// a second would silently overwrite the first. The ActorTemplate CEL
+		// rules are what keep that from happening: they cap gVisor templates at
+		// one durable-dir volume (micro-VM templates, which ignore these
+		// annotations entirely, may declare any number).
 		// TODO(dberkov) needs to revisit this logic once gVisor supports multiple durable-dir volumes.
 		for _, vol := range spec.GetVolumes() {
 			if vol.GetType() == ateletpb.VolumeType_VOLUME_TYPE_DURABLE_DIR {
@@ -814,16 +819,19 @@ func buildAteomWorkloadSpec(spec *ateletpb.WorkloadSpec) *ateompb.WorkloadSpec {
 
 	out := &ateompb.WorkloadSpec{}
 	for _, ctr := range spec.GetContainers() {
-		var ddMountPaths []string
+		var ddMounts []*ateompb.DurableDirVolumeMount
 		for _, vm := range ctr.GetVolumeMounts() {
 			if ddVolumes[vm.GetName()] {
-				ddMountPaths = append(ddMountPaths, vm.GetMountPath())
+				ddMounts = append(ddMounts, &ateompb.DurableDirVolumeMount{
+					VolumeName: vm.GetName(),
+					MountPath:  vm.GetMountPath(),
+				})
 			}
 		}
 		out.Containers = append(out.Containers, &ateompb.Container{
-			Name:              ctr.GetName(),
-			DurableDirVolumes: ddMountPaths,
-			Readyz:            toAteomReadyz(ctr.GetReadyz()),
+			Name:                   ctr.GetName(),
+			DurableDirVolumeMounts: ddMounts,
+			Readyz:                 toAteomReadyz(ctr.GetReadyz()),
 		})
 	}
 	return out

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -491,6 +491,59 @@ func TestBuildAteomWorkloadSpecForwardsReadyz(t *testing.T) {
 	}
 }
 
+func TestBuildAteomWorkloadSpecForwardsDurableDirMounts(t *testing.T) {
+	in := &ateletpb.WorkloadSpec{
+		Volumes: []*ateletpb.Volume{
+			{Name: "data", Type: ateletpb.VolumeType_VOLUME_TYPE_DURABLE_DIR},
+			{Name: "cache", Type: ateletpb.VolumeType_VOLUME_TYPE_DURABLE_DIR},
+			{Name: "scratch", Type: ateletpb.VolumeType_VOLUME_TYPE_EXTERNAL},
+		},
+		Containers: []*ateletpb.Container{
+			{
+				Name: "main",
+				VolumeMounts: []*ateletpb.VolumeMount{
+					{Name: "data", MountPath: "/home/counter"},
+					{Name: "cache", MountPath: "/var/cache"},
+					// Only durable-dir volumes cross to ateom; other volume
+					// types are mounted by atelet itself.
+					{Name: "scratch", MountPath: "/scratch"},
+				},
+			},
+			{
+				Name: "sidecar",
+				VolumeMounts: []*ateletpb.VolumeMount{
+					{Name: "data", MountPath: "/shared"},
+				},
+			},
+			{Name: "no-volumes"},
+		},
+	}
+	// ateom needs the volume NAME as well as the path: the name selects the
+	// per-volume directory on the host, and an actor may have several.
+	want := &ateompb.WorkloadSpec{
+		Containers: []*ateompb.Container{
+			{
+				Name: "main",
+				DurableDirVolumeMounts: []*ateompb.DurableDirVolumeMount{
+					{VolumeName: "data", MountPath: "/home/counter"},
+					{VolumeName: "cache", MountPath: "/var/cache"},
+				},
+			},
+			{
+				Name: "sidecar",
+				DurableDirVolumeMounts: []*ateompb.DurableDirVolumeMount{
+					{VolumeName: "data", MountPath: "/shared"},
+				},
+			},
+			{Name: "no-volumes"},
+		},
+	}
+	got := buildAteomWorkloadSpec(in)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("buildAteomWorkloadSpec mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestIsTerminalFileErr(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -285,7 +285,9 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	case ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA:
 		var ddv []string
 		for _, ctr := range req.GetSpec().GetContainers() {
-			ddv = append(ddv, ctr.GetDurableDirVolumes()...)
+			for _, m := range ctr.GetDurableDirVolumeMounts() {
+				ddv = append(ddv, m.GetMountPath())
+			}
 		}
 		if len(ddv) == 0 {
 			return nil, fmt.Errorf("no durable-dir volumes found for DATA snapshot")

--- a/cmd/ateom-microvm/durable.go
+++ b/cmd/ateom-microvm/durable.go
@@ -27,15 +27,18 @@ package main
 //
 // ateom exposes that host directory to the guest over a SECOND virtiofsd — the
 // kataShared share stays strictly read-only (it is the overlay lower, served
-// with cache=always), so writable volumes get their own share, mounted at
-// kata.GuestDurableVolumeDir(volume) and bind-mounted from there into each
-// container that declares the volume.
+// with cache=always), so writable volumes get their own share. Each volume is a
+// subdirectory of the one share, at kata.GuestDurableVolumeDir(volume),
+// bind-mounted from there into every container that declares it. An actor may
+// have any number of them: they cost a subdirectory each, not a device, so
+// nothing here scales with the volume count (gVisor is the runtime that caps
+// this at one, via the ActorTemplate CEL rules).
 //
-// Snapshots carry the contents as a tar of the whole per-actor directory, so the
-// volume names round-trip without ateom having to learn them from the wire (the
-// ateom protocol carries mount paths only). virtiofsd serves the share
-// write-through (no --writeback), so once the guest is paused every completed
-// guest write is already visible on the host and the tar is complete.
+// Snapshots carry the contents as a tar of the whole per-actor directory, so
+// every volume rides along and the layout is reproduced verbatim on restore.
+// virtiofsd serves the share write-through (no --writeback), so once the guest
+// is paused every completed guest write is already visible on the host and the
+// tar is complete.
 
 import (
 	"context"
@@ -49,8 +52,6 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // durableTarFile is the snapshot file holding the tar of the actor's durable-dir
@@ -61,79 +62,40 @@ const durableTarFile = "durable-dir.tar"
 // hasDurableVolumes reports whether any container mounts a durable-dir volume.
 func hasDurableVolumes(containers []*ateompb.Container) bool {
 	for _, c := range containers {
-		if len(c.GetDurableDirVolumes()) > 0 {
+		if len(c.GetDurableDirVolumeMounts()) > 0 {
 			return true
 		}
 	}
 	return false
 }
 
-// resolveDurableVolumeName returns the name of the actor's durable-dir volume,
-// read from the directory atelet created for it (dir is
-// ateompath.DurableDirVolumeMountsDir for the actor).
-//
-// The ateom protocol carries only the guest mount paths, not volume names, so
-// the name comes from the host layout: the directory holds exactly one
-// subdirectory per volume. The ActorTemplate API allows at most one durable-dir
-// volume per template, so anything other than exactly one directory means ateom
-// and atelet disagree about the actor — fail rather than guess.
-//
-// That makes this the one place ateom depends on atelet's on-disk layout, and
-// the first thing to change if more than one durable-dir volume is ever
-// supported: ateompb.Container would need to carry each mount's volume name
-// alongside its path, and this lookup would go away.
-func resolveDurableVolumeName(dir string) (string, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return "", fmt.Errorf("while reading durable-dir volumes dir %q: %w", dir, err)
-	}
-	var names []string
-	for _, e := range entries {
-		if e.IsDir() {
-			names = append(names, e.Name())
-		}
-	}
-	switch len(names) {
-	case 1:
-		return names[0], nil
-	case 0:
-		return "", status.Errorf(codes.FailedPrecondition,
-			"actor declares durable-dir volume mounts but %q holds no volume directory", dir)
-	default:
-		return "", status.Errorf(codes.Unimplemented,
-			"ateom-microvm supports at most one durable-dir volume, found %d in %q", len(names), dir)
-	}
-}
-
-// durableMounts returns the OCI mounts that expose one durable volume at each of
-// a container's declared mount paths. The source is the volume's directory inside
-// the guest's durable share, which the agent mounts at sandbox creation.
-func durableMounts(volumeName string, mountPaths []string) []specs.Mount {
-	src := kata.GuestDurableVolumeDir(volumeName)
-	mounts := make([]specs.Mount, 0, len(mountPaths))
-	for _, p := range mountPaths {
-		mounts = append(mounts, specs.Mount{
-			Destination: p,
-			Source:      src,
+// durableMounts returns the OCI mounts that expose a container's durable-dir
+// volumes at the paths it declared. Each source is that volume's directory
+// inside the guest's durable share, which the agent mounts at sandbox creation.
+func durableMounts(mounts []*ateompb.DurableDirVolumeMount) []specs.Mount {
+	out := make([]specs.Mount, 0, len(mounts))
+	for _, m := range mounts {
+		out = append(out, specs.Mount{
+			Destination: m.GetMountPath(),
+			Source:      kata.GuestDurableVolumeDir(m.GetVolumeName()),
 			Type:        "bind",
 			Options:     []string{"rbind", "rw"},
 		})
 	}
-	return mounts
+	return out
 }
 
-// workloadSpec returns the OCI spec to start a container's overlay workload with:
-// the prepared spec, plus the durable-dir binds when the actor has a volume and
-// this container mounts it.
+// workloadSpec returns the OCI spec to start a container's overlay workload
+// with: the prepared spec, plus a bind for each durable-dir volume it mounts.
 //
 // The spec is copied rather than mutated so the bundle's on-disk config.json and
 // the carrier's view stay as prepared — only the workload sees the binds.
-func workloadSpec(c actorContainer, durableVolume string) *specs.Spec {
-	if durableVolume == "" || len(c.durableMountPaths) == 0 {
+func workloadSpec(c actorContainer) *specs.Spec {
+	if len(c.durableMounts) == 0 {
 		return c.spec
 	}
 	spec := *c.spec
-	spec.Mounts = append(append([]specs.Mount(nil), c.spec.Mounts...), durableMounts(durableVolume, c.durableMountPaths)...)
+	spec.Mounts = append(append([]specs.Mount(nil), c.spec.Mounts...), durableMounts(c.durableMounts)...)
 	return &spec
 }
 

--- a/cmd/ateom-microvm/durable_test.go
+++ b/cmd/ateom-microvm/durable_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestHasDurableVolumes(t *testing.T) {
@@ -44,7 +42,9 @@ func TestHasDurableVolumes(t *testing.T) {
 			name: "one of several containers has a durable volume",
 			containers: []*ateompb.Container{
 				{Name: "sidecar"},
-				{Name: "app", DurableDirVolumes: []string{"/home/counter"}},
+				{Name: "app", DurableDirVolumeMounts: []*ateompb.DurableDirVolumeMount{
+					{VolumeName: "data", MountPath: "/home/counter"},
+				}},
 			},
 			want: true,
 		},
@@ -76,66 +76,13 @@ func durableDirWith(t *testing.T, volumes []string, strayFile bool) string {
 	return dir
 }
 
-func TestResolveDurableVolumeName(t *testing.T) {
-	tests := []struct {
-		name      string
-		volumes   []string
-		strayFile bool
-		want      string
-		wantCode  codes.Code
-	}{
-		{
-			name:    "single volume",
-			volumes: []string{"data"},
-			want:    "data",
-		},
-		{
-			name:      "regular files are not volumes",
-			volumes:   []string{"data"},
-			strayFile: true,
-			want:      "data",
-		},
-		{
-			name:     "no volume directory",
-			wantCode: codes.FailedPrecondition,
-		},
-		{
-			name:     "more than one volume is unsupported",
-			volumes:  []string{"data", "other"},
-			wantCode: codes.Unimplemented,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := resolveDurableVolumeName(durableDirWith(t, tc.volumes, tc.strayFile))
-			if tc.wantCode != codes.OK {
-				if status.Code(err) != tc.wantCode {
-					t.Fatalf("error = %v (code %v), want code %v", err, status.Code(err), tc.wantCode)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("resolveDurableVolumeName: %v", err)
-			}
-			if got != tc.want {
-				t.Errorf("resolveDurableVolumeName() = %q, want %q", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestResolveDurableVolumeNameMissingDir(t *testing.T) {
-	missing := filepath.Join(t.TempDir(), "no-such-dir")
-	if _, err := resolveDurableVolumeName(missing); err == nil {
-		t.Fatal("resolveDurableVolumeName succeeded with no durable-dir directory, want an error")
-	}
-}
-
 func TestDurableVolumesRoundTrip(t *testing.T) {
-	// Checkpoint: a volume with data, archived while the guest is paused.
-	src := durableDirWith(t, []string{"data"}, false)
-	if err := os.WriteFile(filepath.Join(src, "data", "a.txt"), []byte("42"), 0o644); err != nil {
-		t.Fatalf("writing volume content: %v", err)
+	// Checkpoint: every volume the actor has, archived while the guest is paused.
+	src := durableDirWith(t, []string{"data", "cache"}, false)
+	for vol, content := range map[string]string{"data": "42", "cache": "7"} {
+		if err := os.WriteFile(filepath.Join(src, vol, "a.txt"), []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %q content: %v", vol, err)
+		}
 	}
 	checkpointDir := t.TempDir()
 	if err := tarDurableVolumes(t.Context(), src, checkpointDir); err != nil {
@@ -150,29 +97,32 @@ func TestDurableVolumesRoundTrip(t *testing.T) {
 	if err := untarDurableVolumes(dst, checkpointDir); err != nil {
 		t.Fatalf("untarDurableVolumes: %v", err)
 	}
-	got, err := os.ReadFile(filepath.Join(dst, "data", "a.txt"))
-	if err != nil {
-		t.Fatalf("reading restored content: %v", err)
-	}
-	if string(got) != "42" {
-		t.Errorf("restored content = %q, want %q", got, "42")
-	}
-	// The volume name must survive the round trip: it is how the guest mount
-	// path is resolved after a restore onto another node.
-	name, err := resolveDurableVolumeName(dst)
-	if err != nil {
-		t.Fatalf("resolveDurableVolumeName after restore: %v", err)
-	}
-	if name != "data" {
-		t.Errorf("resolved volume name = %q, want %q", name, "data")
+	// Both volumes come back, each under its own name: the names are what the
+	// guest mount paths are built from after a restore onto another node.
+	for vol, want := range map[string]string{"data": "42", "cache": "7"} {
+		got, err := os.ReadFile(filepath.Join(dst, vol, "a.txt"))
+		if err != nil {
+			t.Errorf("reading restored %q content: %v", vol, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("restored %q content = %q, want %q", vol, got, want)
+		}
 	}
 }
 
 func TestDurableMounts(t *testing.T) {
-	got := durableMounts("data", []string{"/home/counter", "/var/data"})
+	got := durableMounts([]*ateompb.DurableDirVolumeMount{
+		{VolumeName: "data", MountPath: "/home/counter"},
+		{VolumeName: "data", MountPath: "/var/data"},
+		{VolumeName: "cache", MountPath: "/var/cache"},
+	})
+	// Each mount points at its own volume's subdirectory of the shared durable
+	// mount, and one volume may appear at several paths.
 	want := []specs.Mount{
-		{Destination: "/home/counter", Source: "/run/ateom-durable/data", Type: "bind", Options: []string{"rbind", "rw"}},
-		{Destination: "/var/data", Source: "/run/ateom-durable/data", Type: "bind", Options: []string{"rbind", "rw"}},
+		{Destination: "/home/counter", Source: kata.GuestDurableVolumeDir("data"), Type: "bind", Options: []string{"rbind", "rw"}},
+		{Destination: "/var/data", Source: kata.GuestDurableVolumeDir("data"), Type: "bind", Options: []string{"rbind", "rw"}},
+		{Destination: "/var/cache", Source: kata.GuestDurableVolumeDir("cache"), Type: "bind", Options: []string{"rbind", "rw"}},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("durableMounts() returned %d mounts, want %d", len(got), len(want))
@@ -183,48 +133,45 @@ func TestDurableMounts(t *testing.T) {
 			t.Errorf("mount %d = %+v, want %+v", i, got[i], want[i])
 		}
 	}
-	// The source must match what the agent mounts the durable share at.
-	if want[0].Source != kata.GuestDurableVolumeDir("data") {
-		t.Errorf("mount source %q does not match kata.GuestDurableVolumeDir", want[0].Source)
-	}
 }
 
 func TestWorkloadSpec(t *testing.T) {
 	base := []specs.Mount{{Destination: "/proc", Type: "proc", Source: "proc"}}
-	newContainer := func(paths []string) actorContainer {
+	newContainer := func(mounts ...*ateompb.DurableDirVolumeMount) actorContainer {
 		return actorContainer{
-			name:              "app",
-			spec:              &specs.Spec{Mounts: slices.Clone(base)},
-			durableMountPaths: paths,
+			name:          "app",
+			spec:          &specs.Spec{Mounts: slices.Clone(base)},
+			durableMounts: mounts,
 		}
 	}
 
-	t.Run("no durable volume returns the spec unchanged", func(t *testing.T) {
-		c := newContainer(nil)
-		if got := workloadSpec(c, ""); got != c.spec {
+	t.Run("container without durable mounts is unchanged", func(t *testing.T) {
+		c := newContainer()
+		if got := workloadSpec(c); got != c.spec {
 			t.Error("workloadSpec() copied the spec when there was nothing to add")
 		}
 	})
 
-	t.Run("container without mounts is unchanged", func(t *testing.T) {
-		c := newContainer(nil)
-		if got := workloadSpec(c, "data"); got != c.spec {
-			t.Error("workloadSpec() copied the spec for a container with no durable mounts")
+	t.Run("every durable volume is appended without mutating the source spec", func(t *testing.T) {
+		c := newContainer(
+			&ateompb.DurableDirVolumeMount{VolumeName: "data", MountPath: "/home/counter"},
+			&ateompb.DurableDirVolumeMount{VolumeName: "cache", MountPath: "/var/cache"},
+		)
+		got := workloadSpec(c)
+		if len(got.Mounts) != len(base)+2 {
+			t.Fatalf("workload spec has %d mounts, want %d", len(got.Mounts), len(base)+2)
 		}
-	})
-
-	t.Run("durable mounts are appended without mutating the source spec", func(t *testing.T) {
-		c := newContainer([]string{"/home/counter"})
-		got := workloadSpec(c, "data")
-		if len(got.Mounts) != len(base)+1 {
-			t.Fatalf("workload spec has %d mounts, want %d", len(got.Mounts), len(base)+1)
-		}
-		last := got.Mounts[len(got.Mounts)-1]
-		if last.Destination != "/home/counter" || last.Source != kata.GuestDurableVolumeDir("data") {
-			t.Errorf("appended mount = %+v, want the durable volume bound at /home/counter", last)
+		for i, want := range []specs.Mount{
+			{Destination: "/home/counter", Source: kata.GuestDurableVolumeDir("data")},
+			{Destination: "/var/cache", Source: kata.GuestDurableVolumeDir("cache")},
+		} {
+			appended := got.Mounts[len(base)+i]
+			if appended.Destination != want.Destination || appended.Source != want.Source {
+				t.Errorf("appended mount %d = %+v, want %s bound at %s", i, appended, want.Source, want.Destination)
+			}
 		}
 		// The prepared spec (shared with the carrier and the on-disk bundle) must
-		// not gain the bind.
+		// not gain the binds.
 		if len(c.spec.Mounts) != len(base) {
 			t.Errorf("source spec now has %d mounts, want %d", len(c.spec.Mounts), len(base))
 		}

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -127,10 +127,9 @@ type actorContainer struct {
 	name         string
 	bundleRootfs string
 	spec         *specs.Spec
-	// durableMountPaths are the in-container paths where this container mounts
-	// the actor's durable-dir volume (see durable.go). Empty for containers that
-	// declare none.
-	durableMountPaths []string
+	// durableMounts are the durable-dir volumes this container mounts, and where
+	// (see durable.go). Empty for containers that declare none.
+	durableMounts []*ateompb.DurableDirVolumeMount
 }
 
 // resolvedRuntime holds the concrete binary/config paths for a request, taken
@@ -313,14 +312,12 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 		}
 	}()
 
-	// Durable-dir volumes (if any) get their own writable virtio-fs share, served
-	// by a second virtiofsd from the host directory atelet prepared.
-	var durableVolume string
+	// Durable-dir volumes (if any) share one writable virtio-fs share, served by
+	// a second virtiofsd from the host directory atelet prepared; each volume is
+	// a subdirectory of it.
+	durable := hasDurableVolumes(containers)
 	var durableVfsdCmd *exec.Cmd
-	if hasDurableVolumes(containers) {
-		if durableVolume, err = resolveDurableVolumeName(ateompath.DurableDirVolumeMountsDir(actorUID)); err != nil {
-			return err
-		}
+	if durable {
 		if durableVfsdCmd, err = s.stageDurableShare(ctx, rr, actorUID); err != nil {
 			return err
 		}
@@ -355,7 +352,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	// writable upper is a guest tmpfs). serialLog is also read on a failed agent dial
 	// below, so keep it here.
 	serialLog := filepath.Join(kata.VMDir(actorUID), "serial.log")
-	vmCfg := buildVMConfig(actorUID, kernel, image, kparams, serialLog, memMiB, vcpus, durableVolume != "")
+	vmCfg := buildVMConfig(actorUID, kernel, image, kparams, serialLog, memMiB, vcpus, durable)
 	if err := client.CreateVM(ctx, vmCfg); err != nil {
 		return fmt.Errorf("while creating VM: %w", err)
 	}
@@ -411,7 +408,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	}()
 
 	// Post-boot kata-agent setup: sandbox, guest networking, start each container.
-	if err := s.startActorContainers(ctx, ac, actorUID, vsockPath, ctrs, durableVolume); err != nil {
+	if err := s.startActorContainers(ctx, ac, actorUID, vsockPath, ctrs, durable); err != nil {
 		return err
 	}
 
@@ -468,10 +465,10 @@ func (s *AteomService) buildActorContainers(actorUID string, containers []*ateom
 			return nil, fmt.Errorf("while writing guest resolv.conf for %q: %w", cn, err)
 		}
 		ctrs[i] = actorContainer{
-			name:              cn,
-			bundleRootfs:      bundleRootfs,
-			spec:              spec,
-			durableMountPaths: c.GetDurableDirVolumes(),
+			name:          cn,
+			bundleRootfs:  bundleRootfs,
+			spec:          spec,
+			durableMounts: c.GetDurableDirVolumeMounts(),
 		}
 	}
 	return ctrs, nil
@@ -578,15 +575,14 @@ func buildFsConfigs(id string, withDurable bool) []ch.FsConfig {
 // configure guest networking (eth0 IP/MAC/MTU + routes) once, then start each
 // container on its own overlay rootfs. On failure it dumps guest diagnostics.
 //
-// durableVolume is the actor's durable-dir volume name, or "" when it has none;
-// with one, the sandbox also mounts the writable durable share and each container
-// binds the volume at its declared paths.
-func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentClient, id, vsockPath string, ctrs []actorContainer, durableVolume string) error {
+// durable says the actor has durable-dir volumes: the sandbox then also mounts
+// the writable durable share, and each container binds the volumes it declared.
+func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentClient, id, vsockPath string, ctrs []actorContainer, durable bool) error {
 	// Establish the agent sandbox + the kataShared virtio-fs mount (the RO base for
 	// every container's overlay lower). All containers share it, so use the first
 	// container's hostname.
 	sbCtx, sbCancel := context.WithTimeout(ctx, 20*time.Second)
-	err := ac.CreateSandboxForActor(sbCtx, id, ctrs[0].spec.Hostname, durableVolume != "")
+	err := ac.CreateSandboxForActor(sbCtx, id, ctrs[0].spec.Hostname, durable)
 	sbCancel()
 	if err != nil {
 		return fmt.Errorf("while creating agent sandbox: %w", err)
@@ -604,7 +600,7 @@ func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentC
 	}
 
 	for _, c := range ctrs {
-		if err := startOverlayContainer(ctx, ac, vsockPath, c, durableVolume); err != nil {
+		if err := startOverlayContainer(ctx, ac, vsockPath, c); err != nil {
 			return err
 		}
 	}
@@ -619,7 +615,7 @@ func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentC
 // With a durable-dir volume, the WORKLOAD also binds it at the container's declared
 // mount paths. The carrier deliberately does not: its rootfs is the read-only lower,
 // where the agent could not create a missing mount point.
-func startOverlayContainer(ctx context.Context, ac *kata.AgentClient, vsockPath string, c actorContainer, durableVolume string) error {
+func startOverlayContainer(ctx context.Context, ac *kata.AgentClient, vsockPath string, c actorContainer) error {
 	carrierCtx, carrierCancel := context.WithTimeout(ctx, 30*time.Second)
 	err := ac.CreateCarrier(carrierCtx, c.name, c.spec)
 	carrierCancel()
@@ -631,7 +627,7 @@ func startOverlayContainer(ctx context.Context, ac *kata.AgentClient, vsockPath 
 
 	upperBase := kata.OverlayUpperBase(c.name)
 	wlCtx, wlCancel := context.WithTimeout(ctx, 30*time.Second)
-	err = ac.StartOverlayWorkload(wlCtx, c.name, overlayWorkloadID(c.name), upperBase, workloadSpec(c, durableVolume))
+	err = ac.StartOverlayWorkload(wlCtx, c.name, overlayWorkloadID(c.name), upperBase, workloadSpec(c))
 	wlCancel()
 	if err != nil {
 		dump := kata.DebugConsoleDump(ctx, vsockPath,

--- a/demos/counter/counter.go
+++ b/demos/counter/counter.go
@@ -62,6 +62,7 @@ func incrementFileCounter(filePath string) int {
 
 func main() {
 	fileCounterDirectory := pflag.String("file-counter-directory", "/home/counter", "Directory for file counter")
+	secondFileCounterDirectory := pflag.String("second-file-counter-directory", "", "Directory for a second file counter; empty disables it. Used to exercise an Actor with more than one durable volume")
 	validateExistingFilePath := pflag.String("validate-existing-file-path", "", "Path to existing file to validate reading")
 	pflag.Parse()
 	ctx := context.Background()
@@ -87,7 +88,15 @@ func main() {
 			fileContentStr = fmt.Sprintf(" | file content: %s", string(fileContent))
 		}
 
-		response := fmt.Sprintf("hello from: %s | preserved memory count: %d | preserved file counter: %d%s\n", currentIP, memoryCounter, fileCounter, fileContentStr)
+		// A second counter in another directory, so an Actor with more than one
+		// durable volume can show each of them persisting independently.
+		secondFileCounterStr := ""
+		if *secondFileCounterDirectory != "" {
+			secondFileCounter := incrementFileCounter(filepath.Join(*secondFileCounterDirectory, "a.txt"))
+			secondFileCounterStr = fmt.Sprintf(" | preserved second file counter: %d", secondFileCounter)
+		}
+
+		response := fmt.Sprintf("hello from: %s | preserved memory count: %d | preserved file counter: %d%s%s\n", currentIP, memoryCounter, fileCounter, secondFileCounterStr, fileContentStr)
 		slog.InfoContext(ctx, "Handled request", slog.String("response", response))
 
 		w.WriteHeader(http.StatusOK)

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -100,6 +100,7 @@ The `ActorTemplate` defines the code, environment, and state-management policies
 | `workerSelector` | `*LabelSelector` | Optional. Gates which `WorkerPool`s actors from this template may use, by matching against each pool's labels. If unset, all pools are eligible (subject to the actor's own `worker_selector`). |
 | `snapshotsConfig` | `SnapshotsConfig` | **Required.** GCS bucket and folder where memory snapshots are stored. |
 | `pauseImage` | `string` | **Required.** The image used for the sandbox root (e.g. `gcr.io/gke-release/pause`). |
+| `volumes` | `[]Volume` | Optional. Volumes the containers may mount, each either a `durableDir` or an `externalVolumeTemplate`. Every declared volume must be mounted by at least one container. A `microvm` template may declare several `durableDir` volumes; a `gvisor` template is limited to one, and `externalVolumeTemplate` is `gvisor`-only. |
 
 The sandbox binaries (e.g. the gVisor `runsc` binary) are **no longer configured on the `ActorTemplate`**. They are resolved from the referenced `WorkerPool`'s [`SandboxConfig`](#3-sandboxconfig-sandbox-binaries) — by name (`workerPool.spec.sandboxConfigName`) or, by default, the cluster default `SandboxConfig` for the pool's `sandboxClass`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,7 +338,7 @@ A `WorkerPool` selects a **sandbox class** (`spec.sandboxClass`), and each class
 
   * **gVisor** (`ateom-gvisor`, the default): Runs the workload under `runsc` for kernel-level sandboxing. Suspend and resume leverage gVisor's native checkpoint/restore of the sandboxed process tree.
 
-  * **micro-VM** (`ateom-microvm`): Runs the workload inside a [Kata Containers](https://katacontainers.io/) guest on the [Cloud Hypervisor](https://www.cloudhypervisor.org/) VMM. Suspend and resume capture a memory-only VM snapshot and restore it on-demand using `userfaultfd` memory demand-paging, with container rootfs writes captured in guest RAM via a `tmpfs` overlay. `DurableDir` volumes are host-backed instead, served over a second (writable) virtio-fs share and shipped in snapshots as a tar, so a `Data`-scope snapshot can capture them without any guest memory.
+  * **micro-VM** (`ateom-microvm`): Runs the workload inside a [Kata Containers](https://katacontainers.io/) guest on the [Cloud Hypervisor](https://www.cloudhypervisor.org/) VMM. Suspend and resume capture a memory-only VM snapshot and restore it on-demand using `userfaultfd` memory demand-paging, with container rootfs writes captured in guest RAM via a `tmpfs` overlay. `DurableDir` volumes are host-backed instead, served over a second (writable) virtio-fs share and shipped in snapshots as a tar, so a `Data`-scope snapshot can capture them without any guest memory. Each volume is a subdirectory of that one share, so an actor can have several at no extra cost in devices — which is why the micro-VM class lifts the single-`DurableDir` limit that still applies to gVisor.
 
 ### Networking Stack (`atenet` + Envoy)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -76,10 +76,15 @@ because they change too frequently for etcd.
 - **DurableDir volume**: a directory mounted into one or more containers
   whose contents are preserved by the [`Data` snapshot scope](#snapshots)
   and therefore survive across Suspend/Resume independently of process
-  memory or other rootfs writes. An `ActorTemplate` may declare one
-  `DurableDir` volume, and it may be mounted into multiple containers
-  (potentially at different paths). This is the per-Actor
+  memory or other rootfs writes. A volume may be mounted into multiple
+  containers, potentially at different paths. This is the per-Actor
   application-data surface.
+
+  How many an `ActorTemplate` may declare depends on its `sandboxClass`:
+  a `microvm` template may declare several (they are subdirectories of one
+  virtio-fs share, so they cost nothing extra per volume), while a `gvisor`
+  template is limited to one until gVisor can accept more than a single
+  durable mount.
 
 ## Snapshots
 

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -130,6 +130,53 @@ func TestDurableDirLifecycle(t *testing.T) {
 	}
 }
 
+// TestMultipleDurableDirLifecycle covers an Actor with TWO durable-dir volumes:
+// both must survive pause/resume and suspend/resume independently. Only the
+// micro-VM runtime supports more than one — gVisor templates are still capped at
+// one by the ActorTemplate CEL rules, so the template would be rejected there.
+func TestMultipleDurableDirLifecycle(t *testing.T) {
+	if !isMicroVMEnvironment() {
+		t.Skip("Skipping TestMultipleDurableDirLifecycle: multiple DurableDir volumes are micro-VM only")
+	}
+
+	tests := []struct {
+		name string
+		tc   actorLifecycleTestCase
+	}{
+		{
+			name: "onCommit:Full, onPause:Full",
+			tc: actorLifecycleTestCase{
+				onCommit:               v1alpha1.SnapshotScopeFull,
+				onPause:                v1alpha1.SnapshotScopeFull,
+				wantMemoryAfterPause:   2,
+				wantFileAfterPause:     2,
+				wantMemoryAfterSuspend: 3,
+				wantFileAfterSuspend:   3,
+				checkSecondFileCounter: true,
+			},
+		},
+		{
+			name: "onCommit:Data, onPause:Data",
+			tc: actorLifecycleTestCase{
+				onCommit:               v1alpha1.SnapshotScopeData,
+				onPause:                v1alpha1.SnapshotScopeData,
+				wantMemoryAfterPause:   1,
+				wantFileAfterPause:     2,
+				wantMemoryAfterSuspend: 1,
+				wantFileAfterSuspend:   3,
+				checkSecondFileCounter: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			runActorLifecycleTestCase(t, "multi-durabledir-lifecycle", createActorTemplateWithTwoDurableDirs, test.tc)
+		})
+	}
+}
+
 func TestExternalVolumeLifecycle(t *testing.T) {
 	if isMicroVMEnvironment() {
 		t.Skip("Skipping TestExternalVolumeLifecycle for microVM environment")
@@ -175,6 +222,12 @@ type actorLifecycleTestCase struct {
 	wantFileAfterPause     int
 	wantMemoryAfterSuspend int
 	wantFileAfterSuspend   int
+
+	// checkSecondFileCounter also asserts the counter kept in a SECOND durable
+	// volume. Both volumes are written on every request, so it must track the
+	// first counter exactly — if one volume were dropped or restored into the
+	// wrong place, they would diverge.
+	checkSecondFileCounter bool
 }
 
 func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(context.Context, *testing.T, *e2e.Clients, *e2e.Namespace, v1alpha1.SnapshotScope, v1alpha1.SnapshotScope) (*v1alpha1.ActorTemplate, error), tc actorLifecycleTestCase) {
@@ -228,6 +281,9 @@ func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(
 		t.Fatalf("failed to call actor: %v", err)
 	}
 	validateCounterResponse(t, resp, "after creation", 1, 1)
+	if tc.checkSecondFileCounter {
+		validateSecondFileCounter(t, resp, "after creation", 1)
+	}
 
 	//
 	// Pausing the actor
@@ -254,6 +310,9 @@ func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(
 		t.Fatalf("failed to call actor again: %v", err)
 	}
 	validateCounterResponse(t, resp, "after pause", tc.wantMemoryAfterPause, tc.wantFileAfterPause)
+	if tc.checkSecondFileCounter {
+		validateSecondFileCounter(t, resp, "after pause", tc.wantFileAfterPause)
+	}
 
 	//
 	// Suspending the actor
@@ -280,6 +339,19 @@ func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(
 		t.Fatalf("failed to call actor again: %v", err)
 	}
 	validateCounterResponse(t, resp, "after suspend", tc.wantMemoryAfterSuspend, tc.wantFileAfterSuspend)
+	if tc.checkSecondFileCounter {
+		validateSecondFileCounter(t, resp, "after suspend", tc.wantFileAfterSuspend)
+	}
+}
+
+// validateSecondFileCounter checks the counter the workload keeps in its second
+// durable-dir volume (see createActorTemplateWithTwoDurableDirs).
+func validateSecondFileCounter(t *testing.T, resp string, stage string, want int) {
+	t.Helper()
+	const prefix = "preserved second file counter: "
+	if !strings.Contains(resp, prefix+fmt.Sprintf("%d", want)) {
+		t.Errorf("[%s] expected second file count %d, got response: %s", stage, want, resp)
+	}
 }
 
 func validateCounterResponse(t *testing.T, resp string, stage string, wantMemory, wantFile int) {
@@ -675,6 +747,39 @@ func createActorTemplateWithExternalVolume(ctx context.Context, t *testing.T, cl
 		}
 	}
 	return createActorTemplateInternal(ctx, t, clients, nsObj, "counter-ext-vol", onCommit, onPause, modify)
+}
+
+// secondDurableDirVolume is the extra durable-dir volume (and where the counter
+// container mounts it) added by createActorTemplateWithTwoDurableDirs.
+const (
+	secondDurableDirVolume    = "data2"
+	secondDurableDirMountPath = "/home/counter2"
+)
+
+// createActorTemplateWithTwoDurableDirs builds a template with a SECOND
+// durable-dir volume alongside the one the demo already declares, and points the
+// counter's second file counter at it, so both volumes are written on every
+// request. Only the micro-VM runtime accepts this: gVisor templates are still
+// capped at one durable-dir volume by the ActorTemplate CEL rules.
+func createActorTemplateWithTwoDurableDirs(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *e2e.Namespace, onCommit, onPause v1alpha1.SnapshotScope) (*v1alpha1.ActorTemplate, error) {
+	modify := func(at *v1alpha1.ActorTemplate) {
+		for i, c := range at.Spec.Containers {
+			if c.Name != "counter" {
+				continue
+			}
+			c.Command = []string{"/ko-app/counter", "--second-file-counter-directory=" + secondDurableDirMountPath}
+			c.VolumeMounts = append(c.VolumeMounts, v1alpha1.VolumeMount{
+				Name:      secondDurableDirVolume,
+				MountPath: secondDurableDirMountPath,
+			})
+			at.Spec.Containers[i] = c
+		}
+		at.Spec.Volumes = append(at.Spec.Volumes, v1alpha1.Volume{
+			Name:         secondDurableDirVolume,
+			VolumeSource: v1alpha1.VolumeSource{DurableDir: &v1alpha1.DurableDirVolumeSource{}},
+		})
+	}
+	return createActorTemplateInternal(ctx, t, clients, nsObj, "counter-two-durabledirs", onCommit, onPause, modify)
 }
 
 func waitForActorStatus(ctx context.Context, t *testing.T, clients *e2e.Clients, actorName string, expectedStatus ateapipb.Actor_Status) {

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -240,12 +240,14 @@ func (x *WorkloadSpec) GetContainers() []*Container {
 }
 
 type Container struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	Name              string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Readyz            *Readyz                `protobuf:"bytes,2,opt,name=readyz,proto3" json:"readyz,omitempty"`
-	DurableDirVolumes []string               `protobuf:"bytes,3,rep,name=durable_dir_volumes,json=durableDirVolumes,proto3" json:"durable_dir_volumes,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Name   string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Readyz *Readyz                `protobuf:"bytes,2,opt,name=readyz,proto3" json:"readyz,omitempty"`
+	// durable_dir_volume_mounts are the durable-dir volumes this container
+	// mounts, if any.
+	DurableDirVolumeMounts []*DurableDirVolumeMount `protobuf:"bytes,4,rep,name=durable_dir_volume_mounts,json=durableDirVolumeMounts,proto3" json:"durable_dir_volume_mounts,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *Container) Reset() {
@@ -292,11 +294,67 @@ func (x *Container) GetReadyz() *Readyz {
 	return nil
 }
 
-func (x *Container) GetDurableDirVolumes() []string {
+func (x *Container) GetDurableDirVolumeMounts() []*DurableDirVolumeMount {
 	if x != nil {
-		return x.DurableDirVolumes
+		return x.DurableDirVolumeMounts
 	}
 	return nil
+}
+
+// DurableDirVolumeMount is one durable-dir volume mounted into a container.
+type DurableDirVolumeMount struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// volume_name is the name the ActorTemplate gave the volume. It selects the
+	// per-volume directory atelet prepared for the actor on the host.
+	VolumeName string `protobuf:"bytes,1,opt,name=volume_name,json=volumeName,proto3" json:"volume_name,omitempty"`
+	// mount_path is where the container sees the volume.
+	MountPath     string `protobuf:"bytes,2,opt,name=mount_path,json=mountPath,proto3" json:"mount_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DurableDirVolumeMount) Reset() {
+	*x = DurableDirVolumeMount{}
+	mi := &file_ateom_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DurableDirVolumeMount) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DurableDirVolumeMount) ProtoMessage() {}
+
+func (x *DurableDirVolumeMount) ProtoReflect() protoreflect.Message {
+	mi := &file_ateom_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DurableDirVolumeMount.ProtoReflect.Descriptor instead.
+func (*DurableDirVolumeMount) Descriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *DurableDirVolumeMount) GetVolumeName() string {
+	if x != nil {
+		return x.VolumeName
+	}
+	return ""
+}
+
+func (x *DurableDirVolumeMount) GetMountPath() string {
+	if x != nil {
+		return x.MountPath
+	}
+	return ""
 }
 
 // Readyz describes how to check that a container is ready to serve.
@@ -310,7 +368,7 @@ type Readyz struct {
 
 func (x *Readyz) Reset() {
 	*x = Readyz{}
-	mi := &file_ateom_proto_msgTypes[3]
+	mi := &file_ateom_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -322,7 +380,7 @@ func (x *Readyz) String() string {
 func (*Readyz) ProtoMessage() {}
 
 func (x *Readyz) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[3]
+	mi := &file_ateom_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -335,7 +393,7 @@ func (x *Readyz) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Readyz.ProtoReflect.Descriptor instead.
 func (*Readyz) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{3}
+	return file_ateom_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Readyz) GetHttpGet() *HTTPGetAction {
@@ -358,7 +416,7 @@ type HTTPGetAction struct {
 
 func (x *HTTPGetAction) Reset() {
 	*x = HTTPGetAction{}
-	mi := &file_ateom_proto_msgTypes[4]
+	mi := &file_ateom_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -370,7 +428,7 @@ func (x *HTTPGetAction) String() string {
 func (*HTTPGetAction) ProtoMessage() {}
 
 func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[4]
+	mi := &file_ateom_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -383,7 +441,7 @@ func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPGetAction.ProtoReflect.Descriptor instead.
 func (*HTTPGetAction) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{4}
+	return file_ateom_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *HTTPGetAction) GetPath() string {
@@ -408,7 +466,7 @@ type RunWorkloadResponse struct {
 
 func (x *RunWorkloadResponse) Reset() {
 	*x = RunWorkloadResponse{}
-	mi := &file_ateom_proto_msgTypes[5]
+	mi := &file_ateom_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -420,7 +478,7 @@ func (x *RunWorkloadResponse) String() string {
 func (*RunWorkloadResponse) ProtoMessage() {}
 
 func (x *RunWorkloadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[5]
+	mi := &file_ateom_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -433,7 +491,7 @@ func (x *RunWorkloadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunWorkloadResponse.ProtoReflect.Descriptor instead.
 func (*RunWorkloadResponse) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{5}
+	return file_ateom_proto_rawDescGZIP(), []int{6}
 }
 
 type CheckpointWorkloadRequest struct {
@@ -465,7 +523,7 @@ type CheckpointWorkloadRequest struct {
 
 func (x *CheckpointWorkloadRequest) Reset() {
 	*x = CheckpointWorkloadRequest{}
-	mi := &file_ateom_proto_msgTypes[6]
+	mi := &file_ateom_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -477,7 +535,7 @@ func (x *CheckpointWorkloadRequest) String() string {
 func (*CheckpointWorkloadRequest) ProtoMessage() {}
 
 func (x *CheckpointWorkloadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[6]
+	mi := &file_ateom_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -490,7 +548,7 @@ func (x *CheckpointWorkloadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckpointWorkloadRequest.ProtoReflect.Descriptor instead.
 func (*CheckpointWorkloadRequest) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{6}
+	return file_ateom_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CheckpointWorkloadRequest) GetAtespace() string {
@@ -575,7 +633,7 @@ type CheckpointWorkloadResponse struct {
 
 func (x *CheckpointWorkloadResponse) Reset() {
 	*x = CheckpointWorkloadResponse{}
-	mi := &file_ateom_proto_msgTypes[7]
+	mi := &file_ateom_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -587,7 +645,7 @@ func (x *CheckpointWorkloadResponse) String() string {
 func (*CheckpointWorkloadResponse) ProtoMessage() {}
 
 func (x *CheckpointWorkloadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[7]
+	mi := &file_ateom_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -600,7 +658,7 @@ func (x *CheckpointWorkloadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckpointWorkloadResponse.ProtoReflect.Descriptor instead.
 func (*CheckpointWorkloadResponse) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{7}
+	return file_ateom_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *CheckpointWorkloadResponse) GetSnapshotFiles() []string {
@@ -632,7 +690,7 @@ type RestoreWorkloadRequest struct {
 
 func (x *RestoreWorkloadRequest) Reset() {
 	*x = RestoreWorkloadRequest{}
-	mi := &file_ateom_proto_msgTypes[8]
+	mi := &file_ateom_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -644,7 +702,7 @@ func (x *RestoreWorkloadRequest) String() string {
 func (*RestoreWorkloadRequest) ProtoMessage() {}
 
 func (x *RestoreWorkloadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[8]
+	mi := &file_ateom_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -657,7 +715,7 @@ func (x *RestoreWorkloadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreWorkloadRequest.ProtoReflect.Descriptor instead.
 func (*RestoreWorkloadRequest) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{8}
+	return file_ateom_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RestoreWorkloadRequest) GetAtespace() string {
@@ -738,7 +796,7 @@ type RestoreWorkloadResponse struct {
 
 func (x *RestoreWorkloadResponse) Reset() {
 	*x = RestoreWorkloadResponse{}
-	mi := &file_ateom_proto_msgTypes[9]
+	mi := &file_ateom_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -750,7 +808,7 @@ func (x *RestoreWorkloadResponse) String() string {
 func (*RestoreWorkloadResponse) ProtoMessage() {}
 
 func (x *RestoreWorkloadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[9]
+	mi := &file_ateom_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -763,7 +821,7 @@ func (x *RestoreWorkloadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreWorkloadResponse.ProtoReflect.Descriptor instead.
 func (*RestoreWorkloadResponse) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{9}
+	return file_ateom_proto_rawDescGZIP(), []int{10}
 }
 
 var File_ateom_proto protoreflect.FileDescriptor
@@ -788,11 +846,16 @@ const file_ateom_proto_rawDesc = "" +
 	"\fWorkloadSpec\x120\n" +
 	"\n" +
 	"containers\x18\x01 \x03(\v2\x10.ateom.ContainerR\n" +
-	"containers\"v\n" +
+	"containers\"\xba\x01\n" +
 	"\tContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12%\n" +
-	"\x06readyz\x18\x02 \x01(\v2\r.ateom.ReadyzR\x06readyz\x12.\n" +
-	"\x13durable_dir_volumes\x18\x03 \x03(\tR\x11durableDirVolumes\"9\n" +
+	"\x06readyz\x18\x02 \x01(\v2\r.ateom.ReadyzR\x06readyz\x12W\n" +
+	"\x19durable_dir_volume_mounts\x18\x04 \x03(\v2\x1c.ateom.DurableDirVolumeMountR\x16durableDirVolumeMountsJ\x04\b\x03\x10\x04R\x13durable_dir_volumes\"W\n" +
+	"\x15DurableDirVolumeMount\x12\x1f\n" +
+	"\vvolume_name\x18\x01 \x01(\tR\n" +
+	"volumeName\x12\x1d\n" +
+	"\n" +
+	"mount_path\x18\x02 \x01(\tR\tmountPath\"9\n" +
 	"\x06Readyz\x12/\n" +
 	"\bhttp_get\x18\x01 \x01(\v2\x14.ateom.HTTPGetActionR\ahttpGet\"7\n" +
 	"\rHTTPGetAction\x12\x12\n" +
@@ -858,46 +921,48 @@ func file_ateom_proto_rawDescGZIP() []byte {
 }
 
 var file_ateom_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_ateom_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_ateom_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_ateom_proto_goTypes = []any{
 	(SnapshotScope)(0),                 // 0: ateom.SnapshotScope
 	(*RunWorkloadRequest)(nil),         // 1: ateom.RunWorkloadRequest
 	(*WorkloadSpec)(nil),               // 2: ateom.WorkloadSpec
 	(*Container)(nil),                  // 3: ateom.Container
-	(*Readyz)(nil),                     // 4: ateom.Readyz
-	(*HTTPGetAction)(nil),              // 5: ateom.HTTPGetAction
-	(*RunWorkloadResponse)(nil),        // 6: ateom.RunWorkloadResponse
-	(*CheckpointWorkloadRequest)(nil),  // 7: ateom.CheckpointWorkloadRequest
-	(*CheckpointWorkloadResponse)(nil), // 8: ateom.CheckpointWorkloadResponse
-	(*RestoreWorkloadRequest)(nil),     // 9: ateom.RestoreWorkloadRequest
-	(*RestoreWorkloadResponse)(nil),    // 10: ateom.RestoreWorkloadResponse
-	nil,                                // 11: ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
-	nil,                                // 12: ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
-	nil,                                // 13: ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
+	(*DurableDirVolumeMount)(nil),      // 4: ateom.DurableDirVolumeMount
+	(*Readyz)(nil),                     // 5: ateom.Readyz
+	(*HTTPGetAction)(nil),              // 6: ateom.HTTPGetAction
+	(*RunWorkloadResponse)(nil),        // 7: ateom.RunWorkloadResponse
+	(*CheckpointWorkloadRequest)(nil),  // 8: ateom.CheckpointWorkloadRequest
+	(*CheckpointWorkloadResponse)(nil), // 9: ateom.CheckpointWorkloadResponse
+	(*RestoreWorkloadRequest)(nil),     // 10: ateom.RestoreWorkloadRequest
+	(*RestoreWorkloadResponse)(nil),    // 11: ateom.RestoreWorkloadResponse
+	nil,                                // 12: ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
+	nil,                                // 13: ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
+	nil,                                // 14: ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
 }
 var file_ateom_proto_depIdxs = []int32{
 	2,  // 0: ateom.RunWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	11, // 1: ateom.RunWorkloadRequest.runtime_asset_paths:type_name -> ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
+	12, // 1: ateom.RunWorkloadRequest.runtime_asset_paths:type_name -> ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
 	3,  // 2: ateom.WorkloadSpec.containers:type_name -> ateom.Container
-	4,  // 3: ateom.Container.readyz:type_name -> ateom.Readyz
-	5,  // 4: ateom.Readyz.http_get:type_name -> ateom.HTTPGetAction
-	2,  // 5: ateom.CheckpointWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	12, // 6: ateom.CheckpointWorkloadRequest.runtime_asset_paths:type_name -> ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
-	0,  // 7: ateom.CheckpointWorkloadRequest.scope:type_name -> ateom.SnapshotScope
-	2,  // 8: ateom.RestoreWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	13, // 9: ateom.RestoreWorkloadRequest.runtime_asset_paths:type_name -> ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
-	0,  // 10: ateom.RestoreWorkloadRequest.scope:type_name -> ateom.SnapshotScope
-	1,  // 11: ateom.Ateom.RunWorkload:input_type -> ateom.RunWorkloadRequest
-	7,  // 12: ateom.Ateom.CheckpointWorkload:input_type -> ateom.CheckpointWorkloadRequest
-	9,  // 13: ateom.Ateom.RestoreWorkload:input_type -> ateom.RestoreWorkloadRequest
-	6,  // 14: ateom.Ateom.RunWorkload:output_type -> ateom.RunWorkloadResponse
-	8,  // 15: ateom.Ateom.CheckpointWorkload:output_type -> ateom.CheckpointWorkloadResponse
-	10, // 16: ateom.Ateom.RestoreWorkload:output_type -> ateom.RestoreWorkloadResponse
-	14, // [14:17] is the sub-list for method output_type
-	11, // [11:14] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	5,  // 3: ateom.Container.readyz:type_name -> ateom.Readyz
+	4,  // 4: ateom.Container.durable_dir_volume_mounts:type_name -> ateom.DurableDirVolumeMount
+	6,  // 5: ateom.Readyz.http_get:type_name -> ateom.HTTPGetAction
+	2,  // 6: ateom.CheckpointWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
+	13, // 7: ateom.CheckpointWorkloadRequest.runtime_asset_paths:type_name -> ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
+	0,  // 8: ateom.CheckpointWorkloadRequest.scope:type_name -> ateom.SnapshotScope
+	2,  // 9: ateom.RestoreWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
+	14, // 10: ateom.RestoreWorkloadRequest.runtime_asset_paths:type_name -> ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
+	0,  // 11: ateom.RestoreWorkloadRequest.scope:type_name -> ateom.SnapshotScope
+	1,  // 12: ateom.Ateom.RunWorkload:input_type -> ateom.RunWorkloadRequest
+	8,  // 13: ateom.Ateom.CheckpointWorkload:input_type -> ateom.CheckpointWorkloadRequest
+	10, // 14: ateom.Ateom.RestoreWorkload:input_type -> ateom.RestoreWorkloadRequest
+	7,  // 15: ateom.Ateom.RunWorkload:output_type -> ateom.RunWorkloadResponse
+	9,  // 16: ateom.Ateom.CheckpointWorkload:output_type -> ateom.CheckpointWorkloadResponse
+	11, // 17: ateom.Ateom.RestoreWorkload:output_type -> ateom.RestoreWorkloadResponse
+	15, // [15:18] is the sub-list for method output_type
+	12, // [12:15] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_ateom_proto_init() }
@@ -911,7 +976,7 @@ func file_ateom_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateom_proto_rawDesc), len(file_ateom_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -74,7 +74,24 @@ message WorkloadSpec {
 message Container {
   string name = 1;
   Readyz readyz = 2;
-  repeated string durable_dir_volumes = 3;
+
+  // Field 3 was durable_dir_volumes: the mount paths alone, which only worked
+  // while an actor was limited to a single durable-dir volume.
+  reserved 3;
+  reserved "durable_dir_volumes";
+
+  // durable_dir_volume_mounts are the durable-dir volumes this container
+  // mounts, if any.
+  repeated DurableDirVolumeMount durable_dir_volume_mounts = 4;
+}
+
+// DurableDirVolumeMount is one durable-dir volume mounted into a container.
+message DurableDirVolumeMount {
+  // volume_name is the name the ActorTemplate gave the volume. It selects the
+  // per-volume directory atelet prepared for the actor on the host.
+  string volume_name = 1;
+  // mount_path is where the container sees the volume.
+  string mount_path = 2;
 }
 
 // Readyz describes how to check that a container is ready to serve.

--- a/manifests/ate-install/generated/ate.dev_actortemplates.yaml
+++ b/manifests/ate-install/generated/ate.dev_actortemplates.yaml
@@ -421,13 +421,17 @@ spec:
             x-kubernetes-validations:
             - message: Spec is immutable
               rule: self == oldSelf
-            - message: At most one DurableDir-typed volume is supported per ActorTemplate
-              rule: '!has(self.volumes) || self.volumes.filter(v, has(v.durableDir)).size()
-                <= 1'
-            - message: A container may mount at most one DurableDir-typed volume
-              rule: '!has(self.containers) || self.containers.all(c, !has(c.volumeMounts)
+            - message: Only one DurableDir-typed volume is supported when sandboxClass
+                is 'gvisor'
+              rule: (has(self.sandboxClass) && self.sandboxClass == 'microvm') ||
+                !has(self.volumes) || self.volumes.filter(v, has(v.durableDir)).size()
+                <= 1
+            - message: A container may mount only one DurableDir-typed volume when
+                sandboxClass is 'gvisor'
+              rule: (has(self.sandboxClass) && self.sandboxClass == 'microvm') ||
+                !has(self.containers) || self.containers.all(c, !has(c.volumeMounts)
                 || c.volumeMounts.filter(vm, has(self.volumes) && self.volumes.exists(v,
-                v.name == vm.name && has(v.durableDir))).size() <= 1)'
+                v.name == vm.name && has(v.durableDir))).size() <= 1)
             - message: All volumes defined in spec.volumes must be mounted by at least
                 one container
               rule: '!has(self.volumes) || self.volumes.all(v, has(self.containers)

--- a/pkg/api/v1alpha1/actortemplate_types.go
+++ b/pkg/api/v1alpha1/actortemplate_types.go
@@ -294,8 +294,8 @@ type SnapshotsConfig struct {
 
 // ActorTemplateSpec defined desired spec of an actor.
 //
-// +kubebuilder:validation:XValidation:rule="!has(self.volumes) || self.volumes.filter(v, has(v.durableDir)).size() <= 1",message="At most one DurableDir-typed volume is supported per ActorTemplate"
-// +kubebuilder:validation:XValidation:rule="!has(self.containers) || self.containers.all(c, !has(c.volumeMounts) || c.volumeMounts.filter(vm, has(self.volumes) && self.volumes.exists(v, v.name == vm.name && has(v.durableDir))).size() <= 1)",message="A container may mount at most one DurableDir-typed volume"
+// +kubebuilder:validation:XValidation:rule="(has(self.sandboxClass) && self.sandboxClass == 'microvm') || !has(self.volumes) || self.volumes.filter(v, has(v.durableDir)).size() <= 1",message="Only one DurableDir-typed volume is supported when sandboxClass is 'gvisor'"
+// +kubebuilder:validation:XValidation:rule="(has(self.sandboxClass) && self.sandboxClass == 'microvm') || !has(self.containers) || self.containers.all(c, !has(c.volumeMounts) || c.volumeMounts.filter(vm, has(self.volumes) && self.volumes.exists(v, v.name == vm.name && has(v.durableDir))).size() <= 1)",message="A container may mount only one DurableDir-typed volume when sandboxClass is 'gvisor'"
 // +kubebuilder:validation:XValidation:rule="!has(self.volumes) || self.volumes.all(v, has(self.containers) && self.containers.exists(c, has(c.volumeMounts) && c.volumeMounts.exists(vm, vm.name == v.name)))",message="All volumes defined in spec.volumes must be mounted by at least one container"
 // +kubebuilder:validation:XValidation:rule="!has(self.sandboxClass) || self.sandboxClass != 'microvm' || !has(self.volumes) || !self.volumes.exists(v, has(v.externalVolumeTemplate))",message="ExternalVolumes are not supported when sandboxClass is 'microvm'"
 type ActorTemplateSpec struct {

--- a/pkg/api/v1alpha1/actortemplate_validation_test.go
+++ b/pkg/api/v1alpha1/actortemplate_validation_test.go
@@ -572,7 +572,7 @@ func TestActorTemplateValidation(t *testing.T) {
 		},
 		wantErr: false,
 	}, {
-		name: "Volumes: 2 DurableDir volumes in template is invalid",
+		name: "Volumes: 2 DurableDir volumes in template is invalid for gvisor",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.Volumes = []Volume{
 				{Name: "vol1", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
@@ -584,9 +584,9 @@ func TestActorTemplateValidation(t *testing.T) {
 			}
 		},
 		wantErr: true,
-		errMsg:  "At most one DurableDir-typed volume is supported per ActorTemplate",
+		errMsg:  "Only one DurableDir-typed volume is supported when sandboxClass is 'gvisor'",
 	}, {
-		name: "Volumes: 2 DurableDir volumes spread across containers is invalid",
+		name: "Volumes: 2 DurableDir volumes spread across containers is invalid for gvisor",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.Volumes = []Volume{
 				{Name: "vol1", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
@@ -604,9 +604,9 @@ func TestActorTemplateValidation(t *testing.T) {
 			}
 		},
 		wantErr: true,
-		errMsg:  "At most one DurableDir-typed volume is supported per ActorTemplate",
+		errMsg:  "Only one DurableDir-typed volume is supported when sandboxClass is 'gvisor'",
 	}, {
-		name: "Volumes: same DurableDir volume mounted twice in one container is invalid",
+		name: "Volumes: same DurableDir volume mounted twice in one container is invalid for gvisor",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.Volumes = []Volume{
 				{Name: "vol1", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
@@ -617,7 +617,7 @@ func TestActorTemplateValidation(t *testing.T) {
 			}
 		},
 		wantErr: true,
-		errMsg:  "A container may mount at most one DurableDir-typed volume",
+		errMsg:  "A container may mount only one DurableDir-typed volume when sandboxClass is 'gvisor'",
 	}, {
 		name: "Volumes: same DurableDir volume mounted across two containers is valid",
 		mutate: func(at *ActorTemplate) {
@@ -1006,6 +1006,53 @@ func TestActorTemplateValidation(t *testing.T) {
 			}
 			at.Spec.Containers[0].VolumeMounts = []VolumeMount{
 				{Name: "vol1", MountPath: "/home/user"},
+			}
+		},
+		wantErr: false,
+	}, {
+		name: "Volumes: 2 DurableDir volumes with SandboxClass microvm is valid",
+		mutate: func(at *ActorTemplate) {
+			at.Spec.SandboxClass = SandboxClassMicroVM
+			at.Spec.Volumes = []Volume{
+				{Name: "vol1", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
+				{Name: "vol2", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
+			}
+			at.Spec.Containers[0].VolumeMounts = []VolumeMount{
+				{Name: "vol1", MountPath: "/home1"},
+				{Name: "vol2", MountPath: "/home2"},
+			}
+		},
+		wantErr: false,
+	}, {
+		name: "Volumes: 2 DurableDir volumes spread across containers with SandboxClass microvm is valid",
+		mutate: func(at *ActorTemplate) {
+			at.Spec.SandboxClass = SandboxClassMicroVM
+			at.Spec.Volumes = []Volume{
+				{Name: "vol1", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
+				{Name: "vol2", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
+			}
+			at.Spec.Containers = append(at.Spec.Containers, Container{
+				Name:  "sidecar",
+				Image: "busybox@sha256:326e0e090a9a4057e62a1b94236e7a2df2f2f76722f67232e0e47854e4df9c53",
+				VolumeMounts: []VolumeMount{
+					{Name: "vol2", MountPath: "/home2"},
+				},
+			})
+			at.Spec.Containers[0].VolumeMounts = []VolumeMount{
+				{Name: "vol1", MountPath: "/home1"},
+			}
+		},
+		wantErr: false,
+	}, {
+		name: "Volumes: same DurableDir volume mounted twice in one container with SandboxClass microvm is valid",
+		mutate: func(at *ActorTemplate) {
+			at.Spec.SandboxClass = SandboxClassMicroVM
+			at.Spec.Volumes = []Volume{
+				{Name: "vol1", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
+			}
+			at.Spec.Containers[0].VolumeMounts = []VolumeMount{
+				{Name: "vol1", MountPath: "/home1"},
+				{Name: "vol1", MountPath: "/home2"},
 			}
 		},
 		wantErr: false,


### PR DESCRIPTION
An ActorTemplate could declare only one durable-dir volume, and mount it into a container only once. 

That is a gVisor limit, not a general one: atelet declares the mount to gVisor through a single hardcoded annotation key ("dev.gvisor.spec.mount.durabledir"), so a second volume would silently overwrite the first. 

This is being worked on.

The micro-VM runtime has no such constraint. Every volume is a subdirectory of the one writable virtio-fs share, and the snapshot tar already archives that directory whole, so N volumes cost a subdirectory each and round-trip through checkpoint/restore untouched.

What was actually missing was the volume name.
`ateom` received mount paths alone, so it inferred the single name by listing atelet's directory. 

We now carry each mount's name on the wire (`Container.durable_dir_volume_mounts`) and delete the inference. 

A container's binds now come from its own mounts, and the actor-wide "has a durable share" question collapses to a bool.

Fixes https://github.com/agent-substrate/substrate/issues/647

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
