### PR TITLE
[DO NOT SUBMIT] take the Atespace lock across actor creation

### DIFF
--- a/cmd/ateapi/internal/controlapi/create_actor.go
+++ b/cmd/ateapi/internal/controlapi/create_actor.go
@@ -87,6 +87,17 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 	atespace := in.GetMetadata().GetAtespace()
 	name := in.GetMetadata().GetName()
 
+	// Acquire an Atespace lock across the actor creation so concurrent DeleteAtespace cannot orphan the new actor.
+	atespaceLock, err := s.persistence.AcquireLock(ctx, "lock:atespace:"+atespace)
+	if errors.Is(err, store.ErrLockConflict) {
+		return nil, status.Error(codes.Aborted, "another operation is using this Atespace")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("while locking Atespace: %w", err)
+	}
+	defer atespaceLock.Close()
+	ctx = atespaceLock.Context()
+
 	// The atespace must already exist.
 	exists, err := s.persistence.AtespaceExists(ctx, atespace)
 	if err != nil {

--- a/cmd/ateapi/internal/controlapi/create_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/create_actor_test.go
@@ -261,3 +261,31 @@ func TestCreateActor_RejectsSnapshotWithExternalVolumes(t *testing.T) {
 		t.Fatalf("CreateActor status = %v, want FailedPrecondition", status.Code(err))
 	}
 }
+
+func TestCreateActor_AbortsWhileAtespaceLocked(t *testing.T) {
+	ns := namespaceForTest("ns-create-atespace-lock")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	createTemplate(t, tc, ns)
+
+	lock, err := tc.persistence.AcquireLock(context.Background(), "lock:atespace:"+testAtespace)
+	if err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+
+	req := &ateapipb.CreateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+			ActorTemplateNamespace: ns,
+			ActorTemplateName:      "tmpl1",
+		},
+	}
+	if _, err := tc.service.CreateActor(context.Background(), req); status.Code(err) != codes.Aborted {
+		t.Fatalf("CreateActor while Atespace locked: got %v, want %s", err, codes.Aborted)
+	}
+
+	lock.Close()
+	if _, err := tc.service.CreateActor(context.Background(), req); err != nil {
+		t.Fatalf("CreateActor after lock release: %v", err)
+	}
+}


### PR DESCRIPTION
Acquire an Atespace lock across the actor creation so concurrent DeleteAtespace cannot orphan the new actor.

This fixes #620.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
