### PR TITLE
atelet: prune local pause snapshots

### DIFF
--- a/cmd/atelet/local_checkpoints.go
+++ b/cmd/atelet/local_checkpoints.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/agent-substrate/substrate/internal/ateompath"
+)
+
+// pruneLocalCheckpoints removes every local snapshot of the actor.
+// Best-effort: failures are logged, never fatal.
+func pruneLocalCheckpoints(ctx context.Context, actorUID string) {
+	pruneLocalCheckpointDir(ctx, ateompath.LocalCheckpointsDir(actorUID))
+}
+
+func pruneLocalCheckpointDir(ctx context.Context, dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.WarnContext(ctx, "failed to list local checkpoints for pruning", slog.String("dir", dir), slog.Any("err", err))
+		}
+		return
+	}
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			slog.WarnContext(ctx, "failed to prune local checkpoint", slog.String("path", path), slog.Any("err", err))
+			continue
+		}
+		slog.InfoContext(ctx, "pruned local checkpoint", slog.String("path", path))
+	}
+	_ = os.Remove(dir)
+}

--- a/cmd/atelet/local_checkpoints_test.go
+++ b/cmd/atelet/local_checkpoints_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSnapshotDir(t *testing.T, dir, prefix string) {
+	t.Helper()
+	p := filepath.Join(dir, prefix)
+	if err := os.MkdirAll(p, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(p, "memory.img"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPruneRemovesEverySnapshot(t *testing.T) {
+	dir := t.TempDir()
+	writeSnapshotDir(t, dir, "pause-1")
+	writeSnapshotDir(t, dir, "pause-2")
+	writeSnapshotDir(t, dir, "pause-3")
+
+	pruneLocalCheckpointDir(context.Background(), dir)
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("dir still exists (err=%v), want removed entirely", err)
+	}
+}
+
+func TestPruneMissingDirIsNoop(t *testing.T) {
+	pruneLocalCheckpointDir(context.Background(), filepath.Join(t.TempDir(), "absent"))
+}

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -446,6 +446,12 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	sandboxRec.ActorTemplateNamespace = req.GetActorTemplateNamespace()
 	sandboxRec.ActorTemplateName = req.GetActorTemplateName()
 
+	// No earlier pause snapshot can ever be restored again, so remove them
+	// all: the actor's current state was just captured by CheckpointWorkload,
+	// and the control plane tracks only a single local snapshot, which this
+	// checkpoint either overwrites (pause) or clears (suspend).
+	pruneLocalCheckpoints(ctx, actorUID)
+
 	switch req.GetType() {
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL:
 		// TODO(#362): Because we do not cache the external snapshot files when upload fails, we have to mark the Actor as CRASHED.
@@ -1103,8 +1109,8 @@ func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
 			return err
 		}
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-		if req.GetLocalConfig().GetSnapshotPrefix() == "" {
-			return fmt.Errorf("snapshot prefix must be non-empty for type %s", req.GetType().String())
+		if err := resources.ValidateLocalSnapshotPrefix(req.GetLocalConfig().GetSnapshotPrefix()); err != nil {
+			return err
 		}
 	default:
 		return fmt.Errorf("invalid checkpoint type: %v", req.GetType())
@@ -1155,8 +1161,8 @@ func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
 			return err
 		}
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-		if req.GetLocalConfig().GetSnapshotPrefix() == "" {
-			return fmt.Errorf("snapshot prefix must be non-empty for type %s", req.GetType().String())
+		if err := resources.ValidateLocalSnapshotPrefix(req.GetLocalConfig().GetSnapshotPrefix()); err != nil {
+			return err
 		}
 	default:
 		return fmt.Errorf("invalid checkpoint type: %v", req.GetType())

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -283,6 +283,14 @@ func TestValidateCheckpointRequest(t *testing.T) {
 			r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL
 			r.Config = &ateletpb.CheckpointRequest_LocalConfig{LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotPrefix: ""}}
 		}), true},
+		{"nested local snapshot prefix", makeReq(func(r *ateletpb.CheckpointRequest) {
+			r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL
+			r.Config = &ateletpb.CheckpointRequest_LocalConfig{LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotPrefix: "pause/2"}}
+		}), true},
+		{"traversal local snapshot prefix", makeReq(func(r *ateletpb.CheckpointRequest) {
+			r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL
+			r.Config = &ateletpb.CheckpointRequest_LocalConfig{LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotPrefix: ".."}}
+		}), true},
 		{"unspecified snapshot type", makeReq(func(r *ateletpb.CheckpointRequest) { r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_UNSPECIFIED }), true},
 		{"unspecified snapshot scope", makeReq(func(r *ateletpb.CheckpointRequest) { r.Scope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_UNSPECIFIED }), true},
 		{"invalid snapshot scope", makeReq(func(r *ateletpb.CheckpointRequest) { r.Scope = ateletpb.SnapshotScope(23) }), true},
@@ -328,6 +336,14 @@ func TestValidateRestoreRequest(t *testing.T) {
 		{"invalid local snapshot prefix", makeReq(func(r *ateletpb.RestoreRequest) {
 			r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL
 			r.Config = &ateletpb.RestoreRequest_LocalConfig{LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotPrefix: ""}}
+		}), true},
+		{"nested local snapshot prefix", makeReq(func(r *ateletpb.RestoreRequest) {
+			r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL
+			r.Config = &ateletpb.RestoreRequest_LocalConfig{LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotPrefix: "pause/2"}}
+		}), true},
+		{"traversal local snapshot prefix", makeReq(func(r *ateletpb.RestoreRequest) {
+			r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL
+			r.Config = &ateletpb.RestoreRequest_LocalConfig{LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotPrefix: ".."}}
 		}), true},
 		{"unspecified snapshot type", makeReq(func(r *ateletpb.RestoreRequest) { r.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_UNSPECIFIED }), true},
 		{"unspecified snapshot scope", makeReq(func(r *ateletpb.RestoreRequest) { r.Scope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_UNSPECIFIED }), true},

--- a/internal/resources/validate.go
+++ b/internal/resources/validate.go
@@ -205,6 +205,19 @@ func ValidateSnapshotURIPrefix(prefix string) error {
 	return nil
 }
 
+// ValidateLocalSnapshotPrefix ensures a local snapshot prefix is a single
+// path segment: it is joined onto the actor's checkpoint directory, so a
+// nested or relative prefix would escape it or nest below it.
+func ValidateLocalSnapshotPrefix(prefix string) error {
+	if prefix == "" {
+		return fmt.Errorf("snapshot prefix must be non-empty")
+	}
+	if prefix == "." || prefix == ".." || strings.ContainsAny(prefix, `/\`) {
+		return fmt.Errorf("invalid snapshot prefix %q: must be a single path segment", prefix)
+	}
+	return nil
+}
+
 // ValidateWorker checks that the worker message is well-formed.
 func ValidateWorker(worker *ateapipb.Worker, fldPath *field.Path) field.ErrorList {
 	var errs field.ErrorList

--- a/internal/resources/validate_test.go
+++ b/internal/resources/validate_test.go
@@ -302,6 +302,31 @@ func TestValidateSnapshotURIPrefix(t *testing.T) {
 	}
 }
 
+func TestValidateLocalSnapshotPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{"valid", "pause", false},
+		{"valid with dash and digits", "pause-2", false},
+		{"empty", "", true},
+		{"dot", ".", true},
+		{"dotdot", "..", true},
+		{"nested", "pause/2", true},
+		{"absolute", "/pause", true},
+		{"traversal", "../other-actor", true},
+		{"backslash", `pause\2`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateLocalSnapshotPrefix(tt.prefix); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateLocalSnapshotPrefix(%q) err = %v, wantErr %v", tt.prefix, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateWorker(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

atelet never deletes local pause snapshots, so they accumulate until the node disk fills (#668). The control plane only ever references the latest one (`LocalSnapshotInfo` is single-valued), so older directories are dead weight by design. Checkpoint now prunes every existing snapshot before writing the new one — each is superseded by the snapshot about to be written, and pruning first caps disk usage at a single snapshot. Pruning is best-effort: a failed delete is logged and retried by the next prune, never failing the checkpoint.

Snapshot prefixes are now validated as single path segments at the Checkpoint/Restore RPC boundary (shared `ValidateLocalSnapshotPrefix`). Previously only checked non-empty: a nested prefix like `pause/2` would silently write nested directories, and `..` could escape the actor's directory entirely.

Fixes #668

## Test plan

- Unit: prune remove-all/missing-dir cases; validator table (nested, traversal, absolute, backslash); Checkpoint + Restore request rejection cases
- Live on kind: demo e2e suites pass (snapshot + durable-dir lifecycle: pause→resume→suspend→resume across pause-scope configs); atelet logs confirm each checkpoint prunes the prior snapshot before the write
