### PR TITLE
feat(atenet): replicate router dataplane

### DIFF
--- a/hack/verify-atenet-drain.sh
+++ b/hack/verify-atenet-drain.sh
@@ -128,14 +128,15 @@ done
 
 # --- Observers ---------------------------------------------------------------
 
-POD="$(run_kubectl get pods -n "${ROUTER_NS}" -l app=atenet-router --no-headers | awk '$3=="Running"{print $1}')"
-# wc -w pads its output on macOS; compare numerically.
-(( $(wc -w <<<"${POD}") == 1 )) || fail "expected exactly 1 running router pod, got: ${POD:-none}"
+# Pin every observer to one pod: with several replicas the Service would spread
+# the parked request and the probes across pods that are not being deleted.
+POD="$(run_kubectl get pods -n "${ROUTER_NS}" -l app=atenet-router --no-headers | awk '$3=="Running"{print $1; exit}')"
+[[ -n "${POD}" ]] || fail "no running router pod"
 log_step "router pod under test: ${POD}"
 
 run_kubectl logs -n "${ROUTER_NS}" "${POD}" -c atenet-router -f > "${LOG_FILE}" 2>&1 &
 BG_PIDS+=($!)
-run_kubectl port-forward -n "${ROUTER_NS}" svc/atenet-router "${LOCAL_HTTP_PORT}:80" >/dev/null 2>&1 &
+run_kubectl port-forward -n "${ROUTER_NS}" "${POD}" "${LOCAL_HTTP_PORT}:8080" >/dev/null 2>&1 &
 BG_PIDS+=($!)
 run_kubectl port-forward -n "${ROUTER_NS}" "${POD}" "${LOCAL_METRICS_PORT}:9090" >/dev/null 2>&1 &
 BG_PIDS+=($!)

--- a/manifests/ate-install/atenet-router.yaml
+++ b/manifests/ate-install/atenet-router.yaml
@@ -120,7 +120,11 @@ metadata:
   labels:
     app: atenet-router
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: atenet-router
@@ -140,6 +144,13 @@ spec:
       # sum must fit within terminationGracePeriodSeconds, or the kubelet
       # SIGKILLs mid-drain.
       terminationGracePeriodSeconds: 60
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: atenet-router
       containers:
       - name: atenet-router
         image: ko://github.com/agent-substrate/substrate/cmd/atenet
@@ -266,6 +277,11 @@ spec:
           containerPort: 8444
         - name: admin
           containerPort: 9901
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9901
+          periodSeconds: 5
         volumeMounts:
         - name: envoy-config
           mountPath: /etc/envoy
@@ -354,3 +370,14 @@ spec:
     port: 4040
     targetPort: status
     protocol: TCP
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: atenet-router
+  namespace: ate-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: atenet-router


### PR DESCRIPTION
Fixes #645

`atenet-router` is a single-replica data-plane SPOF: a deploy, node drain, or eviction takes actor traffic down. A router pod kill produced about 5.5 seconds of hard connection failures, and one GKE node-pool event produced 6,880 dial errors.

The Deployment now runs two replicas with surge-only rollouts (`maxUnavailable: 0`), soft hostname spreading, and a PodDisruptionBudget. An Envoy readiness probe on admin `/ready` prevents a new replica from receiving traffic before its initial xDS load. The drain verifier pins its request and probes to the pod it deletes so a second replica cannot mask the shutdown path.

The multi-replica xDS concern is already resolved by the restart- and replica-unique version epochs in #699. Each Envoy talks only to the router in the same pod, so replicas do not share an xDS stream.

The DNS controller and its manifest were removed from `main` while this PR was pending, so the rebased change deliberately drops the obsolete DNS replication, PDB, and preStop work.

## Evidence

On a kind cluster, with a 5 req/s in-cluster probe against a running actor:

- rolling restart under traffic: 278/278 requests OK (single-replica baseline: about 5.5 seconds of hard failures)
- force-delete one router replica under traffic: 183/183 requests OK
- strict kustomize rendering passes after the rebase

