### PR TITLE
atenet: make xDS snapshot versions restart-unique

### DIFF
--- a/cmd/atenet/internal/router/xds.go
+++ b/cmd/atenet/internal/router/xds.go
@@ -16,6 +16,7 @@ package router
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"log/slog"
 	"net"
@@ -152,6 +153,7 @@ type XdsServer struct {
 	snapshot     cachev3.SnapshotCache
 	srv          serverv3.Server
 	versionCount int64
+	versionEpoch string
 
 	mu sync.Mutex
 
@@ -204,6 +206,7 @@ func NewXdsServer(xdsPort int) *XdsServer {
 		xdsPort:               xdsPort,
 		snapshot:              cache,
 		srv:                   srv,
+		versionEpoch:          strconv.FormatInt(time.Now().Unix(), 10) + "-" + rand.Text()[:8],
 		extprocPort:           50051, // matches default extproc port
 		extprocAddr:           "127.0.0.1",
 		ingressPort:           8080,
@@ -408,7 +411,7 @@ func (x *XdsServer) UpdateSnapshot() error {
 	defer x.mu.Unlock()
 
 	x.versionCount++
-	ver := strconv.FormatInt(x.versionCount, 10)
+	ver := x.versionEpoch + "-" + strconv.FormatInt(x.versionCount, 10)
 
 	// connectEnabled is true when either CONNECT listener (plaintext or TLS) is
 	// configured; the main_internal cluster/listener only exist to serve them.

--- a/cmd/atenet/internal/router/xds_test.go
+++ b/cmd/atenet/internal/router/xds_test.go
@@ -965,3 +965,36 @@ func TestXdsServer_BuildTracingRandomSamplingFromPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestSnapshotVersionsUniqueAcrossRestarts(t *testing.T) {
+	deployAndGetVersion := func(t *testing.T, x *XdsServer) string {
+		t.Helper()
+		if err := x.UpdateSnapshot(); err != nil {
+			t.Fatalf("UpdateSnapshot: %v", err)
+		}
+		snap, err := x.snapshot.GetSnapshot(NodeID)
+		if err != nil {
+			t.Fatalf("GetSnapshot: %v", err)
+		}
+		return snap.GetVersion(resourcev3.ClusterType)
+	}
+
+	seen := map[string]bool{}
+	first := NewXdsServer(0)
+	for range 3 {
+		v := deployAndGetVersion(t, first)
+		if seen[v] {
+			t.Fatalf("version %q minted twice by the same server", v)
+		}
+		seen[v] = true
+	}
+
+	restarted := NewXdsServer(0)
+	for range 3 {
+		v := deployAndGetVersion(t, restarted)
+		if seen[v] {
+			t.Fatalf("version %q reused after restart; Envoy holding that version would not receive the new config", v)
+		}
+		seen[v] = true
+	}
+}


### PR DESCRIPTION
Fixes #617

## Summary

The xDS snapshot version was an in-memory counter starting at 0, so every router restart re-minted "1", "2", … go-control-plane's snapshot cache compares version strings for equality and skips the push when Envoy already reports that version, so a restarted router whose counter lands on the string Envoy still holds leaves Envoy silently stranded on pre-restart config.

Versions are now `<unix-seconds>-<8-char random>-<counter>` — a per-process epoch no incarnation can repeat, even if the clock jumps backwards across a restart. version_info is opaque to Envoy and only ever compared for equality, so the format change is safe.

## Test plan

- `TestSnapshotVersionsUniqueAcrossRestarts`: two XdsServer instances (simulating a restart) each deploy snapshots through the real SnapshotCache; asserts no version string repeats within or across instances.
- Live verification on a kind cluster: deployed the router, confirmed Envoy ACKed the new format via `config_dump`, then SIGKILLed only the router container (Envoy kept running holding the old version) — after the restart Envoy ACKed a new-epoch version, proving the re-push reaches a reconnecting Envoy.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR (none needed)