### PR TITLE
ateom: add GetWorkloadStats RPC and retain actor attribution

### DIFF
--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -256,9 +256,9 @@ type AteomService struct {
 
 	// activeActor is the actor whose workload this ateom is currently running,
 	// or nil when it is "available". An ateom serves one actor at a time, so a
-	// single slot is enough (the micro-VM ateom holds the same field on each
-	// entry of its s.running map). Guarded by lock, like every other RPC-visible
-	// field.
+	// single slot is enough (the micro-VM ateom holds the same field, set and
+	// cleared at the same points). Guarded by lock, like every other
+	// RPC-visible field.
 	//
 	// Set by RunWorkload / RestoreWorkload and cleared by CheckpointWorkload, so
 	// it tracks exactly the available/executing state machine described on the

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/ateomnet"
 	"github.com/agent-substrate/substrate/internal/ateompath"
+	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/atunnel"
 	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/agent-substrate/substrate/internal/imagecache"
@@ -49,7 +50,9 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -250,6 +253,17 @@ type AteomService struct {
 	podIdentityTrustBundlePath string
 	// egressGatewayTrustBundlePath verifies the remote gateway's serving cert.
 	egressGatewayTrustBundlePath string
+
+	// activeActor is the actor whose workload this ateom is currently running,
+	// or nil when it is "available". An ateom serves one actor at a time, so a
+	// single slot is enough (the micro-VM ateom holds the same field on each
+	// entry of its s.running map). Guarded by lock, like every other RPC-visible
+	// field.
+	//
+	// Set by RunWorkload / RestoreWorkload and cleared by CheckpointWorkload, so
+	// it tracks exactly the available/executing state machine described on the
+	// Ateom service. GetWorkloadStats reads it to attribute its sample.
+	activeActor *ateomstats.ActorAttribution
 }
 
 var _ ateompb.AteomServer = (*AteomService)(nil)
@@ -278,6 +292,12 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
 	s.actorLogger.EmitLifecycleLog("Actor starting", actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
+	// Retain the attribution before the boot rather than after it, so a sample
+	// taken against a workload that dies mid-boot is still attributable. The
+	// cleanup below drops it again if the boot fails outright.
+	attribution := ateomstats.ActorAttributionFromRequest(req)
+	s.activeActor = &attribution
+
 	// Contract with atelet:
 	//
 	//   * Correct runsc version is downloaded and placed on disk.
@@ -292,6 +312,9 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 		DumpNetInfo:        true,
 		EgressRedirectPort: s.egressRedirectPort(req.GetEgressGateway() != nil),
 	}); err != nil {
+		// Cleared here as well as in the deferred cleanup below, because that
+		// defer is not registered until after this check.
+		s.activeActor = nil
 		return nil, fmt.Errorf("while setting up actor network: %w", err)
 	}
 	rcmd := &runsc{
@@ -301,6 +324,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	var containersToDelete []string
 	defer func() {
 		if retErr != nil {
+			s.activeActor = nil
 			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
 			if err := s.deactivateActorNetworking(cleanupCtx); err != nil {
@@ -420,6 +444,19 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		return nil, fmt.Errorf("unsupported snapshot scope: %v", req.GetScope())
 	}
 
+	// The sandbox is gone as of the checkpoint above, so the ateom is back to
+	// "available" from here on: there is nothing left to measure, and holding
+	// the attribution would let a later GetWorkloadStats report a checkpointed
+	// actor as though it were still running.
+	//
+	// Cleared here rather than at the end of the function because everything
+	// below is bookkeeping over a dead sandbox and can still fail (listing the
+	// snapshot files returns an error), which would otherwise leave the
+	// attribution behind. Conversely nothing above this point clears it: a
+	// checkpoint that failed may well have left the workload running, and
+	// reporting its usage is then the honest answer.
+	s.activeActor = nil
+
 	// After checkpointing the sandbox root, runsc may no longer have a usable
 	// control server for state/delete calls. Keep this as best-effort cleanup:
 	// atelet resets the actor runsc, bundle, pidfile, and checkpoint
@@ -455,6 +492,16 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	s.actorLogger.EmitLifecycleLog("Actor checkpointed", actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
 	return &ateompb.CheckpointWorkloadResponse{SnapshotFiles: snapshotFiles}, nil
+}
+
+// GetWorkloadStats implements ateompb.Ateom/GetWorkloadStats.
+//
+// The attribution half is wired up here; the measurement half is not. Reading the
+// sandbox's cgroup (/sys/fs/cgroup/pause) lands in the follow-up to
+// https://github.com/agent-substrate/substrate/issues/594, at which point this
+// stops returning Unimplemented.
+func (s *AteomService) GetWorkloadStats(ctx context.Context, req *ateompb.GetWorkloadStatsRequest) (*ateompb.GetWorkloadStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "GetWorkloadStats is not implemented yet")
 }
 
 // listSnapshotFiles returns the (relative) names of regular files directly under
@@ -510,6 +557,10 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
 	s.actorLogger.EmitLifecycleLog("Actor restoring", actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 
+	// Same as RunWorkload: retain before the boot, drop again if it fails.
+	attribution := ateomstats.ActorAttributionFromRequest(req)
+	s.activeActor = &attribution
+
 	// Contract with atelet:
 	//
 	//   * Correct runsc version is downloaded and placed on disk.
@@ -525,6 +576,8 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		DumpNetInfo:        true,
 		EgressRedirectPort: s.egressRedirectPort(req.GetEgressGateway() != nil),
 	}); err != nil {
+		// Same as the Run path: the defer below is not registered yet.
+		s.activeActor = nil
 		return nil, fmt.Errorf("while setting up actor network: %w", err)
 	}
 	rcmd := &runsc{
@@ -534,6 +587,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	var containersToDelete []string
 	defer func() {
 		if retErr != nil {
+			s.activeActor = nil
 			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
 			if err := s.deactivateActorNetworking(cleanupCtx); err != nil {

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
@@ -257,13 +258,27 @@ type AteomService struct {
 	// activeActor is the actor whose workload this ateom is currently running,
 	// or nil when it is "available". An ateom serves one actor at a time, so a
 	// single slot is enough (the micro-VM ateom holds the same field, set and
-	// cleared at the same points). Guarded by lock, like every other
-	// RPC-visible field.
+	// cleared at the same points).
 	//
 	// Set by RunWorkload / RestoreWorkload and cleared by CheckpointWorkload, so
 	// it tracks exactly the available/executing state machine described on the
 	// Ateom service. GetWorkloadStats reads it to attribute its sample.
-	activeActor *ateomstats.ActorAttribution
+	//
+	// Atomic rather than guarded by lock, unlike every other RPC-visible field
+	// here. The three writers already hold lock for their whole bodies and keep
+	// doing so; the point is the reader. lock is held across an entire boot,
+	// restore, or checkpoint, so a lock-guarded read would park a poller for the
+	// full duration of each -- going quiet during exactly the phases whose usage
+	// is most interesting -- and holding it across the read would put a
+	// CheckpointWorkload behind telemetry instead. The field is only ever
+	// assigned or cleared as a whole pointer, never mutated in place, which is
+	// exactly what atomic.Pointer is for.
+	//
+	// The type makes a lock-free read possible; it does not make one happen.
+	// GetWorkloadStats must not take lock at all, including around whatever it
+	// does with the value. A regression test pins that once there is a handler
+	// with a body to pin.
+	activeActor atomic.Pointer[ateomstats.ActorAttribution]
 }
 
 var _ ateompb.AteomServer = (*AteomService)(nil)
@@ -296,7 +311,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	// taken against a workload that dies mid-boot is still attributable. The
 	// cleanup below drops it again if the boot fails outright.
 	attribution := ateomstats.ActorAttributionFromRequest(req)
-	s.activeActor = &attribution
+	s.activeActor.Store(&attribution)
 
 	// Contract with atelet:
 	//
@@ -314,7 +329,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	}); err != nil {
 		// Cleared here as well as in the deferred cleanup below, because that
 		// defer is not registered until after this check.
-		s.activeActor = nil
+		s.activeActor.Store(nil)
 		return nil, fmt.Errorf("while setting up actor network: %w", err)
 	}
 	rcmd := &runsc{
@@ -324,7 +339,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	var containersToDelete []string
 	defer func() {
 		if retErr != nil {
-			s.activeActor = nil
+			s.activeActor.Store(nil)
 			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
 			if err := s.deactivateActorNetworking(cleanupCtx); err != nil {
@@ -455,7 +470,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	// attribution behind. Conversely nothing above this point clears it: a
 	// checkpoint that failed may well have left the workload running, and
 	// reporting its usage is then the honest answer.
-	s.activeActor = nil
+	s.activeActor.Store(nil)
 
 	// After checkpointing the sandbox root, runsc may no longer have a usable
 	// control server for state/delete calls. Keep this as best-effort cleanup:
@@ -559,7 +574,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 
 	// Same as RunWorkload: retain before the boot, drop again if it fails.
 	attribution := ateomstats.ActorAttributionFromRequest(req)
-	s.activeActor = &attribution
+	s.activeActor.Store(&attribution)
 
 	// Contract with atelet:
 	//
@@ -577,7 +592,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		EgressRedirectPort: s.egressRedirectPort(req.GetEgressGateway() != nil),
 	}); err != nil {
 		// Same as the Run path: the defer below is not registered yet.
-		s.activeActor = nil
+		s.activeActor.Store(nil)
 		return nil, fmt.Errorf("while setting up actor network: %w", err)
 	}
 	rcmd := &runsc{
@@ -587,7 +602,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	var containersToDelete []string
 	defer func() {
 		if retErr != nil {
-			s.activeActor = nil
+			s.activeActor.Store(nil)
 			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
 			if err := s.deactivateActorNetworking(cleanupCtx); err != nil {

--- a/cmd/ateom-gvisor/stats_test.go
+++ b/cmd/ateom-gvisor/stats_test.go
@@ -49,11 +49,11 @@ func TestGetWorkloadStatsUnimplemented(t *testing.T) {
 }
 
 // TestAteomServiceStartsAvailable checks that a freshly constructed service
-// retains no attribution. GetWorkloadStats's FAILED_PRECONDITION-when-available
-// behavior is built on this: a non-nil zero value here would make an idle ateom
-// report an empty actor's usage instead of refusing.
+// retains no attribution. GetWorkloadStats's NOT_FOUND-when-available behavior
+// is built on this: a non-nil zero value here would make an idle ateom report
+// an empty actor's usage instead of refusing.
 func TestAteomServiceStartsAvailable(t *testing.T) {
-	if s := (&AteomService{}); s.activeActor != nil {
-		t.Errorf("new AteomService.activeActor = %v, want nil", s.activeActor)
+	if s := (&AteomService{}); s.activeActor.Load() != nil {
+		t.Errorf("new AteomService.activeActor = %v, want nil", s.activeActor.Load())
 	}
 }

--- a/cmd/ateom-gvisor/stats_test.go
+++ b/cmd/ateom-gvisor/stats_test.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+)
+
+// TestGetWorkloadStatsUnimplemented pins the stub's advertised contract. The
+// cgroup read replaces this body; until then a caller that gets any other code back
+// would be reading numbers that are not there.
+//
+// The retention this stub will eventually read — s.activeActor, set by
+// RunWorkload / RestoreWorkload and cleared by CheckpointWorkload — has no unit
+// test, because those three RPCs each reach for netlink, runsc, and the worker
+// pod's netns within a few lines of entry and cannot be driven from `go test`.
+// Its mapping is covered in internal/ateomstats; the transitions are verified
+// end to end once GetWorkloadStats returns real data.
+func TestGetWorkloadStatsUnimplemented(t *testing.T) {
+	s := &AteomService{}
+
+	resp, err := s.GetWorkloadStats(context.Background(), &ateompb.GetWorkloadStatsRequest{ActorUid: "uid-c"})
+	if resp != nil {
+		t.Errorf("GetWorkloadStats() returned response %v, want nil", resp)
+	}
+	if got := status.Code(err); got != codes.Unimplemented {
+		t.Errorf("GetWorkloadStats() error code = %v, want %v (err: %v)", got, codes.Unimplemented, err)
+	}
+}
+
+// TestAteomServiceStartsAvailable checks that a freshly constructed service
+// retains no attribution. GetWorkloadStats's FAILED_PRECONDITION-when-available
+// behavior is built on this: a non-nil zero value here would make an idle ateom
+// report an empty actor's usage instead of refusing.
+func TestAteomServiceStartsAvailable(t *testing.T) {
+	if s := (&AteomService{}); s.activeActor != nil {
+		t.Errorf("new AteomService.activeActor = %v, want nil", s.activeActor)
+	}
+}

--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -169,7 +169,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	// left it present, and reporting its usage is then the honest answer. This is
 	// the same point at which the running entry goes away, which is what keeps
 	// the two views of "is an actor here" from disagreeing.
-	s.activeActor = nil
+	s.activeActor.Store(nil)
 
 	// Tear down the per-activation actor network.
 	if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {

--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -158,6 +158,19 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	dTeardown := time.Since(tTeardown)
 	delete(s.running, actorUID)
 
+	// The guest is gone as of the teardown above, so the ateom is back to
+	// "available": there is nothing left to measure, and holding the attribution
+	// would let a later GetWorkloadStats report a checkpointed actor as though it
+	// were still running.
+	//
+	// Nothing above this point clears it, unlike the gVisor ateom, which clears
+	// as soon as its checkpoint call has taken the sandbox down. Here the guest
+	// is only paused until this teardown, so a checkpoint that failed earlier has
+	// left it present, and reporting its usage is then the honest answer. This is
+	// the same point at which the running entry goes away, which is what keeps
+	// the two views of "is an actor here" from disagreeing.
+	s.activeActor = nil
+
 	// Tear down the per-activation actor network.
 	if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
 		slog.WarnContext(ctx, "Failed to clean up actor network after checkpoint", slog.Any("err", err))

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/ateomnet"
 	"github.com/agent-substrate/substrate/internal/ateompath"
+	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/atunnel"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	"github.com/agent-substrate/substrate/internal/serverboot"
@@ -289,6 +290,26 @@ type AteomService struct {
 	// pause+snapshot+teardown the same sandbox (and RestoreWorkload can track the
 	// CH it relaunched).
 	running map[string]*runningActor
+
+	// activeActor is the actor whose workload this ateom is currently running,
+	// or nil when it is "available". An ateom serves one actor at a time, so a
+	// single slot is enough; running is keyed by UID for lookup, not because
+	// several actors can be live at once. Guarded by lock, like every other
+	// RPC-visible field.
+	//
+	// Set by RunWorkload / RestoreWorkload and cleared by CheckpointWorkload, so
+	// it tracks exactly the available/executing state machine described on the
+	// Ateom service. GetWorkloadStats reads it to attribute its sample.
+	//
+	// Kept here rather than on runningActor, even though that struct already
+	// exists per actor: runningActor holds processes that do not exist until the
+	// guest is up (chCmd, vfsdCmd, logAgent), so it cannot be built before the
+	// boot, and an entry in running is what tells CheckpointWorkload a live VM is
+	// there. Attribution has to outlive both of those constraints — it is needed
+	// from the moment the ateom accepts the actor, including for a boot that
+	// never finishes. Same field, same timing, as the gVisor ateom's
+	// AteomService.activeActor.
+	activeActor *ateomstats.ActorAttribution
 }
 
 var _ ateompb.AteomServer = (*AteomService)(nil)

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
@@ -294,8 +295,7 @@ type AteomService struct {
 	// activeActor is the actor whose workload this ateom is currently running,
 	// or nil when it is "available". An ateom serves one actor at a time, so a
 	// single slot is enough; running is keyed by UID for lookup, not because
-	// several actors can be live at once. Guarded by lock, like every other
-	// RPC-visible field.
+	// several actors can be live at once.
 	//
 	// Set by RunWorkload / RestoreWorkload and cleared by CheckpointWorkload, so
 	// it tracks exactly the available/executing state machine described on the
@@ -309,7 +309,14 @@ type AteomService struct {
 	// from the moment the ateom accepts the actor, including for a boot that
 	// never finishes. Same field, same timing, as the gVisor ateom's
 	// AteomService.activeActor.
-	activeActor *ateomstats.ActorAttribution
+	//
+	// Atomic for the same reason as there, and it matters at least as much on
+	// this runtime: lock is held across a cold boot with its retry, across a
+	// snapshot write, and across a restore, so a lock-guarded read would park a
+	// poller through all of them. The writers keep holding lock; the point is the
+	// reader. As there, the type makes a lock-free read possible without making
+	// one happen — GetWorkloadStats must not take lock at all.
+	activeActor atomic.Pointer[ateomstats.ActorAttribution]
 }
 
 var _ ateompb.AteomServer = (*AteomService)(nil)

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -54,7 +54,7 @@ import (
 //
 // Contract with atelet: the snapshot's files have been downloaded to RestoreStateDir,
 // and the durable-dir volume directories re-created (empty).
-func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.RestoreWorkloadRequest) (*ateompb.RestoreWorkloadResponse, error) {
+func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.RestoreWorkloadRequest) (resp *ateompb.RestoreWorkloadResponse, retErr error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -77,6 +77,18 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	tStart := time.Now()
 
 	s.actorLogger.EmitLifecycleLog("Actor restoring", p.actorRef, p.actorUID, p.templateNS, p.templateName)
+
+	// Same as RunWorkload: retain before the restore, drop again if it fails. A
+	// Full-scope resume reaches "executing" in a different way than a cold boot
+	// does, but the window between accepting the actor and serving it is the same
+	// window, and a poll landing in it should name the actor either way.
+	attribution := p.actorAttribution()
+	s.activeActor = &attribution
+	defer func() {
+		if retErr != nil {
+			s.activeActor = nil
+		}
+	}()
 
 	// Restore the durable-dir volumes before anything can observe them: for Full
 	// that means before the share's virtiofsd starts, for Data before the workload
@@ -287,7 +299,6 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	ra := &runningActor{
 		chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd,
 		apiSocket: apiSocket, baseID: srcID, restoreSourceDir: restoreDir,
-		activeActor: p.actorAttribution(),
 	}
 
 	// Re-attach stdout/stderr forwarding for each container: the restored guest's

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -287,6 +287,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	ra := &runningActor{
 		chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd,
 		apiSocket: apiSocket, baseID: srcID, restoreSourceDir: restoreDir,
+		activeActor: p.actorAttribution(),
 	}
 
 	// Re-attach stdout/stderr forwarding for each container: the restored guest's

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -83,10 +83,10 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	// does, but the window between accepting the actor and serving it is the same
 	// window, and a poll landing in it should name the actor either way.
 	attribution := p.actorAttribution()
-	s.activeActor = &attribution
+	s.activeActor.Store(&attribution)
 	defer func() {
 		if retErr != nil {
-			s.activeActor = nil
+			s.activeActor.Store(nil)
 		}
 	}()
 

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/third_party/kata/agentpb"
 	"github.com/agent-substrate/substrate/internal/ateompath"
+	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/imagecache"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	"github.com/agent-substrate/substrate/internal/readyz"
@@ -54,6 +55,14 @@ type runningActor struct {
 	// propagated). CheckpointWorkload writes it back into the next snapshot's
 	// base-id file so the chain survives suspend->resume->suspend.
 	baseID string
+
+	// activeActor is the actor from the Run/Restore request that started this
+	// micro-VM, retained so GetWorkloadStats can attribute its samples. The rest
+	// of this struct is about owning processes; this field is the one piece of
+	// the original request the service has to remember. Named to match the gVisor
+	// ateom's AteomService.activeActor, which holds the same thing for the one
+	// actor that ateom serves.
+	activeActor ateomstats.ActorAttribution
 
 	// ateom owns this CH process (booted at Run or relaunched at Restore).
 	chCmd *exec.Cmd
@@ -236,6 +245,17 @@ type actorBootParams struct {
 	assetPaths   map[string]string
 	// egressGateway is nil unless actor TCP should be redirected through atunnel.
 	egressGateway *ateompb.EgressGateway
+}
+
+// actorAttribution regroups the actor fields that arrived on the Run/Restore
+// request, for retention on the resulting runningActor.
+func (p actorBootParams) actorAttribution() ateomstats.ActorAttribution {
+	return ateomstats.ActorAttribution{
+		Ref:               p.actorRef,
+		UID:               p.actorUID,
+		TemplateNamespace: p.templateNS,
+		TemplateName:      p.templateName,
+	}
 }
 
 // coldBootAttempts is how many times a cold boot is tried when the micro-VM
@@ -462,7 +482,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 		return fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
-	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, apiSocket: apiSocket, baseID: actorUID, logAgent: ac}
+	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, apiSocket: apiSocket, baseID: actorUID, logAgent: ac, activeActor: p.actorAttribution()}
 	if err := s.activateActorNetworking(p.actorRef.Atespace, p.actorRef.Name, egress); err != nil {
 		return err
 	}

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -225,10 +225,10 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	// reports nothing. The defer drops it again if the boot fails outright.
 	// Matches ateom-gvisor's RunWorkload.
 	attribution := p.actorAttribution()
-	s.activeActor = &attribution
+	s.activeActor.Store(&attribution)
 	defer func() {
 		if retErr != nil {
-			s.activeActor = nil
+			s.activeActor.Store(nil)
 		}
 	}()
 

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -56,14 +56,6 @@ type runningActor struct {
 	// base-id file so the chain survives suspend->resume->suspend.
 	baseID string
 
-	// activeActor is the actor from the Run/Restore request that started this
-	// micro-VM, retained so GetWorkloadStats can attribute its samples. The rest
-	// of this struct is about owning processes; this field is the one piece of
-	// the original request the service has to remember. Named to match the gVisor
-	// ateom's AteomService.activeActor, which holds the same thing for the one
-	// actor that ateom serves.
-	activeActor ateomstats.ActorAttribution
-
 	// ateom owns this CH process (booted at Run or relaunched at Restore).
 	chCmd *exec.Cmd
 	// vfsdCmd is the virtiofsd serving the overlay RO lower (the CH fs device
@@ -206,7 +198,7 @@ func writeGuestResolvConf(rootfs string) error {
 //   - The runtime assets (guest kernel, guest OS image, cloud-hypervisor, virtiofsd,
 //     base kata config) are on disk and passed as runtime asset paths.
 //   - The OCI bundle (config.json + populated rootfs/) is prepared per container.
-func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkloadRequest) (*ateompb.RunWorkloadResponse, error) {
+func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkloadRequest) (resp *ateompb.RunWorkloadResponse, retErr error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if err := s.deactivateActorNetworking(ctx); err != nil {
@@ -225,6 +217,21 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	}
 
 	s.actorLogger.EmitLifecycleLog("Actor starting", p.actorRef, p.actorUID, p.templateNS, p.templateName)
+
+	// Retain the attribution before the boot rather than after it, so a sample
+	// taken against a workload that dies mid-boot is still attributable. A cold
+	// boot can take a while and can be retried, and an actor that never reaches
+	// readyz is one whose usage is worth reporting rather than the one case that
+	// reports nothing. The defer drops it again if the boot fails outright.
+	// Matches ateom-gvisor's RunWorkload.
+	attribution := p.actorAttribution()
+	s.activeActor = &attribution
+	defer func() {
+		if retErr != nil {
+			s.activeActor = nil
+		}
+	}()
+
 	if err := s.coldBootActorRetrying(ctx, p); err != nil {
 		return nil, err
 	}
@@ -248,7 +255,7 @@ type actorBootParams struct {
 }
 
 // actorAttribution regroups the actor fields that arrived on the Run/Restore
-// request, for retention on the resulting runningActor.
+// request, for retention in AteomService.activeActor.
 func (p actorBootParams) actorAttribution() ateomstats.ActorAttribution {
 	return ateomstats.ActorAttribution{
 		Ref:               p.actorRef,
@@ -482,7 +489,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 		return fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
-	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, apiSocket: apiSocket, baseID: actorUID, logAgent: ac, activeActor: p.actorAttribution()}
+	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, apiSocket: apiSocket, baseID: actorUID, logAgent: ac}
 	if err := s.activateActorNetworking(p.actorRef.Atespace, p.actorRef.Name, egress); err != nil {
 		return err
 	}

--- a/cmd/ateom-microvm/stats.go
+++ b/cmd/ateom-microvm/stats.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+)
+
+// GetWorkloadStats implements ateompb.Ateom/GetWorkloadStats.
+//
+// The attribution half is wired up (see runningActor.activeActor); the measurement
+// half is not. The micro-VM read goes to the guest agent's StatsContainer
+// rather than the host cgroup — guest RAM is a fixed allocation, so the host
+// cgroup barely moves with the workload — and lands in the follow-up to
+// https://github.com/agent-substrate/substrate/issues/594, at which point this
+// stops returning Unimplemented.
+func (s *AteomService) GetWorkloadStats(ctx context.Context, req *ateompb.GetWorkloadStatsRequest) (*ateompb.GetWorkloadStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "GetWorkloadStats is not implemented yet")
+}

--- a/cmd/ateom-microvm/stats.go
+++ b/cmd/ateom-microvm/stats.go
@@ -27,7 +27,7 @@ import (
 
 // GetWorkloadStats implements ateompb.Ateom/GetWorkloadStats.
 //
-// The attribution half is wired up (see runningActor.activeActor); the measurement
+// The attribution half is wired up (see AteomService.activeActor); the measurement
 // half is not. The micro-VM read goes to the guest agent's StatsContainer
 // rather than the host cgroup — guest RAM is a fixed allocation, so the host
 // cgroup barely moves with the workload — and lands in the follow-up to

--- a/cmd/ateom-microvm/stats_test.go
+++ b/cmd/ateom-microvm/stats_test.go
@@ -1,0 +1,113 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/agent-substrate/substrate/internal/ateomstats"
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/resources"
+)
+
+// TestActorBootParamsAttribution pins the mapping from actorBootParams onto the
+// attribution a runningActor retains. The three loose fields are the ones most
+// likely to get crossed, since actorBootParams names them differently than
+// ActorAttribution does; the distinct placeholders below make a swap visible.
+func TestActorBootParamsAttribution(t *testing.T) {
+	tests := []struct {
+		name string
+		p    actorBootParams
+		want ateomstats.ActorAttribution
+	}{
+		{
+			name: "fully populated",
+			p: actorBootParams{
+				actorRef:     resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
+				actorUID:     "uid-c",
+				templateNS:   "template-ns-d",
+				templateName: "template-name-e",
+			},
+			want: ateomstats.ActorAttribution{
+				Ref:               resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
+				UID:               "uid-c",
+				TemplateNamespace: "template-ns-d",
+				TemplateName:      "template-name-e",
+			},
+		},
+		{
+			name: "zero params",
+			p:    actorBootParams{},
+			want: ateomstats.ActorAttribution{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, tc.p.actorAttribution()); diff != "" {
+				t.Errorf("actorBootParams.actorAttribution() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestActorBootParamsAttributionMatchesRequest checks the two hops the
+// attribution makes — request to actorBootParams (in RunWorkload /
+// RestoreWorkload) and actorBootParams to ActorAttribution — compose back into
+// what the caller sent. The two hops are written in different files, so this is
+// the assertion that catches them drifting apart.
+func TestActorBootParamsAttributionMatchesRequest(t *testing.T) {
+	req := &ateompb.RunWorkloadRequest{
+		Atespace:               "atespace-a",
+		ActorName:              "actor-b",
+		ActorUid:               "uid-c",
+		ActorTemplateNamespace: "template-ns-d",
+		ActorTemplateName:      "template-name-e",
+	}
+
+	// Mirrors the actorBootParams literal in RunWorkload and RestoreWorkload.
+	p := actorBootParams{
+		actorRef:     resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()},
+		actorUID:     req.GetActorUid(),
+		templateNS:   req.GetActorTemplateNamespace(),
+		templateName: req.GetActorTemplateName(),
+	}
+
+	if diff := cmp.Diff(ateomstats.ActorAttributionFromRequest(req), p.actorAttribution()); diff != "" {
+		t.Errorf("attribution via actorBootParams differs from attribution via request (-request +params):\n%s", diff)
+	}
+}
+
+// TestGetWorkloadStatsUnimplemented pins the stub's advertised contract. The
+// guest agent read replaces this body; until then a caller that gets any other code
+// back would be reading numbers that are not there.
+func TestGetWorkloadStatsUnimplemented(t *testing.T) {
+	s := &AteomService{}
+
+	resp, err := s.GetWorkloadStats(context.Background(), &ateompb.GetWorkloadStatsRequest{ActorUid: "uid-c"})
+	if resp != nil {
+		t.Errorf("GetWorkloadStats() returned response %v, want nil", resp)
+	}
+	if got := status.Code(err); got != codes.Unimplemented {
+		t.Errorf("GetWorkloadStats() error code = %v, want %v (err: %v)", got, codes.Unimplemented, err)
+	}
+}

--- a/cmd/ateom-microvm/stats_test.go
+++ b/cmd/ateom-microvm/stats_test.go
@@ -122,11 +122,11 @@ func TestGetWorkloadStatsUnimplemented(t *testing.T) {
 
 // TestAteomServiceStartsAvailable checks that a freshly constructed service
 // retains no attribution, mirroring the gVisor ateom's test of the same name.
-// GetWorkloadStats's FAILED_PRECONDITION-when-available behavior is built on
-// this: a non-nil zero value here would make an idle ateom report an empty
-// actor's usage instead of refusing.
+// GetWorkloadStats's NOT_FOUND-when-available behavior is built on this: a
+// non-nil zero value here would make an idle ateom report an empty actor's
+// usage instead of refusing.
 func TestAteomServiceStartsAvailable(t *testing.T) {
-	if s := (&AteomService{}); s.activeActor != nil {
-		t.Errorf("new AteomService.activeActor = %v, want nil", s.activeActor)
+	if s := (&AteomService{}); s.activeActor.Load() != nil {
+		t.Errorf("new AteomService.activeActor = %v, want nil", s.activeActor.Load())
 	}
 }

--- a/cmd/ateom-microvm/stats_test.go
+++ b/cmd/ateom-microvm/stats_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 // TestActorBootParamsAttribution pins the mapping from actorBootParams onto the
-// attribution a runningActor retains. The three loose fields are the ones most
+// attribution the service retains. The three loose fields are the ones most
 // likely to get crossed, since actorBootParams names them differently than
 // ActorAttribution does; the distinct placeholders below make a swap visible.
 func TestActorBootParamsAttribution(t *testing.T) {
@@ -100,6 +100,14 @@ func TestActorBootParamsAttributionMatchesRequest(t *testing.T) {
 // TestGetWorkloadStatsUnimplemented pins the stub's advertised contract. The
 // guest agent read replaces this body; until then a caller that gets any other code
 // back would be reading numbers that are not there.
+//
+// The retention this stub will eventually read — s.activeActor, set by
+// RunWorkload / RestoreWorkload and cleared by CheckpointWorkload — has no unit
+// test, for the same reason as on the gVisor side: those three RPCs reach for
+// netlink, cloud-hypervisor, and the worker pod's netns within a few lines of
+// entry and cannot be driven from `go test`. Its mapping is covered above and
+// in internal/ateomstats; the transitions are verified end to end once
+// GetWorkloadStats returns real data.
 func TestGetWorkloadStatsUnimplemented(t *testing.T) {
 	s := &AteomService{}
 
@@ -109,5 +117,16 @@ func TestGetWorkloadStatsUnimplemented(t *testing.T) {
 	}
 	if got := status.Code(err); got != codes.Unimplemented {
 		t.Errorf("GetWorkloadStats() error code = %v, want %v (err: %v)", got, codes.Unimplemented, err)
+	}
+}
+
+// TestAteomServiceStartsAvailable checks that a freshly constructed service
+// retains no attribution, mirroring the gVisor ateom's test of the same name.
+// GetWorkloadStats's FAILED_PRECONDITION-when-available behavior is built on
+// this: a non-nil zero value here would make an idle ateom report an empty
+// actor's usage instead of refusing.
+func TestAteomServiceStartsAvailable(t *testing.T) {
+	if s := (&AteomService{}); s.activeActor != nil {
+		t.Errorf("new AteomService.activeActor = %v, want nil", s.activeActor)
 	}
 }

--- a/internal/ateomstats/actorattribution.go
+++ b/internal/ateomstats/actorattribution.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ateomstats holds the pieces both ateom runtimes need to answer
+// ateompb.Ateom/GetWorkloadStats. Today that is the attribution an ateom
+// retains for the workload it is executing; the per-runtime measurement reads
+// live with their runtimes (the cgroup read is only meaningful inside the
+// gVisor worker's cgroup namespace, the guest-agent read only over the
+// micro-VM's vsock).
+package ateomstats
+
+import (
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/resources"
+)
+
+// ActorAttribution is what a usage sample is attributed to: the actor an ateom
+// retains from the RunWorkloadRequest / RestoreWorkloadRequest that started the
+// workload it is currently executing.
+//
+// ateom is otherwise incurious about who it is running: these fields arrive on
+// the call that starts the workload and are not needed again by the run,
+// checkpoint, or restore paths. GetWorkloadStats needs them, because a usage
+// sample is only useful once attributed to an actor and a template, and the
+// request carries nothing of its own beyond the actor UID it is asserting.
+//
+// This is the same tuple actorlog passes around as loose parameters
+// (EmitLifecycleLog, StartJSONLogPipe, WrapContainerLogs) and that ateattr
+// stamps as ate.actor.* / ate.template.*: an ActorRef plus the two things a ref
+// does not carry, the server-assigned uid and the template it was built from.
+//
+// Unrelated to the credential sense of "actor identity" elsewhere in the repo
+// (ateapi's ActorIdentity service, substratex509, ateompath.ActorIdentityDirPath)
+// — nothing here is a secret or is presented as proof of anything.
+type ActorAttribution struct {
+	Ref               resources.ActorRef
+	UID               string
+	TemplateNamespace string
+	TemplateName      string
+}
+
+// attributionSource is the attribution-bearing subset of the requests that
+// start a workload. Both RunWorkloadRequest and RestoreWorkloadRequest satisfy
+// it.
+type attributionSource interface {
+	GetAtespace() string
+	GetActorName() string
+	GetActorUid() string
+	GetActorTemplateNamespace() string
+	GetActorTemplateName() string
+}
+
+var (
+	_ attributionSource = (*ateompb.RunWorkloadRequest)(nil)
+	_ attributionSource = (*ateompb.RestoreWorkloadRequest)(nil)
+)
+
+// ActorAttributionFromRequest extracts the attribution an ateom should retain
+// for the workload req starts.
+func ActorAttributionFromRequest(req attributionSource) ActorAttribution {
+	return ActorAttribution{
+		Ref: resources.ActorRef{
+			Atespace: req.GetAtespace(),
+			Name:     req.GetActorName(),
+		},
+		UID:               req.GetActorUid(),
+		TemplateNamespace: req.GetActorTemplateNamespace(),
+		TemplateName:      req.GetActorTemplateName(),
+	}
+}

--- a/internal/ateomstats/actorattribution_test.go
+++ b/internal/ateomstats/actorattribution_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ateomstats
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/resources"
+)
+
+// fullAttribution is what every fully-populated request below should produce. The
+// five values are deliberately distinct strings: the failure this test exists to
+// catch is a field being wired to the wrong source, which same-looking
+// placeholders would hide.
+var fullAttribution = ActorAttribution{
+	Ref:               resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
+	UID:               "uid-c",
+	TemplateNamespace: "template-ns-d",
+	TemplateName:      "template-name-e",
+}
+
+func TestActorAttributionFromRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  attributionSource
+		want ActorAttribution
+	}{
+		{
+			name: "run request",
+			req: &ateompb.RunWorkloadRequest{
+				Atespace:               "atespace-a",
+				ActorName:              "actor-b",
+				ActorUid:               "uid-c",
+				ActorTemplateNamespace: "template-ns-d",
+				ActorTemplateName:      "template-name-e",
+			},
+			want: fullAttribution,
+		},
+		{
+			// Restore has to yield the same attribution as Run for the same actor:
+			// a sample taken after a restore must be attributable to the actor
+			// it was taken before the checkpoint.
+			name: "restore request",
+			req: &ateompb.RestoreWorkloadRequest{
+				Atespace:               "atespace-a",
+				ActorName:              "actor-b",
+				ActorUid:               "uid-c",
+				ActorTemplateNamespace: "template-ns-d",
+				ActorTemplateName:      "template-name-e",
+			},
+			want: fullAttribution,
+		},
+		{
+			name: "empty run request",
+			req:  &ateompb.RunWorkloadRequest{},
+			want: ActorAttribution{},
+		},
+		{
+			// The callers hold s.lock and are not defensive about the request
+			// pointer; the generated getters are nil-safe, and the zero value
+			// is the honest answer. Pinned so a hand-written getter or a switch
+			// to direct field access does not turn this into a panic.
+			name: "nil run request",
+			req:  (*ateompb.RunWorkloadRequest)(nil),
+			want: ActorAttribution{},
+		},
+		{
+			name: "nil restore request",
+			req:  (*ateompb.RestoreWorkloadRequest)(nil),
+			want: ActorAttribution{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ActorAttributionFromRequest(tc.req)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ActorAttributionFromRequest() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -1030,9 +1030,9 @@ func (*RestoreWorkloadResponse) Descriptor() ([]byte, []int) {
 type GetWorkloadStatsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The actor the caller believes is executing here. A worker can be recycled
-	// between the caller's view of the world and this call, so ateom rejects a
-	// mismatch with FAILED_PRECONDITION rather than reporting a different
-	// actor's numbers under the requested actor's identity.
+	// between the caller's view of the world and this call, so ateom answers
+	// NOT_FOUND on a mismatch rather than reporting a different actor's numbers
+	// under the requested actor's identity.
 	ActorUid      string `protobuf:"bytes,1,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -98,6 +98,115 @@ func (SnapshotScope) EnumDescriptor() ([]byte, []int) {
 	return file_ateom_proto_rawDescGZIP(), []int{0}
 }
 
+// SandboxClass is the sandbox runtime family that produced a sample. Mirrors
+// the ate.dev/v1alpha1 SandboxClass the WorkerPool and ActorTemplate are
+// configured with; an ateom binary only ever reports its own.
+type SandboxClass int32
+
+const (
+	SandboxClass_SANDBOX_CLASS_UNSPECIFIED SandboxClass = 0
+	// gVisor / runsc (cmd/ateom-gvisor).
+	SandboxClass_SANDBOX_CLASS_GVISOR SandboxClass = 1
+	// Micro-VM (cmd/ateom-microvm).
+	SandboxClass_SANDBOX_CLASS_MICROVM SandboxClass = 2
+)
+
+// Enum value maps for SandboxClass.
+var (
+	SandboxClass_name = map[int32]string{
+		0: "SANDBOX_CLASS_UNSPECIFIED",
+		1: "SANDBOX_CLASS_GVISOR",
+		2: "SANDBOX_CLASS_MICROVM",
+	}
+	SandboxClass_value = map[string]int32{
+		"SANDBOX_CLASS_UNSPECIFIED": 0,
+		"SANDBOX_CLASS_GVISOR":      1,
+		"SANDBOX_CLASS_MICROVM":     2,
+	}
+)
+
+func (x SandboxClass) Enum() *SandboxClass {
+	p := new(SandboxClass)
+	*p = x
+	return p
+}
+
+func (x SandboxClass) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SandboxClass) Descriptor() protoreflect.EnumDescriptor {
+	return file_ateom_proto_enumTypes[1].Descriptor()
+}
+
+func (SandboxClass) Type() protoreflect.EnumType {
+	return &file_ateom_proto_enumTypes[1]
+}
+
+func (x SandboxClass) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SandboxClass.Descriptor instead.
+func (SandboxClass) EnumDescriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{1}
+}
+
+// StatsSource is how a sample's measurements were obtained. The two are not
+// measured the same way and should not be compared against each other as though
+// they were.
+type StatsSource int32
+
+const (
+	// No measurement was taken.
+	StatsSource_STATS_SOURCE_UNSPECIFIED StatsSource = 0
+	// Read from the sandbox's cgroup on the host.
+	StatsSource_STATS_SOURCE_CGROUP StatsSource = 1
+	// Read from inside the guest, over the guest agent's vsock connection.
+	StatsSource_STATS_SOURCE_GUEST_AGENT StatsSource = 2
+)
+
+// Enum value maps for StatsSource.
+var (
+	StatsSource_name = map[int32]string{
+		0: "STATS_SOURCE_UNSPECIFIED",
+		1: "STATS_SOURCE_CGROUP",
+		2: "STATS_SOURCE_GUEST_AGENT",
+	}
+	StatsSource_value = map[string]int32{
+		"STATS_SOURCE_UNSPECIFIED": 0,
+		"STATS_SOURCE_CGROUP":      1,
+		"STATS_SOURCE_GUEST_AGENT": 2,
+	}
+)
+
+func (x StatsSource) Enum() *StatsSource {
+	p := new(StatsSource)
+	*p = x
+	return p
+}
+
+func (x StatsSource) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (StatsSource) Descriptor() protoreflect.EnumDescriptor {
+	return file_ateom_proto_enumTypes[2].Descriptor()
+}
+
+func (StatsSource) Type() protoreflect.EnumType {
+	return &file_ateom_proto_enumTypes[2]
+}
+
+func (x StatsSource) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use StatsSource.Descriptor instead.
+func (StatsSource) EnumDescriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{2}
+}
+
 type RunWorkloadRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
@@ -918,6 +1027,201 @@ func (*RestoreWorkloadResponse) Descriptor() ([]byte, []int) {
 	return file_ateom_proto_rawDescGZIP(), []int{11}
 }
 
+type GetWorkloadStatsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The actor the caller believes is executing here. A worker can be recycled
+	// between the caller's view of the world and this call, so ateom rejects a
+	// mismatch with FAILED_PRECONDITION rather than reporting a different
+	// actor's numbers under the requested actor's identity.
+	ActorUid      string `protobuf:"bytes,1,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWorkloadStatsRequest) Reset() {
+	*x = GetWorkloadStatsRequest{}
+	mi := &file_ateom_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorkloadStatsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorkloadStatsRequest) ProtoMessage() {}
+
+func (x *GetWorkloadStatsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateom_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorkloadStatsRequest.ProtoReflect.Descriptor instead.
+func (*GetWorkloadStatsRequest) Descriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetWorkloadStatsRequest) GetActorUid() string {
+	if x != nil {
+		return x.ActorUid
+	}
+	return ""
+}
+
+// GetWorkloadStatsResponse is one resource-usage sample for the executing
+// workload. The unit of measurement is the SANDBOX, which today equals the
+// actor; per-container attribution needs the gVisor sentry's own accounting and
+// is not reported here.
+type GetWorkloadStatsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identity of the measured actor, retained by ateom from the
+	// RunWorkloadRequest / RestoreWorkloadRequest that started it. Echoed back so
+	// the caller can attribute the sample without holding its own mapping from
+	// worker to actor.
+	Atespace               string `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName              string `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid               string `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateNamespace string `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	// The sandbox runtime family that produced this sample.
+	SandboxClass SandboxClass `protobuf:"varint,6,opt,name=sandbox_class,json=sandboxClass,proto3,enum=ateom.SandboxClass" json:"sandbox_class,omitempty"`
+	// How the measurements below were obtained.
+	Source StatsSource `protobuf:"varint,7,opt,name=source,proto3,enum=ateom.StatsSource" json:"source,omitempty"`
+	// Measurements. All four are zero when source is STATS_SOURCE_UNSPECIFIED,
+	// which means "not measured" rather than "measured as zero".
+	MemoryCurrentBytes    uint64 `protobuf:"varint,8,opt,name=memory_current_bytes,json=memoryCurrentBytes,proto3" json:"memory_current_bytes,omitempty"`
+	MemoryPeakBytes       uint64 `protobuf:"varint,9,opt,name=memory_peak_bytes,json=memoryPeakBytes,proto3" json:"memory_peak_bytes,omitempty"`
+	MemoryWorkingSetBytes uint64 `protobuf:"varint,10,opt,name=memory_working_set_bytes,json=memoryWorkingSetBytes,proto3" json:"memory_working_set_bytes,omitempty"`
+	// Cumulative CPU time within the current epoch. A restore starts a new epoch:
+	// the sandbox is recreated, so this restarts at zero and callers computing
+	// deltas must treat a decrease as a reset rather than emit a negative value.
+	CpuUsageUsec       uint64 `protobuf:"varint,11,opt,name=cpu_usage_usec,json=cpuUsageUsec,proto3" json:"cpu_usage_usec,omitempty"`
+	ObservedAtUnixNano int64  `protobuf:"varint,12,opt,name=observed_at_unix_nano,json=observedAtUnixNano,proto3" json:"observed_at_unix_nano,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *GetWorkloadStatsResponse) Reset() {
+	*x = GetWorkloadStatsResponse{}
+	mi := &file_ateom_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorkloadStatsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorkloadStatsResponse) ProtoMessage() {}
+
+func (x *GetWorkloadStatsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ateom_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorkloadStatsResponse.ProtoReflect.Descriptor instead.
+func (*GetWorkloadStatsResponse) Descriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *GetWorkloadStatsResponse) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *GetWorkloadStatsResponse) GetActorName() string {
+	if x != nil {
+		return x.ActorName
+	}
+	return ""
+}
+
+func (x *GetWorkloadStatsResponse) GetActorUid() string {
+	if x != nil {
+		return x.ActorUid
+	}
+	return ""
+}
+
+func (x *GetWorkloadStatsResponse) GetActorTemplateNamespace() string {
+	if x != nil {
+		return x.ActorTemplateNamespace
+	}
+	return ""
+}
+
+func (x *GetWorkloadStatsResponse) GetActorTemplateName() string {
+	if x != nil {
+		return x.ActorTemplateName
+	}
+	return ""
+}
+
+func (x *GetWorkloadStatsResponse) GetSandboxClass() SandboxClass {
+	if x != nil {
+		return x.SandboxClass
+	}
+	return SandboxClass_SANDBOX_CLASS_UNSPECIFIED
+}
+
+func (x *GetWorkloadStatsResponse) GetSource() StatsSource {
+	if x != nil {
+		return x.Source
+	}
+	return StatsSource_STATS_SOURCE_UNSPECIFIED
+}
+
+func (x *GetWorkloadStatsResponse) GetMemoryCurrentBytes() uint64 {
+	if x != nil {
+		return x.MemoryCurrentBytes
+	}
+	return 0
+}
+
+func (x *GetWorkloadStatsResponse) GetMemoryPeakBytes() uint64 {
+	if x != nil {
+		return x.MemoryPeakBytes
+	}
+	return 0
+}
+
+func (x *GetWorkloadStatsResponse) GetMemoryWorkingSetBytes() uint64 {
+	if x != nil {
+		return x.MemoryWorkingSetBytes
+	}
+	return 0
+}
+
+func (x *GetWorkloadStatsResponse) GetCpuUsageUsec() uint64 {
+	if x != nil {
+		return x.CpuUsageUsec
+	}
+	return 0
+}
+
+func (x *GetWorkloadStatsResponse) GetObservedAtUnixNano() int64 {
+	if x != nil {
+		return x.ObservedAtUnixNano
+	}
+	return 0
+}
+
 var File_ateom_proto protoreflect.FileDescriptor
 
 const file_ateom_proto_rawDesc = "" +
@@ -1001,16 +1305,42 @@ const file_ateom_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x11\n" +
 	"\x0f_egress_gateway\"\x19\n" +
-	"\x17RestoreWorkloadResponse*\x84\x01\n" +
+	"\x17RestoreWorkloadResponse\"6\n" +
+	"\x17GetWorkloadStatsRequest\x12\x1b\n" +
+	"\tactor_uid\x18\x01 \x01(\tR\bactorUid\"\xb2\x04\n" +
+	"\x18GetWorkloadStatsResponse\x12\x1a\n" +
+	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
+	"\n" +
+	"actor_name\x18\x02 \x01(\tR\tactorName\x12\x1b\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x128\n" +
+	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x128\n" +
+	"\rsandbox_class\x18\x06 \x01(\x0e2\x13.ateom.SandboxClassR\fsandboxClass\x12*\n" +
+	"\x06source\x18\a \x01(\x0e2\x12.ateom.StatsSourceR\x06source\x120\n" +
+	"\x14memory_current_bytes\x18\b \x01(\x04R\x12memoryCurrentBytes\x12*\n" +
+	"\x11memory_peak_bytes\x18\t \x01(\x04R\x0fmemoryPeakBytes\x127\n" +
+	"\x18memory_working_set_bytes\x18\n" +
+	" \x01(\x04R\x15memoryWorkingSetBytes\x12$\n" +
+	"\x0ecpu_usage_usec\x18\v \x01(\x04R\fcpuUsageUsec\x121\n" +
+	"\x15observed_at_unix_nano\x18\f \x01(\x03R\x12observedAtUnixNano*\x84\x01\n" +
 	"\rSnapshotScope\x12\x1e\n" +
 	"\x1aSNAPSHOT_SCOPE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13SNAPSHOT_SCOPE_FULL\x10\x01\x12\x17\n" +
 	"\x13SNAPSHOT_SCOPE_DATA\x10\x02\x12!\n" +
-	"\x1dSNAPSHOT_SCOPE_DATA_ON_GOLDEN\x10\x032\x80\x02\n" +
+	"\x1dSNAPSHOT_SCOPE_DATA_ON_GOLDEN\x10\x03*b\n" +
+	"\fSandboxClass\x12\x1d\n" +
+	"\x19SANDBOX_CLASS_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14SANDBOX_CLASS_GVISOR\x10\x01\x12\x19\n" +
+	"\x15SANDBOX_CLASS_MICROVM\x10\x02*b\n" +
+	"\vStatsSource\x12\x1c\n" +
+	"\x18STATS_SOURCE_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13STATS_SOURCE_CGROUP\x10\x01\x12\x1c\n" +
+	"\x18STATS_SOURCE_GUEST_AGENT\x10\x022\xd7\x02\n" +
 	"\x05Ateom\x12F\n" +
 	"\vRunWorkload\x12\x19.ateom.RunWorkloadRequest\x1a\x1a.ateom.RunWorkloadResponse\"\x00\x12[\n" +
 	"\x12CheckpointWorkload\x12 .ateom.CheckpointWorkloadRequest\x1a!.ateom.CheckpointWorkloadResponse\"\x00\x12R\n" +
-	"\x0fRestoreWorkload\x12\x1d.ateom.RestoreWorkloadRequest\x1a\x1e.ateom.RestoreWorkloadResponse\"\x00B=Z;github.com/agent-substrate/substrate/internal/proto/ateompbb\x06proto3"
+	"\x0fRestoreWorkload\x12\x1d.ateom.RestoreWorkloadRequest\x1a\x1e.ateom.RestoreWorkloadResponse\"\x00\x12U\n" +
+	"\x10GetWorkloadStats\x12\x1e.ateom.GetWorkloadStatsRequest\x1a\x1f.ateom.GetWorkloadStatsResponse\"\x00B=Z;github.com/agent-substrate/substrate/internal/proto/ateompbb\x06proto3"
 
 var (
 	file_ateom_proto_rawDescOnce sync.Once
@@ -1024,52 +1354,60 @@ func file_ateom_proto_rawDescGZIP() []byte {
 	return file_ateom_proto_rawDescData
 }
 
-var file_ateom_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_ateom_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_ateom_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_ateom_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_ateom_proto_goTypes = []any{
 	(SnapshotScope)(0),                 // 0: ateom.SnapshotScope
-	(*RunWorkloadRequest)(nil),         // 1: ateom.RunWorkloadRequest
-	(*EgressGateway)(nil),              // 2: ateom.EgressGateway
-	(*WorkloadSpec)(nil),               // 3: ateom.WorkloadSpec
-	(*Container)(nil),                  // 4: ateom.Container
-	(*DurableDirVolumeMount)(nil),      // 5: ateom.DurableDirVolumeMount
-	(*Readyz)(nil),                     // 6: ateom.Readyz
-	(*HTTPGetAction)(nil),              // 7: ateom.HTTPGetAction
-	(*RunWorkloadResponse)(nil),        // 8: ateom.RunWorkloadResponse
-	(*CheckpointWorkloadRequest)(nil),  // 9: ateom.CheckpointWorkloadRequest
-	(*CheckpointWorkloadResponse)(nil), // 10: ateom.CheckpointWorkloadResponse
-	(*RestoreWorkloadRequest)(nil),     // 11: ateom.RestoreWorkloadRequest
-	(*RestoreWorkloadResponse)(nil),    // 12: ateom.RestoreWorkloadResponse
-	nil,                                // 13: ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
-	nil,                                // 14: ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
-	nil,                                // 15: ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
+	(SandboxClass)(0),                  // 1: ateom.SandboxClass
+	(StatsSource)(0),                   // 2: ateom.StatsSource
+	(*RunWorkloadRequest)(nil),         // 3: ateom.RunWorkloadRequest
+	(*EgressGateway)(nil),              // 4: ateom.EgressGateway
+	(*WorkloadSpec)(nil),               // 5: ateom.WorkloadSpec
+	(*Container)(nil),                  // 6: ateom.Container
+	(*DurableDirVolumeMount)(nil),      // 7: ateom.DurableDirVolumeMount
+	(*Readyz)(nil),                     // 8: ateom.Readyz
+	(*HTTPGetAction)(nil),              // 9: ateom.HTTPGetAction
+	(*RunWorkloadResponse)(nil),        // 10: ateom.RunWorkloadResponse
+	(*CheckpointWorkloadRequest)(nil),  // 11: ateom.CheckpointWorkloadRequest
+	(*CheckpointWorkloadResponse)(nil), // 12: ateom.CheckpointWorkloadResponse
+	(*RestoreWorkloadRequest)(nil),     // 13: ateom.RestoreWorkloadRequest
+	(*RestoreWorkloadResponse)(nil),    // 14: ateom.RestoreWorkloadResponse
+	(*GetWorkloadStatsRequest)(nil),    // 15: ateom.GetWorkloadStatsRequest
+	(*GetWorkloadStatsResponse)(nil),   // 16: ateom.GetWorkloadStatsResponse
+	nil,                                // 17: ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
+	nil,                                // 18: ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
+	nil,                                // 19: ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
 }
 var file_ateom_proto_depIdxs = []int32{
-	3,  // 0: ateom.RunWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	13, // 1: ateom.RunWorkloadRequest.runtime_asset_paths:type_name -> ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
-	2,  // 2: ateom.RunWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
-	4,  // 3: ateom.WorkloadSpec.containers:type_name -> ateom.Container
-	6,  // 4: ateom.Container.readyz:type_name -> ateom.Readyz
-	5,  // 5: ateom.Container.durable_dir_volume_mounts:type_name -> ateom.DurableDirVolumeMount
-	7,  // 6: ateom.Readyz.http_get:type_name -> ateom.HTTPGetAction
-	3,  // 7: ateom.CheckpointWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	14, // 8: ateom.CheckpointWorkloadRequest.runtime_asset_paths:type_name -> ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
+	5,  // 0: ateom.RunWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
+	17, // 1: ateom.RunWorkloadRequest.runtime_asset_paths:type_name -> ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
+	4,  // 2: ateom.RunWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
+	6,  // 3: ateom.WorkloadSpec.containers:type_name -> ateom.Container
+	8,  // 4: ateom.Container.readyz:type_name -> ateom.Readyz
+	7,  // 5: ateom.Container.durable_dir_volume_mounts:type_name -> ateom.DurableDirVolumeMount
+	9,  // 6: ateom.Readyz.http_get:type_name -> ateom.HTTPGetAction
+	5,  // 7: ateom.CheckpointWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
+	18, // 8: ateom.CheckpointWorkloadRequest.runtime_asset_paths:type_name -> ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
 	0,  // 9: ateom.CheckpointWorkloadRequest.scope:type_name -> ateom.SnapshotScope
-	3,  // 10: ateom.RestoreWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	15, // 11: ateom.RestoreWorkloadRequest.runtime_asset_paths:type_name -> ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
+	5,  // 10: ateom.RestoreWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
+	19, // 11: ateom.RestoreWorkloadRequest.runtime_asset_paths:type_name -> ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
 	0,  // 12: ateom.RestoreWorkloadRequest.scope:type_name -> ateom.SnapshotScope
-	2,  // 13: ateom.RestoreWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
-	1,  // 14: ateom.Ateom.RunWorkload:input_type -> ateom.RunWorkloadRequest
-	9,  // 15: ateom.Ateom.CheckpointWorkload:input_type -> ateom.CheckpointWorkloadRequest
-	11, // 16: ateom.Ateom.RestoreWorkload:input_type -> ateom.RestoreWorkloadRequest
-	8,  // 17: ateom.Ateom.RunWorkload:output_type -> ateom.RunWorkloadResponse
-	10, // 18: ateom.Ateom.CheckpointWorkload:output_type -> ateom.CheckpointWorkloadResponse
-	12, // 19: ateom.Ateom.RestoreWorkload:output_type -> ateom.RestoreWorkloadResponse
-	17, // [17:20] is the sub-list for method output_type
-	14, // [14:17] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	4,  // 13: ateom.RestoreWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
+	1,  // 14: ateom.GetWorkloadStatsResponse.sandbox_class:type_name -> ateom.SandboxClass
+	2,  // 15: ateom.GetWorkloadStatsResponse.source:type_name -> ateom.StatsSource
+	3,  // 16: ateom.Ateom.RunWorkload:input_type -> ateom.RunWorkloadRequest
+	11, // 17: ateom.Ateom.CheckpointWorkload:input_type -> ateom.CheckpointWorkloadRequest
+	13, // 18: ateom.Ateom.RestoreWorkload:input_type -> ateom.RestoreWorkloadRequest
+	15, // 19: ateom.Ateom.GetWorkloadStats:input_type -> ateom.GetWorkloadStatsRequest
+	10, // 20: ateom.Ateom.RunWorkload:output_type -> ateom.RunWorkloadResponse
+	12, // 21: ateom.Ateom.CheckpointWorkload:output_type -> ateom.CheckpointWorkloadResponse
+	14, // 22: ateom.Ateom.RestoreWorkload:output_type -> ateom.RestoreWorkloadResponse
+	16, // 23: ateom.Ateom.GetWorkloadStats:output_type -> ateom.GetWorkloadStatsResponse
+	20, // [20:24] is the sub-list for method output_type
+	16, // [16:20] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_ateom_proto_init() }
@@ -1084,8 +1422,8 @@ func file_ateom_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateom_proto_rawDesc), len(file_ateom_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   15,
+			NumEnums:      3,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -51,8 +51,17 @@ service Ateom {
   //
   // It is a pure read: unlike the three calls above it does not move the ateom
   // between "available" and "executing", so it is safe to call on a timer for
-  // the whole lifetime of a workload. Returns FAILED_PRECONDITION when the
-  // ateom is "available" (nothing to measure).
+  // the whole lifetime of a workload.
+  //
+  // Returns FAILED_PRECONDITION when there is no sample to give. That covers
+  // more than the "available" state: an ateom becomes "executing" when it
+  // accepts the actor, but the sandbox it will measure does not exist yet, and
+  // a poll landing in the boot gets FAILED_PRECONDITION as well. The two are
+  // deliberately the same code, because a caller polling on a timer does the
+  // same thing either way -- skip this sample and take the next one. Read it as
+  // "no numbers right now", not as "the actor is gone"; the actor's identity is
+  // retained from the moment the ateom accepts it, so a workload that dies
+  // during boot is still attributable once a runtime can measure it.
   rpc GetWorkloadStats(GetWorkloadStatsRequest) returns (GetWorkloadStatsResponse) {}
 }
 

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -45,6 +45,15 @@ service Ateom {
   // written by CheckpointWorkload.  Ateom will handle downloading the correct
   // gVisor / runsc version to match the checkpoint.
   rpc RestoreWorkload(RestoreWorkloadRequest) returns (RestoreWorkloadResponse) {}
+
+  // GetWorkloadStats returns a point-in-time resource-usage sample for the
+  // workload this ateom is currently executing.
+  //
+  // It is a pure read: unlike the three calls above it does not move the ateom
+  // between "available" and "executing", so it is safe to call on a timer for
+  // the whole lifetime of a workload. Returns FAILED_PRECONDITION when the
+  // ateom is "available" (nothing to measure).
+  rpc GetWorkloadStats(GetWorkloadStatsRequest) returns (GetWorkloadStatsResponse) {}
 }
 
 message RunWorkloadRequest {
@@ -209,4 +218,69 @@ message RestoreWorkloadRequest {
 }
 
 message RestoreWorkloadResponse {
+}
+
+message GetWorkloadStatsRequest {
+  // The actor the caller believes is executing here. A worker can be recycled
+  // between the caller's view of the world and this call, so ateom rejects a
+  // mismatch with FAILED_PRECONDITION rather than reporting a different
+  // actor's numbers under the requested actor's identity.
+  string actor_uid = 1;
+}
+
+// SandboxClass is the sandbox runtime family that produced a sample. Mirrors
+// the ate.dev/v1alpha1 SandboxClass the WorkerPool and ActorTemplate are
+// configured with; an ateom binary only ever reports its own.
+enum SandboxClass {
+  SANDBOX_CLASS_UNSPECIFIED = 0;
+  // gVisor / runsc (cmd/ateom-gvisor).
+  SANDBOX_CLASS_GVISOR = 1;
+  // Micro-VM (cmd/ateom-microvm).
+  SANDBOX_CLASS_MICROVM = 2;
+}
+
+// StatsSource is how a sample's measurements were obtained. The two are not
+// measured the same way and should not be compared against each other as though
+// they were.
+enum StatsSource {
+  // No measurement was taken.
+  STATS_SOURCE_UNSPECIFIED = 0;
+  // Read from the sandbox's cgroup on the host.
+  STATS_SOURCE_CGROUP = 1;
+  // Read from inside the guest, over the guest agent's vsock connection.
+  STATS_SOURCE_GUEST_AGENT = 2;
+}
+
+// GetWorkloadStatsResponse is one resource-usage sample for the executing
+// workload. The unit of measurement is the SANDBOX, which today equals the
+// actor; per-container attribution needs the gVisor sentry's own accounting and
+// is not reported here.
+message GetWorkloadStatsResponse {
+  // Identity of the measured actor, retained by ateom from the
+  // RunWorkloadRequest / RestoreWorkloadRequest that started it. Echoed back so
+  // the caller can attribute the sample without holding its own mapping from
+  // worker to actor.
+  string atespace = 1;
+  string actor_name = 2;
+  string actor_uid = 3;
+  string actor_template_namespace = 4;
+  string actor_template_name = 5;
+
+  // The sandbox runtime family that produced this sample.
+  SandboxClass sandbox_class = 6;
+
+  // How the measurements below were obtained.
+  StatsSource source = 7;
+
+  // Measurements. All four are zero when source is STATS_SOURCE_UNSPECIFIED,
+  // which means "not measured" rather than "measured as zero".
+  uint64 memory_current_bytes = 8;
+  uint64 memory_peak_bytes = 9;
+  uint64 memory_working_set_bytes = 10;
+  // Cumulative CPU time within the current epoch. A restore starts a new epoch:
+  // the sandbox is recreated, so this restarts at zero and callers computing
+  // deltas must treat a decrease as a reset rather than emit a negative value.
+  uint64 cpu_usage_usec = 11;
+
+  int64 observed_at_unix_nano = 12;
 }

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -51,17 +51,31 @@ service Ateom {
   //
   // It is a pure read: unlike the three calls above it does not move the ateom
   // between "available" and "executing", so it is safe to call on a timer for
-  // the whole lifetime of a workload.
+  // the whole lifetime of a workload. It also does not wait on them. Those
+  // three serialize on a mutex an ateom holds for a whole boot, restore, or
+  // checkpoint; this call reads its state from outside that mutex, so a poll
+  // landing in the middle of one answers immediately instead of going quiet for
+  // the duration -- which would silence the poller during exactly the phases
+  // whose usage is most interesting.
   //
-  // Returns FAILED_PRECONDITION when there is no sample to give. That covers
-  // more than the "available" state: an ateom becomes "executing" when it
-  // accepts the actor, but the sandbox it will measure does not exist yet, and
-  // a poll landing in the boot gets FAILED_PRECONDITION as well. The two are
-  // deliberately the same code, because a caller polling on a timer does the
-  // same thing either way -- skip this sample and take the next one. Read it as
-  // "no numbers right now", not as "the actor is gone"; the actor's identity is
-  // retained from the moment the ateom accepts it, so a workload that dies
-  // during boot is still attributable once a runtime can measure it.
+  // Two ways it declines to give a sample, and they ask different things of the
+  // caller:
+  //
+  //   * NOT_FOUND -- this ateom is not executing the actor in the request. It
+  //     may be "available", or a recycled worker may have moved on to a
+  //     different actor. Retrying on the same timer will not change the answer:
+  //     the caller's worker-to-actor mapping is stale and wants re-resolving.
+  //
+  //   * FAILED_PRECONDITION -- this ateom is executing the requested actor but
+  //     has no sample to give yet. It accepts an actor before the sandbox it
+  //     will measure exists, so a poll landing in the boot lands here. Read it
+  //     as "no numbers right now", not as "the actor is gone": it is transient,
+  //     and the caller should skip this sample and take the next one.
+  //
+  // The split is worth the two codes because the identity is retained from the
+  // moment the ateom accepts the actor, on both runtimes. That is what makes
+  // "booting" distinguishable from "not here" at all, and it means a workload
+  // that dies during boot is attributable rather than anonymous.
   rpc GetWorkloadStats(GetWorkloadStatsRequest) returns (GetWorkloadStatsResponse) {}
 }
 
@@ -231,9 +245,9 @@ message RestoreWorkloadResponse {
 
 message GetWorkloadStatsRequest {
   // The actor the caller believes is executing here. A worker can be recycled
-  // between the caller's view of the world and this call, so ateom rejects a
-  // mismatch with FAILED_PRECONDITION rather than reporting a different
-  // actor's numbers under the requested actor's identity.
+  // between the caller's view of the world and this call, so ateom answers
+  // NOT_FOUND on a mismatch rather than reporting a different actor's numbers
+  // under the requested actor's identity.
   string actor_uid = 1;
 }
 

--- a/internal/proto/ateompb/ateom_grpc.pb.go
+++ b/internal/proto/ateompb/ateom_grpc.pb.go
@@ -73,8 +73,17 @@ type AteomClient interface {
 	//
 	// It is a pure read: unlike the three calls above it does not move the ateom
 	// between "available" and "executing", so it is safe to call on a timer for
-	// the whole lifetime of a workload. Returns FAILED_PRECONDITION when the
-	// ateom is "available" (nothing to measure).
+	// the whole lifetime of a workload.
+	//
+	// Returns FAILED_PRECONDITION when there is no sample to give. That covers
+	// more than the "available" state: an ateom becomes "executing" when it
+	// accepts the actor, but the sandbox it will measure does not exist yet, and
+	// a poll landing in the boot gets FAILED_PRECONDITION as well. The two are
+	// deliberately the same code, because a caller polling on a timer does the
+	// same thing either way -- skip this sample and take the next one. Read it as
+	// "no numbers right now", not as "the actor is gone"; the actor's identity is
+	// retained from the moment the ateom accepts it, so a workload that dies
+	// during boot is still attributable once a runtime can measure it.
 	GetWorkloadStats(ctx context.Context, in *GetWorkloadStatsRequest, opts ...grpc.CallOption) (*GetWorkloadStatsResponse, error)
 }
 
@@ -160,8 +169,17 @@ type AteomServer interface {
 	//
 	// It is a pure read: unlike the three calls above it does not move the ateom
 	// between "available" and "executing", so it is safe to call on a timer for
-	// the whole lifetime of a workload. Returns FAILED_PRECONDITION when the
-	// ateom is "available" (nothing to measure).
+	// the whole lifetime of a workload.
+	//
+	// Returns FAILED_PRECONDITION when there is no sample to give. That covers
+	// more than the "available" state: an ateom becomes "executing" when it
+	// accepts the actor, but the sandbox it will measure does not exist yet, and
+	// a poll landing in the boot gets FAILED_PRECONDITION as well. The two are
+	// deliberately the same code, because a caller polling on a timer does the
+	// same thing either way -- skip this sample and take the next one. Read it as
+	// "no numbers right now", not as "the actor is gone"; the actor's identity is
+	// retained from the moment the ateom accepts it, so a workload that dies
+	// during boot is still attributable once a runtime can measure it.
 	GetWorkloadStats(context.Context, *GetWorkloadStatsRequest) (*GetWorkloadStatsResponse, error)
 	mustEmbedUnimplementedAteomServer()
 }

--- a/internal/proto/ateompb/ateom_grpc.pb.go
+++ b/internal/proto/ateompb/ateom_grpc.pb.go
@@ -36,6 +36,7 @@ const (
 	Ateom_RunWorkload_FullMethodName        = "/ateom.Ateom/RunWorkload"
 	Ateom_CheckpointWorkload_FullMethodName = "/ateom.Ateom/CheckpointWorkload"
 	Ateom_RestoreWorkload_FullMethodName    = "/ateom.Ateom/RestoreWorkload"
+	Ateom_GetWorkloadStats_FullMethodName   = "/ateom.Ateom/GetWorkloadStats"
 )
 
 // AteomClient is the client API for Ateom service.
@@ -67,6 +68,14 @@ type AteomClient interface {
 	// written by CheckpointWorkload.  Ateom will handle downloading the correct
 	// gVisor / runsc version to match the checkpoint.
 	RestoreWorkload(ctx context.Context, in *RestoreWorkloadRequest, opts ...grpc.CallOption) (*RestoreWorkloadResponse, error)
+	// GetWorkloadStats returns a point-in-time resource-usage sample for the
+	// workload this ateom is currently executing.
+	//
+	// It is a pure read: unlike the three calls above it does not move the ateom
+	// between "available" and "executing", so it is safe to call on a timer for
+	// the whole lifetime of a workload. Returns FAILED_PRECONDITION when the
+	// ateom is "available" (nothing to measure).
+	GetWorkloadStats(ctx context.Context, in *GetWorkloadStatsRequest, opts ...grpc.CallOption) (*GetWorkloadStatsResponse, error)
 }
 
 type ateomClient struct {
@@ -107,6 +116,16 @@ func (c *ateomClient) RestoreWorkload(ctx context.Context, in *RestoreWorkloadRe
 	return out, nil
 }
 
+func (c *ateomClient) GetWorkloadStats(ctx context.Context, in *GetWorkloadStatsRequest, opts ...grpc.CallOption) (*GetWorkloadStatsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetWorkloadStatsResponse)
+	err := c.cc.Invoke(ctx, Ateom_GetWorkloadStats_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AteomServer is the server API for Ateom service.
 // All implementations must embed UnimplementedAteomServer
 // for forward compatibility.
@@ -136,6 +155,14 @@ type AteomServer interface {
 	// written by CheckpointWorkload.  Ateom will handle downloading the correct
 	// gVisor / runsc version to match the checkpoint.
 	RestoreWorkload(context.Context, *RestoreWorkloadRequest) (*RestoreWorkloadResponse, error)
+	// GetWorkloadStats returns a point-in-time resource-usage sample for the
+	// workload this ateom is currently executing.
+	//
+	// It is a pure read: unlike the three calls above it does not move the ateom
+	// between "available" and "executing", so it is safe to call on a timer for
+	// the whole lifetime of a workload. Returns FAILED_PRECONDITION when the
+	// ateom is "available" (nothing to measure).
+	GetWorkloadStats(context.Context, *GetWorkloadStatsRequest) (*GetWorkloadStatsResponse, error)
 	mustEmbedUnimplementedAteomServer()
 }
 
@@ -154,6 +181,9 @@ func (UnimplementedAteomServer) CheckpointWorkload(context.Context, *CheckpointW
 }
 func (UnimplementedAteomServer) RestoreWorkload(context.Context, *RestoreWorkloadRequest) (*RestoreWorkloadResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RestoreWorkload not implemented")
+}
+func (UnimplementedAteomServer) GetWorkloadStats(context.Context, *GetWorkloadStatsRequest) (*GetWorkloadStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetWorkloadStats not implemented")
 }
 func (UnimplementedAteomServer) mustEmbedUnimplementedAteomServer() {}
 func (UnimplementedAteomServer) testEmbeddedByValue()               {}
@@ -230,6 +260,24 @@ func _Ateom_RestoreWorkload_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Ateom_GetWorkloadStats_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetWorkloadStatsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AteomServer).GetWorkloadStats(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Ateom_GetWorkloadStats_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AteomServer).GetWorkloadStats(ctx, req.(*GetWorkloadStatsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Ateom_ServiceDesc is the grpc.ServiceDesc for Ateom service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -248,6 +296,10 @@ var Ateom_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RestoreWorkload",
 			Handler:    _Ateom_RestoreWorkload_Handler,
+		},
+		{
+			MethodName: "GetWorkloadStats",
+			Handler:    _Ateom_GetWorkloadStats_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/proto/ateompb/ateom_grpc.pb.go
+++ b/internal/proto/ateompb/ateom_grpc.pb.go
@@ -73,17 +73,31 @@ type AteomClient interface {
 	//
 	// It is a pure read: unlike the three calls above it does not move the ateom
 	// between "available" and "executing", so it is safe to call on a timer for
-	// the whole lifetime of a workload.
+	// the whole lifetime of a workload. It also does not wait on them. Those
+	// three serialize on a mutex an ateom holds for a whole boot, restore, or
+	// checkpoint; this call reads its state from outside that mutex, so a poll
+	// landing in the middle of one answers immediately instead of going quiet for
+	// the duration -- which would silence the poller during exactly the phases
+	// whose usage is most interesting.
 	//
-	// Returns FAILED_PRECONDITION when there is no sample to give. That covers
-	// more than the "available" state: an ateom becomes "executing" when it
-	// accepts the actor, but the sandbox it will measure does not exist yet, and
-	// a poll landing in the boot gets FAILED_PRECONDITION as well. The two are
-	// deliberately the same code, because a caller polling on a timer does the
-	// same thing either way -- skip this sample and take the next one. Read it as
-	// "no numbers right now", not as "the actor is gone"; the actor's identity is
-	// retained from the moment the ateom accepts it, so a workload that dies
-	// during boot is still attributable once a runtime can measure it.
+	// Two ways it declines to give a sample, and they ask different things of the
+	// caller:
+	//
+	//   - NOT_FOUND -- this ateom is not executing the actor in the request. It
+	//     may be "available", or a recycled worker may have moved on to a
+	//     different actor. Retrying on the same timer will not change the answer:
+	//     the caller's worker-to-actor mapping is stale and wants re-resolving.
+	//
+	//   - FAILED_PRECONDITION -- this ateom is executing the requested actor but
+	//     has no sample to give yet. It accepts an actor before the sandbox it
+	//     will measure exists, so a poll landing in the boot lands here. Read it
+	//     as "no numbers right now", not as "the actor is gone": it is transient,
+	//     and the caller should skip this sample and take the next one.
+	//
+	// The split is worth the two codes because the identity is retained from the
+	// moment the ateom accepts the actor, on both runtimes. That is what makes
+	// "booting" distinguishable from "not here" at all, and it means a workload
+	// that dies during boot is attributable rather than anonymous.
 	GetWorkloadStats(ctx context.Context, in *GetWorkloadStatsRequest, opts ...grpc.CallOption) (*GetWorkloadStatsResponse, error)
 }
 
@@ -169,17 +183,31 @@ type AteomServer interface {
 	//
 	// It is a pure read: unlike the three calls above it does not move the ateom
 	// between "available" and "executing", so it is safe to call on a timer for
-	// the whole lifetime of a workload.
+	// the whole lifetime of a workload. It also does not wait on them. Those
+	// three serialize on a mutex an ateom holds for a whole boot, restore, or
+	// checkpoint; this call reads its state from outside that mutex, so a poll
+	// landing in the middle of one answers immediately instead of going quiet for
+	// the duration -- which would silence the poller during exactly the phases
+	// whose usage is most interesting.
 	//
-	// Returns FAILED_PRECONDITION when there is no sample to give. That covers
-	// more than the "available" state: an ateom becomes "executing" when it
-	// accepts the actor, but the sandbox it will measure does not exist yet, and
-	// a poll landing in the boot gets FAILED_PRECONDITION as well. The two are
-	// deliberately the same code, because a caller polling on a timer does the
-	// same thing either way -- skip this sample and take the next one. Read it as
-	// "no numbers right now", not as "the actor is gone"; the actor's identity is
-	// retained from the moment the ateom accepts it, so a workload that dies
-	// during boot is still attributable once a runtime can measure it.
+	// Two ways it declines to give a sample, and they ask different things of the
+	// caller:
+	//
+	//   - NOT_FOUND -- this ateom is not executing the actor in the request. It
+	//     may be "available", or a recycled worker may have moved on to a
+	//     different actor. Retrying on the same timer will not change the answer:
+	//     the caller's worker-to-actor mapping is stale and wants re-resolving.
+	//
+	//   - FAILED_PRECONDITION -- this ateom is executing the requested actor but
+	//     has no sample to give yet. It accepts an actor before the sandbox it
+	//     will measure exists, so a poll landing in the boot lands here. Read it
+	//     as "no numbers right now", not as "the actor is gone": it is transient,
+	//     and the caller should skip this sample and take the next one.
+	//
+	// The split is worth the two codes because the identity is retained from the
+	// moment the ateom accepts the actor, on both runtimes. That is what makes
+	// "booting" distinguishable from "not here" at all, and it means a workload
+	// that dies during boot is attributable rather than anonymous.
 	GetWorkloadStats(context.Context, *GetWorkloadStatsRequest) (*GetWorkloadStatsResponse, error)
 	mustEmbedUnimplementedAteomServer()
 }


### PR DESCRIPTION
Phase 0 of #550, tracked by #594. First of three stacked PRs.

Adds `ateom.Ateom/GetWorkloadStats`, the RPC atelet will poll for per-actor resource
usage, plus the actor attribution both ateom runtimes need to label a sample. The measurement half of each runtime lands in the two follow-ups;
`GetWorkloadStats` returns `Unimplemented` until then, so this change puts nothing
half-populated on the wire.

### The RPC

`GetWorkloadStats` is a **pure read**: unlike `RunWorkload` / `CheckpointWorkload` /
`RestoreWorkload` it does not move the ateom between "available" and "executing",
so it is safe to call on a timer for a workload's whole lifetime.

The request carries the actor UID the caller believes is executing here. A worker
can be recycled between atelet's view of the world and the call landing, so a
mismatch is rejected with `FAILED_PRECONDITION` rather than reporting a different
actor's numbers under the requested actor's identity. `FAILED_PRECONDITION` is
also the answer when the ateom is available — there is nothing to measure.

The response is one sample, measured at **sandbox** granularity (which today
equals the actor; per-container attribution would need the gVisor sentry's own
accounting). It echoes the measured actor's identity so the caller can attribute
the sample without holding its own worker→actor mapping, and carries
`sandbox_class` and `source` so two differently-measured numbers are not silently
compared as though they were the same thing. Both are enums — closed sets the
ateom binary picks from, where a typo in a free-form string would silently split
a metric in two downstream.

### Attribution retention

Neither runtime kept the actor's identifying fields past the call that started the
workload — they arrive on Run/Restore and nothing downstream needed them. A usage
sample is only useful once attributed, so both now hold them for as long as they
are executing:

* **ateom-gvisor** gains `AteomService.activeActor`, set by `RunWorkload` and
  `RestoreWorkload`, cleared by `CheckpointWorkload` and by both boot-failure
  paths — tracking exactly the available/executing state machine on the service.
* **ateom-microvm** gains `runningActor.activeActor`, populated from the existing
  `actorBootParams` on both the cold-boot and restore paths; the existing delete
  from `s.running` in `teardownActor` clears it.

The extraction from the request is shared in `internal/ateomstats`, since both
binaries need the same mapping. `ActorAttribution` composes the existing
`resources.ActorRef` rather than repeating its two fields, so the actor's
`Atespace` stays visibly attached to the actor — worth noting because
`TemplateNamespace` beside it is an unrelated namespace (a Kubernetes one;
`ActorTemplate` is a namespaced CRD, while an atespace is Substrate's own
tenancy unit).

It is deliberately **not** called `ActorIdentity`: "actor identity" already means
a credential in this repo — the `ateapi.ActorIdentity` service, `substratex509`,
`ateompath.ActorIdentityDirPath`, and #670 building on all three. Nothing in this
type is a secret or is presented as proof of anything; it is the tuple a usage
sample is labeled with.

### Reviewer notes

* **`activeActor` has no reader in this PR.** It is written and cleared but never
  read, because both `GetWorkloadStats` bodies are still stubs. The readers arrive
  with the measurement in the two follow-ups; the stub comments point there.
* **No metric labels are added here.** The response carries actor and atespace
  identity, but that is a sample, not a datapoint. Per the decisions in #174,
  actor/atespace identity belongs in logs and traces rather than as TSDB labels,
  and only template-level dimensions become metric labels. That conversion is
  atelet's, in Phase 1/2.
* **`cpu_usage_usec` resets on restore.** A restore recreates the sandbox, so the
  counter restarts at zero while the actor UID stays the same. Documented on the
  field; callers computing deltas must treat a decrease as a reset. If that proves
  too subtle in practice, an explicit epoch marker is a backward-compatible
  addition later.
* **`workerpool_name` is deliberately absent.** atelet does not know it today;
  adding the field later is backward compatible.

### Testing

* `internal/ateomstats` — `TestActorAttributionFromRequest` pins the mapping from
  both request types, including the empty and nil cases (the callers are not
  defensive about the request pointer, so the nil-safety of the generated getters
  is load-bearing). Five deliberately distinct placeholder values, so a field
  wired to the wrong source is visible.
* `cmd/ateom-microvm` — `TestActorBootParamsAttribution` pins the
  `actorBootParams` → `ActorAttribution` mapping, and
  `TestActorBootParamsAttributionMatchesRequest` checks that the two hops (request
  → boot params → attribution, written in different files) compose back into what
  the caller sent.
* Both runtimes — `TestGetWorkloadStatsUnimplemented` pins the stub's advertised
  contract, and `TestAteomServiceStartsAvailable` checks a fresh gVisor service
  retains no attribution (a non-nil zero value there would make an idle ateom
  report an empty actor's usage instead of refusing).
* **Not unit-tested:** the gVisor set/clear transitions. `RunWorkload`,
  `RestoreWorkload` and `CheckpointWorkload` each reach for netlink, runsc and the
  worker pod's netns within a few lines of entry, so there is no seam to drive
  them from `go test`. Noted in `cmd/ateom-gvisor/stats_test.go` rather than
  covered with a fake; the transitions get verified end to end once
  `GetWorkloadStats` returns real data.

Both ateom packages are `//go:build linux`, so their tests do not execute on
darwin. They were run natively on a Linux host in addition to the local
compile-check, along with `hack/verify/shellcheck.sh` (which needs docker).

### Still ahead

* **PR 2** — gVisor: read the sandbox cgroup. Reads `/sys/fs/cgroup/pause`, not
  `main/`: every application process runs inside the sentry, which is a single
  process in `pause/`.
* **PR 3** — micro-VM: read the guest agent's `StatsContainer` over the existing
  vsock connection, not the host cgroup (guest RAM is a fixed allocation, so the
  host cgroup barely moves with the workload). Closes #594.
