### PR TITLE
benchmarking: add observability benchmarking for the OTel collector

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -2,6 +2,12 @@
 
 This is the nascent suite for benchmarking Substrate's performance at scale.
 
+The suite also measures the telemetry volume and the capacity of the OTel
+collector: how much trace data and metric data substrate and its actors send,
+and if the collector can accept it. To make a measurement, read
+[telemetry/README.md](telemetry/README.md). For the prerequisites and the
+scenario ladder, read [observability.md](observability.md).
+
 ## Deploy benchmarks
 
 > [!IMPORTANT]

--- a/benchmarking/deploy_locust.sh
+++ b/benchmarking/deploy_locust.sh
@@ -28,6 +28,7 @@ BENCHMARKING_DIR="${ROOT}/benchmarking"
 WORKER_COUNT=1
 SANDBOX_CLASS=gvisor
 SKIP_BUILD=0
+OTLP_ENDPOINT=""
 
 usage() {
   echo "Usage: $0 [options]"
@@ -38,6 +39,8 @@ usage() {
   echo "  --worker-count N        Number of WorkerPool replicas (default: 1)"
   echo "  --sandbox-class CLASS   Sandbox runtime for the WorkerPool: gvisor | microvm (default: gvisor)."
   echo "                          microvm requires hack/install-microvm-deps.sh --install to have run."
+  echo "  --otlp-endpoint URL     Forwarded to workloads/deploy.sh. The address to which an"
+  echo "                          instrumented actor container sends telemetry."
   echo "  --skip-build            Skip locust image build/push (use the existing :latest image)"
   echo "  -h|--help               Show this help message"
   echo ""
@@ -60,6 +63,8 @@ while [[ "$#" -gt 0 ]]; do
     --worker-count=*) WORKER_COUNT="${1#*=}" ;;
     --sandbox-class) shift; SANDBOX_CLASS="$1" ;;
     --sandbox-class=*) SANDBOX_CLASS="${1#*=}" ;;
+    --otlp-endpoint) shift; OTLP_ENDPOINT="$1" ;;
+    --otlp-endpoint=*) OTLP_ENDPOINT="${1#*=}" ;;
     --skip-build) SKIP_BUILD=1 ;;
     -h|--help) usage; exit 0 ;;
     *)
@@ -81,10 +86,14 @@ esac
 
 if [[ "${action}" == "deploy" ]]; then
   echo "=== Deploying benchmark workloads (worker_count=${WORKER_COUNT}, sandbox_class=${SANDBOX_CLASS}) ==="
-  "${BENCHMARKING_DIR}/workloads/deploy.sh" \
-    --deploy \
-    --worker-count "${WORKER_COUNT}" \
-    --sandbox-class "${SANDBOX_CLASS}"
+  # An empty OTLP_ENDPOINT must not become an empty --otlp-endpoint argument,
+  # which would overwrite the default in workloads/deploy.sh with an empty
+  # string and send the actor telemetry nowhere.
+  workload_args=(--deploy --worker-count "${WORKER_COUNT}" --sandbox-class "${SANDBOX_CLASS}")
+  if [[ -n "${OTLP_ENDPOINT}" ]]; then
+    workload_args+=(--otlp-endpoint "${OTLP_ENDPOINT}")
+  fi
+  "${BENCHMARKING_DIR}/workloads/deploy.sh" "${workload_args[@]}"
 
   if [[ "${SKIP_BUILD}" -eq 0 ]]; then
     echo

--- a/benchmarking/monitoring.yaml
+++ b/benchmarking/monitoring.yaml
@@ -50,6 +50,33 @@ subjects:
   name: prometheus
   namespace: benchmarking
 ---
+# A node is a cluster-scoped resource. Thus the namespaced Role above cannot
+# give access to node discovery or to the kubelet proxy. The cadvisor scrape
+# job needs the two permissions.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-benchmarking-nodes
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "nodes/proxy", "nodes/metrics"]
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-benchmarking-nodes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-benchmarking-nodes
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: benchmarking
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -82,6 +109,64 @@ data:
             regex: ([^:]+)(?::\d+)?;(\d+)
             replacement: $1:$2
             target_label: __address__
+
+      # The telemetry-meter gives its substrate_* counts on port 8889, which
+      # the annotation job above collects. It gives its own otelcol_* counters
+      # on port 8888. The annotation relabel can name only one port, thus
+      # scrape port 8888 here. When a service reports zero volume,
+      # otelcol_receiver_accepted_* shows the difference between "sent nothing"
+      # and "arrived nowhere".
+      - job_name: 'telemetry-meter-self'
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - benchmarking
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_pod_label_app
+              - __meta_kubernetes_pod_container_port_number
+            action: keep
+            regex: telemetry-meter;8888
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+
+      # The container memory directly from the cAdvisor endpoint of the
+      # kubelet. `kubectl top` reads metrics-server, which reports an average
+      # across its own window and hides short peaks.
+      # container_memory_working_set_bytes is the value that the OOM killer
+      # uses.
+      - job_name: 'kubernetes-cadvisor'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+        metric_relabel_configs:
+          # cAdvisor sends a very large number of metrics. Keep only the
+          # metrics that the benchmarks read.
+          - source_labels: [__name__]
+            action: keep
+            regex: container_(memory_working_set_bytes|cpu_usage_seconds_total|spec_memory_limit_bytes)
+          # Drop the series that have an empty container label, not the label
+          # itself. cAdvisor gives a rollup for the whole pod cgroup next to
+          # the series for each container. Keeping both counts the memory of
+          # each pod two times.
+          - source_labels: [container]
+            action: drop
+            regex: ""
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/benchmarking/observability.md
+++ b/benchmarking/observability.md
@@ -1,0 +1,72 @@
+# Observability benchmarking
+
+This page shows how much telemetry substrate sends, and what that telemetry
+costs the OTel collector.
+
+- To make a measurement, read [telemetry/README.md](telemetry/README.md).
+- For the volume model and the collector size guidance, read
+  [OTel Collector](../docs/dev/best-practices/otel-collector.md).
+- This page contains the scenario ladder.
+
+This page holds no results. The automation writes the values of each run to
+GCS. A result in this repository becomes incorrect after a change to the
+sample rates or to the instruments, and no reader can then see which copy is
+correct.
+
+---
+
+## 1. Scenario ladder
+
+`SleepUser` ([`locust/tests/sleep.py`](locust/tests/sleep.py)) does one suspend
+operation and one resume operation for each task. Thus
+`cycles/sec ≈ users / (1.0s + avg_wait_time)`. Change the number of users. Do
+not change the wait time.
+
+| # | Scenario | Duration | Setup |
+|---|---|---|---|
+| **S0** | Idle floor | 5m | No load |
+| **S1** | Suspend and resume sweep | 3m for each step | `SleepUser`, `--trace-probability 0.1`, users 5 → 15 → 30 |
+| **S2** | Sample-rate sweep | 3m for each step | The number of users stays the same. `--trace-probability` 0 → 0.1 → 1.0 |
+| **S3** | Soak | 15m | 80% of the maximum load above |
+
+Do not make a step shorter than 3 minutes. The metrics push interval is 60
+seconds. A shorter step gives less than three datapoints for each series. You
+cannot then tell the difference between a trend and noise.
+
+Do these runs with the headless runner in
+[automation/tests.yaml](automation/tests.yaml). In headless mode, `runner.py`
+sends `--trace-probability` to the boomer worker at start, and writes the value
+in the run config header. Thus each run records the rate that it used.
+
+The locust web UI is for manual examination only. Two conditions apply there.
+The `boomer-glutton` sidecar makes its own load for each user class that you
+select in the form. Also, the form changes the sample rate of the boomer worker
+but not of the Python workers: `locust.yaml` gives boomer `--master-web-port`,
+thus boomer reads `/boomer-config` from the master at each spawn message.
+
+**Pass criteria.** `otelcol_receiver_refused_*` must be zero.
+`otelcol_exporter_enqueue_failed_*` must be zero. `queue_full` on the client
+must be zero. The number of collector replicas must stay below `maxReplicas`.
+In S3, the slope of the collector working set and the slope of
+`otelcol_exporter_queue_size` must be equivalent to zero.
+
+Examine the positive control also. `otelcol_receiver_accepted_*` must be more
+than zero for each service that must send data. If you do not examine it, an
+exporter that sends nothing looks the same as a good run.
+
+---
+
+## 2. Open items
+
+- Add the ladder to [automation/tests.yaml](automation/tests.yaml). Write the
+  results as artifacts of each run.
+- Measure the collector CPU and memory from the working set. Do not use
+  `kubectl top`, which calculates an average and hides peaks.
+- Record `otelcol_receiver_accepted_*` with each volume table as a positive
+  control.
+- Record the number of collector replicas with the CPU and the memory. Without
+  the number of replicas, a collector with no capacity and a collector with
+  much capacity give the same table.
+- Measure the actor volume. The `glutton` template now sets an OTLP endpoint,
+  thus actor telemetry arrives for the first time.
+- Measure the DaemonSet configuration in the collector size guidance.

--- a/benchmarking/telemetry/README.md
+++ b/benchmarking/telemetry/README.md
@@ -128,7 +128,7 @@ the pass criteria:
 sum(rate(otelcol_receiver_refused_spans[5m]))   # must be 0
 sum(rate(otelcol_exporter_sent_spans[5m]))      # must be more than 0
 max_over_time(otelcol_exporter_queue_size[5m])  # must stay level
-absent(otelcol_exporter_queue_size)             # must give no result
+absent(otelcol_exporter_sent_spans)             # must give no result
 ```
 
 Do not use `otelcol_exporter_send_failed_spans` alone. The default

--- a/benchmarking/telemetry/README.md
+++ b/benchmarking/telemetry/README.md
@@ -1,0 +1,184 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Telemetry meter
+
+The meter measures how much telemetry substrate sends, and which component
+sends it.
+
+The managed collector sends its self-metrics to Cloud Monitoring only, and
+gives no data for each source. Thus [`meter.yaml`](meter.yaml) is a second
+collector that counts the spans and the datapoints by `service.name`. The meter
+is a tee: it counts the data and then sends it on to the managed collector, thus
+the managed collector keeps the load of the run.
+
+For the prerequisites and the scenario ladder, read
+[observability.md](../observability.md). For the volume model, read
+[OTel Collector](../../docs/dev/best-practices/otel-collector.md).
+
+## Make a measurement
+
+Install the meter, then send the control plane to it:
+
+```bash
+kubectl apply -f benchmarking/telemetry/meter.yaml
+
+METER=http://telemetry-meter.benchmarking.svc.cluster.local:4317
+./hack/install-ate.sh --deploy-ate-system --otlp-endpoint "${METER}"
+```
+
+`--otlp-endpoint` patches the `ate-otel-config` ConfigMap and restarts the
+workloads that read it. One patch is sufficient for `ateapi`, `ate-controller`,
+`atelet`, and `atenet-router`, because each one reads the ConfigMap through
+`envFrom`. `ate-controller` also copies the values to the ateom worker pods
+that it creates.
+
+The actor containers are different. Substrate puts no OTLP configuration in
+them, thus they use the `env` of the ActorTemplate:
+
+```bash
+./benchmarking/workloads/deploy.sh --deploy
+```
+
+Without `--otlp-endpoint`, the script reads the endpoint from the
+`ate-otel-config` ConfigMap. The step above already changed that ConfigMap,
+thus the actors follow the control plane to the meter. Give `--otlp-endpoint`
+only to send the actors to a different address than the control plane.
+
+Keep the load generator on the usual collector. If you do not, the meter counts
+the telemetry of the load generator as telemetry from substrate.
+
+## Read the numbers
+
+[`monitoring.yaml`](../monitoring.yaml) scrapes the meter. Read the values
+through Prometheus. Do not compare raw scrapes manually.
+
+```bash
+kubectl apply -f benchmarking/monitoring.yaml
+kubectl port-forward -n benchmarking svc/prometheus 9090:9090
+```
+
+| To find | Query |
+|---|---|
+| Spans/sec for each service | `sum by (svc) (rate(substrate_spans_total[5m]))` |
+| Datapoints/min for each service | `60 * sum by (svc) (rate(substrate_datapoints_total[5m]))` |
+| If the data arrived | `sum(rate(otelcol_receiver_accepted_spans[5m]))` |
+| If the collector rejected the data | `sum(rate(otelcol_receiver_refused_spans[5m]))` |
+
+Keep the range at three times the 60s push interval or more. `[5m]` is a good
+default. A range less than 3m gives noise.
+
+Always read the last two counters. A service that reports zero volume gives no
+data by itself: `accepted` must be more than zero and `refused` must be zero
+for the same window. If they are not, the zero shows that the data did not
+arrive, not that the service sent no data.
+
+## The meter is a tee
+
+The meter counts the telemetry and then sends it on to the managed collector.
+Thus one run gives both measurements: the volume for each service, from the
+meter, and the cost of the load, from the managed collector.
+
+```promql
+max_over_time(
+  container_memory_working_set_bytes{namespace="gke-managed-otel", container!=""}[5m]
+)
+```
+
+Use the working set for the memory. `kubectl top` reads metrics-server, which
+calculates an average across its own window and hides short peaks. The working
+set is the value that the OOM killer uses. Divide the working set by
+`container_spec_memory_limit_bytes` to get the fraction of the limit in use.
+
+Record the number of replicas with the CPU and the memory. The managed
+collector is an HPA-scaled Deployment. Without the number of replicas, a
+collector at its maximum replica count and a collector with much margin give
+the same table.
+
+### Three conditions of the tee
+
+**The managed collector attributes the telemetry to the meter.** It applies
+`k8sattributes` with `from: connection`, and each forwarded item now comes from
+the meter pod. The volume and the CPU stay correct, but a query that groups by
+pod on the managed side does not. Group by `service.name` from the resource,
+which stays correct after the hop.
+
+**The shape of the load changes.** Usually many processes each keep a
+connection to the managed collector. With the tee there is one sender and
+larger batches. Thus the total is correct, but the distribution across the
+replicas is not, and the effect of connection stickiness disappears.
+
+**The meter can become the limit.** It is one replica. Add its own counters to
+the pass criteria:
+
+```promql
+sum(rate(otelcol_receiver_refused_spans[5m]))   # must be 0
+sum(rate(otelcol_exporter_sent_spans[5m]))      # must be more than 0
+max_over_time(otelcol_exporter_queue_size[5m])  # must stay level
+absent(otelcol_exporter_queue_size)             # must give no result
+```
+
+Do not use `otelcol_exporter_send_failed_spans` alone. The default
+`retry_on_failure.max_elapsed_time` is 5 minutes, thus the exporter retries for
+that period before it counts a failure. A meter that sheds data looks correct
+for the length of a short step. The depth of the queue moves immediately, thus
+it is the signal to watch. `absent()` catches the different condition where the
+meter reports nothing at all.
+
+If the meter sheds data, the volume and the cost are both incorrect, and the
+two errors hide each other.
+
+To make the meter terminal, delete the two forward pipelines in
+[`meter.yaml`](meter.yaml). Use a terminal meter for a long soak, to keep that
+telemetry out of Cloud Monitoring. The resource values of the managed collector
+are then those of an idle collector, and you must not record them.
+
+## Counters for drops at the client
+
+The meter shows the data that arrived. It does not show the data that the
+client dropped. Turn on the instrumentation in the SDK:
+
+```bash
+kubectl set env -n ate-system deployment/ate-api-server OTEL_GO_X_OBSERVABILITY=true
+```
+
+Scrape `:9090/metrics` on the process. That endpoint is a Prometheus reader
+that does not use the OTLP path. Thus it continues to operate during the
+congestion that it measures.
+
+| Metric | Shows |
+|---|---|
+| `otel_sdk_span_started_total{otel_span_parent_origin,otel_span_sampling_result}` | The sample decisions, for root spans and for inherited spans |
+| `otel_sdk_processor_span_processed_total{error_type="queue_full"}` | The spans that the client dropped |
+| `otel_sdk_processor_span_queue_size` vs `_capacity` | The margin before the drops start |
+
+Without the counter for the drops, a loss at the client looks the same as a
+stable plateau.
+
+The flag is experimental. It is in `sdk/internal/x`, thus the names of the
+metrics can change when you upgrade the SDK. Examine the names again after each
+upgrade.
+
+## Remove the meter
+
+```bash
+./hack/install-ate.sh --deploy-ate-system
+./benchmarking/workloads/deploy.sh --deploy
+kubectl delete -f benchmarking/telemetry/meter.yaml
+```
+
+The two scripts go back to the default endpoint when you do not give
+`--otlp-endpoint`.

--- a/benchmarking/telemetry/meter.yaml
+++ b/benchmarking/telemetry/meter.yaml
@@ -1,0 +1,206 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# telemetry-meter: an OTLP sink that counts the telemetry that substrate sends,
+# for each service that sends it.
+#
+# See benchmarking/telemetry/README.md. Send substrate to
+#   http://telemetry-meter.benchmarking.svc.cluster.local:4317
+# for the duration of a measurement, then scrape :8889 for
+#
+#   substrate_spans_total{svc="..."}       the spans from each service
+#   substrate_datapoints_total{svc="..."}  the datapoints from each service
+#
+# Scrape :8888 for the otelcol_* receiver counters of the meter.
+#
+# The meter is a tee. It counts the telemetry and then sends it on to the
+# managed collector, thus the resource values of the managed collector stay
+# correct during a measurement. It is not a replacement for that collector.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmarking
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telemetry-meter-config
+  namespace: benchmarking
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      # The count connector sends deltas. Each batch has a new start timestamp,
+      # and the Prometheus exporter reads a new start timestamp as a reset of
+      # the counter. Without deltatocumulative the counters do not accumulate,
+      # and each scrape shows only the last batch.
+      deltatocumulative:
+
+      # The count connector reads the attributes of a span or a datapoint. It
+      # does not read the attributes of the resource, thus service.name is not
+      # visible to it. Copy service.name to a datapoint attribute. Without this
+      # copy the connector has nothing to group by, and it counts all the
+      # services into one bucket.
+      #
+      # This is not a correction for the scrape configuration. honor_labels
+      # changes what Prometheus does with the labels of a scrape, and a scrape
+      # occurs after the connector counts. Thus honor_labels cannot give the
+      # connector an attribute to count by, and it is not an alternative to
+      # this transform.
+      #
+      # The name is svc, and not job, because Prometheus sets job to the name
+      # of the scrape job.
+      transform/svc:
+        error_mode: ignore
+        trace_statements:
+          - context: span
+            statements:
+              - set(attributes["svc"], resource.attributes["service.name"])
+        metric_statements:
+          - context: datapoint
+            statements:
+              - set(attributes["svc"], resource.attributes["service.name"])
+
+    connectors:
+      count:
+        spans:
+          substrate_spans:
+            description: Spans received, by emitting service.
+            attributes:
+              # Without a default value, the connector removes each item that
+              # has no service.name from the count. The item does not show as
+              # unknown, and the totals are too low with no error message.
+              - key: svc
+                default_value: unknown
+        datapoints:
+          substrate_datapoints:
+            description: Metric datapoints received, by emitting service.
+            attributes:
+              - key: svc
+                default_value: unknown
+
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+
+      # The meter is a tee, not a terminal sink. It counts the telemetry and
+      # then sends it on to the collector that the cluster uses. Thus the
+      # managed collector keeps the load of the run, and its CPU, memory, and
+      # replica count stay correct while you measure the volume.
+      #
+      # To make the meter terminal, delete the two forward pipelines below.
+      # The counts continue to work. A terminal meter keeps the telemetry of a
+      # long run out of Cloud Monitoring, but it makes the resource values of
+      # the managed collector those of an idle collector.
+      otlp/managed:
+        endpoint: opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
+        tls:
+          insecure: true
+
+    service:
+      pipelines:
+        # The count pipelines and the forward pipelines read the same receiver.
+        # The collector sends a copy of the data to each pipeline, and it clones
+        # the data because transform/svc changes it. Thus the svc attribute that
+        # the count needs does not go to the managed collector.
+        traces/count:
+          receivers: [otlp]
+          processors: [transform/svc]
+          exporters: [count]
+        traces/forward:
+          receivers: [otlp]
+          exporters: [otlp/managed]
+        metrics/count:
+          receivers: [otlp]
+          processors: [transform/svc]
+          exporters: [count]
+        metrics/forward:
+          receivers: [otlp]
+          exporters: [otlp/managed]
+        metrics/counts:
+          receivers: [count]
+          processors: [deltatocumulative]
+          exporters: [prometheus]
+      telemetry:
+        metrics:
+          level: detailed
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: 0.0.0.0
+                    port: 8888
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telemetry-meter
+  namespace: benchmarking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: telemetry-meter
+  template:
+    metadata:
+      labels:
+        app: telemetry-meter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8889"
+    spec:
+      containers:
+      - name: collector
+        image: otel/opentelemetry-collector-contrib:0.152.0
+        args: ["--config=/conf/config.yaml"]
+        ports:
+        - {name: otlp-grpc, containerPort: 4317}
+        - {name: otlp-http, containerPort: 4318}
+        - {name: self, containerPort: 8888}
+        - {name: counts, containerPort: 8889}
+        resources:
+          requests:
+            cpu: "1"
+            memory: 1Gi
+          limits:
+            memory: 4Gi
+        volumeMounts:
+        - name: config
+          mountPath: /conf
+      volumes:
+      - name: config
+        configMap:
+          name: telemetry-meter-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: telemetry-meter
+  namespace: benchmarking
+spec:
+  selector:
+    app: telemetry-meter
+  ports:
+  - {name: otlp-grpc, port: 4317, targetPort: 4317}
+  - {name: otlp-http, port: 4318, targetPort: 4318}
+  - {name: self, port: 8888, targetPort: 8888}
+  - {name: counts, port: 8889, targetPort: 8889}

--- a/benchmarking/workloads/deploy.sh
+++ b/benchmarking/workloads/deploy.sh
@@ -38,6 +38,10 @@ fi
 
 WORKER_COUNT=1
 SANDBOX_CLASS="gvisor"
+# The address to which an instrumented actor container sends its telemetry.
+# --otlp-endpoint sets it. Without the flag, resolve_otlp_endpoint reads the
+# address that the control plane uses.
+OTLP_ENDPOINT=""
 
 usage() {
   echo "Usage: $0 [options]"
@@ -48,7 +52,32 @@ usage() {
   echo "  --worker-count N            Number of WorkerPool replicas (default: 1)"
   echo "  --sandbox-class CLASS       Sandbox runtime for the WorkerPool: gvisor | microvm (default: gvisor)."
   echo "                              microvm requires hack/install-microvm-deps.sh --install to have run."
+  echo "  --otlp-endpoint URL         The address to which an instrumented actor container"
+  echo "                              sends telemetry (default: the endpoint in the"
+  echo "                              ate-otel-config ConfigMap)"
   echo "  -h, --help                  Show this help message"
+}
+
+# Read the endpoint from the ate-otel-config ConfigMap, which every control
+# plane component reads through envFrom. The value is correct for the cluster
+# in use: the GKE collector, the kind collector in otel-system, or the
+# telemetry meter while a measurement runs. Thus the actors follow the control
+# plane, and this script needs no test for the type of cluster.
+#
+# ate-system must exist, because the workloads below need its CRDs. Thus an
+# absent ConfigMap is an error and not a condition to work around: a default
+# here would send the actor telemetry to the wrong collector with no message.
+resolve_otlp_endpoint() {
+  if [[ -n "${OTLP_ENDPOINT}" ]]; then
+    return 0
+  fi
+  OTLP_ENDPOINT="$(kubectl get configmap ate-otel-config --namespace=ate-system \
+    -o jsonpath='{.data.OTEL_EXPORTER_OTLP_ENDPOINT}' 2>/dev/null || true)"
+  if [[ -z "${OTLP_ENDPOINT}" ]]; then
+    echo "Error: cannot read OTEL_EXPORTER_OTLP_ENDPOINT from the ate-otel-config" >&2
+    echo "ConfigMap in ate-system. Deploy ate-system first, or give --otlp-endpoint." >&2
+    exit 1
+  fi
 }
 
 substitute() {
@@ -65,11 +94,21 @@ substitute() {
       -e "s|\${WORKER_COUNT}|${WORKER_COUNT}|g" \
       -e "s|\${SANDBOX_CLASS}|${SANDBOX_CLASS}|g" \
       -e "s|\${SANDBOX_CONFIG_NAME}|${sandbox_config_name}|g" \
+      -e "s|\${OTLP_ENDPOINT}|${OTLP_ENDPOINT}|g" \
       "${MANIFEST_TEMPLATE}"
 }
 
 deploy() {
-  echo "Deploying workloads (worker_count=${WORKER_COUNT})..."
+  resolve_otlp_endpoint
+  echo "Deploying workloads (worker_count=${WORKER_COUNT}, otlp_endpoint=${OTLP_ENDPOINT})..."
+  # ActorTemplate.spec has the rule `self == oldSelf` (see
+  # pkg/api/v1alpha1/actortemplate_types.go). Thus the API server rejects an
+  # apply that changes a template. A value that changes for each run — the OTLP
+  # endpoint or the sandbox class — needs the removal of the old template
+  # first. This removal is safe, because the benchmark automation deletes the
+  # actors between the tests.
+  kubectl delete actortemplate --namespace=benchmark-workloads \
+    --all --ignore-not-found
   substitute | hack/run-tool.sh ko apply -f -
 }
 
@@ -107,6 +146,13 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --sandbox-class=*)
       SANDBOX_CLASS="${1#*=}"
+      ;;
+    --otlp-endpoint)
+      shift
+      OTLP_ENDPOINT="$1"
+      ;;
+    --otlp-endpoint=*)
+      OTLP_ENDPOINT="${1#*=}"
       ;;
     -h|--help)
       usage

--- a/benchmarking/workloads/manifests/workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/workloads.yaml.tmpl
@@ -73,6 +73,20 @@ spec:
     - "--metrics-listen-addr=:9090"
     - "--data-dir=/tmp/glutton"
     - "--mode=http"
+    # Substrate puts no OTLP configuration in an actor container:
+    # resolveActorEnv in cmd/atelet/oci.go merges the env of the ActorTemplate
+    # and the ENV of the image, and nothing more. Without the value below, the
+    # SDK uses its default localhost:4317. No process listens on that address
+    # in the sandbox, thus substrate discards each actor span with no error
+    # message. You cannot measure the actor telemetry until you set this value.
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: "${OTLP_ENDPOINT}"
+    # The telemetry meter counts by service.name. Thus this value keeps the
+    # actor volume separate from the volume of the control plane. See
+    # benchmarking/telemetry/README.md.
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: "service.name=glutton-actor"
     # Hold ResumeActor open until port 80 actually answers.
     readyz:
       httpGet:

--- a/docs/dev/best-practices/otel-collector.md
+++ b/docs/dev/best-practices/otel-collector.md
@@ -508,16 +508,118 @@ Regardless of topology, these are the ones that tell you it is struggling:
 | `otelcol_exporter_queue_size` vs `_capacity` | Queue filling — shedding is imminent |
 | `otelcol_processor_incoming_items` vs `_outgoing_items` | Gap means a processor is dropping data |
 
-Substrate's telemetry has two independent rate drivers, and they scale on
-different axes:
+### The volume model
 
-- **Metrics** scale with **fleet size** — roughly
-  `(2 + nodes + actors) × instruments × cardinality` per minute, pushed on a
-  60s unjittered interval.
-- **Traces** scale with **request rate**. `ateapi` roots a trace for every
-  unparented API call; downstream components are `ParentBased(NeverSample)`,
-  so one sampled request fans out into spans across the whole call chain.
+The telemetry of substrate has two independent rate drivers, and each one
+increases on a different axis.
 
-A cluster with many idle actors is metrics-bound; a cluster under load is
-trace-bound. Size for whichever dominates your workload, and use the
-trace sampling probability as the first knob when the collector saturates.
+The model below gives the shape of each driver. It gives no values: those
+change with the instruments of each release and with the cluster. Measure them
+with the telemetry meter, which counts by service. See
+[benchmarking/observability.md](../../../benchmarking/observability.md) for the
+scenario ladder.
+
+**The metrics increase with the number of components that run**, not with the
+quantity of work that they do:
+
+```
+datapoints/min ≈  nodes                  × atelet_dp
+                + ateapi_replicas        × ateapi_dp
+                + router_replicas        × router_dp
+                + worker_pods            × ateom_dp
+                + instrumented_actors    × actor_dp
+```
+
+Each substrate binary pushes on a `PeriodicReader` at the SDK default of 60s,
+with no jitter (`newMeterProvider` in
+[`serverboot.go`](../../../internal/serverboot/serverboot.go)). Thus processes
+that start together also push together. The request rate changes this term
+only a small quantity. A large increase in the actor lifecycle rate moves the
+datapoint volume very little.
+
+Do not assume a value for any term. Each release can add or remove instruments,
+thus a component that sends little today can send much later, and a component
+that looks silent may not be. Measure the terms for your own cluster with the
+telemetry meter, which counts by service; see
+[benchmarking/telemetry/README.md](../../../benchmarking/telemetry/README.md).
+
+One term is a matter of configuration and not of volume: an actor container
+sends telemetry only if its image has instrumentation **and** its ActorTemplate
+sets an OTLP endpoint. Substrate puts no OTLP configuration in an actor
+container.
+
+**The traces increase with the rate of the operations:**
+
+```
+spans/sec ≈ (actor_lifecycle_ops/sec + actor_requests/sec)
+            × P(root sampled)
+            × spans_per_op
+```
+
+Measure `spans_per_op` for your own cluster at a low sample rate, where no
+component drops data, then hold it as a constant for the higher rates. The
+share of each component moves with the code path that the load uses, thus read
+it from the meter for the scenario you run.
+
+> [!IMPORTANT]
+> **With `ParentBased`, the caller makes the root decision.** Since
+> [#711](https://github.com/agent-substrate/substrate/pull/711) the defaults are
+> `ParentBased(TraceIDRatioBased)` at 0.1 for `ateapi`, `atelet`, and `ateom-*`,
+> and 0.01 for `atenet-router` and Envoy. These rates apply only to an operation
+> that arrives with no `traceparent`. A client that sends a `traceparent` makes
+> the decision for the full chain, and the defaults of substrate do not apply.
+> To change the rate for one process, set `OTEL_TRACES_SAMPLER` and
+> `OTEL_TRACES_SAMPLER_ARG`.
+
+The metrics are the limit in a cluster with many components. The traces are the
+limit in a cluster with much load. Calculate the size for the larger of the
+two. If the collector becomes full, decrease the trace sample rate first.
+
+### Deployment or DaemonSet
+
+Users frequently ask at which throughput the collector must change from a
+Deployment to a DaemonSet. The measurements show that **throughput is the wrong
+axis**. At the maximum actor throughput of substrate, the collector used a
+small part of its memory limit and of its CPU limit. But it stayed at
+`maxReplicas` at the same time. A rule that uses throughput shows a large
+margin during all of this condition.
+
+The variable that sets the limit is the **number of pods in the cluster**,
+because of the size of the `k8sattributes` cache:
+
+| Mode | Cache in each instance | When the cluster becomes larger |
+|---|---|---|
+| Deployment | O(pods in the cluster) | Increases with no limit. The HPA cannot decrease it. |
+| DaemonSet, filter scoped to the node | O(pods on the node) | Stays in a limit, because a node holds a limited number of pods |
+
+The DaemonSet is better only **with** `k8sattributes` scoped to the node
+(`filter: node_from_env_var`). Without this scope, a DaemonSet is worse: the
+cache is not sharded per node, thus each node keeps one full copy of the
+cluster cache.
+
+Make the decision in this sequence:
+
+1. **Do you need trace-complete processing?** Tail sampling needs all the spans
+   of a trace in one instance, thus a DaemonSet breaks it. To keep a DaemonSet,
+   add a gateway tier behind `loadbalancingexporter`, which sends all the spans
+   of one trace to the same instance. `spanmetrics` does not need this: it reads
+   each span on its own. This condition frequently makes the decision.
+2. **The number of pods in the cluster.** In a small cluster, a Deployment is
+   more simple and less expensive. As the cluster becomes larger, the cache
+   term increases until the Deployment has no margin for the HPA. Measure the
+   memory of each replica against the number of pods to find this point for
+   your own cluster.
+3. **The concentration on each node**, if some nodes hold workloads that send
+   much telemetry.
+
+Calculate the cost in the other direction also. A DaemonSet puts one collector
+on each node, and each collector has an idle memory floor. Thus a DaemonSet
+uses *more* memory in total than a small number of Deployment replicas, until
+the cache term becomes larger than that floor. The crossover point is the value
+to measure.
+
+> [!WARNING]
+> **No measurement covers the DaemonSet mode.** The statements above for the
+> DaemonSet are an extrapolation from the values of the Deployment mode. To
+> confirm them, measure the two modes against an increasing number of pods, and
+> compare the memory of each instance and the memory of the full cluster.

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -69,6 +69,7 @@ function usage() {
   echo "  --ateapi-client-auth=cert|token        Select how in-cluster clients authenticate to ateapi for --deploy-ate-system (default: cert; the server always accepts both)"
   echo "  --atenet-router=envoy|agentgateway     Select the atenet router dataplane (default: envoy)"
   echo "  --store-backend=redis|postgres         Configure the ateapi store backend (default: redis)"
+  echo "  --otlp-endpoint URL                    Send all control plane telemetry to URL, not to the cluster default (see benchmarking/telemetry/README.md)"
   echo ""
   echo "Infrastructure components:"
   echo ""
@@ -246,6 +247,47 @@ apply_otel_config() {
   else
     run_kubectl apply -f manifests/ate-install/ate-otel-config.yaml
   fi
+}
+
+# --otlp-endpoint sends all control plane telemetry to a different collector for
+# the duration of a measurement. One patch is sufficient: each component reads
+# this ConfigMap through envFrom, and ate-controller copies the values to the
+# ateom worker pods that it creates. See benchmarking/telemetry/README.md.
+#
+# Call this AFTER every apply. The ate-system bundle contains its own copy of
+# ate-otel-config, thus an apply of the bundle replaces a patch that came
+# before it, and the endpoint returns to the cluster default with no error
+# message.
+#
+# A change to a ConfigMap starts no rollout, because the pod template stays the
+# same. Thus restart the consumers that read it. Do the restart only when the
+# value changes: a restart during the rollout of the bundle makes the two
+# rollouts compete, and `kubectl rollout status` can then exceed its timeout.
+# An absent workload is not an error, because a deploy of one component has
+# only that component.
+apply_otel_endpoint_override() {
+  if [[ -z "${ATE_OTLP_ENDPOINT:-}" ]]; then
+    return 0
+  fi
+
+  local current=""
+  current="$(run_kubectl -n ate-system get configmap ate-otel-config \
+    -o jsonpath='{.data.OTEL_EXPORTER_OTLP_ENDPOINT}' 2>/dev/null || true)"
+  if [[ "${current}" == "${ATE_OTLP_ENDPOINT}" ]]; then
+    return 0
+  fi
+
+  echo "Overriding OTEL_EXPORTER_OTLP_ENDPOINT with ${ATE_OTLP_ENDPOINT}"
+  run_kubectl -n ate-system patch configmap ate-otel-config --type=merge \
+    -p "{\"data\":{\"OTEL_EXPORTER_OTLP_ENDPOINT\":\"${ATE_OTLP_ENDPOINT}\"}}"
+
+  local workload
+  for workload in deployment/ate-api-server deployment/ate-controller \
+                  deployment/atenet-router daemonset/atelet; do
+    if run_kubectl -n ate-system get "${workload}" >/dev/null 2>&1; then
+      run_kubectl -n ate-system rollout restart "${workload}"
+    fi
+  done
 }
 
 # Extract a CA pool secret's RootCertificateDER and emit it as a PEM certificate.
@@ -513,6 +555,9 @@ deploy_ate_system() {
   run_kubectl rollout status deployment/atenet-router -n ate-system --timeout=120s
   run_kubectl rollout status deployment/atenet-egress -n ate-system --timeout=120s
   run_kubectl rollout status daemonset/atelet -n ate-system --timeout=120s
+
+  # After the bundle, which carries its own copy of ate-otel-config.
+  apply_otel_endpoint_override
 }
 
 # Ensure secrets and configmaps required by ate-apiserver
@@ -545,6 +590,7 @@ deploy_ate_apiserver() {
 
   ensure_apiserver_prerequisites
   apply_otel_config
+  apply_otel_endpoint_override
 
   run_ko apply -f manifests/ate-install/ate-api-server.yaml
   run_kubectl rollout status deployment/ate-api-server -n ate-system --timeout=120s
@@ -559,6 +605,7 @@ deploy_atelet() {
     && run_kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/ate-system --timeout=60s
 
   apply_otel_config
+  apply_otel_endpoint_override
 
   local manifest=""
   if [[ "${ATE_INSTALL_KIND:-false}" == "true" ]]; then
@@ -581,6 +628,7 @@ deploy_atenet() {
     && run_kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/ate-system --timeout=60s
 
   apply_otel_config
+  apply_otel_endpoint_override
 
   local router_manifest=""
   router_manifest="$(render_atenet_router_manifest)"
@@ -722,10 +770,14 @@ deploy_benchmarks() {
   if [[ "${BENCHMARK_SANDBOX_CLASS}" == "microvm" ]]; then
     "${ROOT}/hack/install-microvm-deps.sh" --install
   fi
-  "${ROOT}/benchmarking/deploy_locust.sh" \
-    --deploy \
-    --worker-count "${BENCHMARK_WORKER_COUNT}" \
-    --sandbox-class "${BENCHMARK_SANDBOX_CLASS}"
+  # Send the actor telemetry to the same place as the control plane telemetry.
+  local benchmark_args=(--deploy
+    --worker-count "${BENCHMARK_WORKER_COUNT}"
+    --sandbox-class "${BENCHMARK_SANDBOX_CLASS}")
+  if [[ -n "${ATE_OTLP_ENDPOINT:-}" ]]; then
+    benchmark_args+=(--otlp-endpoint "${ATE_OTLP_ENDPOINT}")
+  fi
+  "${ROOT}/benchmarking/deploy_locust.sh" "${benchmark_args[@]}"
 }
 
 delete_benchmarks() {
@@ -812,6 +864,14 @@ for ((i = 0; i < ${#prescan_args[@]}; i++)); do
     --benchmark-sandbox-class=*)
       BENCHMARK_SANDBOX_CLASS="${prescan_args[i]#*=}"
       ;;
+    --otlp-endpoint)
+      if (( i + 1 >= ${#prescan_args[@]} )); then
+        echo "Error: --otlp-endpoint requires a URL" >&2
+        exit 1
+      fi
+      ATE_OTLP_ENDPOINT="${prescan_args[$((i + 1))]}"
+      ;;
+    --otlp-endpoint=*) ATE_OTLP_ENDPOINT="${prescan_args[i]#*=}" ;;
     --setup-csi)
       SETUP_CSI=true
       ;;
@@ -895,6 +955,8 @@ while [[ "$#" -gt 0 ]]; do
     --benchmark-worker-count=*) ;;
     --benchmark-sandbox-class) shift ;;
     --benchmark-sandbox-class=*) ;;
+    --otlp-endpoint) shift ;;
+    --otlp-endpoint=*) ;;
 
     --create-jwt-authority-pool-secret) create_jwt_authority_pool_secret ;;
     --create-actor-id-ca-pool-secret) create_actor_id_ca_pool_secret ;;


### PR DESCRIPTION
Part of #563

Substrate had no way to measure how much telemetry it sends. This PR adds one, and builds it from the parts the benchmark suite already has.

The managed collector sends its self-metrics to Cloud Monitoring only, and gives no data for each source. Thus you cannot see which component makes the volume. A second collector, the telemetry meter, counts the spans and the datapoints by `service.name`.

## Contents

- **`benchmarking/telemetry/meter.yaml`** — the meter. A tee: it counts the telemetry by service, then sends it on to the managed collector. Thus one run gives the volume for each service and the cost of the load together.
- **`benchmarking/telemetry/README.md`** — the method: install, measure, read, remove.
- **`hack/install-ate.sh --otlp-endpoint`** — sends all control plane telemetry to the meter. Each component reads the endpoint from the `ate-otel-config` ConfigMap through `envFrom`, and `ate-controller` copies the value to the ateom worker pods, thus one patch is sufficient for all of them.
- **`benchmarking/workloads/deploy.sh --otlp-endpoint`** — the same for actor containers, which substrate configures separately.
- **`benchmarking/monitoring.yaml`** — scrapes the meter and cAdvisor.
- **`benchmarking/observability.md`** — prerequisites and the scenario ladder.
- **`docs/dev/best-practices/otel-collector.md`** — the volume model and the size guidance, corrected for the `ParentBased` defaults from #711.

## Correction

The `glutton` ActorTemplate had no `env`. Substrate puts no OTLP configuration in an actor container, thus the exporter used the SDK default `localhost:4317`, no process listens on that address in the sandbox, and substrate discarded each actor span with no error message. The template now sets `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_RESOURCE_ATTRIBUTES`.

`ActorTemplate.spec` is immutable, thus `deploy.sh --deploy` deletes the templates before it applies them.

## How I verified this

On a GKE cluster with managed OTel. The sequence:

```bash
# 1. Start from a clean state.
./hack/install-ate.sh --delete-benchmarks
./hack/install-ate.sh --delete-ate-system

# 2. Install substrate from this branch.
./hack/install-ate.sh --deploy-ate-system

# 3. Install the meter and Prometheus.
kubectl apply -f benchmarking/telemetry/meter.yaml
kubectl apply -f benchmarking/monitoring.yaml

# 4. Send the control plane to the meter.
METER=http://telemetry-meter.benchmarking.svc.cluster.local:4317
./hack/install-ate.sh --deploy-ate-system --otlp-endpoint "${METER}"

# 5. Install the workloads and locust, with the actors on the meter also.
./benchmarking/deploy_locust.sh --deploy --worker-count 10 \
    --otlp-endpoint "${METER}"

# 6. Read the volume.
kubectl port-forward -n benchmarking svc/prometheus 9090:9090
```

## Result

The idle floor, from one measurement on 10 workers:

| Service | datapoints/min |
|---|---|
| `ate-controller` | 234.8 |
| `ateapi` | 54.3 |
| `atelet` | 44.9 |
| `atenet-router` | 10.4 |
| `ateom-gvisor` | 5.2 |
| `glutton-actor` | 4.2 |
| **Total** | **353.7** |

The `glutton-actor` row is the correction above. Before it, actor telemetry could not arrive at all.

Positive control for the same window: `otelcol_receiver_accepted_metric_points` 10.5/s, and each `otelcol_receiver_refused_*` counter at zero. Thus the zero values in the table are true zeros, and not data that did not arrive.

Two values differ from the earlier manual measurement. `ate-controller` is now the largest source, and `ateom-gvisor` is no longer zero. The new imagecache counters from #831 are a probable cause. This difference is the reason to keep results out of the repository.

### Traces

Trace volume follows the root sample decision, not the rate of each component. `atelet` and `ateom-gvisor` sent zero spans in each run, because they inherit the decision that `ateapi` makes and start no trace of their own. At idle each component is near zero: a trace needs an operation, but a metric pushes on a timer.

This run gives no span volume for a usual load. The actors crashed on suspend, and the failed retries made an artificial rate of 13.7k spans/s. That rate is not a measurement of substrate. It does show that the meter accepted the spans with no refusals.

## Follow-up

A separate PR adds the ladder to `automation/tests.yaml` and writes the results as artifacts of each run. The open items are at the end of `observability.md`.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
