### PR TITLE
ci: harden workflows for zizmor (pin actions, fix template injection)

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
           go-version-file: go.mod
           go-package: ./...

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -89,11 +89,15 @@ jobs:
     - name: Create cluster
       run: hack/create-kind-cluster.sh
     - name: Install Agent Substrate
-      run: hack/install-ate-kind.sh --deploy-ate-system --ateapi-client-auth=${{ matrix.ateapi-client-auth }}
+      env:
+        CLIENT_AUTH: ${{ matrix.ateapi-client-auth }}
+      run: hack/install-ate-kind.sh --deploy-ate-system --ateapi-client-auth="$CLIENT_AUTH"
     - name: Deploy micro-VM counter demo
       # Stages the (cached) assets into the cluster's rustfs and applies the
       # counter-microvm demo onto the control plane installed above.
-      run: hack/run-microvm-demo-kind.sh --ateapi-client-auth=${{ matrix.ateapi-client-auth }}
+      env:
+        CLIENT_AUTH: ${{ matrix.ateapi-client-auth }}
+      run: hack/run-microvm-demo-kind.sh --ateapi-client-auth="$CLIENT_AUTH"
     - name: Deploy gVisor counter demo
       run: hack/install-ate-kind.sh --deploy-demo-counter
     - name: Wait for micro-VM golden snapshot
@@ -134,8 +138,10 @@ jobs:
     if: always()
     steps:
     - name: Check E2E matrix
+      env:
+        MATRIX_RESULT: ${{ needs.e2e-test-matrix.result }}
       run: |
-        if [ "${{ needs.e2e-test-matrix.result }}" != "success" ]; then
-          echo "e2e-test-matrix result: ${{ needs.e2e-test-matrix.result }}"
+        if [ "$MATRIX_RESULT" != "success" ]; then
+          echo "e2e-test-matrix result: $MATRIX_RESULT"
           exit 1
         fi


### PR DESCRIPTION
## What this PR does / why we need it

The zizmor gate has two mandatory checks failing on the workflow files:
`unpinned-uses` and `template-injection`. This PR resolves both.

1. Pin every GitHub Actions `uses:` reference to a full commit SHA, keeping
   the semver in a trailing comment for readability and Dependabot:

   - actions/checkout@v5          -> fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 (v5.1.0)
   - actions/setup-go@v5          -> 40f1582b2485089dde7abd97c1529aa768e1baff (v5.6.0)
   - actions/cache@v4             -> 0057852bfaa89a56745cba8c7296529d2fc39830 (v4.3.0)
   - golang/govulncheck-action@v1 -> 032d45514ae346b1db93c04b0c90b841c370344f (v1.1.0)

2. Fix template injection in pr-workflow.yaml: `${{ matrix.auth-mode }}` and
   `${{ needs.e2e-test-matrix.result }}` were interpolated directly into `run:`
   shell blocks. Move each into an `env:` var and reference it as a quoted
   shell variable so the expansion cannot inject code.

No functional behavior change.

## Testing

- Ran `zizmor --persona=pedantic` on both workflow files: zero findings for any
  mandatory check (unpinned-uses, template-injection, etc.).
- Confirmed both workflows remain valid YAML.