### PR TITLE
Enable MicroVM Benchmarking

### DIFF
--- a/benchmarking/automation/Dockerfile
+++ b/benchmarking/automation/Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-pip \
         python3-venv \
         docker.io \
+        unzip \
+        zstd \
     && rm -rf /var/lib/apt/lists/*
 
 # Go must be new enough to honor the `tool` directive in

--- a/benchmarking/automation/README.md
+++ b/benchmarking/automation/README.md
@@ -15,15 +15,29 @@ Each run uploads results to GCS via `benchmarking/locust/runner.py`.
 4. `docker build && docker push` builds the locust image tagged with the commit
    hash and pushes it to `${KO_DOCKER_REPO}/locust-test:<commit>`.
 5. `hack/install-ate.sh --deploy-ate-system` + `benchmarking/workloads/deploy.sh
-   --deploy` (these build & push substrate / workload images via `ko` as part
-   of their deploy steps — there's no separate `make build-images` step).
+   --deploy --sandbox-class <class>` (these build & push substrate / workload
+   images via `ko` as part of their deploy steps — there's no separate
+   `make build-images` step). For a `microvm` test the orchestrator also
+   runs `hack/install-microvm-deps.sh --install` between the two, which
+   stages kata + cloud-hypervisor + virtiofsd assets to the cluster's object
+   store bucket and applies the cluster-wide `microvm` SandboxConfig.
 6. For each test in `tests.yaml`:
    - Submits a Job using the just-built locust image; the Job runs
      `runner.py -f <file> -t <duration> -u <users> --tag <commit> --name <name>
      --dest <dest>`.
    - Polls until complete/failed/timeout; tails logs; deletes the Job.
-   - Tears down substrate + workloads.
+   - Tears down workloads + micro-VM deps (if any) + substrate.
    - If not the last test, redeploys them so the next run starts clean.
+
+## Choosing a sandbox class
+
+Each entry in `tests.yaml` may set `sandboxClass: gvisor | microvm` (default
+`gvisor`). This controls both `spec.sandboxClass` on the benchmark WorkerPool
+and its `ateomImage` (`ateom-gvisor` vs `ateom-microvm`).
+
+For `microvm` tests the target cluster must have KVM-capable nodes and the
+object store bucket named in its `.ate-dev-env.sh` must be writable by the
+orchestrator's Workload Identity principal.
 
 ## Setup
 

--- a/benchmarking/automation/orchestrator.py
+++ b/benchmarking/automation/orchestrator.py
@@ -285,13 +285,13 @@ def teardown_substrate() -> None:
 
 def install_microvm_deps() -> None:
     """Stage kata/cloud-hypervisor assets and apply the cluster-wide
-    microvm-default SandboxConfig. Required before a microvm WorkerPool can
+    microvm SandboxConfig. Required before a microvm WorkerPool can
     schedule; must run after deploy_substrate() (which installs the CRDs)."""
     run(["hack/install-microvm-deps.sh", "--install"])
 
 
 def teardown_microvm_deps() -> None:
-    """Remove the microvm-default SandboxConfig. Must run before
+    """Remove the microvm SandboxConfig. Must run before
     teardown_substrate(), which deletes the SandboxConfig CRD (and would
     prevent this from succeeding via kubectl)."""
     run_no_check(["hack/install-microvm-deps.sh", "--delete"])
@@ -438,7 +438,7 @@ def main() -> None:
             try:
                 deploy_substrate()
                 # install-microvm-deps needs the CRDs from deploy_substrate;
-                # deploy_workloads needs the microvm-default SandboxConfig.
+                # deploy_workloads needs the microvm SandboxConfig.
                 if sandbox_class == "microvm":
                     install_microvm_deps()
                 deploy_workloads(test.get("workerCount", 1), sandbox_class)

--- a/benchmarking/automation/orchestrator.py
+++ b/benchmarking/automation/orchestrator.py
@@ -272,6 +272,9 @@ def wait_for_job(name: str, timeout_seconds: int) -> str:
     return "timeout"
 
 
+SANDBOX_CLASSES = ("gvisor", "microvm")
+
+
 def deploy_substrate() -> None:
     run(["hack/install-ate.sh", "--deploy-ate-system"])
 
@@ -280,13 +283,29 @@ def teardown_substrate() -> None:
     run_no_check(["hack/install-ate.sh", "--delete-ate-system"])
 
 
-def deploy_workloads(worker_count: int = 1) -> None:
+def install_microvm_deps() -> None:
+    """Stage kata/cloud-hypervisor assets and apply the cluster-wide
+    microvm-default SandboxConfig. Required before a microvm WorkerPool can
+    schedule; must run after deploy_substrate() (which installs the CRDs)."""
+    run(["hack/install-microvm-deps.sh", "--install"])
+
+
+def teardown_microvm_deps() -> None:
+    """Remove the microvm-default SandboxConfig. Must run before
+    teardown_substrate(), which deletes the SandboxConfig CRD (and would
+    prevent this from succeeding via kubectl)."""
+    run_no_check(["hack/install-microvm-deps.sh", "--delete"])
+
+
+def deploy_workloads(worker_count: int = 1, sandbox_class: str = "gvisor") -> None:
     run(
         [
             "benchmarking/workloads/deploy.sh",
             "--deploy",
             "--worker-count",
             str(worker_count),
+            "--sandbox-class",
+            sandbox_class,
         ]
     )
     # Block until ActorTemplates are Ready
@@ -365,6 +384,12 @@ def main() -> None:
             sys.exit(
                 f"test {t.get('name')!r} missing required 'targetCluster' field"
             )
+        sandbox_class = t.get("sandboxClass", "gvisor")
+        if sandbox_class not in SANDBOX_CLASSES:
+            sys.exit(
+                f"test {t.get('name')!r} has invalid sandboxClass "
+                f"{sandbox_class!r} (want one of {list(SANDBOX_CLASSES)})"
+            )
 
     # Per-target-cluster caches: re-running setup for the same target
     # cluster is wasted work, so we track what was last set up and only
@@ -400,15 +425,23 @@ def main() -> None:
             # Idempotent sweep before anything else: a previous CronJob
             # fire that crashed mid-test (or any other process that left
             # state behind) would otherwise leak its substrate + workloads
-            # into this run. Both teardowns use --ignore-not-found, so
-            # this is cheap on a clean cluster.
+            # into this run. All teardowns use --ignore-not-found, so
+            # this is cheap on a clean cluster. Order matters:
+            # microvm-deps deletes a SandboxConfig CR, which requires the
+            # SandboxConfig CRD that teardown_substrate removes.
             teardown_workloads()
+            teardown_microvm_deps()
             teardown_substrate()
 
+            sandbox_class = test.get("sandboxClass", "gvisor")
             status = "error"
             try:
                 deploy_substrate()
-                deploy_workloads(test.get("workerCount", 1))
+                # install-microvm-deps needs the CRDs from deploy_substrate;
+                # deploy_workloads needs the microvm-default SandboxConfig.
+                if sandbox_class == "microvm":
+                    install_microvm_deps()
+                deploy_workloads(test.get("workerCount", 1), sandbox_class)
                 try:
                     status = run_test(test, locust_image, args.dest, commit)
                 except Exception as e:
@@ -418,7 +451,10 @@ def main() -> None:
             finally:
                 # Always tear down, even if deploy or run failed, so the
                 # next test (and the next CronJob fire) starts clean.
+                # microvm-deps must go before substrate for the same reason
+                # as above.
                 teardown_workloads()
+                teardown_microvm_deps()
                 teardown_substrate()
             results.append((test["name"], status))
         finally:

--- a/benchmarking/automation/tests.yaml
+++ b/benchmarking/automation/tests.yaml
@@ -24,6 +24,9 @@
 # the deploy that runs before this test. The orchestrator redeploys
 # workloads between tests, so each test can pick its own scale.
 #
+# Optional `sandboxClass` (default "gvisor") picks the sandbox runtime for
+# the benchmark WorkerPool. Allowed values: "gvisor" | "microvm".
+#
 # Required `targetCluster` names a config file under
 # /etc/orchestrator/target-clusters/ (e.g. `targetCluster: dev` ->
 # /etc/orchestrator/target-clusters/dev.sh). The orchestrator copies that

--- a/benchmarking/workloads/deploy.sh
+++ b/benchmarking/workloads/deploy.sh
@@ -37,20 +37,34 @@ if [[ ! -f "${MANIFEST_TEMPLATE}" ]]; then
 fi
 
 WORKER_COUNT=1
+SANDBOX_CLASS="gvisor"
 
 usage() {
   echo "Usage: $0 [options]"
   echo ""
   echo "Options:"
-  echo "  --deploy             Substitute env vars and deploy workloads to the cluster using ko apply"
-  echo "  --delete             Substitute env vars and delete workloads from the cluster"
-  echo "  --worker-count N     Number of WorkerPool replicas (default: 1)"
-  echo "  -h, --help           Show this help message"
+  echo "  --deploy                    Substitute env vars and deploy workloads to the cluster using ko apply"
+  echo "  --delete                    Substitute env vars and delete workloads from the cluster"
+  echo "  --worker-count N            Number of WorkerPool replicas (default: 1)"
+  echo "  --sandbox-class CLASS       Sandbox runtime for the WorkerPool: gvisor | microvm (default: gvisor)."
+  echo "                              microvm requires hack/install-microvm-deps.sh --install to have run."
+  echo "  -h, --help                  Show this help message"
 }
 
 substitute() {
+  # SandboxConfig names are pinned per class (rather than defaulted) so a stale
+  # config from a dirty teardown fails loudly instead of silently binding this
+  # pool. gvisor-default is applied by hack/install-ate.sh; microvm is applied
+  # by hack/install-microvm-deps.sh.
+  local sandbox_config_name
+  case "${SANDBOX_CLASS}" in
+    gvisor)  sandbox_config_name="gvisor-default" ;;
+    microvm) sandbox_config_name="microvm"        ;;
+  esac
   sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
       -e "s|\${WORKER_COUNT}|${WORKER_COUNT}|g" \
+      -e "s|\${SANDBOX_CLASS}|${SANDBOX_CLASS}|g" \
+      -e "s|\${SANDBOX_CONFIG_NAME}|${sandbox_config_name}|g" \
       "${MANIFEST_TEMPLATE}"
 }
 
@@ -87,6 +101,13 @@ while [[ "$#" -gt 0 ]]; do
     --worker-count=*)
       WORKER_COUNT="${1#*=}"
       ;;
+    --sandbox-class)
+      shift
+      SANDBOX_CLASS="$1"
+      ;;
+    --sandbox-class=*)
+      SANDBOX_CLASS="${1#*=}"
+      ;;
     -h|--help)
       usage
       exit 0
@@ -99,6 +120,14 @@ while [[ "$#" -gt 0 ]]; do
   esac
   shift
 done
+
+case "${SANDBOX_CLASS}" in
+  gvisor|microvm) ;;
+  *)
+    echo "Error: --sandbox-class must be gvisor or microvm, got '${SANDBOX_CLASS}'" >&2
+    exit 1
+    ;;
+esac
 
 if [[ "${action}" == "deploy" ]]; then
   deploy

--- a/benchmarking/workloads/manifests/workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/workloads.yaml.tmpl
@@ -28,7 +28,9 @@ metadata:
     workload: benchmark-ateom
 spec:
   replicas: ${WORKER_COUNT}
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  sandboxClass: ${SANDBOX_CLASS}
+  sandboxConfigName: ${SANDBOX_CONFIG_NAME}
+  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-${SANDBOX_CLASS}
 
 ---
 
@@ -38,6 +40,8 @@ metadata:
   name: sleep
   namespace: benchmark-workloads
 spec:
+  # Must match the WorkerPool's sandboxClass so snapshots stay within a class.
+  sandboxClass: ${SANDBOX_CLASS}
   pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
   containers:
   - name: sleep
@@ -57,6 +61,7 @@ metadata:
   name: glutton
   namespace: benchmark-workloads
 spec:
+  sandboxClass: ${SANDBOX_CLASS}
   pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
   containers:
   - name: glutton

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -16,75 +16,13 @@
 # in-RAM (atomic uint64), so a successful suspend/resume across pods shows the
 # count continuing — proving the guest memory snapshot round-tripped.
 #
-# The sandbox binaries (cloud-hypervisor, virtiofsd, guest kernel, guest rootfs,
-# base configuration.toml) live on a cluster-scoped SandboxConfig, FETCHED at runtime
-# from the cluster object store bucket ${BUCKET_NAME} under kata-assets/ (rustfs on
-# kind, GCS on GKE) — NOT baked into the worker image. ateom boots cloud-hypervisor
-# itself and gives the actor an overlay rootfs (virtio-fs RO lower + guest-tmpfs
-# upper), so it fetches virtiofsd (v1.14.0 — the first release with the vhost-0.16
-# snapshot/restore fix; the kata-bundled v1.13.3 hangs restore). The kata containerd
-# shim is NOT fetched (ateom drives the kata-agent directly). kata assets are 4.0.0.
-# The per-arch sha256 values below are the asset sets produced by
-# hack/microvm-assets/assemble.sh; atelet selects the block matching the node's
-# architecture, and each cluster's bucket holds that arch's binaries at these paths
-# (staged by run-microvm-demo[-kind].sh).
+# The cluster-wide `microvm` SandboxConfig referenced below by name is
+# installed by hack/install-microvm-deps.sh
 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ate-demo-counter-microvm
-
----
-
-apiVersion: ate.dev/v1alpha1
-kind: SandboxConfig
-metadata:
-  name: counter-microvm
-spec:
-  sandboxClass: microvm
-  assets:
-    arm64:
-      cloud-hypervisor:
-        url: "gs://${BUCKET_NAME}/kata-assets/cloud-hypervisor"
-        sha256: "bf004ddc1a148f47caa87ac49a783b8dbd6bf9bc27abe522ed197df7b982d3b1"
-      # virtiofsd serves the overlay RO lower (virtio-fs); v1.14.0 carries the
-      # vhost-0.16 snapshot/restore fix the kata-bundled v1.13.3 lacks.
-      virtiofsd:
-        url: "gs://${BUCKET_NAME}/kata-assets/virtiofsd"
-        # Upstream publishes no arm64 prebuilt, so assemble.sh builds the v1.14.0 tag
-        # from source; the binary is not byte-reproducible across toolchains and can't
-        # carry a fixed pin. run-microvm-demo.sh computes this from the freshly-staged
-        # binary at deploy.
-        sha256: "${VIRTIOFSD_SHA256}"
-      kata-kernel:
-        url: "gs://${BUCKET_NAME}/kata-assets/vmlinux"
-        sha256: "4a8998a2e7ac12d6ad1f15b5e7d00571e4518ea9f33db1a1a568310373ca428d"
-      kata-image:
-        url: "gs://${BUCKET_NAME}/kata-assets/rootfs.img"
-        sha256: "24d77700749846355f3be25b87974c1fdea9fd2a9534256b4e4bbdde5df23588"
-      kata-config:
-        url: "gs://${BUCKET_NAME}/kata-assets/configuration-clh.toml"
-        sha256: "20f5de4f705423ddd1ee93318c784c6aede30c07c78dc6b311a771cc2f6859c7"
-    # amd64 assets are kata 4.0.0 + virtiofsd v1.14.0 (assemble.sh ARCH=amd64).
-    amd64:
-      cloud-hypervisor:
-        url: "gs://${BUCKET_NAME}/kata-assets/cloud-hypervisor"
-        sha256: "829af01ff075bb96c4f183905134c453a88d68cbabdc6b87df21098842581ee9"
-      virtiofsd:
-        url: "gs://${BUCKET_NAME}/kata-assets/virtiofsd"
-        # The x86_64-musl binary attached to the upstream v1.14.0 release (downloaded
-        # by assemble.sh, reproducible bytes), so it carries a fixed pin like the
-        # other downloaded assets.
-        sha256: "15b2e72a78cc08a9bd8a6943e89fb69c88cb3cbeb63069efceade835342ac7d4"
-      kata-kernel:
-        url: "gs://${BUCKET_NAME}/kata-assets/vmlinux"
-        sha256: "6abc48fa83c58e3db314037105d04ec00c1bc80d85eb2dfb2e2854f414573bca"
-      kata-image:
-        url: "gs://${BUCKET_NAME}/kata-assets/rootfs.img"
-        sha256: "fbbd40de605ab2f99dc82c777dc5b41f9a00dad3a0f699f2247c306ac9c1204d"
-      kata-config:
-        url: "gs://${BUCKET_NAME}/kata-assets/configuration-clh.toml"
-        sha256: "1e67eabdfb9d900bf95a00edb52cacc1efe64f23ea095f8b49ee81c7434bce90"
 
 ---
 
@@ -98,7 +36,7 @@ metadata:
 spec:
   replicas: 2
   sandboxClass: microvm
-  sandboxConfigName: counter-microvm
+  sandboxConfigName: microvm
   ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
 
 ---

--- a/hack/install-microvm-deps.sh
+++ b/hack/install-microvm-deps.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install (or delete) the cluster-wide micro-VM (kata + cloud-hypervisor)
+# dependencies. This is opt-in on top of hack/install-ate.sh --deploy-ate-system,
+# which only installs the default gVisor SandboxConfig. Used by:
+#   * hack/run-microvm-demo.sh (before applying the counter-microvm demo)
+#   * benchmarking/automation/orchestrator.py (before deploying a microvm
+#     benchmark workload)
+#
+# On --install: assembles the asset set (assemble.sh; skipped if OUT already
+# has them), stages the assets under kata-assets/ to the cluster's object
+# store bucket (rustfs on kind, GCS on GKE), and applies the cluster-wide
+# `microvm` SandboxConfig referencing those assets. The virtiofsd
+# sha256 is computed from the staged binary and injected at apply time (on
+# arm64 the v1.14.0 binary is built from source, so its bytes vary per
+# toolchain and cannot be pinned in the manifest).
+#
+# WorkerPools must reference the SandboxConfig explicitly via
+# sandboxConfigName: microvm. This avoids a dirty teardown silently binding
+# new pools to a stale config.
+#
+# On --delete: removes the SandboxConfig from the cluster. Bucket contents
+# are left alone (they're inert until a SandboxConfig points at them, and
+# re-staging is cheap on next install).
+#
+# Like the other hack scripts, this sources .ate-dev-env.sh for the cluster /
+# registry / bucket settings unless NO_DEV_ENV is set.
+#
+# Env (most come from .ate-dev-env.sh):
+#   BUCKET_NAME      object store bucket for assets/snapshots (default: ate-snapshots).
+#   KUBECTL_CONTEXT  (optional) kube context; threaded into kubectl.
+#   PROJECT_ID       (optional) GCP project for the GCS asset upload (GKE path).
+#   ARCH             target arch (default: from KO_DEFAULTPLATFORMS, else host arch).
+#   OUT              asset dir (default: $PWD/bin/microvm-assets/$ARCH, gitignored).
+#   ATE_INSTALL_KIND "true" for the kind path (stage assets to rustfs); default
+#                    false uploads assets to GCS.
+
+set -o errexit -o nounset -o pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "${ROOT}"
+
+# Source the environment (cluster, registry, bucket) like the other hack scripts;
+# callers set NO_DEV_ENV to skip this and use kind defaults.
+if [[ -r .ate-dev-env.sh ]] && [[ -z "${NO_DEV_ENV:-}" ]]; then
+  source .ate-dev-env.sh
+fi
+
+BUCKET_NAME="${BUCKET_NAME:-ate-snapshots}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-}"
+ATE_INSTALL_KIND="${ATE_INSTALL_KIND:-false}"
+
+usage() {
+  cat <<EOF
+Usage: $0 (--install | --delete)
+
+Options:
+  --install   Assemble + stage micro-VM assets and apply the cluster-wide
+              microvm SandboxConfig.
+  --delete    Remove the microvm SandboxConfig from the cluster.
+              (Bucket contents are left alone.)
+  -h, --help  Show this message.
+EOF
+}
+
+action=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install) action="install" ;;
+    --delete)  action="delete"  ;;
+    -h|--help) usage; exit 0    ;;
+    *) echo "Error: unknown argument $1" >&2; usage; exit 1 ;;
+  esac
+  shift
+done
+
+if [[ -z "${action}" ]]; then
+  usage
+  exit 1
+fi
+
+# ANSI color codes for prettier output (mirrors hack/install-ate.sh).
+COLOR_CYAN='\033[1;36m'
+COLOR_RESET='\033[0m'
+log() {
+  echo -e "${COLOR_CYAN}[install-microvm-deps]: $*${COLOR_RESET}"
+}
+
+run_kubectl() {
+  kubectl ${KUBECTL_CONTEXT:+--context="${KUBECTL_CONTEXT}"} "$@"
+}
+
+MANIFEST_TEMPLATE="manifests/microvm/sandboxconfig-microvm.yaml.tmpl"
+
+if [[ "${action}" == "delete" ]]; then
+  log "Deleting microvm SandboxConfig..."
+  # Delete by name rather than by manifest so a missing/edited template file
+  # doesn't block cleanup on an older cluster.
+  run_kubectl delete --ignore-not-found sandboxconfig microvm
+  log "Done. (Bucket assets at gs://${BUCKET_NAME}/kata-assets/ left in place.)"
+  exit 0
+fi
+
+# --- install ----------------------------------------------------------------
+
+# Target arch: match the images' platform (KO_DEFAULTPLATFORMS is set by
+# .ate-dev-env.sh on GKE and by the kind wrapper); fall back to the host arch.
+if [[ -z "${ARCH:-}" ]]; then
+  if [[ -n "${KO_DEFAULTPLATFORMS:-}" ]]; then
+    ARCH="${KO_DEFAULTPLATFORMS##*/}"
+  else
+    ARCH="$(go env GOARCH)"
+  fi
+fi
+OUT="${OUT:-${ROOT}/bin/microvm-assets/$ARCH}"
+
+# --- 1. assets: assemble (if missing) --------------------------------------
+need_assemble=false
+for f in cloud-hypervisor virtiofsd vmlinux rootfs.img configuration-clh.toml; do
+  if [[ ! -f "${OUT}/${f}" ]]; then
+    need_assemble=true
+    break
+  fi
+done
+if [[ "${need_assemble}" == "true" ]]; then
+  log "Assembling micro-VM assets into ${OUT} (ARCH=${ARCH})..."
+  ARCH="${ARCH}" OUT="${OUT}" hack/microvm-assets/assemble.sh
+else
+  log "Assets already present in ${OUT}; skipping assemble."
+fi
+
+# --- 2. stage assets to rustfs (kind) / GCS (GKE) --------------------------
+# Upload the five assets under kata-assets/, where atelet fetches them: the
+# in-cluster rustfs (port-forwarded, S3 API) on kind, or the GCS bucket on GKE.
+if [[ "${ATE_INSTALL_KIND}" == "true" ]]; then
+  log "Staging assets to in-cluster rustfs bucket ${BUCKET_NAME} (kata-assets/)..."
+  OUT="${OUT}" BUCKET="${BUCKET_NAME}" KUBECTL_CONTEXT="${KUBECTL_CONTEXT}" hack/microvm-assets/stage-to-rustfs.sh
+else
+  log "Uploading assets to gs://${BUCKET_NAME}/kata-assets/ ..."
+  OUT="${OUT}" BUCKET="${BUCKET_NAME}" hack/microvm-assets/stage-to-gcs.sh
+fi
+
+# --- 3. apply the cluster-wide microvm SandboxConfig -----------------------
+# The arm64 virtiofsd is built from source (release tag in assemble.sh), so
+# its binary bytes are not reproducible across toolchains and its sha can't
+# be a fixed pin in the manifest. Compute it from the freshly-staged binary
+# and inject it, so the deployed SandboxConfig always matches whatever was
+# staged. The downloaded assets (cloud-hypervisor/kernel/rootfs/config, plus
+# virtiofsd on amd64 where upstream publishes a prebuilt) keep their
+# committed, reproducible per-arch shas.
+log "Applying microvm SandboxConfig from ${MANIFEST_TEMPLATE}..."
+VIRTIOFSD_SHA256="$(sha256sum "${OUT}/virtiofsd" | awk '{print $1}')"
+sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
+    -e "s|\${VIRTIOFSD_SHA256}|${VIRTIOFSD_SHA256}|g" \
+    "${MANIFEST_TEMPLATE}" \
+  | run_kubectl apply -f -
+
+log "Done. WorkerPools must reference this SandboxConfig by name (sandboxConfigName: microvm)."

--- a/hack/run-microvm-demo.sh
+++ b/hack/run-microvm-demo.sh
@@ -18,6 +18,13 @@
 # local kind cluster use hack/run-microvm-demo-kind.sh (which sets the kind env
 # and calls this script), mirroring install-ate.sh / install-ate-kind.sh.
 #
+# Composes:
+#   1. hack/install-ate.sh --deploy-ate-system  (control plane)
+#   2. hack/install-microvm-deps.sh --install   (asset build/stage + cluster-wide
+#                                                microvm-default SandboxConfig)
+#   3. Apply the counter-microvm demo manifest (namespace + WorkerPool +
+#      ActorTemplate; resolves to microvm-default via sandboxClass=microvm).
+#
 # Like the other hack scripts, this sources .ate-dev-env.sh for the cluster /
 # registry / bucket settings unless NO_DEV_ENV is set.
 #
@@ -77,17 +84,6 @@ case "${ATE_ATEAPI_CLIENT_AUTH}" in
     ;;
 esac
 
-# Target arch: match the images' platform (KO_DEFAULTPLATFORMS is set by
-# .ate-dev-env.sh on GKE and by the kind wrapper); fall back to the host arch.
-if [[ -z "${ARCH:-}" ]]; then
-  if [[ -n "${KO_DEFAULTPLATFORMS:-}" ]]; then
-    ARCH="${KO_DEFAULTPLATFORMS##*/}"
-  else
-    ARCH="$(go env GOARCH)"
-  fi
-fi
-OUT="${OUT:-${ROOT}/bin/microvm-assets/$ARCH}"
-
 if [[ -z "${KO_DOCKER_REPO}" ]]; then
   echo "Error: KO_DOCKER_REPO is required (set it in .ate-dev-env.sh for GKE," >&2
   echo "       or use hack/run-microvm-demo-kind.sh for a local kind cluster)." >&2
@@ -102,32 +98,7 @@ log() {
   echo -e "${COLOR_CYAN}[run-microvm-demo]: $*${COLOR_RESET}"
 }
 
-# --- 2. assets: assemble (if missing) then stage to rustfs (kind) / GCS (GKE) --
-need_assemble=false
-for f in cloud-hypervisor virtiofsd vmlinux rootfs.img configuration-clh.toml; do
-  if [[ ! -f "${OUT}/${f}" ]]; then
-    need_assemble=true
-    break
-  fi
-done
-if [[ "${need_assemble}" == "true" ]]; then
-  log "Assembling micro-VM assets into ${OUT} (ARCH=${ARCH})..."
-  ARCH="${ARCH}" OUT="${OUT}" hack/microvm-assets/assemble.sh
-else
-  log "Assets already present in ${OUT}; skipping assemble."
-fi
-
-# Upload the five assets under kata-assets/, where atelet fetches them: the
-# in-cluster rustfs (port-forwarded, S3 API) on kind, or the GCS bucket on GKE.
-if [[ "${ATE_INSTALL_KIND}" == "true" ]]; then
-  log "Staging assets to in-cluster rustfs bucket ${BUCKET_NAME} (kata-assets/)..."
-  OUT="${OUT}" BUCKET="${BUCKET_NAME}" KUBECTL_CONTEXT="${KUBECTL_CONTEXT}" hack/microvm-assets/stage-to-rustfs.sh
-else
-  log "Uploading assets to gs://${BUCKET_NAME}/kata-assets/ ..."
-  OUT="${OUT}" BUCKET="${BUCKET_NAME}" hack/microvm-assets/stage-to-gcs.sh
-fi
-
-# --- 3. deploy the control plane --------------------------------------------
+# --- 1. deploy the control plane -------------------------------------------
 log "Deploying the ate control plane (--deploy-ate-system)..."
 if [[ "${ATE_INSTALL_KIND}" == "true" ]]; then
   # install-ate-kind.sh sets NO_DEV_ENV/KO_DOCKER_REPO/ARCH/ATE_INSTALL_KIND itself.
@@ -137,24 +108,23 @@ else
   KUBECTL_CONTEXT="${KUBECTL_CONTEXT}" hack/install-ate.sh --deploy-ate-system --ateapi-client-auth="${ATE_ATEAPI_CLIENT_AUTH}"
 fi
 
-# --- 4. apply the demo ------------------------------------------------------
+# --- 2. install micro-VM deps (assets + cluster-wide SandboxConfig) --------
+# install-microvm-deps.sh handles the assemble/stage/apply flow and injects
+# the arm64 virtiofsd sha at deploy (see that script for details). Ordering
+# matters: the control plane must be up so the SandboxConfig CRD exists.
+log "Installing micro-VM dependencies..."
+hack/install-microvm-deps.sh --install
+
+# --- 3. apply the demo ------------------------------------------------------
 # Use ./hack/run-tool.sh ko so ko honors KO_DOCKER_REPO (the committed .ko.yaml base
 # is used as-is — no override). Only ko apply/create/delete/run accept args after
 # `--`; thread --context there (mirrors the run_ko helper in hack/install-ate.sh).
 log "Applying the counter-microvm demo manifest..."
-# The arm64 virtiofsd is built from source (release tag in assemble.sh), so its binary
-# bytes are not reproducible across toolchains and its sha can't be a fixed pin in the
-# manifest. Compute it from the freshly-staged binary and inject it, so the deployed
-# SandboxConfig always matches whatever was staged. The downloaded assets
-# (cloud-hypervisor/kernel/rootfs/config, plus virtiofsd on amd64 where upstream
-# publishes a prebuilt) keep their committed, reproducible per-arch shas.
-VIRTIOFSD_SHA256="$(sha256sum "${OUT}/virtiofsd" | awk '{print $1}')"
 sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
-    -e "s|\${VIRTIOFSD_SHA256}|${VIRTIOFSD_SHA256}|g" \
     demos/counter/counter-microvm.yaml.tmpl \
   | ./hack/run-tool.sh ko apply -f - ${KUBECTL_CONTEXT:+-- --context="${KUBECTL_CONTEXT}"}
 
-# --- 5. next steps ----------------------------------------------------------
+# --- 4. next steps ----------------------------------------------------------
 KCTX_FLAG=""
 if [[ -n "${KUBECTL_CONTEXT}" ]]; then
   KCTX_FLAG=" --context=${KUBECTL_CONTEXT}"

--- a/hack/run-microvm-demo.sh
+++ b/hack/run-microvm-demo.sh
@@ -21,9 +21,9 @@
 # Composes:
 #   1. hack/install-ate.sh --deploy-ate-system  (control plane)
 #   2. hack/install-microvm-deps.sh --install   (asset build/stage + cluster-wide
-#                                                microvm-default SandboxConfig)
+#                                                microvm SandboxConfig)
 #   3. Apply the counter-microvm demo manifest (namespace + WorkerPool +
-#      ActorTemplate; resolves to microvm-default via sandboxClass=microvm).
+#      ActorTemplate).
 #
 # Like the other hack scripts, this sources .ate-dev-env.sh for the cluster /
 # registry / bucket settings unless NO_DEV_ENV is set.

--- a/manifests/ate-install/atelet.yaml
+++ b/manifests/ate-install/atelet.yaml
@@ -64,14 +64,12 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: atelet
-<<<<<<< HEAD
       # Budget for the full shutdown sequence: --drain-delay (0 for atelet) +
       # --drain-timeout (5m). Sized long because Checkpoint/Restore stream
       # multi-GiB snapshots and must not be force-cancelled mid-upload. The sum
       # must fit within terminationGracePeriodSeconds, plus slack for the force
       # Stop() and the tracer/meter flush on exit.
       terminationGracePeriodSeconds: 330
-=======
       # atelet must run on every node a WorkerPool actor may schedule to.
       # Microvm pools are tainted ate.dev/sandboxClass=<class>:NoSchedule per
       # the convention in cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -82,7 +80,6 @@ spec:
       - key: ate.dev/sandboxClass
         operator: Exists
         effect: NoSchedule
->>>>>>> f9e2aeb6 (microvm-benchmarking)
       containers:
       - name: atelet
         image: ko://github.com/agent-substrate/substrate/cmd/atelet

--- a/manifests/ate-install/atelet.yaml
+++ b/manifests/ate-install/atelet.yaml
@@ -64,12 +64,25 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: atelet
+<<<<<<< HEAD
       # Budget for the full shutdown sequence: --drain-delay (0 for atelet) +
       # --drain-timeout (5m). Sized long because Checkpoint/Restore stream
       # multi-GiB snapshots and must not be force-cancelled mid-upload. The sum
       # must fit within terminationGracePeriodSeconds, plus slack for the force
       # Stop() and the tracer/meter flush on exit.
       terminationGracePeriodSeconds: 330
+=======
+      # atelet must run on every node a WorkerPool actor may schedule to.
+      # Microvm pools are tainted ate.dev/sandboxClass=<class>:NoSchedule per
+      # the convention in cmd/atecontroller/internal/controllers/workerpool_apply.go
+      # (which also adds the matching toleration to ateom worker pods).
+      # Tolerating the key with operator: Exists covers any current or future
+      # sandbox class value without needing another manifest edit.
+      tolerations:
+      - key: ate.dev/sandboxClass
+        operator: Exists
+        effect: NoSchedule
+>>>>>>> f9e2aeb6 (microvm-benchmarking)
       containers:
       - name: atelet
         image: ko://github.com/agent-substrate/substrate/cmd/atelet

--- a/manifests/microvm/sandboxconfig-microvm.yaml.tmpl
+++ b/manifests/microvm/sandboxconfig-microvm.yaml.tmpl
@@ -1,0 +1,90 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cluster-wide SandboxConfig for the micro-VM (kata + cloud-hypervisor) sandbox
+# class. Unlike sandboxconfig-gvisor.yaml (applied unconditionally by
+# hack/install-ate.sh --deploy-ate-system and marked default:true), this is
+# opt-in: apply via hack/install-microvm-deps.sh --install after staging the
+# asset set (assemble.sh + stage-to-gcs.sh / stage-to-rustfs.sh).
+#
+# It is deliberately NOT marked default:true. A dirty teardown could leave this
+# CR behind, and if it were the class default a subsequent WorkerPool that
+# omitted sandboxConfigName would silently resolve to the stale config. Making
+# every microvm WorkerPool name it explicitly (sandboxConfigName: microvm) makes
+# a missing/stale config fail loudly instead.
+#
+# The sandbox binaries (cloud-hypervisor, virtiofsd, guest kernel, guest rootfs,
+# base configuration.toml) are FETCHED at runtime from the cluster object store
+# bucket ${BUCKET_NAME} under kata-assets/ (rustfs on kind, GCS on GKE) - NOT
+# baked into the worker image. ateom boots cloud-hypervisor itself and gives the
+# actor an overlay rootfs (virtio-fs RO lower + guest-tmpfs upper), so it
+# fetches virtiofsd (v1.14.0 - the first release with the vhost-0.16
+# snapshot/restore fix; the kata-bundled v1.13.3 hangs restore). The kata
+# containerd shim is NOT fetched (ateom drives the kata-agent directly). kata
+# assets are 4.0.0.
+#
+# The per-arch sha256 values below are the asset sets produced by
+# hack/microvm-assets/assemble.sh; atelet selects the block matching the node's
+# architecture, and each cluster's bucket holds that arch's binaries at these
+# paths (staged by hack/install-microvm-deps.sh --install).
+
+apiVersion: ate.dev/v1alpha1
+kind: SandboxConfig
+metadata:
+  name: microvm
+spec:
+  sandboxClass: microvm
+  assets:
+    arm64:
+      cloud-hypervisor:
+        url: "gs://${BUCKET_NAME}/kata-assets/cloud-hypervisor"
+        sha256: "bf004ddc1a148f47caa87ac49a783b8dbd6bf9bc27abe522ed197df7b982d3b1"
+      # virtiofsd serves the overlay RO lower (virtio-fs); v1.14.0 carries the
+      # vhost-0.16 snapshot/restore fix the kata-bundled v1.13.3 lacks.
+      virtiofsd:
+        url: "gs://${BUCKET_NAME}/kata-assets/virtiofsd"
+        # Upstream publishes no arm64 prebuilt, so assemble.sh builds the v1.14.0 tag
+        # from source; the binary is not byte-reproducible across toolchains and can't
+        # carry a fixed pin. install-microvm-deps.sh computes this from the freshly-staged
+        # binary at deploy.
+        sha256: "${VIRTIOFSD_SHA256}"
+      kata-kernel:
+        url: "gs://${BUCKET_NAME}/kata-assets/vmlinux"
+        sha256: "4a8998a2e7ac12d6ad1f15b5e7d00571e4518ea9f33db1a1a568310373ca428d"
+      kata-image:
+        url: "gs://${BUCKET_NAME}/kata-assets/rootfs.img"
+        sha256: "24d77700749846355f3be25b87974c1fdea9fd2a9534256b4e4bbdde5df23588"
+      kata-config:
+        url: "gs://${BUCKET_NAME}/kata-assets/configuration-clh.toml"
+        sha256: "20f5de4f705423ddd1ee93318c784c6aede30c07c78dc6b311a771cc2f6859c7"
+    # amd64 assets are kata 4.0.0 + virtiofsd v1.14.0 (assemble.sh ARCH=amd64).
+    amd64:
+      cloud-hypervisor:
+        url: "gs://${BUCKET_NAME}/kata-assets/cloud-hypervisor"
+        sha256: "829af01ff075bb96c4f183905134c453a88d68cbabdc6b87df21098842581ee9"
+      virtiofsd:
+        url: "gs://${BUCKET_NAME}/kata-assets/virtiofsd"
+        # The x86_64-musl binary attached to the upstream v1.14.0 release (downloaded
+        # by assemble.sh, reproducible bytes), so it carries a fixed pin like the
+        # other downloaded assets.
+        sha256: "15b2e72a78cc08a9bd8a6943e89fb69c88cb3cbeb63069efceade835342ac7d4"
+      kata-kernel:
+        url: "gs://${BUCKET_NAME}/kata-assets/vmlinux"
+        sha256: "6abc48fa83c58e3db314037105d04ec00c1bc80d85eb2dfb2e2854f414573bca"
+      kata-image:
+        url: "gs://${BUCKET_NAME}/kata-assets/rootfs.img"
+        sha256: "fbbd40de605ab2f99dc82c777dc5b41f9a00dad3a0f699f2247c306ac9c1204d"
+      kata-config:
+        url: "gs://${BUCKET_NAME}/kata-assets/configuration-clh.toml"
+        sha256: "1e67eabdfb9d900bf95a00edb52cacc1efe64f23ea095f8b49ee81c7434bce90"


### PR DESCRIPTION
Currently we are unable to easily automate the benchmarking of micro VMs.

This PR:

* Refactors the microVM setup scripts to allow discrete installation of uVM sanbox configs separate from counter demo
* Pipes a MicroVM container test  config through the benchmarking system
* Updates default atelet daemonset to tolerate all kinds of sandboxClass taints