### PR TITLE
docs: add PR etiquette guidelines and improve contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,22 +1,43 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a bug to help us improve — please include a reproduction case
 
 ---
 
+## Summary
+
+<!-- One sentence describing the bug -->
+
+## Environment
+
+- Substrate version / commit:
+- Kubernetes version (`kubectl version`):
+- Platform (GKE / kind / other):
+- OS / architecture:
+
 ## Expected Behavior
 
+<!-- What should have happened -->
 
 ## Actual Behavior
 
+<!-- What actually happened. Include full error messages, logs, or stack traces -->
 
-## Steps to Reproduce the Problem
+<details>
+<summary>Logs</summary>
+
+```
+paste logs here
+```
+
+</details>
+
+## Steps to Reproduce
 
 1.
-1.
-1.
+2.
+3.
 
-## Specifications
+## Minimal Reproduction
 
-- Version:
-- Platform:
+<!-- Smallest config, manifest, or code snippet that triggers the issue. Reports without a repro case may be closed. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,15 @@
-Fixes #<issue_number_goes_here>
+Fixes #<issue_number>
 
-> It's a good idea to open an issue first for discussion.
+> **Stop:** Does this PR reference an open issue above? If not, please open one first.
+> PRs without a linked issue will not be reviewed.
 
-- [ ] Tests pass
-- [ ] Appropriate changes to documentation are included in the PR
+## What changed and why
+
+<!-- Brief description of the change and the reasoning behind it -->
+
+## Checklist
+
+- [ ] Issue is linked above
+- [ ] Tests pass locally (`go test ./...`)
+- [ ] Root-gated tests pass if applicable (`hack/run-root-tests.sh`)
+- [ ] Documentation updated if behavior changed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,10 +6,3 @@ Fixes #<issue_number>
 ## What changed and why
 
 <!-- Brief description of the change and the reasoning behind it -->
-
-## Checklist
-
-- [ ] Issue is linked above
-- [ ] Tests pass locally (`go test ./...`)
-- [ ] Root-gated tests pass if applicable (`hack/run-root-tests.sh`)
-- [ ] Documentation updated if behavior changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,18 @@ If you are building something that runs *on* Substrate rather than changing
 Substrate itself, see [Integration
 Repositories](docs/integration-repos.md) for where that code should live.
 
+### PR Etiquette
+
+Before opening a pull request, please follow these steps:
+
+1. **File an issue first.** If you've found a bug or want to propose a change, open an issue before writing code. This lets maintainers confirm the problem is real, align on the right fix, and avoid duplicated effort with work already in flight.
+
+2. **Write a clear bug report.** Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) and include a minimal reproduction case — exact environment, steps to reproduce, what you expected, and what actually happened. Reports without repro steps may be closed.
+
+3. **Reference the issue in your PR.** Every pull request must link to an open issue using `Fixes #<number>`. **PRs with no referenced issue will not be reviewed and may be closed without explanation.**
+
+4. **Discuss the approach before building.** For anything beyond a trivial fix, leave a comment on the issue explaining what you plan to do and wait for a maintainer to signal alignment. This avoids the pain of a rejected PR after significant effort.
+
 ### Sizing PRs for review
 
 We optimize PRs for easy review — large PRs get broken

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ young.  Our immediate focus is on building out the core system and demos, so we
 may not be able to review or merge contributions that don't align with those
 goals in the near term.
 
+### PR Etiquette
+
+Before opening a pull request, please follow these steps — they protect both your time and ours:
+
+1. **File an issue first.** If you've found a bug or want to propose a change, open an issue before writing code. This lets maintainers confirm the problem is real, align on the right fix, and avoid duplicated effort with work already in flight.
+
+2. **Write a clear bug report.** Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) and include a minimal reproduction case — exact environment, steps to reproduce, what you expected, and what actually happened. Reports without repro steps may be closed.
+
+3. **Reference the issue in your PR.** Every pull request must link to an open issue using `Fixes #<number>`. **PRs with no referenced issue will not be reviewed and may be closed without explanation.**
+
+4. **Discuss the approach before building.** For anything beyond a trivial fix, leave a comment on the issue explaining what you plan to do and wait for a maintainer to signal alignment. This avoids the pain of a rejected PR after significant effort.
+
 ## Quickstart (Development)
 
 To quickly set up the complete environment:

--- a/README.md
+++ b/README.md
@@ -80,18 +80,6 @@ young.  Our immediate focus is on building out the core system and demos, so we
 may not be able to review or merge contributions that don't align with those
 goals in the near term.
 
-### PR Etiquette
-
-Before opening a pull request, please follow these steps — they protect both your time and ours:
-
-1. **File an issue first.** If you've found a bug or want to propose a change, open an issue before writing code. This lets maintainers confirm the problem is real, align on the right fix, and avoid duplicated effort with work already in flight.
-
-2. **Write a clear bug report.** Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) and include a minimal reproduction case — exact environment, steps to reproduce, what you expected, and what actually happened. Reports without repro steps may be closed.
-
-3. **Reference the issue in your PR.** Every pull request must link to an open issue using `Fixes #<number>`. **PRs with no referenced issue will not be reviewed and may be closed without explanation.**
-
-4. **Discuss the approach before building.** For anything beyond a trivial fix, leave a comment on the issue explaining what you plan to do and wait for a maintainer to signal alignment. This avoids the pain of a rejected PR after significant effort.
-
 ## Quickstart (Development)
 
 To quickly set up the complete environment:


### PR DESCRIPTION
## Summary

- Adds a **PR Etiquette** section to `README.md` making the issue-first requirement explicit: contributors must file an issue with clear repro steps before opening a PR, and PRs with no linked issue will not be reviewed.
- Strengthens `.github/PULL_REQUEST_TEMPLATE.md` with a prominent stop-sign notice, a "What changed and why" section, and a checklist that requires an issue link.
- Improves `.github/ISSUE_TEMPLATE/bug_report.md` with structured fields (environment, expected/actual behavior, steps to reproduce, collapsible logs block, minimal repro) to raise the quality of incoming reports.

## Motivation

Unanchored PRs cost maintainer time and contributor goodwill. Requiring an issue first lets us confirm the problem, align on the fix, and avoid duplicating in-flight work — before anyone writes code.

## Test plan

- [ ] README renders correctly on GitHub (check the new section under "Developing")
- [ ] PR template appears when opening a new PR
- [ ] Bug report template appears when filing a new issue