### PR TITLE
imagecache: record layer sizes at unpack and image last-use on cache hit

### DIFF
--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -78,7 +78,10 @@ const (
 	layerFinalizedMarkerName = "finalized"
 	// layerSizeFileName holds the layer's byte count, recorded at unpack so
 	// sizing the pool never walks a tree. Absent for layers unpacked by
-	// older atelets (backfilled lazily, see layerSize).
+	// older atelets (backfilled lazily, see layerSize). An estimate: the
+	// value is the tar-stream length when written at unpack, or the summed
+	// file sizes when backfilled, so it may differ from disk usage and
+	// across nodes.
 	layerSizeFileName = "size"
 
 	// layerPullConcurrency bounds concurrent layer download+unpack streams per

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -108,8 +108,8 @@ type Store struct {
 	layerSF singleflight.Group
 
 	// hitMu makes the hit path's record read + last-use touch atomic with
-	// respect to eviction (#463 Phase 2), which will hold it exclusive
-	// around record removal. No exclusive holder yet, so effectively free.
+	// respect to eviction, which will hold it exclusive around record
+	// removal. No exclusive holder yet, so effectively free.
 	hitMu sync.RWMutex
 }
 
@@ -270,7 +270,7 @@ func (s *Store) EnsureImage(ctx context.Context, ref string) (*Image, error) {
 	s.hitMu.RLock()
 	img, err := s.cachedImage(digest)
 	if err == nil && img != nil {
-		// Record last-use for eviction's LRU ordering (#463 Phase 2).
+		// Record last-use for eviction's LRU ordering.
 		s.touchRecord(digest)
 	}
 	s.hitMu.RUnlock()

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -56,7 +56,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -74,6 +76,10 @@ const (
 	layerFSDirName           = "fs"
 	layerWhiteoutsFileName   = "whiteouts.json"
 	layerFinalizedMarkerName = "finalized"
+	// layerSizeFileName holds the layer's byte count, recorded at unpack so
+	// sizing the pool never walks a tree. Absent for layers unpacked by
+	// older atelets (backfilled lazily, see layerSize).
+	layerSizeFileName = "size"
 
 	// layerPullConcurrency bounds concurrent layer download+unpack streams per
 	// image pull. Memory use is O(stream buffers) per slot, independent of
@@ -100,6 +106,11 @@ type Store struct {
 
 	imageSF singleflight.Group
 	layerSF singleflight.Group
+
+	// hitMu makes the hit path's record read + last-use touch atomic with
+	// respect to eviction (#463 Phase 2), which will hold it exclusive
+	// around record removal. No exclusive holder yet, so effectively free.
+	hitMu sync.RWMutex
 }
 
 // Option configures a Store.
@@ -256,9 +267,17 @@ func (s *Store) EnsureImage(ctx context.Context, ref string) (*Image, error) {
 		digest = desc.Digest
 	}
 
-	if img, err := s.cachedImage(digest); err != nil {
+	s.hitMu.RLock()
+	img, err := s.cachedImage(digest)
+	if err == nil && img != nil {
+		// Record last-use for eviction's LRU ordering (#463 Phase 2).
+		s.touchRecord(digest)
+	}
+	s.hitMu.RUnlock()
+	if err != nil {
 		return nil, err
-	} else if img != nil {
+	}
+	if img != nil {
 		slog.InfoContext(ctx, "Image cache hit", slog.String("ref", ref), slog.String("digest", digest.String()))
 		return img, nil
 	}
@@ -430,9 +449,18 @@ func (s *Store) unpackLayerToPool(ctx context.Context, diffID v1.Hash, layer v1.
 	}
 	defer root.Close()
 
-	wh, err := unpackLayer(ctx, rc, root)
+	// The uncompressed tar stream is the recorded size: an optimistic
+	// estimate (tar framing vs. block rounding), cheap to capture here.
+	cr := &countingReader{r: rc}
+	wh, err := unpackLayer(ctx, cr, root)
 	if err != nil {
 		return err
+	}
+	// Non-fatal: a missing size file is recovered by layerSize's backfill,
+	// so a metadata write must not discard a successful unpack.
+	if err := os.WriteFile(filepath.Join(tmp, layerSizeFileName), []byte(strconv.FormatInt(cr.n, 10)+"\n"), 0o600); err != nil {
+		slog.WarnContext(ctx, "Failed to record layer size; will backfill lazily",
+			slog.String("diffid", diffID.String()), slog.Any("err", err))
 	}
 
 	whBytes, err := json.Marshal(wh)

--- a/internal/imagecache/sizes.go
+++ b/internal/imagecache/sizes.go
@@ -71,7 +71,9 @@ func (s *Store) layerSize(layerDir string) (int64, error) {
 
 	var total int64
 	fsRoot := filepath.Join(layerDir, layerFSDirName)
-	err = filepath.WalkDir(fsRoot, func(p string, d fs.DirEntry, err error) error {
+	// The callback swallows every error (skip-and-under-count contract),
+	// so WalkDir cannot return one.
+	_ = filepath.WalkDir(fsRoot, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			// Images legitimately ship unreadable dirs (0111, 0000) and
 			// atelet lacks CAP_DAC_READ_SEARCH, so skip and under-count
@@ -88,9 +90,6 @@ func (s *Store) layerSize(layerDir string) (int64, error) {
 		}
 		return nil
 	})
-	if err != nil {
-		return 0, fmt.Errorf("while backfilling size of %q: %w", layerDir, err)
-	}
 	// Preserve the dir mtime (the eviction age signal) across the write.
 	if fi, statErr := os.Stat(layerDir); statErr == nil {
 		if err := os.WriteFile(filepath.Join(layerDir, layerSizeFileName), []byte(strconv.FormatInt(total, 10)+"\n"), 0o600); err == nil {

--- a/internal/imagecache/sizes.go
+++ b/internal/imagecache/sizes.go
@@ -14,11 +14,10 @@
 
 package imagecache
 
-// Size accounting and last-use recording: the data foundations for
-// eviction (Phase 2 of
-// https://github.com/agent-substrate/substrate/issues/463). Both facts
-// live in the filesystem — a per-layer "size" file and the image record's
-// mtime — so they survive atelet restarts without in-memory state.
+// Size accounting and last-use recording: the data foundations for cache
+// eviction. Both facts live in the filesystem — a per-layer "size" file
+// and the image record's mtime — so they survive atelet restarts without
+// in-memory state.
 
 import (
 	"errors"

--- a/internal/imagecache/sizes.go
+++ b/internal/imagecache/sizes.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagecache
+
+// Size accounting and last-use recording: the data foundations for
+// eviction (Phase 2 of
+// https://github.com/agent-substrate/substrate/issues/463). Both facts
+// live in the filesystem — a per-layer "size" file and the image record's
+// mtime — so they survive atelet restarts without in-memory state.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// countingReader counts bytes read through it.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+// touchRecord refreshes the record's mtime (the persisted last-use
+// timestamp). Best-effort: a failed touch only costs LRU accuracy.
+func (s *Store) touchRecord(digest v1.Hash) {
+	now := time.Now()
+	if err := os.Chtimes(s.recordPath(digest), now, now); err != nil && !errors.Is(err, os.ErrNotExist) {
+		slog.Warn("Failed to touch image record", slog.String("digest", digest.String()), slog.Any("err", err))
+	}
+}
+
+// layerSize returns the layer's recorded byte count, backfilling the size
+// file for layers unpacked before sizes were recorded.
+func (s *Store) layerSize(layerDir string) (int64, error) {
+	b, err := os.ReadFile(filepath.Join(layerDir, layerSizeFileName))
+	if err == nil {
+		n, perr := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+		if perr == nil {
+			return n, nil
+		}
+		// Corrupt size file: fall through to backfill.
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("while reading layer size: %w", err)
+	}
+
+	var total int64
+	fsRoot := filepath.Join(layerDir, layerFSDirName)
+	err = filepath.WalkDir(fsRoot, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Images legitimately ship unreadable dirs (0111, 0000) and
+			// atelet lacks CAP_DAC_READ_SEARCH, so skip and under-count
+			// rather than abort.
+			if p != fsRoot && d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Type().IsRegular() {
+			if info, err := d.Info(); err == nil {
+				total += info.Size()
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("while backfilling size of %q: %w", layerDir, err)
+	}
+	// Preserve the dir mtime (the eviction age signal) across the write.
+	if fi, statErr := os.Stat(layerDir); statErr == nil {
+		if err := os.WriteFile(filepath.Join(layerDir, layerSizeFileName), []byte(strconv.FormatInt(total, 10)+"\n"), 0o600); err == nil {
+			_ = os.Chtimes(layerDir, fi.ModTime(), fi.ModTime())
+		}
+	}
+	return total, nil
+}
+
+// CacheSize returns the sum of recorded sizes of every layer in the pool
+// (the accounting behind --image-cache-max-bytes, distinct from volume
+// usage).
+func (s *Store) CacheSize() (int64, error) {
+	entries, err := os.ReadDir(s.layersDir())
+	if err != nil {
+		return 0, fmt.Errorf("while listing layer pool: %w", err)
+	}
+	var total int64
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") || !e.IsDir() {
+			continue
+		}
+		n, err := s.layerSize(filepath.Join(s.layersDir(), e.Name()))
+		if err != nil {
+			slog.Warn("Failed to size layer", slog.String("layer", e.Name()), slog.Any("err", err))
+			continue
+		}
+		total += n
+	}
+	return total, nil
+}

--- a/internal/imagecache/sizes_test.go
+++ b/internal/imagecache/sizes_test.go
@@ -90,6 +90,21 @@ func TestLayerSizeRecordedAndBackfilled(t *testing.T) {
 		t.Errorf("backfill changed the layer dir mtime (the eviction age signal): %v -> %v", before.ModTime(), after.ModTime())
 	}
 
+	// Corrupt size file: healed the same way as a missing one.
+	if err := os.WriteFile(sizePath, []byte("not-a-number\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	repaired, err := store.layerSize(img.LayerDirs[0])
+	if err != nil {
+		t.Fatalf("layerSize on corrupt size file: %v", err)
+	}
+	if repaired < 4096 {
+		t.Errorf("layerSize = %d, want >= 4096: corrupt file not healed by backfill", repaired)
+	}
+	if b, _ := os.ReadFile(sizePath); strings.TrimSpace(string(b)) == "not-a-number" {
+		t.Error("backfill did not overwrite the corrupt size file")
+	}
+
 	if total, err := store.CacheSize(); err != nil || total < refilled {
 		t.Errorf("CacheSize() = %d, %v; want >= %d", total, err, refilled)
 	}

--- a/internal/imagecache/sizes_test.go
+++ b/internal/imagecache/sizes_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagecache
+
+import (
+	"archive/tar"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// backdate shifts path's mtime age into the past.
+func backdate(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	past := time.Now().Add(-age)
+	if err := os.Chtimes(path, past, past); err != nil {
+		t.Fatalf("backdating %q: %v", path, err)
+	}
+}
+
+func mustEnsure(t *testing.T, s *Store, ref string) *Image {
+	t.Helper()
+	img, err := s.EnsureImage(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("EnsureImage(%q): %v", ref, err)
+	}
+	return img
+}
+
+func TestLayerSizeRecordedAndBackfilled(t *testing.T) {
+	_, host := newTestRegistry(t)
+	ref := host + "/test/sized:latest"
+	pushImage(t, ref, v1.Config{}, layerFromEntries(t, []tarEntry{
+		{name: "data", typeflag: tar.TypeReg, mode: 0o644, body: strings.Repeat("x", 4096)},
+	}))
+
+	store := newTestStore(t)
+	img := mustEnsure(t, store, ref)
+
+	sizePath := filepath.Join(img.LayerDirs[0], layerSizeFileName)
+	if _, err := os.Stat(sizePath); err != nil {
+		t.Fatalf("size file not written at unpack: %v", err)
+	}
+	recorded, err := store.layerSize(img.LayerDirs[0])
+	if err != nil {
+		t.Fatalf("layerSize: %v", err)
+	}
+	if recorded < 4096 {
+		t.Errorf("recorded size = %d, want >= 4096 (content bytes)", recorded)
+	}
+
+	// Backfill: delete the size file (simulating a pre-size-file layer) and
+	// backdate the dir, since the delete itself bumps its mtime. Backfill
+	// counts file content bytes, so it may be smaller than the unpack-time
+	// tar-stream count; both are valid optimistic estimates.
+	if err := os.Remove(sizePath); err != nil {
+		t.Fatal(err)
+	}
+	backdate(t, img.LayerDirs[0], time.Hour)
+	before, _ := os.Stat(img.LayerDirs[0])
+	refilled, err := store.layerSize(img.LayerDirs[0])
+	if err != nil {
+		t.Fatalf("layerSize backfill: %v", err)
+	}
+	if refilled < 4096 {
+		t.Errorf("backfilled size = %d, want >= 4096", refilled)
+	}
+	if _, err := os.Stat(sizePath); err != nil {
+		t.Errorf("backfill did not rewrite the size file: %v", err)
+	}
+	after, _ := os.Stat(img.LayerDirs[0])
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("backfill changed the layer dir mtime (the eviction age signal): %v -> %v", before.ModTime(), after.ModTime())
+	}
+
+	if total, err := store.CacheSize(); err != nil || total < refilled {
+		t.Errorf("CacheSize() = %d, %v; want >= %d", total, err, refilled)
+	}
+}
+
+func TestEnsureImageHitTouchesRecord(t *testing.T) {
+	_, host := newTestRegistry(t)
+	ref := host + "/test/touch:latest"
+	pushImage(t, ref, v1.Config{}, layerFromEntries(t, []tarEntry{
+		{name: "f", typeflag: tar.TypeReg, mode: 0o644, body: "hi"},
+	}))
+
+	store := newTestStore(t)
+	img := mustEnsure(t, store, ref)
+
+	recPath := store.recordPath(img.Digest)
+	backdate(t, recPath, time.Hour)
+	stale, _ := os.Stat(recPath)
+
+	mustEnsure(t, store, ref) // cache hit
+	fresh, _ := os.Stat(recPath)
+	if !fresh.ModTime().After(stale.ModTime()) {
+		t.Errorf("cache hit did not advance record mtime: %v -> %v", stale.ModTime(), fresh.ModTime())
+	}
+}
+
+func TestLayerSizeBackfillSkipsUnreadableDirs(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root with CAP_DAC_READ_SEARCH can list mode-0111 dirs")
+	}
+	store := newTestStore(t)
+
+	dir := filepath.Join(store.layersDir(), strings.Repeat("11", 32))
+	fsDir := filepath.Join(dir, layerFSDirName)
+	readable := filepath.Join(fsDir, "usr")
+	inner := filepath.Join(fsDir, "opt", "secret")
+	for _, d := range []string{readable, inner} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(readable, "blob"), make([]byte, 4096), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inner, "blob"), make([]byte, 8192), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A layer that ships a search-only dir, as some distro images do.
+	if err := os.Chmod(inner, 0o111); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(inner, 0o700) })
+
+	// The contract is "never abort, count what is countable": the 0111
+	// content cannot be enumerated without CAP_DAC_READ_SEARCH (atelet
+	// drops it), and chmod'ing the shared pool would change metadata
+	// running actors see through overlayfs. Under-counting is the correct
+	// outcome; aborting would make CacheSize credit the layer nothing.
+	got, err := store.layerSize(dir)
+	if err != nil {
+		t.Errorf("layerSize aborted on a layer with an unreadable subdir: %v", err)
+	}
+	if got < 4096 {
+		t.Errorf("layerSize = %d, want >= 4096: readable content was not counted", got)
+	}
+
+	// The size file must still be written, so the walk happens once ever.
+	if _, err := os.Stat(filepath.Join(dir, layerSizeFileName)); err != nil {
+		t.Errorf("backfill did not persist a size file: %v", err)
+	}
+	total, err := store.CacheSize()
+	if err != nil {
+		t.Fatalf("CacheSize: %v", err)
+	}
+	if total < 4096 {
+		t.Errorf("CacheSize = %d, want >= 4096: layer omitted from the pool total", total)
+	}
+}


### PR DESCRIPTION
First slice of #463 Phase 2 (GC): the two facts eviction will need, persisted in the
filesystem so they survive atelet restarts. Inert on its own — no behavior change for
any current caller, and nothing deletes anything.

- **Layer sizes**: unpack counts the uncompressed tar stream and writes a per-layer
  `size` file before the atomic rename (best-effort; a missing file is healed by a
  lazy backfill). Backfill covers layers unpacked by older atelets: one walk, once
  ever, skipping unreadable dirs (atelet has no `CAP_DAC_READ_SEARCH`) and preserving
  the dir mtime.
- **Last use**: cache hits touch the image record's mtime — the persisted LRU
  timestamp — under a new `hitMu` (shared side only; the eviction pass will be its
  exclusive holder).
- **`Store.CacheSize()`**: sums recorded sizes; the accounting behind the future
  `--image-cache-max-bytes`.

On-disk changes are purely additive, so no cache-layout version bump and no
migration: an older atelet reads this cache dir fine (ignores `size` files), and
this atelet reads a pre-upgrade dir fine (backfill). Rollback-safe.

**Testing**: unit tests for size recording, backfill (incl. the unreadable-dir
contract and mtime preservation), hit-path touch, and `CacheSize`; `go test -race`
green standalone; the demo e2e suite passes unchanged on Kind against this build,
with `size` files and record-mtime updates verified on the node.
