### PR TITLE
e2e/networking: retry ingress request until xDS routes are ready

### DIFF
--- a/internal/e2e/suites/networking/networking_test.go
+++ b/internal/e2e/suites/networking/networking_test.go
@@ -40,19 +40,31 @@ func TestActorDirectAccess(t *testing.T) {
 	})
 	t.Run("via ingress", func(t *testing.T) {
 		actorRef := resources.ActorRef{Atespace: networkingAtespace, Name: actorName}
-		response, err := router.Get(ctx, actorRef, "/readyz")
-		if err != nil {
-			t.Fatalf("GET Actor through ingress: %v", err)
+		// Retry until the ingress routes are programmed. After ResumeActor returns
+		// the xDS update from the control plane may not have reached the router yet,
+		// causing a transient 503 connection timeout.
+		const timeout = 30 * time.Second
+		deadline := time.Now().Add(timeout)
+		for {
+			response, err := router.Get(ctx, actorRef, "/readyz")
+			if err != nil {
+				t.Fatalf("GET Actor through ingress: %v", err)
+			}
+			body, err := io.ReadAll(response.Body)
+			response.Body.Close()
+			if err != nil {
+				t.Fatalf("reading ingress response body (HTTP %d): %v", response.StatusCode, err)
+			}
+			if response.StatusCode == http.StatusOK {
+				t.Logf("Actor access through ingress succeeded; body: %s", body)
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("Actor access through ingress returned HTTP %d after %v; body: %s", response.StatusCode, timeout, body)
+			}
+			t.Logf("Actor access through ingress returned HTTP %d; retrying...", response.StatusCode)
+			time.Sleep(1 * time.Second)
 		}
-		defer response.Body.Close()
-		body, err := io.ReadAll(response.Body)
-		if err != nil {
-			t.Fatalf("reading ingress response body (HTTP %d): %v", response.StatusCode, err)
-		}
-		if response.StatusCode != http.StatusOK {
-			t.Fatalf("Actor access through ingress returned HTTP %d, want 200; body: %s", response.StatusCode, body)
-		}
-		t.Logf("Actor access through ingress succeeded; body: %s", body)
 	})
 }
 


### PR DESCRIPTION
## Summary

- `TestActorDirectAccess/via_ingress` was intermittently failing with HTTP 503 / connection timeout because the test sent a single request immediately after `ResumeActor` returned, before the Envoy xDS update had propagated to the router.
- Fixed by retrying the GET with a 30 s deadline (1 s intervals), matching the same pattern used by `waitForActorStatus` and `callActor` elsewhere in the e2e suite.
- Also fixes the resource leak in the original code where `defer response.Body.Close()` was called before `io.ReadAll`, but the body was read correctly — the retry loop now closes each response body explicitly per iteration.

Fixes #723.

## Test plan

- [ ] `e2e-test (cert)` and `e2e-test (token)` pass — `TestActorDirectAccess/via_ingress` no longer fails on slow xDS propagation
- [ ] On success the test logs `"Actor access through ingress succeeded"` as before
- [ ] On repeated 503s the test logs each retry attempt and fails with a clear timeout message after 30 s