### PR TITLE
add hack tool to run Substrate against a locally-built runsc

### DIFF
--- a/cmd/ateapi/internal/controlapi/sandbox_assets_test.go
+++ b/cmd/ateapi/internal/controlapi/sandbox_assets_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
+)
+
+const (
+	defaultRunscSHA = "f18a948bf9c8bbb54eb998549a3a8d719a1c7de2efbe8fdd2ff0ee5fecd06f19"
+	pinnedRunscSHA  = "62eee121f8c188e347c428acc96f111568ede3be37b906046b6f28bbe2cc40c0"
+)
+
+func testWorkerPoolLister(t *testing.T, pools ...*atev1alpha1.WorkerPool) listersv1alpha1.WorkerPoolLister {
+	t.Helper()
+	idx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, p := range pools {
+		if err := idx.Add(p); err != nil {
+			t.Fatalf("adding WorkerPool %q to indexer: %v", p.Name, err)
+		}
+	}
+	return listersv1alpha1.NewWorkerPoolLister(idx)
+}
+
+func testSandboxConfigLister(t *testing.T, configs ...*atev1alpha1.SandboxConfig) listersv1alpha1.SandboxConfigLister {
+	t.Helper()
+	idx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, c := range configs {
+		if err := idx.Add(c); err != nil {
+			t.Fatalf("adding SandboxConfig %q to indexer: %v", c.Name, err)
+		}
+	}
+	return listersv1alpha1.NewSandboxConfigLister(idx)
+}
+
+func testWorkerPool(name, configName string, class atev1alpha1.SandboxClass) *atev1alpha1.WorkerPool {
+	return &atev1alpha1.WorkerPool{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ate-demo"},
+		Spec: atev1alpha1.WorkerPoolSpec{
+			SandboxClass:      class,
+			SandboxConfigName: configName,
+		},
+	}
+}
+
+func testGvisorConfig(name, sha string, isDefault bool) *atev1alpha1.SandboxConfig {
+	return &atev1alpha1.SandboxConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: atev1alpha1.SandboxConfigSpec{
+			SandboxClass: atev1alpha1.SandboxClassGvisor,
+			Default:      isDefault,
+			Assets: map[string]map[string]atev1alpha1.AssetFile{
+				"amd64": {"runsc": {URL: "gs://bucket/" + name + "/runsc", SHA256: sha}},
+			},
+		},
+	}
+}
+
+// TestResolveSandboxAssetsNamedConfig covers the spec.sandboxConfigName branch:
+// a pool naming a SandboxConfig gets that config's binaries, not the cluster
+// default's. This is how a pool opts into a non-default runsc (see
+// hack/gvisor-hack/), so a regression here would silently boot actors on the
+// default binary instead of the pinned one — the assets still resolve, so
+// nothing errors; the pool just runs the wrong sandbox.
+func TestResolveSandboxAssetsNamedConfig(t *testing.T) {
+	wpLister := testWorkerPoolLister(t, testWorkerPool("pinned-pool", "pinned", atev1alpha1.SandboxClassGvisor))
+	scLister := testSandboxConfigLister(t,
+		testGvisorConfig("gvisor-default", defaultRunscSHA, true),
+		testGvisorConfig("pinned", pinnedRunscSHA, false),
+	)
+
+	got, err := resolveSandboxAssets(wpLister, scLister, "ate-demo", "pinned-pool")
+	if err != nil {
+		t.Fatalf("resolveSandboxAssets() error = %v", err)
+	}
+
+	want := &ateletpb.SandboxAssets{
+		SandboxClass: string(atev1alpha1.SandboxClassGvisor),
+		Assets: map[string]*ateletpb.ArchAssets{
+			"amd64": {Files: map[string]*ateletpb.AssetFile{
+				"runsc": {Url: "gs://bucket/pinned/runsc", Sha256: pinnedRunscSHA},
+			}},
+		},
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("resolveSandboxAssets() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestResolveSandboxAssetsDefaultConfig covers the no-name branch: an empty
+// sandboxConfigName falls back to the single default for the pool's class.
+func TestResolveSandboxAssetsDefaultConfig(t *testing.T) {
+	wpLister := testWorkerPoolLister(t, testWorkerPool("plain-pool", "", ""))
+	scLister := testSandboxConfigLister(t,
+		testGvisorConfig("gvisor-default", defaultRunscSHA, true),
+		testGvisorConfig("pinned", pinnedRunscSHA, false),
+	)
+
+	got, err := resolveSandboxAssets(wpLister, scLister, "ate-demo", "plain-pool")
+	if err != nil {
+		t.Fatalf("resolveSandboxAssets() error = %v", err)
+	}
+	// An empty spec.sandboxClass defaults to gvisor.
+	if got.GetSandboxClass() != string(atev1alpha1.SandboxClassGvisor) {
+		t.Errorf("SandboxClass = %q, want %q", got.GetSandboxClass(), atev1alpha1.SandboxClassGvisor)
+	}
+	if sha := got.GetAssets()["amd64"].GetFiles()["runsc"].GetSha256(); sha != defaultRunscSHA {
+		t.Errorf("runsc sha256 = %q, want the default config's %q", sha, defaultRunscSHA)
+	}
+}
+
+func TestResolveSandboxAssetsErrors(t *testing.T) {
+	microvmDefault := &atev1alpha1.SandboxConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "microvm-config"},
+		Spec: atev1alpha1.SandboxConfigSpec{
+			SandboxClass: atev1alpha1.SandboxClassMicroVM,
+			Assets:       map[string]map[string]atev1alpha1.AssetFile{"amd64": {"cloud-hypervisor": {URL: "gs://bucket/ch", SHA256: defaultRunscSHA}}},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		pool    *atev1alpha1.WorkerPool
+		configs []*atev1alpha1.SandboxConfig
+		wantErr string
+	}{{
+		// The class gate: naming a micro-VM config from a gVisor pool must fail
+		// rather than hand atelet an asset set the gVisor backend cannot use.
+		name:    "named config has the wrong class",
+		pool:    testWorkerPool("pool", "microvm-config", atev1alpha1.SandboxClassGvisor),
+		configs: []*atev1alpha1.SandboxConfig{microvmDefault},
+		wantErr: "is class",
+	}, {
+		name:    "named config does not exist",
+		pool:    testWorkerPool("pool", "absent", atev1alpha1.SandboxClassGvisor),
+		configs: []*atev1alpha1.SandboxConfig{testGvisorConfig("gvisor-default", defaultRunscSHA, true)},
+		wantErr: "while getting SandboxConfig",
+	}, {
+		// Why hack/gvisor-hack/deploy.sh demotes the incumbent default before
+		// applying a new one with spec.default: true.
+		name: "two defaults for one class",
+		pool: testWorkerPool("pool", "", atev1alpha1.SandboxClassGvisor),
+		configs: []*atev1alpha1.SandboxConfig{
+			testGvisorConfig("gvisor-default", defaultRunscSHA, true),
+			testGvisorConfig("gvisor-hack", pinnedRunscSHA, true),
+		},
+		wantErr: "multiple default SandboxConfigs",
+	}, {
+		name:    "no default for the class",
+		pool:    testWorkerPool("pool", "", atev1alpha1.SandboxClassGvisor),
+		configs: []*atev1alpha1.SandboxConfig{testGvisorConfig("not-default", pinnedRunscSHA, false)},
+		wantErr: "no default SandboxConfig",
+	}, {
+		name:    "worker pool does not exist",
+		pool:    testWorkerPool("other-pool", "", atev1alpha1.SandboxClassGvisor),
+		configs: []*atev1alpha1.SandboxConfig{testGvisorConfig("gvisor-default", defaultRunscSHA, true)},
+		wantErr: "while getting WorkerPool",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wpLister := testWorkerPoolLister(t, tt.pool)
+			scLister := testSandboxConfigLister(t, tt.configs...)
+
+			_, err := resolveSandboxAssets(wpLister, scLister, "ate-demo", "pool")
+			if err == nil {
+				t.Fatalf("resolveSandboxAssets() succeeded, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("resolveSandboxAssets() error = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -225,7 +225,7 @@ spec:
 
 ### Running a locally-built runsc
 
-Because the binary is fetched at runtime rather than baked into the worker image, testing an unreleased runsc is a matter of staging the binary into the cluster's object store and pointing a `SandboxConfig` at its URL + `sha256`. See [`hack/gvisor-hack/`](../hack/gvisor-hack/) for scripts that do this and leave `gvisor-default` untouched. Note that snapshots are version-locked to the runsc that wrote them, so a custom build cannot restore checkpoints taken with the released one.
+Because the binary is fetched at runtime rather than baked into the worker image, testing an unreleased runsc is a matter of staging the binary into the cluster's object store and pointing a `SandboxConfig` at its URL + `sha256`. See [`hack/gvisor-hack/`](../hack/gvisor-hack/) for scripts that do this. By default they add a separate named config and leave `gvisor-default` untouched; opting in to `MAKE_DEFAULT` instead clears `spec.default` on the incumbent so the new config becomes the cluster default. Note that snapshots are version-locked to the runsc that wrote them, so a custom build cannot restore checkpoints taken with the released one.
 
 ### Micro-VM SandboxConfig
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -223,6 +223,10 @@ spec:
         sha256: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9"
 ```
 
+### Running a locally-built runsc
+
+Because the binary is fetched at runtime rather than baked into the worker image, testing an unreleased runsc is a matter of staging the binary into the cluster's object store and pointing a `SandboxConfig` at its URL + `sha256`. See [`hack/gvisor-hack/`](../hack/gvisor-hack/) for scripts that do this and leave `gvisor-default` untouched. Note that snapshots are version-locked to the runsc that wrote them, so a custom build cannot restore checkpoints taken with the released one.
+
 ### Micro-VM SandboxConfig
 
 A `microvm` `SandboxConfig` supplies the [Kata Containers](https://katacontainers.io/) + [Cloud Hypervisor](https://www.cloudhypervisor.org/) toolchain instead of `runsc`. Each architecture must define the full asset set — `kata-shim`, `cloud-hypervisor`, `virtiofsd`, `kata-kernel`, `kata-image`, and `kata-config` — which a `ValidatingAdmissionPolicy` enforces at apply time. Worker pods for a micro-VM pool require `/dev/kvm` and nested-virtualization-capable nodes labeled `ate.dev/sandboxClass=microvm` (the controller adds the device mount and node placement automatically).

--- a/hack/gvisor-hack/README.md
+++ b/hack/gvisor-hack/README.md
@@ -9,10 +9,11 @@ So integrating an unreleased runsc — one with a feature you're developing — 
 just: stage the binary somewhere the cluster can read, and point a
 `SandboxConfig` at it.
 
-The helpers here do exactly that. The committed default
+The helpers here do exactly that. By default the committed
 (`manifests/ate-install/sandboxconfig-gvisor.yaml`, `SandboxConfig/gvisor-default`)
-is left untouched; you get a second, named config that individual WorkerPools
-opt into.
+config is left untouched: you get a second, named config that individual
+WorkerPools opt into. `MAKE_DEFAULT=true` is the one path that does modify it,
+clearing its `spec.default` so the new config takes over cluster-wide.
 
 | File | Purpose |
 | --- | --- |
@@ -113,6 +114,11 @@ demotes the incumbent default first — **two** `SandboxConfig`s of the same cla
 with `spec.default: true` is an error, and every actor launch fails to resolve
 its assets until one is demoted.
 
+Zero defaults is the same kind of error, so the script does not risk trading one
+for the other: it validates the new config with a server-side dry run *before*
+demoting anything, and if the real apply still fails it restores the config it
+demoted (telling you exactly what to run if even that fails).
+
 Assets are resolved when an actor starts, so **actors already running keep the
 runsc they booted with**. Create a new actor, or suspend/resume an existing one,
 to pick up the change.
@@ -186,8 +192,26 @@ kubectl -n ate-demo-counter patch workerpool counter --type=json \
 kubectl delete sandboxconfig gvisor-hack
 ```
 
-If you used `MAKE_DEFAULT=true`, restore the shipped default as well:
+If you used `MAKE_DEFAULT=true`, restore the shipped default as well — the
+script names the configs it demoted in its closing output:
 
 ```sh
 kubectl patch sandboxconfig gvisor-default --type=merge -p '{"spec":{"default":true}}'
 ```
+
+### If the script failed partway
+
+It rolls back its own demotion — on a failed apply and on Ctrl-C — so an
+interrupted run should leave the default where it found it. A `kill -9` is the
+one case nothing can cover. If even the rollback failed, the script says so and prints the
+exact patch to run — until you do, the cluster has **no** default gvisor
+`SandboxConfig` and every actor launch fails to resolve its assets. Check with:
+
+```sh
+kubectl get sandboxconfigs -o custom-columns=NAME:.metadata.name,CLASS:.spec.sandboxClass,DEFAULT:.spec.default
+```
+
+Exactly one gvisor row should read `true`. If none does, patch the one you want
+back; if two do, clear `spec.default` on all but one. A failure before the
+apply (a rejected dry run, a failed upload) changes nothing and needs no
+cleanup, though a staged object may be left behind in the bucket.

--- a/hack/gvisor-hack/README.md
+++ b/hack/gvisor-hack/README.md
@@ -1,0 +1,193 @@
+# Running Substrate against a locally-built gVisor runtime
+
+Substrate pins one specific runsc release, but nothing about that pin is baked
+into an image. The gVisor runtime fetches runsc at **runtime**: atelet reads a
+`url` + `sha256` from a cluster-scoped `SandboxConfig`, downloads the binary,
+verifies the digest, and caches it at
+`/var/lib/ateom-gvisor/static-files/runsc-<sha256>` (a hostPath on the node).
+So integrating an unreleased runsc — one with a feature you're developing — is
+just: stage the binary somewhere the cluster can read, and point a
+`SandboxConfig` at it.
+
+The helpers here do exactly that. The committed default
+(`manifests/ate-install/sandboxconfig-gvisor.yaml`, `SandboxConfig/gvisor-default`)
+is left untouched; you get a second, named config that individual WorkerPools
+opt into.
+
+| File | Purpose |
+| --- | --- |
+| `deploy.sh` | One-shot: hash, stage, render + apply the `SandboxConfig`, optionally repoint a WorkerPool |
+| `stage-to-rustfs.sh` | Upload the binary to the kind cluster's in-cluster rustfs bucket |
+| `stage-to-gcs.sh` | Upload the binary to a GCS bucket (GKE) |
+| `sandboxconfig.yaml.tmpl` | The `SandboxConfig` template `deploy.sh` renders |
+
+These are named for the sandbox **class** rather than any one binary. The gVisor
+class currently takes a single asset named `runsc`; that name appears in the
+`assets` key of `sandboxconfig.yaml.tmpl` and in `runscPathFor`
+(`cmd/atelet/sandbox_assets.go`), which is what the backend looks the path up by.
+Everything else here is asset-name agnostic.
+
+## Prerequisites
+
+- A running cluster with the control plane installed
+  (`hack/create-kind-cluster.sh` + `hack/install-ate-kind.sh`, or
+  `hack/install-ate.sh` for GKE).
+- `aws` CLI for the kind/rustfs path, or an authenticated `gcloud` for GCS.
+- A runsc binary built for the **node's** architecture.
+
+## 1. Build runsc
+
+From your gVisor checkout — see the
+[gVisor build docs](https://gvisor.dev/docs/user_guide/install/#build-from-source)
+for the current invocation:
+
+```sh
+cd ~/src/gvisor
+make copy TARGETS=runsc DESTINATION=bin/
+```
+
+runsc re-execs itself for the sandbox and gofer processes (`/proc/self/exe`), so
+the single binary is the whole asset — there is nothing else to stage.
+
+Copy it somewhere convenient (`bin/` at the repo root is gitignored):
+
+```sh
+cp ~/src/gvisor/bin/runsc /path/to/substrate/bin/runsc
+```
+
+## 2. Deploy it
+
+### kind
+
+```sh
+ATE_INSTALL_KIND=true \
+RUNSC=$PWD/bin/runsc \
+WORKERPOOL=counter WORKERPOOL_NAMESPACE=ate-demo-counter \
+  hack/gvisor-hack/deploy.sh
+```
+
+### GKE
+
+```sh
+RUNSC=$PWD/bin/runsc \
+BUCKET_NAME=my-ate-bucket PROJECT_ID=my-project \
+ARCH=amd64 \
+WORKERPOOL=counter WORKERPOOL_NAMESPACE=ate-demo-counter \
+  hack/gvisor-hack/deploy.sh
+```
+
+The bucket must be readable by atelet's service account. atelet tries an
+anonymous client first and falls back to its main authenticated client, so the
+cluster's own private snapshot bucket works fine.
+
+The script prints the digest and the URL it staged to, uploads the binary to
+`<bucket>/gvisor-hack/runsc-<sha256>`, and applies `SandboxConfig/gvisor-hack`.
+
+### Environment reference
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `RUNSC` | `./bin/runsc` | Binary to deploy |
+| `NAME` | `gvisor-hack` | `SandboxConfig` name |
+| `ARCH` | host `GOARCH` | Node architecture the binary targets |
+| `BUCKET_NAME` | `ate-snapshots` | Object store bucket |
+| `PREFIX` | `gvisor-hack` | Object key prefix in the bucket |
+| `ATE_INSTALL_KIND` | `false` | `true` → stage to in-cluster rustfs instead of GCS |
+| `KUBECTL_CONTEXT` | *(unset)* | Kube context to target |
+| `PROJECT_ID` | *(unset)* | GCP project for the GCS upload |
+| `MAKE_DEFAULT` | `false` | `true` → make this the cluster-wide gvisor default |
+| `WORKERPOOL` / `WORKERPOOL_NAMESPACE` | *(unset)* | Repoint this pool at the new config |
+| `SKIP_STAGE` | `false` | `true` → re-apply the config without re-uploading |
+
+## 3. Point workloads at it
+
+`deploy.sh` does this for you when you pass `WORKERPOOL`. Manually:
+
+```sh
+kubectl -n ate-demo-counter patch workerpool counter --type=merge \
+  -p '{"spec":{"sandboxConfigName":"gvisor-hack"}}'
+```
+
+To make it cluster-wide instead, run with `MAKE_DEFAULT=true`. That path also
+demotes the incumbent default first — **two** `SandboxConfig`s of the same class
+with `spec.default: true` is an error, and every actor launch fails to resolve
+its assets until one is demoted.
+
+Assets are resolved when an actor starts, so **actors already running keep the
+runsc they booted with**. Create a new actor, or suspend/resume an existing one,
+to pick up the change.
+
+## 4. Verify
+
+The staged config and what it pins:
+
+```sh
+kubectl get sandboxconfig gvisor-hack -o yaml
+```
+
+The binary landed on the node (kind):
+
+```sh
+docker exec ate-control-plane ls -l /var/lib/ateom-gvisor/static-files/
+docker exec ate-control-plane /var/lib/ateom-gvisor/static-files/runsc-<sha256> --version
+```
+
+If the download failed, atelet's log says why — a digest mismatch, an
+unreachable bucket, or a permissions error on the object.
+
+## 5. Iterate
+
+Rebuild, then re-run the same command. The digest changes, so the object name
+and the on-node cache path change with it; there is no stale-cache case to
+reason about, and the previous build stays intact for A/B comparison.
+
+For a really tight loop you can skip the object store entirely: atelet returns
+early on a cache hit without ever reading the URL, so preseeding the node works.
+
+```sh
+SHA=$(sha256sum bin/runsc | cut -d' ' -f1)
+docker cp bin/runsc ate-control-plane:/var/lib/ateom-gvisor/static-files/runsc-$SHA
+docker exec ate-control-plane chmod 755 /var/lib/ateom-gvisor/static-files/runsc-$SHA
+```
+
+Then apply a config carrying that digest (`SKIP_STAGE=true` does the rest). This
+is a dev trick, not a deployment: you must repeat it on every worker node, and
+if the file is ever evicted atelet falls back to fetching a URL that has nothing
+behind it.
+
+## Gotchas
+
+- **Checkpoints are version-locked.** The snapshot manifest records the exact
+  asset set used, and restore refetches that same binary — gVisor cannot restore
+  an image written by a different runsc. Snapshots taken with the released runsc
+  will not restore under your build, and vice versa. Test with fresh actors.
+- **The digest must be lowercase 64-hex.** Enforced by both the CRD schema
+  (`pkg/api/v1alpha1/sandboxconfig_types.go`) and `resources.ValidateRunscHash`.
+  `sha256sum` output is already in that form.
+- **Every architecture listed needs a `runsc` asset.** The
+  `sandboxconfig-assets` ValidatingAdmissionPolicy fails the apply otherwise.
+  The template emits a single arch block on purpose; atelet only fetches the one
+  matching its node's `GOARCH`, so a single-arch config is correct for a
+  single-arch cluster.
+- **Wrong-arch binaries fail late.** `deploy.sh` warns if `file` disagrees
+  with `ARCH`, but the authoritative arch is the *node's*, not your laptop's.
+  Set `ARCH` explicitly when they differ.
+- **Assets are capped at 8 GiB** (`maxAssetBytes` in
+  `cmd/atelet/sandbox_assets.go`). Not a concern for runsc; noted so the guard
+  isn't a surprise.
+- **Cleanup.** Staged objects accumulate under `<bucket>/gvisor-hack/`, one per
+  build. Delete them when you're done; the on-node caches go away with the node.
+
+## Reverting
+
+```sh
+kubectl -n ate-demo-counter patch workerpool counter --type=json \
+  -p '[{"op":"remove","path":"/spec/sandboxConfigName"}]'
+kubectl delete sandboxconfig gvisor-hack
+```
+
+If you used `MAKE_DEFAULT=true`, restore the shipped default as well:
+
+```sh
+kubectl patch sandboxconfig gvisor-default --type=merge -p '{"spec":{"default":true}}'
+```

--- a/hack/gvisor-hack/deploy.sh
+++ b/hack/gvisor-hack/deploy.sh
@@ -66,6 +66,14 @@ if [[ -n "${WORKERPOOL}" && -z "${WORKERPOOL_NAMESPACE}" ]]; then
   exit 1
 fi
 
+# NAME becomes a Kubernetes object name. Check it here so a typo costs a second
+# rather than an upload, and so it cannot be the thing that fails the apply after
+# the incumbent default has already been demoted.
+if [[ ${#NAME} -gt 253 ]] || ! [[ "${NAME}" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ ]]; then
+  echo "error: NAME=${NAME} is not a valid Kubernetes object name (DNS-1123 subdomain)" >&2
+  exit 1
+fi
+
 # A quick sanity check that the binary matches the target arch — a runsc built for
 # the wrong arch fails deep inside ateom with an exec format error, which is a
 # needlessly confusing way to learn about it. Advisory only; `file` may be absent.
@@ -96,6 +104,22 @@ log "url:     ${RUNSC_URL}"
 log "arch:    ${ARCH}"
 log "config:  SandboxConfig/${NAME} (default=${MAKE_DEFAULT})"
 
+render_config() {
+  sed -e "s|\${NAME}|${NAME}|g" \
+      -e "s|\${DEFAULT}|${MAKE_DEFAULT}|g" \
+      -e "s|\${ARCH}|${ARCH}|g" \
+      -e "s|\${RUNSC_URL}|${RUNSC_URL}|g" \
+      -e "s|\${RUNSC_SHA256}|${RUNSC_SHA256}|g" \
+      hack/gvisor-hack/sandboxconfig.yaml.tmpl
+}
+
+# Validate against the live API server before doing anything with side effects.
+# The CRD schema and the sandboxconfig-assets ValidatingAdmissionPolicy both run
+# under --dry-run=server, so a config the cluster would reject fails here —
+# before the upload, and before MAKE_DEFAULT demotes the incumbent default.
+log "Validating SandboxConfig/${NAME} (server-side dry run)..."
+render_config | "${KUBECTL[@]}" apply --dry-run=server -f - >/dev/null
+
 if [[ "${SKIP_STAGE}" == "true" ]]; then
   log "SKIP_STAGE=true; not uploading"
 elif [[ "${ATE_INSTALL_KIND}" == "true" ]]; then
@@ -108,26 +132,68 @@ else
     hack/gvisor-hack/stage-to-gcs.sh
 fi
 
+restore_demoted() {
+  # Guard the expansion: an empty array under `set -u` is an error on bash < 4.4.
+  if [[ ${#demoted[@]} -eq 0 ]]; then
+    return
+  fi
+  for sc_name in "${demoted[@]}"; do
+    echo "   restoring spec.default on ${sc_name}" >&2
+    if ! "${KUBECTL[@]}" patch sandboxconfig "${sc_name}" --type=merge -p '{"spec":{"default":true}}'; then
+      echo "error: could not restore ${sc_name} as the default; the cluster has NO default" >&2
+      echo "       gvisor SandboxConfig. Fix with: kubectl patch sandboxconfig ${sc_name} \\" >&2
+      echo "       --type=merge -p '{\"spec\":{\"default\":true}}'" >&2
+    fi
+  done
+}
+
+on_interrupt() {
+  # Ignore further interrupts rather than re-entering this handler: the restore
+  # below is the only thing standing between an impatient second Ctrl-C and a
+  # cluster with no default SandboxConfig, so let it finish.
+  trap '' INT TERM
+  echo >&2
+  echo "error: interrupted before SandboxConfig/${NAME} was applied" >&2
+  restore_demoted
+  exit 130
+}
+
 # Two defaults for one sandbox class make every actor launch fail to resolve its
-# assets, so demote the incumbent BEFORE applying rather than after.
+# assets, so demote the incumbent BEFORE applying rather than after. Both states
+# are broken (see TestResolveSandboxAssetsErrors), but the two-default window
+# closes on the next patch, whereas zero defaults persists until someone notices
+# — so if the apply fails anyway, put the incumbent back.
+demoted=()
 if [[ "${MAKE_DEFAULT}" == "true" ]]; then
+  # Ctrl-C between the demotion and the apply would otherwise leave zero defaults
+  # behind with nothing to put them back. A SIGKILL still escapes this; two object
+  # writes cannot be made atomic from a shell script, only narrowed.
+  trap on_interrupt INT TERM
   log "Clearing spec.default on other gvisor SandboxConfigs..."
   while read -r sc_name sc_class sc_default; do
     [[ -z "${sc_name}" ]] && continue
     if [[ "${sc_name}" != "${NAME}" && "${sc_class}" == "gvisor" && "${sc_default}" == "true" ]]; then
       log "   demoting ${sc_name}"
+      # Record before patching, not after: an interrupt can land after the server
+      # has applied the patch but before kubectl returns, and a name missing from
+      # this list never gets restored. Restoring one that was never demoted just
+      # re-asserts spec.default: true, which is a no-op.
+      demoted+=("${sc_name}")
       "${KUBECTL[@]}" patch sandboxconfig "${sc_name}" --type=merge -p '{"spec":{"default":false}}'
     fi
   done < <("${KUBECTL[@]}" get sandboxconfigs -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.sandboxClass}{" "}{.spec.default}{"\n"}{end}')
 fi
 
 log "Applying SandboxConfig/${NAME}..."
-sed -e "s|\${NAME}|${NAME}|g" \
-    -e "s|\${DEFAULT}|${MAKE_DEFAULT}|g" \
-    -e "s|\${ARCH}|${ARCH}|g" \
-    -e "s|\${RUNSC_URL}|${RUNSC_URL}|g" \
-    -e "s|\${RUNSC_SHA256}|${RUNSC_SHA256}|g" \
-    hack/gvisor-hack/sandboxconfig.yaml.tmpl | "${KUBECTL[@]}" apply -f -
+if ! render_config | "${KUBECTL[@]}" apply -f -; then
+  # The dry run above makes this unlikely, but a transient failure here would
+  # otherwise leave the cluster with no default at all.
+  echo "error: applying SandboxConfig/${NAME} failed" >&2
+  restore_demoted
+  exit 1
+fi
+# Past this point the new default exists, so an interrupt is no longer dangerous.
+trap - INT TERM
 
 if [[ -n "${WORKERPOOL}" ]]; then
   log "Pointing WorkerPool ${WORKERPOOL_NAMESPACE}/${WORKERPOOL} at SandboxConfig/${NAME}..."
@@ -150,5 +216,18 @@ if [[ -z "${WORKERPOOL}" && "${MAKE_DEFAULT}" != "true" ]]; then
 
      kubectl -n <namespace> patch workerpool <name> --type=merge \\
        -p '{"spec":{"sandboxConfigName":"${NAME}"}}'
+EOF
+fi
+
+# Say plainly what was changed outside the config we own. The demotion is logged
+# as it happens, but that scrolls past; this is the line you come back to when
+# you want the cluster the way it was.
+if [[ ${#demoted[@]} -gt 0 ]]; then
+  cat <<EOF
+
+   This cleared spec.default on: ${demoted[*]}
+   To undo, delete SandboxConfig/${NAME} and run:
+
+     kubectl patch sandboxconfig ${demoted[0]} --type=merge -p '{"spec":{"default":true}}'
 EOF
 fi

--- a/hack/gvisor-hack/deploy.sh
+++ b/hack/gvisor-hack/deploy.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploy a locally-built runsc: stage the binary into the cluster's object store,
+# then apply a SandboxConfig pinning it by URL + sha256. See README.md in this
+# directory for the full walkthrough.
+#
+# Env:
+#   RUNSC                 path to the runsc binary to deploy (default ./bin/runsc)
+#   NAME                  SandboxConfig name (default gvisor-hack)
+#   ARCH                  node GOARCH the binary targets (default: host GOARCH)
+#   BUCKET_NAME           object store bucket (default ate-snapshots)
+#   PREFIX                object key prefix within the bucket (default gvisor-hack)
+#   ATE_INSTALL_KIND      "true" -> stage to the in-cluster rustfs; else GCS
+#   KUBECTL_CONTEXT       kube context (optional)
+#   PROJECT_ID            GCP project for the GCS upload (optional)
+#   MAKE_DEFAULT          "true" -> make this the cluster-wide gvisor default
+#   WORKERPOOL            WorkerPool to point at this config (optional)
+#   WORKERPOOL_NAMESPACE  namespace of WORKERPOOL (required with WORKERPOOL)
+#   SKIP_STAGE            "true" -> skip the upload, only (re-)apply the config
+
+set -o errexit -o nounset -o pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "${ROOT}"
+
+RUNSC="${RUNSC:-${ROOT}/bin/runsc}"
+NAME="${NAME:-gvisor-hack}"
+ARCH="${ARCH:-$(go env GOARCH)}"
+BUCKET_NAME="${BUCKET_NAME:-ate-snapshots}"
+PREFIX="${PREFIX:-gvisor-hack}"
+ATE_INSTALL_KIND="${ATE_INSTALL_KIND:-false}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-}"
+MAKE_DEFAULT="${MAKE_DEFAULT:-false}"
+WORKERPOOL="${WORKERPOOL:-}"
+WORKERPOOL_NAMESPACE="${WORKERPOOL_NAMESPACE:-}"
+SKIP_STAGE="${SKIP_STAGE:-false}"
+
+log() { echo ">> $*"; }
+
+if [[ ! -f "${RUNSC}" ]]; then
+  echo "error: runsc binary not found at ${RUNSC} (set RUNSC=/path/to/runsc)" >&2
+  exit 1
+fi
+
+case "${ARCH}" in
+  amd64|arm64) ;;
+  *) echo "error: unsupported ARCH=${ARCH} (want amd64 or arm64)" >&2; exit 1 ;;
+esac
+
+if [[ -n "${WORKERPOOL}" && -z "${WORKERPOOL_NAMESPACE}" ]]; then
+  echo "error: WORKERPOOL_NAMESPACE is required when WORKERPOOL is set" >&2
+  exit 1
+fi
+
+# A quick sanity check that the binary matches the target arch — a runsc built for
+# the wrong arch fails deep inside ateom with an exec format error, which is a
+# needlessly confusing way to learn about it. Advisory only; `file` may be absent.
+if command -v file >/dev/null 2>&1; then
+  file_out="$(file -b "${RUNSC}")"
+  case "${ARCH}:${file_out}" in
+    amd64:*x86-64*|arm64:*aarch64*) ;;
+    *) echo "warning: ${RUNSC} looks like '${file_out}', which may not match ARCH=${ARCH}" >&2 ;;
+  esac
+fi
+
+KUBECTL=(kubectl)
+if [[ -n "${KUBECTL_CONTEXT}" ]]; then
+  KUBECTL+=(--context="${KUBECTL_CONTEXT}")
+fi
+
+# atelet caches assets at static-files/runsc-<sha256> and verifies the download
+# against this digest, so the digest is the real version pin; the object name
+# carries it too, so a rebuild lands at a new URL instead of silently changing the
+# bytes behind an old one.
+RUNSC_SHA256="$(sha256sum "${RUNSC}" | awk '{print $1}')"
+OBJECT="${PREFIX}/runsc-${RUNSC_SHA256}"
+RUNSC_URL="gs://${BUCKET_NAME}/${OBJECT}"
+
+log "runsc:   ${RUNSC}"
+log "sha256:  ${RUNSC_SHA256}"
+log "url:     ${RUNSC_URL}"
+log "arch:    ${ARCH}"
+log "config:  SandboxConfig/${NAME} (default=${MAKE_DEFAULT})"
+
+if [[ "${SKIP_STAGE}" == "true" ]]; then
+  log "SKIP_STAGE=true; not uploading"
+elif [[ "${ATE_INSTALL_KIND}" == "true" ]]; then
+  log "Staging to in-cluster rustfs bucket ${BUCKET_NAME}..."
+  RUNSC="${RUNSC}" OBJECT="${OBJECT}" BUCKET="${BUCKET_NAME}" KUBECTL_CONTEXT="${KUBECTL_CONTEXT}" \
+    hack/gvisor-hack/stage-to-rustfs.sh
+else
+  log "Staging to gs://${BUCKET_NAME}/${OBJECT}..."
+  RUNSC="${RUNSC}" OBJECT="${OBJECT}" BUCKET="${BUCKET_NAME}" \
+    hack/gvisor-hack/stage-to-gcs.sh
+fi
+
+# Two defaults for one sandbox class make every actor launch fail to resolve its
+# assets, so demote the incumbent BEFORE applying rather than after.
+if [[ "${MAKE_DEFAULT}" == "true" ]]; then
+  log "Clearing spec.default on other gvisor SandboxConfigs..."
+  while read -r sc_name sc_class sc_default; do
+    [[ -z "${sc_name}" ]] && continue
+    if [[ "${sc_name}" != "${NAME}" && "${sc_class}" == "gvisor" && "${sc_default}" == "true" ]]; then
+      log "   demoting ${sc_name}"
+      "${KUBECTL[@]}" patch sandboxconfig "${sc_name}" --type=merge -p '{"spec":{"default":false}}'
+    fi
+  done < <("${KUBECTL[@]}" get sandboxconfigs -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.sandboxClass}{" "}{.spec.default}{"\n"}{end}')
+fi
+
+log "Applying SandboxConfig/${NAME}..."
+sed -e "s|\${NAME}|${NAME}|g" \
+    -e "s|\${DEFAULT}|${MAKE_DEFAULT}|g" \
+    -e "s|\${ARCH}|${ARCH}|g" \
+    -e "s|\${RUNSC_URL}|${RUNSC_URL}|g" \
+    -e "s|\${RUNSC_SHA256}|${RUNSC_SHA256}|g" \
+    hack/gvisor-hack/sandboxconfig.yaml.tmpl | "${KUBECTL[@]}" apply -f -
+
+if [[ -n "${WORKERPOOL}" ]]; then
+  log "Pointing WorkerPool ${WORKERPOOL_NAMESPACE}/${WORKERPOOL} at SandboxConfig/${NAME}..."
+  "${KUBECTL[@]}" -n "${WORKERPOOL_NAMESPACE}" patch workerpool "${WORKERPOOL}" \
+    --type=merge -p "{\"spec\":{\"sandboxConfigName\":\"${NAME}\"}}"
+fi
+
+cat <<EOF
+
+>> Deployed. SandboxConfig/${NAME} pins runsc ${RUNSC_SHA256}.
+
+   Sandbox assets are resolved when an actor starts, so actors already running
+   keep the runsc they booted with — create a new actor (or suspend/resume an
+   existing one) to pick this up.
+EOF
+
+if [[ -z "${WORKERPOOL}" && "${MAKE_DEFAULT}" != "true" ]]; then
+  cat <<EOF
+   Nothing references it yet. Point a pool at it with:
+
+     kubectl -n <namespace> patch workerpool <name> --type=merge \\
+       -p '{"spec":{"sandboxConfigName":"${NAME}"}}'
+EOF
+fi

--- a/hack/gvisor-hack/sandboxconfig.yaml.tmpl
+++ b/hack/gvisor-hack/sandboxconfig.yaml.tmpl
@@ -1,0 +1,44 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A SandboxConfig pinning a locally-built runsc, rendered and applied by
+# hack/gvisor-hack/deploy.sh (see the README in this directory). runsc is
+# fetched at runtime by atelet — nothing is baked into the worker image — so
+# swapping in an unreleased build is only a matter of staging the binary and
+# pointing a SandboxConfig at it.
+#
+# Placeholders (dollar-brace substituted by that script): NAME, DEFAULT, ARCH,
+# RUNSC_URL, RUNSC_SHA256.
+apiVersion: ate.dev/v1alpha1
+kind: SandboxConfig
+metadata:
+  name: ${NAME}
+spec:
+  sandboxClass: gvisor
+  # When true this replaces gvisor-default for the whole cluster; deploy.sh
+  # clears the flag on the previous default first, since resolution fails if two
+  # SandboxConfigs of the same class claim it.
+  default: ${DEFAULT}
+  assets:
+    # Single-arch on purpose. The sandboxconfig-assets ValidatingAdmissionPolicy
+    # requires a "runsc" asset for EVERY architecture listed, and atelet only
+    # fetches the block matching its node's GOARCH — so listing just the arch you
+    # built for is both valid and sufficient. Add a second block (and stage a
+    # second binary) for a mixed-arch cluster.
+    ${ARCH}:
+      runsc:
+        # The object name carries the digest, so re-staging a new build can never
+        # serve different bytes under a URL some other SandboxConfig still pins.
+        url: "${RUNSC_URL}"
+        sha256: "${RUNSC_SHA256}"

--- a/hack/gvisor-hack/stage-to-gcs.sh
+++ b/hack/gvisor-hack/stage-to-gcs.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stage a locally-built runsc into the GCS snapshot bucket, where atelet fetches
+# it (per hack/gvisor-hack/sandboxconfig.yaml.tmpl). The GKE counterpart of
+# stage-to-rustfs.sh; usually invoked by deploy.sh rather than directly.
+#
+# The bucket must be readable by atelet's service account: atelet tries an
+# anonymous client first and falls back to its main (authenticated) client, so a
+# private bucket in the cluster's own project works.
+#
+# Requires the `gcloud` CLI authenticated for the bucket's project. Env: RUNSC
+# (binary to stage, default ./bin/runsc), OBJECT (destination object name,
+# default gvisor-hack/runsc), BUCKET (default ate-snapshots), PROJECT_ID (optional;
+# passed to gcloud as --project when set).
+
+set -o errexit -o nounset -o pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+RUNSC="${RUNSC:-${ROOT}/bin/runsc}"
+OBJECT="${OBJECT:-gvisor-hack/runsc}"
+BUCKET="${BUCKET:-ate-snapshots}"
+
+if [[ ! -f "${RUNSC}" ]]; then
+  echo "error: runsc binary not found at ${RUNSC} (set RUNSC=/path/to/runsc)" >&2
+  exit 1
+fi
+
+# Pass --project only when PROJECT_ID is set (mirrors hack/microvm-assets/stage-to-gcs.sh);
+# otherwise gcloud uses its active config project.
+echo ">> Uploading ${RUNSC} to gs://${BUCKET}/${OBJECT} ..."
+gcloud storage cp ${PROJECT_ID:+--project="${PROJECT_ID}"} "${RUNSC}" "gs://${BUCKET}/${OBJECT}"
+
+echo ">> Done. Verify:"
+gcloud storage ls ${PROJECT_ID:+--project="${PROJECT_ID}"} "gs://${BUCKET}/$(dirname "${OBJECT}")/"

--- a/hack/gvisor-hack/stage-to-rustfs.sh
+++ b/hack/gvisor-hack/stage-to-rustfs.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stage a locally-built runsc into the kind cluster's rustfs S3 bucket, where
+# atelet fetches it (per hack/gvisor-hack/sandboxconfig.yaml.tmpl). The kind
+# counterpart of stage-to-gcs.sh; usually invoked by deploy.sh rather than
+# directly. Run after the cluster is up (hack/install-ate-kind.sh).
+#
+# Requires the `aws` CLI. Env: RUNSC (binary to stage, default ./bin/runsc),
+# OBJECT (destination object key, default gvisor-hack/runsc), BUCKET (default
+# ate-snapshots), NAMESPACE (rustfs namespace, default ate-system),
+# KUBECTL_CONTEXT (optional; kube context for the port-forward).
+
+set -o errexit -o nounset -o pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+RUNSC="${RUNSC:-${ROOT}/bin/runsc}"
+OBJECT="${OBJECT:-gvisor-hack/runsc}"
+BUCKET="${BUCKET:-ate-snapshots}"
+NAMESPACE="${NAMESPACE:-ate-system}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-}"
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "error: the 'aws' CLI is required but was not found in PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "${RUNSC}" ]]; then
+  echo "error: runsc binary not found at ${RUNSC} (set RUNSC=/path/to/runsc)" >&2
+  exit 1
+fi
+
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-rustfsadmin}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-rustfsadmin}"
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+
+echo ">> Port-forwarding svc/rustfs 9000 in namespace ${NAMESPACE}..."
+kubectl ${KUBECTL_CONTEXT:+--context="${KUBECTL_CONTEXT}"} -n "${NAMESPACE}" port-forward svc/rustfs 9000:9000 >/tmp/rustfs-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null || true' EXIT
+sleep 3
+
+ENDPOINT="http://localhost:9000"
+echo ">> Uploading ${RUNSC} to s3://${BUCKET}/${OBJECT} via ${ENDPOINT}..."
+aws --endpoint-url "${ENDPOINT}" s3 cp "${RUNSC}" "s3://${BUCKET}/${OBJECT}"
+
+echo ">> Done. Verify:"
+aws --endpoint-url "${ENDPOINT}" s3 ls "s3://${BUCKET}/$(dirname "${OBJECT}")/"

--- a/pkg/api/v1alpha1/sandboxconfig_validation_test.go
+++ b/pkg/api/v1alpha1/sandboxconfig_validation_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -192,5 +193,96 @@ func TestSandboxConfigValidation(t *testing.T) {
 				t.Errorf("Create() error = %q, want it to contain %q", err.Error(), tt.errMsg)
 			}
 		})
+	}
+}
+
+// hackTemplatePath is the SandboxConfig template hack/gvisor-hack/deploy.sh
+// renders to point a cluster at a locally-built gVisor runtime.
+const hackTemplatePath = "../../../hack/gvisor-hack/sandboxconfig.yaml.tmpl"
+
+// hackDeployScriptPath is the script that renders hackTemplatePath.
+const hackDeployScriptPath = "../../../hack/gvisor-hack/deploy.sh"
+
+// hackTemplateValues is what the test substitutes for each placeholder, standing
+// in for the values deploy.sh computes at run time.
+var hackTemplateValues = map[string]string{
+	"NAME":         "gvisor-hack-rendered",
+	"DEFAULT":      "false",
+	"ARCH":         "amd64",
+	"RUNSC_URL":    "gs://ate-snapshots/gvisor-hack/runsc-" + validSHA256,
+	"RUNSC_SHA256": validSHA256,
+}
+
+// TestGvisorHackTemplate renders the hack/gvisor-hack SandboxConfig template and
+// applies it to a real API server carrying the shipped CRD and
+// ValidatingAdmissionPolicy. The dev workflow's whole premise is that the
+// rendered object is accepted, so a schema or policy change that invalidates the
+// template should fail here rather than in someone's kind cluster. It also
+// checks that the template and its renderer agree on the placeholder set: a
+// placeholder deploy.sh does not substitute would reach the API server as a
+// literal "${...}".
+func TestGvisorHackTemplate(t *testing.T) {
+	ctx := t.Context()
+	applyVAP(t, ctx)
+
+	raw, err := os.ReadFile(hackTemplatePath)
+	if err != nil {
+		t.Fatalf("read template: %v", err)
+	}
+	script, err := os.ReadFile(hackDeployScriptPath)
+	if err != nil {
+		t.Fatalf("read deploy script: %v", err)
+	}
+
+	rendered := string(raw)
+	placeholders := regexp.MustCompile(`\$\{([A-Z0-9_]+)\}`).FindAllStringSubmatch(rendered, -1)
+	if len(placeholders) == 0 {
+		t.Fatal("template has no placeholders; it is no longer rendered by deploy.sh")
+	}
+	for _, m := range placeholders {
+		name := m[1]
+		value, ok := hackTemplateValues[name]
+		if !ok {
+			t.Fatalf("template placeholder %s has no value in this test; add one", m[0])
+		}
+		// deploy.sh renders with `sed -e "s|\${NAME}|...|g"`, so its source must
+		// mention each placeholder it is expected to substitute.
+		if !strings.Contains(string(script), `s|\`+m[0]+`|`) {
+			t.Errorf("deploy.sh has no sed expression for template placeholder %s", m[0])
+		}
+		rendered = strings.ReplaceAll(rendered, m[0], value)
+	}
+	if strings.Contains(rendered, "${") {
+		t.Fatalf("rendered template still contains a placeholder:\n%s", rendered)
+	}
+
+	obj := map[string]any{}
+	if err := yaml.Unmarshal([]byte(rendered), &obj); err != nil {
+		t.Fatalf("decode rendered template: %v", err)
+	}
+	u := &unstructured.Unstructured{Object: obj}
+	if err := k8sClient.Create(ctx, u); err != nil {
+		t.Fatalf("Create() rendered template: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, u) })
+
+	// Round-trip through the typed API to confirm the template produces the asset
+	// shape the gVisor backend looks up (atelet reads assets[GOARCH]["runsc"]).
+	sc := &SandboxConfig{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: hackTemplateValues["NAME"]}, sc); err != nil {
+		t.Fatalf("Get() rendered SandboxConfig: %v", err)
+	}
+	if sc.Spec.SandboxClass != SandboxClassGvisor {
+		t.Errorf("sandboxClass = %q, want %q", sc.Spec.SandboxClass, SandboxClassGvisor)
+	}
+	if sc.Spec.Default {
+		t.Error("default = true; the template must not claim the cluster default unless MAKE_DEFAULT is set")
+	}
+	asset, ok := sc.Spec.Assets[hackTemplateValues["ARCH"]]["runsc"]
+	if !ok {
+		t.Fatalf("no runsc asset for arch %q; got assets %v", hackTemplateValues["ARCH"], sc.Spec.Assets)
+	}
+	if asset.SHA256 != validSHA256 || asset.URL != hackTemplateValues["RUNSC_URL"] {
+		t.Errorf("runsc asset = %+v, want url %q sha256 %q", asset, hackTemplateValues["RUNSC_URL"], validSHA256)
 	}
 }


### PR DESCRIPTION
atelet fetches runsc at runtime from a url + sha256 on a cluster-scoped SandboxConfig, so trying an unreleased build needs no image rebuild — but there was no supported way to stage one, and the resolution path it would rely on was untested.

the tool is modelled on hack/microvm-assets/: deploy.sh hashes a local runsc, stages it (rustfs on kind, GCS on GKE), applies a SandboxConfig pinning it, and optionally repoints a WorkerPool. gvisor-default is left untouched; pools opt in via sandboxConfigName. 

So an unreleased gVisor feature can be tested in a cluster without hand-staging binaries or hand-writing a SandboxConfig.