### PR TITLE
demos: add outbound connectivity probe to counter

### DIFF
--- a/demos/counter/README.md
+++ b/demos/counter/README.md
@@ -35,6 +35,22 @@ This command will:
 - Create the `WorkerPool` and `ActorTemplate`.
 - Wait until the template is ready.
 
+#### Outbound connectivity probe
+
+By default the counter fetches `https://www.google.com/generate_204` every 10
+seconds and logs the result, showing that the actor's egress path keeps working
+across suspends and resumes. Override or disable the target at deploy time:
+
+```bash
+# Probe a custom URL
+OUTBOUND_PROBE_URL=http://example.com/health ./hack/install-ate.sh --deploy-demo-counter
+
+# Disable the probe (e.g. air-gapped clusters)
+OUTBOUND_PROBE_URL="" ./hack/install-ate.sh --deploy-demo-counter
+```
+
+The same variable works for the micro-VM variant (`./hack/run-microvm-demo.sh`).
+
 ### 2. Create a Counter Actor
 
 Actors live in an **atespace**, which must exist before you create actors in it. Create one (e.g., `demo`), then create the counter actor with a chosen ID (e.g., `my-counter-1`):

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -73,6 +73,9 @@ spec:
   containers:
   - name: counter
     image: ko://github.com/agent-substrate/substrate/demos/counter
+    command:
+    - /ko-app/counter
+${OUTBOUND_PROBE_URL_ARG}
     readyz:
       httpGet:
         path: /readyz

--- a/demos/counter/counter.go
+++ b/demos/counter/counter.go
@@ -69,6 +69,7 @@ func main() {
 	secondFileCounterDirectory := pflag.String("second-file-counter-directory", "", "Directory for a second file counter; empty disables it. Used to exercise an Actor with more than one durable volume")
 	validateExistingFilePath := pflag.String("validate-existing-file-path", "", "Path to existing file to validate reading")
 	extraPort := pflag.Int("extra-port", 0, "Additional port to listen on, for exercising atenet-router's arbitrary-port ingress support; 0 disables it")
+	outboundProbeURL := pflag.String("outbound-probe-url", "", "URL fetched on every count tick to demonstrate outbound connectivity (e.g. https://www.google.com/generate_204); empty disables it")
 	pflag.Parse()
 	ctx := context.Background()
 
@@ -192,11 +193,34 @@ func main() {
 	slog.InfoContext(ctx, "Count", slog.Int("count", count), slog.String("fshash", hashRandomFile()))
 	count++
 
+	probeClient := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
 	for range time.Tick(10 * time.Second) {
-		// TODO: Test outbound connectivity by pinging google.com
+		logOutboundProbe(ctx, probeClient, *outboundProbeURL)
 		slog.InfoContext(ctx, "Count", slog.Int("count", count), slog.String("fshash", hashRandomFile()))
 		count++
 	}
+}
+
+// A reachable server counts as connectivity, whatever its status code.
+func logOutboundProbe(ctx context.Context, client *http.Client, url string) {
+	if url == "" {
+		return
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	start := time.Now()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, nil)
+	if err != nil {
+		slog.ErrorContext(ctx, "Outbound probe failed", slog.String("url", url), slog.Any("err", err))
+		return
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "Outbound probe failed", slog.String("url", url), slog.Any("err", err))
+		return
+	}
+	resp.Body.Close()
+	slog.InfoContext(ctx, "Outbound probe succeeded", slog.String("url", url), slog.Int("status", resp.StatusCode), slog.Duration("elapsed", time.Since(start)))
 }
 
 func writeRandomFile() error {

--- a/demos/counter/counter.yaml.tmpl
+++ b/demos/counter/counter.yaml.tmpl
@@ -65,6 +65,7 @@ spec:
     # from the primary port 80 every other assertion in this demo uses.
     - --extra-port=9090
 ${VALIDATE_EXISTING_FILE_PATH_ARG}
+${OUTBOUND_PROBE_URL_ARG}
     readyz:
       httpGet:
         path: /readyz

--- a/hack/install-demo-counter.sh
+++ b/hack/install-demo-counter.sh
@@ -48,10 +48,18 @@ demo-counter_deploy() {
     ext_vol_spec_cmd=("-e" "s|\${EXTERNAL_VOLUMES}|  - name: external-data\n    externalVolumeTemplate:\n      capacity: 1Gi\n      storageClassName: standard|g")
   fi
 
+  # On by default; OUTBOUND_PROBE_URL="" disables (e.g. air-gapped clusters).
+  local probe_url="${OUTBOUND_PROBE_URL-https://www.google.com/generate_204}"
+  local probe_cmd=("-e" "/\${OUTBOUND_PROBE_URL_ARG}/d")
+  if [[ -n "${probe_url}" ]]; then
+    probe_cmd=("-e" "s|\${OUTBOUND_PROBE_URL_ARG}|    - --outbound-probe-url=${probe_url}|g")
+  fi
+
   sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
       "${validate_cmd[@]}" \
       "${ext_vol_mount_cmd[@]}" \
       "${ext_vol_spec_cmd[@]}" \
+      "${probe_cmd[@]}" \
       demos/counter/counter.yaml.tmpl \
     | run_ko apply -f -
 
@@ -71,6 +79,7 @@ demo-counter_delete() {
   delete_demo_actors ate-demo-counter counter
   sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
       -e "/\${VALIDATE_EXISTING_FILE_PATH_ARG}/d" \
+      -e "/\${OUTBOUND_PROBE_URL_ARG}/d" \
       -e "/\${EXTERNAL_VOLUME_MOUNTS}/d" \
       -e "/\${EXTERNAL_VOLUMES}/d" \
       demos/counter/counter.yaml.tmpl \

--- a/hack/run-microvm-demo.sh
+++ b/hack/run-microvm-demo.sh
@@ -38,6 +38,9 @@
 #   OUT              asset dir (default: $PWD/bin/microvm-assets/$ARCH, gitignored).
 #   ATE_INSTALL_KIND "true" for the kind path (stage assets to rustfs + install-ate-kind.sh);
 #                    default false uploads assets to GCS + uses install-ate.sh.
+#   OUTBOUND_PROBE_URL
+#                    URL the counter probes every tick (default: google generate_204);
+#                    set to "" to disable, e.g. on air-gapped clusters.
 
 set -o errexit -o nounset -o pipefail
 
@@ -120,7 +123,14 @@ hack/install-microvm-deps.sh --install
 # is used as-is — no override). Only ko apply/create/delete/run accept args after
 # `--`; thread --context there (mirrors the run_ko helper in hack/install-ate.sh).
 log "Applying the counter-microvm demo manifest..."
+# On by default; OUTBOUND_PROBE_URL="" disables (e.g. air-gapped clusters).
+probe_url="${OUTBOUND_PROBE_URL-https://www.google.com/generate_204}"
+probe_cmd=("-e" "/\${OUTBOUND_PROBE_URL_ARG}/d")
+if [[ -n "${probe_url}" ]]; then
+  probe_cmd=("-e" "s|\${OUTBOUND_PROBE_URL_ARG}|    - --outbound-probe-url=${probe_url}|g")
+fi
 sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
+    "${probe_cmd[@]}" \
     demos/counter/counter-microvm.yaml.tmpl \
   | ./hack/run-tool.sh ko apply -f - ${KUBECTL_CONTEXT:+-- --context="${KUBECTL_CONTEXT}"}
 


### PR DESCRIPTION
## Summary

Resolves the `counter.go` TODO ("Test outbound connectivity by pinging google.com"): each count tick now fetches a URL and logs the result, demonstrating that the actor's egress path keeps working across suspend/resume. The probe uses HTTP instead of ICMP (no raw sockets in the sandboxes) and disables keep-alive so every tick proves a fresh DNS+dial rather than a still-open socket.

Both demo deploy paths default the probe to `https://www.google.com/generate_204` via a new optional template arg; `OUTBOUND_PROBE_URL` overrides the target and an empty value disables it for air-gapped clusters. The micro-VM template gains an explicit `command` block (matching the gVisor one) so the same substitution works there.

## Test plan

- Rendered both templates with the probe enabled/custom/disabled and asserted the resulting YAML args (`bash -n` on both scripts).
- Ran the linux binary in a container against a local 204 endpoint: one probe log per tick, fresh connection each time.
- End-to-end on a kind cluster (gVisor sandbox class): deployed the demo, created an actor, observed `Outbound probe succeeded status=204` for `google.com/generate_204` every 10s; suspended and resumed the actor and confirmed the first tick after `Actor restored` probes successfully.

---

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
