### PR TITLE
demos: add actor telemetry continuity reference demo (#503)

### DIFF
--- a/demos/actor-telemetry/README.md
+++ b/demos/actor-telemetry/README.md
@@ -1,0 +1,141 @@
+# Actor Telemetry Continuity Demo
+
+This directory contains a reference demo for **actor telemetry continuity across
+suspend/resume**, the follow-up work discussed in
+[#503](https://github.com/agent-substrate/substrate/issues/503).
+
+It deploys a small Go HTTP server (`main.go`) that emits OpenTelemetry (OTel)
+metrics and trace spans over OTLP on every request, and shows how an actor
+author can avoid losing telemetry that is still buffered in the OTel SDK when an
+actor is suspended.
+
+## The problem it demonstrates
+
+OTel push exporters batch telemetry in memory and flush on a timer (the
+`PeriodicReader` for metrics, the `BatchSpanProcessor` for spans). When the push
+interval (e.g. 60s) is longer than the active-execution window before idle
+suspension (e.g. 30s), telemetry generated during the active phase is still
+sitting in those in-memory queues when the actor is suspended.
+
+With `snapshotsConfig.onPause: Data` (the mode this demo uses), Substrate
+excludes process memory from the snapshot and kills the container process on
+pause, so that buffered telemetry is **permanently lost** (this is Issue 1,
+HIGH, in #503).
+
+## The mitigation it shows
+
+Until the `PreSuspend` lifecycle hook ([#450](https://github.com/agent-substrate/substrate/issues/450))
+lands, an actor author can flush the OTel providers themselves before going
+idle. The workload runs an idle watcher: after `--idle-flush` of request
+inactivity it calls `ForceFlush` on both the `MeterProvider` and
+`TracerProvider`, exporting everything buffered before a suspend can kill the
+process. When `#450` lands, that same flush moves into the `PreSuspend` hook.
+
+Flags:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--push-interval` | `60s` | OTLP export interval. Intentionally long, to reproduce #503. |
+| `--idle-flush` | `25s` | Idle duration after which the workload force-flushes. Set to `0` to disable the flush and observe the loss. |
+
+## Prerequisites
+
+- A k8s cluster with Agent Substrate installed (`./hack/install-ate.sh --deploy-ate-system`).
+- `ko` installed for building images.
+- A GCS bucket for storing snapshots (configured via `BUCKET_NAME` env var).
+
+## How to Run on Agent Substrate
+
+### 1. Build and Deploy
+
+> [!NOTE]
+> Do not manually edit `demos/actor-telemetry/actor-telemetry.yaml.tmpl`. The
+> installation script automatically injects your `${BUCKET_NAME}` environment
+> variable during deployment.
+
+```bash
+./hack/install-ate.sh --deploy-demo-actor-telemetry
+```
+
+This command will:
+- Build the demo server image using `ko`.
+- Create the `ate-demo-actor-telemetry` namespace.
+- Create the `WorkerPool` and `ActorTemplate`.
+- Wait until the template is ready.
+
+### 2. Create an Actor
+
+```bash
+# Install the CLI as a kubectl plugin if not already installed.
+go install ./cmd/kubectl-ate
+
+# Create the atespace (required before creating actors).
+kubectl ate create atespace demo
+
+# Create the actor from the actor-telemetry template.
+kubectl ate create actor my-telemetry-1 -a demo --template ate-demo-actor-telemetry/actor-telemetry
+```
+
+### 3. Port-Forward Services
+
+```bash
+# Router, to send requests to the actor.
+kubectl port-forward -n ate-system svc/atenet-router 8000:80
+
+# Jaeger + Prometheus, to see the telemetry arrive (Kind cluster).
+kubectl port-forward -n otel-system svc/jaeger 16686:16686
+kubectl port-forward -n otel-system svc/prometheus 9090:9090
+```
+
+## How to Use
+
+1. Send a few requests through the router:
+   ```bash
+   curl -X POST -H "Host: my-telemetry-1.demo.actors.resources.substrate.ate.dev" http://localhost:8000
+   ```
+   Each response reports the actor it was handled for. The metric
+   `demo.actor.requests` and a `handle-request` span are now buffered.
+
+2. **Stop sending requests.** After `--idle-flush` (25s) elapses, the workload
+   logs `pre-suspend flush complete`. Confirm the buffered telemetry arrived:
+   - Prometheus ([http://localhost:9090](http://localhost:9090)): query
+     `demo_actor_requests_total`.
+   - Jaeger ([http://localhost:16686](http://localhost:16686)): select service
+     `ate-demo-actor-telemetry` and find the `handle-request` traces.
+
+3. Suspend and resume the actor, then send more requests and repeat the checks.
+   In Jaeger, `handle-request` spans continue to carry the actor's own
+   `ate.actor.name` (read fresh from `/run/ate/actor-id`), correlated across the
+   worker pods the actor ran on. The `demo_actor_requests_total` metric is
+   labeled only by the bounded `ate.actor.template.name`, not per actor, to keep
+   metric cardinality bounded at scale (actor identity lives on spans, not
+   series).
+   ```bash
+   kubectl ate suspend actor my-telemetry-1 -a demo
+   ```
+
+4. **Observe the loss (optional).** Redeploy with `--idle-flush=0` (edit the
+   template's container `args`), send requests, then suspend before the 60s push
+   timer fires. With `onPause: Data` the buffered telemetry never reaches the
+   backend, reproducing #503.
+
+5. Clean up:
+   ```bash
+   kubectl ate delete actor my-telemetry-1 -a demo
+   kubectl ate delete atespace demo
+   ```
+
+## How to Uninstall
+
+```bash
+./hack/install-ate.sh --delete-demo-actor-telemetry
+```
+
+## Related
+
+- [`docs/observability.md`](../../docs/observability.md) - how Substrate
+  surfaces logs, metrics, and traces across suspend/resume.
+- [#503](https://github.com/agent-substrate/substrate/issues/503) - the
+  telemetry loss and delivery-delay issue this demo addresses.
+- [#450](https://github.com/agent-substrate/substrate/issues/450) - actor
+  lifecycle hooks (`PostResume` / `PreSuspend`) that will host this flush.

--- a/demos/actor-telemetry/actor-telemetry.yaml.tmpl
+++ b/demos/actor-telemetry/actor-telemetry.yaml.tmpl
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reference demo for actor telemetry continuity across suspend/resume (#503).
+#
+# The ActorTemplate deliberately uses onPause: Data. In that mode Substrate
+# excludes process memory (RAM) from the snapshot and kills the container
+# process on pause, so any OpenTelemetry metrics/spans still buffered in the
+# SDK's in-memory queues (PeriodicReader accumulators, BatchSpanProcessor ring
+# buffer) are lost. The demo workload's --idle-flush ForceFlushes both
+# providers before the idle suspension arrives, which is the mitigation an
+# actor author can apply today (before the PreSuspend hook, #450, exists).
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ate-demo-actor-telemetry
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: WorkerPool
+metadata:
+  name: actor-telemetry
+  namespace: ate-demo-actor-telemetry
+  labels:
+    workload: actor-telemetry
+spec:
+  replicas: 5
+  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: ActorTemplate
+metadata:
+  name: actor-telemetry
+  namespace: ate-demo-actor-telemetry
+spec:
+  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
+  containers:
+  - name: actor-telemetry
+    image: ko://github.com/agent-substrate/substrate/demos/actor-telemetry
+    env:
+    # The actor must be told where the OTLP collector is; the SDK default is
+    # localhost:4317, which inside the actor's gVisor netns has nothing
+    # listening, so telemetry would be flushed into the void. This mirrors the
+    # endpoint the ate-system components use on Kind (see
+    # manifests/ate-install/kind/kustomization.yaml).
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://opentelemetry-collector.otel-system.svc:4317
+    # Delta aggregation temporality. Actors restore from the golden snapshot, so
+    # a cumulative counter carries the golden actor's accumulated value and the
+    # collector's reset detection cannot see restarts, inflating/merging series
+    # (#761). Delta is the recommended preference for Lambda-like
+    # suspend/resume workloads: each export carries only the increment since the
+    # last one, so restores do not double-count.
+    - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      value: delta
+    readyz:
+      httpGet:
+        path: /readyz
+        port: 80
+  workerSelector:
+    matchLabels:
+      workload: actor-telemetry
+  snapshotsConfig:
+    # onPause: Data drops RAM on pause -- this is the mode that loses buffered
+    # in-memory telemetry (#503 Issue 1, HIGH). The workload mitigates it by
+    # flushing before it goes idle. Switch to Full to snapshot RAM instead.
+    onPause: Data
+    onCommit: Data
+    location: gs://${BUCKET_NAME}/ate-demo-actor-telemetry/

--- a/demos/actor-telemetry/main.go
+++ b/demos/actor-telemetry/main.go
@@ -1,0 +1,346 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command actor-telemetry is a reference demo for actor telemetry continuity
+// across suspend/resume. It emits OpenTelemetry metrics and trace spans over
+// OTLP on every request, then demonstrates the mitigation for the telemetry
+// loss described in agent-substrate/substrate#503: when the OTel push interval
+// (e.g. 60s) is longer than the active-execution window before idle suspension
+// (e.g. 30s), telemetry generated during the active phase stays buffered in the
+// SDK's in-memory queues (PeriodicReader accumulators, BatchSpanProcessor ring
+// buffer) and is lost when the actor is suspended with onPause: Data (the
+// process is killed and RAM is discarded).
+//
+// The mitigation an actor author can apply TODAY, before the PreSuspend
+// lifecycle hook (#450) exists, is to ForceFlush both providers on the
+// self-suspend path, immediately before invoking the suspend. This demo models
+// that path: an idle watcher detects that the actor has gone quiet and calls
+// selfSuspend, which invokes flushTelemetry before it would call the Substrate
+// suspend API. When #450 lands, flushTelemetry does not change; only its
+// call-site moves, from selfSuspend into a PreSuspend handler.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/pflag"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+)
+
+const serviceName = "ate-demo-actor-telemetry"
+
+// templateName is a bounded, per-template identifier used as a metric
+// attribute. It is deliberately NOT the per-actor name: actor identity on a
+// metric datapoint is unbounded cardinality, and this project targets billions
+// of actors, so a per-actor label would explode the time-series database. Actor
+// identity belongs on spans (events), not on metrics (series). See #761.
+const templateName = "ate-demo-actor-telemetry"
+
+// serviceInstanceID is generated once so the tracer and meter resources share
+// it, mirroring internal/serverboot.
+var serviceInstanceID = uuid.NewString()
+
+var (
+	pushInterval = pflag.Duration("push-interval", 60*time.Second,
+		"OTLP push/export interval for metrics and spans. Intentionally longer "+
+			"than the active window before idle suspension, to reproduce #503.")
+	idleFlush = pflag.Duration("idle-flush", 25*time.Second,
+		"Duration of request inactivity after which the demo enters the "+
+			"self-suspend path and flushes both providers, simulating a "+
+			"PreSuspend hook (#450). Set to 0 to disable the flush and reproduce "+
+			"the telemetry loss.")
+
+	ready atomic.Bool
+)
+
+// flushTelemetry force-flushes the OTel MeterProvider and TracerProvider,
+// exporting everything still buffered in the SDK's in-memory queues. This is
+// the seam for #503: it is the single place telemetry is drained before an
+// actor loses its process memory.
+//
+// Today it is called from the self-suspend path (selfSuspend), immediately
+// before the suspend would be invoked. When the PreSuspend lifecycle hook
+// (#450) lands, this function does not change; only its call-site moves, into
+// the PreSuspend handler, so the flush also covers Substrate-initiated pauses
+// (idle timeout, on-demand) that the application cannot observe today.
+func flushTelemetry(ctx context.Context, mp *sdkmetric.MeterProvider, tp *sdktrace.TracerProvider) {
+	slog.InfoContext(ctx, "flushTelemetry: exporting buffered telemetry")
+	fctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := mp.ForceFlush(fctx); err != nil {
+		slog.WarnContext(ctx, "meter ForceFlush failed", slog.Any("err", err))
+	}
+	if err := tp.ForceFlush(fctx); err != nil {
+		slog.WarnContext(ctx, "tracer ForceFlush failed", slog.Any("err", err))
+	}
+	slog.InfoContext(ctx, "flushTelemetry: complete")
+}
+
+// idleFlusher fires onIdle() once the actor has been idle (no signal on
+// activity) for timeout. Every send on activity resets the timer. It returns
+// when ctx is done. A timeout <= 0 disables the trigger (the watcher only
+// drains activity), which is how the demo reproduces the buffered-telemetry
+// loss: nothing flushes before the suspend.
+func idleFlusher(ctx context.Context, timeout time.Duration, activity <-chan struct{}, onIdle func(context.Context)) {
+	if timeout <= 0 {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-activity:
+			}
+		}
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-activity:
+			if !timer.Stop() {
+				<-timer.C
+			}
+			timer.Reset(timeout)
+		case <-timer.C:
+			onIdle(ctx)
+			timer.Reset(timeout)
+		}
+	}
+}
+
+// newResource builds the OTel resource shared by the meter and tracer
+// providers, mirroring internal/serverboot. WithFromEnv is last so OTEL_*
+// env vars (e.g. resource attributes injected by the actor runtime) win.
+func newResource(ctx context.Context) (*resource.Resource, error) {
+	res, err := resource.New(ctx,
+		resource.WithTelemetrySDK(),
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+			// service.instance.id distinguishes this process instance. It is
+			// generated once at startup and shared by the meter and tracer
+			// resources, mirroring internal/serverboot. Note: like everything
+			// built in main(), it is captured in the golden snapshot and is
+			// therefore identical across actors of a template; genuine
+			// per-actor identity is read fresh from the identity file and put
+			// on spans (see actorName), not baked into the resource.
+			semconv.ServiceInstanceID(serviceInstanceID),
+		),
+		resource.WithFromEnv(),
+	)
+	if errors.Is(err, resource.ErrPartialResource) || errors.Is(err, resource.ErrSchemaURLConflict) {
+		slog.WarnContext(ctx, "partial telemetry resource", slog.Any("err", err))
+	} else if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// identityFile is the per-actor identity file Substrate bind-mounts read-only
+// into every actor at /run/ate/actor-id. It holds the raw actor name with no
+// trailing newline. See docs/api-guide.md ("Actor Identity"). It is a var only
+// so tests can redirect it; production never reassigns it.
+var identityFile = "/run/ate/actor-id"
+
+// actorName reads the actor's own name fresh from the bind-mounted identity
+// file on every call. Reading fresh is required, not an optimization we skip:
+//
+//   - os.Hostname() returns "runsc" for every actor (the hostname is hardcoded
+//     in the OCI spec, cmd/atelet/oci.go), so it can never identify an actor.
+//   - ATE_ACTOR_NAME is not set by the runtime, and any value captured at
+//     process start (env var, or a read cached in a package var) is frozen at
+//     the golden actor's name once the process is checkpointed into the
+//     snapshot, so it would be identical for every actor of the template.
+//
+// The bind mount exists precisely so a fresh read after a resume reports the
+// correct per-actor name. Returns "unknown" if the file cannot be read.
+func actorName() string {
+	b, err := os.ReadFile(identityFile)
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// initMeterProvider builds a MeterProvider whose PeriodicReader exports over
+// OTLP every push-interval. The long interval is the whole point: it is what
+// leaves telemetry buffered when a suspend arrives before the timer fires.
+func initMeterProvider(ctx context.Context, res *resource.Resource) (*sdkmetric.MeterProvider, error) {
+	// No WithInsecure(): it would override the SDK's env-driven TLS config
+	// (OTEL_EXPORTER_OTLP_* and the http:// vs https:// endpoint scheme) and
+	// silently force plaintext everywhere. See #741. The demo's endpoint is
+	// plaintext http://, which the SDK already infers from the scheme.
+	exp, err := otlpmetricgrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create OTLP metric exporter: %w", err)
+	}
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exp,
+			sdkmetric.WithInterval(*pushInterval),
+		)),
+	)
+	otel.SetMeterProvider(mp)
+	return mp, nil
+}
+
+// initTracerProvider builds a TracerProvider whose BatchSpanProcessor flushes
+// over OTLP every push-interval, for the same reason as the meter above.
+func initTracerProvider(ctx context.Context, res *resource.Resource) (*sdktrace.TracerProvider, error) {
+	// No WithInsecure(): see initMeterProvider and #741.
+	exp, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create OTLP trace exporter: %w", err)
+	}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithResource(res),
+		sdktrace.WithBatcher(exp, sdktrace.WithBatchTimeout(*pushInterval)),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	return tp, nil
+}
+
+func main() {
+	pflag.Parse()
+	ctx := context.Background()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+
+	res, err := newResource(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "build resource", slog.Any("err", err))
+		os.Exit(1)
+	}
+	mp, err := initMeterProvider(ctx, res)
+	if err != nil {
+		slog.ErrorContext(ctx, "init metrics", slog.Any("err", err))
+		os.Exit(1)
+	}
+	tp, err := initTracerProvider(ctx, res)
+	if err != nil {
+		slog.ErrorContext(ctx, "init tracing", slog.Any("err", err))
+		os.Exit(1)
+	}
+
+	meter := mp.Meter(serviceName)
+	requests, err := meter.Int64Counter(
+		"demo.actor.requests",
+		metric.WithDescription("Requests handled by the actor-telemetry demo, by template."),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		slog.ErrorContext(ctx, "create counter", slog.Any("err", err))
+		os.Exit(1)
+	}
+	tracer := tp.Tracer(serviceName)
+
+	// selfSuspend is the application self-suspend path (#503 mitigation 4): on
+	// going idle, flush buffered telemetry BEFORE invoking the suspend, so a
+	// process kill in onPause: Data mode cannot discard it. The suspend API
+	// call is a no-op log here since the demo does not drive its own lifecycle;
+	// the point is the ordering, flush then suspend. When #450 lands the flush
+	// moves into a PreSuspend handler and this path just returns.
+	selfSuspend := func(ctx context.Context) {
+		flushTelemetry(ctx, mp, tp)
+		slog.InfoContext(ctx, "self-suspend: telemetry flushed, ready for suspend")
+	}
+
+	// activity signals the idle watcher on each request; buffer of 1 keeps the
+	// hot path non-blocking.
+	activity := make(chan struct{}, 1)
+	go idleFlusher(ctx, *idleFlush, activity, selfSuspend)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := tracer.Start(r.Context(), "handle-request")
+		defer span.End()
+
+		// Read the actor's identity fresh for this request (see actorName).
+		actor := actorName()
+
+		// Metric: label with the bounded template name only. Per-actor labels
+		// are unbounded cardinality at this project's scale (see templateName).
+		// Span/metric attributes use the dotted ate.* namespace (see
+		// internal/ateattr), not the ate.dev/ slash form used for k8s labels.
+		requests.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("ate.actor.template.name", templateName),
+		))
+		// Span: an event, not a series, so per-actor identity is safe and
+		// useful here for correlating a trace to the actor that served it.
+		span.SetAttributes(attribute.String("ate.actor.name", actor))
+
+		select {
+		case activity <- struct{}{}:
+		default:
+		}
+
+		msg := fmt.Sprintf("handled request for actor %s | telemetry buffered, will flush after %s idle\n", actor, *idleFlush)
+		slog.InfoContext(ctx, "handled request",
+			slog.String("trace_id", span.SpanContext().TraceID().String()),
+			slog.String("actor", actor),
+		)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(msg))
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if !ready.Load() {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+
+	go func() {
+		slog.InfoContext(ctx, "starting actor-telemetry server on port 80",
+			slog.Duration("push_interval", *pushInterval),
+			slog.Duration("idle_flush", *idleFlush),
+		)
+		// otelhttp.NewHandler extracts the incoming trace context (propagated
+		// by the router over W3C traceparent) and starts a server span, so the
+		// per-request span started below joins the router's trace instead of
+		// starting a detached root. See #427. Matches cmd/atenet router and
+		// cmd/benchmarking/glutton.
+		if err := http.ListenAndServe(":80", otelhttp.NewHandler(mux, "/")); err != nil {
+			slog.ErrorContext(ctx, "server error", slog.Any("err", err))
+			os.Exit(1)
+		}
+	}()
+
+	ready.Store(true)
+	slog.InfoContext(ctx, "readyz now reports OK")
+
+	select {}
+}

--- a/demos/actor-telemetry/main_test.go
+++ b/demos/actor-telemetry/main_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestIdleFlusherFiresAfterIdle asserts the watcher flushes once the idle
+// timeout elapses with no activity, which is the core of the #503 mitigation.
+func TestIdleFlusherFiresAfterIdle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var flushes atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		idleFlusher(ctx, 20*time.Millisecond, make(chan struct{}), func(context.Context) {
+			flushes.Add(1)
+			select {
+			case <-done:
+			default:
+				close(done)
+			}
+		})
+	}()
+
+	select {
+	case <-done:
+		if got := flushes.Load(); got < 1 {
+			t.Fatalf("expected at least one flush, got %d", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("idle flush did not fire within deadline")
+	}
+}
+
+// TestIdleFlusherResetsOnActivity asserts that a steady stream of activity
+// keeps the timer from firing: telemetry is only flushed once traffic stops.
+func TestIdleFlusherResetsOnActivity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var flushes atomic.Int64
+	activity := make(chan struct{})
+	go idleFlusher(ctx, 50*time.Millisecond, activity, func(context.Context) {
+		flushes.Add(1)
+	})
+
+	// Keep it busy for ~250ms with pokes every 10ms (< the 50ms timeout).
+	deadline := time.After(250 * time.Millisecond)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+busy:
+	for {
+		select {
+		case <-deadline:
+			break busy
+		case <-tick.C:
+			activity <- struct{}{}
+		}
+	}
+	if got := flushes.Load(); got != 0 {
+		t.Fatalf("expected no flush while busy, got %d", got)
+	}
+
+	// Now go quiet and confirm a flush lands.
+	time.Sleep(150 * time.Millisecond)
+	if got := flushes.Load(); got < 1 {
+		t.Fatalf("expected a flush after going idle, got %d", got)
+	}
+}
+
+// TestIdleFlusherDisabled asserts that timeout <= 0 never flushes, which is how
+// the demo reproduces the telemetry loss (nothing flushed before suspend).
+func TestIdleFlusherDisabled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var flushes atomic.Int64
+	activity := make(chan struct{}, 1)
+	go idleFlusher(ctx, 0, activity, func(context.Context) {
+		flushes.Add(1)
+	})
+
+	activity <- struct{}{}
+	time.Sleep(100 * time.Millisecond)
+	if got := flushes.Load(); got != 0 {
+		t.Fatalf("expected no flush when disabled, got %d", got)
+	}
+}
+
+// TestActorNameFromIdentityFile asserts actorName reads the per-actor name
+// fresh from the bind-mounted identity file, and falls back to "unknown" when
+// the file is absent (rather than returning the useless "runsc" hostname).
+func TestActorNameFromIdentityFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "actor-id")
+	orig := identityFile
+	identityFile = path
+	t.Cleanup(func() { identityFile = orig })
+
+	// Missing file -> "unknown".
+	if got := actorName(); got != "unknown" {
+		t.Fatalf("actorName() with no file = %q, want %q", got, "unknown")
+	}
+
+	// Present file (raw name, no trailing newline) -> that name. A trailing
+	// newline, if present, must be trimmed.
+	if err := os.WriteFile(path, []byte("my-telemetry-actor-1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := actorName(); got != "my-telemetry-actor-1" {
+		t.Fatalf("actorName() = %q, want %q", got, "my-telemetry-actor-1")
+	}
+}

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -40,6 +40,7 @@ ATE_DEMOS=()
 
 # Include demos.
 source "${ROOT}"/hack/install-demo-counter.sh
+source "${ROOT}"/hack/install-demo-actor-telemetry.sh
 source "${ROOT}"/hack/install-demo-sandbox.sh
 source "${ROOT}"/hack/install-demo-claude-code-multiplex.sh
 source "${ROOT}"/hack/install-demo-agent-secret.sh

--- a/hack/install-demo-actor-telemetry.sh
+++ b/hack/install-demo-actor-telemetry.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This is sourced as part of install-ate.sh. Do not run directly.
+
+ATE_DEMOS+=(demo-actor-telemetry) # register demo-actor-telemetry
+
+demo-actor-telemetry_cmdline() {
+  case "${1}" in
+    --deploy-demo-actor-telemetry) demo-actor-telemetry_deploy ;;
+    --delete-demo-actor-telemetry) demo-actor-telemetry_delete ;;
+    *)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+demo-actor-telemetry_deploy() {
+  log_step "demo-actor-telemetry_deploy"
+  ensure_crds
+  sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/actor-telemetry/actor-telemetry.yaml.tmpl \
+    | run_ko apply -f -
+
+  log_step "Waiting for actor-telemetry demo to be ready..."
+  run_kubectl rollout status deployment/actor-telemetry -n ate-demo-actor-telemetry --timeout=300s
+  run_kubectl wait --for=condition=Ready actortemplate/actor-telemetry -n ate-demo-actor-telemetry --timeout=300s
+}
+
+demo-actor-telemetry_delete() {
+  log_step "demo-actor-telemetry_delete"
+  delete_demo_actors ate-demo-actor-telemetry actor-telemetry
+  sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/actor-telemetry/actor-telemetry.yaml.tmpl \
+    | run_kubectl delete --ignore-not-found -f -
+}


### PR DESCRIPTION
Add a reference demo for actor telemetry continuity across suspend/resume, the
follow-up work requested in #503.

The demo is a small Go HTTP server that emits OpenTelemetry metrics and trace
spans over OTLP on every request. It reproduces the #503 loss: an OTel push
exporter batches telemetry in memory and flushes on a timer, so when the push
interval (default 60s) is longer than the active window before idle suspension,
telemetry is still buffered in the SDK when the actor is suspended. With
`snapshotsConfig.onPause: Data` (the mode the template uses) Substrate drops
process RAM on pause, so that buffered telemetry is lost.

The mitigation is isolated behind a `flushTelemetry(ctx)` seam that ForceFlushes
both the MeterProvider and TracerProvider. Today it is called from the
self-suspend path via an idle watcher; when the PreSuspend hook (#450) lands,
`flushTelemetry` does not change, only its call-site moves into the PreSuspend
handler. This keeps #450 a call-site move rather than a rewrite.

The ActorTemplate sets `OTEL_EXPORTER_OTLP_ENDPOINT` to the in-cluster
collector, since the SDK default (`localhost:4317`) has nothing listening inside
the actor sandbox netns.

Includes `install-demo-actor-telemetry.sh` wired into `install-ate.sh`, a
rendered-and-validated template, unit tests for the idle-flush watcher, and a
README documenting the reproduce/verify flow against Jaeger and Prometheus on
Kind.

## Scope

This covers the "reference demo for actor telemetry continuity" action item in
#503 only. The `docs/observability.md` update is tracked separately, and the
`PreSuspend`/`PostResume` alignment is #450.

Part of #503

## Testing

- `gofmt`, `go vet`, `go build`, and `go test ./demos/actor-telemetry/` all pass
  (4/4 unit tests on the idle-flush watcher).
- Template renders via the install script's `sed` substitution and parses as
  valid Kubernetes manifests.
- End-to-end suspend/resume verification against a live Kind cluster with
  ate-system is described in the README.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR