### PR TITLE
e2e,ci: keep a failed run's namespaces and dump their worker logs

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -114,12 +114,20 @@ jobs:
       if: failure()
       run: |
         kubectl --context kind-kind get actortemplate,workerpool,pods -A -o wide || true
-        for ns in ate-demo-counter-microvm ate-demo-counter ate-system; do
-          for p in $(kubectl --context kind-kind get pods -n "$ns" -o name 2>/dev/null); do
-            echo "=== logs: $ns/$p ==="
-            kubectl --context kind-kind logs -n "$ns" "$p" --all-containers --tail=200 2>/dev/null || true
-          done
+        dump() {
+          echo "=== logs: $1/$2 ==="
+          kubectl --context kind-kind logs -n "$1" "$2" --all-containers --tail=300 2>/dev/null || true
+        }
+        for p in $(kubectl --context kind-kind get pods -n ate-system -o name 2>/dev/null); do
+          dump ate-system "$p"
         done
+        # Every worker pod in any namespace: the demo pools plus the e2e suites'
+        # randomly-named per-test namespaces, which the suites keep on failure.
+        # The failing actor runs in one of these, so this is where its ateom logs
+        # (and, for a micro-VM worker, the guest console tail) live.
+        kubectl --context kind-kind get pods -A -l ate.dev/worker-pool \
+          -o 'custom-columns=:.metadata.namespace,:.metadata.name' --no-headers 2>/dev/null \
+          | while read -r ns name; do dump "$ns" "$name"; done
   e2e-test:
     runs-on: ubuntu-latest
     needs: e2e-test-matrix

--- a/hack/cleanup-e2e.sh
+++ b/hack/cleanup-e2e.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+# Deletes the namespaces a failed e2e run left behind.
+#
+# A failed suite keeps its namespaces so the worker pods — and the ateom logs
+# inside them, which is where an actor failure is actually explained — survive
+# long enough to read (see RetainNamespaces in internal/e2e/namespace.go).
+# Nothing reclaims them afterwards, and each holds a WorkerPool's worth of
+# running pods, so run this once the logs have served their purpose.
+#
+# This deletes EVERY e2e namespace in the cluster, so don't run it while a suite
+# is running.
+#
+# Env: KUBECTL_CONTEXT (optional) kube context to target; KIND_CLUSTER_NAME
+# (optional) shorthand for the matching kind context.
+
+if [[ -z "${KUBECTL_CONTEXT:-}" && -n "${KIND_CLUSTER_NAME:-}" ]]; then
+  KUBECTL_CONTEXT="kind-${KIND_CLUSTER_NAME}"
+fi
+kubectl_args=()
+if [[ -n "${KUBECTL_CONTEXT:-}" ]]; then
+  kubectl_args+=("--context=${KUBECTL_CONTEXT}")
+fi
+
+# The label CreateNamespace stamps on every namespace the suites create.
+selector="ate.dev/e2e"
+
+leftover="$(kubectl "${kubectl_args[@]}" get namespaces -l "${selector}" -o name)"
+if [[ -z "${leftover}" ]]; then
+  echo "No leftover e2e namespaces."
+  exit 0
+fi
+
+echo "Deleting leftover e2e namespaces:"
+echo "${leftover}"
+kubectl "${kubectl_args[@]}" delete namespaces -l "${selector}" --ignore-not-found

--- a/internal/e2e/README.md
+++ b/internal/e2e/README.md
@@ -22,6 +22,24 @@ The e2e tests assume you have a cluster set up with Agent Substrate installed,
 for example via `hack/install-ate.sh --deploy-ate-system` or
 `hack/install-ate-kind.sh --deploy-ate-system`.
 
+## After a failure
+
+A suite deletes the namespaces it created only when it passed. A failed run
+keeps them, because the failure is usually explained inside a worker pod (the
+ateom logs, and for a micro-VM worker the guest's console tail), and deleting
+the namespace takes those pods with it:
+
+```shell
+$ kubectl logs -n <kept-namespace> <worker-pod>
+```
+
+Nothing reclaims them afterwards, and each namespace holds a WorkerPool's worth
+of running pods, so clean up once you are done reading:
+
+```shell
+$ hack/cleanup-e2e.sh   # deletes every namespace labeled ate.dev/e2e
+```
+
 ## Creating a new test suite
 
 Copy `testmain_test.go` from `internal/e2e/suites/example` into your new suite. It will

--- a/internal/e2e/namespace.go
+++ b/internal/e2e/namespace.go
@@ -29,6 +29,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// NamespaceLabel marks the namespaces the suites create, so leftovers from a
+// failed run (which are kept deliberately — see RetainNamespaces) can be found
+// and deleted later: `kubectl delete ns -l ate.dev/e2e`, or hack/cleanup-e2e.sh.
+const NamespaceLabel = "ate.dev/e2e"
+
 var (
 	namespacesToCleanup []string
 	namespacesMu        sync.Mutex
@@ -85,7 +90,8 @@ func CreateNamespace(t *testing.T) *Namespace {
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: nsName,
+			Name:   nsName,
+			Labels: map[string]string{NamespaceLabel: "true"},
 		},
 	}
 
@@ -121,6 +127,24 @@ func (ns *Namespace) Delete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to delete namespace %s: %v", ns.Name, err)
 	}
+}
+
+// RetainNamespaces leaves the registered namespaces in the cluster and reports
+// them, instead of deleting them. Used when the suite failed: the namespaces'
+// worker pods hold the ateom (and, for micro-VM workers, guest) logs a
+// post-mortem needs, and they are deleted long before anyone can read them.
+func RetainNamespaces() {
+	namespacesMu.Lock()
+	defer namespacesMu.Unlock()
+
+	if len(namespacesToCleanup) == 0 {
+		return
+	}
+
+	fmt.Printf("Tests failed: keeping %d namespace(s) for diagnosis: %s\n",
+		len(namespacesToCleanup), strings.Join(namespacesToCleanup, " "))
+	fmt.Printf("Delete them (and any from earlier failed runs) with: hack/cleanup-e2e.sh\n")
+	namespacesToCleanup = nil
 }
 
 // CleanupNamespaces deletes all registered namespaces using the K8s API.

--- a/internal/e2e/testmain.go
+++ b/internal/e2e/testmain.go
@@ -76,7 +76,16 @@ func runAndCleanup(m *testing.M) int {
 		return 1
 	}
 
-	defer CleanupNamespaces()
-
-	return m.Run()
+	// Namespaces are deleted only on success. A failed run keeps them: the actor
+	// lives in a worker pod there, and its ateom logs (for a micro-VM worker, the
+	// guest's console tail too) are the only record of why it failed. Deleting the
+	// namespace takes those pods with it before anyone — a developer or CI's
+	// post-failure log dump — can read them.
+	code := m.Run()
+	if code != 0 {
+		RetainNamespaces()
+		return code
+	}
+	CleanupNamespaces()
+	return code
 }


### PR DESCRIPTION
When an e2e test failed, the evidence was deleted before anyone could read it. The suite deleted every namespace it created on the way out, taking the worker pods with it, and the workflow's post-failure dump only looked at three fixed namespaces — never the suites' randomly-named ones. So a failure inside an actor (#619: a micro-VM resume where the guest died at boot) left nothing behind but the RPC error the test printed.

Keep the namespaces when the suite failed, and dump every worker pod in every namespace, so the ateom logs — which carry the guest's console tail — reach the failed run's output.

Kept namespaces are nobody's to reclaim, and each holds a WorkerPool's worth of running pods, so they now carry an ate.dev/e2e label and hack/cleanup-e2e.sh deletes them once the logs have served their purpose. CI throws its cluster away, but a development cluster accumulates them run after run.

Fixes #<issue_number_goes_here>

Built while debugging https://github.com/agent-substrate/substrate/issues/619

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
