### PR TITLE
(fix): tune otlp metric export cadence in e2e

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -28,11 +28,26 @@ import (
 // uid so each worker pod is a distinct telemetry source.
 const ateomOTelResourceAttributes = "k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),service.instance.id=$(POD_UID)"
 
+// AteomOTelConfig is the OTel SDK configuration the controller propagates into
+// the ateom worker pods it creates. Worker pods are not covered by deployment
+// manifests, so per-environment SDK tuning must flow through here.
+type AteomOTelConfig struct {
+	// Endpoint becomes OTEL_EXPORTER_OTLP_ENDPOINT; empty disables all
+	// telemetry env injection.
+	Endpoint string
+	// MetricExportInterval and MetricExportTimeout carry the spec-defined
+	// OTEL_METRIC_EXPORT_INTERVAL / OTEL_METRIC_EXPORT_TIMEOUT values
+	// (milliseconds). Empty leaves the SDK defaults (60s / 30s); e2e sets them
+	// low so short-lived workers push metrics within the test window.
+	MetricExportInterval string
+	MetricExportTimeout  string
+}
+
 // buildDeploymentApplyConfig constructs the SSA apply configuration for the
 // Deployment managed by a WorkerPool. Only fields owned by this controller
-// are declared here. otelEndpoint, when non-empty, is propagated to the ateom
+// are declared here. otel.Endpoint, when non-empty, is propagated to the ateom
 // container so it pushes telemetry to that collector.
-func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otelEndpoint string) *appsv1ac.DeploymentApplyConfiguration {
+func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel AteomOTelConfig) *appsv1ac.DeploymentApplyConfiguration {
 	containerAC := corev1ac.Container().
 		WithName("ateom").
 		WithImage(wp.Spec.AteomImage).
@@ -40,7 +55,7 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otelEndpoint string)
 			"--pod-uid=$(POD_UID)",
 		).
 		WithSecurityContext(ateomSecurityContext(wp.Spec.SandboxClass)).
-		WithEnv(ateomContainerEnv(otelEndpoint)...).
+		WithEnv(ateomContainerEnv(otel)...).
 		WithVolumeMounts(corev1ac.VolumeMount().
 			WithName("run-ateom").
 			WithMountPath(ateompath.BasePath).
@@ -80,22 +95,29 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otelEndpoint string)
 				WithSpec(podSpecAC)))
 }
 
-// ateomContainerEnv adds the OTLP endpoint and resource identity only when
-// telemetry is configured. POD_* refs precede OTEL_RESOURCE_ATTRIBUTES so its
-// $(POD_*) substitutions resolve.
-func ateomContainerEnv(otelEndpoint string) []*corev1ac.EnvVarApplyConfiguration {
+// ateomContainerEnv adds the OTLP endpoint, resource identity, and optional
+// metric export tuning only when telemetry is configured. POD_* refs precede
+// OTEL_RESOURCE_ATTRIBUTES so its $(POD_*) substitutions resolve.
+func ateomContainerEnv(otel AteomOTelConfig) []*corev1ac.EnvVarApplyConfiguration {
 	envs := []*corev1ac.EnvVarApplyConfiguration{
 		fieldRefEnv("POD_UID", "metadata.uid"),
 	}
-	if otelEndpoint == "" {
+	if otel.Endpoint == "" {
 		return envs
 	}
-	return append(envs,
+	envs = append(envs,
 		fieldRefEnv("POD_NAME", "metadata.name"),
 		fieldRefEnv("POD_NAMESPACE", "metadata.namespace"),
-		corev1ac.EnvVar().WithName("OTEL_EXPORTER_OTLP_ENDPOINT").WithValue(otelEndpoint),
+		corev1ac.EnvVar().WithName("OTEL_EXPORTER_OTLP_ENDPOINT").WithValue(otel.Endpoint),
 		corev1ac.EnvVar().WithName("OTEL_RESOURCE_ATTRIBUTES").WithValue(ateomOTelResourceAttributes),
 	)
+	if otel.MetricExportInterval != "" {
+		envs = append(envs, corev1ac.EnvVar().WithName("OTEL_METRIC_EXPORT_INTERVAL").WithValue(otel.MetricExportInterval))
+	}
+	if otel.MetricExportTimeout != "" {
+		envs = append(envs, corev1ac.EnvVar().WithName("OTEL_METRIC_EXPORT_TIMEOUT").WithValue(otel.MetricExportTimeout))
+	}
+	return envs
 }
 
 func fieldRefEnv(name, fieldPath string) *corev1ac.EnvVarApplyConfiguration {

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -201,7 +201,7 @@ func TestBuildDeploymentApplyConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildDeploymentApplyConfig(tt.wp, "")
+			got := buildDeploymentApplyConfig(tt.wp, AteomOTelConfig{})
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("buildDeploymentApplyConfig() mismatch (-want +got):\n%s", diff)
 			}
@@ -226,7 +226,7 @@ func TestMicroVMPodShape(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wp := testWorkerPoolApplyConfig(nil)
 			wp.Spec.SandboxClass = tt.class
-			ps := buildDeploymentApplyConfig(wp, "").Spec.Template.Spec
+			ps := buildDeploymentApplyConfig(wp, AteomOTelConfig{}).Spec.Template.Spec
 
 			hasVol := false
 			for _, v := range ps.Volumes {
@@ -325,7 +325,7 @@ func TestTerminationGracePeriodSeconds(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wp := testWorkerPoolApplyConfig(nil)
 			wp.Spec.TerminationGracePeriodSeconds = tt.set
-			ps := buildDeploymentApplyConfig(wp, "").Spec.Template.Spec
+			ps := buildDeploymentApplyConfig(wp, AteomOTelConfig{}).Spec.Template.Spec
 			if ps.TerminationGracePeriodSeconds == nil {
 				t.Fatalf("TerminationGracePeriodSeconds not set")
 			}
@@ -336,22 +336,39 @@ func TestTerminationGracePeriodSeconds(t *testing.T) {
 	}
 }
 
-// TestBuildDeploymentApplyConfigOTelEndpoint asserts the OTLP endpoint and the
-// pod-scoped resource identity are set on the ateom container only when an endpoint
-// is configured, and that the $(POD_*) refs precede OTEL_RESOURCE_ATTRIBUTES.
+// TestBuildDeploymentApplyConfigOTelEndpoint asserts the OTLP endpoint, the
+// pod-scoped resource identity, and the metric export tuning are set on the
+// ateom container only when an endpoint is configured, and that the $(POD_*)
+// refs precede OTEL_RESOURCE_ATTRIBUTES.
 func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
-	const endpoint = "http://collector.otel-system.svc:4317"
+	const (
+		endpoint = "http://collector.otel-system.svc:4317"
+		interval = "10000"
+		timeout  = "5000"
+	)
 	tests := []struct {
 		name          string
-		endpoint      string
+		otel          AteomOTelConfig
 		wantTelemetry bool
+		wantInterval  string
+		wantTimeout   string
 	}{
-		{"endpoint empty", "", false},
-		{"endpoint set", endpoint, true},
+		{name: "endpoint empty", otel: AteomOTelConfig{}},
+		// Export tuning without an endpoint configures a push that goes
+		// nowhere; nothing may be injected.
+		{name: "tuning without endpoint", otel: AteomOTelConfig{MetricExportInterval: interval, MetricExportTimeout: timeout}},
+		{name: "endpoint set", otel: AteomOTelConfig{Endpoint: endpoint}, wantTelemetry: true},
+		{
+			name:          "endpoint with export tuning",
+			otel:          AteomOTelConfig{Endpoint: endpoint, MetricExportInterval: interval, MetricExportTimeout: timeout},
+			wantTelemetry: true,
+			wantInterval:  interval,
+			wantTimeout:   timeout,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.endpoint).
+			c := buildDeploymentApplyConfig(testWorkerPoolApplyConfig(nil), tt.otel).
 				Spec.Template.Spec.Containers[0]
 			env := envByName(c.Env)
 
@@ -360,7 +377,11 @@ func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
 			}
 
 			if !tt.wantTelemetry {
-				for _, k := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES", "POD_NAME", "POD_NAMESPACE"} {
+				for _, k := range []string{
+					"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_RESOURCE_ATTRIBUTES",
+					"OTEL_METRIC_EXPORT_INTERVAL", "OTEL_METRIC_EXPORT_TIMEOUT",
+					"POD_NAME", "POD_NAMESPACE",
+				} {
 					if _, ok := env[k]; ok {
 						t.Errorf("%s must be absent without an OTLP endpoint", k)
 					}
@@ -373,6 +394,21 @@ func TestBuildDeploymentApplyConfigOTelEndpoint(t *testing.T) {
 			}
 			if got := env["OTEL_RESOURCE_ATTRIBUTES"].value; got != ateomOTelResourceAttributes {
 				t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want %q", got, ateomOTelResourceAttributes)
+			}
+			for k, want := range map[string]string{
+				"OTEL_METRIC_EXPORT_INTERVAL": tt.wantInterval,
+				"OTEL_METRIC_EXPORT_TIMEOUT":  tt.wantTimeout,
+			} {
+				got, ok := env[k]
+				if want == "" {
+					if ok {
+						t.Errorf("%s must be absent when not configured", k)
+					}
+					continue
+				}
+				if got.value != want {
+					t.Errorf("%s = %q, want %q", k, got.value, want)
+				}
 			}
 			raIdx := env["OTEL_RESOURCE_ATTRIBUTES"].index
 			for _, ref := range []string{"POD_UID", "POD_NAME", "POD_NAMESPACE"} {

--- a/cmd/atecontroller/internal/controllers/workerpool_controller.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller.go
@@ -35,8 +35,8 @@ const workerPoolFieldOwner = "workerpool-controller"
 
 type WorkerPoolReconciler struct {
 	client.Client
-	Scheme       *runtime.Scheme
-	OTelEndpoint string
+	Scheme *runtime.Scheme
+	OTel   AteomOTelConfig
 }
 
 //+kubebuilder:rbac:groups=ate.dev,resources=workerpools,verbs=get;list;watch;create;update;patch;delete
@@ -92,7 +92,7 @@ func (r *WorkerPoolReconciler) reconcileWorkerPool(ctx context.Context, wp *atev
 }
 
 func (r *WorkerPoolReconciler) applyDeployment(ctx context.Context, wp *atev1alpha1.WorkerPool) error {
-	depAC := buildDeploymentApplyConfig(wp, r.OTelEndpoint)
+	depAC := buildDeploymentApplyConfig(wp, r.OTel)
 	if err := r.Apply(ctx, depAC, client.FieldOwner(workerPoolFieldOwner), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply Deployment: %w", err)
 	}

--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -42,6 +42,11 @@ var (
 	otelEndpoint = pflag.String("otel-exporter-otlp-endpoint", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
 		"OTLP endpoint set on ateom worker pods so they push telemetry. Defaults to the controller's own OTEL_EXPORTER_OTLP_ENDPOINT.")
 
+	otelMetricExportInterval = pflag.String("otel-metric-export-interval", os.Getenv("OTEL_METRIC_EXPORT_INTERVAL"),
+		"OTEL_METRIC_EXPORT_INTERVAL (ms) set on ateom worker pods. Empty keeps the SDK default (60s). Defaults to the controller's own value.")
+	otelMetricExportTimeout = pflag.String("otel-metric-export-timeout", os.Getenv("OTEL_METRIC_EXPORT_TIMEOUT"),
+		"OTEL_METRIC_EXPORT_TIMEOUT (ms) set on ateom worker pods. Empty keeps the SDK default (30s). Defaults to the controller's own value.")
+
 	ateapiCAFile     = pflag.String("ateapi-ca-file", ateapiauth.DefaultServiceAccountCAFile, "PEM file with CAs trusted to verify the ateapi server cert.")
 	ateapiServerName = pflag.String("ateapi-server-name", "", "SNI / hostname expected on the ateapi server cert. Optional.")
 	ateapiTokenAuth  = pflag.Bool("ateapi-use-token-auth", false, "Authenticate to ateapi with the Bearer token from --ateapi-token-file instead of the client certificate from --ateapi-client-cert.")
@@ -87,9 +92,13 @@ func main() {
 	}
 
 	if err = (&controllers.WorkerPoolReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		OTelEndpoint: *otelEndpoint,
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		OTel: controllers.AteomOTelConfig{
+			Endpoint:             *otelEndpoint,
+			MetricExportInterval: *otelMetricExportInterval,
+			MetricExportTimeout:  *otelMetricExportTimeout,
+		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkerPool")
 		os.Exit(1)

--- a/manifests/ate-install/kind/kustomization.yaml
+++ b/manifests/ate-install/kind/kustomization.yaml
@@ -27,6 +27,9 @@ resources:
   - ./otel-collector.yaml
   - ./prometheus.yaml
 
+# OTEL_METRIC_EXPORT_INTERVAL/TIMEOUT (ms) shorten the default 60s/30s push
+# cadence so metrics land inside e2e assertion windows; ate-controller mirrors
+# them into the ateom worker pods it creates.
 patches:
   - patch: |-
       apiVersion: apps/v1
@@ -42,6 +45,10 @@ patches:
               env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
+              - name: OTEL_METRIC_EXPORT_INTERVAL
+                value: "10000"
+              - name: OTEL_METRIC_EXPORT_TIMEOUT
+                value: "10000"
   - patch: |-
       apiVersion: apps/v1
       kind: DaemonSet
@@ -56,6 +63,10 @@ patches:
               env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
+              - name: OTEL_METRIC_EXPORT_INTERVAL
+                value: "10000"
+              - name: OTEL_METRIC_EXPORT_TIMEOUT
+                value: "10000"
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -70,3 +81,7 @@ patches:
               env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://opentelemetry-collector.otel-system.svc:4317
+              - name: OTEL_METRIC_EXPORT_INTERVAL
+                value: "10000"
+              - name: OTEL_METRIC_EXPORT_TIMEOUT
+                value: "10000"


### PR DESCRIPTION
Fixes #634

Worker pods only get two 60s export ticks inside the test's 2 minute window, so a transient failure can faile both easily.

This PR adds
 - kind overlay sets the spec standard `OTEL_METRIC_EXPORT_INTERVAL`/`OTEL_METRIC_EXPORT_TIMEOUT` (10s) on ateapi, atelet, and atecontroller. At the same time, production keeps SDK defaults
- atecontroller mirrors both vars into the ateom worker pods it creates (via new AteomOTelConfig), same pattern as the existing endpoint propagation
- unit test coverage for the env injection

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
