### PR TITLE
atecontroller: add NET_BIND_SERVICE to gVisor worker capability set

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -200,12 +200,16 @@ func fieldRefEnv(name, fieldPath string) *corev1ac.EnvVarApplyConfiguration {
 // application (SYS_ADMIN/SYS_CHROOT/SYS_PTRACE), actor networking programs the
 // veth and nftables rules (NET_ADMIN/NET_RAW), and the OCI rootfs is unpacked
 // and device nodes created as root over image-owned trees
-// (DAC_OVERRIDE/FOWNER/CHOWN/MKNOD). This replaces the former privileged worker;
-// the default seccomp and AppArmor profiles are sufficient (no Unconfined).
+// (DAC_OVERRIDE/FOWNER/CHOWN/MKNOD). NET_BIND_SERVICE lets the atunnel listener
+// bind port 443 inside the worker pod: the container drops ALL capabilities and
+// re-adds an explicit list, so being UID 0 is insufficient — privileged-port
+// binding requires an explicit grant even as root when capabilities are dropped.
+// This replaces the former privileged worker; the default seccomp and AppArmor
+// profiles are sufficient (no Unconfined).
 var ateomGvisorCapabilities = []corev1.Capability{
 	"NET_ADMIN", "SYS_ADMIN", "SYS_CHROOT", "SYS_PTRACE",
 	"SETUID", "SETGID", "SETPCAP", "DAC_OVERRIDE",
-	"FOWNER", "CHOWN", "MKNOD", "NET_RAW", "SETFCAP",
+	"FOWNER", "CHOWN", "MKNOD", "NET_RAW", "SETFCAP", "NET_BIND_SERVICE",
 }
 
 // ateomSecurityContext returns the ateom container security context for a sandbox


### PR DESCRIPTION
The ateom container uses Drop: ALL with an explicit Add list, so being UID 0 does not grant privileged-port binding — NET_BIND_SERVICE must be explicitly added. Without it, atunnel's listener on port 443 gets bind: permission denied on bare-metal nodes. GKE masked the bug via platform-level defaults that do not reliably propagate into every pod netns.

Tested on a bare-metal kubeadm cluster (RHEL 10.2, CRI-O 1.36.2).

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
