### PR TITLE
Update gVisor build to fresher version using new release tarball asset.

### DIFF
--- a/cmd/atelet/sandbox_assets.go
+++ b/cmd/atelet/sandbox_assets.go
@@ -15,7 +15,10 @@
 package main
 
 import (
+	"archive/tar"
+	"bufio"
 	"bytes"
+	"compress/bzip2"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -23,9 +26,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/agent-substrate/substrate/cmd/atelet/internal/ategcs"
@@ -44,6 +49,17 @@ const sandboxManifestName = "manifest.json"
 // ponytail: 8GiB ceiling, make it a flag if a rootfs ever needs more.
 var maxAssetBytes int64 = 8 << 30
 
+const (
+	// gvisorAssetName is the gVisor release tarball asset (gvisor.tar.bz2). The
+	// tarball carries `runsc` together with the `gvisor-bin/` helper binaries,
+	// so it is extracted into a content-addressed directory rather than as a
+	// single file.
+	gvisorAssetName = "gvisor"
+
+	// runscAssetName is the legacy single-binary gVisor asset.
+	runscAssetName = "runsc"
+)
+
 // assetEntry is one content-addressed sandbox asset (url + sha256).
 type assetEntry struct {
 	URL    string `json:"url"`
@@ -52,9 +68,11 @@ type assetEntry struct {
 
 // sandboxAssetsRecord is the sandbox runtime an actor is running, projected onto
 // the local node's architecture: the sandbox class plus the asset set keyed by
-// asset name (gVisor uses a single "runsc" asset). It is both the per-actor
-// on-node record (written at Run/Restore, read at Checkpoint) and the snapshot
-// manifest (written at Checkpoint, read at Restore).
+// asset name (gVisor uses a single "gvisor" release-tarball asset; records
+// written before the tarball release mechanism use a bare "runsc" asset).
+// It is both the per-actor on-node record (written at Run/Restore, read at
+// Checkpoint) and the snapshot manifest (written at Checkpoint, read at
+// Restore).
 type sandboxAssetsRecord struct {
 	SandboxClass string                `json:"sandboxClass"`
 	Assets       map[string]assetEntry `json:"assets"`
@@ -95,9 +113,11 @@ func recordFromRequest(sa *ateletpb.SandboxAssets) (*sandboxAssetsRecord, error)
 }
 
 // ensureSandboxAssets fetches every asset in the record content-addressed and
-// returns a map of asset name to local path. gVisor has a single "runsc" asset;
-// the micro-VM runtime has several (kata-shim, cloud-hypervisor, ...). Assets are
-// cached, so re-fetching at Checkpoint/Restore is a no-op once present.
+// returns a map of asset name to local path. gVisor has a single "gvisor"
+// release-tarball asset or a bare "runsc" binary; the micro-VM runtime has
+// several (kata-shim, cloud-hypervisor, ...).
+// Assets are cached, so re-fetching at Checkpoint/Restore is a no-op once
+// present.
 func (s *AteomHerder) ensureSandboxAssets(ctx context.Context, rec *sandboxAssetsRecord) (map[string]string, error) {
 	if err := os.MkdirAll(ateompath.StaticFilesDir, 0o700); err != nil {
 		if isTerminalFileSystemErr(err) {
@@ -107,7 +127,13 @@ func (s *AteomHerder) ensureSandboxAssets(ctx context.Context, rec *sandboxAsset
 	}
 	paths := make(map[string]string, len(rec.Assets))
 	for name, entry := range rec.Assets {
-		p, err := s.fetchAsset(ctx, entry)
+		var p string
+		var err error
+		if name == gvisorAssetName {
+			p, err = s.fetchGVisorRelease(ctx, entry)
+		} else {
+			p, err = s.fetchAsset(ctx, entry)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("while fetching sandbox asset %q: %w", name, err)
 		}
@@ -116,9 +142,14 @@ func (s *AteomHerder) ensureSandboxAssets(ctx context.Context, rec *sandboxAsset
 	return paths, nil
 }
 
-// runscPathFor returns the local path of the gVisor "runsc" asset from a fetched
-// asset-path map, or "" if the runtime has none (e.g. micro-VM).
-func runscPathFor(paths map[string]string) string { return paths["runsc"] }
+// runscPathFor returns the local path of the gVisor `runsc` binary from a
+// fetched asset-path map, or "" if the runtime has none (e.g. micro-VM).
+func runscPathFor(paths map[string]string) string {
+	if p := paths[gvisorAssetName]; p != "" {
+		return p
+	}
+	return paths[runscAssetName]
+}
 
 // fetchAsset downloads one content-addressed asset (verifying its sha256) into
 // the shared static-files cache and returns its local path. On a cache hit it
@@ -136,7 +167,77 @@ func (s *AteomHerder) fetchAsset(ctx context.Context, entry assetEntry) (string,
 		return "", wrapFileSystemErr("while stat-ing local file", err)
 	}
 
-	// Assets live in one of two places: public buckets (gVisor's runsc in
+	tmpName, err := s.downloadVerified(ctx, entry, filepath.Base(localPath)+"-download-")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmpName) // no-op if successful rename later in the function
+
+	if err := os.Chmod(tmpName, 0o755); err != nil {
+		return "", wrapFileSystemErr("while setting file mode", err)
+	}
+	if err := os.Rename(tmpName, localPath); err != nil {
+		return "", wrapFileSystemErr("while renaming temp file to target", err)
+	}
+
+	return localPath, nil
+}
+
+// fetchGVisorRelease downloads the gVisor release tarball (gvisor.tar.bz2,
+// verifying its sha256) and extracts it into a content-addressed directory in
+// the shared static-files cache, returning the local path of the extracted
+// `runsc` binary.
+func (s *AteomHerder) fetchGVisorRelease(ctx context.Context, entry assetEntry) (string, error) {
+	if err := resources.ValidateRunscHash(entry.SHA256); err != nil {
+		return "", wrapFileSystemErr("while validating asset hash", err)
+	}
+
+	releaseDir := ateompath.GVisorReleaseDir(entry.SHA256)
+	runscPath := filepath.Join(releaseDir, "runsc")
+	_, err := os.Stat(releaseDir)
+	if err == nil {
+		return runscPath, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", wrapFileSystemErr("while stat-ing extracted release dir", err)
+	}
+
+	tarball, err := s.downloadVerified(ctx, entry, filepath.Base(releaseDir)+"-download-")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tarball)
+
+	tmpDir, err := os.MkdirTemp(ateompath.StaticFilesDir, filepath.Base(releaseDir)+"-extract-")
+	if err != nil {
+		return "", wrapFileSystemErr("while creating extraction dir", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }() // no-op after rename
+
+	if err := extractTarBz2(tarball, tmpDir); err != nil {
+		return "", err
+	}
+	if fi, err := os.Stat(filepath.Join(tmpDir, "runsc")); err != nil || !fi.Mode().IsRegular() {
+		return "", fmt.Errorf("%w: gvisor tarball %v contains no runsc binary (stat: %v)", ateerrors.ReasonInvalidSandboxAsset, entry.URL, err)
+	}
+	if err := os.Chmod(tmpDir, 0o755); err != nil { // MkdirTemp created it 0700
+		return "", wrapFileSystemErr("while setting extraction dir mode", err)
+	}
+	if err := os.Rename(tmpDir, releaseDir); err != nil {
+		// A concurrent fetch of the same release may have won the rename.
+		if errors.Is(err, syscall.EEXIST) || errors.Is(err, syscall.ENOTEMPTY) {
+			return runscPath, nil
+		}
+		return "", wrapFileSystemErr("while renaming extraction dir to target", err)
+	}
+	return runscPath, nil
+}
+
+// downloadVerified streams entry.URL into a temp file in the static-files
+// cache, hashing as it goes, and returns the temp path once the size cap and
+// sha256 both check out. On error the temp file is removed; on success the
+// caller owns it (rename it into place or extract from it, then remove it).
+func (s *AteomHerder) downloadVerified(ctx context.Context, entry assetEntry, tmpPrefix string) (string, error) {
+	// Assets live in one of two places: public buckets (gVisor's releases in
 	// gs://gvisor — read anonymously) or the cluster's own object store (micro-VM
 	// kata/CH assets staged into the snapshot bucket — read with the main client,
 	// which is rustfs/S3 in kind and authenticated GCS on GKE). Auth is an
@@ -154,13 +255,18 @@ func (s *AteomHerder) fetchAsset(ctx context.Context, entry assetEntry) (string,
 		return "", fmt.Errorf("%w: while parsing sha256 hash: %w", ateerrors.ReasonInvalidSandboxAsset, err)
 	}
 
-	tmpFile, err := os.CreateTemp(filepath.Dir(localPath), filepath.Base(localPath)+"-download-")
+	tmpFile, err := os.CreateTemp(ateompath.StaticFilesDir, tmpPrefix)
 	if err != nil {
 		return "", wrapFileSystemErr("while creating temp file", err)
 	}
 	tmpName := tmpFile.Name()
-	defer os.Remove(tmpName) // partial-download cleanup; no-op after rename
 	defer tmpFile.Close()
+	ok := false
+	defer func() {
+		if !ok {
+			os.Remove(tmpName)
+		}
+	}()
 
 	// Stream to disk, hashing as we go; +1 lets an over-cap asset trip n > cap.
 	// Verify-after-copy keeps a bad download at the temp path, never the cache.
@@ -176,17 +282,79 @@ func (s *AteomHerder) fetchAsset(ctx context.Context, entry assetEntry) (string,
 		return "", fmt.Errorf("%w: sha256 mismatch; got=%x want=%s", ateerrors.ReasonInvalidSandboxAsset, got, entry.SHA256)
 	}
 
-	if err := tmpFile.Chmod(0o755); err != nil {
-		return "", wrapFileSystemErr("while setting file mode", err)
-	}
-	if err := tmpFile.Close(); err != nil { // flush before rename
+	if err := tmpFile.Close(); err != nil { // flush before the caller reads/renames
 		return "", wrapFileSystemErr("while closing temp file", err)
 	}
-	if err := os.Rename(tmpName, localPath); err != nil {
-		return "", wrapFileSystemErr("while renaming temp file to target", err)
+
+	ok = true
+	return tmpName, nil
+}
+
+// extractTarBz2 unpacks the tar.bz2 at tarPath into destDir.
+func extractTarBz2(tarPath, destDir string) error {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return wrapFileSystemErr("while opening downloaded tarball", err)
+	}
+	defer f.Close()
+	tr := tar.NewReader(bzip2.NewReader(bufio.NewReader(f)))
+	var total int64
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("%w: while reading gvisor tarball: %w", ateerrors.ReasonInvalidSandboxAsset, err)
+		}
+		name := filepath.Clean(hdr.Name)
+		if name == "." {
+			continue
+		}
+		if filepath.IsAbs(name) || strings.Contains(name, "..") {
+			return fmt.Errorf("%w: gvisor tarball entry %q escapes the extraction dir", ateerrors.ReasonInvalidSandboxAsset, hdr.Name)
+		}
+		dest := filepath.Join(destDir, name)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(dest, fs.FileMode(hdr.Mode)&0o777|0o700); err != nil {
+				return wrapFileSystemErr("while creating tarball dir", err)
+			}
+		case tar.TypeReg:
+			total += hdr.Size
+			if total > maxAssetBytes {
+				return fmt.Errorf("%w: gvisor tarball inflates past the %d-byte cap", ateerrors.ReasonInvalidSandboxAsset, maxAssetBytes)
+			}
+			if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+				return wrapFileSystemErr("while creating tarball parent dir", err)
+			}
+			if err := writeTarFile(dest, tr, fs.FileMode(hdr.Mode)&0o777); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("%w: gvisor tarball entry %q has unsupported type %d", ateerrors.ReasonInvalidSandboxAsset, hdr.Name, hdr.Typeflag)
+		}
 	}
 
-	return localPath, nil
+}
+
+// writeTarFile writes one regular tarball entry to `dest` with the given mode.
+func writeTarFile(dest string, r io.Reader, mode fs.FileMode) error {
+	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return wrapFileSystemErr("while creating tarball file", err)
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, r); err != nil {
+		return wrapFileSystemErr("while extracting tarball file", err)
+	}
+	if err := out.Chmod(mode); err != nil {
+		return wrapFileSystemErr("while setting tarball file mode", err)
+	}
+	if err := out.Close(); err != nil {
+		return wrapFileSystemErr("while closing tarball file", err)
+	}
+	return nil
 }
 
 // openAsset streams url, trying the anonymous client first (public buckets like

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -198,7 +198,7 @@ This means a single, cluster-managed config pins the sandbox runtime version for
 | :--- | :--- | :--- |
 | `sandboxClass` | `string` | **Required.** Runtime family this config applies to: `gvisor` (default) or `microvm`. A `WorkerPool` only uses `SandboxConfig`s whose `sandboxClass` matches its own. |
 | `default` | `bool` | Optional. Marks this as the cluster default for its `sandboxClass`. A `WorkerPool` with no `sandboxConfigName` resolves to the default for its class. At most one default per class. |
-| `assets` | `map[arch]map[name]AssetFile` | Optional. Content-addressed files atelet fetches, keyed by architecture (`amd64`, `arm64`) then asset name. gVisor expects a `runsc` asset; a micro-VM backend expects several. Each `AssetFile` is a `{ url, sha256 }` pair. |
+| `assets` | `map[arch]map[name]AssetFile` | Optional. Content-addressed files atelet fetches, keyed by architecture (`amd64`, `arm64`) then asset name. gVisor expects a `gvisor` asset (the release's `gvisor.tar.bz2`), which atelet auto-extracts. A micro-VM backend expects several. Each `AssetFile` is a `{ url, sha256 }` pair. |
 
 A default cluster-wide gVisor `SandboxConfig` (`gvisor-default`) is installed with the platform, so gVisor pools work out of the box.
 
@@ -214,13 +214,13 @@ spec:
   default: true
   assets:
     amd64:
-      runsc:
-        url: "gs://gvisor/releases/nightly/2026-05-19/x86_64/runsc"
-        sha256: "a397be1abc2420d26bce6c70e6e2ff96c73aaaab929756c56f5e2089ea842b63"
+      gvisor:
+        url: "gs://gvisor/releases/release/20260727/x86_64/gvisor.tar.bz2"
+        sha256: "0ebce37235dcffad3a165aa86aad24a92ba887ab4c8c26f580db97eb373c39f9"
     arm64:
-      runsc:
-        url: "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"
-        sha256: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9"
+      gvisor:
+        url: "gs://gvisor/releases/release/20260727/aarch64/gvisor.tar.bz2"
+        sha256: "4a54f2c5ace3da0d6b02cce384e6db253d1de8da55648ff96a0b560ef8e2a6c7"
 ```
 
 ### Micro-VM SandboxConfig

--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -40,6 +40,15 @@ func RunSCBinaryPath(sha256 string) string {
 	return filepath.Join(StaticFilesDir, "runsc-"+sha256)
 }
 
+// GVisorReleaseDir is the directory a gVisor release tarball (gvisor.tar.bz2,
+// containing runsc plus its gvisor-bin/ helper binaries) is extracted into,
+// content-addressed by the tarball's sha256. runsc requires the gvisor-bin/
+// subdirectory to sit next to it, so the whole release is kept together under
+// one directory rather than as loose files in StaticFilesDir.
+func GVisorReleaseDir(sha256 string) string {
+	return filepath.Join(StaticFilesDir, "gvisor-"+sha256)
+}
+
 func AteomPath(podUID string) string {
 	return filepath.Join(
 		BasePath,

--- a/internal/proto/ateletpb/atelet.pb.go
+++ b/internal/proto/ateletpb/atelet.pb.go
@@ -295,7 +295,7 @@ func (x *RunRequest) GetSandboxAssets() *SandboxAssets {
 }
 
 // AssetFile is one content-addressed file atelet fetches for a sandbox runtime
-// (e.g. the gVisor runsc binary).
+// (e.g. the gVisor release tarball).
 type AssetFile struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// gs:// URL to download the asset from.
@@ -399,7 +399,8 @@ func (x *ArchAssets) GetFiles() map[string]*AssetFile {
 // SandboxAssets is the generic, backend-agnostic description of the sandbox
 // binaries for an actor: a sandbox class plus assets keyed first by
 // architecture (GOARCH) and then by asset name. atelet's backend code
-// interprets the asset names (gVisor expects "runsc").
+// interprets the asset names (gVisor expects "gvisor", the release tarball;
+// legacy "runsc", a bare binary, is still accepted).
 type SandboxAssets struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SandboxClass  string                 `protobuf:"bytes,1,opt,name=sandbox_class,json=sandboxClass,proto3" json:"sandbox_class,omitempty"`                                           // e.g. "gvisor"

--- a/internal/proto/ateletpb/atelet.proto
+++ b/internal/proto/ateletpb/atelet.proto
@@ -51,7 +51,7 @@ message RunRequest {
 }
 
 // AssetFile is one content-addressed file atelet fetches for a sandbox runtime
-// (e.g. the gVisor runsc binary).
+// (e.g. the gVisor release tarball).
 message AssetFile {
   // gs:// URL to download the asset from.
   string url = 1;
@@ -68,7 +68,8 @@ message ArchAssets {
 // SandboxAssets is the generic, backend-agnostic description of the sandbox
 // binaries for an actor: a sandbox class plus assets keyed first by
 // architecture (GOARCH) and then by asset name. atelet's backend code
-// interprets the asset names (gVisor expects "runsc").
+// interprets the asset names (gVisor expects "gvisor", the release tarball;
+// legacy "runsc", a bare binary, is still accepted).
 message SandboxAssets {
   string sandbox_class = 1;           // e.g. "gvisor"
   map<string, ArchAssets> assets = 2; // arch -> {name -> file}

--- a/manifests/ate-install/generated/ate.dev_sandboxconfigs.yaml
+++ b/manifests/ate-install/generated/ate.dev_sandboxconfigs.yaml
@@ -97,9 +97,12 @@ spec:
                   Assets is the set of files atelet fetches for this runtime, keyed first by
                   architecture (GOARCH, e.g. "amd64", "arm64") and then by asset name. The
                   asset names are interpreted by the sandbox backend: gVisor expects a
-                  "runsc" asset; a micro-VM backend expects several (e.g. "cloud-hypervisor",
-                  "kata-kernel", "kata-image"). The schema is intentionally generic;
-                  per-class requirements are enforced by a ValidatingAdmissionPolicy.
+                  "gvisor" asset (the release's gvisor.tar.bz2, which atelet extracts so
+                  the gvisor-bin/ helpers sit next to runsc; a legacy bare-binary "runsc"
+                  asset is still accepted); a micro-VM backend expects several (e.g.
+                  "cloud-hypervisor", "kata-kernel", "kata-image"). The schema is
+                  intentionally generic; per-class requirements are enforced by a
+                  ValidatingAdmissionPolicy.
                 type: object
               default:
                 description: |-

--- a/manifests/ate-install/sandboxconfig-gvisor.yaml
+++ b/manifests/ate-install/sandboxconfig-gvisor.yaml
@@ -14,9 +14,11 @@
 
 # Cluster-wide default SandboxConfig for the gVisor (runsc) sandbox class. A
 # WorkerPool with sandboxClass gvisor (the default) and no explicit
-# sandboxConfigName resolves to this. atelet fetches the runsc binary matching
-# the worker node's architecture. To pin a different runsc, edit the assets
-# below or create another SandboxConfig and name it from the WorkerPool.
+# sandboxConfigName resolves to this. atelet fetches the gVisor release tarball
+# (gvisor.tar.bz2: runsc plus the gvisor-bin/ helpers runsc requires next to
+# it) matching the worker node's architecture and extracts it locally. To pin a
+# different release, edit the assets below or create another SandboxConfig and
+# name it from the WorkerPool.
 apiVersion: ate.dev/v1alpha1
 kind: SandboxConfig
 metadata:
@@ -26,10 +28,10 @@ spec:
   default: true
   assets:
     amd64:
-      runsc:
-        url: "gs://gvisor/releases/release/20260622/x86_64/runsc"
-        sha256: "f18a948bf9c8bbb54eb998549a3a8d719a1c7de2efbe8fdd2ff0ee5fecd06f19"
+      gvisor:
+        url: "gs://gvisor/releases/release/20260727/x86_64/gvisor.tar.bz2"
+        sha256: "0ebce37235dcffad3a165aa86aad24a92ba887ab4c8c26f580db97eb373c39f9"
     arm64:
-      runsc:
-        url: "gs://gvisor/releases/release/20260622/aarch64/runsc"
-        sha256: "62eee121f8c188e347c428acc96f111568ede3be37b906046b6f28bbe2cc40c0"
+      gvisor:
+        url: "gs://gvisor/releases/release/20260727/aarch64/gvisor.tar.bz2"
+        sha256: "4a54f2c5ace3da0d6b02cce384e6db253d1de8da55648ff96a0b560ef8e2a6c7"

--- a/manifests/ate-install/sandboxconfig-validation.yaml
+++ b/manifests/ate-install/sandboxconfig-validation.yaml
@@ -29,12 +29,16 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["sandboxconfigs"]
   validations:
-  # gVisor needs a "runsc" asset for every architecture it advertises.
+  # gVisor needs a "gvisor" release-tarball asset (gvisor.tar.bz2: runsc plus
+  # its gvisor-bin/ helpers) for every architecture it advertises. A legacy
+  # bare-binary "runsc" asset is still accepted for releases that predate the
+  # tarball.
   - expression: >-
       object.spec.sandboxClass != 'gvisor' ||
       (has(object.spec.assets) && size(object.spec.assets) > 0 &&
-       object.spec.assets.all(arch, 'runsc' in object.spec.assets[arch]))
-    message: "a gvisor SandboxConfig must define a 'runsc' asset for every architecture under spec.assets"
+       object.spec.assets.all(arch,
+         'gvisor' in object.spec.assets[arch] || 'runsc' in object.spec.assets[arch]))
+    message: "a gvisor SandboxConfig must define a 'gvisor' (release tarball) or legacy 'runsc' asset for every architecture under spec.assets"
   # The micro-VM (cloud-hypervisor) runtime needs its asset set for every
   # architecture it advertises.
   - expression: >-

--- a/pkg/api/v1alpha1/sandboxconfig_types.go
+++ b/pkg/api/v1alpha1/sandboxconfig_types.go
@@ -70,9 +70,12 @@ type SandboxConfigSpec struct {
 	// Assets is the set of files atelet fetches for this runtime, keyed first by
 	// architecture (GOARCH, e.g. "amd64", "arm64") and then by asset name. The
 	// asset names are interpreted by the sandbox backend: gVisor expects a
-	// "runsc" asset; a micro-VM backend expects several (e.g. "cloud-hypervisor",
-	// "kata-kernel", "kata-image"). The schema is intentionally generic;
-	// per-class requirements are enforced by a ValidatingAdmissionPolicy.
+	// "gvisor" asset (the release's gvisor.tar.bz2, which atelet extracts so
+	// the gvisor-bin/ helpers sit next to runsc; a legacy bare-binary "runsc"
+	// asset is still accepted); a micro-VM backend expects several (e.g.
+	// "cloud-hypervisor", "kata-kernel", "kata-image"). The schema is
+	// intentionally generic; per-class requirements are enforced by a
+	// ValidatingAdmissionPolicy.
 	//
 	// +optional
 	Assets map[string]map[string]AssetFile `json:"assets,omitempty"`

--- a/pkg/api/v1alpha1/sandboxconfig_validation_test.go
+++ b/pkg/api/v1alpha1/sandboxconfig_validation_test.go
@@ -47,6 +47,10 @@ func sandboxConfig(name string, class SandboxClass, assets map[string]map[string
 
 func runscAsset() AssetFile { return AssetFile{URL: "gs://bucket/runsc", SHA256: validSHA256} }
 
+func gvisorAsset() AssetFile {
+	return AssetFile{URL: "gs://bucket/gvisor.tar.bz2", SHA256: validSHA256}
+}
+
 // microVMAssets returns a full, valid micro-VM asset set for one architecture:
 // the five assets the policy requires. The overlay rootfs serves the OCI image
 // over virtio-fs, so virtiofsd is part of the set.
@@ -113,8 +117,16 @@ func TestSandboxConfigValidation(t *testing.T) {
 		wantErr bool
 		errMsg  string
 	}{{
-		name:    "valid gvisor with runsc",
+		name:    "valid gvisor with release tarball",
+		sc:      sandboxConfig("ok-gvisor-tarball", SandboxClassGvisor, map[string]map[string]AssetFile{"amd64": {"gvisor": gvisorAsset()}, "arm64": {"gvisor": gvisorAsset()}}),
+		wantErr: false,
+	}, {
+		name:    "valid gvisor with legacy runsc",
 		sc:      sandboxConfig("ok-gvisor", SandboxClassGvisor, map[string]map[string]AssetFile{"amd64": {"runsc": runscAsset()}, "arm64": {"runsc": runscAsset()}}),
+		wantErr: false,
+	}, {
+		name:    "valid gvisor mixing tarball and legacy per arch",
+		sc:      sandboxConfig("ok-gvisor-mixed", SandboxClassGvisor, map[string]map[string]AssetFile{"amd64": {"gvisor": gvisorAsset()}, "arm64": {"runsc": runscAsset()}}),
 		wantErr: false,
 	}, {
 		name:    "valid microvm with full asset set",
@@ -143,13 +155,13 @@ func TestSandboxConfigValidation(t *testing.T) {
 		wantErr: true,
 		errMsg:  "microvm SandboxConfig must define",
 	}, {
-		name:    "gvisor arch missing runsc",
+		name:    "gvisor arch missing gvisor and runsc",
 		sc:      sandboxConfig("bad-no-runsc", SandboxClassGvisor, map[string]map[string]AssetFile{"amd64": {"notrunsc": runscAsset()}}),
 		wantErr: true,
 		errMsg:  "runsc",
 	}, {
-		name:    "gvisor one arch missing runsc",
-		sc:      sandboxConfig("bad-mixed-arch", SandboxClassGvisor, map[string]map[string]AssetFile{"amd64": {"runsc": runscAsset()}, "arm64": {"notrunsc": runscAsset()}}),
+		name:    "gvisor one arch missing gvisor and runsc",
+		sc:      sandboxConfig("bad-mixed-arch", SandboxClassGvisor, map[string]map[string]AssetFile{"amd64": {"gvisor": gvisorAsset()}, "arm64": {"notrunsc": runscAsset()}}),
 		wantErr: true,
 		errMsg:  "runsc",
 	}, {


### PR DESCRIPTION
This new release requires multiple files and is released as a tarball. gVisor asset handling code is updated to automatically handle this release format and extract it as necessary.

This build also contains the start of a series of upcoming startup/memory performance optimizations to make Substrate sandbox churn efficient.

Benchmarks between the previous gVisor build and this one:

```
CI benchmark suite:
                                                     │      old       │                    new                    │
                                                          │     sec/op     │     sec/op       vs base                  │
  ResumeActor/glutton_baseline_1_user/p50                   324.7m ±    3%    289.6m ±    2%  -10.79% (p=0.000 n=11)
  ResumeActor/glutton_baseline_1_user/p95                   373.4m ±    9%    328.6m ±    2%  -12.00% (p=0.000 n=11)
  ResumeActor/glutton_baseline_5_users/p50                  319.4m ±    1%    288.6m ±    1%   -9.65% (p=0.000 n=9)
  ResumeActor/glutton_baseline_5_users/p95                  367.6m ±    5%    341.7m ±   11%   -7.05% (p=0.024 n=9)
  ResumeActor/glutton_baseline_10_users/p50                 323.6m ±    1%    293.8m ±    2%   -9.22% (p=0.000 n=9+10)
  ResumeActor/glutton_baseline_10_users/p95                 396.2m ±    4%    372.1m ±    5%   -6.07% (p=0.001 n=9+10)
  ResumeActor/glutton_oversubscribe_15_users/p50            330.8m ±    2%    304.7m ±    1%   -7.89% (p=0.000 n=8+10)
  ResumeActor/glutton_oversubscribe_15_users/p95            402.7m ±    5%    390.4m ±    3%        ~ (p=0.083 n=8+10)
  ResumeActorColdStart/glutton_baseline_1_user/p50          227.0m ±   10%    211.6m ±   19%   -6.79% (p=0.003 n=11)
  ResumeActorColdStart/glutton_baseline_5_users/p50         231.5m ±    5%    216.3m ±    7%   -6.54% (p=0.004 n=9)
  ResumeActorColdStart/glutton_baseline_5_users/p95         246.4m ±    3%    230.2m ±    6%   -6.60% (p=0.000 n=9)
  ResumeActorColdStart/glutton_baseline_10_users/p50        217.4m ±   10%    193.5m ±    7%  -10.99% (p=0.001 n=9+10)
  ResumeActorColdStart/glutton_baseline_10_users/p95        241.8m ±    7%    231.2m ±    9%   -4.39% (p=0.022 n=9+10)
  ResumeActorColdStart/glutton_oversubscribe_15_users/p50   205.9m ±    6%    192.5m ±   28%        ~ (p=0.122 n=8+10)
  ResumeActorColdStart/glutton_oversubscribe_15_users/p95   247.1m ±    4%    229.6m ±  102%   -7.09% (p=0.043 n=8+10)
  SuspendActor/glutton_baseline_1_user/p50                  313.3m ±    7%    294.1m ±    4%   -6.14% (p=0.010 n=11)
  SuspendActor/glutton_baseline_5_users/p50                 304.6m ±    3%    289.1m ±    2%   -5.10% (p=0.000 n=9)
  SuspendActor/glutton_baseline_10_users/p50                309.7m ±    3%    296.9m ±    3%   -4.13% (p=0.000 n=9+10)
  SuspendActor/glutton_oversubscribe_15_users/p50           320.6m ±    3%    305.3m ±    2%   -4.75% (p=0.001 n=8+10)

Manual benchmarks (GKE on a single c3-standard-88 node):

- p50 sandbox lifecycle time (from issuing resume to checkpointed):
  ┌─────────┬──────────┬───────────┬────────┐
  │ workers │   old    │    new    │ delta  │
  ├─────────┼──────────┼───────────┼────────┤
  │ 1       │ 795 ms   │ 565 ms    │ −28.9% │
  ├─────────┼──────────┼───────────┼────────┤
  │ 2       │ 801 ms   │ 590 ms    │ −26.4% │
  ├─────────┼──────────┼───────────┼────────┤
  │ 8       │ 902 ms   │ 759 ms    │ −15.9% │
  ├─────────┼──────────┼───────────┼────────┤
  │ 64      │ 3.25 s   │ 3.14 s    │ −3.4%  │
  ├─────────┼──────────┼───────────┼────────┤
  │ 88      │ 4.47 s   │ 4.30 s    │ −3.8%  │
  └─────────┴──────────┴───────────┴────────┘

- Sandbox starts per second:
  ┌─────────┬────────────┬────────────┬────────┐
  │ workers │    old     │    new     │ delta  │
  ├─────────┼────────────┼────────────┼────────┤
  │ 1       │ 1.256 ± 1% │ 1.755 ± 2% │ +39.7% │
  ├─────────┼────────────┼────────────┼────────┤
  │ 2       │ 2.482 ± 1% │ 3.393 ± 1% │ +36.7% │
  ├─────────┼────────────┼────────────┼────────┤
  │ 8       │ 8.81 ± 2%  │ 10.50 ± 2% │ +19.2% │
  ├─────────┼────────────┼────────────┼────────┤
  │ 64      │ 19.85 ± 3% │ 20.45 ± 1% │ +3.0%  │
  ├─────────┼────────────┼────────────┼────────┤
  │ 88      │ 19.70 ± 1% │ 20.58 ± 2% │ +4.5%  │
  └─────────┴────────────┴────────────┴────────┘
```