### PR TITLE
imagecache: two-phase layer retirement primitives + .rm-* startup sweep

### DIFF
--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -192,23 +192,33 @@ func (s *Store) recordPath(digest v1.Hash) string {
 	return filepath.Join(s.root, "manifests", digest.Algorithm, digest.Hex+".json")
 }
 
-// sweepTempDirs removes unpack temp dirs and manifest-record temp files
-// orphaned by a crash. A layer dir without the temp prefix and a record
-// without a leading dot are always complete (both are moved into place with
-// a single rename), so this is the only recovery the pool needs.
+// sweepTempDirs removes unpack temp dirs, retired layer dirs, and
+// manifest-record temp files orphaned by a crash. A layer dir without the
+// temp/retired prefix and a record without a leading dot are always
+// complete (both are moved into place with a single rename), so this is
+// the only recovery the pool needs.
 func (s *Store) sweepTempDirs() error {
 	entries, err := os.ReadDir(s.layersDir())
 	if err != nil {
 		return fmt.Errorf("while listing layer pool: %w", err)
 	}
+	swept := 0
 	for _, e := range entries {
-		if !strings.HasPrefix(e.Name(), ".tmp-") {
+		// ".tmp-": an unpack in flight at crash. ".rm-": a layer retirement
+		// renamed aside but not yet removed. Either way, unreferenced
+		// garbage.
+		if !strings.HasPrefix(e.Name(), ".tmp-") && !strings.HasPrefix(e.Name(), retiredPrefix) {
 			continue
 		}
 		p := filepath.Join(s.layersDir(), e.Name())
+		slog.Info("Image cache sweeping orphaned layer dir", slog.String("dir", e.Name()))
 		if err := RemoveAllWritable(p); err != nil {
 			return fmt.Errorf("while sweeping orphaned layer temp dir %q: %w", p, err)
 		}
+		swept++
+	}
+	if swept > 0 {
+		slog.Info("Image cache startup sweep removed orphaned layer dirs", slog.Int("count", swept))
 	}
 
 	// writeRecord's temp files are ".<hex>.json.tmp-<rand>"; finished records
@@ -386,6 +396,12 @@ func (s *Store) ensureLayer(ctx context.Context, diffID v1.Hash, layer v1.Layer)
 	dir := s.layerDir(diffID)
 	_, err, _ := s.layerSF.Do(diffID.String(), func() (any, error) {
 		if _, err := os.Stat(filepath.Join(dir, layerFSDirName)); err == nil {
+			// Refresh the dir mtime inside the flight: retireLayer re-checks
+			// the mtime in this same flight, so a layer reused here can
+			// never be renamed away between this stat and the image record
+			// that will re-reference it.
+			now := time.Now()
+			_ = os.Chtimes(dir, now, now)
 			return nil, nil
 		}
 		return nil, s.unpackLayerToPool(ctx, diffID, layer)

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -213,7 +213,7 @@ func (s *Store) sweepTempDirs() error {
 		p := filepath.Join(s.layersDir(), e.Name())
 		slog.Info("Image cache sweeping orphaned layer dir", slog.String("dir", e.Name()))
 		if err := RemoveAllWritable(p); err != nil {
-			return fmt.Errorf("while sweeping orphaned layer temp dir %q: %w", p, err)
+			return fmt.Errorf("while sweeping orphaned layer dir %q: %w", p, err)
 		}
 		swept++
 	}
@@ -394,14 +394,16 @@ func (s *Store) pull(ctx context.Context, parsedRef name.Reference, digest v1.Ha
 // collapsing concurrent requests for the same layer across images.
 func (s *Store) ensureLayer(ctx context.Context, diffID v1.Hash, layer v1.Layer) (string, error) {
 	dir := s.layerDir(diffID)
-	_, err, _ := s.layerSF.Do(diffID.String(), func() (any, error) {
+	_, err, _ := s.layerSF.Do(layerFlightKey(diffID.Hex), func() (any, error) {
 		if _, err := os.Stat(filepath.Join(dir, layerFSDirName)); err == nil {
 			// Refresh the dir mtime inside the flight: retireLayer re-checks
 			// the mtime in this same flight, so a layer reused here can
 			// never be renamed away between this stat and the image record
 			// that will re-reference it.
 			now := time.Now()
-			_ = os.Chtimes(dir, now, now)
+			if err := os.Chtimes(dir, now, now); err != nil {
+				slog.WarnContext(ctx, "Failed to refresh layer mtime on reuse", slog.String("diffid", diffID.String()), slog.Any("err", err))
+			}
 			return nil, nil
 		}
 		return nil, s.unpackLayerToPool(ctx, diffID, layer)

--- a/internal/imagecache/retire.go
+++ b/internal/imagecache/retire.go
@@ -29,8 +29,6 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // retiredPrefix marks a layer dir that eviction has renamed aside and that
@@ -57,6 +55,10 @@ const (
 	// caller removes the renamed dir afterwards.
 	retireRetired
 )
+
+// layerFlightKey is the singleflight key shared by ensureLayer and
+// retireLayer; the retire/reuse interlock depends on both using it.
+func layerFlightKey(hex string) string { return "sha256:" + hex }
 
 // isLayerDirName reports whether name is a well-formed sha256 layer
 // directory name. Callers enumerate directories and read hexes out of
@@ -105,7 +107,9 @@ func (s *Store) retireLayer(hex string, cutoff time.Time) (string, retireStatus,
 
 	var retired string
 	status := retireGone
-	_, err, _ = s.layerSF.Do(v1.Hash{Algorithm: "sha256", Hex: hex}.String(), func() (any, error) {
+	ran := false
+	_, err, _ = s.layerSF.Do(layerFlightKey(hex), func() (any, error) {
+		ran = true
 		fi, err := os.Stat(dir)
 		if errors.Is(err, os.ErrNotExist) {
 			status = retireGone
@@ -130,6 +134,12 @@ func (s *Store) retireLayer(hex string, cutoff time.Time) (string, retireStatus,
 		status = retireRetired
 		return nil, nil
 	})
+	if !ran {
+		// Our closure never executed: Do joined a flight already in progress
+		// (an ensureLayer reuse or another retire), so status/retired are
+		// stale zero values. Concurrent activity on the layer is a veto.
+		return "", retireVetoed, nil
+	}
 	if err != nil {
 		return "", status, err
 	}

--- a/internal/imagecache/retire.go
+++ b/internal/imagecache/retire.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagecache
+
+// Two-phase layer deletion: eviction renames a layer dir aside (one
+// rename(2) inside the layer singleflight — the only step that contends
+// with the pull path) and the slow RemoveAll of the renamed-aside tree
+// happens afterwards, outside all locks. A crash in between leaves a
+// ".rm-*" dir for the startup sweep. Nothing here needs privileges:
+// retirement is rename/chmod/unlink, which plain root can do even on
+// read-only trees.
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// retiredPrefix marks a layer dir that eviction has renamed aside and that
+// no longer exists by diffid. It shares the dot-hidden namespace with
+// ".tmp-" so diffid-named dirs can never collide with it.
+const retiredPrefix = ".rm-"
+
+// logMsgLayerRetireVetoed is a fixed message so an e2e can grep for the
+// exact race being exercised.
+const logMsgLayerRetireVetoed = "Image cache layer retirement vetoed: recently used"
+
+// retireStatus reports what retireLayer did with a layer.
+type retireStatus int
+
+const (
+	// retireGone: no dir under the layer's final name — already removed, or
+	// mid-unpack (only the commit rename creates the final name). Nothing
+	// stranded.
+	retireGone retireStatus = iota
+	// retireVetoed: the layer stays — fresh mtime, in-flight reuse, or a
+	// failed rename.
+	retireVetoed
+	// retireRetired: renamed to a ".rm-*" name, gone from the pool; the
+	// caller removes the renamed dir afterwards.
+	retireRetired
+)
+
+// isLayerDirName reports whether name is a well-formed sha256 layer
+// directory name. Callers enumerate directories and read hexes out of
+// records, so they can encounter anything an operator (or a corrupt
+// record) left there; only conforming names are treated as layers.
+func isLayerDirName(name string) bool {
+	if len(name) != 64 {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if c := name[i]; (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// retireLayer evicts a layer by renaming its dir to a ".rm-*" name and
+// returns the renamed path; the caller deletes it afterwards. A layer
+// with an mtime after cutoff is vetoed and left in place.
+//
+// The mtime check and the rename run inside the layer singleflight — the
+// same flight in which ensureLayer refreshes the mtime — so a retirement
+// and a reuse cannot interleave: whichever runs second sees the first.
+func (s *Store) retireLayer(hex string, cutoff time.Time) (string, retireStatus, error) {
+	if !isLayerDirName(hex) {
+		return "", retireVetoed, fmt.Errorf("not a layer dir name: %q", hex)
+	}
+	dir := filepath.Join(s.layersDir(), hex)
+
+	// Pre-flight, outside the singleflight: a missing dir or a fresh mtime
+	// means nothing to do, and no reason to enter the flight and block
+	// behind an in-progress download. Both checks are re-run inside the
+	// flight before the rename, so this is a fast path, not the
+	// correctness path.
+	fi, err := os.Stat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", retireGone, nil
+	} else if err != nil {
+		return "", retireVetoed, err
+	}
+	if fi.ModTime().After(cutoff) {
+		slog.Info(logMsgLayerRetireVetoed, slog.String("diffid", hex), slog.Time("last_used", fi.ModTime()))
+		return "", retireVetoed, nil
+	}
+
+	var retired string
+	status := retireGone
+	_, err, _ = s.layerSF.Do(v1.Hash{Algorithm: "sha256", Hex: hex}.String(), func() (any, error) {
+		fi, err := os.Stat(dir)
+		if errors.Is(err, os.ErrNotExist) {
+			status = retireGone
+			return nil, nil
+		} else if err != nil {
+			status = retireVetoed
+			return nil, err
+		}
+		// A concurrent ensureLayer touched the dir if it reused this layer
+		// since the pre-flight stat.
+		if fi.ModTime().After(cutoff) {
+			slog.Info(logMsgLayerRetireVetoed, slog.String("diffid", hex), slog.Time("last_used", fi.ModTime()))
+			status = retireVetoed
+			return nil, nil
+		}
+		dst := filepath.Join(s.layersDir(), fmt.Sprintf("%s%s-%d", retiredPrefix, hex[:12], time.Now().UnixNano()))
+		if err := os.Rename(dir, dst); err != nil {
+			status = retireVetoed
+			return nil, fmt.Errorf("while retiring layer %s: %w", hex, err)
+		}
+		retired = dst
+		status = retireRetired
+		return nil, nil
+	})
+	if err != nil {
+		return "", status, err
+	}
+	return retired, status, nil
+}

--- a/internal/imagecache/retire_test.go
+++ b/internal/imagecache/retire_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagecache
+
+import (
+	"archive/tar"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func TestRetireLayerStatuses(t *testing.T) {
+	store := newTestStore(t)
+	hex := strings.Repeat("ab", 32)
+
+	if _, _, err := store.retireLayer("../escape", time.Now()); err == nil {
+		t.Error("retireLayer accepted a non-layer name")
+	}
+
+	if _, st, err := store.retireLayer(hex, time.Now()); err != nil || st != retireGone {
+		t.Errorf("retireLayer(absent) = %v, %v; want retireGone, nil", st, err)
+	}
+
+	dir := filepath.Join(store.layersDir(), hex)
+	if err := os.MkdirAll(filepath.Join(dir, layerFSDirName), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fresh dir, cutoff in the past: vetoed, dir untouched.
+	if _, st, err := store.retireLayer(hex, time.Now().Add(-time.Minute)); err != nil || st != retireVetoed {
+		t.Errorf("retireLayer(fresh) = %v, %v; want retireVetoed, nil", st, err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("vetoed layer dir was touched: %v", err)
+	}
+
+	// Old dir: retired — gone from its diffid name, present under .rm-*.
+	past := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(dir, past, past); err != nil {
+		t.Fatal(err)
+	}
+	retired, st, err := store.retireLayer(hex, time.Now().Add(-time.Minute))
+	if err != nil || st != retireRetired {
+		t.Fatalf("retireLayer(old) = %v, %v; want retireRetired, nil", st, err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("retired layer still present at %q", dir)
+	}
+	if base := filepath.Base(retired); !strings.HasPrefix(base, retiredPrefix) {
+		t.Errorf("retired path %q does not carry the %q prefix", retired, retiredPrefix)
+	}
+	if _, err := os.Stat(retired); err != nil {
+		t.Errorf("renamed-aside dir missing: %v", err)
+	}
+}
+
+func TestNewSweepsRetiredDirs(t *testing.T) {
+	root := t.TempDir()
+	store, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Plant a retired dir (crash between rename and RemoveAll) with a
+	// read-only subdir, which plain os.RemoveAll cannot delete.
+	retired := filepath.Join(store.layersDir(), retiredPrefix+"deadbeef-1")
+	if err := os.MkdirAll(filepath.Join(retired, "fs", "ro"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(retired, "fs", "ro", "f"), []byte("x"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(retired, "fs", "ro"), 0o500); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(root); err != nil {
+		t.Fatalf("New (recovery): %v", err)
+	}
+	if _, err := os.Stat(retired); !os.IsNotExist(err) {
+		t.Errorf("retired dir not swept at startup: %v", err)
+	}
+}
+
+func TestSweepLeavesNonPrefixedEntries(t *testing.T) {
+	root := t.TempDir()
+	store, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// A complete layer dir, an operator artifact, and a stray file: none
+	// carry the temp/retired prefixes, so the sweep must not touch them.
+	keep := []string{
+		filepath.Join(store.layersDir(), strings.Repeat("cd", 32)),
+		filepath.Join(store.layersDir(), "lost+found"),
+	}
+	for _, d := range keep {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	strayFile := filepath.Join(store.layersDir(), "README")
+	if err := os.WriteFile(strayFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New(root); err != nil {
+		t.Fatalf("New (recovery): %v", err)
+	}
+	for _, p := range append(keep, strayFile) {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("startup sweep removed non-prefixed entry %q: %v", p, err)
+		}
+	}
+}
+
+// TestRetireLayerVsEnsureImageRace races retirement against pulls of an
+// image using the same layer. The singleflight serializes the retire
+// rename against unpack, and the in-flight mtime touch turns concurrent
+// reuse into a veto — so neither side may ever error. Run with -race.
+func TestRetireLayerVsEnsureImageRace(t *testing.T) {
+	_, host := newTestRegistry(t)
+	ref := host + "/test/retire-race:latest"
+	pushImage(t, ref, v1.Config{}, layerFromEntries(t, []tarEntry{
+		{name: "f", typeflag: tar.TypeReg, mode: 0o644, body: "hi"},
+	}))
+	store := newTestStore(t)
+
+	img, err := store.EnsureImage(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("EnsureImage: %v", err)
+	}
+	hex := filepath.Base(img.LayerDirs[0])
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 25; i++ {
+			img, err := store.EnsureImage(context.Background(), ref)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			// Age the layer so the other goroutine's cutoff can retire it.
+			past := time.Now().Add(-2 * time.Hour)
+			_ = os.Chtimes(img.LayerDirs[0], past, past) // best-effort: may already be retired
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			if _, _, err := store.retireLayer(hex, time.Now().Add(-time.Minute)); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("race worker failed: %v", err)
+	}
+
+	// The pool must end in a consistent state: a final pull succeeds and
+	// its layer dir exists under the diffid name.
+	img, err = store.EnsureImage(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("EnsureImage (final): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(img.LayerDirs[0], layerFSDirName)); err != nil {
+		t.Errorf("final layer dir missing: %v", err)
+	}
+}

--- a/internal/imagecache/retire_test.go
+++ b/internal/imagecache/retire_test.go
@@ -27,6 +27,16 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
+// The retire/reuse interlock depends on retireLayer and ensureLayer using
+// the same singleflight key; pin the key format to diffID.String()'s.
+func TestLayerFlightKeyMatchesDiffIDString(t *testing.T) {
+	hex := strings.Repeat("ab", 32)
+	want := v1.Hash{Algorithm: "sha256", Hex: hex}.String()
+	if got := layerFlightKey(hex); got != want {
+		t.Errorf("layerFlightKey = %q, want %q", got, want)
+	}
+}
+
 func TestRetireLayerStatuses(t *testing.T) {
 	store := newTestStore(t)
 	hex := strings.Repeat("ab", 32)


### PR DESCRIPTION
Third foundation slice of #463 Phase 2 (GC), independent of #650 and #656. The
primitives are uncalled until the eviction engine PR; the only live behavior is
the startup sweep, which only ever sees `.rm-*` dirs the engine will create.

- **`retireLayer`**: evicts a layer with one atomic rename to a `.rm-*` name
  inside the layer singleflight; the slow `RemoveAll` is the caller's job,
  outside all locks. Existence/mtime pre-flight runs *outside* the flight (a
  retire must never block behind an in-progress download) and both checks are
  re-run inside it before the rename. Returns gone/vetoed/retired so the engine
  can distinguish "nothing there" from "must keep".
- **Reuse interlock**: `ensureLayer` now refreshes the layer dir mtime inside
  the same flight, so a retirement and a reuse cannot interleave — either the
  retire wins (the pull re-unpacks) or the touch wins (the retire vetoes).
- **Startup sweep**: `.rm-*` dirs (a crash between rename and removal) are
  reclaimed alongside the existing `.tmp-*` dirs, via `RemoveAllWritable` since
  layer trees legitimately contain read-only content.
- **`isLayerDirName`** validates names read from disk or records.

Divergence from the prototype: `retireLayer` reports no freed size — size
crediting belongs to the engine's call sites and arrives with it.

**Testing**: unit tests for the status contract, startup-sweep recovery and
non-interference, and a retire-vs-pull race test; `go test -race` green.
