### PR TITLE
graceful termination for atelet

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -25,9 +25,11 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -77,6 +79,9 @@ var (
 
 	showVersion  = pflag.Bool("version", false, "Print version and exit.")
 	logLevelFlag = pflag.String("log-level", "info", "Minimum log level: debug, info, warn, or error.")
+
+	drainDelay   = pflag.Duration("drain-delay", 0, "How long to keep accepting new RPCs after SIGTERM before starting the gRPC drain.")
+	drainTimeout = pflag.Duration("drain-timeout", 5*time.Minute, "Deadline for the graceful gRPC drain on shutdown. In-flight RPCs still running past it are forcefully cancelled.")
 )
 
 func main() {
@@ -90,6 +95,12 @@ func main() {
 	if err := serverboot.SetLogLevel(*logLevelFlag); err != nil {
 		serverboot.Fatal(ctx, "Invalid --log-level", err)
 	}
+
+	// Kept separate from ctx so in-flight work (e.g. a Checkpoint/Restore
+	// streaming a multi-GiB snapshot) is not cancelled the moment SIGTERM
+	// arrives; drainOnShutdown drives the shutdown sequence instead.
+	shutdownCtx, stopSignals := signal.NotifyContext(ctx, syscall.SIGTERM, os.Interrupt)
+	defer stopSignals()
 
 	tp, err := serverboot.InitTracing(ctx, serverboot.TracingOptions{
 		ServiceName: "atelet",
@@ -110,7 +121,14 @@ func main() {
 		serverboot.Fatal(ctx, "Failed to create snapshot size metric", err)
 	}
 
-	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{Addr: *metricsListenAddr})
+	// readiness flips to not-ready on SIGTERM so /readyz reports 503 while the
+	// pod drains, while /healthz stays 200 for liveness.
+	readiness := &serverboot.Readiness{}
+	go serverboot.StartMetricsServer(ctx, serverboot.MetricsServerOptions{
+		Addr:          *metricsListenAddr,
+		Readiness:     readiness,
+		EnableHealthz: true,
+	})
 
 	ateomDialer := &AteomDialer{
 		conns: lru.New(256),
@@ -200,9 +218,45 @@ func main() {
 	ateletpb.RegisterAteomHerderServer(svr, wmService)
 	reflection.Register(svr)
 	slog.InfoContext(ctx, "WorkersManagerService listening", slog.Any("address", lis.Addr()))
+
+	drainDone := drainOnShutdown(shutdownCtx, svr, readiness)
 	if err := svr.Serve(lis); err != nil {
 		serverboot.Fatal(ctx, "Failed to serve", err)
 	}
+	<-drainDone
+	slog.InfoContext(ctx, "Shutdown complete")
+}
+
+// drainOnShutdown drives graceful shutdown when ctx is cancelled (SIGTERM or
+// interrupt): it marks the process not-ready, waits drain-delay while still
+// accepting work, then GracefulStop()s the gRPC server so in-flight RPCs finish.
+// If they run past drain-timeout it forcefully Stop()s. The returned channel
+// closes once shutdown completes, so main can block on it before exiting (and
+// letting the deferred tracer/meter flushes run). Mirrors ateapi's
+// drainOnShutdown.
+func drainOnShutdown(ctx context.Context, srv *grpc.Server, readiness *serverboot.Readiness) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		<-ctx.Done()
+		slog.InfoContext(ctx, "Shutdown signal received; draining")
+		readiness.MarkNotReady()
+		time.Sleep(*drainDelay)
+		slog.InfoContext(ctx, "Starting gRPC drain")
+		drainComplete := make(chan struct{})
+		go func() {
+			srv.GracefulStop()
+			close(drainComplete)
+		}()
+		select {
+		case <-drainComplete:
+			slog.InfoContext(ctx, "Drain completed within deadline")
+		case <-time.After(*drainTimeout):
+			slog.WarnContext(ctx, "Drain deadline exceeded; forcing stop")
+			srv.Stop()
+		}
+	}()
+	return done
 }
 
 // AteomHerder is a service that allows controlling workloads on individual

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -22,21 +22,27 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/agent-substrate/substrate/internal/ateerrors"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/serverboot"
 	"github.com/google/go-cmp/cmp"
 	"github.com/klauspost/compress/zstd"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestSnapshotManifestActorMetadata(t *testing.T) {
@@ -812,5 +818,145 @@ func TestDownloadCombinedCheckpoint(t *testing.T) {
 		if string(got) != content {
 			t.Errorf("%s content = %q, want %q", name, got, content)
 		}
+	}
+}
+
+// blockerDesc registers a single unary method whose handler blocks until block
+// is closed (or the RPC context is cancelled). It lets a test hold one RPC
+// "in-flight" across a drain without any generated proto.
+func blockerDesc(block <-chan struct{}) grpc.ServiceDesc {
+	return grpc.ServiceDesc{
+		ServiceName: "drain.test.Blocker",
+		HandlerType: (*any)(nil),
+		Methods: []grpc.MethodDesc{{
+			MethodName: "Block",
+			Handler: func(_ any, ctx context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+				if err := dec(new(emptypb.Empty)); err != nil {
+					return nil, err
+				}
+				select {
+				case <-block:
+					return new(emptypb.Empty), nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			},
+		}},
+	}
+}
+
+// newBlockingTestServer starts a gRPC server on a loopback port exposing the
+// blocker service and returns it with a connected client.
+func newBlockingTestServer(t *testing.T, block <-chan struct{}) (*grpc.Server, *grpc.ClientConn) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	desc := blockerDesc(block)
+	srv.RegisterService(&desc, nil)
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient(
+		lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return srv, conn
+}
+
+func callBlock(conn *grpc.ClientConn) <-chan error {
+	rpcErr := make(chan error, 1)
+	go func() {
+		rpcErr <- conn.Invoke(context.Background(), "/drain.test.Blocker/Block",
+			new(emptypb.Empty), new(emptypb.Empty))
+	}()
+	return rpcErr
+}
+
+// TestDrainOnShutdownInFlightFinishes asserts that an RPC already in flight when
+// SIGTERM arrives is allowed to complete (GracefulStop waits for it) and that
+// readiness flips to not-ready.
+func TestDrainOnShutdownInFlightFinishes(t *testing.T) {
+	*drainDelay = 0
+	*drainTimeout = 5 * time.Second
+
+	block := make(chan struct{})
+	srv, conn := newBlockingTestServer(t, block)
+
+	rpcErr := callBlock(conn)
+	time.Sleep(100 * time.Millisecond) // let the RPC reach the handler
+
+	readiness := &serverboot.Readiness{}
+	ctx, cancel := context.WithCancel(context.Background())
+	drainDone := drainOnShutdown(ctx, srv, readiness)
+
+	cancel() // simulate SIGTERM
+
+	// Release the handler shortly after the drain begins; a graceful drain must
+	// wait for it rather than abort it.
+	time.Sleep(100 * time.Millisecond)
+	close(block)
+
+	select {
+	case err := <-rpcErr:
+		if err != nil {
+			t.Fatalf("in-flight RPC should complete during graceful drain, got: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("in-flight RPC did not complete")
+	}
+
+	select {
+	case <-drainDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("drain did not complete")
+	}
+	if readiness.Ready() {
+		t.Fatal("readiness should be not-ready after drain")
+	}
+}
+
+// TestDrainOnShutdownForceStopsAfterTimeout asserts that an RPC still running
+// past drain-timeout is forcefully cancelled by Stop().
+func TestDrainOnShutdownForceStopsAfterTimeout(t *testing.T) {
+	*drainDelay = 0
+	*drainTimeout = 200 * time.Millisecond
+
+	block := make(chan struct{}) // never closed → handler blocks past the timeout
+	srv, conn := newBlockingTestServer(t, block)
+
+	rpcErr := callBlock(conn)
+	time.Sleep(100 * time.Millisecond)
+
+	readiness := &serverboot.Readiness{}
+	ctx, cancel := context.WithCancel(context.Background())
+	start := time.Now()
+	drainDone := drainOnShutdown(ctx, srv, readiness)
+	cancel()
+
+	select {
+	case <-drainDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("drain did not force-stop within deadline")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("force stop took too long (%v); expected ~drain-timeout", elapsed)
+	}
+
+	select {
+	case err := <-rpcErr:
+		if err == nil {
+			t.Fatal("in-flight RPC should have been aborted by force stop")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight RPC did not return after force stop")
+	}
+	if readiness.Ready() {
+		t.Fatal("readiness should be not-ready after drain")
 	}
 }

--- a/manifests/ate-install/atelet.yaml
+++ b/manifests/ate-install/atelet.yaml
@@ -64,6 +64,12 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: atelet
+      # Budget for the full shutdown sequence: --drain-delay (0 for atelet) +
+      # --drain-timeout (5m). Sized long because Checkpoint/Restore stream
+      # multi-GiB snapshots and must not be force-cancelled mid-upload. The sum
+      # must fit within terminationGracePeriodSeconds, plus slack for the force
+      # Stop() and the tracer/meter flush on exit.
+      terminationGracePeriodSeconds: 330
       containers:
       - name: atelet
         image: ko://github.com/agent-substrate/substrate/cmd/atelet
@@ -71,6 +77,10 @@ spec:
         - --gcp-auth-for-image-pulls=true
         - --grpc-server-cred-bundle=/run/podidentity.podcert.ate.dev/credential-bundle.pem
         - --client-ca-certs=/run/podidentity.podcert.ate.dev/trust-bundle.pem
+        # Graceful shutdown knobs. The sum must fit within
+        # terminationGracePeriodSeconds above.
+        - --drain-delay=0s
+        - --drain-timeout=5m
         # atelet does no mounts, netlink, device, or namespace operations (those
         # live in the ateom worker pod) — it only reads/writes the
         # /var/lib/ateom-gvisor hostPath as root, so it needs no Linux
@@ -117,6 +127,21 @@ spec:
           containerPort: 9090
           hostPort: 9090
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9090
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          failureThreshold: 3
+        # /healthz stays 200 while a terminating pod drains; /readyz turns 503,
+        # so liveness and readiness diverge correctly during shutdown.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - name: run-ateom
           mountPath: /var/lib/ateom-gvisor


### PR DESCRIPTION
#### What this PR does / why we need it:
`atelet` previously had no `SIGTERM` handling — `main()` ended in a bare `svr.Serve(lis)`, so any pod eviction, `DaemonSet` rollout, or node drain killed the process instantly, aborting in-flight `Run`/`Checkpoint`/`Restore` RPCs mid-execution.

This PR adopts the same graceful-shutdown pattern `ate-api` uses: on `SIGTERM`, mark not-ready, stop accepting new RPCs, let in-flight RPCs finish, and force-stop after a deadline. 

- `cmd/atelet/main.go`: 
  - `signal.NotifyContext` (kept separate from the work ctx so in-flight RPCs aren't cancelled the moment `SIGTERM` arrives) + a local `drainOnShutdown` mirroring `ateapi`'s: `MarkNotReady` → sleep `--drain-delay` → `GracefulStop()` → force `Stop() `after `--drain-timeout`.` /readyz` and `/healthz` are wired into the metrics server (`serverboot.Readiness`), so readiness and liveness diverge correctly during the drain.
  - Flags: `--drain-delay` (default **`0s`** — `atelet` is dialed directly by pod IP, no route-drain window is needed) and `--drain-timeout` (default **`5m`** — `Checkpoint`/`Restore` stream multi-GiB snapshots to object storage and
  can take minutes; force-cancelling one mid-upload crashes the actor).
- `manifests/ate-install/atelet.yaml`: `terminationGracePeriodSeconds: 330 `(drain-delay + drain-timeout + slack — the sum must fit inside the grace period or the kubelet `SIGKILLs` mid-drain), the drain flags, and `/readyz` readiness + `/healthz` liveness probes.

**Test Scenarios Considered:**
| In-flight at `SIGTERM` | Force-stop (past timeout) |
|---|---|
| Idle | n/a |
| Checkpoint (suspend, external) | upload aborted → `CRASHED` (#362) |
| Pause (local checkpoint) | aborted → crash |
| Restore (resume) | RPC fails → ateapi retries |
| Run (cold boot) | RPC fails → retried |
| Multiple concurrent RPCs | one shared timeout; stragglers cut |
| New RPC during drain | rejected `Unavailable` → ateapi retries |

**Testing:**
 - Unit (`cmd/atelet/main_test.go`): a loopback gRPC server with a blocking handler holds an RPC in-flight across the drain.
    - `TestDrainOnShutdownInFlightFinishes` — in-flight RPC completes during `GracefulStop`; readiness flips to not-ready.
    - `TestDrainOnShutdownForceStopsAfterTimeout` — an RPC running past drain-timeout is force-cancelled by Stop().
  - Live on a kind cluster (`hack/install-ate-kind.sh --deploy-atelet`, then `kubectl delete pod` to deliver `SIGTERM`, with `--drain-delay=25s` temporarily set to make the window observable):
    - Steady state: `/readyz=200`, `/healthz=200` (old build had no /readyz at all).
    - During drain:`/readyz=503` while `/healthz=200` for the whole window — `NotReady` but alive.
    - Log sequence in order, with the 25s drain-delay honored exactly: Shutdown signal received; draining → (+25s) Starting gRPC drain → Drain completed within deadline → Shutdown complete.


#### Which issue(s) this PR is related to:
Fixes #719 
Required for System Upgrade flow (#473)

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
