### PR TITLE
install: always re-apply CRDs and RBAC on --deploy-ate-system

### DIFF
--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -327,7 +327,9 @@ deploy_crds() {
 
 deploy_ate_system() {
   log_step "deploy_ate_system"
-  ensure_crds
+  # Not ensure_crds: its existence check skips upgrades, stranding stale CRD
+  # schemas and RBAC (role.yaml has no other apply path).
+  deploy_crds
 
   # Enforce per-class SandboxConfig asset requirements (applied before any
   # SandboxConfig so the defaults below are validated too).


### PR DESCRIPTION
Fixes #697

## Summary

`deploy_ate_system` gated `manifests/ate-install/generated/` behind `ensure_crds`, whose existence check skips the directory on any upgrade — stranding CRD schemas and, since `role.yaml` has no other apply path, all ClusterRoles at first-install state. A controller image needing a new permission then deadlocks on informer start while the rollout reports success.

`deploy_ate_system` now calls `deploy_crds` unconditionally (`kubectl apply` is idempotent). The demo scripts and per-component deploy flags keep `ensure_crds`, where "make sure they exist" is the intended semantic.

## Test plan

- Reproduced on a 4-day-old kind cluster: upgrading the control plane deadlocked ate-controller on `cannot list networkpolicies`; manually applying `role.yaml` unblocked it.
- With this fix, the same `install-ate-kind.sh --deploy-ate-system` run prints the `deploy_crds` step and re-applied the drifted manifests (`actortemplates.ate.dev configured`, `workerpools.ate.dev configured`, ClusterRoles applied); cluster reconciles normally.
- `bash -n hack/install-ate.sh`.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR (none needed)