### PR TITLE
ci: fix zizmor policy failures

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version-file: 'go.mod'
     - run: go test -v ./...
@@ -52,9 +52,9 @@ jobs:
     name: e2e-test (${{ matrix.ateapi-client-auth }})
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version-file: 'go.mod'
     - name: Free disk space
@@ -65,7 +65,7 @@ jobs:
         df -h /
     - name: Cache micro-VM assets
       id: microvm-assets
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         # Assembling the assets (download kata-static + cloud-hypervisor + the
         # prebuilt virtiofsd — all downloads on amd64) is fully pinned by assemble.sh,

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -22,6 +22,10 @@ on:
     # evicts caches idle for 7 days). The push-to-main run populates the cache that
     # PRs inherit; this refreshes it so PRs keep hitting it (no asset re-download).
     - cron: '37 4 * * 1'
+# Nothing here writes to the repository: the jobs check the tree out, build it,
+# and run it in a throwaway cluster.
+permissions:
+  contents: read
 jobs:
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes new org-imposed requirement to pin workflow actions and to explicitly mark workflows as read only. We should've been doing this anyhow. Dependabot even knows how to bump in this format.