### PR TITLE
fix flaky TestPlatformMetrics test

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -43,6 +43,9 @@ type ateomOTelSettings struct {
 	// first export tick fires. Shortening the interval is what keeps that
 	// startup gap inside an e2e budget; production leaves it unset.
 	MetricExportInterval string
+	// MetricExportTimeout overrides the SDK's  per-export timeout, in the same
+	// whole-millisecond form as MetricExportInterval. Empty keeps the default.
+	MetricExportTimeout string
 }
 
 // buildDeploymentApplyConfig constructs the SSA apply configuration for the
@@ -117,6 +120,11 @@ func ateomContainerEnv(otel ateomOTelSettings) []*corev1ac.EnvVarApplyConfigurat
 		envs = append(envs, corev1ac.EnvVar().
 			WithName("OTEL_METRIC_EXPORT_INTERVAL").
 			WithValue(otel.MetricExportInterval))
+	}
+	if otel.MetricExportTimeout != "" {
+		envs = append(envs, corev1ac.EnvVar().
+			WithName("OTEL_METRIC_EXPORT_TIMEOUT").
+			WithValue(otel.MetricExportTimeout))
 	}
 	return envs
 }

--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -28,11 +28,28 @@ import (
 // uid so each worker pod is a distinct telemetry source.
 const ateomOTelResourceAttributes = "k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),service.instance.id=$(POD_UID)"
 
+// ateomOTelSettings is the telemetry configuration propagated to ateom worker
+// pods. A zero value leaves the pods without telemetry env.
+type ateomOTelSettings struct {
+	// Endpoint is the OTLP collector address. Empty disables ateom telemetry
+	// entirely, so the other fields are ignored.
+	Endpoint string
+	// MetricExportInterval overrides the SDK's 60s PeriodicReader interval. It is
+	// the raw OTEL_METRIC_EXPORT_INTERVAL value, i.e. whole milliseconds; the SDK
+	// falls back to its default when it does not parse. Empty keeps the default.
+	//
+	// ateom registers no instruments of its own, so its only telemetry is
+	// otelgrpc's rpc.server.* and it stays invisible to the collector until the
+	// first export tick fires. Shortening the interval is what keeps that
+	// startup gap inside an e2e budget; production leaves it unset.
+	MetricExportInterval string
+}
+
 // buildDeploymentApplyConfig constructs the SSA apply configuration for the
 // Deployment managed by a WorkerPool. Only fields owned by this controller
-// are declared here. otelEndpoint, when non-empty, is propagated to the ateom
-// container so it pushes telemetry to that collector.
-func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otelEndpoint string) *appsv1ac.DeploymentApplyConfiguration {
+// are declared here. otel, when it carries an endpoint, is propagated to the
+// ateom container so it pushes telemetry to that collector.
+func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettings) *appsv1ac.DeploymentApplyConfiguration {
 	containerAC := corev1ac.Container().
 		WithName("ateom").
 		WithImage(wp.Spec.AteomImage).
@@ -40,7 +57,7 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otelEndpoint string)
 			"--pod-uid=$(POD_UID)",
 		).
 		WithSecurityContext(ateomSecurityContext(wp.Spec.SandboxClass)).
-		WithEnv(ateomContainerEnv(otelEndpoint)...).
+		WithEnv(ateomContainerEnv(otel)...).
 		WithVolumeMounts(corev1ac.VolumeMount().
 			WithName("run-ateom").
 			WithMountPath(ateompath.BasePath).
@@ -83,19 +100,25 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otelEndpoint string)
 // ateomContainerEnv adds the OTLP endpoint and resource identity only when
 // telemetry is configured. POD_* refs precede OTEL_RESOURCE_ATTRIBUTES so its
 // $(POD_*) substitutions resolve.
-func ateomContainerEnv(otelEndpoint string) []*corev1ac.EnvVarApplyConfiguration {
+func ateomContainerEnv(otel ateomOTelSettings) []*corev1ac.EnvVarApplyConfiguration {
 	envs := []*corev1ac.EnvVarApplyConfiguration{
 		fieldRefEnv("POD_UID", "metadata.uid"),
 	}
-	if otelEndpoint == "" {
+	if otel.Endpoint == "" {
 		return envs
 	}
-	return append(envs,
+	envs = append(envs,
 		fieldRefEnv("POD_NAME", "metadata.name"),
 		fieldRefEnv("POD_NAMESPACE", "metadata.namespace"),
-		corev1ac.EnvVar().WithName("OTEL_EXPORTER_OTLP_ENDPOINT").WithValue(otelEndpoint),
+		corev1ac.EnvVar().WithName("OTEL_EXPORTER_OTLP_ENDPOINT").WithValue(otel.Endpoint),
 		corev1ac.EnvVar().WithName("OTEL_RESOURCE_ATTRIBUTES").WithValue(ateomOTelResourceAttributes),
 	)
+	if otel.MetricExportInterval != "" {
+		envs = append(envs, corev1ac.EnvVar().
+			WithName("OTEL_METRIC_EXPORT_INTERVAL").
+			WithValue(otel.MetricExportInterval))
+	}
+	return envs
 }
 
 func fieldRefEnv(name, fieldPath string) *corev1ac.EnvVarApplyConfiguration {

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -201,7 +201,7 @@ func TestBuildDeploymentApplyConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildDeploymentApplyConfig(tt.wp, "")
+			got := buildDeploymentApplyConfig(tt.wp, ateomOTelSettings{})
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("buildDeploymentApplyConfig() mismatch (-want +got):\n%s", diff)
 			}
@@ -226,7 +226,7 @@ func TestMicroVMPodShape(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wp := testWorkerPoolApplyConfig(nil)
 			wp.Spec.SandboxClass = tt.class
-			ps := buildDeploymentApplyConfig(wp, "").Spec.Template.Spec
+			ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}).Spec.Template.Spec
 
 			hasVol := false
 			for _, v := range ps.Volumes {
@@ -325,7 +325,7 @@ func TestTerminationGracePeriodSeconds(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wp := testWorkerPoolApplyConfig(nil)
 			wp.Spec.TerminationGracePeriodSeconds = tt.set
-			ps := buildDeploymentApplyConfig(wp, "").Spec.Template.Spec
+			ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}).Spec.Template.Spec
 			if ps.TerminationGracePeriodSeconds == nil {
 				t.Fatalf("TerminationGracePeriodSeconds not set")
 			}
@@ -351,7 +351,7 @@ func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.endpoint).
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), ateomOTelSettings{Endpoint: tt.endpoint}).
 				Spec.Template.Spec.Containers[0]
 			env := envByName(c.Env)
 
@@ -360,7 +360,7 @@ func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
 			}
 
 			if !tt.wantTelemetry {
-				for _, k := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES", "POD_NAME", "POD_NAMESPACE"} {
+				for _, k := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES", "OTEL_METRIC_EXPORT_INTERVAL", "POD_NAME", "POD_NAMESPACE"} {
 					if _, ok := env[k]; ok {
 						t.Errorf("%s must be absent without an OTLP endpoint", k)
 					}
@@ -383,6 +383,37 @@ func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
 				if env[ref].index > raIdx {
 					t.Errorf("%s (index %d) must precede OTEL_RESOURCE_ATTRIBUTES (index %d)", ref, env[ref].index, raIdx)
 				}
+			}
+		})
+	}
+}
+
+// TestBuildDeploymentApplyConfigMetricExportInterval asserts the export interval
+// reaches the ateom container only when both it and an endpoint are set. ateom is
+// invisible to the collector until its first export tick, so the kind stack
+// shortens the SDK's 60s default to keep that gap inside the e2e budget.
+func TestBuildDeploymentApplyConfigMetricExportInterval(t *testing.T) {
+	const endpoint = "http://collector.otel-system.svc:4317"
+	tests := []struct {
+		name    string
+		otel    ateomOTelSettings
+		want    string
+		wantSet bool
+	}{
+		{"unset keeps SDK default", ateomOTelSettings{Endpoint: endpoint}, "", false},
+		{"set with endpoint", ateomOTelSettings{Endpoint: endpoint, MetricExportInterval: "10000"}, "10000", true},
+		{"ignored without endpoint", ateomOTelSettings{MetricExportInterval: "10000"}, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel).
+				Spec.Template.Spec.Containers[0]
+			got, ok := envByName(c.Env)["OTEL_METRIC_EXPORT_INTERVAL"]
+			if ok != tt.wantSet {
+				t.Fatalf("OTEL_METRIC_EXPORT_INTERVAL present = %v, want %v", ok, tt.wantSet)
+			}
+			if ok && got.value != tt.want {
+				t.Errorf("OTEL_METRIC_EXPORT_INTERVAL = %q, want %q", got.value, tt.want)
 			}
 		})
 	}

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -360,7 +360,7 @@ func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
 			}
 
 			if !tt.wantTelemetry {
-				for _, k := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES", "OTEL_METRIC_EXPORT_INTERVAL", "POD_NAME", "POD_NAMESPACE"} {
+				for _, k := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES", "OTEL_METRIC_EXPORT_INTERVAL", "OTEL_METRIC_EXPORT_TIMEOUT", "POD_NAME", "POD_NAMESPACE"} {
 					if _, ok := env[k]; ok {
 						t.Errorf("%s must be absent without an OTLP endpoint", k)
 					}
@@ -388,32 +388,60 @@ func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
 	}
 }
 
-// TestBuildDeploymentApplyConfigMetricExportInterval asserts the export interval
-// reaches the ateom container only when both it and an endpoint are set. ateom is
-// invisible to the collector until its first export tick, so the kind stack
-// shortens the SDK's 60s default to keep that gap inside the e2e budget.
-func TestBuildDeploymentApplyConfigMetricExportInterval(t *testing.T) {
+// TestBuildDeploymentApplyConfigMetricExportTuning asserts the export interval and
+// per-export timeout reach the ateom container only when each is set alongside an
+// endpoint. ateom is invisible to the collector until its first successful export
+// tick, so the kind stack shortens the SDK's 60s interval to keep that gap inside
+// the e2e budget, and its 30s timeout so a failing tick cannot swallow three
+// shortened intervals.
+func TestBuildDeploymentApplyConfigMetricExportTuning(t *testing.T) {
 	const endpoint = "http://collector.otel-system.svc:4317"
 	tests := []struct {
-		name    string
-		otel    ateomOTelSettings
-		want    string
-		wantSet bool
+		name string
+		otel ateomOTelSettings
+		want map[string]string // env name -> value; absent key means must not be set
 	}{
-		{"unset keeps SDK default", ateomOTelSettings{Endpoint: endpoint}, "", false},
-		{"set with endpoint", ateomOTelSettings{Endpoint: endpoint, MetricExportInterval: "10000"}, "10000", true},
-		{"ignored without endpoint", ateomOTelSettings{MetricExportInterval: "10000"}, "", false},
+		{
+			name: "unset keeps SDK defaults",
+			otel: ateomOTelSettings{Endpoint: endpoint},
+			want: nil,
+		},
+		{
+			name: "both set with endpoint",
+			otel: ateomOTelSettings{Endpoint: endpoint, MetricExportInterval: "10000", MetricExportTimeout: "10000"},
+			want: map[string]string{"OTEL_METRIC_EXPORT_INTERVAL": "10000", "OTEL_METRIC_EXPORT_TIMEOUT": "10000"},
+		},
+		{
+			name: "interval alone",
+			otel: ateomOTelSettings{Endpoint: endpoint, MetricExportInterval: "10000"},
+			want: map[string]string{"OTEL_METRIC_EXPORT_INTERVAL": "10000"},
+		},
+		{
+			name: "timeout alone",
+			otel: ateomOTelSettings{Endpoint: endpoint, MetricExportTimeout: "10000"},
+			want: map[string]string{"OTEL_METRIC_EXPORT_TIMEOUT": "10000"},
+		},
+		{
+			name: "ignored without endpoint",
+			otel: ateomOTelSettings{MetricExportInterval: "10000", MetricExportTimeout: "10000"},
+			want: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel).
 				Spec.Template.Spec.Containers[0]
-			got, ok := envByName(c.Env)["OTEL_METRIC_EXPORT_INTERVAL"]
-			if ok != tt.wantSet {
-				t.Fatalf("OTEL_METRIC_EXPORT_INTERVAL present = %v, want %v", ok, tt.wantSet)
-			}
-			if ok && got.value != tt.want {
-				t.Errorf("OTEL_METRIC_EXPORT_INTERVAL = %q, want %q", got.value, tt.want)
+			env := envByName(c.Env)
+			for _, k := range []string{"OTEL_METRIC_EXPORT_INTERVAL", "OTEL_METRIC_EXPORT_TIMEOUT"} {
+				got, ok := env[k]
+				want, wantSet := tt.want[k]
+				if ok != wantSet {
+					t.Errorf("%s present = %v, want %v", k, ok, wantSet)
+					continue
+				}
+				if ok && got.value != want {
+					t.Errorf("%s = %q, want %q", k, got.value, want)
+				}
 			}
 		})
 	}

--- a/cmd/atecontroller/internal/controllers/workerpool_controller.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller.go
@@ -38,8 +38,11 @@ type WorkerPoolReconciler struct {
 	Scheme       *runtime.Scheme
 	OTelEndpoint string
 	// OTelMetricExportInterval is the OTEL_METRIC_EXPORT_INTERVAL propagated to
-	// ateom pods. Empty keeps the SDK's 60s default.
+	// ateom pods. Empty keeps the SDK's default.
 	OTelMetricExportInterval string
+	// OTelMetricExportTimeout is the OTEL_METRIC_EXPORT_TIMEOUT propagated to
+	// ateom pods. Empty keeps the SDK's default.
+	OTelMetricExportTimeout string
 }
 
 //+kubebuilder:rbac:groups=ate.dev,resources=workerpools,verbs=get;list;watch;create;update;patch;delete
@@ -98,6 +101,7 @@ func (r *WorkerPoolReconciler) applyDeployment(ctx context.Context, wp *atev1alp
 	depAC := buildDeploymentApplyConfig(wp, ateomOTelSettings{
 		Endpoint:             r.OTelEndpoint,
 		MetricExportInterval: r.OTelMetricExportInterval,
+		MetricExportTimeout:  r.OTelMetricExportTimeout,
 	})
 	if err := r.Apply(ctx, depAC, client.FieldOwner(workerPoolFieldOwner), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply Deployment: %w", err)

--- a/cmd/atecontroller/internal/controllers/workerpool_controller.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller.go
@@ -37,6 +37,9 @@ type WorkerPoolReconciler struct {
 	client.Client
 	Scheme       *runtime.Scheme
 	OTelEndpoint string
+	// OTelMetricExportInterval is the OTEL_METRIC_EXPORT_INTERVAL propagated to
+	// ateom pods. Empty keeps the SDK's 60s default.
+	OTelMetricExportInterval string
 }
 
 //+kubebuilder:rbac:groups=ate.dev,resources=workerpools,verbs=get;list;watch;create;update;patch;delete
@@ -92,7 +95,10 @@ func (r *WorkerPoolReconciler) reconcileWorkerPool(ctx context.Context, wp *atev
 }
 
 func (r *WorkerPoolReconciler) applyDeployment(ctx context.Context, wp *atev1alpha1.WorkerPool) error {
-	depAC := buildDeploymentApplyConfig(wp, r.OTelEndpoint)
+	depAC := buildDeploymentApplyConfig(wp, ateomOTelSettings{
+		Endpoint:             r.OTelEndpoint,
+		MetricExportInterval: r.OTelMetricExportInterval,
+	})
 	if err := r.Apply(ctx, depAC, client.FieldOwner(workerPoolFieldOwner), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply Deployment: %w", err)
 	}

--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -42,6 +42,9 @@ var (
 	otelEndpoint = pflag.String("otel-exporter-otlp-endpoint", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
 		"OTLP endpoint set on ateom worker pods so they push telemetry. Defaults to the controller's own OTEL_EXPORTER_OTLP_ENDPOINT.")
 
+	otelMetricExportInterval = pflag.String("otel-metric-export-interval", os.Getenv("OTEL_METRIC_EXPORT_INTERVAL"),
+		"Metric export interval in milliseconds set on ateom worker pods. Empty keeps the OTel SDK's 60s default. Defaults to the controller's own OTEL_METRIC_EXPORT_INTERVAL.")
+
 	ateapiCAFile     = pflag.String("ateapi-ca-file", ateapiauth.DefaultServiceAccountCAFile, "PEM file with CAs trusted to verify the ateapi server cert.")
 	ateapiServerName = pflag.String("ateapi-server-name", "", "SNI / hostname expected on the ateapi server cert. Optional.")
 	ateapiTokenAuth  = pflag.Bool("ateapi-use-token-auth", false, "Authenticate to ateapi with the Bearer token from --ateapi-token-file instead of the client certificate from --ateapi-client-cert.")
@@ -87,9 +90,10 @@ func main() {
 	}
 
 	if err = (&controllers.WorkerPoolReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		OTelEndpoint: *otelEndpoint,
+		Client:                   mgr.GetClient(),
+		Scheme:                   mgr.GetScheme(),
+		OTelEndpoint:             *otelEndpoint,
+		OTelMetricExportInterval: *otelMetricExportInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkerPool")
 		os.Exit(1)

--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -45,6 +45,9 @@ var (
 	otelMetricExportInterval = pflag.String("otel-metric-export-interval", os.Getenv("OTEL_METRIC_EXPORT_INTERVAL"),
 		"Metric export interval in milliseconds set on ateom worker pods. Empty keeps the OTel SDK's 60s default. Defaults to the controller's own OTEL_METRIC_EXPORT_INTERVAL.")
 
+	otelMetricExportTimeout = pflag.String("otel-metric-export-timeout", os.Getenv("OTEL_METRIC_EXPORT_TIMEOUT"),
+		"Per-export timeout in milliseconds set on ateom worker pods. Empty keeps the OTel SDK's 30s default. Defaults to the controller's own OTEL_METRIC_EXPORT_TIMEOUT.")
+
 	ateapiCAFile     = pflag.String("ateapi-ca-file", ateapiauth.DefaultServiceAccountCAFile, "PEM file with CAs trusted to verify the ateapi server cert.")
 	ateapiServerName = pflag.String("ateapi-server-name", "", "SNI / hostname expected on the ateapi server cert. Optional.")
 	ateapiTokenAuth  = pflag.Bool("ateapi-use-token-auth", false, "Authenticate to ateapi with the Bearer token from --ateapi-token-file instead of the client certificate from --ateapi-client-cert.")
@@ -94,6 +97,7 @@ func main() {
 		Scheme:                   mgr.GetScheme(),
 		OTelEndpoint:             *otelEndpoint,
 		OTelMetricExportInterval: *otelMetricExportInterval,
+		OTelMetricExportTimeout:  *otelMetricExportTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkerPool")
 		os.Exit(1)

--- a/internal/e2e/collector_metrics.go
+++ b/internal/e2e/collector_metrics.go
@@ -108,13 +108,13 @@ func MissingPlatformMetrics(scrape string, prefixes []string) []string {
 }
 
 // CollectorHasService reports whether any named service has pushed telemetry to
-// the collector. Its prometheus exporter surfaces each pushed resource as a
-// target_info series and stamps the service.name as the job label, so a service
-// that has exported anything shows up under either.
+// the collector. Its prometheus exporter maps each pushed resource's service.name
+// onto the job label, so a service that has exported at least one data point
+// shows up there. Note the exporter never emits a service_name label, and a
+// resource whose instruments have recorded nothing yet produces no series at all.
 func CollectorHasService(scrape string, services ...string) bool {
 	for _, svc := range services {
-		if strings.Contains(scrape, `service_name="`+svc+`"`) ||
-			strings.Contains(scrape, `job="`+svc+`"`) {
+		if strings.Contains(scrape, `job="`+svc+`"`) {
 			return true
 		}
 	}

--- a/manifests/ate-install/kind/kustomization.yaml
+++ b/manifests/ate-install/kind/kustomization.yaml
@@ -27,6 +27,13 @@ resources:
   - ./otel-collector.yaml
   - ./prometheus.yaml
 
+# OTEL_METRIC_EXPORT_INTERVAL shortens the OTel SDK's 60s metric export tick to
+# 10s. A component is invisible to the collector until its first tick, and the
+# metrics e2e suite asserts against the collector's scrape on a bounded deadline,
+# so the default leaves too little headroom on a loaded runner. On ate-controller
+# it does double duty: the controller also propagates it to the ateom worker pods
+# it creates, which have no other way to receive it. Kind only; production keeps
+# the SDK default.
 patches:
   - patch: |-
       apiVersion: apps/v1
@@ -42,6 +49,8 @@ patches:
               env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
+              - name: OTEL_METRIC_EXPORT_INTERVAL
+                value: "10000"
   - patch: |-
       apiVersion: apps/v1
       kind: DaemonSet
@@ -56,6 +65,8 @@ patches:
               env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
+              - name: OTEL_METRIC_EXPORT_INTERVAL
+                value: "10000"
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -70,3 +81,5 @@ patches:
               env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
+              - name: OTEL_METRIC_EXPORT_INTERVAL
+                value: "10000"

--- a/manifests/ate-install/kind/kustomization.yaml
+++ b/manifests/ate-install/kind/kustomization.yaml
@@ -30,10 +30,16 @@ resources:
 # OTEL_METRIC_EXPORT_INTERVAL shortens the OTel SDK's 60s metric export tick to
 # 10s. A component is invisible to the collector until its first tick, and the
 # metrics e2e suite asserts against the collector's scrape on a bounded deadline,
-# so the default leaves too little headroom on a loaded runner. On ate-controller
-# it does double duty: the controller also propagates it to the ateom worker pods
-# it creates, which have no other way to receive it. Kind only; production keeps
-# the SDK default.
+# so the default leaves too little headroom on a loaded runner.
+#
+# OTEL_METRIC_EXPORT_TIMEOUT bounds a tick that fails rather than one that
+# succeeds, and its 30s default swallows three shortened intervals: a collector
+# blip or slow DNS drops a component back to roughly one attempt per 30s, undoing
+# the shorter interval. Matching it to the interval keeps every tick an attempt.
+#
+# On ate-controller both do double duty: the controller also propagates them to
+# the ateom worker pods it creates, which have no other way to receive them.
+# Kind only; production keeps the SDK defaults.
 patches:
   - patch: |-
       apiVersion: apps/v1
@@ -51,6 +57,8 @@ patches:
                 value: http://opentelemetry-collector.otel-system.svc:4317
               - name: OTEL_METRIC_EXPORT_INTERVAL
                 value: "10000"
+              - name: OTEL_METRIC_EXPORT_TIMEOUT
+                value: "10000"
   - patch: |-
       apiVersion: apps/v1
       kind: DaemonSet
@@ -67,6 +75,8 @@ patches:
                 value: http://opentelemetry-collector.otel-system.svc:4317
               - name: OTEL_METRIC_EXPORT_INTERVAL
                 value: "10000"
+              - name: OTEL_METRIC_EXPORT_TIMEOUT
+                value: "10000"
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -82,4 +92,6 @@ patches:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
               - name: OTEL_METRIC_EXPORT_INTERVAL
+                value: "10000"
+              - name: OTEL_METRIC_EXPORT_TIMEOUT
                 value: "10000"


### PR DESCRIPTION
Cut the OTel metric export interval to 10s in the kind stack, plumbing OTEL_METRIC_EXPORT_INTERVAL from ate-controller through to the ateom worker pods it creates. ateom registers no instruments of its own, so it stays invisible to the collector until its first export tick - which consumed ~50s of TestPlatformMetricsEmitted's 120s budget and made the suite flaky on loaded CI runners. 

also removes a dead `service_name=` in CollectorHasService, since the Prometheus exporter only ever emits that resource attribute as the job label.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
