### PR TITLE
imagecache: record image digest in bundle overlay specs; atomic WriteSpec

### DIFF
--- a/cmd/atelet/oci.go
+++ b/cmd/atelet/oci.go
@@ -102,8 +102,9 @@ func prepareOCIDirectory(ctx context.Context, imageCache *imagecache.Store, acto
 		extraDirs = append(extraDirs, vm.GetMountPath())
 	}
 	if err := imagecache.WriteSpec(bundlePath, &imagecache.OverlaySpec{
-		Layers:    img.LayerDirs,
-		ExtraDirs: extraDirs,
+		ImageDigest: img.Digest.String(),
+		Layers:      img.LayerDirs,
+		ExtraDirs:   extraDirs,
 	}); err != nil {
 		return fmt.Errorf("while writing overlay spec: %w", err)
 	}

--- a/internal/imagecache/spec.go
+++ b/internal/imagecache/spec.go
@@ -38,9 +38,11 @@ const OverlaySpecFileName = "rootfs-overlay.json"
 type OverlaySpec struct {
 	Version int `json:"version"`
 	// ImageDigest is the manifest digest the bundle's image ref resolved to
-	// ("sha256:<hex>"). The cache GC's root-set scan uses it to protect the
-	// image while the bundle exists; consumers ignore it. Optional: older
-	// specs lack it.
+	// ("sha256:<hex>"). For a multi-arch ref this is the index digest; the
+	// cache may hold a twin record under the platform-child digest, and GC
+	// must treat the pair as one image. The GC's root-set scan uses it to
+	// protect the image while the bundle exists; consumers ignore it.
+	// Optional: older specs lack it.
 	ImageDigest string `json:"imageDigest,omitempty"`
 	// Layers are the cached layer directories (each holding its tree under
 	// fs/), bottom-most layer first — the order the image manifest lists

--- a/internal/imagecache/spec.go
+++ b/internal/imagecache/spec.go
@@ -55,9 +55,10 @@ type OverlaySpec struct {
 
 // WriteSpec writes spec into the bundle at bundlePath.
 //
-// The write is atomic (temp file + rename): the cache GC's root-set scan
-// reads these files concurrently, and a torn spec would under-report the
-// layers an actor is using — failing toward deletion.
+// The write is atomic (temp file + rename): concurrent readers — notably
+// the cache GC's root-set scan — must never see a partial spec, which
+// could parse with layers missing and leave them eligible for eviction
+// while the actor is using them.
 func WriteSpec(bundlePath string, spec *OverlaySpec) error {
 	spec.Version = 1
 	b, err := json.MarshalIndent(spec, "", "  ")

--- a/internal/imagecache/spec.go
+++ b/internal/imagecache/spec.go
@@ -37,6 +37,11 @@ const OverlaySpecFileName = "rootfs-overlay.json"
 // bundle path by the consumer rather than trusted from the file.
 type OverlaySpec struct {
 	Version int `json:"version"`
+	// ImageDigest is the manifest digest the bundle's image ref resolved to
+	// ("sha256:<hex>"). The cache GC's root-set scan uses it to protect the
+	// image while the bundle exists; consumers ignore it. Optional: older
+	// specs lack it.
+	ImageDigest string `json:"imageDigest,omitempty"`
 	// Layers are the cached layer directories (each holding its tree under
 	// fs/), bottom-most layer first — the order the image manifest lists
 	// them. Consumers reverse this into overlayfs's top-first lowerdir.
@@ -49,14 +54,35 @@ type OverlaySpec struct {
 }
 
 // WriteSpec writes spec into the bundle at bundlePath.
+//
+// The write is atomic (temp file + rename): the cache GC's root-set scan
+// reads these files concurrently, and a torn spec would under-report the
+// layers an actor is using — failing toward deletion.
 func WriteSpec(bundlePath string, spec *OverlaySpec) error {
 	spec.Version = 1
 	b, err := json.MarshalIndent(spec, "", "  ")
 	if err != nil {
 		return fmt.Errorf("while encoding overlay spec: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(bundlePath, OverlaySpecFileName), b, 0o600); err != nil {
+	path := filepath.Join(bundlePath, OverlaySpecFileName)
+	tmp, err := os.CreateTemp(bundlePath, "."+OverlaySpecFileName+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("while creating overlay spec temp file: %w", err)
+	}
+	defer os.Remove(tmp.Name()) // no-op once the rename succeeds
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
 		return fmt.Errorf("while writing overlay spec: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("while setting overlay spec mode: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("while closing overlay spec: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("while moving overlay spec into place: %w", err)
 	}
 	return nil
 }

--- a/internal/imagecache/spec_test.go
+++ b/internal/imagecache/spec_test.go
@@ -15,9 +15,11 @@
 package imagecache
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -36,6 +38,7 @@ func TestOverlaySpecRoundTrip(t *testing.T) {
 	}
 	if out == nil {
 		t.Fatalf("ReadSpec returned nil for a bundle with a spec")
+		return // unreachable; makes the non-nil-ness explicit to static analysis
 	}
 	if !slices.Equal(out.Layers, in.Layers) {
 		t.Errorf("Layers = %v, want %v", out.Layers, in.Layers)
@@ -130,4 +133,51 @@ func TestCreateExtraDirs(t *testing.T) {
 			t.Errorf("expected error for a parent-traversal extra dir, got nil")
 		}
 	})
+}
+
+func TestSpecImageDigestCompat(t *testing.T) {
+	dir := t.TempDir()
+	// Round trip with the new field.
+	if err := WriteSpec(dir, &OverlaySpec{ImageDigest: "sha256:" + strings.Repeat("ef", 32), Layers: []string{"/pool/layers/sha256/aa"}}); err != nil {
+		t.Fatalf("WriteSpec: %v", err)
+	}
+	spec, err := ReadSpec(dir)
+	if err != nil || spec == nil {
+		t.Fatalf("ReadSpec: %v, %v", spec, err)
+	}
+	if spec.ImageDigest == "" {
+		t.Error("ImageDigest lost in round trip")
+	}
+
+	// A spec written by an older atelet (no imageDigest) still parses.
+	old, err := json.Marshal(map[string]any{"version": 1, "layers": []string{"/pool/layers/sha256/bb"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, OverlaySpecFileName), old, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	spec, err = ReadSpec(dir)
+	if err != nil || spec == nil {
+		t.Fatalf("ReadSpec(old): %v, %v", spec, err)
+	}
+	if spec.ImageDigest != "" {
+		t.Errorf("old spec ImageDigest = %q, want empty", spec.ImageDigest)
+	}
+}
+
+func TestWriteSpecLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteSpec(dir, &OverlaySpec{Layers: []string{"/pool/layers/sha256/aa"}}); err != nil {
+		t.Fatalf("WriteSpec: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != OverlaySpecFileName {
+			t.Errorf("unexpected file left in bundle: %q", e.Name())
+		}
+	}
 }

--- a/internal/imagecache/spec_test.go
+++ b/internal/imagecache/spec_test.go
@@ -145,8 +145,8 @@ func TestSpecImageDigestCompat(t *testing.T) {
 	if err != nil || spec == nil {
 		t.Fatalf("ReadSpec: %v, %v", spec, err)
 	}
-	if spec.ImageDigest == "" {
-		t.Error("ImageDigest lost in round trip")
+	if want := "sha256:" + strings.Repeat("ef", 32); spec.ImageDigest != want {
+		t.Errorf("ImageDigest = %q, want %q", spec.ImageDigest, want)
 	}
 
 	// A spec written by an older atelet (no imageDigest) still parses.


### PR DESCRIPTION
Second foundation slice of #463 Phase 2 (GC), independent of #650 and inert on its
own: nothing reads the new field and nothing deletes anything.

- **`OverlaySpec.ImageDigest`** (optional, `omitempty`): the manifest digest the
  bundle's image ref resolved to, populated in `prepareOCIDirectory`. The GC
  root-set scan will use it to root the whole image record while the bundle
  exists. Compatible in both directions: ateom consumers never read the field
  (old binaries drop the unknown JSON key), and specs written by older atelets
  keep parsing with the field empty — so there is no deploy-ordering constraint.
- **Atomic `WriteSpec`** (temp file + rename in the bundle dir): the root-set scan
  will read specs concurrently with bundle preparation, and a torn spec would
  under-report the layers an actor is using — an error in the dangerous
  direction (toward deleting in-use layers). With the rename, a reader sees the
  complete old spec or the complete new one, never a fragment.

Landing early matters: every bundle written from now on carries the digest,
shrinking the digestless-spec population the GC's compatibility fallback has to
cover.

**Testing**: round-trip + old-spec compat and no-temp-files-left unit tests;
`go test -race` green on both affected packages.
