### PR TITLE
docs: convention for integration repository structure and naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,10 @@ duplicating work that is already in flight.
 extensive review. We are not trying to be discouraging, but we need to make
 sure that we are focused on the most important work.
 
+If you are building something that runs *on* Substrate rather than changing
+Substrate itself, see [Integration
+Repositories](docs/integration-repos.md) for where that code should live.
+
 ### Sizing PRs for review
 
 We optimize PRs for easy review — large PRs get broken

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ We provide several sample applications demonstrating Agent Substrate's capabilit
 * [API Configuration Guide](docs/api-guide.md): Detailed reference for configuring WorkerPools, ActorTemplates, Secrets, and Volumes.
 * [Full CLI Documentation](cmd/kubectl-ate/README.md): Installation and usage for `kubectl-ate`.
 * [Glossary](docs/glossary.md): Core terms (Actor, Atespace, ActorTemplate, WorkerPool, Worker, ate-api-server, atenet, atelet, ateom) and how they relate.
+* [Integration Repositories](docs/integration-repos.md): Where integrations live, how their repositories are named, and how fixes flow back to core.
 * [Observability Guide](docs/observability.md): Guide to actor logging, metrics, and distributed tracing.
 * [Request Parking](docs/request-parking.md): How the router parks requests through transient worker-pool saturation.
 * [Threat Model](docs/threat-model.md): Trust boundaries, assumptions, and known risks.

--- a/docs/integration-repos.md
+++ b/docs/integration-repos.md
@@ -58,7 +58,7 @@ repositories under `agent-substrate` does not.
 Two cases, depending on what the repository actually is:
 
 **Capability-named**, when it provides a general Substrate capability that
-happens to have one implementation today. Prefer `code-execution-sandbox` over
+happens to have one implementation today. Prefer `execution-sandbox` over
 `sandbox` (too broad) or a vendor's product name (too narrow).
 
 **Integration-named**, when it integrates one specific *open-source* project.
@@ -70,13 +70,19 @@ name refers to something anyone can read, run, and fork, so using it
 descriptively claims nothing. A proprietary product's name is a brand we would
 be borrowing, and borrowing it implies an endorsement or a compatibility promise
 that neither side has made. When the thing being integrated is proprietary, use
-a capability name instead: `code-execution-sandbox`, not the vendor's product
+a capability name instead: `execution-sandbox`, not the vendor's product
 name.
 
 Avoid:
 
 - **Generic names** such as `sandbox` or `plugins`, which claim far more ground
   than any one repository covers.
+- **Over-specific names**, which have the opposite failure: they steer people
+  away from a solution that would have worked for them. A sandbox that is often
+  used for code execution is still a general execution sandbox, and naming it
+  `code-execution-sandbox` invites a reader with a different workload to
+  conclude it is not for them. A name should be just long enough to describe
+  the thing, and no longer.
 - **Names that clone a proprietary API or brand**, which quietly commits the
   project to chasing someone else's naming decisions.
 - **The `-integration` suffix.** Every repository in this category is an
@@ -120,9 +126,11 @@ first" a short path rather than a blocking one.
 
 These two validate the convention rather than merely following it:
 
-- **`agent-substrate/code-execution-sandbox`** — capability-named. A sandboxed
-  code-execution service built on Substrate, in the spirit of existing
-  code-execution products but not modeled on any one of their APIs.
+- **`agent-substrate/execution-sandbox`** — capability-named. A sandboxed
+  execution service built on Substrate, in the spirit of existing sandbox
+  products but not modeled on any one of their APIs. The name stops at the
+  capability on purpose: code execution is one workload it serves, not the
+  boundary of what it is.
 
 - **`agent-substrate/always-on-agent`** — a connection-holding agent: a
   multi-tenant gateway plus a suspendable per-conversation actor. Its first

--- a/docs/integration-repos.md
+++ b/docs/integration-repos.md
@@ -1,0 +1,140 @@
+# Integration Repositories: Structure and Naming
+
+## Summary
+
+Substrate is acquiring its first end-to-end integrations — workloads that *run
+on* Substrate rather than demonstrate it. This document records where that code
+lives, how the repositories are named, and how fixes flow back into core.
+
+In short: trivial demos stay in the core repository, each non-trivial
+integration gets one dedicated repository under the `agent-substrate`
+organization, and gaps in core are closed by landing the change in core
+first — never by patching core downstream.
+
+## Motivation
+
+Until now every in-repo example has been small enough to live beside the code it
+exercises. The first real integrations are not: they carry their own container
+images, dependencies, release cadence, and potentially their own maintainers.
+
+Without a written convention, whichever repository happens to be created first
+sets the precedent for everything after it. This document makes the convention
+explicit instead, so that the choice is deliberate.
+
+## Where code lives
+
+**Stays in the core repository.** Trivial demos and keyless API exercisers — the
+counter demo, and the lifecycle mocks that CI uses to drive create, resume, and
+suspend. The test is roughly: no API keys, no external services, no third-party
+accounts required to run it.
+
+**Gets its own repository under `agent-substrate`.** Non-trivial, end-to-end
+integrations, including their code, container images, manifests, and SDKs. One
+repository per integration. These are too large to carry in core, and a
+dedicated repository lets them have their own maintainers without granting
+access to core.
+
+**Lives outside the organization otherwise.** Everything under `agent-substrate`
+is official and held to the standards in this document. Anyone is welcome to
+build an integration and host it themselves, and we are glad when they do —
+but carrying something under the project's brand that the project does not
+consider official is confusing to users, so the organization holds only
+integrations the project maintains.
+
+**Not a second organization.** GitHub supports only one level of organization
+parentage, so a nested org is not actually available; a sibling org would add
+onboarding and access-management overhead that a small number of peer
+repositories under `agent-substrate` does not.
+
+| Thing | Where it goes |
+|---|---|
+| Counter demo, keyless lifecycle mocks used by CI | Core repository |
+| Non-trivial end-to-end integration (code, images, manifests, SDKs) | `agent-substrate/<name>` |
+| A fix or new knob in Substrate that an integration needs | PR to the core repository |
+| A community-maintained integration or proof of concept | Outside the `agent-substrate` organization |
+
+## Naming
+
+Two cases, depending on what the repository actually is:
+
+**Capability-named**, when it provides a general Substrate capability that
+happens to have one implementation today. Prefer `code-execution-sandbox` over
+`sandbox` (too broad) or a vendor's product name (too narrow).
+
+**Integration-named**, when it integrates one specific *open-source* project.
+Name it for the project, not the vendor behind it — `hermes`, not the name of
+the organization that publishes Hermes.
+
+Integration-naming is limited to open-source projects. An open-source project's
+name refers to something anyone can read, run, and fork, so using it
+descriptively claims nothing. A proprietary product's name is a brand we would
+be borrowing, and borrowing it implies an endorsement or a compatibility promise
+that neither side has made. When the thing being integrated is proprietary, use
+a capability name instead: `code-execution-sandbox`, not the vendor's product
+name.
+
+Avoid:
+
+- **Generic names** such as `sandbox` or `plugins`, which claim far more ground
+  than any one repository covers.
+- **Names that clone a proprietary API or brand**, which quietly commits the
+  project to chasing someone else's naming decisions.
+- **The `-integration` suffix.** Every repository in this category is an
+  integration, so the suffix carries no information: `hermes`, not
+  `hermes-integration`.
+
+Even for an open-source project, the name is used descriptively and not as a
+claim of affiliation: the repository README should say that the project is not
+affiliated with the upstream project and that trademarks belong to their
+respective owners. Clear brand and policy edge cases before the repository is
+created, not after.
+
+## Upstreaming: the core change lands first
+
+Real integrations surface real gaps in core. Building a long-running agent on
+Substrate turned up the need for configurable timeouts and golden-snapshot
+warmup ([#487](https://github.com/agent-substrate/substrate/pull/487)), and ran
+into suspend-safe actor networking
+([#465](https://github.com/agent-substrate/substrate/issues/465)).
+
+Repositories under `agent-substrate` do not carry those gaps as patches. An
+integration repository builds and runs against core as released: no fork of
+core, no vendored patch, no dependency on an unmerged change. When an
+integration needs something core does not do, the core change lands first and
+the integration then depends on a released version that has it.
+
+We are our own upstream here — the same project hosts both repositories, so
+there is no window in which a patch has to wait downstream for someone else to
+act. An official integration that depends on a change missing from our own core
+is embarrassing rather than merely inconvenient, so the rule is absolute rather
+than a preference. Independent proofs of concept, which live outside the
+organization, are free to carry whatever patches they need; that freedom is part
+of why they live outside it.
+
+The corollary is a design preference for core: when core behavior blocks an
+integration, prefer making that behavior **configurable with defaults
+unchanged** over special-casing the caller. That is what keeps "land it in core
+first" a short path rather than a blocking one.
+
+## Worked examples
+
+These two validate the convention rather than merely following it:
+
+- **`agent-substrate/code-execution-sandbox`** — capability-named. A sandboxed
+  code-execution service built on Substrate, in the spirit of existing
+  code-execution products but not modeled on any one of their APIs.
+
+- **`agent-substrate/always-on-agent`** — a connection-holding agent: a
+  multi-tenant gateway plus a suspendable per-conversation actor. Its first
+  implementation is built on a third-party agent runtime, but the capability
+  outlives any one runtime and the repository is capability-named rather than
+  named for that runtime. It is the edge case the open-source-only rule above is
+  meant to catch.
+
+## Not settled yet
+
+One open question for the maintainers, deliberately left out of scope here so it
+does not block the first repositories:
+
+- **Repository creation and access.** Who creates integration repositories, and
+  who grants per-integration maintainer access.


### PR DESCRIPTION
## Summary

Adds `docs/integration-repos.md`: where end-to-end integrations live, how their
repositories are named, and how the fixes they need flow back into core.

The convention in one line — trivial demos stay in the core repo, each
non-trivial integration gets one dedicated repo under the `agent-substrate`
org, and core gaps get closed by making core configurable with defaults
unchanged rather than by patching it downstream.

## Why now

We are about to create the first real, end-to-end integrations rather than
counter-style demos: a code-execution sandbox, and an always-on agent. Both are
large enough to need their own images, dependencies, and release cadence.

Whichever repository gets created first will set the precedent for every one
after it. This writes the convention down so that precedent is chosen
deliberately instead of inherited by accident.

## What it covers

- **Where code lives** — the core-repo/dedicated-repo split, the rough test for
  which side something falls on (API keys, external services, third-party
  accounts), and why this is a set of peer repos rather than a second org.
- **Naming** — capability-named for general capabilities
  (`code-execution-sandbox`), integration-named for specific third-party
  products, named for the product rather than the vendor behind it. Plus what to
  avoid: over-broad names, names that clone a vendor's API or brand, and the
  redundant `-integration` suffix.
- **Third-party names** — allowed descriptively, with a non-affiliation note in
  the repo README, and brand/policy edge cases cleared before the repo exists.
- **Upstreaming** — the part with teeth for this repo. Integration repos that
  accumulate local patches against core bitrot, and the gap they work around
  stays invisible to everyone else. So: prefer making core behavior configurable
  with defaults unchanged. #487 and #465 are linked as illustrations of that
  pattern — this PR does not depend on either, and branches from `main`.
- **Two worked examples** that validate the convention rather than just
  following it, including the third-party-name edge case.

## Review

This was announced at the community meeting and circulated as a shared design
doc with a 7-day review window, which has now closed. It synthesizes the
`#integrations` thread discussion. Comment history:

<https://docs.google.com/document/d/1Tb6u0b1XSvWrNpoyD4jdsQaJ58aAgDtQOM18uxujs-8/edit>

This PR is the trimmed version: doc-review scaffolding — status block, reviewer
list, self-link — is dropped, and only the durable convention is carried over.

## Left open

Two questions are deliberately out of scope, called out in the doc rather than
answered. Both are maintainer calls and neither blocks the first repositories:

- Governance tiers — whether to distinguish "official" from "community"
  integrations with different review bars, as Home Assistant and Obsidian do.
- Who creates integration repositories and grants per-integration maintainer
  access.

## Also in this PR

- README gets an entry in the docs list, matching every other file in `docs/`.
- `CONTRIBUTING.md` gets one sentence pointing there, since "where does my
  integration go?" is a question a contributor asks before opening a PR.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
