### PR TITLE
Add ActorTemplate/ActorTemplateVersion Substrate resource protos

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ We provide several sample applications demonstrating Agent Substrate's capabilit
 * [API Configuration Guide](docs/api-guide.md): Detailed reference for configuring WorkerPools, ActorTemplates, Secrets, and Volumes.
 * [Full CLI Documentation](cmd/kubectl-ate/README.md): Installation and usage for `kubectl-ate`.
 * [Glossary](docs/glossary.md): Core terms (Actor, Atespace, ActorTemplate, WorkerPool, Worker, ate-api-server, atenet, atelet, ateom) and how they relate.
+* [Counter E2E Testing Guide](docs/dev/counter-e2e-testing.md): Manual end-to-end walkthrough — provision GCP, deploy the counter template, and exercise suspend/resume and ActorTemplateVersion upgrades.
 * [Observability Guide](docs/observability.md): Guide to actor logging, metrics, and distributed tracing.
 * [Request Parking](docs/request-parking.md): How the router parks requests through transient worker-pool saturation.
 * [Threat Model](docs/threat-model.md): Trust boundaries, assumptions, and known risks.

--- a/cmd/ateapi/internal/controlapi/create_actor.go
+++ b/cmd/ateapi/internal/controlapi/create_actor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/resources"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,12 +38,18 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 	}
 	start := time.Now()
 	in := req.GetActor()
+	templateNamespace := in.GetActorTemplateNamespace()
+	templateName := in.GetActorTemplateName()
+	if in.GetActorTemplate() != "" {
+		// Native templates are global-scoped: the namespace attribute stays empty.
+		templateName = in.GetActorTemplate()
+	}
 	// Recorded only after validation, so every operation uniformly measures a
 	// validated request; malformed ones stay visible in rpc.server.call.duration.
 	defer func() {
 		s.instruments.recordLifecycleOp(ctx, ateattr.OperationCreate, start, err,
-			ateattr.TemplateNameKey.String(in.GetActorTemplateName()),
-			ateattr.TemplateNamespaceKey.String(in.GetActorTemplateNamespace()),
+			ateattr.TemplateNameKey.String(templateName),
+			ateattr.TemplateNamespaceKey.String(templateNamespace),
 		)
 	}()
 	var sourceSnapshot *ateapipb.ActorSnapshot
@@ -70,17 +77,56 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 			return nil, status.Error(codes.FailedPrecondition, "source ActorSnapshot tag has an invalid scope")
 		}
 	}
-	templateNamespace := in.GetActorTemplateNamespace()
-	templateName := in.GetActorTemplateName()
-
 	setSpanActorRefAttributes(ctx, resources.ActorRefFromActor(in))
 
-	template, err := s.actorTemplateLister.ActorTemplates(templateNamespace).Get(templateName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %s/%s not found", templateNamespace, templateName)
+	var template *atev1alpha1.ActorTemplate
+	var versionPin string
+	if in.GetActorTemplate() != "" {
+		at, err := s.persistence.GetActorTemplate(ctx, in.GetActorTemplate())
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %q not found", in.GetActorTemplate())
+			}
+			return nil, fmt.Errorf("while getting ActorTemplate: %w", err)
 		}
-		return nil, fmt.Errorf("while getting ActorTemplate: %w", err)
+		versionPin = in.GetActorTemplateVersion()
+		if versionPin == "" {
+			versionPin = at.GetSpec().GetDefaultVersionOnCreate().GetName()
+		}
+		if versionPin == "" {
+			return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %q has no default_version_on_create; pin a version", in.GetActorTemplate())
+		}
+		atv, err := s.persistence.GetActorTemplateVersion(ctx, versionPin)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %q not found", versionPin)
+			}
+			return nil, fmt.Errorf("while getting ActorTemplateVersion: %w", err)
+		}
+		if atv.GetActorTemplate().GetName() != at.GetMetadata().GetName() {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"ActorTemplateVersion %q belongs to ActorTemplate %q, not %q",
+				versionPin, atv.GetActorTemplate().GetName(), at.GetMetadata().GetName())
+		}
+		// Only READY versions have a golden snapshot to run from. The golden
+		// actor building that snapshot is the one exception; like
+		// commitSnapshotScope, the reserved atespace is the discriminator.
+		if state := atv.GetStatus().GetState(); state != ateapipb.ActorTemplateVersionStatus_STATE_READY &&
+			in.GetMetadata().GetAtespace() != resources.GoldenActorAtespace {
+			return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %q is not READY (state %s)", versionPin, state)
+		}
+		if template, err = crdTemplateFromVersion(at, atv); err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		template, err = s.actorTemplateLister.ActorTemplates(templateNamespace).Get(templateName)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %s/%s not found", templateNamespace, templateName)
+			}
+			return nil, fmt.Errorf("while getting ActorTemplate: %w", err)
+		}
 	}
 	// TODO: Permit compatible DATA snapshots when runtimes can extract portable data.
 	if sourceSnapshot != nil && sourceSnapshot.GetActorTemplateUid() != string(template.GetUID()) {
@@ -119,8 +165,10 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 			Name:     name,
 		},
 		Status:                 ateapipb.Actor_STATUS_SUSPENDED,
-		ActorTemplateNamespace: templateNamespace,
-		ActorTemplateName:      templateName,
+		ActorTemplateNamespace: in.GetActorTemplateNamespace(),
+		ActorTemplateName:      in.GetActorTemplateName(),
+		ActorTemplate:          in.GetActorTemplate(),
+		ActorTemplateVersion:   versionPin,
 		WorkerSelector:         in.GetWorkerSelector(),
 		ActorVolumes:           initVols,
 		LatestSnapshot:         sourceSnapshotRef,
@@ -160,18 +208,36 @@ func validateCreateActorRequest(req *ateapipb.CreateActorRequest) field.ErrorLis
 		errs = append(errs, resources.ValidateResourceName(val, p)...)
 	}
 
-	if val, p := actor.GetActorTemplateNamespace(), actorPath.Child("actor_template_namespace"); val == "" {
-		errs = append(errs, field.Required(p, ""))
-	} else {
-		for _, msg := range content.IsDNS1123Label(val) {
-			errs = append(errs, field.Invalid(p, val, msg))
+	// The actor names its template either as a global-scoped control-plane
+	// ActorTemplate or as a namespaced CRD ActorTemplate, never both.
+	if val := actor.GetActorTemplate(); val != "" {
+		errs = append(errs, resources.ValidateResourceName(val, actorPath.Child("actor_template"))...)
+		if actor.GetActorTemplateNamespace() != "" {
+			errs = append(errs, field.Forbidden(actorPath.Child("actor_template_namespace"), "must be empty when actor_template is set"))
 		}
-	}
-	if val, p := actor.GetActorTemplateName(), actorPath.Child("actor_template_name"); val == "" {
-		errs = append(errs, field.Required(p, ""))
+		if actor.GetActorTemplateName() != "" {
+			errs = append(errs, field.Forbidden(actorPath.Child("actor_template_name"), "must be empty when actor_template is set"))
+		}
+		if pin := actor.GetActorTemplateVersion(); pin != "" {
+			errs = append(errs, resources.ValidateResourceName(pin, actorPath.Child("actor_template_version"))...)
+		}
 	} else {
-		for _, msg := range content.IsDNS1123Subdomain(val) {
-			errs = append(errs, field.Invalid(p, val, msg))
+		if actor.GetActorTemplateVersion() != "" {
+			errs = append(errs, field.Forbidden(actorPath.Child("actor_template_version"), "requires actor_template"))
+		}
+		if val, p := actor.GetActorTemplateNamespace(), actorPath.Child("actor_template_namespace"); val == "" {
+			errs = append(errs, field.Required(p, ""))
+		} else {
+			for _, msg := range content.IsDNS1123Label(val) {
+				errs = append(errs, field.Invalid(p, val, msg))
+			}
+		}
+		if val, p := actor.GetActorTemplateName(), actorPath.Child("actor_template_name"); val == "" {
+			errs = append(errs, field.Required(p, ""))
+		} else {
+			for _, msg := range content.IsDNS1123Subdomain(val) {
+				errs = append(errs, field.Invalid(p, val, msg))
+			}
 		}
 	}
 

--- a/cmd/ateapi/internal/controlapi/create_actor_template.go
+++ b/cmd/ateapi/internal/controlapi/create_actor_template.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// actorTemplateLockKey names the distributed lock serializing the operations
+// that maintain cross-resource invariants within one template family:
+// DeleteActorTemplate vs CreateActorTemplateVersion, and
+// DeleteActorTemplateVersion vs UpdateActorTemplate setting a default.
+func actorTemplateLockKey(name string) string {
+	return "lock:actor-template:" + name
+}
+
+func (s *Service) CreateActorTemplate(ctx context.Context, req *ateapipb.CreateActorTemplateRequest) (*ateapipb.ActorTemplate, error) {
+	if errs := validateCreateActorTemplateRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	name := req.GetActorTemplate().GetMetadata().GetName()
+	template := &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{
+			Name: name,
+		},
+		Spec: &ateapipb.ActorTemplateSpec{
+			WorkerSelector: req.GetActorTemplate().GetSpec().GetWorkerSelector(),
+		},
+	}
+	stored, err := s.persistence.CreateActorTemplate(ctx, template)
+	if err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			return nil, status.Errorf(codes.AlreadyExists, "ActorTemplate %s already exists", name)
+		}
+		return nil, fmt.Errorf("while recording actor template: %w", err)
+	}
+
+	return stored, nil
+}
+
+func validateCreateActorTemplateRequest(req *ateapipb.CreateActorTemplateRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	template := req.GetActorTemplate()
+	templatePath := fldPath.Child("actor_template")
+	if template == nil {
+		errs = append(errs, field.Required(templatePath, ""))
+		return errs
+	}
+
+	// ActorTemplate is global-scoped: metadata.atespace must be empty, name required + valid.
+	metaPath := templatePath.Child("metadata")
+	if val, p := template.GetMetadata().GetAtespace(), metaPath.Child("atespace"); val != "" {
+		errs = append(errs, field.Invalid(p, val, "must be empty for a global-scoped resource"))
+	}
+	if val, p := template.GetMetadata().GetName(), metaPath.Child("name"); val == "" {
+		errs = append(errs, field.Required(p, ""))
+	} else {
+		errs = append(errs, resources.ValidateResourceName(val, p)...)
+	}
+
+	specPath := templatePath.Child("spec")
+	if selector := template.GetSpec().GetWorkerSelector(); selector != nil {
+		errs = append(errs, validateSelector(selector, specPath.Child("worker_selector"))...)
+	}
+	// No version of a brand-new template can exist yet, so a default set at
+	// creation could never be valid.
+	if template.GetSpec().GetDefaultVersionOnCreate() != nil {
+		errs = append(errs, field.Forbidden(specPath.Child("default_version_on_create"),
+			"cannot be set at creation; set it via UpdateActorTemplate once the version exists"))
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/create_actor_template_test.go
+++ b/cmd/ateapi/internal/controlapi/create_actor_template_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateCreateActorTemplateRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.CreateActorTemplateRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+		}},
+		nil,
+	}, {
+		"valid with worker selector",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "1"}},
+			},
+		}},
+		nil,
+	}, {
+		"missing actor_template",
+		&ateapipb.CreateActorTemplateRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor_template"), "")},
+	}, {
+		"metadata.atespace must be empty",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tmpl-a"},
+		}},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "metadata", "atespace"), "ns1", "")},
+	}, {
+		"missing metadata.name",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{},
+		}},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "metadata", "name"), "")},
+	}, {
+		"invalid metadata.name",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "Tmpl_A"},
+		}},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "metadata", "name"), "Tmpl_A", "")},
+	}, {
+		"invalid worker selector",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"bad key!": "1"}},
+			},
+		}},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "spec", "worker_selector", "match_labels").Key("bad key!"), "bad key!", "")},
+	}, {
+		"default_version_on_create forbidden at creation",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec: &ateapipb.ActorTemplateSpec{
+				DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: "tmpl-a-v1"},
+			},
+		}},
+		field.ErrorList{field.Forbidden(field.NewPath("actor_template", "spec", "default_version_on_create"), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateCreateActorTemplateRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/create_actor_template_version.go
+++ b/cmd/ateapi/internal/controlapi/create_actor_template_version.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func (s *Service) CreateActorTemplateVersion(ctx context.Context, req *ateapipb.CreateActorTemplateVersionRequest) (*ateapipb.ActorTemplateVersion, error) {
+	if errs := validateCreateActorTemplateVersionRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+	in := req.GetActorTemplateVersion()
+	name := in.GetMetadata().GetName()
+	parent := in.GetActorTemplate().GetName()
+
+	// Default before validating: readyz fields are checked at their effective
+	// values, and the defaulted spec is what gets stored.
+	spec := proto.Clone(in.GetSpec()).(*ateapipb.ActorTemplateVersionSpec)
+	defaultActorTemplateVersionSpec(spec)
+	if errs := validateActorTemplateVersionSpec(spec, field.NewPath("actor_template_version", "spec")); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	// Freeze the sandbox resolution into status at creation time.
+	assets, err := resolveTemplateVersionSandbox(s.sandboxConfigLister, spec.GetSandboxConfig())
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "while resolving sandbox for ActorTemplateVersion %s: %v", name, err)
+	}
+
+	// The parent-exists check must not race DeleteActorTemplate's
+	// no-remaining-versions scan.
+	lock, err := s.persistence.AcquireLock(ctx, actorTemplateLockKey(parent))
+	if errors.Is(err, store.ErrLockConflict) {
+		return nil, status.Error(codes.Aborted, "another operation is using this ActorTemplate")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("while locking ActorTemplate: %w", err)
+	}
+	defer lock.Close()
+
+	exists, err := s.persistence.ActorTemplateExists(lock.Context(), parent)
+	if err != nil {
+		return nil, fmt.Errorf("while checking ActorTemplate existence: %w", err)
+	}
+	if !exists {
+		return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %s not found", parent)
+	}
+
+	// The request's status is ignored: versions start INITIAL with the
+	// sandbox resolution frozen at creation.
+	version := &ateapipb.ActorTemplateVersion{
+		Metadata: &ateapipb.ResourceMetadata{
+			Name: name,
+		},
+		ActorTemplate: &ateapipb.ObjectRef{Name: parent},
+		Spec:          spec,
+		Status: &ateapipb.ActorTemplateVersionStatus{
+			State:           ateapipb.ActorTemplateVersionStatus_STATE_INITIAL,
+			ResolvedSandbox: assets,
+		},
+	}
+	stored, err := s.persistence.CreateActorTemplateVersion(lock.Context(), version)
+	if err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			return nil, status.Errorf(codes.AlreadyExists, "ActorTemplateVersion %s already exists", name)
+		}
+		return nil, fmt.Errorf("while recording actor template version: %w", err)
+	}
+
+	return stored, nil
+}
+
+func validateCreateActorTemplateVersionRequest(req *ateapipb.CreateActorTemplateVersionRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	version := req.GetActorTemplateVersion()
+	versionPath := fldPath.Child("actor_template_version")
+	if version == nil {
+		errs = append(errs, field.Required(versionPath, ""))
+		return errs
+	}
+
+	// ActorTemplateVersion is global-scoped: metadata.atespace must be empty,
+	// name required + valid.
+	metaPath := versionPath.Child("metadata")
+	if val, p := version.GetMetadata().GetAtespace(), metaPath.Child("atespace"); val != "" {
+		errs = append(errs, field.Invalid(p, val, "must be empty for a global-scoped resource"))
+	}
+	if val, p := version.GetMetadata().GetName(), metaPath.Child("name"); val == "" {
+		errs = append(errs, field.Required(p, ""))
+	} else {
+		errs = append(errs, resources.ValidateResourceName(val, p)...)
+	}
+
+	if val, p := version.GetActorTemplate(), versionPath.Child("actor_template"); val == nil {
+		errs = append(errs, field.Required(p, ""))
+	} else {
+		errs = append(errs, resources.ValidateGlobalObjectRef(val, p)...)
+	}
+
+	// Spec content is validated by validateActorTemplateVersionSpec after
+	// defaulting; only its presence is a request-shape concern.
+	if version.GetSpec() == nil {
+		errs = append(errs, field.Required(versionPath.Child("spec"), ""))
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/create_actor_template_version_test.go
+++ b/cmd/ateapi/internal/controlapi/create_actor_template_version_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateCreateActorTemplateVersionRequest(t *testing.T) {
+	validReq := func(mutations ...func(*ateapipb.ActorTemplateVersion)) *ateapipb.CreateActorTemplateVersionRequest {
+		version := &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v1"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+			Spec:          validTemplateVersionSpec(),
+		}
+		for _, m := range mutations {
+			m(version)
+		}
+		return &ateapipb.CreateActorTemplateVersionRequest{ActorTemplateVersion: version}
+	}
+
+	tests := []struct {
+		name string
+		req  *ateapipb.CreateActorTemplateVersionRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		validReq(),
+		nil,
+	}, {
+		"missing actor_template_version",
+		&ateapipb.CreateActorTemplateVersionRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor_template_version"), "")},
+	}, {
+		"metadata.atespace must be empty",
+		validReq(func(v *ateapipb.ActorTemplateVersion) { v.Metadata.Atespace = "ns1" }),
+		field.ErrorList{field.Invalid(field.NewPath("actor_template_version", "metadata", "atespace"), "ns1", "")},
+	}, {
+		"missing metadata.name",
+		validReq(func(v *ateapipb.ActorTemplateVersion) { v.Metadata.Name = "" }),
+		field.ErrorList{field.Required(field.NewPath("actor_template_version", "metadata", "name"), "")},
+	}, {
+		"invalid metadata.name",
+		validReq(func(v *ateapipb.ActorTemplateVersion) { v.Metadata.Name = "V1" }),
+		field.ErrorList{field.Invalid(field.NewPath("actor_template_version", "metadata", "name"), "V1", "")},
+	}, {
+		"missing actor_template parent ref",
+		validReq(func(v *ateapipb.ActorTemplateVersion) { v.ActorTemplate = nil }),
+		field.ErrorList{field.Required(field.NewPath("actor_template_version", "actor_template"), "")},
+	}, {
+		"parent ref with atespace",
+		validReq(func(v *ateapipb.ActorTemplateVersion) { v.ActorTemplate.Atespace = "ns1" }),
+		field.ErrorList{field.Invalid(field.NewPath("actor_template_version", "actor_template", "atespace"), "ns1", "")},
+	}, {
+		"missing spec",
+		validReq(func(v *ateapipb.ActorTemplateVersion) { v.Spec = nil }),
+		field.ErrorList{field.Required(field.NewPath("actor_template_version", "spec"), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateCreateActorTemplateVersionRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/create_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/create_actor_test.go
@@ -124,6 +124,47 @@ func TestValidateCreateActorRequest(t *testing.T) {
 		validActor(func(a *ateapipb.Actor) { a.ActorTemplateName = "invalid value" }),
 		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template_name"), "invalid value", "")},
 	}, {
+		"valid native actor_template",
+		validActor(func(a *ateapipb.Actor) {
+			a.ActorTemplateNamespace, a.ActorTemplateName = "", ""
+			a.ActorTemplate = "tmpl1"
+		}),
+		nil,
+	}, {
+		"valid native actor_template with version pin",
+		validActor(func(a *ateapipb.Actor) {
+			a.ActorTemplateNamespace, a.ActorTemplateName = "", ""
+			a.ActorTemplate = "tmpl1"
+			a.ActorTemplateVersion = "tmpl1-v1"
+		}),
+		nil,
+	}, {
+		"invalid native actor_template name",
+		validActor(func(a *ateapipb.Actor) {
+			a.ActorTemplateNamespace, a.ActorTemplateName = "", ""
+			a.ActorTemplate = "TMPL1"
+		}),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template"), "TMPL1", "")},
+	}, {
+		"invalid actor_template_version",
+		validActor(func(a *ateapipb.Actor) {
+			a.ActorTemplateNamespace, a.ActorTemplateName = "", ""
+			a.ActorTemplate = "tmpl1"
+			a.ActorTemplateVersion = "TMPL1-V1"
+		}),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template_version"), "TMPL1-V1", "")},
+	}, {
+		"actor_template excludes actor_template_namespace and actor_template_name",
+		validActor(func(a *ateapipb.Actor) { a.ActorTemplate = "tmpl1" }),
+		field.ErrorList{
+			field.Forbidden(field.NewPath("actor", "actor_template_namespace"), ""),
+			field.Forbidden(field.NewPath("actor", "actor_template_name"), ""),
+		},
+	}, {
+		"actor_template_version requires actor_template",
+		validActor(func(a *ateapipb.Actor) { a.ActorTemplateVersion = "tmpl1-v1" }),
+		field.ErrorList{field.Forbidden(field.NewPath("actor", "actor_template_version"), "")},
+	}, {
 		"worker_selector with nil match_labels",
 		validActor(func(a *ateapipb.Actor) { a.WorkerSelector = &ateapipb.Selector{} }),
 		nil,

--- a/cmd/ateapi/internal/controlapi/delete_actor_template.go
+++ b/cmd/ateapi/internal/controlapi/delete_actor_template.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func (s *Service) DeleteActorTemplate(ctx context.Context, req *ateapipb.DeleteActorTemplateRequest) (*ateapipb.ActorTemplate, error) {
+	if errs := validateDeleteActorTemplateRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	name := req.GetActorTemplate().GetName()
+	lock, err := s.persistence.AcquireLock(ctx, actorTemplateLockKey(name))
+	if errors.Is(err, store.ErrLockConflict) {
+		return nil, status.Error(codes.Aborted, "another operation is using this ActorTemplate")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("while locking ActorTemplate: %w", err)
+	}
+	defer lock.Close()
+	deleted, err := s.persistence.DeleteActorTemplate(lock.Context(), name)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "ActorTemplate %s not found", name)
+		}
+		if errors.Is(err, store.ErrFailedPrecondition) {
+			return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %s still has versions", name)
+		}
+		return nil, fmt.Errorf("while deleting actor template from DB: %w", err)
+	}
+
+	return deleted, nil
+}
+
+func validateDeleteActorTemplateRequest(req *ateapipb.DeleteActorTemplateRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.ActorTemplate, fldPath.Child("actor_template"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateGlobalObjectRef(val, fldPath)...)
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/delete_actor_template_test.go
+++ b/cmd/ateapi/internal/controlapi/delete_actor_template_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateDeleteActorTemplateRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.DeleteActorTemplateRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}},
+		nil,
+	}, {
+		"missing actor_template",
+		&ateapipb.DeleteActorTemplateRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor_template"), "")},
+	}, {
+		"atespace must be empty",
+		&ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl-a"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "atespace"), "ns1", "")},
+	}, {
+		"missing name",
+		&ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{}},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "name"), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateDeleteActorTemplateRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/delete_actor_template_version.go
+++ b/cmd/ateapi/internal/controlapi/delete_actor_template_version.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func (s *Service) DeleteActorTemplateVersion(ctx context.Context, req *ateapipb.DeleteActorTemplateVersionRequest) (*ateapipb.ActorTemplateVersion, error) {
+	if errs := validateDeleteActorTemplateVersionRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	// Read the version first to learn the parent, whose lock serializes this
+	// delete with UpdateActorTemplate setting it as the default.
+	name := req.GetActorTemplateVersion().GetName()
+	version, err := s.persistence.GetActorTemplateVersion(ctx, name)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "ActorTemplateVersion %s not found", name)
+		}
+		return nil, fmt.Errorf("while getting actor template version: %w", err)
+	}
+	parent := version.GetActorTemplate().GetName()
+
+	lock, err := s.persistence.AcquireLock(ctx, actorTemplateLockKey(parent))
+	if errors.Is(err, store.ErrLockConflict) {
+		return nil, status.Error(codes.Aborted, "another operation is using this ActorTemplate")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("while locking ActorTemplate: %w", err)
+	}
+	defer lock.Close()
+
+	deleted, err := s.persistence.DeleteActorTemplateVersion(lock.Context(), name)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "ActorTemplateVersion %s not found", name)
+		}
+		if errors.Is(err, store.ErrFailedPrecondition) {
+			return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %s is the default_version_on_create of ActorTemplate %s", name, parent)
+		}
+		return nil, fmt.Errorf("while deleting actor template version from DB: %w", err)
+	}
+
+	return deleted, nil
+}
+
+func validateDeleteActorTemplateVersionRequest(req *ateapipb.DeleteActorTemplateVersionRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.ActorTemplateVersion, fldPath.Child("actor_template_version"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateGlobalObjectRef(val, fldPath)...)
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/delete_actor_template_version_test.go
+++ b/cmd/ateapi/internal/controlapi/delete_actor_template_version_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateDeleteActorTemplateVersionRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.DeleteActorTemplateVersionRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.DeleteActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}},
+		nil,
+	}, {
+		"missing actor_template_version",
+		&ateapipb.DeleteActorTemplateVersionRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor_template_version"), "")},
+	}, {
+		"atespace must be empty",
+		&ateapipb.DeleteActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl-a-v1"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template_version", "atespace"), "ns1", "")},
+	}, {
+		"missing name",
+		&ateapipb.DeleteActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{}},
+		field.ErrorList{field.Required(field.NewPath("actor_template_version", "name"), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateDeleteActorTemplateVersionRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -4047,3 +4047,144 @@ func TestActorTemplate_LockConflict(t *testing.T) {
 		t.Errorf("UpdateActorTemplate(selector) under held lock failed: %v", err)
 	}
 }
+
+// markTemplateVersionReady flips a stored ActorTemplateVersion to READY while
+// preserving the sandbox frozen at creation, standing in for the golden
+// snapshot build loop.
+func markTemplateVersionReady(t *testing.T, tc *testContext, name string) *ateapipb.ActorTemplateVersion {
+	t.Helper()
+	current, err := tc.persistence.GetActorTemplateVersion(context.Background(), name)
+	if err != nil {
+		t.Fatalf("GetActorTemplateVersion(%s) failed: %v", name, err)
+	}
+	status := proto.Clone(current.GetStatus()).(*ateapipb.ActorTemplateVersionStatus)
+	status.State = ateapipb.ActorTemplateVersionStatus_STATE_READY
+	ready, err := tc.persistence.UpdateActorTemplateVersionStatus(context.Background(), name, status, current.GetMetadata().GetVersion())
+	if err != nil {
+		t.Fatalf("UpdateActorTemplateVersionStatus(%s) failed: %v", name, err)
+	}
+	return ready
+}
+
+func TestCreateActorFromTemplateVersion(t *testing.T) {
+	ns := namespaceForTest("ns-create-native")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	createTemplateForVersions(t, tc, "tmpl-a")
+	createTemplateVersion(t, tc, "tmpl-a-v1", "tmpl-a")
+
+	nativeActor := func(name, atespace, version string) *ateapipb.CreateActorRequest {
+		return &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+			Metadata:             &ateapipb.ResourceMetadata{Atespace: atespace, Name: name},
+			ActorTemplate:        "tmpl-a",
+			ActorTemplateVersion: version,
+		}}
+	}
+
+	// No pin and no default_version_on_create.
+	_, err := tc.client.CreateActor(ctx, nativeActor("id1", testAtespace, ""))
+	assertGrpcError(t, err, codes.FailedPrecondition, `ActorTemplate "tmpl-a" has no default_version_on_create; pin a version`)
+
+	// Pinned, but the version is still INITIAL.
+	_, err = tc.client.CreateActor(ctx, nativeActor("id1", testAtespace, "tmpl-a-v1"))
+	assertGrpcError(t, err, codes.FailedPrecondition, `ActorTemplateVersion "tmpl-a-v1" is not READY (state STATE_INITIAL)`)
+
+	// The golden atespace bypasses the READY gate: this is how the build
+	// loop's golden actor is created from a version still being built.
+	createAtespace(t, tc, resources.GoldenActorAtespace)
+	if _, err := tc.client.CreateActor(ctx, nativeActor("golden-1", resources.GoldenActorAtespace, "tmpl-a-v1")); err != nil {
+		t.Fatalf("CreateActor in %s should bypass the READY gate, got: %v", resources.GoldenActorAtespace, err)
+	}
+
+	// Missing template and mismatched parent are rejected.
+	_, err = tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: "nope",
+	}})
+	assertGrpcError(t, err, codes.FailedPrecondition, `ActorTemplate "nope" not found`)
+	createTemplateForVersions(t, tc, "tmpl-b")
+	_, err = tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:             &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate:        "tmpl-b",
+		ActorTemplateVersion: "tmpl-a-v1",
+	}})
+	assertGrpcError(t, err, codes.FailedPrecondition, `ActorTemplateVersion "tmpl-a-v1" belongs to ActorTemplate "tmpl-a", not "tmpl-b"`)
+
+	readyVersion := markTemplateVersionReady(t, tc, "tmpl-a-v1")
+
+	// A pinned create works once READY, and stores the native identity.
+	pinned, err := tc.client.CreateActor(ctx, nativeActor("id-pinned", testAtespace, "tmpl-a-v1"))
+	if err != nil {
+		t.Fatalf("CreateActor(pinned) failed: %v", err)
+	}
+	if pinned.GetActorTemplate() != "tmpl-a" || pinned.GetActorTemplateVersion() != "tmpl-a-v1" {
+		t.Errorf("stored native identity = (%q, %q), want (tmpl-a, tmpl-a-v1)", pinned.GetActorTemplate(), pinned.GetActorTemplateVersion())
+	}
+	if pinned.GetActorTemplateNamespace() != "" || pinned.GetActorTemplateName() != "" {
+		t.Errorf("CRD identity should stay empty, got (%q, %q)", pinned.GetActorTemplateNamespace(), pinned.GetActorTemplateName())
+	}
+
+	// An unpinned create resolves the template's default.
+	if _, err := tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec:     &ateapipb.ActorTemplateSpec{DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{defaultVersionMaskPath}},
+	}); err != nil {
+		t.Fatalf("UpdateActorTemplate(default) failed: %v", err)
+	}
+	defaulted, err := tc.client.CreateActor(ctx, nativeActor("id-default", testAtespace, ""))
+	if err != nil {
+		t.Fatalf("CreateActor(default) failed: %v", err)
+	}
+	if defaulted.GetActorTemplateVersion() != "tmpl-a-v1" {
+		t.Errorf("default resolution stored version %q, want tmpl-a-v1", defaulted.GetActorTemplateVersion())
+	}
+
+	// Resume boots from the version spec with its frozen sandbox, and atelet
+	// sees the version name as the template identity (namespace empty).
+	createWorkerPool(t, tc, ns, "pool1", map[string]string{poolLabelKey: ns})
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id-pinned"},
+	}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+	if !tc.fakeAtelet.RunCalled {
+		t.Fatal("expected a boot Run call for a version with no golden snapshot")
+	}
+	runReq := tc.fakeAtelet.RunRequest
+	if runReq.GetActorTemplateNamespace() != "" || runReq.GetActorTemplateName() != "tmpl-a-v1" {
+		t.Errorf("RunRequest template identity = (%q, %q), want (\"\", tmpl-a-v1)", runReq.GetActorTemplateNamespace(), runReq.GetActorTemplateName())
+	}
+	if got := runReq.GetSpec().GetPauseImage(); got != "pause@sha256:abc" {
+		t.Errorf("RunRequest pause image = %q, want the version's", got)
+	}
+	if got := runReq.GetSandboxAssets().GetSandboxClass(); got != "gvisor" {
+		t.Errorf("RunRequest sandbox class = %q, want the frozen gvisor sandbox", got)
+	}
+
+	// Suspend records the version as the snapshot's provenance.
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id-pinned"},
+	}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	suspended, err := tc.client.GetActor(ctx, &ateapipb.GetActorRequest{Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id-pinned"}})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	snapshot, err := tc.persistence.GetActorSnapshot(ctx, testAtespace, suspended.GetLatestSnapshot().GetName())
+	if err != nil {
+		t.Fatalf("GetActorSnapshot failed: %v", err)
+	}
+	if snapshot.GetActorTemplateUid() != readyVersion.GetMetadata().GetUid() {
+		t.Errorf("snapshot ActorTemplateUid = %q, want the version uid %q", snapshot.GetActorTemplateUid(), readyVersion.GetMetadata().GetUid())
+	}
+	if snapshot.GetActorTemplateNamespace() != "" || snapshot.GetActorTemplateName() != "tmpl-a-v1" {
+		t.Errorf("snapshot template identity = (%q, %q), want (\"\", tmpl-a-v1)", snapshot.GetActorTemplateNamespace(), snapshot.GetActorTemplateName())
+	}
+}

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -3129,34 +3129,47 @@ func TestResumeActor_DanglingWorker(t *testing.T) {
 
 	deleteWorkerPod(t, tc, ns, "worker-a")
 
-	// 6. Create Worker Pod B
-	createWorkerPod(t, tc, ns, "worker-b", "node1", "pool1")
-
-	// 7. Configure fake Atelet to SUCCEED on Restore
-	tc.fakeAtelet.FailRestore = nil
-	tc.fakeAtelet.RestoreCalled = false // reset
-
-	// 8. Call ResumeActor again -> Expect it to fail because it is already CRASHED by background syncer.
-	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
-		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
-	})
-	if err == nil {
-		t.Fatalf("expected ResumeActor to fail because worker is gone")
+	// 6. The background syncer crashes the actor once its worker vanished:
+	// CRASHED with the worker assignment cleared.
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		stored, err := tc.persistence.GetActor(ctx, resources.ActorRef{Atespace: testAtespace, Name: name})
+		if err != nil {
+			return false, err
+		}
+		return stored.GetStatus() == ateapipb.Actor_STATUS_CRASHED, nil
+	}); err != nil {
+		t.Fatalf("actor never reached CRASHED after its worker vanished: %v", err)
 	}
-	if status.Code(err) != codes.FailedPrecondition || !strings.Contains(err.Error(), "STATUS_CRASHED") {
-		t.Errorf("expected FailedPrecondition/STATUS_CRASHED error, got %v", err)
-	}
-
-	// Verify actor state is CRASHED and worker assignment is empty
-	actor, err = tc.persistence.GetActor(context.Background(), resources.ActorRef{Atespace: testAtespace, Name: name})
+	crashed, err := tc.persistence.GetActor(context.Background(), resources.ActorRef{Atespace: testAtespace, Name: name})
 	if err != nil {
 		t.Fatalf("failed to get actor from store: %v", err)
 	}
-	if actor.GetStatus() != ateapipb.Actor_STATUS_CRASHED {
-		t.Errorf("expected status CRASHED, got %v", actor.GetStatus())
+	if crashed.GetWorkerAssignment().GetWorkerPod() != "" {
+		t.Errorf("expected worker to be unassigned, got %v", crashed.GetWorkerAssignment().GetWorkerPod())
 	}
-	if actor.GetWorkerAssignment().GetWorkerPod() != "" {
-		t.Errorf("expected worker to be unassigned, got %v", actor.GetWorkerAssignment().GetWorkerPod())
+
+	// 7. Create Worker Pod B and let Restore succeed.
+	createWorkerPod(t, tc, ns, "worker-b", "node1", "pool1")
+	tc.fakeAtelet.FailRestore = nil
+	tc.fakeAtelet.RestoreCalled = false // reset
+
+	// 8. CRASHED actors are resumable: the actor recovers onto the fresh worker.
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	}); err != nil {
+		t.Fatalf("ResumeActor from CRASHED failed: %v", err)
+	}
+	actor, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if actor.GetStatus() != ateapipb.Actor_STATUS_RUNNING {
+		t.Errorf("expected status RUNNING after recovery, got %v", actor.GetStatus())
+	}
+	if actor.GetWorkerAssignment().GetWorkerPod() != "worker-b" {
+		t.Errorf("expected worker-b assigned, got %v", actor.GetWorkerAssignment().GetWorkerPod())
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -16,6 +16,7 @@ package controlapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -26,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/ateredis"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
@@ -3582,4 +3584,466 @@ func TestDeleteAtespace_NotFound(t *testing.T) {
 func assertValidateErr(t *testing.T, got field.ErrorList, want field.ErrorList) {
 	t.Helper()
 	field.ErrorMatcher{}.ByType().ByField().ByValue().Test(t, want, got)
+}
+
+func TestActorTemplateCRUD(t *testing.T) {
+	ns := namespaceForTest("ns-template-crud")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+
+	created, err := tc.client.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}},
+				// Server-owned fields on the request are ignored.
+				DefaultVersionOnCreate: nil,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	want := &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a", Version: 1},
+		Spec: &ateapipb.ActorTemplateSpec{
+			WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}},
+		},
+	}
+	if diff := cmp.Diff(want, created, protocmp.Transform(), ignoreUID, ignoreTimestamps); diff != "" {
+		t.Errorf("CreateActorTemplate response mismatch (-want +got):\n%s", diff)
+	}
+
+	_, err = tc.client.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"}},
+	})
+	assertGrpcError(t, err, codes.AlreadyExists, "ActorTemplate tmpl-a already exists")
+
+	got, err := tc.client.GetActorTemplate(ctx, &ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}})
+	if err != nil {
+		t.Fatalf("GetActorTemplate failed: %v", err)
+	}
+	if diff := cmp.Diff(created, got, protocmp.Transform()); diff != "" {
+		t.Errorf("GetActorTemplate response mismatch (-created +got):\n%s", diff)
+	}
+
+	list, err := tc.client.ListActorTemplates(ctx, &ateapipb.ListActorTemplatesRequest{})
+	if err != nil {
+		t.Fatalf("ListActorTemplates failed: %v", err)
+	}
+	if len(list.GetActorTemplates()) != 1 || list.GetActorTemplates()[0].GetMetadata().GetName() != "tmpl-a" {
+		t.Errorf("ListActorTemplates = %v, want [tmpl-a]", list.GetActorTemplates())
+	}
+
+	deleted, err := tc.client.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}})
+	if err != nil {
+		t.Fatalf("DeleteActorTemplate failed: %v", err)
+	}
+	if diff := cmp.Diff(created, deleted, protocmp.Transform()); diff != "" {
+		t.Errorf("DeleteActorTemplate response mismatch (-created +deleted):\n%s", diff)
+	}
+	_, err = tc.client.GetActorTemplate(ctx, &ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}})
+	assertGrpcError(t, err, codes.NotFound, "ActorTemplate tmpl-a not found")
+	_, err = tc.client.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}})
+	assertGrpcError(t, err, codes.NotFound, "ActorTemplate tmpl-a not found")
+}
+
+// createTemplateVersion creates a version through the RPC surface with a
+// valid spec, requiring the gvisor-default SandboxConfig named in the fixture.
+func createTemplateVersion(t *testing.T, tc *testContext, name, template string) *ateapipb.ActorTemplateVersion {
+	t.Helper()
+	version, err := tc.client.CreateActorTemplateVersion(context.Background(), &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: name},
+			ActorTemplate: &ateapipb.ObjectRef{Name: template},
+			Spec:          validTemplateVersionSpec(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActorTemplateVersion(%s) failed: %v", name, err)
+	}
+	return version
+}
+
+func createTemplateForVersions(t *testing.T, tc *testContext, name string) {
+	t.Helper()
+	if _, err := tc.client.CreateActorTemplate(context.Background(), &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{Metadata: &ateapipb.ResourceMetadata{Name: name}},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplate(%s) failed: %v", name, err)
+	}
+}
+
+func TestCreateActorTemplateVersion(t *testing.T) {
+	ns := namespaceForTest("ns-template-version-create")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	ctx := context.Background()
+
+	// The parent must exist first.
+	_, err := tc.client.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v1"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+			Spec:          validTemplateVersionSpec(),
+		},
+	})
+	assertGrpcError(t, err, codes.FailedPrecondition, "ActorTemplate tmpl-a not found")
+
+	createTemplateForVersions(t, tc, "tmpl-a")
+
+	// The caller's status and server-owned metadata are ignored: versions
+	// start INITIAL with the named gvisor SandboxConfig frozen into status.
+	created, err := tc.client.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v1", Uid: "11111111-2222-3333-4444-555555555555"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+			Spec:          validTemplateVersionSpec(),
+			Status: &ateapipb.ActorTemplateVersionStatus{
+				State:          ateapipb.ActorTemplateVersionStatus_STATE_READY,
+				GoldenSnapshot: &ateapipb.ObjectRef{Atespace: "ate-golden", Name: "bogus"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+	wantStatus := &ateapipb.ActorTemplateVersionStatus{
+		State: ateapipb.ActorTemplateVersionStatus_STATE_INITIAL,
+		ResolvedSandbox: &ateapipb.SandboxAssets{
+			SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+			Assets: map[string]*ateapipb.ArchAssets{
+				"amd64": {Files: map[string]*ateapipb.AssetFile{"runsc": {
+					Url:    "gs://gvisor/releases/nightly/2026-05-19/x86_64/runsc",
+					Sha256: "a397be1abc2420d26bce6c70e6e2ff96c73aaaab929756c56f5e2089ea842b63",
+				}}},
+				"arm64": {Files: map[string]*ateapipb.AssetFile{"runsc": {
+					Url:    "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc",
+					Sha256: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9",
+				}}},
+			},
+		},
+	}
+	if diff := cmp.Diff(wantStatus, created.GetStatus(), protocmp.Transform()); diff != "" {
+		t.Errorf("created status mismatch (-want +got):\n%s", diff)
+	}
+	if got := created.GetMetadata().GetUid(); got == "" || got == "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("uid = %q, want a fresh server-assigned uid", got)
+	}
+
+	_, err = tc.client.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v1"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+			Spec:          validTemplateVersionSpec(),
+		},
+	})
+	assertGrpcError(t, err, codes.AlreadyExists, "ActorTemplateVersion tmpl-a-v1 already exists")
+
+	// One spec rule end-to-end: an unpinned image is InvalidArgument.
+	_, err = tc.client.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v2"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+			Spec: validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+				s.Containers[0].Image = "app:latest"
+			}),
+		},
+	})
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Errorf("CreateActorTemplateVersion(unpinned image) code = %v, want InvalidArgument (err: %v)", got, err)
+	}
+
+	// A spec omitting sandbox_config is rejected at validation: the server
+	// never falls back to a default SandboxConfig.
+	_, err = tc.client.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v3"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+			Spec: validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+				s.SandboxConfig = nil
+			}),
+		},
+	})
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Errorf("CreateActorTemplateVersion(no sandbox_config) code = %v, want InvalidArgument (err: %v)", got, err)
+	}
+
+	// Naming a SandboxConfig that does not exist is FailedPrecondition.
+	_, err = tc.client.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v3"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+			Spec: validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+				s.SandboxConfig = &ateapipb.SandboxConfig{
+					SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM,
+					ConfigName:   "no-such-config",
+				}
+			}),
+		},
+	})
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Errorf("CreateActorTemplateVersion(missing named SandboxConfig) code = %v, want FailedPrecondition (err: %v)", got, err)
+	}
+
+	// The version blocks the parent's deletion until it is deleted itself.
+	_, err = tc.client.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}})
+	assertGrpcError(t, err, codes.FailedPrecondition, "ActorTemplate tmpl-a still has versions")
+	if _, err := tc.client.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}}); err != nil {
+		t.Fatalf("DeleteActorTemplateVersion failed: %v", err)
+	}
+	if _, err := tc.client.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}}); err != nil {
+		t.Errorf("DeleteActorTemplate after version removed failed: %v", err)
+	}
+}
+
+func TestUpdateActorTemplate(t *testing.T) {
+	ns := namespaceForTest("ns-template-update")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	ctx := context.Background()
+
+	createTemplateForVersions(t, tc, "tmpl-a")
+	createTemplateForVersions(t, tc, "tmpl-b")
+	createTemplateVersion(t, tc, "tmpl-a-v1", "tmpl-a")
+	createTemplateVersion(t, tc, "tmpl-b-v1", "tmpl-b")
+
+	setDefault := func(template, version string) (*ateapipb.ActorTemplate, error) {
+		var ref *ateapipb.ObjectRef
+		if version != "" {
+			ref = &ateapipb.ObjectRef{Name: version}
+		}
+		return tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+			ActorTemplate: &ateapipb.ActorTemplate{
+				Metadata: &ateapipb.ResourceMetadata{Name: template},
+				Spec:     &ateapipb.ActorTemplateSpec{DefaultVersionOnCreate: ref},
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.default_version_on_create"}},
+		})
+	}
+
+	// Selector-only update.
+	updated, err := tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.worker_selector"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateActorTemplate(selector) failed: %v", err)
+	}
+	if got := updated.GetSpec().GetWorkerSelector().GetMatchLabels()["tier"]; got != "paid" {
+		t.Errorf("worker_selector[tier] = %q, want paid", got)
+	}
+	if got := updated.GetMetadata().GetVersion(); got != 2 {
+		t.Errorf("version after update = %d, want 2", got)
+	}
+
+	// A default must name an existing version of THIS template.
+	_, err = setDefault("tmpl-a", "no-such-version")
+	assertGrpcError(t, err, codes.FailedPrecondition, "ActorTemplateVersion no-such-version not found")
+	_, err = setDefault("tmpl-a", "tmpl-b-v1")
+	assertGrpcError(t, err, codes.FailedPrecondition, "ActorTemplateVersion tmpl-b-v1 belongs to ActorTemplate tmpl-b, not tmpl-a")
+
+	// A version still building (INITIAL) is accepted: readiness is enforced
+	// at CreateActor time, not here.
+	updated, err = setDefault("tmpl-a", "tmpl-a-v1")
+	if err != nil {
+		t.Fatalf("UpdateActorTemplate(set default) failed: %v", err)
+	}
+	if got := updated.GetSpec().GetDefaultVersionOnCreate().GetName(); got != "tmpl-a-v1" {
+		t.Errorf("default_version_on_create = %q, want tmpl-a-v1", got)
+	}
+	// The selector set before the default update must have survived it.
+	if got := updated.GetSpec().GetWorkerSelector().GetMatchLabels()["tier"]; got != "paid" {
+		t.Errorf("worker_selector[tier] after default update = %q, want paid", got)
+	}
+
+	// Precondition guards.
+	_, err = tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a", Uid: "00000000-0000-0000-0000-000000000000"},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.worker_selector"}},
+	})
+	if got := status.Code(err); got != codes.Aborted {
+		t.Errorf("UpdateActorTemplate(stale uid) code = %v, want Aborted (err: %v)", got, err)
+	}
+	_, err = tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a", Version: 1},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.worker_selector"}},
+	})
+	assertGrpcError(t, err, codes.Aborted, "concurrent update conflict, please retry")
+
+	_, err = tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{Metadata: &ateapipb.ResourceMetadata{Name: "nope"}},
+		UpdateMask:    &fieldmaskpb.FieldMask{Paths: []string{"spec.worker_selector"}},
+	})
+	assertGrpcError(t, err, codes.NotFound, "ActorTemplate nope not found")
+}
+
+func TestDeleteActorTemplateVersion_Default(t *testing.T) {
+	ns := namespaceForTest("ns-template-version-default")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	ctx := context.Background()
+
+	createTemplateForVersions(t, tc, "tmpl-a")
+	createTemplateVersion(t, tc, "tmpl-a-v1", "tmpl-a")
+	if _, err := tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec:     &ateapipb.ActorTemplateSpec{DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.default_version_on_create"}},
+	}); err != nil {
+		t.Fatalf("UpdateActorTemplate(set default) failed: %v", err)
+	}
+
+	_, err := tc.client.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}})
+	assertGrpcError(t, err, codes.FailedPrecondition, "ActorTemplateVersion tmpl-a-v1 is the default_version_on_create of ActorTemplate tmpl-a")
+
+	// Clearing the default (masked path, unset value) unblocks the delete.
+	if _, err := tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"}},
+		UpdateMask:    &fieldmaskpb.FieldMask{Paths: []string{"spec.default_version_on_create"}},
+	}); err != nil {
+		t.Fatalf("UpdateActorTemplate(clear default) failed: %v", err)
+	}
+	if _, err := tc.client.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}}); err != nil {
+		t.Errorf("DeleteActorTemplateVersion after clearing default failed: %v", err)
+	}
+	_, err = tc.client.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}})
+	assertGrpcError(t, err, codes.NotFound, "ActorTemplateVersion tmpl-a-v1 not found")
+}
+
+func TestDeleteActorTemplateVersion_GoldenCleanup(t *testing.T) {
+	ns := namespaceForTest("ns-template-version-golden")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+
+	// Seed a version whose status already records a golden snapshot; the RPC
+	// surface never accepts caller status, so go through the store like the
+	// future golden driver will.
+	if _, err := tc.persistence.CreateActorSnapshot(ctx, &ateapipb.ActorSnapshot{
+		Metadata:    &ateapipb.ResourceMetadata{Atespace: resources.GoldenActorAtespace, Name: "golden-v1"},
+		SnapshotUri: "gs://fake-fake-fake/snapshots/" + resources.GoldenActorAtespace + "/golden-v1",
+	}); err != nil {
+		t.Fatalf("CreateActorSnapshot failed: %v", err)
+	}
+	if _, err := tc.persistence.CreateActorTemplateVersion(ctx, &ateapipb.ActorTemplateVersion{
+		Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v1"},
+		ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+		Spec:          validTemplateVersionSpec(),
+		Status: &ateapipb.ActorTemplateVersionStatus{
+			State:          ateapipb.ActorTemplateVersionStatus_STATE_READY,
+			GoldenSnapshot: &ateapipb.ObjectRef{Atespace: resources.GoldenActorAtespace, Name: "golden-v1"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplateVersion (store) failed: %v", err)
+	}
+
+	if _, err := tc.client.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}}); err != nil {
+		t.Fatalf("DeleteActorTemplateVersion failed: %v", err)
+	}
+	if _, err := tc.persistence.GetActorSnapshot(ctx, resources.GoldenActorAtespace, "golden-v1"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("golden snapshot after delete = %v, want ErrNotFound", err)
+	}
+}
+
+func TestListActorTemplateVersions_Filter(t *testing.T) {
+	ns := namespaceForTest("ns-template-version-list")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	ctx := context.Background()
+
+	createTemplateForVersions(t, tc, "tmpl-a")
+	createTemplateForVersions(t, tc, "tmpl-b")
+	createTemplateVersion(t, tc, "tmpl-a-v1", "tmpl-a")
+	createTemplateVersion(t, tc, "tmpl-a-v2", "tmpl-a")
+	createTemplateVersion(t, tc, "tmpl-b-v1", "tmpl-b")
+
+	all, err := tc.client.ListActorTemplateVersions(ctx, &ateapipb.ListActorTemplateVersionsRequest{})
+	if err != nil {
+		t.Fatalf("ListActorTemplateVersions(all) failed: %v", err)
+	}
+	if got := len(all.GetActorTemplateVersions()); got != 3 {
+		t.Errorf("unfiltered list returned %d versions, want 3", got)
+	}
+
+	filtered, err := tc.client.ListActorTemplateVersions(ctx, &ateapipb.ListActorTemplateVersionsRequest{ActorTemplate: "tmpl-a"})
+	if err != nil {
+		t.Fatalf("ListActorTemplateVersions(tmpl-a) failed: %v", err)
+	}
+	if got := len(filtered.GetActorTemplateVersions()); got != 2 {
+		t.Fatalf("filtered list returned %d versions, want 2", got)
+	}
+	for _, v := range filtered.GetActorTemplateVersions() {
+		if v.GetActorTemplate().GetName() != "tmpl-a" {
+			t.Errorf("filtered list returned version %q of template %q", v.GetMetadata().GetName(), v.GetActorTemplate().GetName())
+		}
+	}
+}
+
+func TestActorTemplate_LockConflict(t *testing.T) {
+	ns := namespaceForTest("ns-template-lock")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	ctx := context.Background()
+
+	createTemplateForVersions(t, tc, "tmpl-a")
+	createTemplateVersion(t, tc, "tmpl-a-v1", "tmpl-a")
+
+	lock, err := tc.persistence.AcquireLock(ctx, actorTemplateLockKey("tmpl-a"))
+	if err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+	defer lock.Close()
+
+	const wantMsg = "another operation is using this ActorTemplate"
+	_, err = tc.client.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}})
+	assertGrpcError(t, err, codes.Aborted, wantMsg)
+	_, err = tc.client.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v2"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+			Spec:          validTemplateVersionSpec(),
+		},
+	})
+	assertGrpcError(t, err, codes.Aborted, wantMsg)
+	_, err = tc.client.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}})
+	assertGrpcError(t, err, codes.Aborted, wantMsg)
+	_, err = tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec:     &ateapipb.ActorTemplateSpec{DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.default_version_on_create"}},
+	})
+	assertGrpcError(t, err, codes.Aborted, wantMsg)
+
+	// Selector-only updates don't take the lock and still go through.
+	if _, err := tc.client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}},
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.worker_selector"}},
+	}); err != nil {
+		t.Errorf("UpdateActorTemplate(selector) under held lock failed: %v", err)
+	}
 }

--- a/cmd/ateapi/internal/controlapi/get_actor_template.go
+++ b/cmd/ateapi/internal/controlapi/get_actor_template.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func (s *Service) GetActorTemplate(ctx context.Context, req *ateapipb.GetActorTemplateRequest) (*ateapipb.ActorTemplate, error) {
+	if errs := validateGetActorTemplateRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	name := req.GetActorTemplate().GetName()
+	template, err := s.persistence.GetActorTemplate(ctx, name)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, status.Errorf(codes.NotFound, "ActorTemplate %s not found", name)
+	} else if err != nil {
+		return nil, fmt.Errorf("while getting actor template from DB: %w", err)
+	}
+
+	return template, nil
+}
+
+func validateGetActorTemplateRequest(req *ateapipb.GetActorTemplateRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.ActorTemplate, fldPath.Child("actor_template"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateGlobalObjectRef(val, fldPath)...)
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/get_actor_template_test.go
+++ b/cmd/ateapi/internal/controlapi/get_actor_template_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateGetActorTemplateRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.GetActorTemplateRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}},
+		nil,
+	}, {
+		"missing actor_template",
+		&ateapipb.GetActorTemplateRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor_template"), "")},
+	}, {
+		"atespace must be empty",
+		&ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl-a"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "atespace"), "ns1", "")},
+	}, {
+		"missing name",
+		&ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{}},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "name"), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateGetActorTemplateRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/get_actor_template_version.go
+++ b/cmd/ateapi/internal/controlapi/get_actor_template_version.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func (s *Service) GetActorTemplateVersion(ctx context.Context, req *ateapipb.GetActorTemplateVersionRequest) (*ateapipb.ActorTemplateVersion, error) {
+	if errs := validateGetActorTemplateVersionRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	name := req.GetActorTemplateVersion().GetName()
+	version, err := s.persistence.GetActorTemplateVersion(ctx, name)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, status.Errorf(codes.NotFound, "ActorTemplateVersion %s not found", name)
+	} else if err != nil {
+		return nil, fmt.Errorf("while getting actor template version from DB: %w", err)
+	}
+
+	return version, nil
+}
+
+func validateGetActorTemplateVersionRequest(req *ateapipb.GetActorTemplateVersionRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.ActorTemplateVersion, fldPath.Child("actor_template_version"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateGlobalObjectRef(val, fldPath)...)
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/get_actor_template_version_test.go
+++ b/cmd/ateapi/internal/controlapi/get_actor_template_version_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateGetActorTemplateVersionRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.GetActorTemplateVersionRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.GetActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Name: "tmpl-a-v1"}},
+		nil,
+	}, {
+		"missing actor_template_version",
+		&ateapipb.GetActorTemplateVersionRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor_template_version"), "")},
+	}, {
+		"atespace must be empty",
+		&ateapipb.GetActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl-a-v1"}},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template_version", "atespace"), "ns1", "")},
+	}, {
+		"missing name",
+		&ateapipb.GetActorTemplateVersionRequest{ActorTemplateVersion: &ateapipb.ObjectRef{}},
+		field.ErrorList{field.Required(field.NewPath("actor_template_version", "name"), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateGetActorTemplateVersionRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/list_actor_template_versions.go
+++ b/cmd/ateapi/internal/controlapi/list_actor_template_versions.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func (s *Service) ListActorTemplateVersions(ctx context.Context, req *ateapipb.ListActorTemplateVersionsRequest) (*ateapipb.ListActorTemplateVersionsResponse, error) {
+	if errs := validateListActorTemplateVersionsRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	versions, nextToken, err := s.persistence.ListActorTemplateVersions(ctx, req.GetActorTemplate(), effectivePageSize(req.GetPageSize()), req.GetPageToken())
+	if err != nil {
+		return nil, fmt.Errorf("while listing actor template versions in db: %w", err)
+	}
+	return &ateapipb.ListActorTemplateVersionsResponse{
+		ActorTemplateVersions: versions,
+		NextPageToken:         nextToken,
+	}, nil
+}
+
+func validateListActorTemplateVersionsRequest(req *ateapipb.ListActorTemplateVersionsRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	// Empty means "across all templates"; a non-empty filter must be a valid name.
+	if val, fldPath := req.ActorTemplate, fldPath.Child("actor_template"); val != "" {
+		errs = append(errs, resources.ValidateResourceName(val, fldPath)...)
+	}
+
+	if val, fldPath := req.PageSize, fldPath.Child("page_size"); val < 0 {
+		errs = append(errs, field.Invalid(fldPath, val, "must be greater than or equal to 0"))
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/list_actor_template_versions_test.go
+++ b/cmd/ateapi/internal/controlapi/list_actor_template_versions_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateListActorTemplateVersionsRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.ListActorTemplateVersionsRequest
+		want field.ErrorList
+	}{{
+		"valid with filter",
+		&ateapipb.ListActorTemplateVersionsRequest{ActorTemplate: "tmpl-a", PageSize: 10},
+		nil,
+	}, {
+		"valid without filter",
+		&ateapipb.ListActorTemplateVersionsRequest{},
+		nil,
+	}, {
+		"invalid filter name",
+		&ateapipb.ListActorTemplateVersionsRequest{ActorTemplate: "Tmpl_A"},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template"), "Tmpl_A", "")},
+	}, {
+		"negative page size",
+		&ateapipb.ListActorTemplateVersionsRequest{PageSize: -1},
+		field.ErrorList{field.Invalid(field.NewPath("page_size"), int32(-1), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateListActorTemplateVersionsRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/list_actor_templates.go
+++ b/cmd/ateapi/internal/controlapi/list_actor_templates.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func (s *Service) ListActorTemplates(ctx context.Context, req *ateapipb.ListActorTemplatesRequest) (*ateapipb.ListActorTemplatesResponse, error) {
+	if errs := validateListActorTemplatesRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	templates, nextToken, err := s.persistence.ListActorTemplates(ctx, effectivePageSize(req.GetPageSize()), req.GetPageToken())
+	if err != nil {
+		return nil, fmt.Errorf("while listing actor templates in db: %w", err)
+	}
+	return &ateapipb.ListActorTemplatesResponse{
+		ActorTemplates: templates,
+		NextPageToken:  nextToken,
+	}, nil
+}
+
+func validateListActorTemplatesRequest(req *ateapipb.ListActorTemplatesRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.PageSize, fldPath.Child("page_size"); val < 0 {
+		errs = append(errs, field.Invalid(fldPath, val, "must be greater than or equal to 0"))
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/list_actor_templates_test.go
+++ b/cmd/ateapi/internal/controlapi/list_actor_templates_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateListActorTemplatesRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.ListActorTemplatesRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.ListActorTemplatesRequest{PageSize: 10},
+		nil,
+	}, {
+		"zero page size",
+		&ateapipb.ListActorTemplatesRequest{},
+		nil,
+	}, {
+		"negative page size",
+		&ateapipb.ListActorTemplatesRequest{PageSize: -1},
+		field.ErrorList{field.Invalid(field.NewPath("page_size"), int32(-1), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateListActorTemplatesRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/repin.go
+++ b/cmd/ateapi/internal/controlapi/repin.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// validateVersionRepin checks that an actor may be re-pinned to the
+// ActorTemplateVersion named target. Shared by ResumeActor (upgrade on
+// resume) and UpdateActor (pin revert). The actor's guest memory never
+// survives a re-pin — resume restores only durable data — so the actor must
+// be off-worker with no node-local state.
+func validateVersionRepin(ctx context.Context, persistence store.Interface, actor *ateapipb.Actor, target string) error {
+	if actor.GetActorTemplate() == "" {
+		return status.Error(codes.FailedPrecondition, "only actors created from a control-plane ActorTemplate can be re-pinned")
+	}
+	switch actor.GetStatus() {
+	case ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_CRASHED:
+	default:
+		return status.Errorf(codes.FailedPrecondition, "actor %s is %s; re-pinning requires %s or %s",
+			actor.GetMetadata().GetName(), actor.GetStatus(), ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_CRASHED)
+	}
+	// A pause checkpoint is bound to its node and the images it ran; it cannot
+	// restore under a different version.
+	if actor.GetLocalSnapshotInfo() != nil {
+		return status.Error(codes.FailedPrecondition, "actor holds a node-local snapshot; re-pinning requires a durable suspend")
+	}
+
+	atv, err := persistence.GetActorTemplateVersion(ctx, target)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %q not found", target)
+		}
+		return fmt.Errorf("while getting ActorTemplateVersion: %w", err)
+	}
+	if atv.GetActorTemplate().GetName() != actor.GetActorTemplate() {
+		return status.Errorf(codes.FailedPrecondition,
+			"ActorTemplateVersion %q belongs to ActorTemplate %q, not %q",
+			target, atv.GetActorTemplate().GetName(), actor.GetActorTemplate())
+	}
+	if state := atv.GetStatus().GetState(); state != ateapipb.ActorTemplateVersionStatus_STATE_READY {
+		return status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %q is not READY (state %s)", target, state)
+	}
+
+	current, err := persistence.GetActorTemplateVersion(ctx, actor.GetActorTemplateVersion())
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return status.Errorf(codes.FailedPrecondition, "current ActorTemplateVersion %q not found", actor.GetActorTemplateVersion())
+		}
+		return fmt.Errorf("while getting current ActorTemplateVersion: %w", err)
+	}
+	if cur, next := current.GetStatus().GetResolvedSandbox().GetSandboxClass(), atv.GetStatus().GetResolvedSandbox().GetSandboxClass(); cur != next {
+		return status.Errorf(codes.FailedPrecondition,
+			"ActorTemplateVersion %q has sandbox class %s; the actor runs %s and cannot change class", target, next, cur)
+	}
+	if err := checkVolumesUnchanged(current, atv); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkVolumesUnchanged rejects a re-pin that would add, remove, or alter
+// volumes or their mount paths: the actor's durable data must re-materialize
+// at exactly the paths the previous version wrote it.
+func checkVolumesUnchanged(current, next *ateapipb.ActorTemplateVersion) error {
+	curVols := volumesByName(current)
+	nextVols := volumesByName(next)
+	for name, vol := range curVols {
+		other, ok := nextVols[name]
+		if !ok {
+			return status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %q removes volume %q; volumes are immutable across versions", next.GetMetadata().GetName(), name)
+		}
+		if !proto.Equal(vol, other) {
+			return status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %q changes volume %q; volumes are immutable across versions", next.GetMetadata().GetName(), name)
+		}
+	}
+	for name := range nextVols {
+		if _, ok := curVols[name]; !ok {
+			return status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %q adds volume %q; volumes are immutable across versions", next.GetMetadata().GetName(), name)
+		}
+	}
+	if cur, next2 := volumeMounts(current), volumeMounts(next); !slices.Equal(cur, next2) {
+		return status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %q changes volume mount paths; volumes are immutable across versions", next.GetMetadata().GetName())
+	}
+	return nil
+}
+
+func volumesByName(atv *ateapipb.ActorTemplateVersion) map[string]*ateapipb.Volume {
+	out := make(map[string]*ateapipb.Volume, len(atv.GetSpec().GetVolumes()))
+	for _, vol := range atv.GetSpec().GetVolumes() {
+		out[vol.GetName()] = vol
+	}
+	return out
+}
+
+// volumeMounts flattens a version's (volume, mount path) pairs into a sorted
+// list, deliberately ignoring which container mounts them: containers may be
+// renamed or replaced between versions, but the paths where volume data
+// appears must not move.
+func volumeMounts(atv *ateapipb.ActorTemplateVersion) []string {
+	var out []string
+	for _, ctr := range atv.GetSpec().GetContainers() {
+		for _, mount := range ctr.GetVolumeMounts() {
+			out = append(out, mount.GetName()+":"+mount.GetMountPath())
+		}
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}

--- a/cmd/ateapi/internal/controlapi/repin_test.go
+++ b/cmd/ateapi/internal/controlapi/repin_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestCheckVolumesUnchanged(t *testing.T) {
+	version := func(name string, mutations ...func(*ateapipb.ActorTemplateVersionSpec)) *ateapipb.ActorTemplateVersion {
+		return &ateapipb.ActorTemplateVersion{
+			Metadata: &ateapipb.ResourceMetadata{Name: name},
+			Spec:     validTemplateVersionSpec(mutations...),
+		}
+	}
+
+	tests := []struct {
+		name   string
+		next   *ateapipb.ActorTemplateVersion
+		wantOK bool
+	}{{
+		"identical volumes",
+		version("v2"),
+		true,
+	}, {
+		"new image, same volumes",
+		version("v2", func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers[0].Image = "app@sha256:fff"
+		}),
+		true,
+	}, {
+		"same mounts under a renamed container",
+		version("v2", func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers[0].Name = "renamed"
+		}),
+		true,
+	}, {
+		"added volume",
+		version("v2", func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Volumes = append(s.Volumes, &ateapipb.Volume{
+				Name:   "extra",
+				Source: &ateapipb.Volume_DurableDir{DurableDir: &ateapipb.DurableDirVolumeSource{}},
+			})
+		}),
+		false,
+	}, {
+		"removed volume",
+		version("v2", func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Volumes = nil
+			s.Containers[0].VolumeMounts = nil
+		}),
+		false,
+	}, {
+		"changed volume source",
+		version("v2", func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Volumes[0].Source = &ateapipb.Volume_ExternalVolumeTemplate{
+				ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{Capacity: "1Gi", StorageClassName: "fast"},
+			}
+		}),
+		false,
+	}, {
+		"changed mount path",
+		version("v2", func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers[0].VolumeMounts[0].MountPath = "/data-v2"
+		}),
+		false,
+	}}
+	current := version("v1")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkVolumesUnchanged(current, tt.next)
+			if tt.wantOK && err != nil {
+				t.Fatalf("checkVolumesUnchanged() = %v, want nil", err)
+			}
+			if !tt.wantOK {
+				if status.Code(err) != codes.FailedPrecondition {
+					t.Fatalf("checkVolumesUnchanged() = %v, want FailedPrecondition", err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/resume_actor.go
+++ b/cmd/ateapi/internal/controlapi/resume_actor.go
@@ -33,7 +33,7 @@ func (s *Service) ResumeActor(ctx context.Context, req *ateapipb.ResumeActorRequ
 	actorRef := resources.ActorRefFromObjectRef(req.GetActor())
 	setSpanActorRefAttributes(ctx, actorRef)
 
-	actor, resumed, err := s.actorWorkflow.ResumeActor(ctx, actorRef, req.GetBoot())
+	actor, resumed, err := s.actorWorkflow.ResumeActor(ctx, actorRef, req.GetBoot(), req.GetActorTemplateVersion())
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
@@ -56,6 +56,9 @@ func validateResumeActorRequest(req *ateapipb.ResumeActorRequest) field.ErrorLis
 		errs = append(errs, field.Required(fldPath, ""))
 	} else {
 		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
+	}
+	if val := req.GetActorTemplateVersion(); val != "" {
+		errs = append(errs, resources.ValidateResourceName(val, fldPath.Child("actor_template_version"))...)
 	}
 
 	return errs

--- a/cmd/ateapi/internal/controlapi/resume_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/resume_actor_test.go
@@ -71,6 +71,20 @@ func TestValidateResumeActorRequest(t *testing.T) {
 		"invalid actor.name",
 		&ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: "ns1", Name: "ID1"}},
 		field.ErrorList{field.Invalid(field.NewPath("actor", "name"), "ID1", "")},
+	}, {
+		"valid actor_template_version",
+		&ateapipb.ResumeActorRequest{
+			Actor:                &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
+			ActorTemplateVersion: "tmpl-a-v2",
+		},
+		nil,
+	}, {
+		"invalid actor_template_version",
+		&ateapipb.ResumeActorRequest{
+			Actor:                &ateapipb.ObjectRef{Atespace: "ns1", Name: "id1"},
+			ActorTemplateVersion: "Tmpl_A",
+		},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template_version"), "Tmpl_A", "")},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/ateapi/internal/controlapi/sandbox_assets.go
+++ b/cmd/ateapi/internal/controlapi/sandbox_assets.go
@@ -20,6 +20,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -82,6 +83,60 @@ func defaultSandboxConfig(lister listersv1alpha1.SandboxConfigLister, class atev
 		return nil, fmt.Errorf("no default SandboxConfig for class %q; set one with spec.default=true or name one via WorkerPool.spec.sandboxConfigName", class)
 	}
 	return match, nil
+}
+
+// resolveTemplateVersionSandbox resolves an ActorTemplateVersion's
+// spec.sandbox_config into the SandboxAssets frozen into
+// status.resolved_sandbox at creation time. Spec validation guarantees
+// config_name is set; the named SandboxConfig must match the class.
+func resolveTemplateVersionSandbox(
+	sandboxConfigLister listersv1alpha1.SandboxConfigLister,
+	cfg *ateapipb.SandboxConfig,
+) (*ateapipb.SandboxAssets, error) {
+	class := sandboxClassFromProto(cfg.GetSandboxClass())
+
+	name := cfg.GetConfigName()
+	sc, err := sandboxConfigLister.Get(name)
+	if err != nil {
+		return nil, fmt.Errorf("while getting SandboxConfig %q: %w", name, err)
+	}
+	if sc.Spec.SandboxClass != class {
+		return nil, fmt.Errorf("SandboxConfig %q has class %q but the version asks for class %q",
+			name, sc.Spec.SandboxClass, class)
+	}
+
+	return sandboxAssetsAPIProto(class, sc), nil
+}
+
+// sandboxClassFromProto maps the control API sandbox class onto the CRD
+// class; UNSPECIFIED means gvisor.
+func sandboxClassFromProto(class ateapipb.SandboxClass) atev1alpha1.SandboxClass {
+	if class == ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM {
+		return atev1alpha1.SandboxClassMicroVM
+	}
+	return atev1alpha1.SandboxClassGvisor
+}
+
+// sandboxAssetsAPIProto converts a resolved SandboxConfig into the control
+// API twin of sandboxAssetsProto, for freezing into ActorTemplateVersion
+// status.
+func sandboxAssetsAPIProto(class atev1alpha1.SandboxClass, sc *atev1alpha1.SandboxConfig) *ateapipb.SandboxAssets {
+	protoClass := ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR
+	if class == atev1alpha1.SandboxClassMicroVM {
+		protoClass = ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM
+	}
+	out := &ateapipb.SandboxAssets{
+		SandboxClass: protoClass,
+		Assets:       make(map[string]*ateapipb.ArchAssets, len(sc.Spec.Assets)),
+	}
+	for arch, files := range sc.Spec.Assets {
+		archAssets := &ateapipb.ArchAssets{Files: make(map[string]*ateapipb.AssetFile, len(files))}
+		for name, f := range files {
+			archAssets.Files[name] = &ateapipb.AssetFile{Url: f.URL, Sha256: f.SHA256}
+		}
+		out.Assets[arch] = archAssets
+	}
+	return out
 }
 
 // sandboxAssetsProto converts a resolved SandboxConfig into the proto atelet

--- a/cmd/ateapi/internal/controlapi/service.go
+++ b/cmd/ateapi/internal/controlapi/service.go
@@ -36,6 +36,7 @@ type Service struct {
 	dialer                *AteletDialer
 	actorTemplateLister   listersv1alpha1.ActorTemplateLister
 	workerPoolLister      listersv1alpha1.WorkerPoolLister
+	sandboxConfigLister   listersv1alpha1.SandboxConfigLister
 	csiDriverConfigLister listersv1alpha1.CSIDriverConfigLister
 	storageClassLister    storagev1listers.StorageClassLister
 	actorWorkflow         *ActorWorkflow
@@ -71,6 +72,7 @@ func NewService(
 		workerCache:           workerCache,
 		actorTemplateLister:   actorTemplateLister,
 		workerPoolLister:      workerPoolLister,
+		sandboxConfigLister:   sandboxConfigLister,
 		csiDriverConfigLister: csiDriverConfigLister,
 		storageClassLister:    storageClassLister,
 		dialer:                dialer,

--- a/cmd/ateapi/internal/controlapi/template_resolve.go
+++ b/cmd/ateapi/internal/controlapi/template_resolve.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// crdTemplateFromVersion projects a control-plane (ActorTemplate,
+// ActorTemplateVersion) pair onto an in-memory CRD ActorTemplate, so every
+// workflow step that consumes a template (workload spec, snapshot scopes,
+// scheduling, volumes, golden resume) works unchanged on both paths.
+//
+// Transitional shim: remove together with the CRD ActorTemplate path.
+func crdTemplateFromVersion(at *ateapipb.ActorTemplate, atv *ateapipb.ActorTemplateVersion) (*atev1alpha1.ActorTemplate, error) {
+	spec := atv.GetSpec()
+
+	tmpl := &atev1alpha1.ActorTemplate{
+		// The UID is the version's: snapshot provenance and clone checks then
+		// compare actors against the exact immutable spec they ran.
+		ObjectMeta: metav1.ObjectMeta{
+			Name: atv.GetMetadata().GetName(),
+			UID:  types.UID(atv.GetMetadata().GetUid()),
+		},
+		Spec: atev1alpha1.ActorTemplateSpec{
+			PauseImage:   spec.GetPauseImage(),
+			SandboxClass: sandboxClassFromProto(atv.GetStatus().GetResolvedSandbox().GetSandboxClass()),
+			SnapshotsConfig: atev1alpha1.SnapshotsConfig{
+				Location: spec.GetSnapshotsConfig().GetStorageLocation(),
+				OnPause:  snapshotScopeFromProto(spec.GetSnapshotsConfig().GetOnPause()),
+				OnCommit: snapshotScopeFromProto(spec.GetSnapshotsConfig().GetOnCommit()),
+				OnResume: atev1alpha1.OnResumeConfig{
+					FromData: resumeSourceFromProto(spec.GetSnapshotsConfig().GetOnResume().GetFromData()),
+				},
+			},
+		},
+		Status: atev1alpha1.ActorTemplateStatus{
+			GoldenSnapshot: atv.GetStatus().GetGoldenSnapshot().GetName(),
+		},
+	}
+
+	if labels := at.GetSpec().GetWorkerSelector().GetMatchLabels(); len(labels) > 0 {
+		tmpl.Spec.WorkerSelector = &metav1.LabelSelector{MatchLabels: labels}
+	}
+
+	for _, vol := range spec.GetVolumes() {
+		out := atev1alpha1.Volume{Name: vol.GetName()}
+		switch {
+		case vol.GetDurableDir() != nil:
+			out.DurableDir = &atev1alpha1.DurableDirVolumeSource{}
+		case vol.GetExternalVolumeTemplate() != nil:
+			capacity, err := resource.ParseQuantity(vol.GetExternalVolumeTemplate().GetCapacity())
+			if err != nil {
+				return nil, fmt.Errorf("volume %q has invalid capacity: %w", vol.GetName(), err)
+			}
+			out.ExternalVolumeTemplate = &atev1alpha1.ExternalVolumeTemplate{
+				Capacity:         capacity,
+				StorageClassName: vol.GetExternalVolumeTemplate().GetStorageClassName(),
+			}
+		}
+		tmpl.Spec.Volumes = append(tmpl.Spec.Volumes, out)
+	}
+
+	for _, ctr := range spec.GetContainers() {
+		out := atev1alpha1.Container{
+			Name:    ctr.GetName(),
+			Image:   ctr.GetImage(),
+			Command: ctr.GetCommand(),
+			Args:    ctr.GetArgs(),
+		}
+		for _, env := range ctr.GetEnv() {
+			value := env.GetValue()
+			out.Env = append(out.Env, atev1alpha1.EnvVar{Name: env.GetName(), Value: &value})
+		}
+		if readyz := ctr.GetReadyz(); readyz != nil {
+			out.Readyz = &atev1alpha1.ContainerReadyz{
+				TimeoutSeconds: readyz.GetTimeoutSeconds(),
+				HTTPGet: &atev1alpha1.HTTPGetAction{
+					Path: readyz.GetHttpGet().GetPath(),
+					Port: readyz.GetHttpGet().GetPort(),
+				},
+			}
+		}
+		for _, mount := range ctr.GetVolumeMounts() {
+			out.VolumeMounts = append(out.VolumeMounts, atev1alpha1.VolumeMount{
+				Name:      mount.GetName(),
+				MountPath: mount.GetMountPath(),
+			})
+		}
+		tmpl.Spec.Containers = append(tmpl.Spec.Containers, out)
+	}
+
+	return tmpl, nil
+}
+
+func snapshotScopeFromProto(scope ateapipb.SnapshotContentScope) atev1alpha1.SnapshotScope {
+	if scope == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA {
+		return atev1alpha1.SnapshotScopeData
+	}
+	return atev1alpha1.SnapshotScopeFull
+}
+
+func resumeSourceFromProto(source ateapipb.ResumeSource) atev1alpha1.ResumeSource {
+	if source == ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN {
+		return atev1alpha1.ResumeSourceGolden
+	}
+	return atev1alpha1.ResumeSourceColdBoot
+}
+
+// ateletSandboxAssetsFromAPI converts the SandboxAssets frozen into an
+// ActorTemplateVersion's status into the proto atelet consumes; the twin of
+// sandboxAssetsProto for the pre-resolved case.
+func ateletSandboxAssetsFromAPI(in *ateapipb.SandboxAssets) *ateletpb.SandboxAssets {
+	out := &ateletpb.SandboxAssets{
+		SandboxClass: string(sandboxClassFromProto(in.GetSandboxClass())),
+		Assets:       make(map[string]*ateletpb.ArchAssets, len(in.GetAssets())),
+	}
+	for arch, files := range in.GetAssets() {
+		archAssets := &ateletpb.ArchAssets{Files: make(map[string]*ateletpb.AssetFile, len(files.GetFiles()))}
+		for name, f := range files.GetFiles() {
+			archAssets.Files[name] = &ateletpb.AssetFile{Url: f.GetUrl(), Sha256: f.GetSha256()}
+		}
+		out.Assets[arch] = archAssets
+	}
+	return out
+}
+
+// templateRefForAtelet returns the template identity recorded on atelet
+// requests and snapshots: the CRD namespace/name, or ("", version-name) for
+// native actors. Consumers use it for metrics attribution and provenance
+// only, never in filesystem paths.
+func templateRefForAtelet(actor *ateapipb.Actor) (namespace, name string) {
+	if actor.GetActorTemplateVersion() != "" {
+		return "", actor.GetActorTemplateVersion()
+	}
+	return actor.GetActorTemplateNamespace(), actor.GetActorTemplateName()
+}
+
+// resolveTemplateForActor loads the template an actor runs from: the
+// control-plane (ActorTemplate, ActorTemplateVersion) pair projected onto a
+// synthetic CRD template when the actor carries a version pin, or the CRD
+// ActorTemplate named by namespace/name otherwise. frozenAssets is non-nil
+// only on the native path, where boot resumes must use the version's frozen
+// sandbox instead of resolving it from the worker pool.
+func resolveTemplateForActor(ctx context.Context, persistence store.Interface, lister listersv1alpha1.ActorTemplateLister, actor *ateapipb.Actor) (tmpl *atev1alpha1.ActorTemplate, frozenAssets *ateletpb.SandboxAssets, err error) {
+	if actor.GetActorTemplateVersion() == "" {
+		tmpl, err := lister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
+		if err != nil {
+			return nil, nil, fmt.Errorf("while getting ActorTemplate: %w", err)
+		}
+		return tmpl, nil, nil
+	}
+
+	at, err := persistence.GetActorTemplate(ctx, actor.GetActorTemplate())
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %q not found", actor.GetActorTemplate())
+		}
+		return nil, nil, fmt.Errorf("while getting ActorTemplate: %w", err)
+	}
+	atv, err := persistence.GetActorTemplateVersion(ctx, actor.GetActorTemplateVersion())
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil, status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %q not found", actor.GetActorTemplateVersion())
+		}
+		return nil, nil, fmt.Errorf("while getting ActorTemplateVersion: %w", err)
+	}
+	if atv.GetActorTemplate().GetName() != at.GetMetadata().GetName() {
+		return nil, nil, status.Errorf(codes.FailedPrecondition,
+			"ActorTemplateVersion %q belongs to ActorTemplate %q, not %q",
+			atv.GetMetadata().GetName(), atv.GetActorTemplate().GetName(), at.GetMetadata().GetName())
+	}
+
+	tmpl, err = crdTemplateFromVersion(at, atv)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tmpl, ateletSandboxAssetsFromAPI(atv.GetStatus().GetResolvedSandbox()), nil
+}

--- a/cmd/ateapi/internal/controlapi/template_resolve_test.go
+++ b/cmd/ateapi/internal/controlapi/template_resolve_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/protobuf/testing/protocmp"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestCRDTemplateFromVersion(t *testing.T) {
+	prod := "prod"
+	at := &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a", Uid: "at-uid"},
+		Spec: &ateapipb.ActorTemplateSpec{
+			WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "1"}},
+		},
+	}
+	atv := &ateapipb.ActorTemplateVersion{
+		Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v1", Uid: "atv-uid"},
+		ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+		Spec: validTemplateVersionSpec(func(spec *ateapipb.ActorTemplateVersionSpec) {
+			spec.Volumes = append(spec.Volumes, &ateapipb.Volume{
+				Name: "scratch",
+				Source: &ateapipb.Volume_ExternalVolumeTemplate{ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+					Capacity: "1Gi", StorageClassName: "standard",
+				}},
+			})
+			spec.SnapshotsConfig.OnPause = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+			spec.SnapshotsConfig.OnCommit = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+			spec.SnapshotsConfig.OnResume = &ateapipb.OnResumeConfig{FromData: ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN}
+		}),
+		Status: &ateapipb.ActorTemplateVersionStatus{
+			State:           ateapipb.ActorTemplateVersionStatus_STATE_READY,
+			GoldenSnapshot:  &ateapipb.ObjectRef{Atespace: "ate-golden", Name: "snap-1"},
+			ResolvedSandbox: &ateapipb.SandboxAssets{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM},
+		},
+	}
+
+	got, err := crdTemplateFromVersion(at, atv)
+	if err != nil {
+		t.Fatalf("crdTemplateFromVersion failed: %v", err)
+	}
+
+	want := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "tmpl-a-v1", UID: types.UID("atv-uid")},
+		Spec: atev1alpha1.ActorTemplateSpec{
+			PauseImage:   "pause@sha256:abc",
+			SandboxClass: atev1alpha1.SandboxClassMicroVM,
+			SnapshotsConfig: atev1alpha1.SnapshotsConfig{
+				Location: "gs://bucket/snapshots",
+				OnPause:  atev1alpha1.SnapshotScopeData,
+				OnCommit: atev1alpha1.SnapshotScopeData,
+				OnResume: atev1alpha1.OnResumeConfig{FromData: atev1alpha1.ResumeSourceGolden},
+			},
+			WorkerSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "1"}},
+			Volumes: []atev1alpha1.Volume{{
+				Name:         "data",
+				VolumeSource: atev1alpha1.VolumeSource{DurableDir: &atev1alpha1.DurableDirVolumeSource{}},
+			}, {
+				Name: "scratch",
+				VolumeSource: atev1alpha1.VolumeSource{ExternalVolumeTemplate: &atev1alpha1.ExternalVolumeTemplate{
+					Capacity: resource.MustParse("1Gi"), StorageClassName: "standard",
+				}},
+			}},
+			Containers: []atev1alpha1.Container{{
+				Name:  "main",
+				Image: "app@sha256:def",
+				Env:   []atev1alpha1.EnvVar{{Name: "MODE", Value: &prod}},
+				Readyz: &atev1alpha1.ContainerReadyz{
+					HTTPGet:        &atev1alpha1.HTTPGetAction{Path: "/readyz", Port: 8080},
+					TimeoutSeconds: 30,
+				},
+				VolumeMounts: []atev1alpha1.VolumeMount{{Name: "data", MountPath: "/data"}},
+			}},
+		},
+		Status: atev1alpha1.ActorTemplateStatus{GoldenSnapshot: "snap-1"},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("crdTemplateFromVersion mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCRDTemplateFromVersion_Defaults(t *testing.T) {
+	// UNSPECIFIED scopes mean Full, UNSPECIFIED resume source means ColdBoot,
+	// UNSPECIFIED sandbox class means gvisor, and no selector stays nil.
+	at := &ateapipb.ActorTemplate{Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"}}
+	atv := &ateapipb.ActorTemplateVersion{
+		Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v1"},
+		ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+		Spec: &ateapipb.ActorTemplateVersionSpec{
+			PauseImage:      "pause@sha256:abc",
+			SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://bucket/snapshots"},
+		},
+	}
+
+	got, err := crdTemplateFromVersion(at, atv)
+	if err != nil {
+		t.Fatalf("crdTemplateFromVersion failed: %v", err)
+	}
+	if got.Spec.SandboxClass != atev1alpha1.SandboxClassGvisor {
+		t.Errorf("SandboxClass = %q, want gvisor", got.Spec.SandboxClass)
+	}
+	if got.Spec.SnapshotsConfig.OnPause != atev1alpha1.SnapshotScopeFull || got.Spec.SnapshotsConfig.OnCommit != atev1alpha1.SnapshotScopeFull {
+		t.Errorf("snapshot scopes = (%q, %q), want (Full, Full)", got.Spec.SnapshotsConfig.OnPause, got.Spec.SnapshotsConfig.OnCommit)
+	}
+	if got.Spec.SnapshotsConfig.OnResume.FromData != atev1alpha1.ResumeSourceColdBoot {
+		t.Errorf("OnResume.FromData = %q, want ColdBoot", got.Spec.SnapshotsConfig.OnResume.FromData)
+	}
+	if got.Spec.WorkerSelector != nil {
+		t.Errorf("WorkerSelector = %v, want nil", got.Spec.WorkerSelector)
+	}
+	if got.Status.GoldenSnapshot != "" {
+		t.Errorf("GoldenSnapshot = %q, want empty", got.Status.GoldenSnapshot)
+	}
+}
+
+func TestCRDTemplateFromVersion_BadCapacity(t *testing.T) {
+	at := &ateapipb.ActorTemplate{Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"}}
+	atv := &ateapipb.ActorTemplateVersion{
+		Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v1"},
+		ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+		Spec: validTemplateVersionSpec(func(spec *ateapipb.ActorTemplateVersionSpec) {
+			spec.Volumes = []*ateapipb.Volume{{
+				Name: "data",
+				Source: &ateapipb.Volume_ExternalVolumeTemplate{ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+					Capacity: "not-a-quantity", StorageClassName: "standard",
+				}},
+			}}
+		}),
+	}
+	if _, err := crdTemplateFromVersion(at, atv); err == nil {
+		t.Fatal("crdTemplateFromVersion accepted an invalid capacity; want error")
+	}
+}
+
+func TestAteletSandboxAssetsFromAPI(t *testing.T) {
+	in := &ateapipb.SandboxAssets{
+		SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM,
+		Assets: map[string]*ateapipb.ArchAssets{
+			"amd64": {Files: map[string]*ateapipb.AssetFile{
+				"runsc": {Url: "https://assets/runsc", Sha256: "abc"},
+			}},
+		},
+	}
+	want := &ateletpb.SandboxAssets{
+		SandboxClass: "microvm",
+		Assets: map[string]*ateletpb.ArchAssets{
+			"amd64": {Files: map[string]*ateletpb.AssetFile{
+				"runsc": {Url: "https://assets/runsc", Sha256: "abc"},
+			}},
+		},
+	}
+	if diff := cmp.Diff(want, ateletSandboxAssetsFromAPI(in), protocmp.Transform()); diff != "" {
+		t.Errorf("ateletSandboxAssetsFromAPI mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTemplateRefForAtelet(t *testing.T) {
+	crdActor := &ateapipb.Actor{ActorTemplateNamespace: "ns1", ActorTemplateName: "tmpl1"}
+	if ns, name := templateRefForAtelet(crdActor); ns != "ns1" || name != "tmpl1" {
+		t.Errorf("templateRefForAtelet(crd) = (%q, %q), want (ns1, tmpl1)", ns, name)
+	}
+	nativeActor := &ateapipb.Actor{ActorTemplate: "tmpl1", ActorTemplateVersion: "tmpl1-v1"}
+	if ns, name := templateRefForAtelet(nativeActor); ns != "" || name != "tmpl1-v1" {
+		t.Errorf("templateRefForAtelet(native) = (%q, %q), want (\"\", tmpl1-v1)", ns, name)
+	}
+}

--- a/cmd/ateapi/internal/controlapi/template_version_builder.go
+++ b/cmd/ateapi/internal/controlapi/template_version_builder.go
@@ -1,0 +1,284 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	// templateVersionBuildInterval is the poll period for versions with a
+	// build in progress. Coarse is fine: a build takes tens of seconds.
+	templateVersionBuildInterval = 5 * time.Second
+
+	// templateVersionBuildTimeout bounds a build measured from the version's
+	// create_time; transient errors retry until it elapses, then the version
+	// goes FAILED with the last error.
+	templateVersionBuildTimeout = 20 * time.Minute
+
+	// templateVersionWarmup is the delay between resuming the golden actor
+	// and snapshotting it, for versions without readyz on every container
+	// (mirrors the CRD reconciler's goldenSnapshotWarmup).
+	templateVersionWarmup = 20 * time.Second
+
+	templateVersionListPageSize = 1000
+)
+
+// actorTemplateVersionLockKey serializes the build loop across ateapi
+// replicas, per version. Distinct from actorTemplateLockKey, which guards
+// template-level invariants.
+func actorTemplateVersionLockKey(name string) string {
+	return "lock:actor-template-version:" + name
+}
+
+// TemplateVersionBuilder drives ActorTemplateVersions from STATE_INITIAL to
+// STATE_READY by building their golden snapshot: boot a golden actor in the
+// reserved ate-golden atespace, wait for warmup, suspend it, and record the
+// resulting snapshot. The in-process port of the CRD ActorTemplateReconciler.
+//
+// All progress is persisted in the version's status (CAS on
+// metadata.version), so any replica can pick up a build at any step; a
+// per-version distributed lock keeps replicas from stepping on each other.
+type TemplateVersionBuilder struct {
+	service *Service
+	store   store.Interface
+
+	interval     time.Duration
+	buildTimeout time.Duration
+	now          func() time.Time
+}
+
+func NewTemplateVersionBuilder(service *Service, persistence store.Interface) *TemplateVersionBuilder {
+	return &TemplateVersionBuilder{
+		service:      service,
+		store:        persistence,
+		interval:     templateVersionBuildInterval,
+		buildTimeout: templateVersionBuildTimeout,
+		now:          time.Now,
+	}
+}
+
+// Start runs the build loop until ctx is canceled. An interrupted transition
+// is retried here or by a peer replica from the persisted status.
+func (b *TemplateVersionBuilder) Start(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(b.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				b.runOnce(ctx)
+			}
+		}
+	}()
+}
+
+// runOnce advances every non-terminal version by at most one state
+// transition. Errors are contained per version: one broken build never
+// stalls the others.
+func (b *TemplateVersionBuilder) runOnce(ctx context.Context) {
+	pageToken := ""
+	for {
+		versions, nextToken, err := b.store.ListActorTemplateVersions(ctx, "", templateVersionListPageSize, pageToken)
+		if err != nil {
+			slog.ErrorContext(ctx, "Template version build: list failed", slog.Any("error", err))
+			return
+		}
+		for _, atv := range versions {
+			if templateVersionStateTerminal(atv.GetStatus().GetState()) {
+				continue
+			}
+			b.buildOne(ctx, atv.GetMetadata().GetName())
+		}
+		if nextToken == "" {
+			return
+		}
+		pageToken = nextToken
+	}
+}
+
+// buildOne performs one state transition for the named version under its
+// distributed lock, classifying errors into retry (next tick), FAILED on
+// build timeout, or FAILED immediately for permanent ones.
+func (b *TemplateVersionBuilder) buildOne(ctx context.Context, name string) {
+	lock, err := b.store.AcquireLock(ctx, actorTemplateVersionLockKey(name))
+	if err != nil {
+		if !errors.Is(err, store.ErrLockConflict) {
+			slog.ErrorContext(ctx, "Template version build: lock failed", slog.String("version", name), slog.Any("error", err))
+		}
+		return
+	}
+	defer lock.Close()
+	ctx = lock.Context()
+
+	// Re-read under the lock: the listed copy may be stale.
+	atv, err := b.store.GetActorTemplateVersion(ctx, name)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			slog.ErrorContext(ctx, "Template version build: get failed", slog.String("version", name), slog.Any("error", err))
+		}
+		return
+	}
+	if templateVersionStateTerminal(atv.GetStatus().GetState()) {
+		return
+	}
+
+	transitionErr := b.advance(ctx, atv)
+	if transitionErr == nil {
+		return
+	}
+	if !templateVersionBuildErrPermanent(transitionErr) &&
+		b.now().Sub(atv.GetMetadata().GetCreateTime().AsTime()) < b.buildTimeout {
+		slog.WarnContext(ctx, "Template version build: transition failed, will retry",
+			slog.String("version", name), slog.String("state", atv.GetStatus().GetState().String()), slog.Any("error", transitionErr))
+		return
+	}
+
+	slog.ErrorContext(ctx, "Template version build failed",
+		slog.String("version", name), slog.String("state", atv.GetStatus().GetState().String()), slog.Any("error", transitionErr))
+	failed := proto.Clone(atv.GetStatus()).(*ateapipb.ActorTemplateVersionStatus)
+	failed.State = ateapipb.ActorTemplateVersionStatus_STATE_FAILED
+	failed.Message = transitionErr.Error()
+	if _, err := b.store.UpdateActorTemplateVersionStatus(ctx, name, failed, atv.GetMetadata().GetVersion()); err != nil {
+		slog.ErrorContext(ctx, "Template version build: persisting FAILED state failed", slog.String("version", name), slog.Any("error", err))
+	}
+}
+
+// advance performs the single transition the version's persisted state calls
+// for. Every service call tolerates "already done" so a transition
+// interrupted after acting but before persisting replays cleanly.
+func (b *TemplateVersionBuilder) advance(ctx context.Context, atv *ateapipb.ActorTemplateVersion) error {
+	name := atv.GetMetadata().GetName()
+	next := proto.Clone(atv.GetStatus()).(*ateapipb.ActorTemplateVersionStatus)
+
+	switch atv.GetStatus().GetState() {
+	case ateapipb.ActorTemplateVersionStatus_STATE_UNSPECIFIED, ateapipb.ActorTemplateVersionStatus_STATE_INITIAL:
+		// Golden actors live in the reserved ate-golden system atespace and
+		// are named by the version's uid.
+		goldenActor := &ateapipb.ObjectRef{Atespace: resources.GoldenActorAtespace, Name: atv.GetMetadata().GetUid()}
+		if _, err := b.service.CreateAtespace(ctx, &ateapipb.CreateAtespaceRequest{
+			Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: resources.GoldenActorAtespace}},
+		}); err != nil && status.Code(err) != codes.AlreadyExists {
+			return fmt.Errorf("while ensuring atespace %q: %w", resources.GoldenActorAtespace, err)
+		}
+		if _, err := b.service.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+			Metadata:             &ateapipb.ResourceMetadata{Atespace: goldenActor.GetAtespace(), Name: goldenActor.GetName()},
+			ActorTemplate:        atv.GetActorTemplate().GetName(),
+			ActorTemplateVersion: name,
+		}}); err != nil && status.Code(err) != codes.AlreadyExists {
+			return fmt.Errorf("while creating golden actor: %w", err)
+		}
+		next.State = ateapipb.ActorTemplateVersionStatus_STATE_RESUME_GOLDEN_ACTOR
+		next.GoldenActor = goldenActor
+
+	case ateapipb.ActorTemplateVersionStatus_STATE_RESUME_GOLDEN_ACTOR:
+		// Resuming a version with no golden snapshot boots the workload from
+		// its spec; with readyz on every container the call only returns
+		// once the workload reports ready, so no extra warmup is needed.
+		if _, err := b.service.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: atv.GetStatus().GetGoldenActor()}); err != nil {
+			return fmt.Errorf("while resuming golden actor: %w", err)
+		}
+		next.State = ateapipb.ActorTemplateVersionStatus_STATE_WAIT_GOLDEN_ACTOR
+		next.TakeGoldenSnapshotAt = timestamppb.New(b.now().Add(templateVersionWarmupFor(atv.GetSpec())))
+
+	case ateapipb.ActorTemplateVersionStatus_STATE_WAIT_GOLDEN_ACTOR:
+		if b.now().Before(atv.GetStatus().GetTakeGoldenSnapshotAt().AsTime()) {
+			return nil
+		}
+		// Suspending an already-SUSPENDED actor fast-forwards, so an
+		// interrupted transition still reads the snapshot back here.
+		resp, err := b.service.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: atv.GetStatus().GetGoldenActor()})
+		if err != nil {
+			return fmt.Errorf("while suspending golden actor: %w", err)
+		}
+		snapshot := resp.GetActor().GetLatestSnapshot()
+		if snapshot == nil {
+			return fmt.Errorf("suspending golden actor returned no ActorSnapshot")
+		}
+		next.State = ateapipb.ActorTemplateVersionStatus_STATE_READY
+		next.GoldenSnapshot = snapshot
+		next.Message = ""
+		if _, err := b.store.UpdateActorTemplateVersionStatus(ctx, name, next, atv.GetMetadata().GetVersion()); err != nil {
+			return fmt.Errorf("while persisting status: %w", err)
+		}
+		// READY is durable; only now delete the golden actor (its snapshot
+		// record survives — an improvement over the CRD reconciler, which
+		// leaks it). Best-effort: a leak here is harmless.
+		if _, err := b.service.DeleteActor(ctx, &ateapipb.DeleteActorRequest{Actor: atv.GetStatus().GetGoldenActor()}); err != nil {
+			slog.WarnContext(ctx, "Template version build: deleting golden actor failed",
+				slog.String("version", name), slog.Any("error", err))
+		}
+		slog.InfoContext(ctx, "Template version build: READY",
+			slog.String("version", name), slog.String("golden_snapshot", snapshot.GetName()))
+		return nil
+
+	default:
+		return fmt.Errorf("unrecognized state %q", atv.GetStatus().GetState())
+	}
+
+	if _, err := b.store.UpdateActorTemplateVersionStatus(ctx, name, next, atv.GetMetadata().GetVersion()); err != nil {
+		return fmt.Errorf("while persisting status: %w", err)
+	}
+	return nil
+}
+
+func templateVersionStateTerminal(state ateapipb.ActorTemplateVersionStatus_State) bool {
+	return state == ateapipb.ActorTemplateVersionStatus_STATE_READY ||
+		state == ateapipb.ActorTemplateVersionStatus_STATE_FAILED
+}
+
+// templateVersionBuildErrPermanent reports whether a transition error can
+// never heal by retrying: a malformed spec or lost data. Everything else
+// (no free worker, a worker mid-drain, a CAS conflict) retries until the
+// build timeout.
+func templateVersionBuildErrPermanent(err error) bool {
+	switch status.Code(err) {
+	case codes.InvalidArgument, codes.DataLoss:
+		return true
+	}
+	// The golden actor vanished mid-build; recreating it belongs to a new
+	// version, not endless retries against a missing actor.
+	return status.Code(err) == codes.NotFound
+}
+
+// templateVersionWarmupFor mirrors the CRD reconciler's
+// goldenSnapshotWarmupFor: zero when every container has readyz (resume
+// already blocked on readiness), the default warmup otherwise.
+func templateVersionWarmupFor(spec *ateapipb.ActorTemplateVersionSpec) time.Duration {
+	containers := spec.GetContainers()
+	if len(containers) == 0 {
+		return templateVersionWarmup
+	}
+	for _, ctr := range containers {
+		if ctr.GetReadyz() == nil {
+			return templateVersionWarmup
+		}
+	}
+	return 0
+}

--- a/cmd/ateapi/internal/controlapi/template_version_builder_test.go
+++ b/cmd/ateapi/internal/controlapi/template_version_builder_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+)
+
+func newTestBuilder(tc *testContext) (*TemplateVersionBuilder, *time.Time) {
+	builder := NewTemplateVersionBuilder(tc.service, tc.persistence)
+	now := time.Now()
+	builder.now = func() time.Time { return now }
+	return builder, &now
+}
+
+func getVersionState(t *testing.T, tc *testContext, name string) *ateapipb.ActorTemplateVersion {
+	t.Helper()
+	atv, err := tc.persistence.GetActorTemplateVersion(context.Background(), name)
+	if err != nil {
+		t.Fatalf("GetActorTemplateVersion(%s) failed: %v", name, err)
+	}
+	return atv
+}
+
+func TestTemplateVersionBuilder_BuildsGoldenSnapshot(t *testing.T) {
+	ns := namespaceForTest("ns-atv-build")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	createWorkerPool(t, tc, ns, "pool1", map[string]string{poolLabelKey: ns})
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+	createTemplateForVersions(t, tc, "tmpl-a")
+	// validTemplateVersionSpec puts readyz on every container, so the warmup
+	// is zero and READY needs no clock manipulation.
+	created := createTemplateVersion(t, tc, "tmpl-a-v1", "tmpl-a")
+
+	builder, _ := newTestBuilder(tc)
+
+	// Tick 1: INITIAL -> RESUME_GOLDEN_ACTOR, golden actor created.
+	builder.runOnce(ctx)
+	atv := getVersionState(t, tc, "tmpl-a-v1")
+	if got := atv.GetStatus().GetState(); got != ateapipb.ActorTemplateVersionStatus_STATE_RESUME_GOLDEN_ACTOR {
+		t.Fatalf("after tick 1, state = %s, want RESUME_GOLDEN_ACTOR", got)
+	}
+	goldenActor := atv.GetStatus().GetGoldenActor()
+	if goldenActor.GetAtespace() != resources.GoldenActorAtespace || goldenActor.GetName() != created.GetMetadata().GetUid() {
+		t.Fatalf("golden actor = %v, want %s/%s", goldenActor, resources.GoldenActorAtespace, created.GetMetadata().GetUid())
+	}
+	golden, err := tc.persistence.GetActor(ctx, resources.ActorRef{Atespace: goldenActor.GetAtespace(), Name: goldenActor.GetName()})
+	if err != nil {
+		t.Fatalf("golden actor not stored: %v", err)
+	}
+	if golden.GetActorTemplateVersion() != "tmpl-a-v1" {
+		t.Errorf("golden actor pins version %q, want tmpl-a-v1", golden.GetActorTemplateVersion())
+	}
+
+	// Tick 2: RESUME_GOLDEN_ACTOR -> WAIT_GOLDEN_ACTOR, workload booted.
+	builder.runOnce(ctx)
+	atv = getVersionState(t, tc, "tmpl-a-v1")
+	if got := atv.GetStatus().GetState(); got != ateapipb.ActorTemplateVersionStatus_STATE_WAIT_GOLDEN_ACTOR {
+		t.Fatalf("after tick 2, state = %s, want WAIT_GOLDEN_ACTOR", got)
+	}
+	if !tc.fakeAtelet.RunCalled {
+		t.Error("expected the golden actor to boot via Run")
+	}
+
+	// Tick 3: WAIT_GOLDEN_ACTOR -> READY (readyz everywhere, warmup 0).
+	builder.runOnce(ctx)
+	atv = getVersionState(t, tc, "tmpl-a-v1")
+	if got := atv.GetStatus().GetState(); got != ateapipb.ActorTemplateVersionStatus_STATE_READY {
+		t.Fatalf("after tick 3, state = %s (message %q), want READY", got, atv.GetStatus().GetMessage())
+	}
+	goldenSnapshot := atv.GetStatus().GetGoldenSnapshot()
+	if goldenSnapshot.GetAtespace() != resources.GoldenActorAtespace {
+		t.Errorf("golden snapshot atespace = %q, want %s", goldenSnapshot.GetAtespace(), resources.GoldenActorAtespace)
+	}
+	snapshot, err := tc.persistence.GetActorSnapshot(ctx, goldenSnapshot.GetAtespace(), goldenSnapshot.GetName())
+	if err != nil {
+		t.Fatalf("golden snapshot not resolvable: %v", err)
+	}
+	if snapshot.GetContentScope() != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL {
+		t.Errorf("golden snapshot scope = %s, want FULL", snapshot.GetContentScope())
+	}
+	if snapshot.GetActorTemplateUid() != created.GetMetadata().GetUid() {
+		t.Errorf("golden snapshot template uid = %q, want the version uid %q", snapshot.GetActorTemplateUid(), created.GetMetadata().GetUid())
+	}
+	// The sandbox frozen at creation must survive every status write.
+	if atv.GetStatus().GetResolvedSandbox() == nil {
+		t.Error("resolved_sandbox lost during the build")
+	}
+	// The golden actor is deleted once READY; its snapshot record stays.
+	if _, err := tc.persistence.GetActor(ctx, resources.ActorRef{Atespace: goldenActor.GetAtespace(), Name: goldenActor.GetName()}); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("golden actor after READY = %v, want ErrNotFound", err)
+	}
+
+	// A READY version is terminal: another tick must not touch it.
+	version := atv.GetMetadata().GetVersion()
+	builder.runOnce(ctx)
+	if got := getVersionState(t, tc, "tmpl-a-v1").GetMetadata().GetVersion(); got != version {
+		t.Errorf("READY version advanced from %d to %d on an extra tick", version, got)
+	}
+}
+
+func TestTemplateVersionBuilder_WarmupWithoutReadyz(t *testing.T) {
+	ns := namespaceForTest("ns-atv-warmup")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	createWorkerPool(t, tc, ns, "pool1", map[string]string{poolLabelKey: ns})
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+	createTemplateForVersions(t, tc, "tmpl-a")
+	if _, err := tc.client.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-a-v1"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"},
+			Spec: validTemplateVersionSpec(func(spec *ateapipb.ActorTemplateVersionSpec) {
+				spec.Containers[0].Readyz = nil
+			}),
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+
+	builder, now := newTestBuilder(tc)
+	builder.runOnce(ctx) // INITIAL -> RESUME_GOLDEN_ACTOR
+	builder.runOnce(ctx) // RESUME_GOLDEN_ACTOR -> WAIT_GOLDEN_ACTOR
+
+	atv := getVersionState(t, tc, "tmpl-a-v1")
+	wantAt := now.Add(templateVersionWarmup)
+	if got := atv.GetStatus().GetTakeGoldenSnapshotAt().AsTime(); !got.Equal(wantAt) {
+		t.Fatalf("take_golden_snapshot_at = %v, want %v", got, wantAt)
+	}
+
+	// Before the deadline the version idles in WAIT_GOLDEN_ACTOR.
+	builder.runOnce(ctx)
+	if got := getVersionState(t, tc, "tmpl-a-v1").GetStatus().GetState(); got != ateapipb.ActorTemplateVersionStatus_STATE_WAIT_GOLDEN_ACTOR {
+		t.Fatalf("state before warmup deadline = %s, want WAIT_GOLDEN_ACTOR", got)
+	}
+
+	*now = now.Add(templateVersionWarmup + time.Second)
+	builder.runOnce(ctx)
+	if got := getVersionState(t, tc, "tmpl-a-v1").GetStatus().GetState(); got != ateapipb.ActorTemplateVersionStatus_STATE_READY {
+		t.Fatalf("state after warmup deadline = %s, want READY", got)
+	}
+}
+
+func TestTemplateVersionBuilder_LockConflictSkips(t *testing.T) {
+	ns := namespaceForTest("ns-atv-lock")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	createTemplateForVersions(t, tc, "tmpl-a")
+	createTemplateVersion(t, tc, "tmpl-a-v1", "tmpl-a")
+
+	lock, err := tc.persistence.AcquireLock(ctx, actorTemplateVersionLockKey("tmpl-a-v1"))
+	if err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+	defer lock.Close()
+
+	builder, _ := newTestBuilder(tc)
+	builder.runOnce(ctx)
+	if got := getVersionState(t, tc, "tmpl-a-v1").GetStatus().GetState(); got != ateapipb.ActorTemplateVersionStatus_STATE_INITIAL {
+		t.Fatalf("state under a held peer lock = %s, want INITIAL untouched", got)
+	}
+}
+
+func TestTemplateVersionBuilder_FailsAfterBuildTimeout(t *testing.T) {
+	ns := namespaceForTest("ns-atv-timeout")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	// No pool matches this selector (worker pods from sibling tests leak in
+	// through the shared envtest cluster), so resuming the golden actor
+	// keeps failing.
+	if _, err := tc.client.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "no-such-pool"}},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	createTemplateVersion(t, tc, "tmpl-a-v1", "tmpl-a")
+
+	builder, now := newTestBuilder(tc)
+	builder.runOnce(ctx) // INITIAL -> RESUME_GOLDEN_ACTOR
+
+	// Within the build timeout the resume failure only retries.
+	builder.runOnce(ctx)
+	if got := getVersionState(t, tc, "tmpl-a-v1").GetStatus().GetState(); got != ateapipb.ActorTemplateVersionStatus_STATE_RESUME_GOLDEN_ACTOR {
+		t.Fatalf("state after transient failure = %s, want RESUME_GOLDEN_ACTOR retained", got)
+	}
+
+	*now = now.Add(builder.buildTimeout + time.Minute)
+	builder.runOnce(ctx)
+	atv := getVersionState(t, tc, "tmpl-a-v1")
+	if got := atv.GetStatus().GetState(); got != ateapipb.ActorTemplateVersionStatus_STATE_FAILED {
+		t.Fatalf("state after build timeout = %s, want FAILED", got)
+	}
+	if !strings.Contains(atv.GetStatus().GetMessage(), "while resuming golden actor") {
+		t.Errorf("FAILED message = %q, want the last resume error", atv.GetStatus().GetMessage())
+	}
+}

--- a/cmd/ateapi/internal/controlapi/template_version_spec.go
+++ b/cmd/ateapi/internal/controlapi/template_version_spec.go
@@ -1,0 +1,467 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/api/validate/content"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Limits and defaults ported from the ActorTemplate CRD's kubebuilder markers
+// (pkg/api/v1alpha1/actortemplate_types.go); keep the two in sync while both
+// exist. This validator is a deliberate superset of the CRD: following
+// upstream Kubernetes pod validation it also requires a non-empty containers
+// list and unique mount paths within a container, which the CRD does not.
+const (
+	maxContainers        = 10
+	maxCommandItems      = 64
+	maxArgsItems         = 64
+	maxEnvItems          = 32
+	maxVolumes           = 32
+	maxVolumeMounts      = 32
+	maxMountPathLen      = 4096
+	maxReadyzPathLen     = 1024
+	maxReadyzTimeout     = 3600
+	defaultReadyzTimeout = 30
+	defaultReadyzPath    = "/readyz"
+)
+
+const pinnedImageMsg = "must be pinned by digest and contain '@' (changing the image invalidates snapshots)"
+
+var (
+	// envNameRegexp accepts any printable ASCII character except '='.
+	envNameRegexp = regexp.MustCompile(`^[ -<>-~]+$`)
+	// readyzPathRegexp accepts RFC 3986 path segments with well-formed
+	// percent-escapes; query strings and fragments are excluded.
+	readyzPathRegexp = regexp.MustCompile(`^/([A-Za-z0-9\-._~!$&'()*+,;=:@/]|%[0-9A-Fa-f]{2})*$`)
+)
+
+// defaultActorTemplateVersionSpec materializes server-applied defaults into
+// the spec before validation and storage, mirroring the CRD's API-server
+// defaulting: a readyz timeout of 0 means 30s and an empty readyz path means
+// "/readyz", so the effective values are visible on the stored object.
+func defaultActorTemplateVersionSpec(spec *ateapipb.ActorTemplateVersionSpec) {
+	for _, c := range spec.GetContainers() {
+		readyz := c.GetReadyz()
+		if readyz == nil {
+			continue
+		}
+		if readyz.GetTimeoutSeconds() == 0 {
+			readyz.TimeoutSeconds = defaultReadyzTimeout
+		}
+		if httpGet := readyz.GetHttpGet(); httpGet != nil && httpGet.GetPath() == "" {
+			httpGet.Path = defaultReadyzPath
+		}
+	}
+}
+
+// validateActorTemplateVersionSpec ports the ActorTemplate CRD's CEL and
+// kubebuilder invariants onto the proto spec. Call
+// defaultActorTemplateVersionSpec first: readyz fields are validated at their
+// effective (defaulted) values.
+func validateActorTemplateVersionSpec(spec *ateapipb.ActorTemplateVersionSpec, fldPath *field.Path) field.ErrorList {
+	if spec == nil {
+		return field.ErrorList{field.Required(fldPath, "")}
+	}
+
+	allErrs := field.ErrorList{}
+
+	pauseImagePath := fldPath.Child("pause_image")
+	if spec.GetPauseImage() == "" {
+		allErrs = append(allErrs, field.Required(pauseImagePath, ""))
+	} else if !strings.Contains(spec.GetPauseImage(), "@") {
+		allErrs = append(allErrs, field.Invalid(pauseImagePath, spec.GetPauseImage(), pinnedImageMsg))
+	}
+
+	microvm := spec.GetSandboxConfig().GetSandboxClass() == ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM
+
+	volumeNames, volumeErrs := validateVolumes(spec.GetVolumes(), microvm, fldPath.Child("volumes"))
+	allErrs = append(allErrs, volumeErrs...)
+
+	allErrs = append(allErrs, validateContainers(spec.GetContainers(), volumeNames, fldPath.Child("containers"))...)
+
+	// Every declared volume must be mounted by at least one container.
+	mounted := mountedVolumeNames(spec.GetContainers(), volumeNames)
+	for i, v := range spec.GetVolumes() {
+		if name := v.GetName(); name != "" && !mounted[name] {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("volumes").Index(i).Child("name"), name,
+				"all volumes must be mounted by at least one container"))
+		}
+	}
+
+	allErrs = append(allErrs, validateSnapshotsConfig(spec.GetSnapshotsConfig(), microvm, fldPath.Child("snapshots_config"))...)
+
+	// sandbox_config is required in full: the server never defaults the class
+	// or falls back to a cluster-default SandboxConfig for versions.
+	cfgPath := fldPath.Child("sandbox_config")
+	if cfg := spec.GetSandboxConfig(); cfg == nil {
+		allErrs = append(allErrs, field.Required(cfgPath, ""))
+	} else {
+		classPath := cfgPath.Child("sandbox_class")
+		switch class := cfg.GetSandboxClass(); class {
+		case ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR, ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM:
+		case ateapipb.SandboxClass_SANDBOX_CLASS_UNSPECIFIED:
+			allErrs = append(allErrs, field.Required(classPath, ""))
+		default:
+			allErrs = append(allErrs, field.NotSupported(classPath, class, []string{
+				ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR.String(),
+				ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM.String(),
+			}))
+		}
+
+		configNamePath := cfgPath.Child("config_name")
+		if cfg.GetConfigName() == "" {
+			allErrs = append(allErrs, field.Required(configNamePath, ""))
+		} else {
+			for _, msg := range content.IsDNS1123Subdomain(cfg.GetConfigName()) {
+				allErrs = append(allErrs, field.Invalid(configNamePath, cfg.GetConfigName(), msg))
+			}
+		}
+	}
+
+	return allErrs
+}
+
+// validateVolumes checks the declared volumes and returns the set of valid
+// volume names for the mount cross-checks.
+func validateVolumes(volumes []*ateapipb.Volume, microvm bool, fldPath *field.Path) (map[string]bool, field.ErrorList) {
+	allErrs := field.ErrorList{}
+	if len(volumes) > maxVolumes {
+		allErrs = append(allErrs, field.TooMany(fldPath, len(volumes), maxVolumes))
+	}
+
+	volumeNames := make(map[string]bool, len(volumes))
+	for i, v := range volumes {
+		idxPath := fldPath.Index(i)
+
+		namePath := idxPath.Child("name")
+		if name := v.GetName(); name == "" {
+			allErrs = append(allErrs, field.Required(namePath, ""))
+		} else {
+			allErrs = append(allErrs, resources.ValidateResourceName(name, namePath)...)
+			if volumeNames[name] {
+				allErrs = append(allErrs, field.Duplicate(namePath, name))
+			}
+			volumeNames[name] = true
+		}
+
+		switch source := v.GetSource().(type) {
+		case *ateapipb.Volume_DurableDir:
+			// No fields to validate.
+		case *ateapipb.Volume_ExternalVolumeTemplate:
+			allErrs = append(allErrs, validateExternalVolumeTemplate(source.ExternalVolumeTemplate, microvm, idxPath.Child("external_volume_template"))...)
+		default:
+			allErrs = append(allErrs, field.Required(idxPath.Child("source"), "exactly one volume source must be set"))
+		}
+	}
+	return volumeNames, allErrs
+}
+
+func validateExternalVolumeTemplate(evt *ateapipb.ExternalVolumeTemplate, microvm bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if microvm {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "external volumes are not supported when sandbox_class is SANDBOX_CLASS_MICROVM"))
+	}
+
+	capacityPath := fldPath.Child("capacity")
+	if capacity := evt.GetCapacity(); capacity == "" {
+		allErrs = append(allErrs, field.Required(capacityPath, ""))
+	} else if _, err := k8sresource.ParseQuantity(capacity); err != nil {
+		allErrs = append(allErrs, field.Invalid(capacityPath, capacity, `must be a Kubernetes resource quantity (e.g. "10Gi")`))
+	}
+
+	storageClassPath := fldPath.Child("storage_class_name")
+	if name := evt.GetStorageClassName(); name == "" {
+		allErrs = append(allErrs, field.Required(storageClassPath, ""))
+	} else {
+		for _, msg := range content.IsDNS1123Subdomain(name) {
+			allErrs = append(allErrs, field.Invalid(storageClassPath, name, msg))
+		}
+	}
+	return allErrs
+}
+
+// validateContainers checks the containers list; per-container rules live in
+// validateContainer.
+func validateContainers(containers []*ateapipb.Container, volumeNames map[string]bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(containers) == 0 {
+		return append(allErrs, field.Required(fldPath, ""))
+	}
+	if len(containers) > maxContainers {
+		allErrs = append(allErrs, field.TooMany(fldPath, len(containers), maxContainers))
+	}
+
+	allNames := make(map[string]bool, len(containers))
+	for i, c := range containers {
+		idxPath := fldPath.Index(i)
+
+		allErrs = append(allErrs, validateContainer(c, volumeNames, idxPath)...)
+
+		// Container names must be unique within the spec.
+		if name := c.GetName(); name != "" {
+			if allNames[name] {
+				allErrs = append(allErrs, field.Duplicate(idxPath.Child("name"), name))
+			}
+			allNames[name] = true
+		}
+	}
+	return allErrs
+}
+
+// validateContainer checks a single container. Name rules match
+// resources.ValidateContainerNames: a DNS label, not the reserved "pause"
+// sandbox-infra name (uniqueness is checked by validateContainers).
+func validateContainer(c *ateapipb.Container, volumeNames map[string]bool, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	namePath := path.Child("name")
+	if name := c.GetName(); name == "" {
+		allErrs = append(allErrs, field.Required(namePath, ""))
+	} else {
+		allErrs = append(allErrs, resources.ValidateResourceName(name, namePath)...)
+		if name == "pause" {
+			allErrs = append(allErrs, field.Invalid(namePath, name, "reserved for sandbox infrastructure"))
+		}
+	}
+
+	imagePath := path.Child("image")
+	if image := c.GetImage(); image == "" {
+		allErrs = append(allErrs, field.Required(imagePath, ""))
+	} else if !strings.Contains(image, "@") {
+		allErrs = append(allErrs, field.Invalid(imagePath, image, pinnedImageMsg))
+	}
+
+	if n := len(c.GetCommand()); n > maxCommandItems {
+		allErrs = append(allErrs, field.TooMany(path.Child("command"), n, maxCommandItems))
+	}
+	if n := len(c.GetArgs()); n > maxArgsItems {
+		allErrs = append(allErrs, field.TooMany(path.Child("args"), n, maxArgsItems))
+	}
+
+	allErrs = append(allErrs, validateEnv(c.GetEnv(), path.Child("env"))...)
+
+	if readyz := c.GetReadyz(); readyz != nil {
+		allErrs = append(allErrs, validateReadyz(readyz, path.Child("readyz"))...)
+	}
+
+	allErrs = append(allErrs, validateVolumeMounts(c.GetVolumeMounts(), volumeNames, path.Child("volume_mounts"))...)
+
+	return allErrs
+}
+
+func validateEnv(env []*ateapipb.EnvVar, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if len(env) > maxEnvItems {
+		allErrs = append(allErrs, field.TooMany(fldPath, len(env), maxEnvItems))
+	}
+
+	for i, e := range env {
+		idxPath := fldPath.Index(i)
+
+		namePath := idxPath.Child("name")
+		if name := e.GetName(); name == "" {
+			allErrs = append(allErrs, field.Required(namePath, ""))
+		} else if !envNameRegexp.MatchString(name) {
+			allErrs = append(allErrs, field.Invalid(namePath, name, "may contain any printable ASCII character except '='"))
+		}
+
+		if e.GetSource() == nil {
+			allErrs = append(allErrs, field.Required(idxPath.Child("value"), "exactly one source must be set"))
+		}
+	}
+	return allErrs
+}
+
+// validateVolumeMounts checks one container's mounts against the declared
+// volume names. Mount paths must be unique within the container.
+func validateVolumeMounts(mounts []*ateapipb.VolumeMount, volumeNames map[string]bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if len(mounts) > maxVolumeMounts {
+		allErrs = append(allErrs, field.TooMany(fldPath, len(mounts), maxVolumeMounts))
+	}
+
+	mountPaths := make(map[string]bool, len(mounts))
+	for i, vm := range mounts {
+		idxPath := fldPath.Index(i)
+
+		namePath := idxPath.Child("name")
+		if name := vm.GetName(); name == "" {
+			allErrs = append(allErrs, field.Required(namePath, ""))
+		} else if !volumeNames[name] {
+			allErrs = append(allErrs, field.Invalid(namePath, name, "must match the name of a volume in spec.volumes"))
+		}
+
+		mountPathPath := idxPath.Child("mount_path")
+		allErrs = append(allErrs, validateMountPath(vm.GetMountPath(), mountPathPath)...)
+		if mountPaths[vm.GetMountPath()] {
+			allErrs = append(allErrs, field.Invalid(mountPathPath, vm.GetMountPath(), "must be unique"))
+		}
+		mountPaths[vm.GetMountPath()] = true
+	}
+	return allErrs
+}
+
+// mountedVolumeNames returns the declared volume names referenced by at least
+// one valid mount, for the every-volume-must-be-mounted cross-check.
+func mountedVolumeNames(containers []*ateapipb.Container, volumeNames map[string]bool) map[string]bool {
+	mounted := make(map[string]bool, len(volumeNames))
+	for _, c := range containers {
+		for _, vm := range c.GetVolumeMounts() {
+			if volumeNames[vm.GetName()] {
+				mounted[vm.GetName()] = true
+			}
+		}
+	}
+	return mounted
+}
+
+// validateReadyz checks a container's readiness probe at its effective
+// (defaulted) values.
+func validateReadyz(readyz *ateapipb.ContainerReadyz, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if httpGet := readyz.GetHttpGet(); httpGet == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("http_get"), ""))
+	} else {
+		allErrs = append(allErrs, validateHTTPGet(httpGet, fldPath.Child("http_get"))...)
+	}
+
+	timeoutPath := fldPath.Child("timeout_seconds")
+	if timeout := readyz.GetTimeoutSeconds(); timeout < 1 || timeout > maxReadyzTimeout {
+		allErrs = append(allErrs, field.Invalid(timeoutPath, timeout, "must be between 1 and 3600"))
+	}
+
+	return allErrs
+}
+
+func validateHTTPGet(httpGet *ateapipb.HTTPGetAction, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	portPath := fldPath.Child("port")
+	if port := httpGet.GetPort(); port < 1 || port > 65535 {
+		allErrs = append(allErrs, field.Invalid(portPath, port, "must be between 1 and 65535"))
+	}
+
+	pathPath := fldPath.Child("path")
+	if path := httpGet.GetPath(); len(path) > maxReadyzPathLen {
+		allErrs = append(allErrs, field.TooLong(pathPath, path, maxReadyzPathLen))
+	} else if !readyzPathRegexp.MatchString(path) {
+		allErrs = append(allErrs, field.Invalid(pathPath, path, "must be a valid URL path starting with '/', without query strings or fragments"))
+	}
+
+	return allErrs
+}
+
+// validateSnapshotsConfig checks the snapshots configuration, including the
+// on_commit-is-a-subset-of-on_pause rule (UNSPECIFIED means FULL) and the
+// microvm gate on golden resume.
+func validateSnapshotsConfig(sc *ateapipb.SnapshotsConfig, microvm bool, fldPath *field.Path) field.ErrorList {
+	if sc == nil {
+		return field.ErrorList{field.Required(fldPath, "")}
+	}
+
+	allErrs := field.ErrorList{}
+
+	locationPath := fldPath.Child("storage_location")
+	if location := sc.GetStorageLocation(); location == "" {
+		allErrs = append(allErrs, field.Required(locationPath, ""))
+	} else if err := resources.ValidateSnapshotLocation(location); err != nil {
+		allErrs = append(allErrs, field.Invalid(locationPath, location, err.Error()))
+	}
+
+	scopeNames := []string{
+		ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL.String(),
+		ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA.String(),
+	}
+	if onPause := sc.GetOnPause(); ateapipb.SnapshotContentScope_name[int32(onPause)] == "" {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("on_pause"), onPause, scopeNames))
+	}
+	onCommitPath := fldPath.Child("on_commit")
+	if onCommit := sc.GetOnCommit(); ateapipb.SnapshotContentScope_name[int32(onCommit)] == "" {
+		allErrs = append(allErrs, field.NotSupported(onCommitPath, onCommit, scopeNames))
+	} else if effectiveScope(sc.GetOnPause()) == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA &&
+		effectiveScope(onCommit) != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA {
+		allErrs = append(allErrs, field.Invalid(onCommitPath, onCommit, "must be a subset of on_pause"))
+	}
+
+	fromDataPath := fldPath.Child("on_resume", "from_data")
+	if fromData := sc.GetOnResume().GetFromData(); ateapipb.ResumeSource_name[int32(fromData)] == "" {
+		allErrs = append(allErrs, field.NotSupported(fromDataPath, fromData, []string{
+			ateapipb.ResumeSource_RESUME_SOURCE_COLD_BOOT.String(),
+			ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN.String(),
+		}))
+	} else if fromData == ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN && !microvm {
+		allErrs = append(allErrs, field.Invalid(fromDataPath, fromData, "RESUME_SOURCE_GOLDEN requires SANDBOX_CLASS_MICROVM"))
+	}
+
+	return allErrs
+}
+
+// effectiveScope resolves the proto zero value to the documented FULL
+// default.
+func effectiveScope(s ateapipb.SnapshotContentScope) ateapipb.SnapshotContentScope {
+	if s == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED {
+		return ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL
+	}
+	return s
+}
+
+// validateMountPath ports the CRD's mount-path CEL rule: a clean absolute
+// Unix path that cannot escape or alias the mount tree.
+func validateMountPath(path string, fldPath *field.Path) field.ErrorList {
+	const mountPathMsg = "must be a clean absolute Unix path: must start with '/', not be '/', and contain no ':', '..', '.', '//', trailing '/', or control characters"
+
+	if path == "" {
+		return field.ErrorList{field.Required(fldPath, "")}
+	}
+
+	allErrs := field.ErrorList{}
+	if len(path) > maxMountPathLen {
+		allErrs = append(allErrs, field.TooLong(fldPath, path, maxMountPathLen))
+	}
+
+	ok := strings.HasPrefix(path, "/") && len(path) > 1 &&
+		!strings.HasSuffix(path, "/") && !strings.Contains(path, "//") &&
+		!strings.Contains(path, ":")
+	if ok {
+		for i := 0; i < len(path); i++ {
+			if path[i] <= 0x1f || path[i] == 0x7f {
+				ok = false
+				break
+			}
+		}
+	}
+	if ok {
+		for _, seg := range strings.Split(path[1:], "/") {
+			if seg == "." || seg == ".." {
+				ok = false
+				break
+			}
+		}
+	}
+	if !ok {
+		allErrs = append(allErrs, field.Invalid(fldPath, path, mountPathMsg))
+	}
+	return allErrs
+}

--- a/cmd/ateapi/internal/controlapi/template_version_spec.go
+++ b/cmd/ateapi/internal/controlapi/template_version_spec.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/internal/templateversion"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/api/validate/content"
@@ -55,22 +56,10 @@ var (
 )
 
 // defaultActorTemplateVersionSpec materializes server-applied defaults into
-// the spec before validation and storage, mirroring the CRD's API-server
-// defaulting: a readyz timeout of 0 means 30s and an empty readyz path means
-// "/readyz", so the effective values are visible on the stored object.
+// the spec before validation and storage; shared with kubectl-ate, which
+// must default identically before comparing manifests on re-apply.
 func defaultActorTemplateVersionSpec(spec *ateapipb.ActorTemplateVersionSpec) {
-	for _, c := range spec.GetContainers() {
-		readyz := c.GetReadyz()
-		if readyz == nil {
-			continue
-		}
-		if readyz.GetTimeoutSeconds() == 0 {
-			readyz.TimeoutSeconds = defaultReadyzTimeout
-		}
-		if httpGet := readyz.GetHttpGet(); httpGet != nil && httpGet.GetPath() == "" {
-			httpGet.Path = defaultReadyzPath
-		}
-	}
+	templateversion.DefaultSpec(spec)
 }
 
 // validateActorTemplateVersionSpec ports the ActorTemplate CRD's CEL and

--- a/cmd/ateapi/internal/controlapi/template_version_spec_test.go
+++ b/cmd/ateapi/internal/controlapi/template_version_spec_test.go
@@ -1,0 +1,398 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// validTemplateVersionSpec returns a fully-populated spec that passes
+// validation, optionally mutated. It is already in defaulted form.
+func validTemplateVersionSpec(mutations ...func(*ateapipb.ActorTemplateVersionSpec)) *ateapipb.ActorTemplateVersionSpec {
+	spec := &ateapipb.ActorTemplateVersionSpec{
+		PauseImage: "pause@sha256:abc",
+		Containers: []*ateapipb.Container{{
+			Name:  "main",
+			Image: "app@sha256:def",
+			Env:   []*ateapipb.EnvVar{{Name: "MODE", Source: &ateapipb.EnvVar_Value{Value: "prod"}}},
+			Readyz: &ateapipb.ContainerReadyz{
+				HttpGet:        &ateapipb.HTTPGetAction{Path: "/readyz", Port: 8080},
+				TimeoutSeconds: 30,
+			},
+			VolumeMounts: []*ateapipb.VolumeMount{{Name: "data", MountPath: "/data"}},
+		}},
+		Volumes: []*ateapipb.Volume{{
+			Name:   "data",
+			Source: &ateapipb.Volume_DurableDir{DurableDir: &ateapipb.DurableDirVolumeSource{}},
+		}},
+		SnapshotsConfig: &ateapipb.SnapshotsConfig{
+			StorageLocation: "gs://bucket/snapshots",
+		},
+		SandboxConfig: &ateapipb.SandboxConfig{
+			SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+			ConfigName:   "gvisor-default",
+		},
+	}
+	for _, m := range mutations {
+		m(spec)
+	}
+	return spec
+}
+
+func TestValidateActorTemplateVersionSpec(t *testing.T) {
+	specPath := field.NewPath("spec")
+	tests := []struct {
+		name string
+		spec *ateapipb.ActorTemplateVersionSpec
+		want field.ErrorList
+	}{{
+		"valid full spec",
+		validTemplateVersionSpec(),
+		nil,
+	}, {
+		"valid minimal spec",
+		&ateapipb.ActorTemplateVersionSpec{
+			PauseImage:      "pause@sha256:abc",
+			Containers:      []*ateapipb.Container{{Name: "main", Image: "app@sha256:def"}},
+			SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://bucket/snapshots"},
+			SandboxConfig: &ateapipb.SandboxConfig{
+				SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+				ConfigName:   "gvisor-default",
+			},
+		},
+		nil,
+	}, {
+		"nil spec",
+		nil,
+		field.ErrorList{field.Required(specPath, "")},
+	}, {
+		"missing pause_image",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.PauseImage = "" }),
+		field.ErrorList{field.Required(specPath.Child("pause_image"), "")},
+	}, {
+		"unpinned pause_image",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.PauseImage = "pause:latest" }),
+		field.ErrorList{field.Invalid(specPath.Child("pause_image"), "pause:latest", "")},
+	}, {
+		"missing container name",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Name = "" }),
+		field.ErrorList{field.Required(specPath.Child("containers").Index(0).Child("name"), "")},
+	}, {
+		"invalid container name",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Name = "MAIN" }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("name"), "MAIN", "")},
+	}, {
+		"reserved container name",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Name = "pause" }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("name"), "pause", "")},
+	}, {
+		"duplicate container names",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers = append(s.Containers, &ateapipb.Container{Name: "main", Image: "app@sha256:def"})
+		}),
+		field.ErrorList{field.Duplicate(specPath.Child("containers").Index(1).Child("name"), "main")},
+	}, {
+		"too many containers",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers = nil
+			for i := 0; i < maxContainers+1; i++ {
+				s.Containers = append(s.Containers, &ateapipb.Container{
+					Name: fmt.Sprintf("c%d", i), Image: "app@sha256:def",
+				})
+			}
+			s.Volumes = nil
+		}),
+		field.ErrorList{field.TooMany(specPath.Child("containers"), maxContainers+1, maxContainers)},
+	}, {
+		"no containers",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers = nil
+			s.Volumes = nil
+		}),
+		field.ErrorList{field.Required(specPath.Child("containers"), "")},
+	}, {
+		"missing container image",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Image = "" }),
+		field.ErrorList{field.Required(specPath.Child("containers").Index(0).Child("image"), "")},
+	}, {
+		"unpinned container image",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Image = "app:v1" }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("image"), "app:v1", "")},
+	}, {
+		"too many command items",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers[0].Command = make([]string, maxCommandItems+1)
+		}),
+		field.ErrorList{field.TooMany(specPath.Child("containers").Index(0).Child("command"), maxCommandItems+1, maxCommandItems)},
+	}, {
+		"missing env name",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Env[0].Name = "" }),
+		field.ErrorList{field.Required(specPath.Child("containers").Index(0).Child("env").Index(0).Child("name"), "")},
+	}, {
+		"env name with equals sign",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Env[0].Name = "A=B" }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("env").Index(0).Child("name"), "A=B", "")},
+	}, {
+		"env without source",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Env[0].Source = nil }),
+		field.ErrorList{field.Required(specPath.Child("containers").Index(0).Child("env").Index(0).Child("value"), "")},
+	}, {
+		"readyz without http_get",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Readyz.HttpGet = nil }),
+		field.ErrorList{field.Required(specPath.Child("containers").Index(0).Child("readyz", "http_get"), "")},
+	}, {
+		"readyz port out of range",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Readyz.HttpGet.Port = 0 }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("readyz", "http_get", "port"), int32(0), "")},
+	}, {
+		"readyz path with query string",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].Readyz.HttpGet.Path = "/readyz?x=1" }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("readyz", "http_get", "path"), "/readyz?x=1", "")},
+	}, {
+		"readyz timeout above maximum",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers[0].Readyz.TimeoutSeconds = maxReadyzTimeout + 1
+		}),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("readyz", "timeout_seconds"), int32(maxReadyzTimeout+1), "")},
+	}, {
+		"volume mount references unknown volume",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, &ateapipb.VolumeMount{Name: "ghost", MountPath: "/ghost"})
+		}),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("volume_mounts").Index(1).Child("name"), "ghost", "")},
+	}, {
+		"duplicate mount path",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, &ateapipb.VolumeMount{Name: "data", MountPath: "/data"})
+		}),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("volume_mounts").Index(1).Child("mount_path"), "/data", "")},
+	}, {
+		"missing mount path",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].VolumeMounts[0].MountPath = "" }),
+		field.ErrorList{field.Required(specPath.Child("containers").Index(0).Child("volume_mounts").Index(0).Child("mount_path"), "")},
+	}, {
+		"relative mount path",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].VolumeMounts[0].MountPath = "data" }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("volume_mounts").Index(0).Child("mount_path"), "data", "")},
+	}, {
+		"mount path with dotdot segment",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].VolumeMounts[0].MountPath = "/data/../etc" }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("volume_mounts").Index(0).Child("mount_path"), "/data/../etc", "")},
+	}, {
+		"mount path with trailing slash",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].VolumeMounts[0].MountPath = "/data/" }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("volume_mounts").Index(0).Child("mount_path"), "/data/", "")},
+	}, {
+		"mount path with colon",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Containers[0].VolumeMounts[0].MountPath = "/da:ta" }),
+		field.ErrorList{field.Invalid(specPath.Child("containers").Index(0).Child("volume_mounts").Index(0).Child("mount_path"), "/da:ta", "")},
+	}, {
+		"mount path too long",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers[0].VolumeMounts[0].MountPath = "/" + strings.Repeat("a", maxMountPathLen)
+		}),
+		field.ErrorList{field.TooLong(specPath.Child("containers").Index(0).Child("volume_mounts").Index(0).Child("mount_path"), "/"+strings.Repeat("a", maxMountPathLen), maxMountPathLen)},
+	}, {
+		"missing volume name",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Volumes[0].Name = "" }),
+		field.ErrorList{
+			field.Required(specPath.Child("volumes").Index(0).Child("name"), ""),
+			// The mount referencing "data" no longer matches a declared volume.
+			field.Invalid(specPath.Child("containers").Index(0).Child("volume_mounts").Index(0).Child("name"), "data", ""),
+		},
+	}, {
+		"duplicate volume names",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Volumes = append(s.Volumes, &ateapipb.Volume{
+				Name:   "data",
+				Source: &ateapipb.Volume_DurableDir{DurableDir: &ateapipb.DurableDirVolumeSource{}},
+			})
+		}),
+		field.ErrorList{field.Duplicate(specPath.Child("volumes").Index(1).Child("name"), "data")},
+	}, {
+		"volume without source",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.Volumes[0].Source = nil }),
+		field.ErrorList{field.Required(specPath.Child("volumes").Index(0).Child("source"), "")},
+	}, {
+		"unmounted volume",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Volumes = append(s.Volumes, &ateapipb.Volume{
+				Name:   "scratch",
+				Source: &ateapipb.Volume_DurableDir{DurableDir: &ateapipb.DurableDirVolumeSource{}},
+			})
+		}),
+		field.ErrorList{field.Invalid(specPath.Child("volumes").Index(1).Child("name"), "scratch", "")},
+	}, {
+		"external volume missing capacity",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Volumes[0].Source = &ateapipb.Volume_ExternalVolumeTemplate{
+				ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{StorageClassName: "standard"},
+			}
+		}),
+		field.ErrorList{field.Required(specPath.Child("volumes").Index(0).Child("external_volume_template", "capacity"), "")},
+	}, {
+		"external volume bad capacity",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Volumes[0].Source = &ateapipb.Volume_ExternalVolumeTemplate{
+				ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{Capacity: "lots", StorageClassName: "standard"},
+			}
+		}),
+		field.ErrorList{field.Invalid(specPath.Child("volumes").Index(0).Child("external_volume_template", "capacity"), "lots", "")},
+	}, {
+		"external volume missing storage class",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Volumes[0].Source = &ateapipb.Volume_ExternalVolumeTemplate{
+				ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{Capacity: "10Gi"},
+			}
+		}),
+		field.ErrorList{field.Required(specPath.Child("volumes").Index(0).Child("external_volume_template", "storage_class_name"), "")},
+	}, {
+		"external volume forbidden on microvm",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SandboxConfig = &ateapipb.SandboxConfig{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM, ConfigName: "microvm"}
+			s.Volumes[0].Source = &ateapipb.Volume_ExternalVolumeTemplate{
+				ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{Capacity: "10Gi", StorageClassName: "standard"},
+			}
+		}),
+		field.ErrorList{field.Forbidden(specPath.Child("volumes").Index(0).Child("external_volume_template"), "")},
+	}, {
+		"missing snapshots_config",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.SnapshotsConfig = nil }),
+		field.ErrorList{field.Required(specPath.Child("snapshots_config"), "")},
+	}, {
+		"missing storage_location",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.SnapshotsConfig.StorageLocation = "" }),
+		field.ErrorList{field.Required(specPath.Child("snapshots_config", "storage_location"), "")},
+	}, {
+		"storage_location without bucket",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) { s.SnapshotsConfig.StorageLocation = "/just/a/path" }),
+		field.ErrorList{field.Invalid(specPath.Child("snapshots_config", "storage_location"), "/just/a/path", "")},
+	}, {
+		"on_commit FULL not a subset of on_pause DATA",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SnapshotsConfig.OnPause = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+			s.SnapshotsConfig.OnCommit = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL
+		}),
+		field.ErrorList{field.Invalid(specPath.Child("snapshots_config", "on_commit"), ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL, "")},
+	}, {
+		"on_commit UNSPECIFIED means FULL, not a subset of on_pause DATA",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SnapshotsConfig.OnPause = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+		}),
+		field.ErrorList{field.Invalid(specPath.Child("snapshots_config", "on_commit"), ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED, "")},
+	}, {
+		"on_pause DATA with on_commit DATA is valid",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SnapshotsConfig.OnPause = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+			s.SnapshotsConfig.OnCommit = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+		}),
+		nil,
+	}, {
+		"undefined on_pause enum value",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SnapshotsConfig.OnPause = ateapipb.SnapshotContentScope(99)
+		}),
+		field.ErrorList{field.NotSupported[string](specPath.Child("snapshots_config", "on_pause"), ateapipb.SnapshotContentScope(99), nil)},
+	}, {
+		"golden resume requires microvm",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SnapshotsConfig.OnResume = &ateapipb.OnResumeConfig{FromData: ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN}
+		}),
+		field.ErrorList{field.Invalid(specPath.Child("snapshots_config", "on_resume", "from_data"), ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN, "")},
+	}, {
+		"golden resume valid on microvm",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SandboxConfig = &ateapipb.SandboxConfig{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM, ConfigName: "microvm"}
+			s.SnapshotsConfig.OnResume = &ateapipb.OnResumeConfig{FromData: ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN}
+		}),
+		nil,
+	}, {
+		"missing sandbox_config",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SandboxConfig = nil
+		}),
+		field.ErrorList{field.Required(specPath.Child("sandbox_config"), "")},
+	}, {
+		"unspecified sandbox class",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SandboxConfig.SandboxClass = ateapipb.SandboxClass_SANDBOX_CLASS_UNSPECIFIED
+		}),
+		field.ErrorList{field.Required(specPath.Child("sandbox_config", "sandbox_class"), "")},
+	}, {
+		"undefined sandbox class",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SandboxConfig.SandboxClass = ateapipb.SandboxClass(99)
+		}),
+		field.ErrorList{field.NotSupported[string](specPath.Child("sandbox_config", "sandbox_class"), ateapipb.SandboxClass(99), nil)},
+	}, {
+		"missing sandbox config_name",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SandboxConfig.ConfigName = ""
+		}),
+		field.ErrorList{field.Required(specPath.Child("sandbox_config", "config_name"), "")},
+	}, {
+		"invalid sandbox config_name",
+		validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.SandboxConfig.ConfigName = "Bad_Name"
+		}),
+		field.ErrorList{field.Invalid(specPath.Child("sandbox_config", "config_name"), "Bad_Name", "")},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateActorTemplateVersionSpec(tt.spec, specPath)
+			assertValidateErr(t, got, tt.want)
+		})
+	}
+}
+
+func TestDefaultActorTemplateVersionSpec(t *testing.T) {
+	spec := &ateapipb.ActorTemplateVersionSpec{
+		Containers: []*ateapipb.Container{
+			{Name: "no-readyz"},
+			{Name: "defaulted", Readyz: &ateapipb.ContainerReadyz{HttpGet: &ateapipb.HTTPGetAction{Port: 8080}}},
+			{Name: "explicit", Readyz: &ateapipb.ContainerReadyz{
+				HttpGet:        &ateapipb.HTTPGetAction{Path: "/healthz", Port: 9090},
+				TimeoutSeconds: 120,
+			}},
+		},
+	}
+
+	defaultActorTemplateVersionSpec(spec)
+
+	if got := spec.Containers[0].GetReadyz(); got != nil {
+		t.Errorf("container without readyz gained one: %v", got)
+	}
+	if got := spec.Containers[1].GetReadyz().GetTimeoutSeconds(); got != defaultReadyzTimeout {
+		t.Errorf("defaulted timeout = %d, want %d", got, defaultReadyzTimeout)
+	}
+	if got := spec.Containers[1].GetReadyz().GetHttpGet().GetPath(); got != defaultReadyzPath {
+		t.Errorf("defaulted path = %q, want %q", got, defaultReadyzPath)
+	}
+	if got := spec.Containers[2].GetReadyz().GetTimeoutSeconds(); got != 120 {
+		t.Errorf("explicit timeout changed to %d, want 120", got)
+	}
+	if got := spec.Containers[2].GetReadyz().GetHttpGet().GetPath(); got != "/healthz" {
+		t.Errorf("explicit path changed to %q, want /healthz", got)
+	}
+	if got := spec.GetSandboxConfig(); got != nil {
+		t.Errorf("defaulting materialized a sandbox config: %v", got)
+	}
+}

--- a/cmd/ateapi/internal/controlapi/update_actor.go
+++ b/cmd/ateapi/internal/controlapi/update_actor.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/resources"
@@ -30,7 +31,8 @@ import (
 // actorMutableFields lists the Actor field paths a client may name in an
 // UpdateActor update_mask.
 var actorMutableFields = mutableFields[*ateapipb.Actor]{
-	"worker_selector": func(dst, src *ateapipb.Actor) { dst.WorkerSelector = src.GetWorkerSelector() },
+	"worker_selector":        func(dst, src *ateapipb.Actor) { dst.WorkerSelector = src.GetWorkerSelector() },
+	"actor_template_version": func(dst, src *ateapipb.Actor) { dst.ActorTemplateVersion = src.GetActorTemplateVersion() },
 }
 
 func (s *Service) UpdateActor(ctx context.Context, req *ateapipb.UpdateActorRequest) (*ateapipb.Actor, error) {
@@ -57,6 +59,13 @@ func (s *Service) UpdateActor(ctx context.Context, req *ateapipb.UpdateActorRequ
 	expectedVersion := actor.GetMetadata().GetVersion()
 	if version := in.GetMetadata().GetVersion(); version != 0 {
 		expectedVersion = version
+	}
+
+	if slices.Contains(req.GetUpdateMask().GetPaths(), "actor_template_version") &&
+		in.GetActorTemplateVersion() != actor.GetActorTemplateVersion() {
+		if err := validateVersionRepin(ctx, s.persistence, actor, in.GetActorTemplateVersion()); err != nil {
+			return nil, err
+		}
 	}
 
 	applyUpdateMask(actor, in, req.GetUpdateMask(), actorMutableFields)
@@ -89,6 +98,14 @@ func validateUpdateActorRequest(req *ateapipb.UpdateActorRequest) field.ErrorLis
 
 	if selector := actor.GetWorkerSelector(); selector != nil {
 		errs = append(errs, validateSelector(selector, actorPath.Child("worker_selector"))...)
+	}
+	if slices.Contains(req.GetUpdateMask().GetPaths(), "actor_template_version") {
+		p := actorPath.Child("actor_template_version")
+		if val := actor.GetActorTemplateVersion(); val == "" {
+			errs = append(errs, field.Required(p, "the version pin cannot be cleared"))
+		} else {
+			errs = append(errs, resources.ValidateResourceName(val, p)...)
+		}
 	}
 
 	return errs

--- a/cmd/ateapi/internal/controlapi/update_actor_template.go
+++ b/cmd/ateapi/internal/controlapi/update_actor_template.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+const defaultVersionMaskPath = "spec.default_version_on_create"
+
+// actorTemplateMutableFields lists the ActorTemplate field paths a client may
+// name in an UpdateActorTemplate update_mask.
+var actorTemplateMutableFields = mutableFields[*ateapipb.ActorTemplate]{
+	"spec.worker_selector": func(dst, src *ateapipb.ActorTemplate) {
+		if dst.Spec == nil {
+			dst.Spec = &ateapipb.ActorTemplateSpec{}
+		}
+		dst.Spec.WorkerSelector = src.GetSpec().GetWorkerSelector()
+	},
+	defaultVersionMaskPath: func(dst, src *ateapipb.ActorTemplate) {
+		if dst.Spec == nil {
+			dst.Spec = &ateapipb.ActorTemplateSpec{}
+		}
+		dst.Spec.DefaultVersionOnCreate = src.GetSpec().GetDefaultVersionOnCreate()
+	},
+}
+
+func (s *Service) UpdateActorTemplate(ctx context.Context, req *ateapipb.UpdateActorTemplateRequest) (*ateapipb.ActorTemplate, error) {
+	if errs := validateUpdateActorTemplateRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+	in := req.GetActorTemplate()
+	name := in.GetMetadata().GetName()
+
+	// Setting a new default names an ActorTemplateVersion; take the template
+	// lock so the reference check below cannot race a concurrent
+	// DeleteActorTemplateVersion. Clearing the default or updating only the
+	// selector needs no cross-resource check, so it stays lock-free.
+	newDefault := in.GetSpec().GetDefaultVersionOnCreate()
+	setsDefault := newDefault != nil && slices.Contains(req.GetUpdateMask().GetPaths(), defaultVersionMaskPath)
+	if setsDefault {
+		lock, err := s.persistence.AcquireLock(ctx, actorTemplateLockKey(name))
+		if errors.Is(err, store.ErrLockConflict) {
+			return nil, status.Error(codes.Aborted, "another operation is using this ActorTemplate")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("while locking ActorTemplate: %w", err)
+		}
+		defer lock.Close()
+		ctx = lock.Context()
+	}
+
+	template, err := s.persistence.GetActorTemplate(ctx, name)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "ActorTemplate %s not found", name)
+		}
+		return nil, fmt.Errorf("while getting actor template: %w", err)
+	}
+
+	// UID and version preconditions
+	if uid := in.GetMetadata().GetUid(); uid != "" && uid != template.GetMetadata().GetUid() {
+		return nil, status.Errorf(codes.Aborted, "ActorTemplate %s has uid %s, not %s", name, template.GetMetadata().GetUid(), uid)
+	}
+
+	expectedVersion := template.GetMetadata().GetVersion()
+	if version := in.GetMetadata().GetVersion(); version != 0 {
+		expectedVersion = version
+	}
+
+	// The new default must exist and belong to this template. Readiness is
+	// deliberately not checked here: CreateActor enforces it when the default
+	// is used, so a template can point at a version that is still building.
+	if setsDefault {
+		version, err := s.persistence.GetActorTemplateVersion(ctx, newDefault.GetName())
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %s not found", newDefault.GetName())
+			}
+			return nil, fmt.Errorf("while getting actor template version: %w", err)
+		}
+		if parent := version.GetActorTemplate().GetName(); parent != name {
+			return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplateVersion %s belongs to ActorTemplate %s, not %s",
+				newDefault.GetName(), parent, name)
+		}
+	}
+
+	applyUpdateMask(template, in, req.GetUpdateMask(), actorTemplateMutableFields)
+
+	updated, err := s.persistence.UpdateActorTemplate(ctx, template, expectedVersion)
+	if err != nil {
+		if errors.Is(err, store.ErrVersionConflict) {
+			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
+		}
+		return nil, fmt.Errorf("while updating actor template: %w", err)
+	}
+
+	return updated, nil
+}
+
+func validateUpdateActorTemplateRequest(req *ateapipb.UpdateActorTemplateRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	template := req.GetActorTemplate()
+	templatePath := fldPath.Child("actor_template")
+	if template == nil {
+		return field.ErrorList{field.Required(templatePath, "")}
+	}
+
+	errs = append(errs, resources.ValidateGlobalResourceMetadataRef(template.GetMetadata(), templatePath.Child("metadata"))...)
+
+	errs = append(errs, validateUpdateMask(req.GetUpdateMask(), actorTemplateMutableFields)...)
+
+	specPath := templatePath.Child("spec")
+	if selector := template.GetSpec().GetWorkerSelector(); selector != nil {
+		errs = append(errs, validateSelector(selector, specPath.Child("worker_selector"))...)
+	}
+	if ref := template.GetSpec().GetDefaultVersionOnCreate(); ref != nil {
+		errs = append(errs, resources.ValidateGlobalObjectRef(ref, specPath.Child("default_version_on_create"))...)
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/update_actor_template_test.go
+++ b/cmd/ateapi/internal/controlapi/update_actor_template_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateUpdateActorTemplateRequest(t *testing.T) {
+	supported := []string{"spec.default_version_on_create", "spec.worker_selector"}
+	validReq := func(mutations ...func(*ateapipb.UpdateActorTemplateRequest)) *ateapipb.UpdateActorTemplateRequest {
+		req := &ateapipb.UpdateActorTemplateRequest{
+			ActorTemplate: &ateapipb.ActorTemplate{
+				Metadata: &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+				Spec: &ateapipb.ActorTemplateSpec{
+					WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "1"}},
+				},
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.worker_selector"}},
+		}
+		for _, m := range mutations {
+			m(req)
+		}
+		return req
+	}
+
+	tests := []struct {
+		name string
+		req  *ateapipb.UpdateActorTemplateRequest
+		want field.ErrorList
+	}{{
+		"valid selector update",
+		validReq(),
+		nil,
+	}, {
+		"valid default update",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) {
+			r.ActorTemplate.Spec = &ateapipb.ActorTemplateSpec{
+				DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: "tmpl-a-v1"},
+			}
+			r.UpdateMask = &fieldmaskpb.FieldMask{Paths: []string{"spec.default_version_on_create"}}
+		}),
+		nil,
+	}, {
+		"valid default clear",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) {
+			r.ActorTemplate.Spec = nil
+			r.UpdateMask = &fieldmaskpb.FieldMask{Paths: []string{"spec.default_version_on_create"}}
+		}),
+		nil,
+	}, {
+		"missing actor_template",
+		&ateapipb.UpdateActorTemplateRequest{UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.worker_selector"}}},
+		field.ErrorList{field.Required(field.NewPath("actor_template"), "")},
+	}, {
+		"metadata.atespace must be empty",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) { r.ActorTemplate.Metadata.Atespace = "ns1" }),
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "metadata", "atespace"), "ns1", "")},
+	}, {
+		"missing metadata.name",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) { r.ActorTemplate.Metadata.Name = "" }),
+		field.ErrorList{field.Required(field.NewPath("actor_template", "metadata", "name"), "")},
+	}, {
+		"invalid uid precondition",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) { r.ActorTemplate.Metadata.Uid = "not-a-uuid" }),
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "metadata", "uid"), "not-a-uuid", "")},
+	}, {
+		"negative version precondition",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) { r.ActorTemplate.Metadata.Version = -1 }),
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "metadata", "version"), int64(-1), "")},
+	}, {
+		"missing update mask",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) { r.UpdateMask = nil }),
+		field.ErrorList{field.Required(field.NewPath("update_mask"), "")},
+	}, {
+		"unsupported mask path",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) {
+			r.UpdateMask = &fieldmaskpb.FieldMask{Paths: []string{"spec"}}
+		}),
+		field.ErrorList{field.NotSupported(field.NewPath("update_mask"), "spec", supported)},
+	}, {
+		"invalid worker selector",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) {
+			r.ActorTemplate.Spec.WorkerSelector = &ateapipb.Selector{MatchLabels: map[string]string{"bad key!": "1"}}
+		}),
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "spec", "worker_selector", "match_labels").Key("bad key!"), "bad key!", "")},
+	}, {
+		"default ref with atespace",
+		validReq(func(r *ateapipb.UpdateActorTemplateRequest) {
+			r.ActorTemplate.Spec.DefaultVersionOnCreate = &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl-a-v1"}
+		}),
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "spec", "default_version_on_create", "atespace"), "ns1", "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateUpdateActorTemplateRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/update_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/update_actor_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestValidateUpdateActorRequest(t *testing.T) {
-	mutableFields := []string{"worker_selector"}
+	mutableFields := []string{"actor_template_version", "worker_selector"}
 
 	tests := []struct {
 		name string
@@ -122,6 +122,22 @@ func TestValidateUpdateActorRequest(t *testing.T) {
 		"too many worker_selector.match_labels",
 		updateActorReq(withSelector(selectorLabelsOfSize(11))),
 		field.ErrorList{field.TooMany(field.NewPath("actor", "worker_selector", "match_labels"), 11, 10)},
+	}, {
+		"valid actor_template_version re-pin",
+		updateActorReq(withMaskPaths("actor_template_version"), func(req *ateapipb.UpdateActorRequest) {
+			req.GetActor().ActorTemplateVersion = "tmpl-a-v2"
+		}),
+		nil,
+	}, {
+		"masked actor_template_version left empty",
+		updateActorReq(withMaskPaths("actor_template_version")),
+		field.ErrorList{field.Required(field.NewPath("actor", "actor_template_version"), "")},
+	}, {
+		"invalid actor_template_version",
+		updateActorReq(withMaskPaths("actor_template_version"), func(req *ateapipb.UpdateActorRequest) {
+			req.GetActor().ActorTemplateVersion = "Tmpl_A"
+		}),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template_version"), "Tmpl_A", "")},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/ateapi/internal/controlapi/upgrade_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/upgrade_resume_test.go
@@ -1,0 +1,499 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// upgradeTestVersion creates a version of template with the given spec
+// mutations and marks it READY.
+func upgradeTestVersion(t *testing.T, tc *testContext, name, template string, mutations ...func(*ateapipb.ActorTemplateVersionSpec)) *ateapipb.ActorTemplateVersion {
+	t.Helper()
+	if _, err := tc.client.CreateActorTemplateVersion(context.Background(), &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: name},
+			ActorTemplate: &ateapipb.ObjectRef{Name: template},
+			Spec:          validTemplateVersionSpec(mutations...),
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplateVersion(%s) failed: %v", name, err)
+	}
+	return markTemplateVersionReady(t, tc, name)
+}
+
+func getActor(t *testing.T, tc *testContext, name string) *ateapipb.Actor {
+	t.Helper()
+	actor, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("GetActor(%s) failed: %v", name, err)
+	}
+	return actor
+}
+
+// TestResumeActor_UpgradeToNewVersion walks the whole upgrade primitive: a
+// FULL snapshot taken under v1 restores as-is while the pin is v1, restores
+// data-only with v2's spec and sandbox after the upgrade resume, and rolls
+// back to v1 via UpdateActor + plain resume.
+func TestResumeActor_UpgradeToNewVersion(t *testing.T) {
+	ns := namespaceForTest("ns-upgrade-resume")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	createTemplateForVersions(t, tc, "tmpl-up")
+	upgradeTestVersion(t, tc, "tmpl-up-v1", "tmpl-up")
+	upgradeTestVersion(t, tc, "tmpl-up-v2", "tmpl-up", func(s *ateapipb.ActorTemplateVersionSpec) {
+		s.Containers[0].Image = "app@sha256:fff"
+	})
+	createWorkerPool(t, tc, ns, "pool1", map[string]string{poolLabelKey: ns})
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id-up"}
+	if _, err := tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:             &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id-up"},
+		ActorTemplate:        "tmpl-up",
+		ActorTemplateVersion: "tmpl-up-v1",
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("ResumeActor(boot) failed: %v", err)
+	}
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+
+	// The suspend recorded the producing version on the snapshot.
+	suspended := getActor(t, tc, "id-up")
+	snapshot, err := tc.persistence.GetActorSnapshot(ctx, testAtespace, suspended.GetLatestSnapshot().GetName())
+	if err != nil {
+		t.Fatalf("GetActorSnapshot failed: %v", err)
+	}
+	if got := snapshot.GetActorTemplateVersion(); got != "tmpl-up-v1" {
+		t.Errorf("snapshot actor_template_version = %q, want tmpl-up-v1", got)
+	}
+	if got := snapshot.GetContentScope(); got != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL {
+		t.Fatalf("snapshot content scope = %v, want FULL", got)
+	}
+
+	// Same-version resume restores the FULL snapshot as-is, manifest-described.
+	tc.fakeAtelet.Reset()
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("ResumeActor(same version) failed: %v", err)
+	}
+	restore := tc.fakeAtelet.lastRestoreRequest()
+	if got := restore.GetScope(); got != ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL {
+		t.Errorf("same-version restore scope = %v, want FULL", got)
+	}
+	if restore.GetSandboxAssets() != nil {
+		t.Errorf("same-version restore carries sandbox_assets = %v, want none", restore.GetSandboxAssets())
+	}
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+
+	// Upgrade: the resume re-pins to v2 and restores durable data only, with
+	// v2's images and frozen sandbox.
+	tc.fakeAtelet.Reset()
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor:                actorRef,
+		ActorTemplateVersion: "tmpl-up-v2",
+	}); err != nil {
+		t.Fatalf("ResumeActor(upgrade to v2) failed: %v", err)
+	}
+	if got := getActor(t, tc, "id-up").GetActorTemplateVersion(); got != "tmpl-up-v2" {
+		t.Errorf("actor pin after upgrade = %q, want tmpl-up-v2", got)
+	}
+	restore = tc.fakeAtelet.lastRestoreRequest()
+	if got := restore.GetScope(); got != ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA {
+		t.Errorf("upgrade restore scope = %v, want DATA", got)
+	}
+	if got := restore.GetSpec().GetContainers()[0].GetImage(); got != "app@sha256:fff" {
+		t.Errorf("upgrade restore image = %q, want v2's app@sha256:fff", got)
+	}
+	if got := restore.GetActorTemplateName(); got != "tmpl-up-v2" {
+		t.Errorf("upgrade restore template identity = %q, want tmpl-up-v2", got)
+	}
+	if got := restore.GetSandboxAssets().GetSandboxClass(); got != "gvisor" {
+		t.Errorf("upgrade restore sandbox class = %q, want the frozen gvisor sandbox", got)
+	}
+
+	// The next suspend pins the new version on its snapshot.
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	suspended = getActor(t, tc, "id-up")
+	snapshot, err = tc.persistence.GetActorSnapshot(ctx, testAtespace, suspended.GetLatestSnapshot().GetName())
+	if err != nil {
+		t.Fatalf("GetActorSnapshot failed: %v", err)
+	}
+	if got := snapshot.GetActorTemplateVersion(); got != "tmpl-up-v2" {
+		t.Errorf("post-upgrade snapshot actor_template_version = %q, want tmpl-up-v2", got)
+	}
+
+	// Rollback: revert the pin via UpdateActor, then a plain resume restores
+	// v1's spec. The latest snapshot was produced under v2, so this is again
+	// a cross-version, data-only restore.
+	if _, err := tc.client.UpdateActor(ctx, &ateapipb.UpdateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:             &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id-up"},
+			ActorTemplateVersion: "tmpl-up-v1",
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"actor_template_version"}},
+	}); err != nil {
+		t.Fatalf("UpdateActor(rollback pin) failed: %v", err)
+	}
+	tc.fakeAtelet.Reset()
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("ResumeActor(after rollback) failed: %v", err)
+	}
+	restore = tc.fakeAtelet.lastRestoreRequest()
+	if got := restore.GetScope(); got != ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA {
+		t.Errorf("rollback restore scope = %v, want DATA", got)
+	}
+	if got := restore.GetSpec().GetContainers()[0].GetImage(); got != "app@sha256:def" {
+		t.Errorf("rollback restore image = %q, want v1's app@sha256:def", got)
+	}
+}
+
+// TestResumeActor_UpgradeRetryKeepsPin verifies the re-pin is durable before
+// any restore attempt: after a failed upgrade resume, a plain retry without
+// the version argument still restores the new version's shape.
+func TestResumeActor_UpgradeRetryKeepsPin(t *testing.T) {
+	ns := namespaceForTest("ns-upgrade-retry")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	createTemplateForVersions(t, tc, "tmpl-up")
+	upgradeTestVersion(t, tc, "tmpl-up-v1", "tmpl-up")
+	upgradeTestVersion(t, tc, "tmpl-up-v2", "tmpl-up", func(s *ateapipb.ActorTemplateVersionSpec) {
+		s.Containers[0].Image = "app@sha256:fff"
+	})
+	createWorkerPool(t, tc, ns, "pool1", map[string]string{poolLabelKey: ns})
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id-retry"}
+	if _, err := tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:             &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id-retry"},
+		ActorTemplate:        "tmpl-up",
+		ActorTemplateVersion: "tmpl-up-v1",
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("ResumeActor(boot) failed: %v", err)
+	}
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+
+	tc.fakeAtelet.Reset()
+	tc.fakeAtelet.FailRestore = status.Error(codes.Unavailable, "atelet down")
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor:                actorRef,
+		ActorTemplateVersion: "tmpl-up-v2",
+	}); err == nil {
+		t.Fatal("ResumeActor(upgrade) should fail while atelet is down")
+	}
+	if got := getActor(t, tc, "id-retry").GetActorTemplateVersion(); got != "tmpl-up-v2" {
+		t.Fatalf("pin after failed upgrade = %q, want tmpl-up-v2 (persisted before restore)", got)
+	}
+
+	tc.fakeAtelet.Reset()
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("plain retry after failed upgrade failed: %v", err)
+	}
+	restore := tc.fakeAtelet.lastRestoreRequest()
+	if got := restore.GetSpec().GetContainers()[0].GetImage(); got != "app@sha256:fff" {
+		t.Errorf("retried restore image = %q, want v2's app@sha256:fff", got)
+	}
+	if got := restore.GetScope(); got != ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA {
+		t.Errorf("retried restore scope = %v, want DATA", got)
+	}
+}
+
+// TestResumeActor_FromCrashed covers the rollback flow the design prescribes
+// for failed upgrades: a CRASHED actor can be resumed directly, including
+// with an explicit version to revert to.
+func TestResumeActor_FromCrashed(t *testing.T) {
+	ns := namespaceForTest("ns-upgrade-crashed")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	createTemplateForVersions(t, tc, "tmpl-up")
+	upgradeTestVersion(t, tc, "tmpl-up-v1", "tmpl-up")
+	upgradeTestVersion(t, tc, "tmpl-up-v2", "tmpl-up", func(s *ateapipb.ActorTemplateVersionSpec) {
+		s.Containers[0].Image = "app@sha256:fff"
+	})
+	createWorkerPool(t, tc, ns, "pool1", map[string]string{poolLabelKey: ns})
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id-crash"}
+	if _, err := tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:             &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id-crash"},
+		ActorTemplate:        "tmpl-up",
+		ActorTemplateVersion: "tmpl-up-v1",
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("ResumeActor(boot) failed: %v", err)
+	}
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+
+	// A failed upgrade leaves the actor CRASHED with the new pin.
+	ref := resources.ActorRef{Atespace: testAtespace, Name: "id-crash"}
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor:                actorRef,
+		ActorTemplateVersion: "tmpl-up-v2",
+	}); err != nil {
+		t.Fatalf("ResumeActor(upgrade) failed: %v", err)
+	}
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	if err := crashActor(ctx, tc.persistence, ref, ateattr.OperationResume, ateattr.ReasonCorruptedAssignment); err != nil {
+		t.Fatalf("crashActor failed: %v", err)
+	}
+
+	// Rollback straight from CRASHED with an explicit version.
+	tc.fakeAtelet.Reset()
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor:                actorRef,
+		ActorTemplateVersion: "tmpl-up-v1",
+	}); err != nil {
+		t.Fatalf("ResumeActor(rollback from CRASHED) failed: %v", err)
+	}
+	actor := getActor(t, tc, "id-crash")
+	if got := actor.GetStatus(); got != ateapipb.Actor_STATUS_RUNNING {
+		t.Errorf("actor status after rollback = %v, want RUNNING", got)
+	}
+	if got := actor.GetActorTemplateVersion(); got != "tmpl-up-v1" {
+		t.Errorf("actor pin after rollback = %q, want tmpl-up-v1", got)
+	}
+	restore := tc.fakeAtelet.lastRestoreRequest()
+	if got := restore.GetSpec().GetContainers()[0].GetImage(); got != "app@sha256:def" {
+		t.Errorf("rollback restore image = %q, want v1's app@sha256:def", got)
+	}
+
+	// A plain resume also works from CRASHED (retry-with-current-pin).
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	if err := crashActor(ctx, tc.persistence, ref, ateattr.OperationResume, ateattr.ReasonCorruptedAssignment); err != nil {
+		t.Fatalf("crashActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("ResumeActor(plain, from CRASHED) failed: %v", err)
+	}
+	if got := getActor(t, tc, "id-crash").GetStatus(); got != ateapipb.Actor_STATUS_RUNNING {
+		t.Errorf("actor status after plain resume = %v, want RUNNING", got)
+	}
+}
+
+// TestResumeActor_RepinRejections exercises validateVersionRepin end to end
+// through both ResumeActor and UpdateActor.
+func TestResumeActor_RepinRejections(t *testing.T) {
+	ns := namespaceForTest("ns-upgrade-reject")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+	ensureDefaultGvisorSandboxConfig(t, tc)
+	createTemplateForVersions(t, tc, "tmpl-up")
+	upgradeTestVersion(t, tc, "tmpl-up-v1", "tmpl-up")
+	createTemplateVersion(t, tc, "tmpl-up-v2-building", "tmpl-up") // stays INITIAL
+	upgradeTestVersion(t, tc, "tmpl-up-v3-vols", "tmpl-up", func(s *ateapipb.ActorTemplateVersionSpec) {
+		s.Volumes = nil
+		s.Containers[0].VolumeMounts = nil
+	})
+	createTemplateForVersions(t, tc, "tmpl-other")
+	upgradeTestVersion(t, tc, "tmpl-other-v1", "tmpl-other")
+	// Creates pool1 alongside the CRD template tmpl1 (for the CRD-path case).
+	createTemplate(t, tc, ns)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id-rej"}
+	if _, err := tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:             &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id-rej"},
+		ActorTemplate:        "tmpl-up",
+		ActorTemplateVersion: "tmpl-up-v1",
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("ResumeActor(boot) failed: %v", err)
+	}
+
+	// RUNNING actors cannot be re-pinned, via either RPC.
+	const notSuspendedMsg = "actor id-rej is STATUS_RUNNING; re-pinning requires STATUS_SUSPENDED or STATUS_CRASHED"
+	_, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef, ActorTemplateVersion: "tmpl-up-v3-vols"})
+	assertGrpcError(t, err, codes.FailedPrecondition, notSuspendedMsg)
+	_, err = tc.client.UpdateActor(ctx, &ateapipb.UpdateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:             &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id-rej"},
+			ActorTemplateVersion: "tmpl-up-v3-vols",
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"actor_template_version"}},
+	})
+	assertGrpcError(t, err, codes.FailedPrecondition, notSuspendedMsg)
+
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+
+	_, err = tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef, ActorTemplateVersion: "no-such-version"})
+	assertGrpcError(t, err, codes.FailedPrecondition, `ActorTemplateVersion "no-such-version" not found`)
+	_, err = tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef, ActorTemplateVersion: "tmpl-up-v2-building"})
+	assertGrpcError(t, err, codes.FailedPrecondition, `ActorTemplateVersion "tmpl-up-v2-building" is not READY (state STATE_INITIAL)`)
+	_, err = tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef, ActorTemplateVersion: "tmpl-other-v1"})
+	assertGrpcError(t, err, codes.FailedPrecondition, `ActorTemplateVersion "tmpl-other-v1" belongs to ActorTemplate "tmpl-other", not "tmpl-up"`)
+	_, err = tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef, ActorTemplateVersion: "tmpl-up-v3-vols"})
+	assertGrpcError(t, err, codes.FailedPrecondition, `ActorTemplateVersion "tmpl-up-v3-vols" removes volume "data"; volumes are immutable across versions`)
+
+	// A rejected re-pin leaves the pin untouched.
+	if got := getActor(t, tc, "id-rej").GetActorTemplateVersion(); got != "tmpl-up-v1" {
+		t.Errorf("pin after rejected re-pins = %q, want tmpl-up-v1", got)
+	}
+
+	// CRD-path actors cannot be re-pinned at all.
+	if _, err := tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id-crd"},
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      "tmpl1",
+	}}); err != nil {
+		t.Fatalf("CreateActor(CRD) failed: %v", err)
+	}
+	_, err = tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor:                &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id-crd"},
+		ActorTemplateVersion: "tmpl-up-v1",
+	})
+	assertGrpcError(t, err, codes.FailedPrecondition, "only actors created from a control-plane ActorTemplate can be re-pinned")
+}
+
+// TestResumeActor_UpgradeOnResumeGolden verifies that when the new version's
+// onResume policy selects the golden snapshot, an upgrade restores as
+// DATA_ON_GOLDEN combining the new version's golden with the actor's data.
+func TestResumeActor_UpgradeOnResumeGolden(t *testing.T) {
+	ns := namespaceForTest("ns-upgrade-golden")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+
+	// Seed READY versions through the store: v2 uses onResume FromData=GOLDEN
+	// (spec validation restricts that to microvm at create time; the resume
+	// path is class-agnostic and this test drives it with gvisor workers).
+	gvisorSandbox := &ateapipb.SandboxAssets{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR}
+	createTemplateForVersions(t, tc, "tmpl-up")
+	if _, err := tc.persistence.CreateActorTemplateVersion(ctx, &ateapipb.ActorTemplateVersion{
+		Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-up-v1"},
+		ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-up"},
+		Spec:          validTemplateVersionSpec(),
+		Status: &ateapipb.ActorTemplateVersionStatus{
+			State:           ateapipb.ActorTemplateVersionStatus_STATE_READY,
+			ResolvedSandbox: gvisorSandbox,
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplateVersion(v1, store) failed: %v", err)
+	}
+	goldenURI := "gs://bucket/snapshots/" + resources.GoldenActorAtespace + "/golden-v2"
+	if _, err := tc.persistence.CreateActorSnapshot(ctx, &ateapipb.ActorSnapshot{
+		Metadata:     &ateapipb.ResourceMetadata{Atespace: resources.GoldenActorAtespace, Name: "golden-v2"},
+		ContentScope: ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
+		SnapshotUri:  goldenURI,
+	}); err != nil {
+		t.Fatalf("CreateActorSnapshot(golden) failed: %v", err)
+	}
+	if _, err := tc.persistence.CreateActorTemplateVersion(ctx, &ateapipb.ActorTemplateVersion{
+		Metadata:      &ateapipb.ResourceMetadata{Name: "tmpl-up-v2"},
+		ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-up"},
+		Spec: validTemplateVersionSpec(func(s *ateapipb.ActorTemplateVersionSpec) {
+			s.Containers[0].Image = "app@sha256:fff"
+			s.SnapshotsConfig.OnResume = &ateapipb.OnResumeConfig{FromData: ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN}
+		}),
+		Status: &ateapipb.ActorTemplateVersionStatus{
+			State:           ateapipb.ActorTemplateVersionStatus_STATE_READY,
+			ResolvedSandbox: gvisorSandbox,
+			GoldenSnapshot:  &ateapipb.ObjectRef{Atespace: resources.GoldenActorAtespace, Name: "golden-v2"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplateVersion(v2, store) failed: %v", err)
+	}
+	createWorkerPool(t, tc, ns, "pool1", map[string]string{poolLabelKey: ns})
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id-golden"}
+	if _, err := tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:             &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id-golden"},
+		ActorTemplate:        "tmpl-up",
+		ActorTemplateVersion: "tmpl-up-v1",
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef, Boot: true}); err != nil {
+		t.Fatalf("ResumeActor(boot) failed: %v", err)
+	}
+	if _, err := tc.client.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	actorSnapshotURI := ""
+	{
+		suspended := getActor(t, tc, "id-golden")
+		snapshot, err := tc.persistence.GetActorSnapshot(ctx, testAtespace, suspended.GetLatestSnapshot().GetName())
+		if err != nil {
+			t.Fatalf("GetActorSnapshot failed: %v", err)
+		}
+		actorSnapshotURI = snapshot.GetSnapshotUri()
+	}
+
+	tc.fakeAtelet.Reset()
+	if _, err := tc.client.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor:                actorRef,
+		ActorTemplateVersion: "tmpl-up-v2",
+	}); err != nil {
+		t.Fatalf("ResumeActor(upgrade to v2) failed: %v", err)
+	}
+	restore := tc.fakeAtelet.lastRestoreRequest()
+	if got := restore.GetScope(); got != ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN {
+		t.Errorf("upgrade restore scope = %v, want DATA_ON_GOLDEN", got)
+	}
+	if got := restore.GetGoldenSnapshotUri(); got != goldenURI {
+		t.Errorf("upgrade restore golden URI = %q, want v2's %q", got, goldenURI)
+	}
+	if got := restore.GetExternalConfig().GetSnapshotUri(); got != actorSnapshotURI {
+		t.Errorf("upgrade restore snapshot URI = %q, want the actor's %q", got, actorSnapshotURI)
+	}
+	if got := restore.GetSpec().GetContainers()[0].GetImage(); got != "app@sha256:fff" {
+		t.Errorf("upgrade restore image = %q, want v2's app@sha256:fff", got)
+	}
+	if restore.GetSandboxAssets() != nil {
+		t.Errorf("DATA_ON_GOLDEN restore carries sandbox_assets = %v, want none (golden manifest wins)", restore.GetSandboxAssets())
+	}
+}

--- a/cmd/ateapi/internal/controlapi/workflow.go
+++ b/cmd/ateapi/internal/controlapi/workflow.go
@@ -180,11 +180,14 @@ func NewActorWorkflow(
 }
 
 // ResumeActor executes the workflow to resume a suspended actor. Idempotent.
-func (w *ActorWorkflow) ResumeActor(ctx context.Context, actorRef resources.ActorRef, boot bool) (actor *ateapipb.Actor, resumed bool, err error) {
+// A non-empty targetVersion re-pins the actor to that ActorTemplateVersion
+// before resuming.
+func (w *ActorWorkflow) ResumeActor(ctx context.Context, actorRef resources.ActorRef, boot bool, targetVersion string) (actor *ateapipb.Actor, resumed bool, err error) {
 	start := time.Now()
 	input := &ResumeInput{
-		ActorRef: actorRef,
-		Boot:     boot,
+		ActorRef:      actorRef,
+		Boot:          boot,
+		TargetVersion: targetVersion,
 	}
 	state := &ResumeState{}
 

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -64,9 +64,9 @@ func (s *LoadActorForPauseStep) Execute(ctx context.Context, input *PauseInput, 
 	}
 	state.Actor = actor
 
-	actorTemplate, err := s.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
+	actorTemplate, _, err := resolveTemplateForActor(ctx, s.store, s.actorTemplateLister, actor)
 	if err != nil {
-		return fmt.Errorf("while getting ActorTemplate: %w", err)
+		return err
 	}
 	state.ActorTemplate = actorTemplate
 
@@ -151,12 +151,13 @@ func (s *CallAteletPauseStep) Execute(ctx context.Context, input *PauseInput, st
 	// Checkpoint does not carry the sandbox config: atelet uses the version the
 	// actor is currently running (recorded on-node at Run/Restore) and pins it
 	// into the snapshot manifest.
+	tmplNamespace, tmplName := templateRefForAtelet(state.Actor)
 	req := &ateletpb.CheckpointRequest{
 		TargetAteomUid:         assignment.GetWorkerPodUid(),
 		Atespace:               state.Actor.GetMetadata().GetAtespace(),
 		ActorName:              state.Actor.GetMetadata().GetName(),
-		ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
-		ActorTemplateName:      state.Actor.GetActorTemplateName(),
+		ActorTemplateNamespace: tmplNamespace,
+		ActorTemplateName:      tmplName,
 		Spec:                   workloadSpec,
 		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL,
 		Config: &ateletpb.CheckpointRequest_LocalConfig{

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -64,6 +64,11 @@ type ResumeState struct {
 	// pending restore: restore then combines the golden snapshot with the
 	// actor's data.
 	GoldenSnapshotURI resources.SnapshotURI
+	// FrozenSandboxAssets is the sandbox resolved into the actor's
+	// ActorTemplateVersion at its creation. Non-nil only on the native
+	// template path; boots then use it instead of resolving the sandbox from
+	// the worker pool.
+	FrozenSandboxAssets *ateletpb.SandboxAssets
 }
 
 // validateGoldenSnapshotScope rejects a golden snapshot that does not carry
@@ -107,11 +112,12 @@ func (s *LoadActorForResumeStep) Execute(ctx context.Context, input *ResumeInput
 	state.Actor = actor
 	state.WasRunning = (actor.GetStatus() == ateapipb.Actor_STATUS_RUNNING)
 
-	actorTemplate, err := s.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
+	actorTemplate, frozenAssets, err := resolveTemplateForActor(ctx, s.store, s.actorTemplateLister, actor)
 	if err != nil {
-		return fmt.Errorf("while getting ActorTemplate: %w", err)
+		return err
 	}
 	state.ActorTemplate = actorTemplate
+	state.FrozenSandboxAssets = frozenAssets
 	if ref := actor.GetLatestSnapshot(); ref != nil {
 		snapshot, err := s.store.GetActorSnapshot(ctx, ref.GetAtespace(), ref.GetName())
 		if errors.Is(err, store.ErrNotFound) {
@@ -372,10 +378,11 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 	// Workers() returns pointers directly from the cache so we need to clone before
 	// mutating so that the cache is not corrupted if UpdateWorker fails.
 	assignedWorker = proto.Clone(assignedWorker).(*ateapipb.Worker)
+	assignmentNamespace, assignmentName := templateRefForAtelet(state.Actor)
 	assignedWorker.Assignment = &ateapipb.Assignment{
 		ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
-			Namespace: state.Actor.GetActorTemplateNamespace(),
-			Name:      state.Actor.GetActorTemplateName(),
+			Namespace: assignmentNamespace,
+			Name:      assignmentName,
 		},
 		Actor: &ateapipb.ObjectRef{
 			Atespace: state.Actor.GetMetadata().GetAtespace(),
@@ -570,6 +577,7 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 		return err
 	}
 	egressGateway := s.egressGateway()
+	tmplNamespace, tmplName := templateRefForAtelet(state.Actor)
 
 	if local := state.Actor.GetLocalSnapshotInfo(); local != nil {
 		slog.InfoContext(ctx, "Actor has snapshot; Restoring from snapshot")
@@ -579,8 +587,8 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 			TargetAteomUid:         assignment.GetWorkerPodUid(),
 			Atespace:               state.Actor.GetMetadata().GetAtespace(),
 			ActorName:              state.Actor.GetMetadata().GetName(),
-			ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
-			ActorTemplateName:      state.Actor.GetActorTemplateName(),
+			ActorTemplateNamespace: tmplNamespace,
+			ActorTemplateName:      tmplName,
 			Spec:                   workloadSpec,
 			ActorUid:               state.Actor.GetMetadata().Uid,
 			EgressGateway:          egressGateway,
@@ -625,8 +633,8 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 			TargetAteomUid:         assignment.GetWorkerPodUid(),
 			Atespace:               state.Actor.GetMetadata().GetAtespace(),
 			ActorName:              state.Actor.GetMetadata().GetName(),
-			ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
-			ActorTemplateName:      state.Actor.GetActorTemplateName(),
+			ActorTemplateNamespace: tmplNamespace,
+			ActorTemplateName:      tmplName,
 			Spec:                   workloadSpec,
 			Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
 			Config: &ateletpb.RestoreRequest_ExternalConfig{
@@ -650,17 +658,23 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 		// Booting from scratch: resolve the sandbox binaries from the pool's
 		// SandboxConfig and send them so atelet can fetch and record them.
 		// (Restores above are self-describing via the snapshot manifest.)
-		sandboxAssets, err := resolveSandboxAssets(s.workerPoolLister, s.sandboxConfigLister, assignment.GetWorkerNamespace(), assignment.GetWorkerPool())
-		if err != nil {
-			return fmt.Errorf("while resolving sandbox assets: %w", err)
+		// Native actors instead boot the sandbox frozen into their
+		// ActorTemplateVersion at creation.
+		sandboxAssets := state.FrozenSandboxAssets
+		if sandboxAssets == nil {
+			var err error
+			sandboxAssets, err = resolveSandboxAssets(s.workerPoolLister, s.sandboxConfigLister, assignment.GetWorkerNamespace(), assignment.GetWorkerPool())
+			if err != nil {
+				return fmt.Errorf("while resolving sandbox assets: %w", err)
+			}
 		}
 
 		req := &ateletpb.RunRequest{
 			TargetAteomUid:         assignment.GetWorkerPodUid(),
 			Atespace:               state.Actor.GetMetadata().GetAtespace(),
 			ActorName:              state.Actor.GetMetadata().GetName(),
-			ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
-			ActorTemplateName:      state.Actor.GetActorTemplateName(),
+			ActorTemplateNamespace: tmplNamespace,
+			ActorTemplateName:      tmplName,
 			SandboxAssets:          sandboxAssets,
 			Spec:                   workloadSpec,
 			ActorUid:               state.Actor.GetMetadata().Uid,

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -44,6 +44,9 @@ import (
 type ResumeInput struct {
 	ActorRef resources.ActorRef
 	Boot     bool
+	// TargetVersion, when non-empty, re-pins the actor to this
+	// ActorTemplateVersion before resuming.
+	TargetVersion string
 }
 
 // ResumeState holds the mutable state loaded and modified during execution.
@@ -88,6 +91,21 @@ func validateGoldenSnapshotScope(snapshot *ateapipb.ActorSnapshot) error {
 	}
 }
 
+// crossVersionSnapshot reports whether snapshot was produced under a
+// different ActorTemplateVersion than the actor is pinned to now. Only
+// meaningful on the native template path; tmpl's UID is the pinned version's
+// uid there (crdTemplateFromVersion), which older snapshots recorded as
+// actor_template_uid before the explicit field existed.
+func crossVersionSnapshot(actor *ateapipb.Actor, snapshot *ateapipb.ActorSnapshot, tmpl *atev1alpha1.ActorTemplate) bool {
+	if actor.GetActorTemplateVersion() == "" {
+		return false
+	}
+	if v := snapshot.GetActorTemplateVersion(); v != "" {
+		return v != actor.GetActorTemplateVersion()
+	}
+	return snapshot.GetActorTemplateUid() != string(tmpl.GetUID())
+}
+
 type LoadActorForResumeStep struct {
 	store               store.Interface
 	actorTemplateLister listersv1alpha1.ActorTemplateLister
@@ -108,6 +126,24 @@ func (s *LoadActorForResumeStep) Execute(ctx context.Context, input *ResumeInput
 			return status.Errorf(codes.NotFound, "Actor %s not found", input.ActorRef)
 		}
 		return fmt.Errorf("while getting actor from DB: %w", err)
+	}
+
+	// Re-pin before any status transition so retried workflows (with or
+	// without the version argument) resolve the same template from the
+	// persisted pin.
+	if input.TargetVersion != "" && input.TargetVersion != actor.GetActorTemplateVersion() {
+		if err := validateVersionRepin(ctx, s.store, actor, input.TargetVersion); err != nil {
+			return err
+		}
+		slog.InfoContext(ctx, "Re-pinning actor to new ActorTemplateVersion",
+			slog.String("actor", input.ActorRef.String()),
+			slog.String("from", actor.GetActorTemplateVersion()),
+			slog.String("to", input.TargetVersion))
+		actor.ActorTemplateVersion = input.TargetVersion
+		actor, err = s.store.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion())
+		if err != nil {
+			return fmt.Errorf("while re-pinning actor to ActorTemplateVersion %q: %w", input.TargetVersion, err)
+		}
 	}
 	state.Actor = actor
 	state.WasRunning = (actor.GetStatus() == ateapipb.Actor_STATUS_RUNNING)
@@ -130,6 +166,17 @@ func (s *LoadActorForResumeStep) Execute(ctx context.Context, input *ResumeInput
 			return status.Errorf(codes.DataLoss, "ActorSnapshot %s/%s: %v", ref.GetAtespace(), ref.GetName(), err)
 		}
 		state.SnapshotScope = snapshot.GetContentScope()
+		// A snapshot taken under a different ActorTemplateVersion cannot
+		// restore its guest memory on the pinned version's images; restore
+		// only its durable data. The onResume policy below may still boot
+		// that data on the pinned version's golden snapshot.
+		if crossVersionSnapshot(actor, snapshot, actorTemplate) {
+			slog.InfoContext(ctx, "Snapshot predates the actor's version pin; restoring durable data only",
+				slog.String("actor", input.ActorRef.String()),
+				slog.String("snapshot", ref.GetName()),
+				slog.String("pinned_version", actor.GetActorTemplateVersion()))
+			state.SnapshotScope = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+		}
 	} else if actorTemplate.Status.GoldenSnapshot != "" && !input.Boot {
 		snapshot, err := s.store.GetActorSnapshot(ctx, resources.GoldenActorAtespace, actorTemplate.Status.GoldenSnapshot)
 		if errors.Is(err, store.ErrNotFound) {
@@ -291,8 +338,16 @@ func (s *AssignWorkerStep) CheckPrerequisite(ctx context.Context, input *ResumeI
 	switch state.Actor.GetStatus() {
 	case ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_PAUSED:
 		return nil
+	case ateapipb.Actor_STATUS_CRASHED:
+		// Resumable: crashActor released the worker and left LatestSnapshot
+		// intact. A lingering assignment means corrupted state — refuse
+		// rather than claim a second worker.
+		if state.Actor.GetWorkerAssignment() != nil {
+			return status.Errorf(codes.FailedPrecondition, "crashed Actor %s still has a worker assignment; refusing to resume", input.ActorRef)
+		}
+		return nil
 	default:
-		return status.Errorf(codes.FailedPrecondition, "AssignWorkerStep prerequisite not met for Actor: %s (got: %v, want %s or %s)", input.ActorRef, state.Actor.GetStatus(), ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_PAUSED)
+		return status.Errorf(codes.FailedPrecondition, "AssignWorkerStep prerequisite not met for Actor: %s (got: %v, want %s, %s or %s)", input.ActorRef, state.Actor.GetStatus(), ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_PAUSED, ateapipb.Actor_STATUS_CRASHED)
 	}
 }
 
@@ -410,6 +465,9 @@ func (s *AssignWorkerStep) Execute(ctx context.Context, input *ResumeInput, stat
 			return err
 		}
 		switch fresh.GetStatus() {
+		// CRASHED is deliberately absent: a concurrent crash surfaces as
+		// Aborted so the caller decides (retry, or roll the pin back) —
+		// resuming from CRASHED is a fresh, explicit ResumeActor call.
 		case ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_PAUSED:
 			slog.InfoContext(ctx, "Retrying assignment due to actor version conflict", slog.Any("actor", input.ActorRef))
 			state.Actor = fresh
@@ -629,6 +687,14 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 			scope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN
 		}
 		state.WireSnapshotScope = ateattr.SnapshotScopeValue(scope)
+		// A Data restore is a cold boot of the pinned version's images, so it
+		// must run the pinned version's sandbox too: send the frozen assets to
+		// override the manifest's recorded binaries, which may predate a
+		// re-pin. FULL and DATA_ON_GOLDEN restores stay manifest-described.
+		var sandboxAssets *ateletpb.SandboxAssets
+		if scope == ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA {
+			sandboxAssets = state.FrozenSandboxAssets
+		}
 		req := &ateletpb.RestoreRequest{
 			TargetAteomUid:         assignment.GetWorkerPodUid(),
 			Atespace:               state.Actor.GetMetadata().GetAtespace(),
@@ -647,6 +713,7 @@ func (s *CallAteletRestoreStep) Execute(ctx context.Context, input *ResumeInput,
 			GoldenSnapshotUri: state.GoldenSnapshotURI.String(),
 			ActorUid:          state.Actor.GetMetadata().Uid,
 			EgressGateway:     egressGateway,
+			SandboxAssets:     sandboxAssets,
 		}
 		_, err = client.Restore(ctx, req)
 		return maybeCrashActor(ctx, s.store, input.ActorRef, err, "while restoring durable snapshot", ateattr.OperationResume)

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -485,7 +485,7 @@ func TestResumeActorWorkflow_RejectedAndIdempotentPaths(t *testing.T) {
 				}
 			})
 
-			actor, resumed, err := w.ResumeActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, false)
+			actor, resumed, err := w.ResumeActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, false, "")
 			if tc.wantErr {
 				if got := status.Code(err); got != codes.FailedPrecondition {
 					t.Fatalf("status.Code(err) = %v, want %v (err: %v)", got, codes.FailedPrecondition, err)
@@ -537,13 +537,15 @@ func TestResumeSteps_CheckPrerequisite(t *testing.T) {
 			allowed: nil,
 		},
 		{
-			// Resuming is allowed from SUSPENDED and PAUSED (RESUMING and
-			// RUNNING are fast-forwarded by IsComplete).
+			// Resuming is allowed from SUSPENDED, PAUSED and CRASHED —
+			// crashActor released the worker, so a crashed actor recovers via
+			// resume (RESUMING and RUNNING are fast-forwarded by IsComplete).
 			name: "AssignWorkerStep",
 			step: &AssignWorkerStep{},
 			allowed: map[ateapipb.Actor_Status]bool{
 				ateapipb.Actor_STATUS_SUSPENDED: true,
 				ateapipb.Actor_STATUS_PAUSED:    true,
+				ateapipb.Actor_STATUS_CRASHED:   true,
 			},
 		},
 		{
@@ -588,6 +590,24 @@ func TestResumeSteps_CheckPrerequisite(t *testing.T) {
 	}
 }
 
+// TestAssignWorkerStep_RejectsCrashedWithAssignment guards the corrupted-state
+// check: crashActor always clears the assignment, so a CRASHED actor that
+// still holds one must not claim a second worker.
+func TestAssignWorkerStep_RejectsCrashedWithAssignment(t *testing.T) {
+	step := &AssignWorkerStep{}
+	state := &ResumeState{
+		Actor: &ateapipb.Actor{
+			Metadata:         &ateapipb.ResourceMetadata{Name: "id1"},
+			Status:           ateapipb.Actor_STATUS_CRASHED,
+			WorkerAssignment: &ateapipb.WorkerAssignment{WorkerPod: "pod-1"},
+		},
+	}
+	err := step.CheckPrerequisite(context.Background(), &ResumeInput{ActorRef: resources.ActorRef{Name: "id1"}}, state)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("CheckPrerequisite = %v, want FailedPrecondition for CRASHED with a lingering assignment", err)
+	}
+}
+
 // TestResumeActor_MetricSkipsAlreadyRunningNoop guards the recording rule: the
 // router resumes per routed request, so a clean already-running no-op must not
 // be recorded, while failures must be.
@@ -618,7 +638,7 @@ func TestResumeActor_MetricSkipsAlreadyRunningNoop(t *testing.T) {
 				}
 			})
 
-			_, _, err := w.ResumeActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, false)
+			_, _, err := w.ResumeActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, false, "")
 			if tt.wantRecord && err == nil {
 				t.Fatal("expected resume to fail, got nil error")
 			}
@@ -649,7 +669,7 @@ func TestResumeActor_CrashesOnMissingWorkerAssignment(t *testing.T) {
 		a.WorkerAssignment = nil // RESUMING without a worker: corrupt record
 	})
 
-	_, _, err := w.ResumeActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, false)
+	_, _, err := w.ResumeActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, false, "")
 	if got := status.Code(err); got != codes.Aborted {
 		t.Fatalf("status.Code(err) = %v, want %v (err: %v)", got, codes.Aborted, err)
 	}

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -305,6 +305,7 @@ func (s *FinalizeSuspendedStep) Execute(ctx context.Context, input *SuspendInput
 			ActorTemplateNamespace: tmplNamespace,
 			ActorTemplateName:      tmplName,
 			ActorTemplateUid:       string(state.ActorTemplate.GetUID()),
+			ActorTemplateVersion:   latestActor.GetActorTemplateVersion(),
 			ContentScope:           toActorSnapshotContentScope(commitSnapshotScope(input.ActorRef.Atespace, state.ActorTemplate)),
 			SnapshotUri:            snapshotURI.String(),
 		}

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -69,9 +69,9 @@ func (s *LoadActorForSuspendStep) Execute(ctx context.Context, input *SuspendInp
 		state.SourceVersion = actor.GetInProgressSnapshotSourceActorVersion()
 	}
 
-	actorTemplate, err := s.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
+	actorTemplate, _, err := resolveTemplateForActor(ctx, s.store, s.actorTemplateLister, actor)
 	if err != nil {
-		return fmt.Errorf("while getting ActorTemplate: %w", err)
+		return err
 	}
 	state.ActorTemplate = actorTemplate
 
@@ -179,12 +179,13 @@ func (s *CallAteletSuspendStep) Execute(ctx context.Context, input *SuspendInput
 	// Checkpoint does not carry the sandbox config: atelet uses the version the
 	// actor is currently running (recorded on-node at Run/Restore) and pins it
 	// into the snapshot manifest.
+	tmplNamespace, tmplName := templateRefForAtelet(state.Actor)
 	req := &ateletpb.CheckpointRequest{
 		TargetAteomUid:         assignment.GetWorkerPodUid(),
 		Atespace:               state.Actor.GetMetadata().GetAtespace(),
 		ActorName:              state.Actor.GetMetadata().GetName(),
-		ActorTemplateNamespace: state.Actor.GetActorTemplateNamespace(),
-		ActorTemplateName:      state.Actor.GetActorTemplateName(),
+		ActorTemplateNamespace: tmplNamespace,
+		ActorTemplateName:      tmplName,
 		Spec:                   workloadSpec,
 		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
 		Config: &ateletpb.CheckpointRequest_ExternalConfig{
@@ -295,13 +296,14 @@ func (s *FinalizeSuspendedStep) Execute(ctx context.Context, input *SuspendInput
 		if err != nil {
 			return err
 		}
+		tmplNamespace, tmplName := templateRefForAtelet(latestActor)
 		snapshot := &ateapipb.ActorSnapshot{
 			Metadata:               &ateapipb.ResourceMetadata{Atespace: input.ActorRef.Atespace, Name: snapshotName},
 			SourceActor:            input.ActorRef.ToObjectRef(),
 			SourceActorUid:         latestActor.GetMetadata().GetUid(),
 			SourceActorVersion:     state.SourceVersion,
-			ActorTemplateNamespace: latestActor.GetActorTemplateNamespace(),
-			ActorTemplateName:      latestActor.GetActorTemplateName(),
+			ActorTemplateNamespace: tmplNamespace,
+			ActorTemplateName:      tmplName,
 			ActorTemplateUid:       string(state.ActorTemplate.GetUID()),
 			ContentScope:           toActorSnapshotContentScope(commitSnapshotScope(input.ActorRef.Atespace, state.ActorTemplate)),
 			SnapshotUri:            snapshotURI.String(),

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -62,6 +62,9 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// globalAteSpace in Substrate is represented by "".
+const globalAteSpace = ""
+
 type workerPubSubMsg struct {
 	Type   int    `json:"t"`
 	Worker string `json:"w"` // protojson-encoded Worker
@@ -101,7 +104,7 @@ func actorDBKey(actorRef resources.ActorRef) string {
 // atespace lists across all atespaces (actor:*); a non-empty atespace scopes the
 // scan to that atespace (actor:<atespace>:*).
 func actorScanPattern(atespace string) string {
-	if atespace == "" {
+	if atespace == globalAteSpace {
 		return "actor:*"
 	}
 	return "actor:" + atespace + ":*"
@@ -112,7 +115,7 @@ func actorSnapshotDBKey(atespace, name string) string {
 }
 
 func actorSnapshotScanPattern(atespace string) string {
-	if atespace == "" {
+	if atespace == globalAteSpace {
 		return "actor-snapshot:*"
 	}
 	return "actor-snapshot:" + atespace + ":*"
@@ -135,7 +138,7 @@ func (s *Persistence) CreateAtespace(ctx context.Context, atespace *ateapipb.Ate
 
 	dbAtespace := proto.Clone(atespace).(*ateapipb.Atespace)
 	// Atespace is global-scoped: identity is the name alone (atespace stays empty).
-	dbAtespace.Metadata = newCreateMetadata("", atespace.GetMetadata().GetName())
+	dbAtespace.Metadata = newCreateMetadata(globalAteSpace, atespace.GetMetadata().GetName())
 
 	dbBytes, err := protojson.Marshal(dbAtespace)
 	if err != nil {
@@ -258,6 +261,299 @@ func (s *Persistence) hasMatching(ctx context.Context, pattern string) (bool, er
 		}
 	}
 	return false, nil
+}
+
+func actorTemplateDBKey(name string) string {
+	return "actor-template:" + name
+}
+
+func actorTemplateVersionDBKey(name string) string {
+	return "actor-template-version:" + name
+}
+
+func (s *Persistence) CreateActorTemplate(ctx context.Context, template *ateapipb.ActorTemplate) (*ateapipb.ActorTemplate, error) {
+	dbKey := actorTemplateDBKey(template.GetMetadata().GetName())
+
+	dbTemplate := proto.Clone(template).(*ateapipb.ActorTemplate)
+	// ActorTemplate is global-scoped: identity is the name alone (atespace stays empty).
+	dbTemplate.Metadata = newCreateMetadata(globalAteSpace, template.GetMetadata().GetName())
+
+	dbBytes, err := protojson.Marshal(dbTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("in protojson.Marshal: %w", err)
+	}
+	ok, err := s.rdb.SetNX(ctx, dbKey, dbBytes, 0).Result()
+	if err != nil {
+		return nil, fmt.Errorf("while executing redis set: %w", err)
+	}
+	if !ok {
+		return nil, store.ErrAlreadyExists
+	}
+	return dbTemplate, nil
+}
+
+func (s *Persistence) GetActorTemplate(ctx context.Context, name string) (*ateapipb.ActorTemplate, error) {
+	dbKey := actorTemplateDBKey(name)
+	dbBytes, err := s.rdb.Get(ctx, dbKey).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, store.ErrNotFound
+		}
+		return nil, fmt.Errorf("while getting actor template key %q: %w", dbKey, err)
+	}
+	template := &ateapipb.ActorTemplate{}
+	if err := protojson.Unmarshal(dbBytes, template); err != nil {
+		return nil, fmt.Errorf("while unmarshaling actor template: %w", err)
+	}
+	if template.GetMetadata().GetName() != name {
+		return nil, fmt.Errorf("(impossible) mismatch between stored name and key %q", dbKey)
+	}
+	return template, nil
+}
+
+// ActorTemplateExists reports whether the ActorTemplate exists. This is a
+// plain EXISTS check and is NOT atomic with respect to a concurrent
+// DeleteActorTemplate.
+func (s *Persistence) ActorTemplateExists(ctx context.Context, name string) (bool, error) {
+	n, err := s.rdb.Exists(ctx, actorTemplateDBKey(name)).Result()
+	if err != nil {
+		return false, fmt.Errorf("while checking actor template existence: %w", err)
+	}
+	return n > 0, nil
+}
+
+func (s *Persistence) UpdateActorTemplate(ctx context.Context, template *ateapipb.ActorTemplate, expectedVersion int64) (*ateapipb.ActorTemplate, error) {
+	dbKey := actorTemplateDBKey(template.GetMetadata().GetName())
+
+	// Clone because we will update the version field, and we don't want to
+	// stomp the caller's copy.
+	dbTemplate := proto.Clone(template).(*ateapipb.ActorTemplate)
+
+	err := s.rdb.Watch(ctx, func(tx *redis.Tx) error {
+		currentVal, err := tx.Get(ctx, dbKey).Bytes()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				return store.ErrNotFound
+			}
+			return fmt.Errorf("while getting actor template: %w", err)
+		}
+
+		currentTemplate := &ateapipb.ActorTemplate{}
+		if err := protojson.Unmarshal(currentVal, currentTemplate); err != nil {
+			return fmt.Errorf("in protojson.Unmarshal: %w", err)
+		}
+
+		if currentTemplate.GetMetadata().GetVersion() != expectedVersion {
+			return store.ErrVersionConflict
+		}
+		if currentTemplate.GetMetadata().GetName() != dbTemplate.GetMetadata().GetName() {
+			return fmt.Errorf("name is immutable")
+		}
+		if dbTemplate.GetMetadata().GetAtespace() != globalAteSpace {
+			return fmt.Errorf("atespace must stay empty on a global-scoped resource")
+		}
+		// The stored metadata is authoritative; derive the next metadata from it.
+		dbTemplate.Metadata = newUpdateMetadata(currentTemplate.GetMetadata())
+
+		newVal, err := protojson.Marshal(dbTemplate)
+		if err != nil {
+			return fmt.Errorf("in protojson.Marshal: %w", err)
+		}
+
+		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Set(ctx, dbKey, newVal, 0)
+			return nil
+		})
+		return err
+	}, dbKey)
+
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, store.ErrNotFound
+		}
+		if errors.Is(err, store.ErrVersionConflict) || errors.Is(err, redis.TxFailedErr) {
+			return nil, store.ErrVersionConflict
+		}
+		return nil, fmt.Errorf("while executing update actor template transaction: %w", err)
+	}
+
+	// dbTemplate is the persisted state (advanced version and update_time).
+	// The caller's input is left unmodified.
+	return dbTemplate, nil
+}
+
+func (s *Persistence) ListActorTemplates(ctx context.Context, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorTemplate, string, error) {
+	var result []*ateapipb.ActorTemplate
+	nextToken, err := s.listPage(ctx, "actor-template:*", pageSize, pageTokenStr, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
+		templates, err := fetchProtos(ctx, master, keys, func() *ateapipb.ActorTemplate { return &ateapipb.ActorTemplate{} })
+		if err != nil {
+			return 0, err
+		}
+		result = append(result, templates...)
+		return len(templates), nil
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return result, nextToken, nil
+}
+
+// DeleteActorTemplate deletes an ActorTemplate with no remaining versions.
+// Returns store.ErrNotFound if the template does not exist, or
+// store.ErrFailedPrecondition while any ActorTemplateVersion still names it
+// as parent.
+func (s *Persistence) DeleteActorTemplate(ctx context.Context, name string) (*ateapipb.ActorTemplate, error) {
+	dbKey := actorTemplateDBKey(name)
+
+	// Read first, so a missing template returns NotFound (not a silent no-op)
+	// and so we can return the deleted resource.
+	currentVal, err := s.rdb.Get(ctx, dbKey).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, store.ErrNotFound
+		}
+		return nil, fmt.Errorf("while getting actor template key %q: %w", dbKey, err)
+	}
+
+	deleted := &ateapipb.ActorTemplate{}
+	if err := protojson.Unmarshal(currentVal, deleted); err != nil {
+		return nil, fmt.Errorf("in protojson.Unmarshal: %w", err)
+	}
+
+	// Reject while any version still names this template as parent. The
+	// parent lives in the stored value, not the key, so probe via the
+	// filtered list (pageSize 1 stops at the first match).
+	versions, _, err := s.ListActorTemplateVersions(ctx, name, 1, "")
+	if err != nil {
+		return nil, fmt.Errorf("while checking for remaining versions: %w", err)
+	}
+	if len(versions) > 0 {
+		return nil, store.ErrFailedPrecondition
+	}
+	if err := s.rdb.Del(ctx, dbKey).Err(); err != nil {
+		return nil, fmt.Errorf("while deleting actor template key %q: %w", dbKey, err)
+	}
+	return deleted, nil
+}
+
+func (s *Persistence) CreateActorTemplateVersion(ctx context.Context, version *ateapipb.ActorTemplateVersion) (*ateapipb.ActorTemplateVersion, error) {
+	dbKey := actorTemplateVersionDBKey(version.GetMetadata().GetName())
+
+	dbVersion := proto.Clone(version).(*ateapipb.ActorTemplateVersion)
+	// ActorTemplateVersion is global-scoped: identity is the name alone.
+	dbVersion.Metadata = newCreateMetadata(globalAteSpace, version.GetMetadata().GetName())
+
+	dbBytes, err := protojson.Marshal(dbVersion)
+	if err != nil {
+		return nil, fmt.Errorf("in protojson.Marshal: %w", err)
+	}
+	ok, err := s.rdb.SetNX(ctx, dbKey, dbBytes, 0).Result()
+	if err != nil {
+		return nil, fmt.Errorf("while executing redis set: %w", err)
+	}
+	if !ok {
+		return nil, store.ErrAlreadyExists
+	}
+	return dbVersion, nil
+}
+
+func (s *Persistence) GetActorTemplateVersion(ctx context.Context, name string) (*ateapipb.ActorTemplateVersion, error) {
+	dbKey := actorTemplateVersionDBKey(name)
+	dbBytes, err := s.rdb.Get(ctx, dbKey).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, store.ErrNotFound
+		}
+		return nil, fmt.Errorf("while getting actor template version key %q: %w", dbKey, err)
+	}
+	version := &ateapipb.ActorTemplateVersion{}
+	if err := protojson.Unmarshal(dbBytes, version); err != nil {
+		return nil, fmt.Errorf("while unmarshaling actor template version: %w", err)
+	}
+	if version.GetMetadata().GetName() != name {
+		return nil, fmt.Errorf("(impossible) mismatch between stored name and key %q", dbKey)
+	}
+	return version, nil
+}
+
+// ListActorTemplateVersions lists ActorTemplateVersions, filtered to one
+// parent template when actorTemplate is non-empty. The parent lives in the
+// stored value rather than the key, so filtering happens after fetching:
+// only matches count toward the page, which keeps pages full but means a
+// request may scan the whole keyspace when few versions match (there are no
+// secondary indexes; see the package doc).
+func (s *Persistence) ListActorTemplateVersions(ctx context.Context, actorTemplate string, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorTemplateVersion, string, error) {
+	var result []*ateapipb.ActorTemplateVersion
+	nextToken, err := s.listPage(ctx, "actor-template-version:*", pageSize, pageTokenStr, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
+		versions, err := fetchProtos(ctx, master, keys, func() *ateapipb.ActorTemplateVersion { return &ateapipb.ActorTemplateVersion{} })
+		if err != nil {
+			return 0, err
+		}
+		matched := 0
+		for _, v := range versions {
+			if actorTemplate != "" && v.GetActorTemplate().GetName() != actorTemplate {
+				continue
+			}
+			result = append(result, v)
+			matched++
+		}
+		return matched, nil
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return result, nextToken, nil
+}
+
+// DeleteActorTemplateVersion deletes an ActorTemplateVersion together with
+// the golden snapshot recorded in its status. Returns store.ErrNotFound if
+// the version does not exist, or store.ErrFailedPrecondition while it is its
+// parent's default_version_on_create.
+func (s *Persistence) DeleteActorTemplateVersion(ctx context.Context, name string) (*ateapipb.ActorTemplateVersion, error) {
+	dbKey := actorTemplateVersionDBKey(name)
+
+	currentVal, err := s.rdb.Get(ctx, dbKey).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, store.ErrNotFound
+		}
+		return nil, fmt.Errorf("while getting actor template version key %q: %w", dbKey, err)
+	}
+
+	deleted := &ateapipb.ActorTemplateVersion{}
+	if err := protojson.Unmarshal(currentVal, deleted); err != nil {
+		return nil, fmt.Errorf("in protojson.Unmarshal: %w", err)
+	}
+
+	// Reject while the parent still names this version as its default. A
+	// missing parent imposes no constraint (nil getters compare unequal to a
+	// non-empty name).
+	parent, err := s.GetActorTemplate(ctx, deleted.GetActorTemplate().GetName())
+	if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return nil, fmt.Errorf("while getting parent actor template: %w", err)
+	}
+	if parent.GetSpec().GetDefaultVersionOnCreate().GetName() == name {
+		return nil, store.ErrFailedPrecondition
+	}
+	// TODO(actor-template-versions): also reject while any Actor or
+	// ActorSnapshot references this version, once those resources carry
+	// template-version fields.
+
+	// Delete the golden snapshot first: if its DEL fails the version record
+	// survives and the operation can be retried, whereas the reverse order
+	// could orphan the snapshot with nothing pointing at it. A missing
+	// snapshot key counts as already cleaned (retry idempotency).
+	if golden := deleted.GetStatus().GetGoldenSnapshot(); golden != nil {
+		goldenKey := actorSnapshotDBKey(golden.GetAtespace(), golden.GetName())
+		if err := s.rdb.Del(ctx, goldenKey).Err(); err != nil {
+			return nil, fmt.Errorf("while deleting golden snapshot key %q: %w", goldenKey, err)
+		}
+	}
+
+	if err := s.rdb.Del(ctx, dbKey).Err(); err != nil {
+		return nil, fmt.Errorf("while deleting actor template version key %q: %w", dbKey, err)
+	}
+	return deleted, nil
 }
 
 func workerDBKey(namespace, poolName, podName string) string {

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -476,6 +476,59 @@ func (s *Persistence) GetActorTemplateVersion(ctx context.Context, name string) 
 	return version, nil
 }
 
+// UpdateActorTemplateVersionStatus replaces only the status of an
+// ActorTemplateVersion, leaving the immutable spec and parent untouched.
+func (s *Persistence) UpdateActorTemplateVersionStatus(ctx context.Context, name string, status *ateapipb.ActorTemplateVersionStatus, expectedVersion int64) (*ateapipb.ActorTemplateVersion, error) {
+	dbKey := actorTemplateVersionDBKey(name)
+
+	var dbVersion *ateapipb.ActorTemplateVersion
+	err := s.rdb.Watch(ctx, func(tx *redis.Tx) error {
+		currentVal, err := tx.Get(ctx, dbKey).Bytes()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				return store.ErrNotFound
+			}
+			return fmt.Errorf("while getting actor template version: %w", err)
+		}
+
+		current := &ateapipb.ActorTemplateVersion{}
+		if err := protojson.Unmarshal(currentVal, current); err != nil {
+			return fmt.Errorf("in protojson.Unmarshal: %w", err)
+		}
+
+		if current.GetMetadata().GetVersion() != expectedVersion {
+			return store.ErrVersionConflict
+		}
+
+		dbVersion = current
+		dbVersion.Status = proto.Clone(status).(*ateapipb.ActorTemplateVersionStatus)
+		dbVersion.Metadata = newUpdateMetadata(current.GetMetadata())
+
+		newVal, err := protojson.Marshal(dbVersion)
+		if err != nil {
+			return fmt.Errorf("in protojson.Marshal: %w", err)
+		}
+
+		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Set(ctx, dbKey, newVal, 0)
+			return nil
+		})
+		return err
+	}, dbKey)
+
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, store.ErrNotFound
+		}
+		if errors.Is(err, store.ErrVersionConflict) || errors.Is(err, redis.TxFailedErr) {
+			return nil, store.ErrVersionConflict
+		}
+		return nil, fmt.Errorf("while executing update actor template version status transaction: %w", err)
+	}
+
+	return dbVersion, nil
+}
+
 // ListActorTemplateVersions lists ActorTemplateVersions, filtered to one
 // parent template when actorTemplate is non-empty. The parent lives in the
 // stored value rather than the key, so filtering happens after fetching:

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -1915,3 +1915,395 @@ func failsNTimesThenHangs(n int, err error) evalFunc {
 		return hangs(ctx, sha1, keys, args...)
 	}
 }
+
+func newTestActorTemplate(name string) *ateapipb.ActorTemplate {
+	return &ateapipb.ActorTemplate{Metadata: &ateapipb.ResourceMetadata{Name: name}}
+}
+
+func newTestActorTemplateVersion(name, template string) *ateapipb.ActorTemplateVersion {
+	return &ateapipb.ActorTemplateVersion{
+		Metadata:      &ateapipb.ResourceMetadata{Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Name: template},
+		Spec:          &ateapipb.ActorTemplateVersionSpec{PauseImage: "pause@sha256:abc"},
+		Status:        &ateapipb.ActorTemplateVersionStatus{State: ateapipb.ActorTemplateVersionStatus_STATE_INITIAL},
+	}
+}
+
+func TestActorTemplateLifecycle(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	want := newTestActorTemplate("tmpl-a")
+	created, err := s.CreateActorTemplate(ctx, want)
+	if err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	if created.GetMetadata().GetUid() == "" {
+		t.Errorf("CreateActorTemplate returned empty uid; want server-assigned uid")
+	}
+	if created.GetMetadata().GetVersion() != 1 {
+		t.Errorf("CreateActorTemplate returned version %d, want 1", created.GetMetadata().GetVersion())
+	}
+	if created.GetMetadata().GetCreateTime() == nil || created.GetMetadata().GetUpdateTime() == nil {
+		t.Errorf("CreateActorTemplate returned unset create/update time")
+	}
+	// The input must not be mutated.
+	if want.GetMetadata().GetUid() != "" || want.GetMetadata().GetVersion() != 0 {
+		t.Errorf("CreateActorTemplate must not mutate its input, got metadata %v", want.GetMetadata())
+	}
+
+	got, err := s.GetActorTemplate(ctx, "tmpl-a")
+	if err != nil {
+		t.Fatalf("GetActorTemplate failed: %v", err)
+	}
+	if diff := cmp.Diff(created, got, protocmp.Transform()); diff != "" {
+		t.Errorf("CreateActorTemplate return does not match stored state (-created +got):\n%s", diff)
+	}
+
+	list, _, err := s.ListActorTemplates(ctx, 1000, "")
+	if err != nil {
+		t.Fatalf("ListActorTemplates failed: %v", err)
+	}
+	if len(list) != 1 || list[0].GetMetadata().GetName() != "tmpl-a" {
+		t.Errorf("ListActorTemplates = %v, want [tmpl-a]", list)
+	}
+
+	deleted, err := s.DeleteActorTemplate(ctx, "tmpl-a")
+	if err != nil {
+		t.Fatalf("DeleteActorTemplate failed: %v", err)
+	}
+	if diff := cmp.Diff(created, deleted, protocmp.Transform()); diff != "" {
+		t.Errorf("DeleteActorTemplate returned unexpected resource (-created +deleted):\n%s", diff)
+	}
+	if _, err := s.GetActorTemplate(ctx, "tmpl-a"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("after delete, GetActorTemplate = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCreateActorTemplate_AlreadyExists(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	if _, err := s.CreateActorTemplate(ctx, newTestActorTemplate("tmpl-a")); err != nil {
+		t.Fatalf("first CreateActorTemplate failed: %v", err)
+	}
+	if _, err := s.CreateActorTemplate(ctx, newTestActorTemplate("tmpl-a")); !errors.Is(err, store.ErrAlreadyExists) {
+		t.Errorf("expected ErrAlreadyExists, got %v", err)
+	}
+}
+
+func TestGetActorTemplate_NotFound(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	if _, err := s.GetActorTemplate(ctx, "nope"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestActorTemplateExists(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	if ok, err := s.ActorTemplateExists(ctx, "tmpl-a"); err != nil || ok {
+		t.Fatalf("ActorTemplateExists before create = (%v, %v), want (false, nil)", ok, err)
+	}
+	if _, err := s.CreateActorTemplate(ctx, newTestActorTemplate("tmpl-a")); err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	if ok, err := s.ActorTemplateExists(ctx, "tmpl-a"); err != nil || !ok {
+		t.Fatalf("ActorTemplateExists after create = (%v, %v), want (true, nil)", ok, err)
+	}
+}
+
+func TestUpdateActorTemplate(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	created, err := s.CreateActorTemplate(ctx, newTestActorTemplate("tmpl-a"))
+	if err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+
+	updated := proto.Clone(created).(*ateapipb.ActorTemplate)
+	updated.Spec = &ateapipb.ActorTemplateSpec{
+		WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "1"}},
+	}
+	stored, err := s.UpdateActorTemplate(ctx, updated, 1)
+	if err != nil {
+		t.Fatalf("UpdateActorTemplate failed: %v", err)
+	}
+	if stored.GetMetadata().GetVersion() != 2 {
+		t.Errorf("updated version = %d, want 2", stored.GetMetadata().GetVersion())
+	}
+	got, err := s.GetActorTemplate(ctx, "tmpl-a")
+	if err != nil {
+		t.Fatalf("GetActorTemplate failed: %v", err)
+	}
+	if diff := cmp.Diff(stored, got, protocmp.Transform()); diff != "" {
+		t.Errorf("UpdateActorTemplate return does not match stored state (-stored +got):\n%s", diff)
+	}
+
+	// A stale expected version must be rejected.
+	if _, err := s.UpdateActorTemplate(ctx, updated, 1); !errors.Is(err, store.ErrVersionConflict) {
+		t.Errorf("stale update = %v, want ErrVersionConflict", err)
+	}
+
+	missing := newTestActorTemplate("nope")
+	if _, err := s.UpdateActorTemplate(ctx, missing, 1); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("update of missing template = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeleteActorTemplate_NotFound(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	if _, err := s.DeleteActorTemplate(ctx, "nope"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDeleteActorTemplate_HasVersions_Rejected(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	if _, err := s.CreateActorTemplate(ctx, newTestActorTemplate("tmpl-a")); err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	// A version parented to a DIFFERENT template must not block the delete.
+	if _, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion("tmpl-b-v1", "tmpl-b")); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+	if _, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion("tmpl-a-v1", "tmpl-a")); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+
+	if _, err := s.DeleteActorTemplate(ctx, "tmpl-a"); !errors.Is(err, store.ErrFailedPrecondition) {
+		t.Fatalf("DeleteActorTemplate with versions = %v, want ErrFailedPrecondition", err)
+	}
+	// The template must survive a rejected delete.
+	if _, err := s.GetActorTemplate(ctx, "tmpl-a"); err != nil {
+		t.Fatalf("template should still exist after rejected delete, got %v", err)
+	}
+
+	if _, err := s.DeleteActorTemplateVersion(ctx, "tmpl-a-v1"); err != nil {
+		t.Fatalf("DeleteActorTemplateVersion failed: %v", err)
+	}
+	if _, err := s.DeleteActorTemplate(ctx, "tmpl-a"); err != nil {
+		t.Errorf("DeleteActorTemplate after versions removed = %v, want nil", err)
+	}
+}
+
+func TestActorTemplateVersionLifecycle(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	want := newTestActorTemplateVersion("tmpl-a-v1", "tmpl-a")
+	created, err := s.CreateActorTemplateVersion(ctx, want)
+	if err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+	if created.GetMetadata().GetUid() == "" {
+		t.Errorf("CreateActorTemplateVersion returned empty uid; want server-assigned uid")
+	}
+	if created.GetMetadata().GetVersion() != 1 {
+		t.Errorf("CreateActorTemplateVersion returned version %d, want 1", created.GetMetadata().GetVersion())
+	}
+	// The caller-built spec and status are persisted verbatim.
+	if diff := cmp.Diff(want, created, protocmp.Transform(), ignoreUID, ignoreVersion, ignoreTimestamps); diff != "" {
+		t.Errorf("CreateActorTemplateVersion returned unexpected resource (-want +got):\n%s", diff)
+	}
+
+	got, err := s.GetActorTemplateVersion(ctx, "tmpl-a-v1")
+	if err != nil {
+		t.Fatalf("GetActorTemplateVersion failed: %v", err)
+	}
+	if diff := cmp.Diff(created, got, protocmp.Transform()); diff != "" {
+		t.Errorf("CreateActorTemplateVersion return does not match stored state (-created +got):\n%s", diff)
+	}
+
+	deleted, err := s.DeleteActorTemplateVersion(ctx, "tmpl-a-v1")
+	if err != nil {
+		t.Fatalf("DeleteActorTemplateVersion failed: %v", err)
+	}
+	if diff := cmp.Diff(created, deleted, protocmp.Transform()); diff != "" {
+		t.Errorf("DeleteActorTemplateVersion returned unexpected resource (-created +deleted):\n%s", diff)
+	}
+	if _, err := s.GetActorTemplateVersion(ctx, "tmpl-a-v1"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("after delete, GetActorTemplateVersion = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCreateActorTemplateVersion_AlreadyExists(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	if _, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion("v1", "tmpl-a")); err != nil {
+		t.Fatalf("first CreateActorTemplateVersion failed: %v", err)
+	}
+	if _, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion("v1", "tmpl-a")); !errors.Is(err, store.ErrAlreadyExists) {
+		t.Errorf("expected ErrAlreadyExists, got %v", err)
+	}
+}
+
+func TestDeleteActorTemplateVersion_IsParentDefault_Rejected(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	if _, err := s.CreateActorTemplate(ctx, newTestActorTemplate("tmpl-a")); err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	if _, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion("tmpl-a-v1", "tmpl-a")); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+	withDefault := newTestActorTemplate("tmpl-a")
+	withDefault.Spec = &ateapipb.ActorTemplateSpec{
+		DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: "tmpl-a-v1"},
+	}
+	if _, err := s.UpdateActorTemplate(ctx, withDefault, 1); err != nil {
+		t.Fatalf("UpdateActorTemplate failed: %v", err)
+	}
+
+	if _, err := s.DeleteActorTemplateVersion(ctx, "tmpl-a-v1"); !errors.Is(err, store.ErrFailedPrecondition) {
+		t.Fatalf("DeleteActorTemplateVersion while default = %v, want ErrFailedPrecondition", err)
+	}
+	// The version must survive a rejected delete.
+	if _, err := s.GetActorTemplateVersion(ctx, "tmpl-a-v1"); err != nil {
+		t.Fatalf("version should still exist after rejected delete, got %v", err)
+	}
+
+	// Clearing the default unblocks the delete.
+	if _, err := s.UpdateActorTemplate(ctx, newTestActorTemplate("tmpl-a"), 2); err != nil {
+		t.Fatalf("UpdateActorTemplate (clear default) failed: %v", err)
+	}
+	if _, err := s.DeleteActorTemplateVersion(ctx, "tmpl-a-v1"); err != nil {
+		t.Errorf("DeleteActorTemplateVersion after clearing default = %v, want nil", err)
+	}
+}
+
+func TestDeleteActorTemplateVersion_MissingParent_Allowed(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	if _, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion("orphan-v1", "gone")); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+	if _, err := s.DeleteActorTemplateVersion(ctx, "orphan-v1"); err != nil {
+		t.Errorf("DeleteActorTemplateVersion with missing parent = %v, want nil", err)
+	}
+}
+
+func TestDeleteActorTemplateVersion_DeletesGoldenSnapshot(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	if _, err := s.CreateActorSnapshot(ctx, &ateapipb.ActorSnapshot{
+		Metadata:    &ateapipb.ResourceMetadata{Atespace: "ate-golden", Name: "golden-1"},
+		SnapshotUri: "gs://bucket/root/snapshots/ate-golden/golden-1",
+	}); err != nil {
+		t.Fatalf("CreateActorSnapshot failed: %v", err)
+	}
+	version := newTestActorTemplateVersion("tmpl-a-v1", "tmpl-a")
+	version.Status.GoldenSnapshot = &ateapipb.ObjectRef{Atespace: "ate-golden", Name: "golden-1"}
+	if _, err := s.CreateActorTemplateVersion(ctx, version); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+
+	if _, err := s.DeleteActorTemplateVersion(ctx, "tmpl-a-v1"); err != nil {
+		t.Fatalf("DeleteActorTemplateVersion failed: %v", err)
+	}
+	if _, err := s.GetActorSnapshot(ctx, "ate-golden", "golden-1"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("golden snapshot after delete = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeleteActorTemplateVersion_GoldenSnapshotAlreadyGone(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	version := newTestActorTemplateVersion("tmpl-a-v1", "tmpl-a")
+	version.Status.GoldenSnapshot = &ateapipb.ObjectRef{Atespace: "ate-golden", Name: "never-created"}
+	if _, err := s.CreateActorTemplateVersion(ctx, version); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+	if _, err := s.DeleteActorTemplateVersion(ctx, "tmpl-a-v1"); err != nil {
+		t.Errorf("DeleteActorTemplateVersion with missing golden snapshot = %v, want nil", err)
+	}
+}
+
+func TestListActorTemplates_Pagination(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	for i := 0; i < 5; i++ {
+		if _, err := s.CreateActorTemplate(ctx, newTestActorTemplate(fmt.Sprintf("tmpl-%d", i))); err != nil {
+			t.Fatalf("failed to create template %d: %v", i, err)
+		}
+	}
+
+	var all []*ateapipb.ActorTemplate
+	pageToken := ""
+	for {
+		templates, nextToken, err := s.ListActorTemplates(ctx, 2, pageToken)
+		if err != nil {
+			t.Fatalf("ListActorTemplates failed: %v", err)
+		}
+		all = append(all, templates...)
+		pageToken = nextToken
+		if pageToken == "" {
+			break
+		}
+	}
+
+	if len(all) != 5 {
+		t.Fatalf("expected 5 templates total, got %d", len(all))
+	}
+	seen := make(map[string]bool)
+	for _, tmpl := range all {
+		if seen[tmpl.GetMetadata().GetName()] {
+			t.Errorf("duplicate template found in paginated results: %s", tmpl.GetMetadata().GetName())
+		}
+		seen[tmpl.GetMetadata().GetName()] = true
+	}
+}
+
+func TestListActorTemplateVersions_ParentFilter(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	// Interleave versions of two templates.
+	for i := 0; i < 3; i++ {
+		if _, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion(fmt.Sprintf("tmpl-a-v%d", i), "tmpl-a")); err != nil {
+			t.Fatalf("failed to create tmpl-a version %d: %v", i, err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion(fmt.Sprintf("tmpl-b-v%d", i), "tmpl-b")); err != nil {
+			t.Fatalf("failed to create tmpl-b version %d: %v", i, err)
+		}
+	}
+
+	unfiltered, _, err := s.ListActorTemplateVersions(ctx, "", 1000, "")
+	if err != nil {
+		t.Fatalf("ListActorTemplateVersions(all) failed: %v", err)
+	}
+	if len(unfiltered) != 5 {
+		t.Fatalf("unfiltered list returned %d versions, want 5", len(unfiltered))
+	}
+
+	// Filtered list, paged with a small page size to exercise the
+	// matched-count pagination semantics.
+	var filtered []*ateapipb.ActorTemplateVersion
+	pageToken := ""
+	for {
+		versions, nextToken, err := s.ListActorTemplateVersions(ctx, "tmpl-a", 2, pageToken)
+		if err != nil {
+			t.Fatalf("ListActorTemplateVersions(tmpl-a) failed: %v", err)
+		}
+		filtered = append(filtered, versions...)
+		pageToken = nextToken
+		if pageToken == "" {
+			break
+		}
+	}
+
+	if len(filtered) != 3 {
+		t.Fatalf("filtered list returned %d versions, want 3", len(filtered))
+	}
+	seen := make(map[string]bool)
+	for _, v := range filtered {
+		if v.GetActorTemplate().GetName() != "tmpl-a" {
+			t.Errorf("filtered list returned version %q of template %q", v.GetMetadata().GetName(), v.GetActorTemplate().GetName())
+		}
+		if seen[v.GetMetadata().GetName()] {
+			t.Errorf("duplicate version found in paginated results: %s", v.GetMetadata().GetName())
+		}
+		seen[v.GetMetadata().GetName()] = true
+	}
+}

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -2127,6 +2127,54 @@ func TestActorTemplateVersionLifecycle(t *testing.T) {
 	}
 }
 
+func TestUpdateActorTemplateVersionStatus(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	created, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion("tmpl-a-v1", "tmpl-a"))
+	if err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+
+	newStatus := &ateapipb.ActorTemplateVersionStatus{
+		State:          ateapipb.ActorTemplateVersionStatus_STATE_READY,
+		GoldenSnapshot: &ateapipb.ObjectRef{Atespace: "ate-golden", Name: "snap-1"},
+		GoldenActor:    &ateapipb.ObjectRef{Atespace: "ate-golden", Name: "uid-1"},
+	}
+	stored, err := s.UpdateActorTemplateVersionStatus(ctx, "tmpl-a-v1", newStatus, 1)
+	if err != nil {
+		t.Fatalf("UpdateActorTemplateVersionStatus failed: %v", err)
+	}
+	if stored.GetMetadata().GetVersion() != 2 {
+		t.Errorf("updated version = %d, want 2", stored.GetMetadata().GetVersion())
+	}
+	if diff := cmp.Diff(newStatus, stored.GetStatus(), protocmp.Transform()); diff != "" {
+		t.Errorf("stored status mismatch (-want +got):\n%s", diff)
+	}
+	// Only status may change: spec and parent stay as created.
+	if diff := cmp.Diff(created.GetSpec(), stored.GetSpec(), protocmp.Transform()); diff != "" {
+		t.Errorf("spec must not change (-created +stored):\n%s", diff)
+	}
+	if diff := cmp.Diff(created.GetActorTemplate(), stored.GetActorTemplate(), protocmp.Transform()); diff != "" {
+		t.Errorf("actor_template must not change (-created +stored):\n%s", diff)
+	}
+	got, err := s.GetActorTemplateVersion(ctx, "tmpl-a-v1")
+	if err != nil {
+		t.Fatalf("GetActorTemplateVersion failed: %v", err)
+	}
+	if diff := cmp.Diff(stored, got, protocmp.Transform()); diff != "" {
+		t.Errorf("UpdateActorTemplateVersionStatus return does not match stored state (-stored +got):\n%s", diff)
+	}
+
+	// A stale expected version must be rejected.
+	if _, err := s.UpdateActorTemplateVersionStatus(ctx, "tmpl-a-v1", newStatus, 1); !errors.Is(err, store.ErrVersionConflict) {
+		t.Errorf("stale update = %v, want ErrVersionConflict", err)
+	}
+
+	if _, err := s.UpdateActorTemplateVersionStatus(ctx, "nope", newStatus, 1); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("update of missing version = %v, want ErrNotFound", err)
+	}
+}
+
 func TestCreateActorTemplateVersion_AlreadyExists(t *testing.T) {
 	_, s, ctx := setupTest(t)
 

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -139,6 +139,12 @@ type Interface interface {
 	// Fetches an ActorTemplateVersion by name. Returns ErrNotFound if missing.
 	GetActorTemplateVersion(ctx context.Context, name string) (*ateapipb.ActorTemplateVersion, error)
 
+	// Replaces the status of an ActorTemplateVersion with optimistic
+	// concurrency check and returns the stored resource. Spec and parent are
+	// left untouched (the spec is immutable). Returns ErrNotFound if missing,
+	// or ErrVersionConflict if expectedVersion does not match.
+	UpdateActorTemplateVersionStatus(ctx context.Context, name string, status *ateapipb.ActorTemplateVersionStatus, expectedVersion int64) (*ateapipb.ActorTemplateVersion, error)
+
 	// Lists ActorTemplateVersions parented to the named ActorTemplate, or
 	// across all templates when actorTemplate is empty.
 	ListActorTemplateVersions(ctx context.Context, actorTemplate string, pageSize int32, pageToken string) ([]*ateapipb.ActorTemplateVersion, string, error)

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -105,6 +105,50 @@ type Interface interface {
 	// (e.g. there are actors in it).
 	DeleteAtespace(ctx context.Context, name string) (*ateapipb.Atespace, error)
 
+	// Stores a new ActorTemplate and returns the stored resource with
+	// server-assigned metadata (uid, version, timestamps). The input is not
+	// mutated. Returns ErrAlreadyExists if the name is taken.
+	CreateActorTemplate(ctx context.Context, template *ateapipb.ActorTemplate) (*ateapipb.ActorTemplate, error)
+
+	// Fetches an ActorTemplate by name. Returns ErrNotFound if missing.
+	GetActorTemplate(ctx context.Context, name string) (*ateapipb.ActorTemplate, error)
+
+	// ActorTemplateExists reports whether the ActorTemplate exists.
+	ActorTemplateExists(ctx context.Context, name string) (bool, error)
+
+	// Updates an ActorTemplate with optimistic concurrency check and returns
+	// the stored resource with advanced metadata (version, update_time). The
+	// input is not mutated. Returns ErrNotFound if missing, or
+	// ErrVersionConflict on version mismatch.
+	UpdateActorTemplate(ctx context.Context, template *ateapipb.ActorTemplate, expectedVersion int64) (*ateapipb.ActorTemplate, error)
+
+	// Lists ActorTemplates. Returns a page of templates and a next page token.
+	ListActorTemplates(ctx context.Context, pageSize int32, pageToken string) ([]*ateapipb.ActorTemplate, string, error)
+
+	// Removes an ActorTemplate and returns the deleted resource. Returns
+	// ErrNotFound if missing, or ErrFailedPrecondition while any
+	// ActorTemplateVersion still names it as parent.
+	DeleteActorTemplate(ctx context.Context, name string) (*ateapipb.ActorTemplate, error)
+
+	// Stores a new ActorTemplateVersion and returns the stored resource with
+	// server-assigned metadata. The caller is responsible for the
+	// parent-exists check and for initializing status. The input is not
+	// mutated. Returns ErrAlreadyExists if the name is taken.
+	CreateActorTemplateVersion(ctx context.Context, version *ateapipb.ActorTemplateVersion) (*ateapipb.ActorTemplateVersion, error)
+
+	// Fetches an ActorTemplateVersion by name. Returns ErrNotFound if missing.
+	GetActorTemplateVersion(ctx context.Context, name string) (*ateapipb.ActorTemplateVersion, error)
+
+	// Lists ActorTemplateVersions parented to the named ActorTemplate, or
+	// across all templates when actorTemplate is empty.
+	ListActorTemplateVersions(ctx context.Context, actorTemplate string, pageSize int32, pageToken string) ([]*ateapipb.ActorTemplateVersion, string, error)
+
+	// Removes an ActorTemplateVersion and returns the deleted resource, also
+	// deleting the golden snapshot recorded in status.golden_snapshot, if any.
+	// Returns ErrNotFound if missing, or ErrFailedPrecondition while the
+	// version is its parent's default_version_on_create.
+	DeleteActorTemplateVersion(ctx context.Context, name string) (*ateapipb.ActorTemplateVersion, error)
+
 	// Fetches worker state by namespace, pool, and pod name. Returns ErrNotFound if missing.
 	GetWorker(ctx context.Context, namespace, pool, pod string) (*ateapipb.Worker, error)
 

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -189,6 +189,10 @@ func main() {
 	ateletDialer := controlapi.NewAteletDialer(workerPodInformer.GetIndexer(), ateletPodInformer.GetIndexer(), *ateletClientCredBundle, *podIdentityCACerts)
 	sm := controlapi.NewService(redisPersistence, workerCache, actorTemplateLister, workerPoolLister, sandboxConfigLister, csiDriverConfigLister, storageClassLister, ateletDialer, clientset, instruments, *egressGatewayAddress, volPlugins)
 
+	// Builds golden snapshots for ActorTemplateVersions; replicas coordinate
+	// through per-version locks, so every replica runs the loop.
+	controlapi.NewTemplateVersionBuilder(sm, redisPersistence).Start(shutdownCtx)
+
 	jwtIssuerDiscoveryClient := buildK8sServiceAccountIssuerDiscoveryClient(ctx, *clientJWTCAFile, *clientJWTIssuer)
 
 	actorIdentitySrv := actoridentity.New(*clientJWTIssuer, *clientJWTAudience, *actorIDJWTPoolFile, *actorIDCAPoolFile, *podIdentityCACerts, jwtIssuerDiscoveryClient, redisPersistence, workerCache)

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -1406,8 +1406,12 @@ func validateRunRequest(req *ateletpb.RunRequest) error {
 	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
-	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+	// Empty on actors from a control-plane ActorTemplateVersion, which is
+	// global-scoped; the field feeds metrics and the sandbox record only.
+	if req.GetActorTemplateNamespace() != "" {
+		for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
+			errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+		}
 	}
 	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
 		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
@@ -1431,8 +1435,12 @@ func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
 	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
-	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+	// Empty on actors from a control-plane ActorTemplateVersion, which is
+	// global-scoped; the field feeds metrics and the sandbox record only.
+	if req.GetActorTemplateNamespace() != "" {
+		for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
+			errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+		}
 	}
 	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
 		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
@@ -1483,8 +1491,12 @@ func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
 	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
-	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+	// Empty on actors from a control-plane ActorTemplateVersion, which is
+	// global-scoped; the field feeds metrics and the sandbox record only.
+	if req.GetActorTemplateNamespace() != "" {
+		for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
+			errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+		}
 	}
 	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
 		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -834,6 +834,30 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	if goldenRec != nil {
 		runtimeRec = goldenRec
 	}
+	// A DATA restore cold-boots, so the request may pin the sandbox instead
+	// (validated DATA-only): a re-pinned actor then runs its new version's
+	// binaries rather than the ones recorded when the snapshot was taken.
+	if req.GetSandboxAssets() != nil {
+		overrideRec, err := recordFromRequest(req.GetSandboxAssets())
+		if err != nil {
+			return nil, ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonInvalidSandboxAsset)
+		}
+		if overrideRec.SandboxClass != sandboxRec.SandboxClass {
+			return nil, status.Errorf(codes.FailedPrecondition, "sandbox_assets class %q does not match snapshot sandbox class %q", overrideRec.SandboxClass, sandboxRec.SandboxClass)
+		}
+		runtimeRec = overrideRec
+	}
+
+	// The actor snapshot's contribution to a DATA_ON_GOLDEN restore is its
+	// durable data. Data-scope snapshots hold nothing else, but a Full
+	// snapshot's memory/VM-state files would shadow the golden's guest files
+	// under goldenOnlyFiles — stage only its durable tar. Manifests written
+	// before the Scope field existed are Data snapshots on every flow that
+	// reaches DATA_ON_GOLDEN, so they pass through unfiltered.
+	actorFiles := sandboxRec.SnapshotFiles
+	if goldenRec != nil && sandboxRec.Scope == ateattr.SnapshotScopeFull {
+		actorFiles = durableOnlyFiles(actorFiles)
+	}
 
 	// Download the memory snapshot and prepare the sandbox assets + OCI bundle
 	// CONCURRENTLY. They are independent — only the final ateom.RestoreWorkload
@@ -859,7 +883,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 				if goldenRec == nil {
 					return fmt.Errorf("no golden snapshot record for a %s restore", req.GetScope())
 				}
-				if err := s.downloadCombinedCheckpoint(gctx, req.GetExternalConfig().GetSnapshotUri(), req.GetGoldenSnapshotUri(), checkpointDir, sandboxRec.SnapshotFiles, goldenRec.SnapshotFiles); err != nil {
+				if err := s.downloadCombinedCheckpoint(gctx, req.GetExternalConfig().GetSnapshotUri(), req.GetGoldenSnapshotUri(), checkpointDir, actorFiles, goldenRec.SnapshotFiles); err != nil {
 					return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonFailedGetExternalObject, ateerrors.ReasonInvalidObjectURL, ateerrors.ReasonTerminalFileSystemError)
 				}
 			} else if err := s.downloadExternalCheckpoint(gctx, req.GetExternalConfig().GetSnapshotUri(), checkpointDir, sandboxRec.SnapshotFiles); err != nil {
@@ -875,14 +899,14 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			// the golden's from object storage, concurrently.
 			gLocal, gLocalCtx := errgroup.WithContext(gctx)
 			gLocal.Go(func() error {
-				if err := s.copyLocalCheckpoint(gLocalCtx, req.GetLocalConfig().GetSnapshotName(), ateompath.LocalCheckpointsDir(actorUID), checkpointDir, sandboxRec.SnapshotFiles); err != nil {
+				if err := s.copyLocalCheckpoint(gLocalCtx, req.GetLocalConfig().GetSnapshotName(), ateompath.LocalCheckpointsDir(actorUID), checkpointDir, actorFiles); err != nil {
 					return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonTerminalFileSystemError)
 				}
 				return nil
 			})
 			if combineWithGolden {
 				gLocal.Go(func() error {
-					if err := s.downloadExternalCheckpoint(gLocalCtx, req.GetGoldenSnapshotUri(), checkpointDir, goldenOnlyFiles(sandboxRec.SnapshotFiles, goldenRec.SnapshotFiles)); err != nil {
+					if err := s.downloadExternalCheckpoint(gLocalCtx, req.GetGoldenSnapshotUri(), checkpointDir, goldenOnlyFiles(actorFiles, goldenRec.SnapshotFiles)); err != nil {
 						return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonFailedGetExternalObject, ateerrors.ReasonInvalidObjectURL, ateerrors.ReasonTerminalFileSystemError)
 					}
 					return nil
@@ -1137,6 +1161,18 @@ func copySparse(src *os.File, dst sparseDest, size int64) error {
 		off = holeOff
 	}
 	return nil
+}
+
+// durableOnlyFiles filters a snapshot's file set down to its durable-dir
+// tar, dropping the guest memory/VM-state files a Full snapshot also holds.
+func durableOnlyFiles(files []string) []string {
+	var out []string
+	for _, f := range files {
+		if f == ateompath.DurableTarFile {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 // goldenOnlyFiles returns the golden snapshot files not shadowed by the
@@ -1542,6 +1578,13 @@ func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
 		}
 	} else if req.GetGoldenSnapshotUri() != "" {
 		return fmt.Errorf("golden_snapshot_uri is only valid with snapshot scope %s", ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN)
+	}
+
+	// A FULL or DATA_ON_GOLDEN restore resumes a memory image, which must run
+	// on the exact binaries that produced it — the manifest (or golden
+	// manifest) pins those. Only a DATA restore, a cold boot, may override.
+	if req.GetSandboxAssets() != nil && req.GetScope() != ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA {
+		return fmt.Errorf("sandbox_assets is only valid with snapshot scope %s", ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA)
 	}
 	return nil
 }

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -403,6 +403,21 @@ func TestValidateRestoreRequest(t *testing.T) {
 		{"golden uri with non-data-on-golden scope", makeReq(func(r *ateletpb.RestoreRequest) {
 			r.GoldenSnapshotUri = "gs://bucket/golden-root/snapshots/ate-golden/golden-1"
 		}), true},
+		// sandbox_assets pins a cold boot's binaries, so it rides only DATA
+		// restores; FULL and DATA_ON_GOLDEN resume a memory image the
+		// manifest's (or golden's) recorded binaries must run.
+		{"sandbox_assets with data scope", makeReq(func(r *ateletpb.RestoreRequest) {
+			r.Scope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
+			r.SandboxAssets = &ateletpb.SandboxAssets{SandboxClass: "gvisor"}
+		}), false},
+		{"sandbox_assets with full scope", makeReq(func(r *ateletpb.RestoreRequest) {
+			r.SandboxAssets = &ateletpb.SandboxAssets{SandboxClass: "gvisor"}
+		}), true},
+		{"sandbox_assets with data-on-golden scope", makeReq(func(r *ateletpb.RestoreRequest) {
+			r.Scope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN
+			r.GoldenSnapshotUri = "gs://bucket/golden-root/snapshots/ate-golden/golden-1"
+			r.SandboxAssets = &ateletpb.SandboxAssets{SandboxClass: "gvisor"}
+		}), true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -801,6 +816,29 @@ func TestGoldenOnlyFiles(t *testing.T) {
 				t.Errorf("goldenOnlyFiles diff (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestDurableOnlyFiles guards the DATA_ON_GOLDEN staging rule for Full-scope
+// actor snapshots: only the durable tar survives the filter, so the composed
+// golden set keeps its guest files instead of losing them to shadowing.
+func TestDurableOnlyFiles(t *testing.T) {
+	fullSet := []string{"config.json", "state.json", "memory-ranges", "durable-dir.tar"}
+	goldenSet := []string{"config.json", "state.json", "memory-ranges", "base-id", "durable-dir.tar"}
+
+	filtered := durableOnlyFiles(fullSet)
+	if diff := cmp.Diff([]string{"durable-dir.tar"}, filtered); diff != "" {
+		t.Errorf("durableOnlyFiles diff (-want +got):\n%s", diff)
+	}
+	if got := durableOnlyFiles([]string{"config.json"}); got != nil {
+		t.Errorf("durableOnlyFiles(no tar) = %v, want nil", got)
+	}
+
+	// Unfiltered, the Full actor set would shadow every golden guest file;
+	// filtered, the golden supplies them all except the durable tar.
+	want := []string{"config.json", "state.json", "memory-ranges", "base-id"}
+	if diff := cmp.Diff(want, goldenOnlyFiles(filtered, goldenSet)); diff != "" {
+		t.Errorf("goldenOnlyFiles(filtered full set) diff (-want +got):\n%s", diff)
 	}
 }
 

--- a/cmd/ateom-microvm/durable.go
+++ b/cmd/ateom-microvm/durable.go
@@ -54,10 +54,9 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-// durableTarFile is the snapshot file holding the tar of the actor's durable-dir
-// volumes. Its entries are <volumeName>/... relative to
+// durableTarFile's entries are <volumeName>/... relative to
 // ateompath.DurableDirVolumeMountsDir, so extraction restores the same layout.
-const durableTarFile = "durable-dir.tar"
+const durableTarFile = ateompath.DurableTarFile
 
 // hasDurableVolumes reports whether any container mounts a durable-dir volume.
 func hasDurableVolumes(containers []*ateompb.Container) bool {

--- a/cmd/kubectl-ate/internal/cmd/apply.go
+++ b/cmd/kubectl-ate/internal/cmd/apply.go
@@ -1,0 +1,302 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/agent-substrate/substrate/internal/ateclient"
+	"github.com/agent-substrate/substrate/internal/templateversion"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
+)
+
+// applyAPIVersion is the manifest envelope for control-plane resources
+// applied through the ate API — deliberately distinct from the
+// ate.dev/v1alpha1 CRDs applied with plain kubectl, whose ActorTemplate has
+// a different spec shape.
+const applyAPIVersion = "api.ate.dev/v1alpha1"
+
+var applyFile string
+
+// applyDoc is one parsed manifest document.
+type applyDoc struct {
+	template *ateapipb.ActorTemplate
+	version  *ateapipb.ActorTemplateVersion
+	// maskPaths are the mutable ActorTemplate fields present in the
+	// manifest, applied with UpdateActorTemplate after all creates.
+	maskPaths []string
+}
+
+var applyCmd = &cobra.Command{
+	Use:   "apply -f FILENAME",
+	Short: "Apply ActorTemplate and ActorTemplateVersion manifests",
+	Long: `Apply ActorTemplate and ActorTemplateVersion manifests (apiVersion ` + applyAPIVersion + `).
+
+Templates are created, then their mutable fields (spec.workerSelector,
+spec.defaultVersionOnCreate) are applied — after every create, so a template
+may name a version defined later in the same file. Versions are immutable:
+re-applying an identical version is a no-op, and changing one is an error —
+ship the change as a new version instead. Mutable fields absent from the
+manifest are left as they are, not cleared.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		docs, err := readApplyDocs(applyFile)
+		if err != nil {
+			return err
+		}
+		if len(docs) == 0 {
+			return errors.New("no resources found in the manifest")
+		}
+
+		apiClient, err := ateclient.NewClient(ctx, kubeconfig, k8sContext, endpoint, traceEnabled)
+		if err != nil {
+			return fmt.Errorf("failed to connect to ate-api-server: %w", err)
+		}
+		defer apiClient.Close()
+
+		return applyDocs(ctx, cmd.OutOrStdout(), apiClient.ControlClient, docs)
+	},
+}
+
+func applyDocs(ctx context.Context, out io.Writer, client ateapipb.ControlClient, docs []*applyDoc) error {
+	// Pass 1: creates. Templates are created without their mutable fields
+	// (the API forbids default_version_on_create at creation); versions are
+	// created or verified unchanged.
+	templateExisted := map[string]bool{}
+	for _, doc := range docs {
+		switch {
+		case doc.template != nil:
+			name := doc.template.GetMetadata().GetName()
+			create := proto.Clone(doc.template).(*ateapipb.ActorTemplate)
+			if create.GetSpec() != nil {
+				create.Spec.DefaultVersionOnCreate = nil
+			}
+			_, err := client.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{ActorTemplate: create})
+			switch {
+			case err == nil:
+			case status.Code(err) == codes.AlreadyExists:
+				templateExisted[name] = true
+			default:
+				return fmt.Errorf("while creating ActorTemplate %q: %w", name, err)
+			}
+		case doc.version != nil:
+			verdict, err := applyVersion(ctx, client, doc.version)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "actortemplateversion/%s %s\n", doc.version.GetMetadata().GetName(), verdict)
+		}
+	}
+
+	// Pass 2: template mutable fields, now that every version in the file
+	// exists. A fresh create already carries its worker selector, so only
+	// the default (or updates to a pre-existing template) need this.
+	for _, doc := range docs {
+		if doc.template == nil {
+			continue
+		}
+		name := doc.template.GetMetadata().GetName()
+		paths := doc.maskPaths
+		if !templateExisted[name] {
+			paths = nil
+			if doc.template.GetSpec().GetDefaultVersionOnCreate() != nil {
+				paths = []string{"spec.default_version_on_create"}
+			}
+		}
+		if len(paths) > 0 {
+			if _, err := client.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+				ActorTemplate: doc.template,
+				UpdateMask:    &fieldmaskpb.FieldMask{Paths: paths},
+			}); err != nil {
+				return fmt.Errorf("while updating ActorTemplate %q: %w", name, err)
+			}
+		}
+		verdict := "created"
+		if templateExisted[name] {
+			verdict = "configured"
+		}
+		fmt.Fprintf(out, "actortemplate/%s %s\n", name, verdict)
+	}
+	return nil
+}
+
+// applyVersion creates a version, or — versions being immutable — verifies
+// an existing one matches the manifest after server-style defaulting.
+func applyVersion(ctx context.Context, client ateapipb.ControlClient, version *ateapipb.ActorTemplateVersion) (string, error) {
+	name := version.GetMetadata().GetName()
+	_, err := client.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{ActorTemplateVersion: version})
+	if err == nil {
+		return "created", nil
+	}
+	if status.Code(err) != codes.AlreadyExists {
+		return "", fmt.Errorf("while creating ActorTemplateVersion %q: %w", name, err)
+	}
+
+	stored, err := client.GetActorTemplateVersion(ctx, &ateapipb.GetActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ObjectRef{Name: name},
+	})
+	if err != nil {
+		return "", fmt.Errorf("while reading existing ActorTemplateVersion %q: %w", name, err)
+	}
+	wantSpec := proto.Clone(version.GetSpec()).(*ateapipb.ActorTemplateVersionSpec)
+	templateversion.DefaultSpec(wantSpec)
+	if !proto.Equal(stored.GetSpec(), wantSpec) {
+		return "", fmt.Errorf("ActorTemplateVersion %q exists with a different spec; versions are immutable, ship the change as a new version", name)
+	}
+	if stored.GetActorTemplate().GetName() != version.GetActorTemplate().GetName() {
+		return "", fmt.Errorf("ActorTemplateVersion %q exists under ActorTemplate %q, not %q",
+			name, stored.GetActorTemplate().GetName(), version.GetActorTemplate().GetName())
+	}
+	return "unchanged", nil
+}
+
+func readApplyDocs(filename string) ([]*applyDoc, error) {
+	var in io.Reader
+	if filename == "-" {
+		in = os.Stdin
+	} else {
+		f, err := os.Open(filename)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		in = f
+	}
+	return parseApplyDocs(in)
+}
+
+func parseApplyDocs(in io.Reader) ([]*applyDoc, error) {
+	var docs []*applyDoc
+	reader := utilyaml.NewYAMLReader(bufio.NewReader(in))
+	for i := 0; ; i++ {
+		raw, err := reader.Read()
+		if err == io.EOF {
+			return docs, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("while reading document %d: %w", i+1, err)
+		}
+		doc, err := parseApplyDoc(raw)
+		if err != nil {
+			return nil, fmt.Errorf("document %d: %w", i+1, err)
+		}
+		if doc != nil {
+			docs = append(docs, doc)
+		}
+	}
+}
+
+func parseApplyDoc(raw []byte) (*applyDoc, error) {
+	jsonBytes, err := yaml.YAMLToJSON(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid YAML: %w", err)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(jsonBytes, &body); err != nil {
+		if string(jsonBytes) == "null" {
+			return nil, nil // Empty document.
+		}
+		return nil, fmt.Errorf("expected an object, got: %s", jsonBytes)
+	}
+	if len(body) == 0 {
+		return nil, nil
+	}
+
+	var apiVersion, kind string
+	if raw, ok := body["apiVersion"]; ok {
+		_ = json.Unmarshal(raw, &apiVersion)
+	}
+	if raw, ok := body["kind"]; ok {
+		_ = json.Unmarshal(raw, &kind)
+	}
+	if apiVersion != applyAPIVersion {
+		return nil, fmt.Errorf("unsupported apiVersion %q; kubectl ate apply only handles %s (CRD manifests go through plain kubectl apply)", apiVersion, applyAPIVersion)
+	}
+	// The envelope is CLI-level routing, not part of the proto shape.
+	delete(body, "apiVersion")
+	delete(body, "kind")
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	switch kind {
+	case "ActorTemplate":
+		template := &ateapipb.ActorTemplate{}
+		if err := protojson.Unmarshal(payload, template); err != nil {
+			return nil, fmt.Errorf("invalid ActorTemplate: %w", err)
+		}
+		return &applyDoc{template: template, maskPaths: templateMaskPaths(body)}, nil
+	case "ActorTemplateVersion":
+		version := &ateapipb.ActorTemplateVersion{}
+		if err := protojson.Unmarshal(payload, version); err != nil {
+			return nil, fmt.Errorf("invalid ActorTemplateVersion: %w", err)
+		}
+		return &applyDoc{version: version}, nil
+	default:
+		return nil, fmt.Errorf("unsupported kind %q; expected ActorTemplate or ActorTemplateVersion", kind)
+	}
+}
+
+// templateMaskPaths maps the mutable spec fields present in the manifest to
+// the UpdateActorTemplate mask paths. Absent fields stay off the mask so
+// re-applying a partial manifest never clears them.
+func templateMaskPaths(body map[string]json.RawMessage) []string {
+	specRaw, ok := body["spec"]
+	if !ok {
+		return nil
+	}
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal(specRaw, &spec); err != nil {
+		return nil // protojson.Unmarshal already rejected the document.
+	}
+	has := func(keys ...string) bool {
+		for _, k := range keys {
+			if _, ok := spec[k]; ok {
+				return true
+			}
+		}
+		return false
+	}
+	var paths []string
+	// protojson accepts both spellings on input.
+	if has("workerSelector", "worker_selector") {
+		paths = append(paths, "spec.worker_selector")
+	}
+	if has("defaultVersionOnCreate", "default_version_on_create") {
+		paths = append(paths, "spec.default_version_on_create")
+	}
+	return paths
+}
+
+func init() {
+	applyCmd.Flags().StringVarP(&applyFile, "filename", "f", "", "Manifest file to apply, or - for stdin")
+	_ = applyCmd.MarkFlagRequired("filename")
+	rootCmd.AddCommand(applyCmd)
+}

--- a/cmd/kubectl-ate/internal/cmd/apply_test.go
+++ b/cmd/kubectl-ate/internal/cmd/apply_test.go
@@ -272,8 +272,11 @@ func TestParseApplyDocs_CounterDemoTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseApplyDocs failed: %v", err)
 	}
-	if len(docs) != 2 || docs[0].template == nil || docs[1].version == nil {
-		t.Fatalf("parsed %d documents, want ActorTemplate + ActorTemplateVersion", len(docs))
+	if len(docs) != 3 || docs[0].template == nil || docs[1].version == nil || docs[2].version == nil {
+		t.Fatalf("parsed %d documents, want ActorTemplate + two ActorTemplateVersions", len(docs))
+	}
+	if got := docs[2].version.GetMetadata().GetName(); got != "counter-atv-v2" {
+		t.Errorf("second version name = %q, want counter-atv-v2", got)
 	}
 	spec := docs[1].version.GetSpec()
 	if got := spec.GetSnapshotsConfig().GetOnPause(); got != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL {

--- a/cmd/kubectl-ate/internal/cmd/apply_test.go
+++ b/cmd/kubectl-ate/internal/cmd/apply_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+const applyManifest = `apiVersion: api.ate.dev/v1alpha1
+kind: ActorTemplate
+metadata:
+  name: counter
+spec:
+  workerSelector:
+    matchLabels:
+      workload: counter
+  defaultVersionOnCreate:
+    name: counter-v1
+---
+apiVersion: api.ate.dev/v1alpha1
+kind: ActorTemplateVersion
+metadata:
+  name: counter-v1
+actorTemplate:
+  name: counter
+spec:
+  pauseImage: pause@sha256:abc
+  containers:
+  - name: counter
+    image: app@sha256:def
+    readyz:
+      httpGet:
+        port: 80
+  snapshotsConfig:
+    storageLocation: gs://bucket/counter/
+`
+
+// fakeControl stubs the few Control RPCs apply uses; any other call panics
+// through the nil embedded interface.
+type fakeControl struct {
+	ateapipb.ControlClient
+
+	templateExists bool
+	storedVersion  *ateapipb.ActorTemplateVersion
+
+	createdTemplates []*ateapipb.ActorTemplate
+	createdVersions  []*ateapipb.ActorTemplateVersion
+	updates          []*ateapipb.UpdateActorTemplateRequest
+}
+
+func (f *fakeControl) CreateActorTemplate(ctx context.Context, req *ateapipb.CreateActorTemplateRequest, opts ...grpc.CallOption) (*ateapipb.ActorTemplate, error) {
+	if f.templateExists {
+		return nil, status.Error(codes.AlreadyExists, "exists")
+	}
+	f.createdTemplates = append(f.createdTemplates, req.GetActorTemplate())
+	return req.GetActorTemplate(), nil
+}
+
+func (f *fakeControl) CreateActorTemplateVersion(ctx context.Context, req *ateapipb.CreateActorTemplateVersionRequest, opts ...grpc.CallOption) (*ateapipb.ActorTemplateVersion, error) {
+	if f.storedVersion != nil {
+		return nil, status.Error(codes.AlreadyExists, "exists")
+	}
+	f.createdVersions = append(f.createdVersions, req.GetActorTemplateVersion())
+	return req.GetActorTemplateVersion(), nil
+}
+
+func (f *fakeControl) GetActorTemplateVersion(ctx context.Context, req *ateapipb.GetActorTemplateVersionRequest, opts ...grpc.CallOption) (*ateapipb.ActorTemplateVersion, error) {
+	if f.storedVersion == nil {
+		return nil, status.Error(codes.NotFound, "not found")
+	}
+	return f.storedVersion, nil
+}
+
+func (f *fakeControl) UpdateActorTemplate(ctx context.Context, req *ateapipb.UpdateActorTemplateRequest, opts ...grpc.CallOption) (*ateapipb.ActorTemplate, error) {
+	f.updates = append(f.updates, req)
+	return req.GetActorTemplate(), nil
+}
+
+func TestParseApplyDocs(t *testing.T) {
+	docs, err := parseApplyDocs(strings.NewReader(applyManifest))
+	if err != nil {
+		t.Fatalf("parseApplyDocs failed: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("parsed %d documents, want 2", len(docs))
+	}
+	wantTemplate := &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{Name: "counter"},
+		Spec: &ateapipb.ActorTemplateSpec{
+			WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"workload": "counter"}},
+			DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: "counter-v1"},
+		},
+	}
+	if diff := cmp.Diff(wantTemplate, docs[0].template, protocmp.Transform()); diff != "" {
+		t.Errorf("template mismatch (-want +got):\n%s", diff)
+	}
+	if want := []string{"spec.worker_selector", "spec.default_version_on_create"}; !cmp.Equal(want, docs[0].maskPaths) {
+		t.Errorf("maskPaths = %v, want %v", docs[0].maskPaths, want)
+	}
+	if docs[1].version.GetMetadata().GetName() != "counter-v1" || docs[1].version.GetActorTemplate().GetName() != "counter" {
+		t.Errorf("version parsed wrong: %v", docs[1].version)
+	}
+}
+
+func TestParseApplyDocs_Errors(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest string
+		wantErr  string
+	}{{
+		"CRD apiVersion rejected",
+		"apiVersion: ate.dev/v1alpha1\nkind: ActorTemplate\nmetadata: {name: x}\n",
+		"unsupported apiVersion",
+	}, {
+		"unknown kind",
+		"apiVersion: api.ate.dev/v1alpha1\nkind: Actor\nmetadata: {name: x}\n",
+		`unsupported kind "Actor"`,
+	}, {
+		"unknown field",
+		"apiVersion: api.ate.dev/v1alpha1\nkind: ActorTemplate\nmetadata: {name: x}\nspec: {bogus: 1}\n",
+		"invalid ActorTemplate",
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseApplyDocs(strings.NewReader(tc.manifest))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %v, want contains %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseApplyDocs_SkipsEmptyDocuments(t *testing.T) {
+	docs, err := parseApplyDocs(strings.NewReader("---\n# just a comment\n---\n" + applyManifest))
+	if err != nil {
+		t.Fatalf("parseApplyDocs failed: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Errorf("parsed %d documents, want 2", len(docs))
+	}
+}
+
+func TestApplyDocs_FreshCreate(t *testing.T) {
+	docs, err := parseApplyDocs(strings.NewReader(applyManifest))
+	if err != nil {
+		t.Fatalf("parseApplyDocs failed: %v", err)
+	}
+	fake := &fakeControl{}
+	var out bytes.Buffer
+	if err := applyDocs(context.Background(), &out, fake, docs); err != nil {
+		t.Fatalf("applyDocs failed: %v", err)
+	}
+
+	// The create must not carry the default (the API forbids it at
+	// creation); the default lands via the pass-2 update, after the version
+	// defined later in the file was created.
+	if len(fake.createdTemplates) != 1 || fake.createdTemplates[0].GetSpec().GetDefaultVersionOnCreate() != nil {
+		t.Errorf("created templates = %v, want one create without default_version_on_create", fake.createdTemplates)
+	}
+	if len(fake.createdVersions) != 1 {
+		t.Errorf("created %d versions, want 1", len(fake.createdVersions))
+	}
+	if len(fake.updates) != 1 {
+		t.Fatalf("update calls = %d, want 1", len(fake.updates))
+	}
+	if want := []string{"spec.default_version_on_create"}; !cmp.Equal(want, fake.updates[0].GetUpdateMask().GetPaths()) {
+		t.Errorf("fresh-create update mask = %v, want %v (selector already set at create)", fake.updates[0].GetUpdateMask().GetPaths(), want)
+	}
+	for _, want := range []string{"actortemplate/counter created", "actortemplateversion/counter-v1 created"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output %q missing %q", out.String(), want)
+		}
+	}
+}
+
+func TestApplyDocs_ExistingTemplateConfigured(t *testing.T) {
+	docs, err := parseApplyDocs(strings.NewReader(applyManifest))
+	if err != nil {
+		t.Fatalf("parseApplyDocs failed: %v", err)
+	}
+	fake := &fakeControl{templateExists: true}
+	var out bytes.Buffer
+	if err := applyDocs(context.Background(), &out, fake, docs); err != nil {
+		t.Fatalf("applyDocs failed: %v", err)
+	}
+	if len(fake.updates) != 1 {
+		t.Fatalf("update calls = %d, want 1", len(fake.updates))
+	}
+	if want := []string{"spec.worker_selector", "spec.default_version_on_create"}; !cmp.Equal(want, fake.updates[0].GetUpdateMask().GetPaths()) {
+		t.Errorf("update mask = %v, want %v", fake.updates[0].GetUpdateMask().GetPaths(), want)
+	}
+	if !strings.Contains(out.String(), "actortemplate/counter configured") {
+		t.Errorf("output %q missing configured verdict", out.String())
+	}
+}
+
+func TestApplyDocs_VersionUnchangedAndDrifted(t *testing.T) {
+	docs, err := parseApplyDocs(strings.NewReader(applyManifest))
+	if err != nil {
+		t.Fatalf("parseApplyDocs failed: %v", err)
+	}
+
+	// The stored spec carries server-applied defaults (readyz timeout 30,
+	// path /readyz) that the manifest omits; the comparison must default
+	// the manifest the same way and call this unchanged.
+	stored := &ateapipb.ActorTemplateVersion{
+		Metadata:      &ateapipb.ResourceMetadata{Name: "counter-v1"},
+		ActorTemplate: &ateapipb.ObjectRef{Name: "counter"},
+		Spec: &ateapipb.ActorTemplateVersionSpec{
+			PauseImage: "pause@sha256:abc",
+			Containers: []*ateapipb.Container{{
+				Name:  "counter",
+				Image: "app@sha256:def",
+				Readyz: &ateapipb.ContainerReadyz{
+					HttpGet:        &ateapipb.HTTPGetAction{Path: "/readyz", Port: 80},
+					TimeoutSeconds: 30,
+				},
+			}},
+			SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://bucket/counter/"},
+		},
+	}
+	fake := &fakeControl{templateExists: true, storedVersion: stored}
+	var out bytes.Buffer
+	if err := applyDocs(context.Background(), &out, fake, docs); err != nil {
+		t.Fatalf("applyDocs failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "actortemplateversion/counter-v1 unchanged") {
+		t.Errorf("output %q missing unchanged verdict", out.String())
+	}
+
+	drifted := &fakeControl{templateExists: true, storedVersion: stored}
+	docs[1].version.Spec.PauseImage = "pause@sha256:other"
+	err = applyDocs(context.Background(), &bytes.Buffer{}, drifted, docs)
+	if err == nil || !strings.Contains(err.Error(), "versions are immutable") {
+		t.Errorf("drifted apply error = %v, want immutability error", err)
+	}
+}

--- a/cmd/kubectl-ate/internal/cmd/apply_test.go
+++ b/cmd/kubectl-ate/internal/cmd/apply_test.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -255,5 +256,36 @@ func TestApplyDocs_VersionUnchangedAndDrifted(t *testing.T) {
 	err = applyDocs(context.Background(), &bytes.Buffer{}, drifted, docs)
 	if err == nil || !strings.Contains(err.Error(), "versions are immutable") {
 		t.Errorf("drifted apply error = %v, want immutability error", err)
+	}
+}
+
+// The demo manifest is the reference api.ate.dev document; parsing it here
+// pins the accepted enum spellings and field names.
+func TestParseApplyDocs_CounterDemoTemplate(t *testing.T) {
+	raw, err := os.ReadFile("../../../../demos/counter/counter-atv.yaml.tmpl")
+	if err != nil {
+		t.Fatalf("read demo template: %v", err)
+	}
+	manifest := strings.ReplaceAll(string(raw), "${BUCKET_NAME}", "test-bucket")
+
+	docs, err := parseApplyDocs(strings.NewReader(manifest))
+	if err != nil {
+		t.Fatalf("parseApplyDocs failed: %v", err)
+	}
+	if len(docs) != 2 || docs[0].template == nil || docs[1].version == nil {
+		t.Fatalf("parsed %d documents, want ActorTemplate + ActorTemplateVersion", len(docs))
+	}
+	spec := docs[1].version.GetSpec()
+	if got := spec.GetSnapshotsConfig().GetOnPause(); got != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL {
+		t.Errorf("onPause = %v, want FULL", got)
+	}
+	if got := spec.GetSnapshotsConfig().GetOnCommit(); got != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA {
+		t.Errorf("onCommit = %v, want DATA", got)
+	}
+	if got := spec.GetSnapshotsConfig().GetStorageLocation(); got != "gs://test-bucket/ate-demo-counter-atv/" {
+		t.Errorf("storageLocation = %q", got)
+	}
+	if got := docs[0].template.GetSpec().GetDefaultVersionOnCreate().GetName(); got != "counter-atv-v1" {
+		t.Errorf("defaultVersionOnCreate = %q, want counter-atv-v1", got)
 	}
 }

--- a/cmd/kubectl-ate/internal/cmd/create_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/create_actor.go
@@ -25,6 +25,7 @@ import (
 )
 
 var templateFlag string
+var templateVersionFlag string
 var atespaceFlag string
 var sourceSnapshotTagFlag string
 
@@ -41,21 +42,29 @@ var createActorCmd = &cobra.Command{
 		defer apiClient.Close()
 
 		actorName := args[0]
-		parts := strings.Split(templateFlag, "/")
-		if len(parts) != 2 {
-			return fmt.Errorf("malformed --template: %s (expected <namespace>/<name>)", templateFlag)
-		}
-
-		request := &ateapipb.CreateActorRequest{
-			Actor: &ateapipb.Actor{
-				Metadata: &ateapipb.ResourceMetadata{
-					Atespace: atespaceFlag,
-					Name:     actorName,
-				},
-				ActorTemplateNamespace: parts[0],
-				ActorTemplateName:      parts[1],
+		actor := &ateapipb.Actor{
+			Metadata: &ateapipb.ResourceMetadata{
+				Atespace: atespaceFlag,
+				Name:     actorName,
 			},
 		}
+		// <namespace>/<name> selects a CRD ActorTemplate; a bare name selects
+		// a global control-plane ActorTemplate (see kubectl ate apply).
+		switch parts := strings.Split(templateFlag, "/"); len(parts) {
+		case 1:
+			actor.ActorTemplate = templateFlag
+			actor.ActorTemplateVersion = templateVersionFlag
+		case 2:
+			if templateVersionFlag != "" {
+				return fmt.Errorf("--template-version only applies to control-plane templates (--template without a namespace)")
+			}
+			actor.ActorTemplateNamespace = parts[0]
+			actor.ActorTemplateName = parts[1]
+		default:
+			return fmt.Errorf("malformed --template: %s (expected <namespace>/<name> or <name>)", templateFlag)
+		}
+
+		request := &ateapipb.CreateActorRequest{Actor: actor}
 		if sourceSnapshotTagFlag != "" {
 			ref, err := parseNamespacedName(sourceSnapshotTagFlag)
 			if err != nil {
@@ -73,8 +82,9 @@ var createActorCmd = &cobra.Command{
 }
 
 func init() {
-	createActorCmd.Flags().StringVarP(&templateFlag, "template", "t", "", "Template to derive the actor from in <namespace>/<name> format (required)")
+	createActorCmd.Flags().StringVarP(&templateFlag, "template", "t", "", "Template to derive the actor from: <namespace>/<name> for a CRD ActorTemplate, <name> for a control-plane ActorTemplate (required)")
 	_ = createActorCmd.MarkFlagRequired("template")
+	createActorCmd.Flags().StringVar(&templateVersionFlag, "template-version", "", "Pin a control-plane ActorTemplateVersion (default: the template's defaultVersionOnCreate)")
 	createActorCmd.Flags().StringVarP(&atespaceFlag, "atespace", "a", "", "Atespace to create the actor in (required)")
 	_ = createActorCmd.MarkFlagRequired("atespace")
 	createActorCmd.Flags().StringVar(&sourceSnapshotTagFlag, "snapshot-tag", "", "Initialize from an ActorSnapshot tag in <atespace>/<name> format")

--- a/cmd/kubectl-ate/internal/cmd/delete_actor_template.go
+++ b/cmd/kubectl-ate/internal/cmd/delete_actor_template.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/agent-substrate/substrate/internal/ateclient"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/spf13/cobra"
+)
+
+var deleteActorTemplateCmd = &cobra.Command{
+	Use:   "actor-template <name>",
+	Short: "Delete an actor template (must have no remaining versions)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		c, err := ateclient.NewClient(ctx, kubeconfig, k8sContext, endpoint, traceEnabled)
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+
+		if _, err := c.ControlClient.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{
+			ActorTemplate: &ateapipb.ObjectRef{Name: args[0]},
+		}); err != nil {
+			return err
+		}
+		fmt.Printf("actor template %q deleted\n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	deleteCmd.AddCommand(deleteActorTemplateCmd)
+}

--- a/cmd/kubectl-ate/internal/cmd/delete_actor_template_version.go
+++ b/cmd/kubectl-ate/internal/cmd/delete_actor_template_version.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/agent-substrate/substrate/internal/ateclient"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+var deleteActorTemplateVersionClearDefault bool
+
+var deleteActorTemplateVersionCmd = &cobra.Command{
+	Use:   "actor-template-version <name>",
+	Short: "Delete an actor template version",
+	Long: `Delete an actor template version.
+
+A version that is its template's defaultVersionOnCreate cannot be deleted;
+pass --clear-default to clear the template's default first.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		c, err := ateclient.NewClient(ctx, kubeconfig, k8sContext, endpoint, traceEnabled)
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+
+		name := args[0]
+		if deleteActorTemplateVersionClearDefault {
+			version, err := c.ControlClient.GetActorTemplateVersion(ctx, &ateapipb.GetActorTemplateVersionRequest{
+				ActorTemplateVersion: &ateapipb.ObjectRef{Name: name},
+			})
+			if err != nil {
+				return err
+			}
+			template := version.GetActorTemplate().GetName()
+			parent, err := c.ControlClient.GetActorTemplate(ctx, &ateapipb.GetActorTemplateRequest{
+				ActorTemplate: &ateapipb.ObjectRef{Name: template},
+			})
+			if err != nil {
+				return err
+			}
+			if parent.GetSpec().GetDefaultVersionOnCreate().GetName() == name {
+				if _, err := c.ControlClient.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+					ActorTemplate: &ateapipb.ActorTemplate{
+						Metadata: &ateapipb.ResourceMetadata{Name: template},
+						Spec:     &ateapipb.ActorTemplateSpec{DefaultVersionOnCreate: nil},
+					},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.default_version_on_create"}},
+				}); err != nil {
+					return fmt.Errorf("while clearing default_version_on_create of ActorTemplate %q: %w", template, err)
+				}
+				fmt.Printf("actor template %q default version cleared\n", template)
+			}
+		}
+
+		if _, err := c.ControlClient.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{
+			ActorTemplateVersion: &ateapipb.ObjectRef{Name: name},
+		}); err != nil {
+			return err
+		}
+		fmt.Printf("actor template version %q deleted\n", name)
+		return nil
+	},
+}
+
+func init() {
+	deleteActorTemplateVersionCmd.Flags().BoolVar(&deleteActorTemplateVersionClearDefault, "clear-default", false, "Clear the parent template's defaultVersionOnCreate first if it names this version")
+	deleteCmd.AddCommand(deleteActorTemplateVersionCmd)
+}

--- a/cmd/kubectl-ate/internal/cmd/get_actor_template_versions.go
+++ b/cmd/kubectl-ate/internal/cmd/get_actor_template_versions.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/kubectl-ate/internal/printer"
+	"github.com/agent-substrate/substrate/internal/ateclient"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/spf13/cobra"
+)
+
+var getActorTemplateVersionsTemplateFlag string
+
+var getActorTemplateVersionsCmd = &cobra.Command{
+	Use:     "actor-template-versions <name ...>",
+	Aliases: []string{"actor-template-version"},
+	Short:   "List actor template versions or get one or more actor template versions",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		apiClient, err := ateclient.NewClient(ctx, kubeconfig, k8sContext, endpoint, traceEnabled)
+		if err != nil {
+			return fmt.Errorf("failed to connect to ate-api-server: %w", err)
+		}
+		defer apiClient.Close()
+
+		if len(args) > 0 {
+			if getActorTemplateVersionsTemplateFlag != "" {
+				return fmt.Errorf("--template only filters listings; it cannot be used when getting versions by name")
+			}
+			versions := make([]*ateapipb.ActorTemplateVersion, 0, len(args))
+			for _, name := range args {
+				resp, err := apiClient.GetActorTemplateVersion(ctx, &ateapipb.GetActorTemplateVersionRequest{
+					ActorTemplateVersion: &ateapipb.ObjectRef{Name: name},
+				})
+				if err != nil {
+					return fmt.Errorf("failed to get actor template version %q: %w", name, err)
+				}
+				versions = append(versions, resp)
+			}
+			return printer.PrintActorTemplateVersions(versions, outputFmt)
+		}
+
+		var versions []*ateapipb.ActorTemplateVersion
+		pageToken := ""
+		for {
+			resp, err := apiClient.ListActorTemplateVersions(ctx, &ateapipb.ListActorTemplateVersionsRequest{
+				ActorTemplate: getActorTemplateVersionsTemplateFlag,
+				PageSize:      1000,
+				PageToken:     pageToken,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list actor template versions: %w", err)
+			}
+			versions = append(versions, resp.GetActorTemplateVersions()...)
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
+			}
+		}
+		return printer.PrintActorTemplateVersions(versions, outputFmt)
+	},
+}
+
+func init() {
+	getActorTemplateVersionsCmd.Flags().StringVar(&getActorTemplateVersionsTemplateFlag, "template", "", "Only list versions of this actor template")
+	getCmd.AddCommand(getActorTemplateVersionsCmd)
+}

--- a/cmd/kubectl-ate/internal/cmd/get_actor_templates.go
+++ b/cmd/kubectl-ate/internal/cmd/get_actor_templates.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/kubectl-ate/internal/printer"
+	"github.com/agent-substrate/substrate/internal/ateclient"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/spf13/cobra"
+)
+
+var getActorTemplatesCmd = &cobra.Command{
+	Use:     "actor-templates <name ...>",
+	Aliases: []string{"actor-template"},
+	Short:   "List all actor templates or get one or more actor templates",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		apiClient, err := ateclient.NewClient(ctx, kubeconfig, k8sContext, endpoint, traceEnabled)
+		if err != nil {
+			return fmt.Errorf("failed to connect to ate-api-server: %w", err)
+		}
+		defer apiClient.Close()
+
+		if len(args) > 0 {
+			templates := make([]*ateapipb.ActorTemplate, 0, len(args))
+			for _, name := range args {
+				resp, err := apiClient.GetActorTemplate(ctx, &ateapipb.GetActorTemplateRequest{
+					ActorTemplate: &ateapipb.ObjectRef{Name: name},
+				})
+				if err != nil {
+					return fmt.Errorf("failed to get actor template %q: %w", name, err)
+				}
+				templates = append(templates, resp)
+			}
+			return printer.PrintActorTemplates(templates, outputFmt)
+		}
+
+		var templates []*ateapipb.ActorTemplate
+		pageToken := ""
+		for {
+			resp, err := apiClient.ListActorTemplates(ctx, &ateapipb.ListActorTemplatesRequest{
+				PageSize:  1000,
+				PageToken: pageToken,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list actor templates: %w", err)
+			}
+			templates = append(templates, resp.GetActorTemplates()...)
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
+			}
+		}
+		return printer.PrintActorTemplates(templates, outputFmt)
+	},
+}
+
+func init() {
+	getCmd.AddCommand(getActorTemplatesCmd)
+}

--- a/cmd/kubectl-ate/internal/cmd/resume_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/resume_actor.go
@@ -26,6 +26,7 @@ import (
 
 var bootFlag bool
 var resumeAtespaceFlag string
+var resumeTemplateVersionFlag string
 
 var resumeActorCmd = &cobra.Command{
 	Use:   "actor <actor-name>",
@@ -41,8 +42,9 @@ var resumeActorCmd = &cobra.Command{
 
 		actorRef := resources.ActorRef{Atespace: resumeAtespaceFlag, Name: args[0]}
 		resp, err := apiClient.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
-			Actor: actorRef.ToObjectRef(),
-			Boot:  bootFlag,
+			Actor:                actorRef.ToObjectRef(),
+			Boot:                 bootFlag,
+			ActorTemplateVersion: resumeTemplateVersionFlag,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to resume actor: %w", err)
@@ -55,6 +57,7 @@ var resumeActorCmd = &cobra.Command{
 func init() {
 	resumeActorCmd.Flags().BoolVarP(&bootFlag, "boot", "", false, "Skip golden snapshot and boot from scratch.")
 	resumeActorCmd.Flags().StringVarP(&resumeAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
+	resumeActorCmd.Flags().StringVarP(&resumeTemplateVersionFlag, "template-version", "", "", "Re-pin the actor to this ActorTemplateVersion before resuming (SUSPENDED or CRASHED actors only). Durable data is preserved; memory restarts from the new version.")
 	_ = resumeActorCmd.MarkFlagRequired("atespace")
 	resumeCmd.AddCommand(resumeActorCmd)
 }

--- a/cmd/kubectl-ate/internal/printer/printer.go
+++ b/cmd/kubectl-ate/internal/printer/printer.go
@@ -74,7 +74,12 @@ func PrintActorsTo(out io.Writer, actors []*ateapipb.Actor, format string) error
 		for _, actor := range actors {
 			atespace := actor.GetMetadata().GetAtespace()
 			name := actor.GetMetadata().GetName()
+			// Native actors run an ActorTemplateVersion; CRD actors a
+			// namespaced template.
 			template := actor.GetActorTemplateNamespace() + "/" + actor.GetActorTemplateName()
+			if actor.GetActorTemplateVersion() != "" {
+				template = actor.GetActorTemplateVersion()
+			}
 			status := actor.GetStatus().String()
 
 			assignment := actor.GetWorkerAssignment()

--- a/cmd/kubectl-ate/internal/printer/printer.go
+++ b/cmd/kubectl-ate/internal/printer/printer.go
@@ -309,6 +309,77 @@ func PrintAtespace(atespace *ateapipb.Atespace, format string) error {
 	return PrintAtespaces([]*ateapipb.Atespace{atespace}, format)
 }
 
+// PrintActorTemplates prints actor templates to stdout in the requested format.
+func PrintActorTemplates(templates []*ateapipb.ActorTemplate, format string) error {
+	return PrintActorTemplatesTo(os.Stdout, templates, format)
+}
+
+func sortActorTemplates(templates []*ateapipb.ActorTemplate) {
+	slices.SortFunc(templates, func(a, b *ateapipb.ActorTemplate) int {
+		return cmp.Compare(a.GetMetadata().GetName(), b.GetMetadata().GetName())
+	})
+}
+
+// PrintActorTemplatesTo prints actor templates to the provided writer.
+func PrintActorTemplatesTo(out io.Writer, templates []*ateapipb.ActorTemplate, format string) error {
+	sortActorTemplates(templates)
+	switch format {
+	case "json", "yaml":
+		return printProto(out, &ateapipb.ListActorTemplatesResponse{ActorTemplates: templates}, format)
+	case "table":
+		w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NAME\tDEFAULT-VERSION\tAGE")
+		for _, t := range templates {
+			defaultVersion := t.GetSpec().GetDefaultVersionOnCreate().GetName()
+			if defaultVersion == "" {
+				defaultVersion = "<none>"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\n", t.GetMetadata().GetName(), defaultVersion, formatAge(t.GetMetadata().GetCreateTime()))
+		}
+		return w.Flush()
+	default:
+		return fmt.Errorf("unsupported format %q", format)
+	}
+}
+
+// PrintActorTemplateVersions prints actor template versions to stdout in the
+// requested format.
+func PrintActorTemplateVersions(versions []*ateapipb.ActorTemplateVersion, format string) error {
+	return PrintActorTemplateVersionsTo(os.Stdout, versions, format)
+}
+
+func sortActorTemplateVersions(versions []*ateapipb.ActorTemplateVersion) {
+	slices.SortFunc(versions, func(a, b *ateapipb.ActorTemplateVersion) int {
+		if c := cmp.Compare(a.GetActorTemplate().GetName(), b.GetActorTemplate().GetName()); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.GetMetadata().GetName(), b.GetMetadata().GetName())
+	})
+}
+
+// PrintActorTemplateVersionsTo prints actor template versions to the
+// provided writer.
+func PrintActorTemplateVersionsTo(out io.Writer, versions []*ateapipb.ActorTemplateVersion, format string) error {
+	sortActorTemplateVersions(versions)
+	switch format {
+	case "json", "yaml":
+		return printProto(out, &ateapipb.ListActorTemplateVersionsResponse{ActorTemplateVersions: versions}, format)
+	case "table":
+		w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "NAME\tTEMPLATE\tSTATE\tAGE")
+		for _, v := range versions {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+				v.GetMetadata().GetName(),
+				v.GetActorTemplate().GetName(),
+				v.GetStatus().GetState().String(),
+				formatAge(v.GetMetadata().GetCreateTime()))
+		}
+		return w.Flush()
+	default:
+		return fmt.Errorf("unsupported format %q", format)
+	}
+}
+
 func printProto(out io.Writer, msg proto.Message, format string) error {
 	m := protojson.MarshalOptions{}
 	b, err := m.Marshal(msg)

--- a/cmd/kubectl-ate/internal/printer/printer_test.go
+++ b/cmd/kubectl-ate/internal/printer/printer_test.go
@@ -512,3 +512,52 @@ func TestPrintWorkerTopTo_Invalid(t *testing.T) {
 		t.Errorf("expected error for invalid format, got nil")
 	}
 }
+
+func TestPrintActorTemplatesTo_Table(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
+	var buf bytes.Buffer
+	templates := []*ateapipb.ActorTemplate{{
+		Metadata: &ateapipb.ResourceMetadata{Name: "zeta", CreateTime: timestamppb.New(now.Add(-5 * time.Minute))},
+	}, {
+		Metadata: &ateapipb.ResourceMetadata{Name: "counter", CreateTime: timestamppb.New(now.Add(-5 * time.Hour))},
+		Spec: &ateapipb.ActorTemplateSpec{
+			DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: "counter-v1"},
+		},
+	}}
+	if err := PrintActorTemplatesTo(&buf, templates, "table"); err != nil {
+		t.Fatalf("PrintActorTemplatesTo failed: %v", err)
+	}
+	want := "NAME      DEFAULT-VERSION   AGE\n" +
+		"counter   counter-v1        5h\n" +
+		"zeta      <none>            5m\n"
+	if diff := cmp.Diff(want, buf.String()); diff != "" {
+		t.Errorf("table mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintActorTemplateVersionsTo_Table(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
+	var buf bytes.Buffer
+	versions := []*ateapipb.ActorTemplateVersion{{
+		Metadata:      &ateapipb.ResourceMetadata{Name: "counter-v2", CreateTime: timestamppb.New(now.Add(-5 * time.Minute))},
+		ActorTemplate: &ateapipb.ObjectRef{Name: "counter"},
+		Status:        &ateapipb.ActorTemplateVersionStatus{State: ateapipb.ActorTemplateVersionStatus_STATE_INITIAL},
+	}, {
+		Metadata:      &ateapipb.ResourceMetadata{Name: "counter-v1", CreateTime: timestamppb.New(now.Add(-5 * time.Hour))},
+		ActorTemplate: &ateapipb.ObjectRef{Name: "counter"},
+		Status:        &ateapipb.ActorTemplateVersionStatus{State: ateapipb.ActorTemplateVersionStatus_STATE_READY},
+	}}
+	if err := PrintActorTemplateVersionsTo(&buf, versions, "table"); err != nil {
+		t.Fatalf("PrintActorTemplateVersionsTo failed: %v", err)
+	}
+	want := "NAME         TEMPLATE   STATE           AGE\n" +
+		"counter-v1   counter    STATE_READY     5h\n" +
+		"counter-v2   counter    STATE_INITIAL   5m\n"
+	if diff := cmp.Diff(want, buf.String()); diff != "" {
+		t.Errorf("table mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/demos/counter/README.md
+++ b/demos/counter/README.md
@@ -84,6 +84,47 @@ kubectl ate delete actor my-counter-1 -a demo
 kubectl ate delete atespace demo
 ```
 
+## Control-plane AT/ATV variant and upgrades
+
+[`counter-atv.yaml.tmpl`](counter-atv.yaml.tmpl) runs the same counter on
+control-plane-native `ActorTemplate`/`ActorTemplateVersion` resources (issue
+#477). It ships two versions, `counter-atv-v1` and `counter-atv-v2`, identical
+except for the `VERSION` env var echoed in the response — so an upgrade is
+visible in plain curl output.
+
+```bash
+# Deploys the CRD demo (for its WorkerPool), then the AT/ATV manifests, and
+# waits for both versions' golden snapshots to build.
+./hack/install-ate.sh --deploy-demo-counter-atv
+
+# Create an actor on the default version (v1) and drive it.
+kubectl ate create atespace demo
+kubectl ate create actor my-counter-1 -a demo --template counter-atv
+curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" http://localhost:8000
+# -> hello from: ... | version: v1 | preserved memory count: 1 | preserved file counter: 1
+```
+
+To upgrade, suspend the actor and resume it onto the new version. The durable
+volume (the file counter) carries over; the in-memory count restarts, because
+a memory snapshot cannot run on a different version's images:
+
+```bash
+kubectl ate suspend actor my-counter-1 -a demo
+kubectl ate resume actor my-counter-1 -a demo --template-version counter-atv-v2
+curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" http://localhost:8000
+# -> hello from: ... | version: v2 | preserved memory count: 1 | preserved file counter: 2
+```
+
+Rolling back is the same operation with the previous version (after another
+suspend):
+
+```bash
+kubectl ate suspend actor my-counter-1 -a demo
+kubectl ate resume actor my-counter-1 -a demo --template-version counter-atv-v1
+```
+
+Clean up with `./hack/install-ate.sh --delete-demo-counter-atv`.
+
 ## Micro-VM variant
 
 The same in-RAM-counter suspend/resume-continuity demo also runs on the micro-VM

--- a/demos/counter/counter-atv.yaml.tmpl
+++ b/demos/counter/counter-atv.yaml.tmpl
@@ -42,6 +42,47 @@ spec:
     image: ko://github.com/agent-substrate/substrate/demos/counter
     command:
     - /ko-app/counter
+    env:
+    - name: VERSION
+      value: v1
+    readyz:
+      httpGet:
+        path: /readyz
+        port: 80
+    volumeMounts:
+    - name: data
+      mountPath: /home/counter
+  volumes:
+  - name: data
+    durableDir: {}
+  snapshotsConfig:
+    onPause: SNAPSHOT_CONTENT_SCOPE_FULL
+    onCommit: SNAPSHOT_CONTENT_SCOPE_DATA
+    storageLocation: gs://${BUCKET_NAME}/ate-demo-counter-atv/
+  sandboxConfig:
+    sandboxClass: SANDBOX_CLASS_GVISOR
+    configName: gvisor-default
+---
+# v2 differs from v1 only by the VERSION env var, so an upgrade is visible in
+# the counter's response. Upgrade a suspended actor with:
+#   kubectl ate resume actor <name> -a <atespace> --template-version counter-atv-v2
+# The file counter (durable data) carries over; the memory count restarts.
+apiVersion: api.ate.dev/v1alpha1
+kind: ActorTemplateVersion
+metadata:
+  name: counter-atv-v2
+actorTemplate:
+  name: counter-atv
+spec:
+  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
+  containers:
+  - name: counter
+    image: ko://github.com/agent-substrate/substrate/demos/counter
+    command:
+    - /ko-app/counter
+    env:
+    - name: VERSION
+      value: v2
     readyz:
       httpGet:
         path: /readyz

--- a/demos/counter/counter-atv.yaml.tmpl
+++ b/demos/counter/counter-atv.yaml.tmpl
@@ -1,0 +1,61 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The counter demo on control-plane-native ActorTemplate/ActorTemplateVersion
+# resources (issue #477) instead of the ate.dev CRDs. Reuses the workers of
+# the CRD counter demo (WorkerPool labeled workload=counter in
+# ate-demo-counter). Applied with:
+#   ko resolve -f - | kubectl ate apply -f -
+# ko resolve pins the ko:// image by digest, which the version spec requires.
+apiVersion: api.ate.dev/v1alpha1
+kind: ActorTemplate
+metadata:
+  name: counter-atv
+spec:
+  workerSelector:
+    matchLabels:
+      workload: counter
+  defaultVersionOnCreate:
+    name: counter-atv-v1
+---
+apiVersion: api.ate.dev/v1alpha1
+kind: ActorTemplateVersion
+metadata:
+  name: counter-atv-v1
+actorTemplate:
+  name: counter-atv
+spec:
+  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
+  containers:
+  - name: counter
+    image: ko://github.com/agent-substrate/substrate/demos/counter
+    command:
+    - /ko-app/counter
+    readyz:
+      httpGet:
+        path: /readyz
+        port: 80
+    volumeMounts:
+    - name: data
+      mountPath: /home/counter
+  volumes:
+  - name: data
+    durableDir: {}
+  snapshotsConfig:
+    onPause: SNAPSHOT_CONTENT_SCOPE_FULL
+    onCommit: SNAPSHOT_CONTENT_SCOPE_DATA
+    storageLocation: gs://${BUCKET_NAME}/ate-demo-counter-atv/
+  sandboxConfig:
+    sandboxClass: SANDBOX_CLASS_GVISOR
+    configName: gvisor-default

--- a/demos/counter/counter.go
+++ b/demos/counter/counter.go
@@ -69,6 +69,13 @@ func main() {
 
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 
+	// The ActorTemplateVersion sets VERSION per version, making an upgrade
+	// visible in the response while the same image serves every version.
+	versionSuffix := ""
+	if v := os.Getenv("VERSION"); v != "" {
+		versionSuffix = fmt.Sprintf(" | version: %s", v)
+	}
+
 	defaultMux := http.NewServeMux()
 	defaultMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -96,7 +103,7 @@ func main() {
 			secondFileCounterStr = fmt.Sprintf(" | preserved second file counter: %d", secondFileCounter)
 		}
 
-		response := fmt.Sprintf("hello from: %s | preserved memory count: %d | preserved file counter: %d%s%s\n", currentIP, memoryCounter, fileCounter, secondFileCounterStr, fileContentStr)
+		response := fmt.Sprintf("hello from: %s%s | preserved memory count: %d | preserved file counter: %d%s%s\n", currentIP, versionSuffix, memoryCounter, fileCounter, secondFileCounterStr, fileContentStr)
 		slog.InfoContext(ctx, "Handled request", slog.String("response", response))
 
 		w.WriteHeader(http.StatusOK)

--- a/docs/dev/counter-e2e-testing.md
+++ b/docs/dev/counter-e2e-testing.md
@@ -1,0 +1,236 @@
+# Counter demo: manual end-to-end testing guide
+
+This guide walks through manually testing the counter template on a fresh GCP
+environment, end to end: provision a cluster, deploy the two-version counter
+demo, drive an actor through suspend/resume, upgrade it to a new
+`ActorTemplateVersion`, roll it back, and clean everything up. Use it to
+verify a build by hand, or as a checklist when reproducing issues.
+
+The counter server ([`demos/counter/counter.go`](../../demos/counter/counter.go))
+keeps two counters — one in process memory, one in a file on a durable
+volume — and echoes both plus its `VERSION` env var on every request. That
+makes each state-preservation property directly observable in curl output.
+
+## 1. Prerequisites
+
+- A GCP project you can create clusters and buckets in.
+- `gcloud` with application-default credentials, `kubectl`, and Go.
+- Images are built automatically with `ko` (fetched via `hack/run-tool.sh`);
+  no manual image builds are needed.
+
+> [!NOTE]
+> macOS ships bash 3.2, which is too old for `install-ate.sh`. Install a
+> current bash (`brew install bash`) and prefix the install commands with
+> `/opt/homebrew/bin/bash`.
+
+## 2. Provision a cluster from scratch
+
+Skip to step 3 if you already have a cluster with Agent Substrate deployed —
+you still need the env file sourced (set `KUBECTL_CONTEXT` there to target an
+existing cluster).
+
+```bash
+# Configure and source the dev environment (PROJECT_ID, CLUSTER_NAME,
+# BUCKET_NAME, KO_DOCKER_REPO are the ones to review).
+cp hack/ate-dev-env.sh.example .ate-dev-env.sh
+$EDITOR .ate-dev-env.sh
+source .ate-dev-env.sh
+
+gcloud auth application-default login --project=${PROJECT_ID}
+
+# Idempotent: enables APIs, creates the GKE cluster and snapshot bucket,
+# and sets up IAM bindings. See tools/setup-gcp/README.md for the pieces.
+go run ./tools/setup-gcp bootstrap
+
+# Build images with ko and deploy the control plane; waits for rollouts.
+./hack/install-ate.sh --deploy-ate-system
+```
+
+## 3. Deploy the two-version counter demo
+
+```bash
+./hack/install-ate.sh --deploy-demo-counter-atv
+```
+
+This deploys the CRD counter demo first (the AT/ATV variant reuses its
+`WorkerPool` and warm node), then applies
+[`demos/counter/counter-atv.yaml.tmpl`](../../demos/counter/counter-atv.yaml.tmpl):
+one `ActorTemplate` (`counter-atv`) and two `ActorTemplateVersion`s
+(`counter-atv-v1`, `counter-atv-v2`) that differ only in the `VERSION` env
+var. The script blocks until both versions' golden snapshots are `STATE_READY`
+— on a cold cluster the first build pays one-time costs (runsc download,
+image pulls), so expect a few minutes.
+
+Install the CLI and confirm what was created:
+
+```bash
+go install ./cmd/kubectl-ate
+
+kubectl ate get actor-templates
+kubectl ate get actor-template-versions --template counter-atv
+```
+
+> [!NOTE]
+> After pulling proto changes, reinstall `kubectl-ate`. A stale binary can
+> fail with confusing wire-level errors (e.g. "invalid page token") against a
+> newer API server.
+
+## 4. Create an actor and drive traffic
+
+```bash
+kubectl ate create atespace demo
+kubectl ate create actor my-counter-1 -a demo --template counter-atv
+```
+
+The actor is pinned to the template's `defaultVersionOnCreate`
+(`counter-atv-v1`). Traffic goes through the atenet router, which is a
+`ClusterIP` service — port-forward it (and keep this running in a separate
+terminal):
+
+```bash
+kubectl port-forward -n ate-system svc/atenet-router 8000:80
+```
+
+This is unrelated to `kubectl ate` itself, which auto-port-forwards to the
+API server (or use `--endpoint` to target it directly).
+
+```bash
+curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" http://localhost:8000
+# hello from: <pod-ip> | version: v1 | preserved memory count: 1 | preserved file counter: 1
+```
+
+The first request activates the actor on demand: it boots from the v1 golden
+snapshot onto an available worker. Confirm:
+
+```bash
+kubectl ate get actor my-counter-1 -a demo -o json
+# "status": "STATUS_RUNNING", "actorTemplateVersion": "counter-atv-v1",
+# "workerAssignment": {...}
+```
+
+## 5. Suspend, resume, and what survives
+
+```bash
+kubectl ate suspend actor my-counter-1 -a demo
+kubectl ate get actor my-counter-1 -a demo -o json
+# "status": "STATUS_SUSPENDED", "latestSnapshot": {...}, no workerAssignment
+```
+
+Either resume explicitly (`kubectl ate resume actor my-counter-1 -a demo`) or
+just send traffic — the router resumes suspended actors on demand:
+
+```bash
+curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" http://localhost:8000
+# hello from: <pod-ip> | version: v1 | preserved memory count: 1 | preserved file counter: 2
+```
+
+What survived is determined by the snapshot scope. This demo's versions set
+`onCommit: SNAPSHOT_CONTENT_SCOPE_DATA`, so a suspend captures only the
+durable volume: the file counter carries over, the memory count restarts. To
+see process memory survive instead, use `pause` — the demo sets `onPause:
+FULL`, which takes a full local snapshot on the worker:
+
+```bash
+kubectl ate pause actor my-counter-1 -a demo
+curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" http://localhost:8000
+# ... | preserved memory count: 2 | preserved file counter: 3   (memory continued)
+```
+
+## 6. Upgrade to v2
+
+An upgrade is a resume with a new version pin. It requires the actor to be
+`SUSPENDED` (or `CRASHED`) — a paused actor's local snapshot is bound to its
+node and image, so it cannot be re-pinned. As a quick self-check, the request
+is rejected while the actor is running:
+
+```bash
+kubectl ate resume actor my-counter-1 -a demo --template-version counter-atv-v2
+# Error: ... FailedPrecondition ... requires STATUS_SUSPENDED or STATUS_CRASHED
+
+kubectl ate suspend actor my-counter-1 -a demo
+kubectl ate resume actor my-counter-1 -a demo --template-version counter-atv-v2
+
+curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" http://localhost:8000
+# hello from: <pod-ip> | version: v2 | preserved memory count: 1 | preserved file counter: 4
+```
+
+The response shows exactly what an upgrade preserves: the durable file
+counter carried over onto the new version, while the memory count restarted —
+a memory snapshot cannot run on a different version's images, so the actor
+cold-boots on v2 and unpacks its durable data. The pin is persisted before the
+resume starts, so a retried or bare resume after a mid-flight failure still
+lands on v2:
+
+```bash
+kubectl ate get actor my-counter-1 -a demo -o json
+# "actorTemplateVersion": "counter-atv-v2"
+```
+
+Re-pins are validated: the target version must exist under the same template
+and be `STATE_READY`, with the same sandbox class and unchanged volumes.
+
+## 7. Roll back to v1
+
+Rolling back is the same operation with the previous version:
+
+```bash
+kubectl ate suspend actor my-counter-1 -a demo
+kubectl ate resume actor my-counter-1 -a demo --template-version counter-atv-v1
+
+curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" http://localhost:8000
+# hello from: <pod-ip> | version: v1 | preserved memory count: 1 | preserved file counter: 5
+```
+
+(The API also exposes the pin via `UpdateActor` with an
+`actor_template_version` field mask, followed by a plain resume; the CLI flag
+does both in one step.)
+
+## 8. Observing and troubleshooting
+
+```bash
+kubectl ate logs actors my-counter-1 -a demo -f   # stream actor logs
+kubectl ate get workers -n ate-demo-counter       # worker pool state
+kubectl ate top workers                           # per-worker utilization
+```
+
+| Symptom | What to check |
+|---|---|
+| Deploy hangs "Waiting for ActorTemplateVersion ... READY" | `kubectl ate get actor-template-versions counter-atv-v1 -o json` — a `STATE_FAILED` build includes a message; `STATE_BUILDING` on a cold cluster just needs time. |
+| Actor is `STATUS_CRASHED` | Crashed actors keep their last committed snapshot and are directly resumable — `kubectl ate resume actor ...` (with or without `--template-version`). |
+| curl: connection refused | The router port-forward dropped; restart it (step 4). |
+| `kubectl ate` wire/parse errors | Stale binary — `go install ./cmd/kubectl-ate` again, or run `go run ./cmd/kubectl-ate ...` from the branch under test. |
+| Deeper state inspection | [Observability guide](../observability.md) for logs/metrics/traces; [valkey direct access](valkey-direct-access.md) to inspect raw actor records. |
+
+## 9. Micro-VM variant
+
+The same counter also runs on the micro-VM sandbox class, which is the
+easiest way to test guest-memory snapshots surviving suspend/resume across
+workers:
+
+```bash
+./hack/run-microvm-demo.sh        # GKE; kind: hack/run-microvm-demo-kind.sh
+```
+
+The script composes `--deploy-ate-system`, the micro-VM asset staging, and
+the `counter-microvm` manifest; then repeat the create/curl/suspend/resume
+loop from steps 4–5 against that template. See the
+[micro-VM section of the demo README](../../demos/counter/README.md#micro-vm-variant).
+
+> [!NOTE]
+> The micro-VM demo still uses the CRD `ActorTemplate`, so the
+> `--template-version` upgrade flow in steps 6–7 does not apply to it.
+
+## 10. Cleanup
+
+```bash
+kubectl ate delete actor my-counter-1 -a demo   # requires SUSPENDED/CRASHED; suspend first
+kubectl ate delete atespace demo                # must be empty
+
+# Suspends and deletes any remaining counter-atv actors, then removes
+# v2, v1 (clearing the template's default), and the template.
+./hack/install-ate.sh --delete-demo-counter-atv
+./hack/install-ate.sh --delete-demo-counter
+
+# Optional: tear down the GCP resources entirely.
+./hack/teardown.sh --all
+```

--- a/hack/install-demo-counter.sh
+++ b/hack/install-demo-counter.sh
@@ -20,13 +20,16 @@ ATE_DEMOS+=(demo-counter) # register demo-counter
 
 demo-counter_usage() {
   echo "  --deploy-demo-counter-with-external-volume    Deploy demo-counter with external volume validation"
+  echo "  --deploy-demo-counter-atv                     Deploy demo-counter on control-plane ActorTemplate/ActorTemplateVersion"
 }
 
 demo-counter_cmdline() {
   case "${1}" in
     --deploy-demo-counter) demo-counter_deploy "false" ;;
     --deploy-demo-counter-with-external-volume) demo-counter_deploy "true" ;;
+    --deploy-demo-counter-atv) demo-counter-atv_deploy ;;
     --delete-demo-counter) demo-counter_delete ;;
+    --delete-demo-counter-atv) demo-counter-atv_delete ;;
     *)
       return 1
       ;;
@@ -64,6 +67,65 @@ demo-counter_deploy() {
   log_step "Waiting for counter demo to be ready..."
   run_kubectl rollout status deployment/counter -n ate-demo-counter --timeout=300s
   run_kubectl wait --for=condition=Ready actortemplate/counter -n ate-demo-counter --timeout=300s
+}
+
+# Deploys the counter demo on control-plane ActorTemplate/ActorTemplateVersion
+# resources. Reuses the CRD demo's WorkerPool (and its warm node), so the CRD
+# demo is deployed first; the AT/ATV manifests then go through ko resolve
+# (digest-pins the ko:// image, as the version spec requires) and
+# kubectl ate apply.
+demo-counter-atv_deploy() {
+  log_step "demo-counter-atv_deploy"
+  demo-counter_deploy "false"
+
+  sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
+      demos/counter/counter-atv.yaml.tmpl \
+    | run_ko resolve -f - \
+    | run_kubectl_ate apply -f -
+
+  log_step "Waiting for ActorTemplateVersion counter-atv-v1 to be READY..."
+  local deadline=$((SECONDS + 300))
+  while true; do
+    local json
+    json="$(run_kubectl_ate get actor-template-versions counter-atv-v1 -o json 2>/dev/null || true)"
+    if grep -q '"state": "STATE_READY"' <<<"${json}"; then
+      break
+    fi
+    if grep -q '"state": "STATE_FAILED"' <<<"${json}"; then
+      echo "ActorTemplateVersion counter-atv-v1 failed to build:" >&2
+      grep '"message"' <<<"${json}" >&2 || true
+      return 1
+    fi
+    if ((SECONDS >= deadline)); then
+      echo "Timed out waiting for ActorTemplateVersion counter-atv-v1 to be READY" >&2
+      return 1
+    fi
+    sleep 5
+  done
+}
+
+demo-counter-atv_delete() {
+  log_step "demo-counter-atv_delete"
+
+  # Native actors carry actorTemplate (global name), not the CRD
+  # namespace/name pair delete_demo_actors filters on.
+  if command -v jq &>/dev/null; then
+    local actors_json atespace actor_name
+    if actors_json=$(run_kubectl_ate get actors -A -o json 2>/dev/null); then
+      while IFS=$'\t' read -r atespace actor_name; do
+        [[ -z "${actor_name}" ]] && continue
+        log_step "  preparing actor ${atespace}/${actor_name} for delete"
+        prepare_actor_for_delete "${actor_name}" "${atespace}"
+        run_kubectl_ate delete actor "${actor_name}" -a "${atespace}"
+      done < <(
+        jq -r '.actors[]? | select(.actorTemplate == "counter-atv") | "\(.metadata.atespace)\t\(.metadata.name)"' \
+          <<<"${actors_json}"
+      )
+    fi
+  fi
+
+  run_kubectl_ate delete actor-template-version counter-atv-v1 --clear-default || true
+  run_kubectl_ate delete actor-template counter-atv || true
 }
 
 demo-counter_delete() {

--- a/hack/install-demo-counter.sh
+++ b/hack/install-demo-counter.sh
@@ -83,21 +83,29 @@ demo-counter-atv_deploy() {
     | run_ko resolve -f - \
     | run_kubectl_ate apply -f -
 
-  log_step "Waiting for ActorTemplateVersion counter-atv-v1 to be READY..."
+  wait_for_template_version_ready counter-atv-v1
+  wait_for_template_version_ready counter-atv-v2
+}
+
+# Polls a control-plane ActorTemplateVersion until its golden snapshot build
+# reaches STATE_READY; fails fast on STATE_FAILED.
+wait_for_template_version_ready() {
+  local version="${1}"
+  log_step "Waiting for ActorTemplateVersion ${version} to be READY..."
   local deadline=$((SECONDS + 300))
   while true; do
     local json
-    json="$(run_kubectl_ate get actor-template-versions counter-atv-v1 -o json 2>/dev/null || true)"
+    json="$(run_kubectl_ate get actor-template-versions "${version}" -o json 2>/dev/null || true)"
     if grep -q '"state": "STATE_READY"' <<<"${json}"; then
       break
     fi
     if grep -q '"state": "STATE_FAILED"' <<<"${json}"; then
-      echo "ActorTemplateVersion counter-atv-v1 failed to build:" >&2
+      echo "ActorTemplateVersion ${version} failed to build:" >&2
       grep '"message"' <<<"${json}" >&2 || true
       return 1
     fi
     if ((SECONDS >= deadline)); then
-      echo "Timed out waiting for ActorTemplateVersion counter-atv-v1 to be READY" >&2
+      echo "Timed out waiting for ActorTemplateVersion ${version} to be READY" >&2
       return 1
     fi
     sleep 5
@@ -124,6 +132,7 @@ demo-counter-atv_delete() {
     fi
   fi
 
+  run_kubectl_ate delete actor-template-version counter-atv-v2 || true
   run_kubectl_ate delete actor-template-version counter-atv-v1 --clear-default || true
   run_kubectl_ate delete actor-template counter-atv || true
 }

--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -23,6 +23,11 @@ const (
 	// The base path.  This is both the path of the root shared folder on the
 	// host filesystem, and when it is mounted into ateom and atelet containers.
 	BasePath = "/var/lib/ateom-gvisor"
+
+	// DurableTarFile is the snapshot file holding the tar of the actor's
+	// durable-dir volumes. Written by the micro-VM ateom at checkpoint; atelet
+	// also names it to stage only the durable data out of a Full snapshot.
+	DurableTarFile = "durable-dir.tar"
 )
 
 var (

--- a/internal/e2e/suites/actortemplate/actortemplate_test.go
+++ b/internal/e2e/suites/actortemplate/actortemplate_test.go
@@ -1,0 +1,687 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package actortemplate exercises the control-plane-native ActorTemplate /
+// ActorTemplateVersion path end-to-end (issue #477): create AT+ATV via the
+// Substrate API, wait for the in-ateapi builder to produce the golden
+// snapshot, run counter actors from the version (pinned and via the
+// template default), and verify the deletion invariants — the same coverage
+// the demo suite has for the CRD path.
+//
+// Like the demo suite, it copies digest-resolved images from the deployed
+// counter demo (ate-demo-counter/counter, overridable via
+// E2E_TEMPLATE_NAMESPACE / E2E_TEMPLATE_NAME), so deploy the demo first:
+// ./hack/install-ate.sh --deploy-demo-counter
+package actortemplate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agent-substrate/substrate/internal/ateclient"
+	"github.com/agent-substrate/substrate/internal/e2e"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+const defaultVersionMaskPath = "spec.default_version_on_create"
+
+// sourceDemo reads the deployed counter demo's WorkerPool and ActorTemplate
+// CRDs, the source of digest-resolved images and the sandbox class.
+func sourceDemo(ctx context.Context, t *testing.T, clients *e2e.Clients) (*v1alpha1.WorkerPool, *v1alpha1.ActorTemplate) {
+	t.Helper()
+	srcNS := "ate-demo-counter"
+	if v := os.Getenv("E2E_TEMPLATE_NAMESPACE"); v != "" {
+		srcNS = v
+	}
+	srcName := "counter"
+	if v := os.Getenv("E2E_TEMPLATE_NAME"); v != "" {
+		srcName = v
+	}
+	wp, err := clients.SubstrateK8s.ApiV1alpha1().WorkerPools(srcNS).Get(ctx, srcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get source WorkerPool %s/%s (deploy the counter demo first): %v", srcNS, srcName, err)
+	}
+	at, err := clients.SubstrateK8s.ApiV1alpha1().ActorTemplates(srcNS).Get(ctx, srcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get source ActorTemplate %s/%s: %v", srcNS, srcName, err)
+	}
+	return wp, at
+}
+
+// containersToProto projects the source CRD containers onto the
+// ActorTemplateVersion spec shape (literal env only).
+func containersToProto(containers []v1alpha1.Container) []*ateapipb.Container {
+	var out []*ateapipb.Container
+	for _, c := range containers {
+		pc := &ateapipb.Container{
+			Name:    c.Name,
+			Image:   c.Image,
+			Command: c.Command,
+			Args:    c.Args,
+		}
+		for _, env := range c.Env {
+			if env.Value != nil {
+				pc.Env = append(pc.Env, &ateapipb.EnvVar{
+					Name:   env.Name,
+					Source: &ateapipb.EnvVar_Value{Value: *env.Value},
+				})
+			}
+		}
+		if c.Readyz != nil && c.Readyz.HTTPGet != nil {
+			pc.Readyz = &ateapipb.ContainerReadyz{
+				TimeoutSeconds: c.Readyz.TimeoutSeconds,
+				HttpGet: &ateapipb.HTTPGetAction{
+					Path: c.Readyz.HTTPGet.Path,
+					Port: c.Readyz.HTTPGet.Port,
+				},
+			}
+		}
+		for _, m := range c.VolumeMounts {
+			pc.VolumeMounts = append(pc.VolumeMounts, &ateapipb.VolumeMount{Name: m.Name, MountPath: m.MountPath})
+		}
+		out = append(out, pc)
+	}
+	return out
+}
+
+func volumesToProto(volumes []v1alpha1.Volume) []*ateapipb.Volume {
+	var out []*ateapipb.Volume
+	for _, v := range volumes {
+		pv := &ateapipb.Volume{Name: v.Name}
+		switch {
+		case v.DurableDir != nil:
+			pv.Source = &ateapipb.Volume_DurableDir{DurableDir: &ateapipb.DurableDirVolumeSource{}}
+		case v.ExternalVolumeTemplate != nil:
+			pv.Source = &ateapipb.Volume_ExternalVolumeTemplate{ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				Capacity:         v.ExternalVolumeTemplate.Capacity.String(),
+				StorageClassName: v.ExternalVolumeTemplate.StorageClassName,
+			}}
+		}
+		out = append(out, pv)
+	}
+	return out
+}
+
+// defaultGvisorSandboxConfigName is the SandboxConfig installed by
+// manifests/ate-install/sandboxconfig-gvisor.yaml.
+const defaultGvisorSandboxConfigName = "gvisor-default"
+
+func sandboxConfigToProto(class v1alpha1.SandboxClass, configName string) *ateapipb.SandboxConfig {
+	protoClass := ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR
+	if class == v1alpha1.SandboxClassMicroVM {
+		protoClass = ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM
+	}
+	// The gvisor demo WorkerPool names no SandboxConfig; the native ATV spec
+	// requires an explicit name.
+	if configName == "" {
+		configName = defaultGvisorSandboxConfigName
+	}
+	return &ateapipb.SandboxConfig{SandboxClass: protoClass, ConfigName: configName}
+}
+
+// nativeTemplate is one AT + ATV pair created for a test, with cleanup of
+// the global-scoped resources registered on t.
+type nativeTemplate struct {
+	template string
+	version  string
+}
+
+// createNativeTemplate creates a per-test WorkerPool CRD plus an
+// ActorTemplate and one ActorTemplateVersion via the Substrate API. The
+// template's worker selector pins it to this test's pool so no other suite's
+// actors land on it (and vice versa).
+func createNativeTemplate(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *e2e.Namespace) *nativeTemplate {
+	t.Helper()
+	env, err := e2e.CheckEnv("BUCKET_NAME")
+	if err != nil {
+		t.Fatalf("CheckEnv failed: %v", err)
+	}
+	srcWP, srcAT := sourceDemo(ctx, t, clients)
+
+	wp := &v1alpha1.WorkerPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "counter-atv",
+			Namespace: nsObj.Name,
+			Labels:    map[string]string{"demo": nsObj.Name},
+		},
+		Spec: v1alpha1.WorkerPoolSpec{
+			Replicas:          5,
+			AteomImage:        srcWP.Spec.AteomImage,
+			SandboxClass:      srcWP.Spec.SandboxClass,
+			SandboxConfigName: srcWP.Spec.SandboxConfigName,
+		},
+	}
+	if _, err := clients.SubstrateK8s.ApiV1alpha1().WorkerPools(nsObj.Name).Create(ctx, wp, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create WorkerPool: %v", err)
+	}
+
+	// AT/ATV are global-scoped; derive globally-unique names from the test
+	// namespace and clean them up explicitly — namespace GC won't.
+	nt := &nativeTemplate{template: nsObj.Name, version: nsObj.Name + "-v1"}
+	if _, err := clients.SubstrateAPI.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: nt.template},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"demo": nsObj.Name}},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+
+	if _, err := clients.SubstrateAPI.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: nt.version},
+			ActorTemplate: &ateapipb.ObjectRef{Name: nt.template},
+			Spec: &ateapipb.ActorTemplateVersionSpec{
+				PauseImage: srcAT.Spec.PauseImage,
+				Containers: containersToProto(srcAT.Spec.Containers),
+				Volumes:    volumesToProto(srcAT.Spec.Volumes),
+				SnapshotsConfig: &ateapipb.SnapshotsConfig{
+					OnPause:         ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
+					OnCommit:        ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
+					StorageLocation: "gs://" + env["BUCKET_NAME"] + "/ate-e2e-atv/" + nsObj.Name + "/",
+				},
+				SandboxConfig: sandboxConfigToProto(srcAT.Spec.SandboxClass, srcWP.Spec.SandboxConfigName),
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+
+	t.Cleanup(func() { cleanupNativeTemplate(t, clients, nt) })
+	return nt
+}
+
+// cleanupNativeTemplate removes the global AT/ATV pair, tolerating partial
+// state: clear the default pin, delete a mid-build golden actor if one is
+// still around, then delete version and template.
+func cleanupNativeTemplate(t *testing.T, clients *e2e.Clients, nt *nativeTemplate) {
+	ctx := context.Background()
+	_, _ = clients.SubstrateAPI.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: nt.template},
+			Spec:     &ateapipb.ActorTemplateSpec{DefaultVersionOnCreate: nil},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{defaultVersionMaskPath}},
+	})
+	if atv, err := clients.SubstrateAPI.GetActorTemplateVersion(ctx, &ateapipb.GetActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ObjectRef{Name: nt.version},
+	}); err == nil {
+		if golden := atv.GetStatus().GetGoldenActor(); golden != nil {
+			_, _ = clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{Actor: golden})
+		}
+	}
+	if _, err := clients.SubstrateAPI.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ObjectRef{Name: nt.version},
+	}); err != nil && status.Code(err) != codes.NotFound {
+		t.Logf("cleanup: DeleteActorTemplateVersion(%s): %v", nt.version, err)
+	}
+	if _, err := clients.SubstrateAPI.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{
+		ActorTemplate: &ateapipb.ObjectRef{Name: nt.template},
+	}); err != nil && status.Code(err) != codes.NotFound {
+		t.Logf("cleanup: DeleteActorTemplate(%s): %v", nt.template, err)
+	}
+}
+
+// waitForVersionReady polls until the builder marks the version READY,
+// failing fast on FAILED with the builder's message.
+func waitForVersionReady(ctx context.Context, t *testing.T, clients *e2e.Clients, version string) *ateapipb.ActorTemplateVersion {
+	t.Helper()
+	timeout := 90 * time.Second
+	if v := os.Getenv("E2E_TEMPLATE_READY_TIMEOUT"); v != "" {
+		d, perr := time.ParseDuration(v)
+		if perr != nil {
+			t.Fatalf("invalid E2E_TEMPLATE_READY_TIMEOUT %q: %v", v, perr)
+		}
+		timeout = d
+	}
+	deadline := time.Now().Add(timeout)
+	var last ateapipb.ActorTemplateVersionStatus_State
+	for time.Now().Before(deadline) {
+		atv, err := clients.SubstrateAPI.GetActorTemplateVersion(ctx, &ateapipb.GetActorTemplateVersionRequest{
+			ActorTemplateVersion: &ateapipb.ObjectRef{Name: version},
+		})
+		if err == nil {
+			last = atv.GetStatus().GetState()
+			switch last {
+			case ateapipb.ActorTemplateVersionStatus_STATE_READY:
+				t.Logf("ActorTemplateVersion %s is READY with golden snapshot %q", version, atv.GetStatus().GetGoldenSnapshot().GetName())
+				return atv
+			case ateapipb.ActorTemplateVersionStatus_STATE_FAILED:
+				t.Fatalf("ActorTemplateVersion %s FAILED: %s", version, atv.GetStatus().GetMessage())
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatalf("timed out after %v waiting for ActorTemplateVersion %s to be READY (last state: %s)", timeout, version, last)
+	return nil
+}
+
+func createAtespace(ctx context.Context, t *testing.T, clients *e2e.Clients, name string) {
+	t.Helper()
+	if _, err := clients.SubstrateAPI.CreateAtespace(ctx, &ateapipb.CreateAtespaceRequest{
+		Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: name}},
+	}); err != nil && status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("CreateAtespace(%s) failed: %v", name, err)
+	}
+}
+
+func waitForActorStatus(ctx context.Context, t *testing.T, clients *e2e.Clients, actorRef resources.ActorRef, expected ateapipb.Actor_Status) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{Actor: actorRef.ToObjectRef()})
+		if err == nil && resp.GetStatus() == expected {
+			return
+		}
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatalf("timed out waiting for actor %s to reach %v", actorRef, expected)
+}
+
+func validateCounterResponse(t *testing.T, resp, stage string, wantMemory, wantFile int) {
+	t.Helper()
+	if !strings.Contains(resp, fmt.Sprintf("preserved memory count: %d", wantMemory)) {
+		t.Errorf("[%s] expected memory count %d, got response: %s", stage, wantMemory, resp)
+	}
+	if !strings.Contains(resp, fmt.Sprintf("preserved file counter: %d", wantFile)) {
+		t.Errorf("[%s] expected file count %d, got response: %s", stage, wantFile, resp)
+	}
+}
+
+// callActor sends one HTTP request to the actor through an atenet-router
+// pod, retrying while routing converges. Ported from the demo suite.
+func callActor(t *testing.T, actorRef resources.ActorRef) (string, error) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := callActorOnce(t, actorRef)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		time.Sleep(1 * time.Second)
+	}
+	return "", fmt.Errorf("timed out waiting for actor response: %w", lastErr)
+}
+
+func callActorOnce(t *testing.T, actorRef resources.ActorRef) (string, error) {
+	t.Helper()
+	clients := e2e.GetClients()
+
+	svc, err := clients.K8s.CoreV1().Services("ate-system").Get(context.Background(), "atenet-router", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get atenet-router service: %w", err)
+	}
+	selector := labels.SelectorFromSet(svc.Spec.Selector).String()
+	pods, err := clients.K8s.CoreV1().Pods("ate-system").List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return "", fmt.Errorf("failed to list atenet-router pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no atenet-router pods found")
+	}
+	targetPod := pods.Items[0]
+
+	config, err := ateclient.LoadConfig(e2e.KubeConfig, e2e.KubeContext)
+	if err != nil {
+		return "", fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+	reqConfig := clients.K8s.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(targetPod.Namespace).
+		Name(targetPod.Name).
+		SubResource("portforward")
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return "", fmt.Errorf("failed to create SPDY transport: %w", err)
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, reqConfig.URL())
+
+	stopCh := make(chan struct{})
+	readyCh := make(chan struct{})
+	defer close(stopCh)
+	fw, err := portforward.New(dialer, []string{"0:8080"}, stopCh, readyCh, io.Discard, io.Discard)
+	if err != nil {
+		return "", fmt.Errorf("failed to create port forwarder: %w", err)
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		if err := fw.ForwardPorts(); err != nil {
+			errCh <- err
+		}
+	}()
+	select {
+	case <-readyCh:
+	case err := <-errCh:
+		return "", fmt.Errorf("port forwarding failed: %w", err)
+	case <-time.After(10 * time.Second):
+		return "", fmt.Errorf("timeout waiting for port-forward")
+	}
+	forwardedPorts, err := fw.GetPorts()
+	if err != nil || len(forwardedPorts) == 0 {
+		return "", fmt.Errorf("failed to get forwarded ports: %w", err)
+	}
+
+	reqHTTP, err := http.NewRequest("POST", fmt.Sprintf("http://127.0.0.1:%d", forwardedPorts[0].Local), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	reqHTTP.Host = actorRef.DNSName()
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	resp, err := httpClient.Do(reqHTTP)
+	if err != nil {
+		return "", fmt.Errorf("failed to do request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+	return string(body), nil
+}
+
+// TestActorTemplateVersionBuildAndLifecycle drives the whole native path:
+// AT+ATV creation, golden-snapshot build, actor creation pinned and via the
+// template default, live traffic, and suspend/resume + pause/resume state
+// preservation.
+func TestActorTemplateVersionBuildAndLifecycle(t *testing.T) {
+	ctx := context.Background()
+	clients := e2e.GetClients()
+	nsObj := e2e.CreateNamespace(t)
+
+	nt := createNativeTemplate(ctx, t, clients, nsObj)
+	ready := waitForVersionReady(ctx, t, clients, nt.version)
+
+	// The golden snapshot must resolve to a stored ActorSnapshot in the
+	// reserved golden atespace.
+	golden := ready.GetStatus().GetGoldenSnapshot()
+	if golden.GetAtespace() != resources.GoldenActorAtespace {
+		t.Errorf("golden snapshot atespace = %q, want %s", golden.GetAtespace(), resources.GoldenActorAtespace)
+	}
+	if _, err := clients.SubstrateAPI.GetActorSnapshot(ctx, &ateapipb.GetActorSnapshotRequest{
+		Snapshot: &ateapipb.ActorSnapshotRef{Reference: &ateapipb.ActorSnapshotRef_Snapshot{Snapshot: golden}},
+	}); err != nil {
+		t.Errorf("golden snapshot %v not resolvable: %v", golden, err)
+	}
+
+	atespace := nsObj.Name
+	createAtespace(ctx, t, clients, atespace)
+
+	// Pinned create.
+	pinnedRef := resources.ActorRef{Atespace: atespace, Name: "counter-pinned"}
+	pinned, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:             &ateapipb.ResourceMetadata{Atespace: atespace, Name: pinnedRef.Name},
+		ActorTemplate:        nt.template,
+		ActorTemplateVersion: nt.version,
+	}})
+	if err != nil {
+		t.Fatalf("CreateActor(pinned) failed: %v", err)
+	}
+	defer clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{Actor: pinnedRef.ToObjectRef()})
+	if pinned.GetActorTemplateNamespace() != "" || pinned.GetActorTemplateName() != "" {
+		t.Errorf("native actor carries CRD identity (%q, %q), want empty", pinned.GetActorTemplateNamespace(), pinned.GetActorTemplateName())
+	}
+
+	// Unpinned create resolves the template default once one is set.
+	if _, err := clients.SubstrateAPI.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: nt.template},
+			Spec:     &ateapipb.ActorTemplateSpec{DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: nt.version}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{defaultVersionMaskPath}},
+	}); err != nil {
+		t.Fatalf("UpdateActorTemplate(default) failed: %v", err)
+	}
+	defaultedRef := resources.ActorRef{Atespace: atespace, Name: "counter-defaulted"}
+	defaulted, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: atespace, Name: defaultedRef.Name},
+		ActorTemplate: nt.template,
+	}})
+	if err != nil {
+		t.Fatalf("CreateActor(via default) failed: %v", err)
+	}
+	defer clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{Actor: defaultedRef.ToObjectRef()})
+	if defaulted.GetActorTemplateVersion() != nt.version {
+		t.Errorf("default resolution stored version %q, want %q", defaulted.GetActorTemplateVersion(), nt.version)
+	}
+
+	// Resume from the golden snapshot and serve traffic.
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: pinnedRef.ToObjectRef()}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, pinnedRef, ateapipb.Actor_STATUS_RUNNING)
+	resp, err := callActor(t, pinnedRef)
+	if err != nil {
+		t.Fatalf("callActor failed: %v", err)
+	}
+	validateCounterResponse(t, resp, "initial", 1, 1)
+
+	// Suspend/resume: FULL commit snapshots preserve memory and files.
+	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: pinnedRef.ToObjectRef()}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, pinnedRef, ateapipb.Actor_STATUS_SUSPENDED)
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: pinnedRef.ToObjectRef()}); err != nil {
+		t.Fatalf("ResumeActor after suspend failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, pinnedRef, ateapipb.Actor_STATUS_RUNNING)
+	resp, err = callActor(t, pinnedRef)
+	if err != nil {
+		t.Fatalf("callActor after suspend/resume failed: %v", err)
+	}
+	validateCounterResponse(t, resp, "after suspend/resume", 2, 2)
+
+	// Pause/resume preserves the local snapshot state the same way.
+	if _, err := clients.SubstrateAPI.PauseActor(ctx, &ateapipb.PauseActorRequest{Actor: pinnedRef.ToObjectRef()}); err != nil {
+		t.Fatalf("PauseActor failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, pinnedRef, ateapipb.Actor_STATUS_PAUSED)
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: pinnedRef.ToObjectRef()}); err != nil {
+		t.Fatalf("ResumeActor after pause failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, pinnedRef, ateapipb.Actor_STATUS_RUNNING)
+	resp, err = callActor(t, pinnedRef)
+	if err != nil {
+		t.Fatalf("callActor after pause/resume failed: %v", err)
+	}
+	validateCounterResponse(t, resp, "after pause/resume", 3, 3)
+
+	// Suspend before delete so the actor is deletable.
+	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: pinnedRef.ToObjectRef()}); err != nil {
+		t.Fatalf("final SuspendActor failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, pinnedRef, ateapipb.Actor_STATUS_SUSPENDED)
+}
+
+// TestActorTemplateVersionGating verifies CreateActor's native-path
+// preconditions: no default, non-READY version, missing parents.
+func TestActorTemplateVersionGating(t *testing.T) {
+	ctx := context.Background()
+	clients := e2e.GetClients()
+	nsObj := e2e.CreateNamespace(t)
+
+	atespace := nsObj.Name
+	createAtespace(ctx, t, clients, atespace)
+
+	// A template with a selector matching no pool: its version never
+	// becomes READY within this test.
+	nt := &nativeTemplate{template: nsObj.Name + "-gate", version: nsObj.Name + "-gate-v1"}
+	if _, err := clients.SubstrateAPI.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: nt.template},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"demo": nsObj.Name + "-nopool"}},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	t.Cleanup(func() { cleanupNativeTemplate(t, clients, nt) })
+
+	// No pin and no default.
+	_, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: atespace, Name: "no-default"},
+		ActorTemplate: nt.template,
+	}})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("CreateActor without default = %v, want FailedPrecondition", err)
+	}
+
+	// Version exists but is not READY.
+	_, srcAT := sourceDemo(ctx, t, clients)
+	if _, err := clients.SubstrateAPI.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: nt.version},
+			ActorTemplate: &ateapipb.ObjectRef{Name: nt.template},
+			Spec: &ateapipb.ActorTemplateVersionSpec{
+				PauseImage: srcAT.Spec.PauseImage,
+				SnapshotsConfig: &ateapipb.SnapshotsConfig{
+					StorageLocation: "gs://e2e-fake-bucket/ate-e2e-atv/" + nsObj.Name + "/",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+	_, err = clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:             &ateapipb.ResourceMetadata{Atespace: atespace, Name: "not-ready"},
+		ActorTemplate:        nt.template,
+		ActorTemplateVersion: nt.version,
+	}})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("CreateActor with non-READY version = %v, want FailedPrecondition", err)
+	}
+
+	// Missing template, and a version under a nonexistent template.
+	_, err = clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: atespace, Name: "no-template"},
+		ActorTemplate: nsObj.Name + "-does-not-exist",
+	}})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("CreateActor with missing template = %v, want FailedPrecondition", err)
+	}
+	_, err = clients.SubstrateAPI.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: nsObj.Name + "-orphan-v1"},
+			ActorTemplate: &ateapipb.ObjectRef{Name: nsObj.Name + "-does-not-exist"},
+			Spec: &ateapipb.ActorTemplateVersionSpec{
+				PauseImage:      srcAT.Spec.PauseImage,
+				SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://e2e-fake-bucket/orphan/"},
+			},
+		},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("CreateActorTemplateVersion under missing template = %v, want FailedPrecondition", err)
+	}
+}
+
+// TestActorTemplateDeletionInvariants verifies the deletion ordering rules:
+// no template delete while versions exist, no version delete while it is the
+// default.
+func TestActorTemplateDeletionInvariants(t *testing.T) {
+	ctx := context.Background()
+	clients := e2e.GetClients()
+	nsObj := e2e.CreateNamespace(t)
+
+	_, srcAT := sourceDemo(ctx, t, clients)
+	nt := &nativeTemplate{template: nsObj.Name + "-del", version: nsObj.Name + "-del-v1"}
+	if _, err := clients.SubstrateAPI.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: nt.template},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"demo": nsObj.Name + "-nopool"}},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	t.Cleanup(func() { cleanupNativeTemplate(t, clients, nt) })
+	if _, err := clients.SubstrateAPI.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+			Metadata:      &ateapipb.ResourceMetadata{Name: nt.version},
+			ActorTemplate: &ateapipb.ObjectRef{Name: nt.template},
+			Spec: &ateapipb.ActorTemplateVersionSpec{
+				PauseImage:      srcAT.Spec.PauseImage,
+				SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://e2e-fake-bucket/ate-e2e-del/" + nsObj.Name + "/"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplateVersion failed: %v", err)
+	}
+
+	// Template delete is blocked while a version exists.
+	if _, err := clients.SubstrateAPI.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{
+		ActorTemplate: &ateapipb.ObjectRef{Name: nt.template},
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("DeleteActorTemplate with versions = %v, want FailedPrecondition", err)
+	}
+
+	// Version delete is blocked while it is the default.
+	if _, err := clients.SubstrateAPI.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: nt.template},
+			Spec:     &ateapipb.ActorTemplateSpec{DefaultVersionOnCreate: &ateapipb.ObjectRef{Name: nt.version}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{defaultVersionMaskPath}},
+	}); err != nil {
+		t.Fatalf("UpdateActorTemplate(default) failed: %v", err)
+	}
+	if _, err := clients.SubstrateAPI.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ObjectRef{Name: nt.version},
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("DeleteActorTemplateVersion while default = %v, want FailedPrecondition", err)
+	}
+
+	// Clearing the default unblocks the version, then the template.
+	if _, err := clients.SubstrateAPI.UpdateActorTemplate(ctx, &ateapipb.UpdateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: nt.template},
+			Spec:     &ateapipb.ActorTemplateSpec{DefaultVersionOnCreate: nil},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{defaultVersionMaskPath}},
+	}); err != nil {
+		t.Fatalf("UpdateActorTemplate(clear default) failed: %v", err)
+	}
+	if _, err := clients.SubstrateAPI.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{
+		ActorTemplateVersion: &ateapipb.ObjectRef{Name: nt.version},
+	}); err != nil {
+		t.Fatalf("DeleteActorTemplateVersion after clearing default failed: %v", err)
+	}
+	if _, err := clients.SubstrateAPI.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{
+		ActorTemplate: &ateapipb.ObjectRef{Name: nt.template},
+	}); err != nil {
+		t.Fatalf("DeleteActorTemplate after versions removed failed: %v", err)
+	}
+}

--- a/internal/e2e/suites/actortemplate/actortemplate_test.go
+++ b/internal/e2e/suites/actortemplate/actortemplate_test.go
@@ -412,6 +412,215 @@ func callActorOnce(t *testing.T, actorRef resources.ActorRef) (string, error) {
 	return string(body), nil
 }
 
+// withVersionEnv appends a VERSION env var to every container, so the
+// counter's response identifies which version served it.
+func withVersionEnv(containers []*ateapipb.Container, version string) []*ateapipb.Container {
+	for _, c := range containers {
+		c.Env = append(c.Env, &ateapipb.EnvVar{Name: "VERSION", Source: &ateapipb.EnvVar_Value{Value: version}})
+	}
+	return containers
+}
+
+// createUpgradeTemplate creates a WorkerPool, an ActorTemplate, and two
+// versions differing only by their VERSION env var, committing DATA
+// snapshots: an upgrade restore is data-only by design, so this template
+// shape shows exactly what the upgrade preserves (durable files) and what it
+// restarts (memory).
+func createUpgradeTemplate(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *e2e.Namespace) (nt *nativeTemplate, v2 string) {
+	t.Helper()
+	env, err := e2e.CheckEnv("BUCKET_NAME")
+	if err != nil {
+		t.Fatalf("CheckEnv failed: %v", err)
+	}
+	srcWP, srcAT := sourceDemo(ctx, t, clients)
+
+	wp := &v1alpha1.WorkerPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "counter-upgrade",
+			Namespace: nsObj.Name,
+			Labels:    map[string]string{"demo": nsObj.Name},
+		},
+		Spec: v1alpha1.WorkerPoolSpec{
+			Replicas:          5,
+			AteomImage:        srcWP.Spec.AteomImage,
+			SandboxClass:      srcWP.Spec.SandboxClass,
+			SandboxConfigName: srcWP.Spec.SandboxConfigName,
+		},
+	}
+	if _, err := clients.SubstrateK8s.ApiV1alpha1().WorkerPools(nsObj.Name).Create(ctx, wp, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create WorkerPool: %v", err)
+	}
+
+	nt = &nativeTemplate{template: nsObj.Name, version: nsObj.Name + "-v1"}
+	v2 = nsObj.Name + "-v2"
+	if _, err := clients.SubstrateAPI.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{Name: nt.template},
+			Spec: &ateapipb.ActorTemplateSpec{
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"demo": nsObj.Name}},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	// Registered before the v2 cleanup below, so (LIFO) v2 is deleted first
+	// and the template delete does not trip the versions-exist invariant.
+	t.Cleanup(func() { cleanupNativeTemplate(t, clients, nt) })
+
+	for _, v := range []struct{ name, label string }{{nt.version, "v1"}, {v2, "v2"}} {
+		if _, err := clients.SubstrateAPI.CreateActorTemplateVersion(ctx, &ateapipb.CreateActorTemplateVersionRequest{
+			ActorTemplateVersion: &ateapipb.ActorTemplateVersion{
+				Metadata:      &ateapipb.ResourceMetadata{Name: v.name},
+				ActorTemplate: &ateapipb.ObjectRef{Name: nt.template},
+				Spec: &ateapipb.ActorTemplateVersionSpec{
+					PauseImage: srcAT.Spec.PauseImage,
+					Containers: withVersionEnv(containersToProto(srcAT.Spec.Containers), v.label),
+					Volumes:    volumesToProto(srcAT.Spec.Volumes),
+					SnapshotsConfig: &ateapipb.SnapshotsConfig{
+						OnPause:         ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
+						OnCommit:        ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA,
+						StorageLocation: "gs://" + env["BUCKET_NAME"] + "/ate-e2e-upgrade/" + nsObj.Name + "/",
+					},
+					SandboxConfig: sandboxConfigToProto(srcAT.Spec.SandboxClass, srcWP.Spec.SandboxConfigName),
+				},
+			},
+		}); err != nil {
+			t.Fatalf("CreateActorTemplateVersion(%s) failed: %v", v.name, err)
+		}
+	}
+	t.Cleanup(func() {
+		ctx := context.Background()
+		if atv, err := clients.SubstrateAPI.GetActorTemplateVersion(ctx, &ateapipb.GetActorTemplateVersionRequest{
+			ActorTemplateVersion: &ateapipb.ObjectRef{Name: v2},
+		}); err == nil {
+			if golden := atv.GetStatus().GetGoldenActor(); golden != nil {
+				_, _ = clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{Actor: golden})
+			}
+		}
+		if _, err := clients.SubstrateAPI.DeleteActorTemplateVersion(ctx, &ateapipb.DeleteActorTemplateVersionRequest{
+			ActorTemplateVersion: &ateapipb.ObjectRef{Name: v2},
+		}); err != nil && status.Code(err) != codes.NotFound {
+			t.Logf("cleanup: DeleteActorTemplateVersion(%s): %v", v2, err)
+		}
+	})
+	return nt, v2
+}
+
+func validateVersionedResponse(t *testing.T, resp, stage, wantVersion string, wantMemory, wantFile int) {
+	t.Helper()
+	validateCounterResponse(t, resp, stage, wantMemory, wantFile)
+	if !strings.Contains(resp, "version: "+wantVersion) {
+		t.Errorf("[%s] expected version %s, got response: %s", stage, wantVersion, resp)
+	}
+}
+
+// TestActorUpgradeOnResume drives the M2 upgrade primitive end to end:
+// resume with a target version re-pins the actor and restores its durable
+// data under the new version's spec (memory restarts — DATA commits cold
+// boot), a running actor cannot be re-pinned, and reverting the pin via
+// UpdateActor plus a plain resume rolls back. Requires a deployed counter
+// demo image that echoes the VERSION env var.
+//
+// Two golden snapshot builds run back to back; on a cold cluster raise
+// E2E_TEMPLATE_READY_TIMEOUT accordingly.
+func TestActorUpgradeOnResume(t *testing.T) {
+	ctx := context.Background()
+	clients := e2e.GetClients()
+	nsObj := e2e.CreateNamespace(t)
+
+	nt, v2 := createUpgradeTemplate(ctx, t, clients, nsObj)
+	waitForVersionReady(ctx, t, clients, nt.version)
+	waitForVersionReady(ctx, t, clients, v2)
+
+	atespace := nsObj.Name
+	createAtespace(ctx, t, clients, atespace)
+
+	actorRef := resources.ActorRef{Atespace: atespace, Name: "counter-upgrade"}
+	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:             &ateapipb.ResourceMetadata{Atespace: atespace, Name: actorRef.Name},
+		ActorTemplate:        nt.template,
+		ActorTemplateVersion: nt.version,
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	defer clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{Actor: actorRef.ToObjectRef()})
+
+	// v1 serves traffic.
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef.ToObjectRef()}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, actorRef, ateapipb.Actor_STATUS_RUNNING)
+	resp, err := callActor(t, actorRef)
+	if err != nil {
+		t.Fatalf("callActor failed: %v", err)
+	}
+	validateVersionedResponse(t, resp, "on v1", "v1", 1, 1)
+
+	// A running actor cannot be re-pinned.
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor:                actorRef.ToObjectRef(),
+		ActorTemplateVersion: v2,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("ResumeActor(version) on RUNNING actor = %v, want FailedPrecondition", err)
+	}
+
+	// Upgrade: suspend, then resume onto v2. The durable file counter
+	// carries over; the memory count restarts with the cold boot.
+	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef.ToObjectRef()}); err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, actorRef, ateapipb.Actor_STATUS_SUSPENDED)
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor:                actorRef.ToObjectRef(),
+		ActorTemplateVersion: v2,
+	}); err != nil {
+		t.Fatalf("ResumeActor(upgrade to %s) failed: %v", v2, err)
+	}
+	waitForActorStatus(ctx, t, clients, actorRef, ateapipb.Actor_STATUS_RUNNING)
+	upgraded, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{Actor: actorRef.ToObjectRef()})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if got := upgraded.GetActorTemplateVersion(); got != v2 {
+		t.Errorf("actor pin after upgrade = %q, want %q", got, v2)
+	}
+	resp, err = callActor(t, actorRef)
+	if err != nil {
+		t.Fatalf("callActor after upgrade failed: %v", err)
+	}
+	validateVersionedResponse(t, resp, "after upgrade", "v2", 1, 2)
+
+	// Rollback via the UpdateActor primitive: revert the pin, plain resume.
+	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef.ToObjectRef()}); err != nil {
+		t.Fatalf("SuspendActor before rollback failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, actorRef, ateapipb.Actor_STATUS_SUSPENDED)
+	if _, err := clients.SubstrateAPI.UpdateActor(ctx, &ateapipb.UpdateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:             &ateapipb.ResourceMetadata{Atespace: atespace, Name: actorRef.Name},
+			ActorTemplateVersion: nt.version,
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"actor_template_version"}},
+	}); err != nil {
+		t.Fatalf("UpdateActor(rollback pin) failed: %v", err)
+	}
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef.ToObjectRef()}); err != nil {
+		t.Fatalf("ResumeActor after rollback failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, actorRef, ateapipb.Actor_STATUS_RUNNING)
+	resp, err = callActor(t, actorRef)
+	if err != nil {
+		t.Fatalf("callActor after rollback failed: %v", err)
+	}
+	validateVersionedResponse(t, resp, "after rollback", "v1", 1, 3)
+
+	// Suspend before delete so the actor is deletable.
+	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: actorRef.ToObjectRef()}); err != nil {
+		t.Fatalf("final SuspendActor failed: %v", err)
+	}
+	waitForActorStatus(ctx, t, clients, actorRef, ateapipb.Actor_STATUS_SUSPENDED)
+}
+
 // TestActorTemplateVersionBuildAndLifecycle drives the whole native path:
 // AT+ATV creation, golden-snapshot build, actor creation pinned and via the
 // template default, live traffic, and suspend/resume + pause/resume state

--- a/internal/e2e/suites/actortemplate/testmain_test.go
+++ b/internal/e2e/suites/actortemplate/testmain_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actortemplate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/agent-substrate/substrate/internal/e2e"
+)
+
+func TestMain(m *testing.M) { os.Exit(e2e.RunTestMain(m)) }

--- a/internal/proto/ateletpb/atelet.pb.go
+++ b/internal/proto/ateletpb/atelet.pb.go
@@ -1515,9 +1515,9 @@ type RestoreRequest struct {
 	ActorUid               string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
 	ActorTemplateNamespace string                 `protobuf:"bytes,5,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
 	ActorTemplateName      string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	// Sandbox binary config is not sent on restore: the snapshot is
-	// self-describing. atelet reads the snapshot manifest to recover the pinned
-	// sandbox version that created it.
+	// For FULL and DATA_ON_GOLDEN restores the snapshot is self-describing:
+	// atelet reads the snapshot manifest to recover the pinned sandbox version
+	// that created it. DATA restores may override it via sandbox_assets.
 	Spec *WorkloadSpec  `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
 	Type CheckpointType `protobuf:"varint,8,opt,name=type,proto3,enum=atelet.CheckpointType" json:"type,omitempty"`
 	// The checkpoint configuration, depending on the type.
@@ -1538,6 +1538,12 @@ type RestoreRequest struct {
 	GoldenSnapshotUri string `protobuf:"bytes,12,opt,name=golden_snapshot_uri,json=goldenSnapshotUri,proto3" json:"golden_snapshot_uri,omitempty"`
 	// When absent, actor traffic uses direct egress instead of atunnel.
 	EgressGateway *EgressGateway `protobuf:"bytes,13,opt,name=egress_gateway,json=egressGateway,proto3,oneof" json:"egress_gateway,omitempty"`
+	// Sandbox binaries for the restored actor. Only honored when scope is
+	// SNAPSHOT_SCOPE_DATA (a cold boot, so nothing couples the memory image to
+	// the binaries): overrides the snapshot manifest's pinned set, letting a
+	// re-pinned actor cold-boot on its new version's sandbox. Invalid for FULL
+	// and DATA_ON_GOLDEN, where the manifest (or golden manifest) must win.
+	SandboxAssets *SandboxAssets `protobuf:"bytes,14,opt,name=sandbox_assets,json=sandboxAssets,proto3" json:"sandbox_assets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1670,6 +1676,13 @@ func (x *RestoreRequest) GetGoldenSnapshotUri() string {
 func (x *RestoreRequest) GetEgressGateway() *EgressGateway {
 	if x != nil {
 		return x.EgressGateway
+	}
+	return nil
+}
+
+func (x *RestoreRequest) GetSandboxAssets() *SandboxAssets {
+	if x != nil {
+		return x.SandboxAssets
 	}
 	return nil
 }
@@ -1831,7 +1844,7 @@ const file_atelet_proto_rawDesc = "" +
 	" \x01(\v2'.atelet.ExternalCheckpointConfigurationH\x00R\x0eexternalConfig\x12+\n" +
 	"\x05scope\x18\v \x01(\x0e2\x15.atelet.SnapshotScopeR\x05scopeB\b\n" +
 	"\x06config\"\x14\n" +
-	"\x12CheckpointResponse\"\xae\x05\n" +
+	"\x12CheckpointResponse\"\xec\x05\n" +
 	"\x0eRestoreRequest\x12(\n" +
 	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
 	"\batespace\x18\x02 \x01(\tR\batespace\x12\x1d\n" +
@@ -1847,7 +1860,8 @@ const file_atelet_proto_rawDesc = "" +
 	" \x01(\v2'.atelet.ExternalCheckpointConfigurationH\x00R\x0eexternalConfig\x12+\n" +
 	"\x05scope\x18\v \x01(\x0e2\x15.atelet.SnapshotScopeR\x05scope\x12.\n" +
 	"\x13golden_snapshot_uri\x18\f \x01(\tR\x11goldenSnapshotUri\x12A\n" +
-	"\x0eegress_gateway\x18\r \x01(\v2\x15.atelet.EgressGatewayH\x01R\regressGateway\x88\x01\x01B\b\n" +
+	"\x0eegress_gateway\x18\r \x01(\v2\x15.atelet.EgressGatewayH\x01R\regressGateway\x88\x01\x01\x12<\n" +
+	"\x0esandbox_assets\x18\x0e \x01(\v2\x15.atelet.SandboxAssetsR\rsandboxAssetsB\b\n" +
 	"\x06configB\x11\n" +
 	"\x0f_egress_gateway\"\x11\n" +
 	"\x0fRestoreResponse*`\n" +
@@ -1945,21 +1959,22 @@ var file_atelet_proto_depIdxs = []int32{
 	21, // 23: atelet.RestoreRequest.external_config:type_name -> atelet.ExternalCheckpointConfiguration
 	2,  // 24: atelet.RestoreRequest.scope:type_name -> atelet.SnapshotScope
 	6,  // 25: atelet.RestoreRequest.egress_gateway:type_name -> atelet.EgressGateway
-	7,  // 26: atelet.ArchAssets.FilesEntry.value:type_name -> atelet.AssetFile
-	8,  // 27: atelet.SandboxAssets.AssetsEntry.value:type_name -> atelet.ArchAssets
-	3,  // 28: atelet.CredentialBroker.MintActorCertificate:input_type -> atelet.MintActorCertificateRequest
-	5,  // 29: atelet.AteomHerder.Run:input_type -> atelet.RunRequest
-	22, // 30: atelet.AteomHerder.Checkpoint:input_type -> atelet.CheckpointRequest
-	24, // 31: atelet.AteomHerder.Restore:input_type -> atelet.RestoreRequest
-	4,  // 32: atelet.CredentialBroker.MintActorCertificate:output_type -> atelet.MintActorCertificateResponse
-	19, // 33: atelet.AteomHerder.Run:output_type -> atelet.RunResponse
-	23, // 34: atelet.AteomHerder.Checkpoint:output_type -> atelet.CheckpointResponse
-	25, // 35: atelet.AteomHerder.Restore:output_type -> atelet.RestoreResponse
-	32, // [32:36] is the sub-list for method output_type
-	28, // [28:32] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	9,  // 26: atelet.RestoreRequest.sandbox_assets:type_name -> atelet.SandboxAssets
+	7,  // 27: atelet.ArchAssets.FilesEntry.value:type_name -> atelet.AssetFile
+	8,  // 28: atelet.SandboxAssets.AssetsEntry.value:type_name -> atelet.ArchAssets
+	3,  // 29: atelet.CredentialBroker.MintActorCertificate:input_type -> atelet.MintActorCertificateRequest
+	5,  // 30: atelet.AteomHerder.Run:input_type -> atelet.RunRequest
+	22, // 31: atelet.AteomHerder.Checkpoint:input_type -> atelet.CheckpointRequest
+	24, // 32: atelet.AteomHerder.Restore:input_type -> atelet.RestoreRequest
+	4,  // 33: atelet.CredentialBroker.MintActorCertificate:output_type -> atelet.MintActorCertificateResponse
+	19, // 34: atelet.AteomHerder.Run:output_type -> atelet.RunResponse
+	23, // 35: atelet.AteomHerder.Checkpoint:output_type -> atelet.CheckpointResponse
+	25, // 36: atelet.AteomHerder.Restore:output_type -> atelet.RestoreResponse
+	33, // [33:37] is the sub-list for method output_type
+	29, // [29:33] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_atelet_proto_init() }

--- a/internal/proto/ateletpb/atelet.proto
+++ b/internal/proto/ateletpb/atelet.proto
@@ -260,9 +260,9 @@ message RestoreRequest {
   string actor_template_namespace = 5;
   string actor_template_name = 6;
 
-  // Sandbox binary config is not sent on restore: the snapshot is
-  // self-describing. atelet reads the snapshot manifest to recover the pinned
-  // sandbox version that created it.
+  // For FULL and DATA_ON_GOLDEN restores the snapshot is self-describing:
+  // atelet reads the snapshot manifest to recover the pinned sandbox version
+  // that created it. DATA restores may override it via sandbox_assets.
   WorkloadSpec spec = 7;
 
   CheckpointType type = 8;
@@ -286,6 +286,13 @@ message RestoreRequest {
 
   // When absent, actor traffic uses direct egress instead of atunnel.
   optional EgressGateway egress_gateway = 13;
+
+  // Sandbox binaries for the restored actor. Only honored when scope is
+  // SNAPSHOT_SCOPE_DATA (a cold boot, so nothing couples the memory image to
+  // the binaries): overrides the snapshot manifest's pinned set, letting a
+  // re-pinned actor cold-boot on its new version's sandbox. Invalid for FULL
+  // and DATA_ON_GOLDEN, where the manifest (or golden manifest) must win.
+  SandboxAssets sandbox_assets = 14;
 }
 
 message RestoreResponse {

--- a/internal/resources/validate.go
+++ b/internal/resources/validate.go
@@ -127,6 +127,36 @@ func ValidateGlobalObjectRef(ref *ateapipb.ObjectRef, fldPath *field.Path) field
 	return errs
 }
 
+// ValidateGlobalResourceMetadataRef checks the metadata a mutating request
+// uses to name the global-scoped resource it acts on: name identifies the
+// resource and is required, atespace must be empty (global resources do not
+// belong to an atespace), and uid and version are optional preconditions.
+// Like ValidateResourceMetadataRef, nil metadata is an error rather than a
+// no-op: a request that names no resource cannot be served.
+func ValidateGlobalResourceMetadataRef(meta *ateapipb.ResourceMetadata, fldPath *field.Path) field.ErrorList {
+	var errs field.ErrorList
+
+	if val, fldPath := meta.GetAtespace(), fldPath.Child("atespace"); val != "" {
+		errs = append(errs, field.Invalid(fldPath, val, "must be empty for a global-scoped resource"))
+	}
+
+	if val, fldPath := meta.GetName(), fldPath.Child("name"); val == "" {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, ValidateResourceName(val, fldPath)...)
+	}
+
+	if val, fldPath := meta.GetUid(), fldPath.Child("uid"); val != "" {
+		errs = append(errs, ValidateUUID(val, fldPath)...)
+	}
+
+	if val, fldPath := meta.GetVersion(), fldPath.Child("version"); val < 0 {
+		errs = append(errs, field.Invalid(fldPath, val, "must not be negative"))
+	}
+
+	return errs
+}
+
 // ValidateAteomUID rejects a target ateom pod UID that could escape the host
 // paths built from it: the netns path (/run/netns/ateom:<uid>) and the ateom
 // control socket (.../ateoms/<uid>/ateom.sock). Kubernetes pod UIDs are UUIDs,

--- a/internal/resources/validate_test.go
+++ b/internal/resources/validate_test.go
@@ -198,6 +198,64 @@ func TestValidateGlobalObjectRef(t *testing.T) {
 	}
 }
 
+func TestValidateGlobalResourceMetadataRef(t *testing.T) {
+	const uid = "8bf5b1a2-3c4d-4e5f-8a9b-0c1d2e3f4a5b"
+	tests := []struct {
+		name      string
+		input     *ateapipb.ResourceMetadata
+		wantError field.ErrorList
+	}{
+		{
+			name:      "valid without preconditions",
+			input:     &ateapipb.ResourceMetadata{Name: "tmpl-a"},
+			wantError: nil,
+		},
+		{
+			name:      "valid with preconditions",
+			input:     &ateapipb.ResourceMetadata{Name: "tmpl-a", Uid: uid, Version: 7},
+			wantError: nil,
+		},
+		{
+			name:  "nil metadata",
+			input: nil,
+			wantError: field.ErrorList{
+				field.Required(field.NewPath("path", "name"), ""),
+			},
+		},
+		{
+			name:      "atespace must be empty",
+			input:     &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tmpl-a"},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("path", "atespace"), "ns1", "")},
+		},
+		{
+			name:      "missing name",
+			input:     &ateapipb.ResourceMetadata{},
+			wantError: field.ErrorList{field.Required(field.NewPath("path", "name"), "")},
+		},
+		{
+			name:      "invalid name",
+			input:     &ateapipb.ResourceMetadata{Name: "TMPL"},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("path", "name"), "TMPL", "")},
+		},
+		{
+			name:      "invalid uid",
+			input:     &ateapipb.ResourceMetadata{Name: "tmpl-a", Uid: "not-a-uuid"},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("path", "uid"), "not-a-uuid", "")},
+		},
+		{
+			name:      "negative version",
+			input:     &ateapipb.ResourceMetadata{Name: "tmpl-a", Version: -1},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("path", "version"), int64(-1), "")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateGlobalResourceMetadataRef(tt.input, field.NewPath("path"))
+			field.ErrorMatcher{}.ByType().ByField().ByValue().Test(t, tt.wantError, got)
+		})
+	}
+}
+
 func TestValidateAteomUID(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/templateversion/defaults.go
+++ b/internal/templateversion/defaults.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package templateversion holds ActorTemplateVersion helpers shared between
+// the ateapi server and kubectl-ate, which must default a spec identically:
+// the server before validation and storage, the CLI before comparing a
+// manifest against the stored (defaulted) spec on re-apply.
+package templateversion
+
+import (
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+)
+
+const (
+	defaultReadyzTimeout = 30
+	defaultReadyzPath    = "/readyz"
+)
+
+// DefaultSpec materializes server-applied defaults into the spec, mirroring
+// the CRD's API-server defaulting: a readyz timeout of 0 means 30s and an
+// empty readyz path means "/readyz", so the effective values are visible on
+// the stored object.
+func DefaultSpec(spec *ateapipb.ActorTemplateVersionSpec) {
+	for _, c := range spec.GetContainers() {
+		readyz := c.GetReadyz()
+		if readyz == nil {
+			continue
+		}
+		if readyz.GetTimeoutSeconds() == 0 {
+			readyz.TimeoutSeconds = defaultReadyzTimeout
+		}
+		if httpGet := readyz.GetHttpGet(); httpGet != nil && httpGet.GetPath() == "" {
+			httpGet.Path = defaultReadyzPath
+		}
+	}
+}

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -815,7 +815,16 @@ type Actor struct {
 	Metadata               *ResourceMetadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	ActorTemplateNamespace string            `protobuf:"bytes,2,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
 	ActorTemplateName      string            `protobuf:"bytes,3,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	Status                 Actor_Status      `protobuf:"varint,4,opt,name=status,proto3,enum=ateapi.Actor_Status" json:"status,omitempty"`
+	// actor_template names the control-plane ActorTemplate (global-scoped) this
+	// actor runs from. Exactly one of actor_template or
+	// (actor_template_namespace, actor_template_name) is set.
+	ActorTemplate string `protobuf:"bytes,13,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	// actor_template_version pins the ActorTemplateVersion this actor runs.
+	// Optional at CreateActor (the server resolves the template's
+	// default_version_on_create when unset); always stored resolved and
+	// immutable thereafter. Non-empty iff actor_template is set.
+	ActorTemplateVersion string       `protobuf:"bytes,14,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
+	Status               Actor_Status `protobuf:"varint,4,opt,name=status,proto3,enum=ateapi.Actor_Status" json:"status,omitempty"`
 	// worker_assignment points at the worker currently hosting this Actor.
 	// Unset whenever the Actor has no worker (SUSPENDED, PAUSED, CRASHED).
 	WorkerAssignment       *WorkerAssignment `protobuf:"bytes,5,opt,name=worker_assignment,json=workerAssignment,proto3" json:"worker_assignment,omitempty"`
@@ -886,6 +895,20 @@ func (x *Actor) GetActorTemplateNamespace() string {
 func (x *Actor) GetActorTemplateName() string {
 	if x != nil {
 		return x.ActorTemplateName
+	}
+	return ""
+}
+
+func (x *Actor) GetActorTemplate() string {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return ""
+}
+
+func (x *Actor) GetActorTemplateVersion() string {
+	if x != nil {
+		return x.ActorTemplateVersion
 	}
 	return ""
 }
@@ -1856,9 +1879,16 @@ type ActorTemplateVersionStatus struct {
 	ResolvedSandbox *SandboxAssets `protobuf:"bytes,3,opt,name=resolved_sandbox,json=resolvedSandbox,proto3" json:"resolved_sandbox,omitempty"`
 	// message is a human-readable explanation of the current state, most
 	// useful when state is FAILED.
-	Message       string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Message string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	// golden_actor points at the actor, in the reserved ate-golden system
+	// atespace, being built to produce golden_snapshot. Set while the build is
+	// in progress; the actor is deleted once the snapshot is taken.
+	GoldenActor *ObjectRef `protobuf:"bytes,5,opt,name=golden_actor,json=goldenActor,proto3" json:"golden_actor,omitempty"`
+	// take_golden_snapshot_at is when the WAIT_GOLDEN_ACTOR warmup elapses and
+	// the golden snapshot is taken.
+	TakeGoldenSnapshotAt *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=take_golden_snapshot_at,json=takeGoldenSnapshotAt,proto3" json:"take_golden_snapshot_at,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ActorTemplateVersionStatus) Reset() {
@@ -1917,6 +1947,20 @@ func (x *ActorTemplateVersionStatus) GetMessage() string {
 		return x.Message
 	}
 	return ""
+}
+
+func (x *ActorTemplateVersionStatus) GetGoldenActor() *ObjectRef {
+	if x != nil {
+		return x.GoldenActor
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionStatus) GetTakeGoldenSnapshotAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.TakeGoldenSnapshotAt
+	}
+	return nil
 }
 
 // Container is a single application container of an ActorTemplateVersion.
@@ -5076,11 +5120,13 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eSTATUS_PENDING\x10\x01\x12\x12\n" +
 	"\x0eSTATUS_CREATED\x10\x02\x12\x13\n" +
-	"\x0fSTATUS_DELETING\x10\x03\"\xbe\a\n" +
+	"\x0fSTATUS_DELETING\x10\x03\"\x9b\b\n" +
 	"\x05Actor\x124\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x18.ateapi.ResourceMetadataR\bmetadata\x128\n" +
 	"\x18actor_template_namespace\x18\x02 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
-	"\x13actor_template_name\x18\x03 \x01(\tR\x11actorTemplateName\x12,\n" +
+	"\x13actor_template_name\x18\x03 \x01(\tR\x11actorTemplateName\x12%\n" +
+	"\x0eactor_template\x18\r \x01(\tR\ractorTemplate\x124\n" +
+	"\x16actor_template_version\x18\x0e \x01(\tR\x14actorTemplateVersion\x12,\n" +
 	"\x06status\x18\x04 \x01(\x0e2\x14.ateapi.Actor.StatusR\x06status\x12E\n" +
 	"\x11worker_assignment\x18\x05 \x01(\v2\x18.ateapi.WorkerAssignmentR\x10workerAssignment\x129\n" +
 	"\x19in_progress_snapshot_name\x18\x06 \x01(\tR\x16inProgressSnapshotName\x129\n" +
@@ -5162,12 +5208,14 @@ const file_ateapi_proto_rawDesc = "" +
 	"\ton_resume\x18\x03 \x01(\v2\x16.ateapi.OnResumeConfigR\bonResume\x12)\n" +
 	"\x10storage_location\x18\x04 \x01(\tR\x0fstorageLocation\"C\n" +
 	"\x0eOnResumeConfig\x121\n" +
-	"\tfrom_data\x18\x01 \x01(\x0e2\x14.ateapi.ResumeSourceR\bfromData\"\x87\x03\n" +
+	"\tfrom_data\x18\x01 \x01(\x0e2\x14.ateapi.ResumeSourceR\bfromData\"\x90\x04\n" +
 	"\x1aActorTemplateVersionStatus\x12:\n" +
 	"\x0fgolden_snapshot\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x0egoldenSnapshot\x12>\n" +
 	"\x05state\x18\x02 \x01(\x0e2(.ateapi.ActorTemplateVersionStatus.StateR\x05state\x12@\n" +
 	"\x10resolved_sandbox\x18\x03 \x01(\v2\x15.ateapi.SandboxAssetsR\x0fresolvedSandbox\x12\x18\n" +
-	"\amessage\x18\x04 \x01(\tR\amessage\"\x90\x01\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\x124\n" +
+	"\fgolden_actor\x18\x05 \x01(\v2\x11.ateapi.ObjectRefR\vgoldenActor\x12Q\n" +
+	"\x17take_golden_snapshot_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x14takeGoldenSnapshotAt\"\x90\x01\n" +
 	"\x05State\x12\x15\n" +
 	"\x11STATE_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rSTATE_INITIAL\x10\x01\x12\x1d\n" +
@@ -5583,123 +5631,125 @@ var file_ateapi_proto_depIdxs = []int32{
 	18,  // 39: ateapi.ActorTemplateVersionStatus.golden_snapshot:type_name -> ateapi.ObjectRef
 	7,   // 40: ateapi.ActorTemplateVersionStatus.state:type_name -> ateapi.ActorTemplateVersionStatus.State
 	36,  // 41: ateapi.ActorTemplateVersionStatus.resolved_sandbox:type_name -> ateapi.SandboxAssets
-	29,  // 42: ateapi.Container.env:type_name -> ateapi.EnvVar
-	30,  // 43: ateapi.Container.readyz:type_name -> ateapi.ContainerReadyz
-	35,  // 44: ateapi.Container.volume_mounts:type_name -> ateapi.VolumeMount
-	31,  // 45: ateapi.ContainerReadyz.http_get:type_name -> ateapi.HTTPGetAction
-	33,  // 46: ateapi.Volume.durable_dir:type_name -> ateapi.DurableDirVolumeSource
-	34,  // 47: ateapi.Volume.external_volume_template:type_name -> ateapi.ExternalVolumeTemplate
-	2,   // 48: ateapi.SandboxAssets.sandbox_class:type_name -> ateapi.SandboxClass
-	86,  // 49: ateapi.SandboxAssets.assets:type_name -> ateapi.SandboxAssets.AssetsEntry
-	87,  // 50: ateapi.ArchAssets.files:type_name -> ateapi.ArchAssets.FilesEntry
-	17,  // 51: ateapi.CreateAtespaceRequest.atespace:type_name -> ateapi.Atespace
-	18,  // 52: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
-	17,  // 53: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
-	18,  // 54: ateapi.DeleteAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
-	20,  // 55: ateapi.CreateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
-	18,  // 56: ateapi.GetActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
-	20,  // 57: ateapi.UpdateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
-	90,  // 58: ateapi.UpdateActorTemplateRequest.update_mask:type_name -> google.protobuf.FieldMask
-	20,  // 59: ateapi.ListActorTemplatesResponse.actor_templates:type_name -> ateapi.ActorTemplate
-	18,  // 60: ateapi.DeleteActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
-	22,  // 61: ateapi.CreateActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ActorTemplateVersion
-	18,  // 62: ateapi.GetActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ObjectRef
-	22,  // 63: ateapi.ListActorTemplateVersionsResponse.actor_template_versions:type_name -> ateapi.ActorTemplateVersion
-	18,  // 64: ateapi.DeleteActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ObjectRef
-	18,  // 65: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
-	13,  // 66: ateapi.CreateActorRequest.actor:type_name -> ateapi.Actor
-	19,  // 67: ateapi.CreateActorRequest.source_snapshot:type_name -> ateapi.ActorSnapshotRef
-	13,  // 68: ateapi.UpdateActorRequest.actor:type_name -> ateapi.Actor
-	90,  // 69: ateapi.UpdateActorRequest.update_mask:type_name -> google.protobuf.FieldMask
-	18,  // 70: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
-	13,  // 71: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
-	18,  // 72: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
-	13,  // 73: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
-	18,  // 74: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
-	13,  // 75: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
-	18,  // 76: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
-	19,  // 77: ateapi.GetActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
-	15,  // 78: ateapi.ListActorSnapshotsResponse.snapshots:type_name -> ateapi.ActorSnapshot
-	19,  // 79: ateapi.TagActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
-	16,  // 80: ateapi.TagActorSnapshotRequest.tag:type_name -> ateapi.ActorSnapshotTag
-	16,  // 81: ateapi.UpdateActorSnapshotTagRequest.tag:type_name -> ateapi.ActorSnapshotTag
-	90,  // 82: ateapi.UpdateActorSnapshotTagRequest.update_mask:type_name -> google.protobuf.FieldMask
-	18,  // 83: ateapi.DeleteActorSnapshotTagRequest.tag:type_name -> ateapi.ObjectRef
-	75,  // 84: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
-	13,  // 85: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
-	76,  // 86: ateapi.Worker.assignment:type_name -> ateapi.Assignment
-	88,  // 87: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
-	8,   // 88: ateapi.Worker.state:type_name -> ateapi.Worker.State
-	77,  // 89: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	18,  // 90: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
-	4,   // 91: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
-	37,  // 92: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
-	38,  // 93: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
-	55,  // 94: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	56,  // 95: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	57,  // 96: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	58,  // 97: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	60,  // 98: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	62,  // 99: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	64,  // 100: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	65,  // 101: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
-	66,  // 102: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
-	68,  // 103: ateapi.Control.TagActorSnapshot:input_type -> ateapi.TagActorSnapshotRequest
-	69,  // 104: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
-	70,  // 105: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
-	71,  // 106: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	73,  // 107: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	39,  // 108: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	40,  // 109: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	41,  // 110: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	43,  // 111: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	44,  // 112: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
-	45,  // 113: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
-	46,  // 114: ateapi.Control.UpdateActorTemplate:input_type -> ateapi.UpdateActorTemplateRequest
-	47,  // 115: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
-	49,  // 116: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
-	50,  // 117: ateapi.Control.CreateActorTemplateVersion:input_type -> ateapi.CreateActorTemplateVersionRequest
-	51,  // 118: ateapi.Control.GetActorTemplateVersion:input_type -> ateapi.GetActorTemplateVersionRequest
-	52,  // 119: ateapi.Control.ListActorTemplateVersions:input_type -> ateapi.ListActorTemplateVersionsRequest
-	54,  // 120: ateapi.Control.DeleteActorTemplateVersion:input_type -> ateapi.DeleteActorTemplateVersionRequest
-	78,  // 121: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
-	80,  // 122: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	82,  // 123: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	13,  // 124: ateapi.Control.GetActor:output_type -> ateapi.Actor
-	13,  // 125: ateapi.Control.CreateActor:output_type -> ateapi.Actor
-	13,  // 126: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
-	59,  // 127: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	61,  // 128: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	63,  // 129: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	13,  // 130: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
-	15,  // 131: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
-	67,  // 132: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
-	16,  // 133: ateapi.Control.TagActorSnapshot:output_type -> ateapi.ActorSnapshotTag
-	16,  // 134: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	16,  // 135: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	72,  // 136: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	74,  // 137: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	17,  // 138: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
-	17,  // 139: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
-	42,  // 140: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	17,  // 141: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
-	20,  // 142: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
-	20,  // 143: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
-	20,  // 144: ateapi.Control.UpdateActorTemplate:output_type -> ateapi.ActorTemplate
-	48,  // 145: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
-	20,  // 146: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
-	22,  // 147: ateapi.Control.CreateActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
-	22,  // 148: ateapi.Control.GetActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
-	53,  // 149: ateapi.Control.ListActorTemplateVersions:output_type -> ateapi.ListActorTemplateVersionsResponse
-	22,  // 150: ateapi.Control.DeleteActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
-	79,  // 151: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
-	81,  // 152: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	83,  // 153: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	124, // [124:154] is the sub-list for method output_type
-	94,  // [94:124] is the sub-list for method input_type
-	94,  // [94:94] is the sub-list for extension type_name
-	94,  // [94:94] is the sub-list for extension extendee
-	0,   // [0:94] is the sub-list for field type_name
+	18,  // 42: ateapi.ActorTemplateVersionStatus.golden_actor:type_name -> ateapi.ObjectRef
+	89,  // 43: ateapi.ActorTemplateVersionStatus.take_golden_snapshot_at:type_name -> google.protobuf.Timestamp
+	29,  // 44: ateapi.Container.env:type_name -> ateapi.EnvVar
+	30,  // 45: ateapi.Container.readyz:type_name -> ateapi.ContainerReadyz
+	35,  // 46: ateapi.Container.volume_mounts:type_name -> ateapi.VolumeMount
+	31,  // 47: ateapi.ContainerReadyz.http_get:type_name -> ateapi.HTTPGetAction
+	33,  // 48: ateapi.Volume.durable_dir:type_name -> ateapi.DurableDirVolumeSource
+	34,  // 49: ateapi.Volume.external_volume_template:type_name -> ateapi.ExternalVolumeTemplate
+	2,   // 50: ateapi.SandboxAssets.sandbox_class:type_name -> ateapi.SandboxClass
+	86,  // 51: ateapi.SandboxAssets.assets:type_name -> ateapi.SandboxAssets.AssetsEntry
+	87,  // 52: ateapi.ArchAssets.files:type_name -> ateapi.ArchAssets.FilesEntry
+	17,  // 53: ateapi.CreateAtespaceRequest.atespace:type_name -> ateapi.Atespace
+	18,  // 54: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
+	17,  // 55: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
+	18,  // 56: ateapi.DeleteAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
+	20,  // 57: ateapi.CreateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
+	18,  // 58: ateapi.GetActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
+	20,  // 59: ateapi.UpdateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
+	90,  // 60: ateapi.UpdateActorTemplateRequest.update_mask:type_name -> google.protobuf.FieldMask
+	20,  // 61: ateapi.ListActorTemplatesResponse.actor_templates:type_name -> ateapi.ActorTemplate
+	18,  // 62: ateapi.DeleteActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
+	22,  // 63: ateapi.CreateActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ActorTemplateVersion
+	18,  // 64: ateapi.GetActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ObjectRef
+	22,  // 65: ateapi.ListActorTemplateVersionsResponse.actor_template_versions:type_name -> ateapi.ActorTemplateVersion
+	18,  // 66: ateapi.DeleteActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ObjectRef
+	18,  // 67: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 68: ateapi.CreateActorRequest.actor:type_name -> ateapi.Actor
+	19,  // 69: ateapi.CreateActorRequest.source_snapshot:type_name -> ateapi.ActorSnapshotRef
+	13,  // 70: ateapi.UpdateActorRequest.actor:type_name -> ateapi.Actor
+	90,  // 71: ateapi.UpdateActorRequest.update_mask:type_name -> google.protobuf.FieldMask
+	18,  // 72: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 73: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
+	18,  // 74: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 75: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
+	18,  // 76: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 77: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
+	18,  // 78: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
+	19,  // 79: ateapi.GetActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
+	15,  // 80: ateapi.ListActorSnapshotsResponse.snapshots:type_name -> ateapi.ActorSnapshot
+	19,  // 81: ateapi.TagActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
+	16,  // 82: ateapi.TagActorSnapshotRequest.tag:type_name -> ateapi.ActorSnapshotTag
+	16,  // 83: ateapi.UpdateActorSnapshotTagRequest.tag:type_name -> ateapi.ActorSnapshotTag
+	90,  // 84: ateapi.UpdateActorSnapshotTagRequest.update_mask:type_name -> google.protobuf.FieldMask
+	18,  // 85: ateapi.DeleteActorSnapshotTagRequest.tag:type_name -> ateapi.ObjectRef
+	75,  // 86: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
+	13,  // 87: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
+	76,  // 88: ateapi.Worker.assignment:type_name -> ateapi.Assignment
+	88,  // 89: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
+	8,   // 90: ateapi.Worker.state:type_name -> ateapi.Worker.State
+	77,  // 91: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
+	18,  // 92: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
+	4,   // 93: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
+	37,  // 94: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
+	38,  // 95: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
+	55,  // 96: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	56,  // 97: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	57,  // 98: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	58,  // 99: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	60,  // 100: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	62,  // 101: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	64,  // 102: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	65,  // 103: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
+	66,  // 104: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
+	68,  // 105: ateapi.Control.TagActorSnapshot:input_type -> ateapi.TagActorSnapshotRequest
+	69,  // 106: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
+	70,  // 107: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
+	71,  // 108: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	73,  // 109: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	39,  // 110: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	40,  // 111: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	41,  // 112: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	43,  // 113: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	44,  // 114: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
+	45,  // 115: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
+	46,  // 116: ateapi.Control.UpdateActorTemplate:input_type -> ateapi.UpdateActorTemplateRequest
+	47,  // 117: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
+	49,  // 118: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
+	50,  // 119: ateapi.Control.CreateActorTemplateVersion:input_type -> ateapi.CreateActorTemplateVersionRequest
+	51,  // 120: ateapi.Control.GetActorTemplateVersion:input_type -> ateapi.GetActorTemplateVersionRequest
+	52,  // 121: ateapi.Control.ListActorTemplateVersions:input_type -> ateapi.ListActorTemplateVersionsRequest
+	54,  // 122: ateapi.Control.DeleteActorTemplateVersion:input_type -> ateapi.DeleteActorTemplateVersionRequest
+	78,  // 123: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
+	80,  // 124: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	82,  // 125: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	13,  // 126: ateapi.Control.GetActor:output_type -> ateapi.Actor
+	13,  // 127: ateapi.Control.CreateActor:output_type -> ateapi.Actor
+	13,  // 128: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
+	59,  // 129: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	61,  // 130: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	63,  // 131: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	13,  // 132: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
+	15,  // 133: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
+	67,  // 134: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
+	16,  // 135: ateapi.Control.TagActorSnapshot:output_type -> ateapi.ActorSnapshotTag
+	16,  // 136: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	16,  // 137: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	72,  // 138: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	74,  // 139: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	17,  // 140: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
+	17,  // 141: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
+	42,  // 142: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	17,  // 143: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
+	20,  // 144: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
+	20,  // 145: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
+	20,  // 146: ateapi.Control.UpdateActorTemplate:output_type -> ateapi.ActorTemplate
+	48,  // 147: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
+	20,  // 148: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
+	22,  // 149: ateapi.Control.CreateActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	22,  // 150: ateapi.Control.GetActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	53,  // 151: ateapi.Control.ListActorTemplateVersions:output_type -> ateapi.ListActorTemplateVersionsResponse
+	22,  // 152: ateapi.Control.DeleteActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	79,  // 153: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
+	81,  // 154: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	83,  // 155: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	126, // [126:156] is the sub-list for method output_type
+	96,  // [96:126] is the sub-list for method input_type
+	96,  // [96:96] is the sub-list for extension type_name
+	96,  // [96:96] is the sub-list for extension extendee
+	0,   // [0:96] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -138,6 +138,112 @@ func (ActorSnapshotTagScope) EnumDescriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{1}
 }
 
+// SandboxClass selects the sandbox runtime family. Snapshots are not portable
+// across classes.
+type SandboxClass int32
+
+const (
+	SandboxClass_SANDBOX_CLASS_UNSPECIFIED SandboxClass = 0
+	SandboxClass_SANDBOX_CLASS_GVISOR      SandboxClass = 1
+	SandboxClass_SANDBOX_CLASS_MICROVM     SandboxClass = 2
+)
+
+// Enum value maps for SandboxClass.
+var (
+	SandboxClass_name = map[int32]string{
+		0: "SANDBOX_CLASS_UNSPECIFIED",
+		1: "SANDBOX_CLASS_GVISOR",
+		2: "SANDBOX_CLASS_MICROVM",
+	}
+	SandboxClass_value = map[string]int32{
+		"SANDBOX_CLASS_UNSPECIFIED": 0,
+		"SANDBOX_CLASS_GVISOR":      1,
+		"SANDBOX_CLASS_MICROVM":     2,
+	}
+)
+
+func (x SandboxClass) Enum() *SandboxClass {
+	p := new(SandboxClass)
+	*p = x
+	return p
+}
+
+func (x SandboxClass) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SandboxClass) Descriptor() protoreflect.EnumDescriptor {
+	return file_ateapi_proto_enumTypes[2].Descriptor()
+}
+
+func (SandboxClass) Type() protoreflect.EnumType {
+	return &file_ateapi_proto_enumTypes[2]
+}
+
+func (x SandboxClass) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SandboxClass.Descriptor instead.
+func (SandboxClass) EnumDescriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{2}
+}
+
+// ResumeSource selects what supplies the guest state when an actor is resumed
+// from one of the snapshot situations named by OnResumeConfig's fields.
+type ResumeSource int32
+
+const (
+	ResumeSource_RESUME_SOURCE_UNSPECIFIED ResumeSource = 0
+	// Starts the actor's containers afresh from the OCI image, with the
+	// durable-dir volumes pre-populated from the snapshot.
+	ResumeSource_RESUME_SOURCE_COLD_BOOT ResumeSource = 1
+	// Restores with the version's golden snapshot and the actor's own
+	// durable data.
+	ResumeSource_RESUME_SOURCE_GOLDEN ResumeSource = 2
+)
+
+// Enum value maps for ResumeSource.
+var (
+	ResumeSource_name = map[int32]string{
+		0: "RESUME_SOURCE_UNSPECIFIED",
+		1: "RESUME_SOURCE_COLD_BOOT",
+		2: "RESUME_SOURCE_GOLDEN",
+	}
+	ResumeSource_value = map[string]int32{
+		"RESUME_SOURCE_UNSPECIFIED": 0,
+		"RESUME_SOURCE_COLD_BOOT":   1,
+		"RESUME_SOURCE_GOLDEN":      2,
+	}
+)
+
+func (x ResumeSource) Enum() *ResumeSource {
+	p := new(ResumeSource)
+	*p = x
+	return p
+}
+
+func (x ResumeSource) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ResumeSource) Descriptor() protoreflect.EnumDescriptor {
+	return file_ateapi_proto_enumTypes[3].Descriptor()
+}
+
+func (ResumeSource) Type() protoreflect.EnumType {
+	return &file_ateapi_proto_enumTypes[3]
+}
+
+func (x ResumeSource) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ResumeSource.Descriptor instead.
+func (ResumeSource) EnumDescriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{3}
+}
+
 type ActorCertificatePurpose int32
 
 const (
@@ -168,11 +274,11 @@ func (x ActorCertificatePurpose) String() string {
 }
 
 func (ActorCertificatePurpose) Descriptor() protoreflect.EnumDescriptor {
-	return file_ateapi_proto_enumTypes[2].Descriptor()
+	return file_ateapi_proto_enumTypes[4].Descriptor()
 }
 
 func (ActorCertificatePurpose) Type() protoreflect.EnumType {
-	return &file_ateapi_proto_enumTypes[2]
+	return &file_ateapi_proto_enumTypes[4]
 }
 
 func (x ActorCertificatePurpose) Number() protoreflect.EnumNumber {
@@ -181,7 +287,7 @@ func (x ActorCertificatePurpose) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ActorCertificatePurpose.Descriptor instead.
 func (ActorCertificatePurpose) EnumDescriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{2}
+	return file_ateapi_proto_rawDescGZIP(), []int{4}
 }
 
 type ExternalVolume_Status int32
@@ -223,11 +329,11 @@ func (x ExternalVolume_Status) String() string {
 }
 
 func (ExternalVolume_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_ateapi_proto_enumTypes[3].Descriptor()
+	return file_ateapi_proto_enumTypes[5].Descriptor()
 }
 
 func (ExternalVolume_Status) Type() protoreflect.EnumType {
-	return &file_ateapi_proto_enumTypes[3]
+	return &file_ateapi_proto_enumTypes[5]
 }
 
 func (x ExternalVolume_Status) Number() protoreflect.EnumNumber {
@@ -290,11 +396,11 @@ func (x Actor_Status) String() string {
 }
 
 func (Actor_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_ateapi_proto_enumTypes[4].Descriptor()
+	return file_ateapi_proto_enumTypes[6].Descriptor()
 }
 
 func (Actor_Status) Type() protoreflect.EnumType {
-	return &file_ateapi_proto_enumTypes[4]
+	return &file_ateapi_proto_enumTypes[6]
 }
 
 func (x Actor_Status) Number() protoreflect.EnumNumber {
@@ -304,6 +410,67 @@ func (x Actor_Status) Number() protoreflect.EnumNumber {
 // Deprecated: Use Actor_Status.Descriptor instead.
 func (Actor_Status) EnumDescriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{4, 0}
+}
+
+// State machine, mirroring the ActorTemplateVersion CRD PhaseType:
+// INITIAL -> RESUME_GOLDEN_ACTOR -> WAIT_GOLDEN_ACTOR -> {READY | FAILED}.
+// READY and FAILED are terminal; the version is only usable once READY.
+type ActorTemplateVersionStatus_State int32
+
+const (
+	ActorTemplateVersionStatus_STATE_UNSPECIFIED         ActorTemplateVersionStatus_State = 0
+	ActorTemplateVersionStatus_STATE_INITIAL             ActorTemplateVersionStatus_State = 1
+	ActorTemplateVersionStatus_STATE_RESUME_GOLDEN_ACTOR ActorTemplateVersionStatus_State = 2
+	ActorTemplateVersionStatus_STATE_WAIT_GOLDEN_ACTOR   ActorTemplateVersionStatus_State = 3
+	ActorTemplateVersionStatus_STATE_READY               ActorTemplateVersionStatus_State = 4
+	ActorTemplateVersionStatus_STATE_FAILED              ActorTemplateVersionStatus_State = 5
+)
+
+// Enum value maps for ActorTemplateVersionStatus_State.
+var (
+	ActorTemplateVersionStatus_State_name = map[int32]string{
+		0: "STATE_UNSPECIFIED",
+		1: "STATE_INITIAL",
+		2: "STATE_RESUME_GOLDEN_ACTOR",
+		3: "STATE_WAIT_GOLDEN_ACTOR",
+		4: "STATE_READY",
+		5: "STATE_FAILED",
+	}
+	ActorTemplateVersionStatus_State_value = map[string]int32{
+		"STATE_UNSPECIFIED":         0,
+		"STATE_INITIAL":             1,
+		"STATE_RESUME_GOLDEN_ACTOR": 2,
+		"STATE_WAIT_GOLDEN_ACTOR":   3,
+		"STATE_READY":               4,
+		"STATE_FAILED":              5,
+	}
+)
+
+func (x ActorTemplateVersionStatus_State) Enum() *ActorTemplateVersionStatus_State {
+	p := new(ActorTemplateVersionStatus_State)
+	*p = x
+	return p
+}
+
+func (x ActorTemplateVersionStatus_State) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ActorTemplateVersionStatus_State) Descriptor() protoreflect.EnumDescriptor {
+	return file_ateapi_proto_enumTypes[7].Descriptor()
+}
+
+func (ActorTemplateVersionStatus_State) Type() protoreflect.EnumType {
+	return &file_ateapi_proto_enumTypes[7]
+}
+
+func (x ActorTemplateVersionStatus_State) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ActorTemplateVersionStatus_State.Descriptor instead.
+func (ActorTemplateVersionStatus_State) EnumDescriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{18, 0}
 }
 
 type Worker_State int32
@@ -339,11 +506,11 @@ func (x Worker_State) String() string {
 }
 
 func (Worker_State) Descriptor() protoreflect.EnumDescriptor {
-	return file_ateapi_proto_enumTypes[5].Descriptor()
+	return file_ateapi_proto_enumTypes[8].Descriptor()
 }
 
 func (Worker_State) Type() protoreflect.EnumType {
-	return &file_ateapi_proto_enumTypes[5]
+	return &file_ateapi_proto_enumTypes[8]
 }
 
 func (x Worker_State) Number() protoreflect.EnumNumber {
@@ -352,7 +519,7 @@ func (x Worker_State) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Worker_State.Descriptor instead.
 func (Worker_State) EnumDescriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{36, 0}
+	return file_ateapi_proto_rawDescGZIP(), []int{66, 0}
 }
 
 type LocalSnapshotInfo struct {
@@ -1226,6 +1393,1223 @@ func (*ActorSnapshotRef_Snapshot) isActorSnapshotRef_Reference() {}
 
 func (*ActorSnapshotRef_Tag) isActorSnapshotRef_Reference() {}
 
+// ActorTemplate groups the versions of one actor application and carries the
+// version-independent placement policy.
+type ActorTemplate struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Common resource metadata: name, uid, version, timestamps.
+	Metadata      *ResourceMetadata  `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Spec          *ActorTemplateSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActorTemplate) Reset() {
+	*x = ActorTemplate{}
+	mi := &file_ateapi_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplate) ProtoMessage() {}
+
+func (x *ActorTemplate) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplate.ProtoReflect.Descriptor instead.
+func (*ActorTemplate) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ActorTemplate) GetMetadata() *ResourceMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ActorTemplate) GetSpec() *ActorTemplateSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+type ActorTemplateSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// worker_selector restricts which worker pools actors from this template
+	// may use.
+	WorkerSelector *Selector `protobuf:"bytes,1,opt,name=worker_selector,json=workerSelector,proto3" json:"worker_selector,omitempty"`
+	// default_version_on_create names the ActorTemplateVersion used by
+	// CreateActor calls that do not pin a version. If unset, CreateActor
+	// without an explicit version fails with FailedPrecondition.
+	DefaultVersionOnCreate *ObjectRef `protobuf:"bytes,2,opt,name=default_version_on_create,json=defaultVersionOnCreate,proto3" json:"default_version_on_create,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *ActorTemplateSpec) Reset() {
+	*x = ActorTemplateSpec{}
+	mi := &file_ateapi_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplateSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplateSpec) ProtoMessage() {}
+
+func (x *ActorTemplateSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplateSpec.ProtoReflect.Descriptor instead.
+func (*ActorTemplateSpec) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ActorTemplateSpec) GetWorkerSelector() *Selector {
+	if x != nil {
+		return x.WorkerSelector
+	}
+	return nil
+}
+
+func (x *ActorTemplateSpec) GetDefaultVersionOnCreate() *ObjectRef {
+	if x != nil {
+		return x.DefaultVersionOnCreate
+	}
+	return nil
+}
+
+// ActorTemplateVersion is one immutable released version of an ActorTemplate:
+// the workload definition plus everything that affects snapshot validity.
+// Global-scoped: metadata.atespace is always empty and metadata.name must be
+// globally unique (by convention "<template-name>-<version>").
+type ActorTemplateVersion struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Common resource metadata: name, uid, version, timestamps.
+	Metadata *ResourceMetadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// actor_template is the parent ActorTemplate. Required at creation and
+	// immutable.
+	ActorTemplate *ObjectRef `protobuf:"bytes,2,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	// spec is immutable after creation.
+	Spec          *ActorTemplateVersionSpec   `protobuf:"bytes,3,opt,name=spec,proto3" json:"spec,omitempty"`
+	Status        *ActorTemplateVersionStatus `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActorTemplateVersion) Reset() {
+	*x = ActorTemplateVersion{}
+	mi := &file_ateapi_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplateVersion) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplateVersion) ProtoMessage() {}
+
+func (x *ActorTemplateVersion) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplateVersion.ProtoReflect.Descriptor instead.
+func (*ActorTemplateVersion) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ActorTemplateVersion) GetMetadata() *ResourceMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersion) GetActorTemplate() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersion) GetSpec() *ActorTemplateVersionSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersion) GetStatus() *ActorTemplateVersionStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+type ActorTemplateVersionSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// pause_image is the container to use as the root sandbox container.
+	PauseImage      string           `protobuf:"bytes,1,opt,name=pause_image,json=pauseImage,proto3" json:"pause_image,omitempty"`
+	Containers      []*Container     `protobuf:"bytes,2,rep,name=containers,proto3" json:"containers,omitempty"`
+	Volumes         []*Volume        `protobuf:"bytes,3,rep,name=volumes,proto3" json:"volumes,omitempty"`
+	SnapshotsConfig *SnapshotsConfig `protobuf:"bytes,4,opt,name=snapshots_config,json=snapshotsConfig,proto3" json:"snapshots_config,omitempty"`
+	// sandbox_config selects the sandbox runtime this version's actors run on.
+	// Required. Resolved and frozen into status.resolved_sandbox at creation
+	// time.
+	SandboxConfig *SandboxConfig `protobuf:"bytes,5,opt,name=sandbox_config,json=sandboxConfig,proto3" json:"sandbox_config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActorTemplateVersionSpec) Reset() {
+	*x = ActorTemplateVersionSpec{}
+	mi := &file_ateapi_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplateVersionSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplateVersionSpec) ProtoMessage() {}
+
+func (x *ActorTemplateVersionSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplateVersionSpec.ProtoReflect.Descriptor instead.
+func (*ActorTemplateVersionSpec) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ActorTemplateVersionSpec) GetPauseImage() string {
+	if x != nil {
+		return x.PauseImage
+	}
+	return ""
+}
+
+func (x *ActorTemplateVersionSpec) GetContainers() []*Container {
+	if x != nil {
+		return x.Containers
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionSpec) GetVolumes() []*Volume {
+	if x != nil {
+		return x.Volumes
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionSpec) GetSnapshotsConfig() *SnapshotsConfig {
+	if x != nil {
+		return x.SnapshotsConfig
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionSpec) GetSandboxConfig() *SandboxConfig {
+	if x != nil {
+		return x.SandboxConfig
+	}
+	return nil
+}
+
+// SandboxConfig selects the sandbox runtime for an ActorTemplateVersion.
+type SandboxConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// sandbox_class selects the sandbox runtime family.
+	// Required; must not be UNSPECIFIED.
+	SandboxClass SandboxClass `protobuf:"varint,1,opt,name=sandbox_class,json=sandboxClass,proto3,enum=ateapi.SandboxClass" json:"sandbox_class,omitempty"`
+	// config_name names the cluster-scoped SandboxConfig Kubernetes object
+	// supplying the sandbox binaries. Required; must match sandbox_class.
+	ConfigName    string `protobuf:"bytes,2,opt,name=config_name,json=configName,proto3" json:"config_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxConfig) Reset() {
+	*x = SandboxConfig{}
+	mi := &file_ateapi_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxConfig) ProtoMessage() {}
+
+func (x *SandboxConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxConfig.ProtoReflect.Descriptor instead.
+func (*SandboxConfig) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *SandboxConfig) GetSandboxClass() SandboxClass {
+	if x != nil {
+		return x.SandboxClass
+	}
+	return SandboxClass_SANDBOX_CLASS_UNSPECIFIED
+}
+
+func (x *SandboxConfig) GetConfigName() string {
+	if x != nil {
+		return x.ConfigName
+	}
+	return ""
+}
+
+type SnapshotsConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// on_pause selects what is captured during pause actor.
+	OnPause SnapshotContentScope `protobuf:"varint,1,opt,name=on_pause,json=onPause,proto3,enum=ateapi.SnapshotContentScope" json:"on_pause,omitempty"`
+	// on_commit selects what captures.
+	// Must be a subset of on_pause: FULL allows FULL or DATA, DATA allows DATA.
+	OnCommit SnapshotContentScope `protobuf:"varint,2,opt,name=on_commit,json=onCommit,proto3,enum=ateapi.SnapshotContentScope" json:"on_commit,omitempty"`
+	// on_resume selects, per snapshot situation, what supplies the guest state
+	// at resume. Unset means the defaults documented on OnResumeConfig.
+	OnResume *OnResumeConfig `protobuf:"bytes,3,opt,name=on_resume,json=onResume,proto3" json:"on_resume,omitempty"`
+	// storage_location is the base object-storage URI snapshots of actors on
+	// this version are stored under. Required.
+	StorageLocation string `protobuf:"bytes,4,opt,name=storage_location,json=storageLocation,proto3" json:"storage_location,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *SnapshotsConfig) Reset() {
+	*x = SnapshotsConfig{}
+	mi := &file_ateapi_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotsConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotsConfig) ProtoMessage() {}
+
+func (x *SnapshotsConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotsConfig.ProtoReflect.Descriptor instead.
+func (*SnapshotsConfig) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *SnapshotsConfig) GetOnPause() SnapshotContentScope {
+	if x != nil {
+		return x.OnPause
+	}
+	return SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED
+}
+
+func (x *SnapshotsConfig) GetOnCommit() SnapshotContentScope {
+	if x != nil {
+		return x.OnCommit
+	}
+	return SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED
+}
+
+func (x *SnapshotsConfig) GetOnResume() *OnResumeConfig {
+	if x != nil {
+		return x.OnResume
+	}
+	return nil
+}
+
+func (x *SnapshotsConfig) GetStorageLocation() string {
+	if x != nil {
+		return x.StorageLocation
+	}
+	return ""
+}
+
+// OnResumeConfig selects, per snapshot situation, what supplies the guest
+// state at resume. Each field names what is being resumed FROM; the value
+// names the boot source. Full snapshots that are still valid always restore
+// from their own content and are not configurable here.
+type OnResumeConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// from_data applies when the resume uses a DATA-scope snapshot (from
+	// on_pause or on_commit).
+	FromData      ResumeSource `protobuf:"varint,1,opt,name=from_data,json=fromData,proto3,enum=ateapi.ResumeSource" json:"from_data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OnResumeConfig) Reset() {
+	*x = OnResumeConfig{}
+	mi := &file_ateapi_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OnResumeConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OnResumeConfig) ProtoMessage() {}
+
+func (x *OnResumeConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OnResumeConfig.ProtoReflect.Descriptor instead.
+func (*OnResumeConfig) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *OnResumeConfig) GetFromData() ResumeSource {
+	if x != nil {
+		return x.FromData
+	}
+	return ResumeSource_RESUME_SOURCE_UNSPECIFIED
+}
+
+type ActorTemplateVersionStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// golden_snapshot points at the ActorSnapshot, in the reserved ate-golden
+	// system atespace, built for this version by ate-api. Set once state is
+	// READY.
+	GoldenSnapshot *ObjectRef                       `protobuf:"bytes,1,opt,name=golden_snapshot,json=goldenSnapshot,proto3" json:"golden_snapshot,omitempty"`
+	State          ActorTemplateVersionStatus_State `protobuf:"varint,2,opt,name=state,proto3,enum=ateapi.ActorTemplateVersionStatus_State" json:"state,omitempty"`
+	// resolved_sandbox is the referenced SandboxConfig's content frozen at
+	// creation time.
+	ResolvedSandbox *SandboxAssets `protobuf:"bytes,3,opt,name=resolved_sandbox,json=resolvedSandbox,proto3" json:"resolved_sandbox,omitempty"`
+	// message is a human-readable explanation of the current state, most
+	// useful when state is FAILED.
+	Message       string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActorTemplateVersionStatus) Reset() {
+	*x = ActorTemplateVersionStatus{}
+	mi := &file_ateapi_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplateVersionStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplateVersionStatus) ProtoMessage() {}
+
+func (x *ActorTemplateVersionStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplateVersionStatus.ProtoReflect.Descriptor instead.
+func (*ActorTemplateVersionStatus) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ActorTemplateVersionStatus) GetGoldenSnapshot() *ObjectRef {
+	if x != nil {
+		return x.GoldenSnapshot
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionStatus) GetState() ActorTemplateVersionStatus_State {
+	if x != nil {
+		return x.State
+	}
+	return ActorTemplateVersionStatus_STATE_UNSPECIFIED
+}
+
+func (x *ActorTemplateVersionStatus) GetResolvedSandbox() *SandboxAssets {
+	if x != nil {
+		return x.ResolvedSandbox
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionStatus) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+// Container is a single application container of an ActorTemplateVersion.
+type Container struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Image string                 `protobuf:"bytes,2,opt,name=image,proto3" json:"image,omitempty"`
+	// Entrypoint array; when set, the image's ENTRYPOINT and CMD are both
+	// ignored and the process argv is command + args. Unlike Kubernetes,
+	// $(VAR_NAME) references are NOT expanded.
+	Command []string `protobuf:"bytes,3,rep,name=command,proto3" json:"command,omitempty"`
+	// Arguments to the entrypoint; the image's CMD is used if unset (unless
+	// command is set, which discards the image's CMD).
+	Args []string  `protobuf:"bytes,4,rep,name=args,proto3" json:"args,omitempty"`
+	Env  []*EnvVar `protobuf:"bytes,5,rep,name=env,proto3" json:"env,omitempty"`
+	// readyz is an optional HTTP readiness probe; when set the actor is not
+	// ready until the endpoint returns 200.
+	Readyz        *ContainerReadyz `protobuf:"bytes,6,opt,name=readyz,proto3" json:"readyz,omitempty"`
+	VolumeMounts  []*VolumeMount   `protobuf:"bytes,7,rep,name=volume_mounts,json=volumeMounts,proto3" json:"volume_mounts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Container) Reset() {
+	*x = Container{}
+	mi := &file_ateapi_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Container) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Container) ProtoMessage() {}
+
+func (x *Container) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Container.ProtoReflect.Descriptor instead.
+func (*Container) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *Container) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Container) GetImage() string {
+	if x != nil {
+		return x.Image
+	}
+	return ""
+}
+
+func (x *Container) GetCommand() []string {
+	if x != nil {
+		return x.Command
+	}
+	return nil
+}
+
+func (x *Container) GetArgs() []string {
+	if x != nil {
+		return x.Args
+	}
+	return nil
+}
+
+func (x *Container) GetEnv() []*EnvVar {
+	if x != nil {
+		return x.Env
+	}
+	return nil
+}
+
+func (x *Container) GetReadyz() *ContainerReadyz {
+	if x != nil {
+		return x.Readyz
+	}
+	return nil
+}
+
+func (x *Container) GetVolumeMounts() []*VolumeMount {
+	if x != nil {
+		return x.VolumeMounts
+	}
+	return nil
+}
+
+// EnvVar supplies one environment variable to a container. Values are not
+// expanded with Kubernetes-style $(VAR) references.
+type EnvVar struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name may be any printable ASCII character except '='.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Exactly one source must be set.
+	//
+	// Types that are valid to be assigned to Source:
+	//
+	//	*EnvVar_Value
+	Source        isEnvVar_Source `protobuf_oneof:"source"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnvVar) Reset() {
+	*x = EnvVar{}
+	mi := &file_ateapi_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnvVar) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnvVar) ProtoMessage() {}
+
+func (x *EnvVar) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnvVar.ProtoReflect.Descriptor instead.
+func (*EnvVar) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *EnvVar) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *EnvVar) GetSource() isEnvVar_Source {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *EnvVar) GetValue() string {
+	if x != nil {
+		if x, ok := x.Source.(*EnvVar_Value); ok {
+			return x.Value
+		}
+	}
+	return ""
+}
+
+type isEnvVar_Source interface {
+	isEnvVar_Source()
+}
+
+type EnvVar_Value struct {
+	// Literal value.
+	Value string `protobuf:"bytes,2,opt,name=value,proto3,oneof"`
+}
+
+func (*EnvVar_Value) isEnvVar_Source() {}
+
+// ContainerReadyz configures the readiness signal for a container.
+type ContainerReadyz struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// http_get specifies the HTTP request to perform. Required.
+	HttpGet *HTTPGetAction `protobuf:"bytes,1,opt,name=http_get,json=httpGet,proto3" json:"http_get,omitempty"`
+	// timeout_seconds bounds how long to poll http_get before failing the
+	// actor start. 0 means the server-applied default (30s).
+	TimeoutSeconds int32 `protobuf:"varint,2,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ContainerReadyz) Reset() {
+	*x = ContainerReadyz{}
+	mi := &file_ateapi_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContainerReadyz) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerReadyz) ProtoMessage() {}
+
+func (x *ContainerReadyz) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerReadyz.ProtoReflect.Descriptor instead.
+func (*ContainerReadyz) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ContainerReadyz) GetHttpGet() *HTTPGetAction {
+	if x != nil {
+		return x.HttpGet
+	}
+	return nil
+}
+
+func (x *ContainerReadyz) GetTimeoutSeconds() int32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
+}
+
+// HTTPGetAction describes an HTTP GET against the container's interior IP.
+type HTTPGetAction struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// path defaults to "/readyz".
+	Path          string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Port          int32  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HTTPGetAction) Reset() {
+	*x = HTTPGetAction{}
+	mi := &file_ateapi_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HTTPGetAction) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HTTPGetAction) ProtoMessage() {}
+
+func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HTTPGetAction.ProtoReflect.Descriptor instead.
+func (*HTTPGetAction) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *HTTPGetAction) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *HTTPGetAction) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+type Volume struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name of the volume. Must be a DNS label.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Exactly one source must be set.
+	//
+	// Types that are valid to be assigned to Source:
+	//
+	//	*Volume_DurableDir
+	//	*Volume_ExternalVolumeTemplate
+	Source        isVolume_Source `protobuf_oneof:"source"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Volume) Reset() {
+	*x = Volume{}
+	mi := &file_ateapi_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Volume) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Volume) ProtoMessage() {}
+
+func (x *Volume) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Volume.ProtoReflect.Descriptor instead.
+func (*Volume) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *Volume) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Volume) GetSource() isVolume_Source {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *Volume) GetDurableDir() *DurableDirVolumeSource {
+	if x != nil {
+		if x, ok := x.Source.(*Volume_DurableDir); ok {
+			return x.DurableDir
+		}
+	}
+	return nil
+}
+
+func (x *Volume) GetExternalVolumeTemplate() *ExternalVolumeTemplate {
+	if x != nil {
+		if x, ok := x.Source.(*Volume_ExternalVolumeTemplate); ok {
+			return x.ExternalVolumeTemplate
+		}
+	}
+	return nil
+}
+
+type isVolume_Source interface {
+	isVolume_Source()
+}
+
+type Volume_DurableDir struct {
+	DurableDir *DurableDirVolumeSource `protobuf:"bytes,2,opt,name=durable_dir,json=durableDir,proto3,oneof"`
+}
+
+type Volume_ExternalVolumeTemplate struct {
+	ExternalVolumeTemplate *ExternalVolumeTemplate `protobuf:"bytes,3,opt,name=external_volume_template,json=externalVolumeTemplate,proto3,oneof"`
+}
+
+func (*Volume_DurableDir) isVolume_Source() {}
+
+func (*Volume_ExternalVolumeTemplate) isVolume_Source() {}
+
+// DurableDirVolumeSource is a durable directory on rootfs that persists
+// across resumes and participates in snapshots.
+type DurableDirVolumeSource struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DurableDirVolumeSource) Reset() {
+	*x = DurableDirVolumeSource{}
+	mi := &file_ateapi_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DurableDirVolumeSource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DurableDirVolumeSource) ProtoMessage() {}
+
+func (x *DurableDirVolumeSource) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DurableDirVolumeSource.ProtoReflect.Descriptor instead.
+func (*DurableDirVolumeSource) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{24}
+}
+
+// ExternalVolumeTemplate provisions an external volume per actor; the volume
+// lives only as long as the actor. Not supported with SANDBOX_CLASS_MICROVM.
+type ExternalVolumeTemplate struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// capacity of the volume to create, in Kubernetes resource.Quantity string
+	// form (e.g. "10Gi"). Required.
+	Capacity string `protobuf:"bytes,1,opt,name=capacity,proto3" json:"capacity,omitempty"`
+	// storage_class_name names the cluster-scoped Kubernetes StorageClass to
+	// create the volume from. Required.
+	StorageClassName string `protobuf:"bytes,2,opt,name=storage_class_name,json=storageClassName,proto3" json:"storage_class_name,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ExternalVolumeTemplate) Reset() {
+	*x = ExternalVolumeTemplate{}
+	mi := &file_ateapi_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExternalVolumeTemplate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExternalVolumeTemplate) ProtoMessage() {}
+
+func (x *ExternalVolumeTemplate) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExternalVolumeTemplate.ProtoReflect.Descriptor instead.
+func (*ExternalVolumeTemplate) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *ExternalVolumeTemplate) GetCapacity() string {
+	if x != nil {
+		return x.Capacity
+	}
+	return ""
+}
+
+func (x *ExternalVolumeTemplate) GetStorageClassName() string {
+	if x != nil {
+		return x.StorageClassName
+	}
+	return ""
+}
+
+// VolumeMount mounts a named Volume into a container.
+type VolumeMount struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name must match the name of a Volume.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// mount_path within the container. Must be a clean absolute Unix path.
+	MountPath     string `protobuf:"bytes,2,opt,name=mount_path,json=mountPath,proto3" json:"mount_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VolumeMount) Reset() {
+	*x = VolumeMount{}
+	mi := &file_ateapi_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VolumeMount) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VolumeMount) ProtoMessage() {}
+
+func (x *VolumeMount) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VolumeMount.ProtoReflect.Descriptor instead.
+func (*VolumeMount) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *VolumeMount) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *VolumeMount) GetMountPath() string {
+	if x != nil {
+		return x.MountPath
+	}
+	return ""
+}
+
+// SandboxAssets is the frozen description of the sandbox binaries an actor
+// boots with: a class plus content-addressed files keyed first by
+// architecture and then by asset name, mirroring the SandboxConfig
+// CRD schema.
+type SandboxAssets struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	SandboxClass SandboxClass           `protobuf:"varint,1,opt,name=sandbox_class,json=sandboxClass,proto3,enum=ateapi.SandboxClass" json:"sandbox_class,omitempty"`
+	// assets maps architecture (GOARCH, e.g. "amd64") to that arch's files.
+	Assets        map[string]*ArchAssets `protobuf:"bytes,2,rep,name=assets,proto3" json:"assets,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxAssets) Reset() {
+	*x = SandboxAssets{}
+	mi := &file_ateapi_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxAssets) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxAssets) ProtoMessage() {}
+
+func (x *SandboxAssets) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxAssets.ProtoReflect.Descriptor instead.
+func (*SandboxAssets) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *SandboxAssets) GetSandboxClass() SandboxClass {
+	if x != nil {
+		return x.SandboxClass
+	}
+	return SandboxClass_SANDBOX_CLASS_UNSPECIFIED
+}
+
+func (x *SandboxAssets) GetAssets() map[string]*ArchAssets {
+	if x != nil {
+		return x.Assets
+	}
+	return nil
+}
+
+type ArchAssets struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// files maps asset name (e.g. "gvisor", "kata-kernel") to its file.
+	Files         map[string]*AssetFile `protobuf:"bytes,1,rep,name=files,proto3" json:"files,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ArchAssets) Reset() {
+	*x = ArchAssets{}
+	mi := &file_ateapi_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ArchAssets) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ArchAssets) ProtoMessage() {}
+
+func (x *ArchAssets) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ArchAssets.ProtoReflect.Descriptor instead.
+func (*ArchAssets) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *ArchAssets) GetFiles() map[string]*AssetFile {
+	if x != nil {
+		return x.Files
+	}
+	return nil
+}
+
+// AssetFile is one content-addressed file atelet fetches for a sandbox
+// runtime.
+type AssetFile struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// URL to download the asset from (e.g. a gs:// URL).
+	Url string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	// Lower-case hex SHA256 naming the cached file and verifying the download.
+	Sha256        string `protobuf:"bytes,2,opt,name=sha256,proto3" json:"sha256,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssetFile) Reset() {
+	*x = AssetFile{}
+	mi := &file_ateapi_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssetFile) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssetFile) ProtoMessage() {}
+
+func (x *AssetFile) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssetFile.ProtoReflect.Descriptor instead.
+func (*AssetFile) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *AssetFile) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *AssetFile) GetSha256() string {
+	if x != nil {
+		return x.Sha256
+	}
+	return ""
+}
+
 type CreateAtespaceRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The atespace to create.
@@ -1236,7 +2620,7 @@ type CreateAtespaceRequest struct {
 
 func (x *CreateAtespaceRequest) Reset() {
 	*x = CreateAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[11]
+	mi := &file_ateapi_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1248,7 +2632,7 @@ func (x *CreateAtespaceRequest) String() string {
 func (*CreateAtespaceRequest) ProtoMessage() {}
 
 func (x *CreateAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[11]
+	mi := &file_ateapi_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1261,7 +2645,7 @@ func (x *CreateAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*CreateAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{11}
+	return file_ateapi_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *CreateAtespaceRequest) GetAtespace() *Atespace {
@@ -1280,7 +2664,7 @@ type GetAtespaceRequest struct {
 
 func (x *GetAtespaceRequest) Reset() {
 	*x = GetAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[12]
+	mi := &file_ateapi_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1292,7 +2676,7 @@ func (x *GetAtespaceRequest) String() string {
 func (*GetAtespaceRequest) ProtoMessage() {}
 
 func (x *GetAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[12]
+	mi := &file_ateapi_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1305,7 +2689,7 @@ func (x *GetAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*GetAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{12}
+	return file_ateapi_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetAtespaceRequest) GetAtespace() *ObjectRef {
@@ -1330,7 +2714,7 @@ type ListAtespacesRequest struct {
 
 func (x *ListAtespacesRequest) Reset() {
 	*x = ListAtespacesRequest{}
-	mi := &file_ateapi_proto_msgTypes[13]
+	mi := &file_ateapi_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1342,7 +2726,7 @@ func (x *ListAtespacesRequest) String() string {
 func (*ListAtespacesRequest) ProtoMessage() {}
 
 func (x *ListAtespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[13]
+	mi := &file_ateapi_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1355,7 +2739,7 @@ func (x *ListAtespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAtespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListAtespacesRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{13}
+	return file_ateapi_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ListAtespacesRequest) GetPageSize() int32 {
@@ -1384,7 +2768,7 @@ type ListAtespacesResponse struct {
 
 func (x *ListAtespacesResponse) Reset() {
 	*x = ListAtespacesResponse{}
-	mi := &file_ateapi_proto_msgTypes[14]
+	mi := &file_ateapi_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1396,7 +2780,7 @@ func (x *ListAtespacesResponse) String() string {
 func (*ListAtespacesResponse) ProtoMessage() {}
 
 func (x *ListAtespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[14]
+	mi := &file_ateapi_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1409,7 +2793,7 @@ func (x *ListAtespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAtespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListAtespacesResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{14}
+	return file_ateapi_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ListAtespacesResponse) GetAtespaces() []*Atespace {
@@ -1435,7 +2819,7 @@ type DeleteAtespaceRequest struct {
 
 func (x *DeleteAtespaceRequest) Reset() {
 	*x = DeleteAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[15]
+	mi := &file_ateapi_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1447,7 +2831,7 @@ func (x *DeleteAtespaceRequest) String() string {
 func (*DeleteAtespaceRequest) ProtoMessage() {}
 
 func (x *DeleteAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[15]
+	mi := &file_ateapi_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1460,12 +2844,577 @@ func (x *DeleteAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{15}
+	return file_ateapi_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *DeleteAtespaceRequest) GetAtespace() *ObjectRef {
 	if x != nil {
 		return x.Atespace
+	}
+	return nil
+}
+
+type CreateActorTemplateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The actor template to create. Server-assigned metadata (uid, version,
+	// timestamps) is ignored.
+	ActorTemplate *ActorTemplate `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateActorTemplateRequest) Reset() {
+	*x = CreateActorTemplateRequest{}
+	mi := &file_ateapi_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateActorTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateActorTemplateRequest) ProtoMessage() {}
+
+func (x *CreateActorTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateActorTemplateRequest.ProtoReflect.Descriptor instead.
+func (*CreateActorTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *CreateActorTemplateRequest) GetActorTemplate() *ActorTemplate {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+type GetActorTemplateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ActorTemplate *ObjectRef             `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetActorTemplateRequest) Reset() {
+	*x = GetActorTemplateRequest{}
+	mi := &file_ateapi_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetActorTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetActorTemplateRequest) ProtoMessage() {}
+
+func (x *GetActorTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetActorTemplateRequest.ProtoReflect.Descriptor instead.
+func (*GetActorTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *GetActorTemplateRequest) GetActorTemplate() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+// Request to update mutable fields on an existing ActorTemplate.
+type UpdateActorTemplateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The actor template to update.
+	// actor_template.metadata.name identifies which resource to update.
+	// actor_template.metadata.version and actor_template.metadata.uid are
+	// optional preconditions and zero values skip the check.
+	ActorTemplate *ActorTemplate `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	// The set of fields to update. Required.
+	//
+	// Only the following fields are supported:
+	//   - spec.worker_selector
+	//   - spec.default_version_on_create
+	UpdateMask    *fieldmaskpb.FieldMask `protobuf:"bytes,2,opt,name=update_mask,json=updateMask,proto3" json:"update_mask,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateActorTemplateRequest) Reset() {
+	*x = UpdateActorTemplateRequest{}
+	mi := &file_ateapi_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateActorTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateActorTemplateRequest) ProtoMessage() {}
+
+func (x *UpdateActorTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateActorTemplateRequest.ProtoReflect.Descriptor instead.
+func (*UpdateActorTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *UpdateActorTemplateRequest) GetActorTemplate() *ActorTemplate {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+func (x *UpdateActorTemplateRequest) GetUpdateMask() *fieldmaskpb.FieldMask {
+	if x != nil {
+		return x.UpdateMask
+	}
+	return nil
+}
+
+type ListActorTemplatesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Requested page size; the server may return fewer, or occasionally
+	// slightly more. If unspecified, defaults to a server-chosen value;
+	// values above 1000 are coerced to 1000.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// Pagination token from a previous ListActorTemplates response.
+	// Omit or leave empty for the first request.
+	PageToken     string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListActorTemplatesRequest) Reset() {
+	*x = ListActorTemplatesRequest{}
+	mi := &file_ateapi_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListActorTemplatesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListActorTemplatesRequest) ProtoMessage() {}
+
+func (x *ListActorTemplatesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListActorTemplatesRequest.ProtoReflect.Descriptor instead.
+func (*ListActorTemplatesRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *ListActorTemplatesRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListActorTemplatesRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+type ListActorTemplatesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The page of actor templates. This list may be empty even if there are
+	// more results.
+	ActorTemplates []*ActorTemplate `protobuf:"bytes,1,rep,name=actor_templates,json=actorTemplates,proto3" json:"actor_templates,omitempty"`
+	// Pagination token for the next page. Empty if this is the last page.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListActorTemplatesResponse) Reset() {
+	*x = ListActorTemplatesResponse{}
+	mi := &file_ateapi_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListActorTemplatesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListActorTemplatesResponse) ProtoMessage() {}
+
+func (x *ListActorTemplatesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListActorTemplatesResponse.ProtoReflect.Descriptor instead.
+func (*ListActorTemplatesResponse) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *ListActorTemplatesResponse) GetActorTemplates() []*ActorTemplate {
+	if x != nil {
+		return x.ActorTemplates
+	}
+	return nil
+}
+
+func (x *ListActorTemplatesResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+type DeleteActorTemplateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ActorTemplate *ObjectRef             `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteActorTemplateRequest) Reset() {
+	*x = DeleteActorTemplateRequest{}
+	mi := &file_ateapi_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteActorTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteActorTemplateRequest) ProtoMessage() {}
+
+func (x *DeleteActorTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteActorTemplateRequest.ProtoReflect.Descriptor instead.
+func (*DeleteActorTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *DeleteActorTemplateRequest) GetActorTemplate() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+type CreateActorTemplateVersionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The actor template version to create. Server-assigned metadata (uid,
+	// version, timestamps) is ignored, as is status: the server initializes
+	// new versions to STATE_INITIAL.
+	ActorTemplateVersion *ActorTemplateVersion `protobuf:"bytes,1,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *CreateActorTemplateVersionRequest) Reset() {
+	*x = CreateActorTemplateVersionRequest{}
+	mi := &file_ateapi_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateActorTemplateVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateActorTemplateVersionRequest) ProtoMessage() {}
+
+func (x *CreateActorTemplateVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateActorTemplateVersionRequest.ProtoReflect.Descriptor instead.
+func (*CreateActorTemplateVersionRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *CreateActorTemplateVersionRequest) GetActorTemplateVersion() *ActorTemplateVersion {
+	if x != nil {
+		return x.ActorTemplateVersion
+	}
+	return nil
+}
+
+type GetActorTemplateVersionRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	ActorTemplateVersion *ObjectRef             `protobuf:"bytes,1,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *GetActorTemplateVersionRequest) Reset() {
+	*x = GetActorTemplateVersionRequest{}
+	mi := &file_ateapi_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetActorTemplateVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetActorTemplateVersionRequest) ProtoMessage() {}
+
+func (x *GetActorTemplateVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetActorTemplateVersionRequest.ProtoReflect.Descriptor instead.
+func (*GetActorTemplateVersionRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *GetActorTemplateVersionRequest) GetActorTemplateVersion() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplateVersion
+	}
+	return nil
+}
+
+type ListActorTemplateVersionsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The parent ActorTemplate whose versions to list, by name. Empty lists
+	// versions across all templates.
+	ActorTemplate string `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	// Requested page size; the server may return fewer, or occasionally
+	// slightly more. If unspecified, defaults to a server-chosen value;
+	// values above 1000 are coerced to 1000.
+	PageSize int32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// Pagination token from a previous ListActorTemplateVersions response.
+	// Omit or leave empty for the first request.
+	PageToken     string `protobuf:"bytes,3,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListActorTemplateVersionsRequest) Reset() {
+	*x = ListActorTemplateVersionsRequest{}
+	mi := &file_ateapi_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListActorTemplateVersionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListActorTemplateVersionsRequest) ProtoMessage() {}
+
+func (x *ListActorTemplateVersionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListActorTemplateVersionsRequest.ProtoReflect.Descriptor instead.
+func (*ListActorTemplateVersionsRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *ListActorTemplateVersionsRequest) GetActorTemplate() string {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return ""
+}
+
+func (x *ListActorTemplateVersionsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListActorTemplateVersionsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+type ListActorTemplateVersionsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The page of actor template versions. This list may be empty even if
+	// there are more results.
+	ActorTemplateVersions []*ActorTemplateVersion `protobuf:"bytes,1,rep,name=actor_template_versions,json=actorTemplateVersions,proto3" json:"actor_template_versions,omitempty"`
+	// Pagination token for the next page. Empty if this is the last page.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListActorTemplateVersionsResponse) Reset() {
+	*x = ListActorTemplateVersionsResponse{}
+	mi := &file_ateapi_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListActorTemplateVersionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListActorTemplateVersionsResponse) ProtoMessage() {}
+
+func (x *ListActorTemplateVersionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListActorTemplateVersionsResponse.ProtoReflect.Descriptor instead.
+func (*ListActorTemplateVersionsResponse) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *ListActorTemplateVersionsResponse) GetActorTemplateVersions() []*ActorTemplateVersion {
+	if x != nil {
+		return x.ActorTemplateVersions
+	}
+	return nil
+}
+
+func (x *ListActorTemplateVersionsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+type DeleteActorTemplateVersionRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	ActorTemplateVersion *ObjectRef             `protobuf:"bytes,1,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *DeleteActorTemplateVersionRequest) Reset() {
+	*x = DeleteActorTemplateVersionRequest{}
+	mi := &file_ateapi_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteActorTemplateVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteActorTemplateVersionRequest) ProtoMessage() {}
+
+func (x *DeleteActorTemplateVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteActorTemplateVersionRequest.ProtoReflect.Descriptor instead.
+func (*DeleteActorTemplateVersionRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *DeleteActorTemplateVersionRequest) GetActorTemplateVersion() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplateVersion
 	}
 	return nil
 }
@@ -1479,7 +3428,7 @@ type GetActorRequest struct {
 
 func (x *GetActorRequest) Reset() {
 	*x = GetActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[16]
+	mi := &file_ateapi_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1491,7 +3440,7 @@ func (x *GetActorRequest) String() string {
 func (*GetActorRequest) ProtoMessage() {}
 
 func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[16]
+	mi := &file_ateapi_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1504,7 +3453,7 @@ func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorRequest.ProtoReflect.Descriptor instead.
 func (*GetActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{16}
+	return file_ateapi_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GetActorRequest) GetActor() *ObjectRef {
@@ -1527,7 +3476,7 @@ type CreateActorRequest struct {
 
 func (x *CreateActorRequest) Reset() {
 	*x = CreateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[17]
+	mi := &file_ateapi_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1539,7 +3488,7 @@ func (x *CreateActorRequest) String() string {
 func (*CreateActorRequest) ProtoMessage() {}
 
 func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[17]
+	mi := &file_ateapi_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1552,7 +3501,7 @@ func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateActorRequest.ProtoReflect.Descriptor instead.
 func (*CreateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{17}
+	return file_ateapi_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CreateActorRequest) GetActor() *Actor {
@@ -1591,7 +3540,7 @@ type UpdateActorRequest struct {
 
 func (x *UpdateActorRequest) Reset() {
 	*x = UpdateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[18]
+	mi := &file_ateapi_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1603,7 +3552,7 @@ func (x *UpdateActorRequest) String() string {
 func (*UpdateActorRequest) ProtoMessage() {}
 
 func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[18]
+	mi := &file_ateapi_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1616,7 +3565,7 @@ func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorRequest.ProtoReflect.Descriptor instead.
 func (*UpdateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{18}
+	return file_ateapi_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *UpdateActorRequest) GetActor() *Actor {
@@ -1642,7 +3591,7 @@ type SuspendActorRequest struct {
 
 func (x *SuspendActorRequest) Reset() {
 	*x = SuspendActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[19]
+	mi := &file_ateapi_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1654,7 +3603,7 @@ func (x *SuspendActorRequest) String() string {
 func (*SuspendActorRequest) ProtoMessage() {}
 
 func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[19]
+	mi := &file_ateapi_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1667,7 +3616,7 @@ func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorRequest.ProtoReflect.Descriptor instead.
 func (*SuspendActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{19}
+	return file_ateapi_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *SuspendActorRequest) GetActor() *ObjectRef {
@@ -1686,7 +3635,7 @@ type SuspendActorResponse struct {
 
 func (x *SuspendActorResponse) Reset() {
 	*x = SuspendActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[20]
+	mi := &file_ateapi_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1698,7 +3647,7 @@ func (x *SuspendActorResponse) String() string {
 func (*SuspendActorResponse) ProtoMessage() {}
 
 func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[20]
+	mi := &file_ateapi_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1711,7 +3660,7 @@ func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorResponse.ProtoReflect.Descriptor instead.
 func (*SuspendActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{20}
+	return file_ateapi_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *SuspendActorResponse) GetActor() *Actor {
@@ -1730,7 +3679,7 @@ type PauseActorRequest struct {
 
 func (x *PauseActorRequest) Reset() {
 	*x = PauseActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[21]
+	mi := &file_ateapi_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1742,7 +3691,7 @@ func (x *PauseActorRequest) String() string {
 func (*PauseActorRequest) ProtoMessage() {}
 
 func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[21]
+	mi := &file_ateapi_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1755,7 +3704,7 @@ func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorRequest.ProtoReflect.Descriptor instead.
 func (*PauseActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{21}
+	return file_ateapi_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *PauseActorRequest) GetActor() *ObjectRef {
@@ -1774,7 +3723,7 @@ type PauseActorResponse struct {
 
 func (x *PauseActorResponse) Reset() {
 	*x = PauseActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1786,7 +3735,7 @@ func (x *PauseActorResponse) String() string {
 func (*PauseActorResponse) ProtoMessage() {}
 
 func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1799,7 +3748,7 @@ func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorResponse.ProtoReflect.Descriptor instead.
 func (*PauseActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{22}
+	return file_ateapi_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *PauseActorResponse) GetActor() *Actor {
@@ -1820,7 +3769,7 @@ type ResumeActorRequest struct {
 
 func (x *ResumeActorRequest) Reset() {
 	*x = ResumeActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1832,7 +3781,7 @@ func (x *ResumeActorRequest) String() string {
 func (*ResumeActorRequest) ProtoMessage() {}
 
 func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1845,7 +3794,7 @@ func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorRequest.ProtoReflect.Descriptor instead.
 func (*ResumeActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{23}
+	return file_ateapi_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ResumeActorRequest) GetActor() *ObjectRef {
@@ -1874,7 +3823,7 @@ type ResumeActorResponse struct {
 
 func (x *ResumeActorResponse) Reset() {
 	*x = ResumeActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1886,7 +3835,7 @@ func (x *ResumeActorResponse) String() string {
 func (*ResumeActorResponse) ProtoMessage() {}
 
 func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1899,7 +3848,7 @@ func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorResponse.ProtoReflect.Descriptor instead.
 func (*ResumeActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{24}
+	return file_ateapi_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ResumeActorResponse) GetActor() *Actor {
@@ -1925,7 +3874,7 @@ type DeleteActorRequest struct {
 
 func (x *DeleteActorRequest) Reset() {
 	*x = DeleteActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1937,7 +3886,7 @@ func (x *DeleteActorRequest) String() string {
 func (*DeleteActorRequest) ProtoMessage() {}
 
 func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1950,7 +3899,7 @@ func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorRequest.ProtoReflect.Descriptor instead.
 func (*DeleteActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{25}
+	return file_ateapi_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *DeleteActorRequest) GetActor() *ObjectRef {
@@ -1969,7 +3918,7 @@ type GetActorSnapshotRequest struct {
 
 func (x *GetActorSnapshotRequest) Reset() {
 	*x = GetActorSnapshotRequest{}
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1981,7 +3930,7 @@ func (x *GetActorSnapshotRequest) String() string {
 func (*GetActorSnapshotRequest) ProtoMessage() {}
 
 func (x *GetActorSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1994,7 +3943,7 @@ func (x *GetActorSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*GetActorSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{26}
+	return file_ateapi_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetActorSnapshotRequest) GetSnapshot() *ActorSnapshotRef {
@@ -2015,7 +3964,7 @@ type ListActorSnapshotsRequest struct {
 
 func (x *ListActorSnapshotsRequest) Reset() {
 	*x = ListActorSnapshotsRequest{}
-	mi := &file_ateapi_proto_msgTypes[27]
+	mi := &file_ateapi_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2027,7 +3976,7 @@ func (x *ListActorSnapshotsRequest) String() string {
 func (*ListActorSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListActorSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[27]
+	mi := &file_ateapi_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2040,7 +3989,7 @@ func (x *ListActorSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListActorSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{27}
+	return file_ateapi_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ListActorSnapshotsRequest) GetAtespace() string {
@@ -2074,7 +4023,7 @@ type ListActorSnapshotsResponse struct {
 
 func (x *ListActorSnapshotsResponse) Reset() {
 	*x = ListActorSnapshotsResponse{}
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2086,7 +4035,7 @@ func (x *ListActorSnapshotsResponse) String() string {
 func (*ListActorSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListActorSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2099,7 +4048,7 @@ func (x *ListActorSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListActorSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{28}
+	return file_ateapi_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ListActorSnapshotsResponse) GetSnapshots() []*ActorSnapshot {
@@ -2126,7 +4075,7 @@ type TagActorSnapshotRequest struct {
 
 func (x *TagActorSnapshotRequest) Reset() {
 	*x = TagActorSnapshotRequest{}
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2138,7 +4087,7 @@ func (x *TagActorSnapshotRequest) String() string {
 func (*TagActorSnapshotRequest) ProtoMessage() {}
 
 func (x *TagActorSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2151,7 +4100,7 @@ func (x *TagActorSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TagActorSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*TagActorSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{29}
+	return file_ateapi_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *TagActorSnapshotRequest) GetSnapshot() *ActorSnapshotRef {
@@ -2189,7 +4138,7 @@ type UpdateActorSnapshotTagRequest struct {
 
 func (x *UpdateActorSnapshotTagRequest) Reset() {
 	*x = UpdateActorSnapshotTagRequest{}
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2201,7 +4150,7 @@ func (x *UpdateActorSnapshotTagRequest) String() string {
 func (*UpdateActorSnapshotTagRequest) ProtoMessage() {}
 
 func (x *UpdateActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2214,7 +4163,7 @@ func (x *UpdateActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorSnapshotTagRequest.ProtoReflect.Descriptor instead.
 func (*UpdateActorSnapshotTagRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{30}
+	return file_ateapi_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *UpdateActorSnapshotTagRequest) GetTag() *ActorSnapshotTag {
@@ -2240,7 +4189,7 @@ type DeleteActorSnapshotTagRequest struct {
 
 func (x *DeleteActorSnapshotTagRequest) Reset() {
 	*x = DeleteActorSnapshotTagRequest{}
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2252,7 +4201,7 @@ func (x *DeleteActorSnapshotTagRequest) String() string {
 func (*DeleteActorSnapshotTagRequest) ProtoMessage() {}
 
 func (x *DeleteActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2265,7 +4214,7 @@ func (x *DeleteActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorSnapshotTagRequest.ProtoReflect.Descriptor instead.
 func (*DeleteActorSnapshotTagRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{31}
+	return file_ateapi_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *DeleteActorSnapshotTagRequest) GetTag() *ObjectRef {
@@ -2290,7 +4239,7 @@ type ListWorkersRequest struct {
 
 func (x *ListWorkersRequest) Reset() {
 	*x = ListWorkersRequest{}
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2302,7 +4251,7 @@ func (x *ListWorkersRequest) String() string {
 func (*ListWorkersRequest) ProtoMessage() {}
 
 func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2315,7 +4264,7 @@ func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkersRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{32}
+	return file_ateapi_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ListWorkersRequest) GetPageSize() int32 {
@@ -2344,7 +4293,7 @@ type ListWorkersResponse struct {
 
 func (x *ListWorkersResponse) Reset() {
 	*x = ListWorkersResponse{}
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2356,7 +4305,7 @@ func (x *ListWorkersResponse) String() string {
 func (*ListWorkersResponse) ProtoMessage() {}
 
 func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2369,7 +4318,7 @@ func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkersResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{33}
+	return file_ateapi_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListWorkersResponse) GetWorkers() []*Worker {
@@ -2405,7 +4354,7 @@ type ListActorsRequest struct {
 
 func (x *ListActorsRequest) Reset() {
 	*x = ListActorsRequest{}
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2417,7 +4366,7 @@ func (x *ListActorsRequest) String() string {
 func (*ListActorsRequest) ProtoMessage() {}
 
 func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2430,7 +4379,7 @@ func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsRequest.ProtoReflect.Descriptor instead.
 func (*ListActorsRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{34}
+	return file_ateapi_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ListActorsRequest) GetAtespace() string {
@@ -2466,7 +4415,7 @@ type ListActorsResponse struct {
 
 func (x *ListActorsResponse) Reset() {
 	*x = ListActorsResponse{}
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2478,7 +4427,7 @@ func (x *ListActorsResponse) String() string {
 func (*ListActorsResponse) ProtoMessage() {}
 
 func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2491,7 +4440,7 @@ func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsResponse.ProtoReflect.Descriptor instead.
 func (*ListActorsResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{35}
+	return file_ateapi_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ListActorsResponse) GetActors() []*Actor {
@@ -2527,7 +4476,7 @@ type Worker struct {
 
 func (x *Worker) Reset() {
 	*x = Worker{}
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2539,7 +4488,7 @@ func (x *Worker) String() string {
 func (*Worker) ProtoMessage() {}
 
 func (x *Worker) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2552,7 +4501,7 @@ func (x *Worker) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Worker.ProtoReflect.Descriptor instead.
 func (*Worker) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{36}
+	return file_ateapi_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *Worker) GetWorkerNamespace() string {
@@ -2643,7 +4592,7 @@ type Assignment struct {
 
 func (x *Assignment) Reset() {
 	*x = Assignment{}
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2655,7 +4604,7 @@ func (x *Assignment) String() string {
 func (*Assignment) ProtoMessage() {}
 
 func (x *Assignment) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2668,7 +4617,7 @@ func (x *Assignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Assignment.ProtoReflect.Descriptor instead.
 func (*Assignment) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{37}
+	return file_ateapi_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *Assignment) GetActorTemplate() *KubeNamespacedObjectRef {
@@ -2702,7 +4651,7 @@ type KubeNamespacedObjectRef struct {
 
 func (x *KubeNamespacedObjectRef) Reset() {
 	*x = KubeNamespacedObjectRef{}
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2714,7 +4663,7 @@ func (x *KubeNamespacedObjectRef) String() string {
 func (*KubeNamespacedObjectRef) ProtoMessage() {}
 
 func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2727,7 +4676,7 @@ func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeNamespacedObjectRef.ProtoReflect.Descriptor instead.
 func (*KubeNamespacedObjectRef) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{38}
+	return file_ateapi_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *KubeNamespacedObjectRef) GetNamespace() string {
@@ -2752,7 +4701,7 @@ type DebugClearRequest struct {
 
 func (x *DebugClearRequest) Reset() {
 	*x = DebugClearRequest{}
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2764,7 +4713,7 @@ func (x *DebugClearRequest) String() string {
 func (*DebugClearRequest) ProtoMessage() {}
 
 func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2777,7 +4726,7 @@ func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearRequest.ProtoReflect.Descriptor instead.
 func (*DebugClearRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{39}
+	return file_ateapi_proto_rawDescGZIP(), []int{69}
 }
 
 type DebugClearResponse struct {
@@ -2788,7 +4737,7 @@ type DebugClearResponse struct {
 
 func (x *DebugClearResponse) Reset() {
 	*x = DebugClearResponse{}
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2800,7 +4749,7 @@ func (x *DebugClearResponse) String() string {
 func (*DebugClearResponse) ProtoMessage() {}
 
 func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2813,7 +4762,7 @@ func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearResponse.ProtoReflect.Descriptor instead.
 func (*DebugClearResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{40}
+	return file_ateapi_proto_rawDescGZIP(), []int{70}
 }
 
 type MintJWTRequest struct {
@@ -2828,7 +4777,7 @@ type MintJWTRequest struct {
 
 func (x *MintJWTRequest) Reset() {
 	*x = MintJWTRequest{}
-	mi := &file_ateapi_proto_msgTypes[41]
+	mi := &file_ateapi_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2840,7 +4789,7 @@ func (x *MintJWTRequest) String() string {
 func (*MintJWTRequest) ProtoMessage() {}
 
 func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[41]
+	mi := &file_ateapi_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2853,7 +4802,7 @@ func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTRequest.ProtoReflect.Descriptor instead.
 func (*MintJWTRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{41}
+	return file_ateapi_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *MintJWTRequest) GetAudience() []string {
@@ -2914,7 +4863,7 @@ type MintJWTResponse struct {
 
 func (x *MintJWTResponse) Reset() {
 	*x = MintJWTResponse{}
-	mi := &file_ateapi_proto_msgTypes[42]
+	mi := &file_ateapi_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2926,7 +4875,7 @@ func (x *MintJWTResponse) String() string {
 func (*MintJWTResponse) ProtoMessage() {}
 
 func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[42]
+	mi := &file_ateapi_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2939,7 +4888,7 @@ func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTResponse.ProtoReflect.Descriptor instead.
 func (*MintJWTResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{42}
+	return file_ateapi_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *MintJWTResponse) GetActorJwt() string {
@@ -2971,7 +4920,7 @@ type MintCertRequest struct {
 
 func (x *MintCertRequest) Reset() {
 	*x = MintCertRequest{}
-	mi := &file_ateapi_proto_msgTypes[43]
+	mi := &file_ateapi_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2983,7 +4932,7 @@ func (x *MintCertRequest) String() string {
 func (*MintCertRequest) ProtoMessage() {}
 
 func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[43]
+	mi := &file_ateapi_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2996,7 +4945,7 @@ func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertRequest.ProtoReflect.Descriptor instead.
 func (*MintCertRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{43}
+	return file_ateapi_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *MintCertRequest) GetWorkerNamespace() string {
@@ -3053,7 +5002,7 @@ type MintCertResponse struct {
 
 func (x *MintCertResponse) Reset() {
 	*x = MintCertResponse{}
-	mi := &file_ateapi_proto_msgTypes[44]
+	mi := &file_ateapi_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3065,7 +5014,7 @@ func (x *MintCertResponse) String() string {
 func (*MintCertResponse) ProtoMessage() {}
 
 func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[44]
+	mi := &file_ateapi_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3078,7 +5027,7 @@ func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertResponse.ProtoReflect.Descriptor instead.
 func (*MintCertResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{44}
+	return file_ateapi_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *MintCertResponse) GetActorCertificates() [][]byte {
@@ -3181,7 +5130,98 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x10ActorSnapshotRef\x12/\n" +
 	"\bsnapshot\x18\x01 \x01(\v2\x11.ateapi.ObjectRefH\x00R\bsnapshot\x12%\n" +
 	"\x03tag\x18\x02 \x01(\v2\x11.ateapi.ObjectRefH\x00R\x03tagB\v\n" +
-	"\treference\"E\n" +
+	"\treference\"t\n" +
+	"\rActorTemplate\x124\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x18.ateapi.ResourceMetadataR\bmetadata\x12-\n" +
+	"\x04spec\x18\x02 \x01(\v2\x19.ateapi.ActorTemplateSpecR\x04spec\"\x9c\x01\n" +
+	"\x11ActorTemplateSpec\x129\n" +
+	"\x0fworker_selector\x18\x01 \x01(\v2\x10.ateapi.SelectorR\x0eworkerSelector\x12L\n" +
+	"\x19default_version_on_create\x18\x02 \x01(\v2\x11.ateapi.ObjectRefR\x16defaultVersionOnCreate\"\xf8\x01\n" +
+	"\x14ActorTemplateVersion\x124\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x18.ateapi.ResourceMetadataR\bmetadata\x128\n" +
+	"\x0eactor_template\x18\x02 \x01(\v2\x11.ateapi.ObjectRefR\ractorTemplate\x124\n" +
+	"\x04spec\x18\x03 \x01(\v2 .ateapi.ActorTemplateVersionSpecR\x04spec\x12:\n" +
+	"\x06status\x18\x04 \x01(\v2\".ateapi.ActorTemplateVersionStatusR\x06status\"\x9a\x02\n" +
+	"\x18ActorTemplateVersionSpec\x12\x1f\n" +
+	"\vpause_image\x18\x01 \x01(\tR\n" +
+	"pauseImage\x121\n" +
+	"\n" +
+	"containers\x18\x02 \x03(\v2\x11.ateapi.ContainerR\n" +
+	"containers\x12(\n" +
+	"\avolumes\x18\x03 \x03(\v2\x0e.ateapi.VolumeR\avolumes\x12B\n" +
+	"\x10snapshots_config\x18\x04 \x01(\v2\x17.ateapi.SnapshotsConfigR\x0fsnapshotsConfig\x12<\n" +
+	"\x0esandbox_config\x18\x05 \x01(\v2\x15.ateapi.SandboxConfigR\rsandboxConfig\"k\n" +
+	"\rSandboxConfig\x129\n" +
+	"\rsandbox_class\x18\x01 \x01(\x0e2\x14.ateapi.SandboxClassR\fsandboxClass\x12\x1f\n" +
+	"\vconfig_name\x18\x02 \x01(\tR\n" +
+	"configName\"\xe5\x01\n" +
+	"\x0fSnapshotsConfig\x127\n" +
+	"\bon_pause\x18\x01 \x01(\x0e2\x1c.ateapi.SnapshotContentScopeR\aonPause\x129\n" +
+	"\ton_commit\x18\x02 \x01(\x0e2\x1c.ateapi.SnapshotContentScopeR\bonCommit\x123\n" +
+	"\ton_resume\x18\x03 \x01(\v2\x16.ateapi.OnResumeConfigR\bonResume\x12)\n" +
+	"\x10storage_location\x18\x04 \x01(\tR\x0fstorageLocation\"C\n" +
+	"\x0eOnResumeConfig\x121\n" +
+	"\tfrom_data\x18\x01 \x01(\x0e2\x14.ateapi.ResumeSourceR\bfromData\"\x87\x03\n" +
+	"\x1aActorTemplateVersionStatus\x12:\n" +
+	"\x0fgolden_snapshot\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x0egoldenSnapshot\x12>\n" +
+	"\x05state\x18\x02 \x01(\x0e2(.ateapi.ActorTemplateVersionStatus.StateR\x05state\x12@\n" +
+	"\x10resolved_sandbox\x18\x03 \x01(\v2\x15.ateapi.SandboxAssetsR\x0fresolvedSandbox\x12\x18\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\"\x90\x01\n" +
+	"\x05State\x12\x15\n" +
+	"\x11STATE_UNSPECIFIED\x10\x00\x12\x11\n" +
+	"\rSTATE_INITIAL\x10\x01\x12\x1d\n" +
+	"\x19STATE_RESUME_GOLDEN_ACTOR\x10\x02\x12\x1b\n" +
+	"\x17STATE_WAIT_GOLDEN_ACTOR\x10\x03\x12\x0f\n" +
+	"\vSTATE_READY\x10\x04\x12\x10\n" +
+	"\fSTATE_FAILED\x10\x05\"\xf0\x01\n" +
+	"\tContainer\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05image\x18\x02 \x01(\tR\x05image\x12\x18\n" +
+	"\acommand\x18\x03 \x03(\tR\acommand\x12\x12\n" +
+	"\x04args\x18\x04 \x03(\tR\x04args\x12 \n" +
+	"\x03env\x18\x05 \x03(\v2\x0e.ateapi.EnvVarR\x03env\x12/\n" +
+	"\x06readyz\x18\x06 \x01(\v2\x17.ateapi.ContainerReadyzR\x06readyz\x128\n" +
+	"\rvolume_mounts\x18\a \x03(\v2\x13.ateapi.VolumeMountR\fvolumeMounts\">\n" +
+	"\x06EnvVar\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x05value\x18\x02 \x01(\tH\x00R\x05valueB\b\n" +
+	"\x06source\"l\n" +
+	"\x0fContainerReadyz\x120\n" +
+	"\bhttp_get\x18\x01 \x01(\v2\x15.ateapi.HTTPGetActionR\ahttpGet\x12'\n" +
+	"\x0ftimeout_seconds\x18\x02 \x01(\x05R\x0etimeoutSeconds\"7\n" +
+	"\rHTTPGetAction\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\"\xc5\x01\n" +
+	"\x06Volume\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12A\n" +
+	"\vdurable_dir\x18\x02 \x01(\v2\x1e.ateapi.DurableDirVolumeSourceH\x00R\n" +
+	"durableDir\x12Z\n" +
+	"\x18external_volume_template\x18\x03 \x01(\v2\x1e.ateapi.ExternalVolumeTemplateH\x00R\x16externalVolumeTemplateB\b\n" +
+	"\x06source\"\x18\n" +
+	"\x16DurableDirVolumeSource\"b\n" +
+	"\x16ExternalVolumeTemplate\x12\x1a\n" +
+	"\bcapacity\x18\x01 \x01(\tR\bcapacity\x12,\n" +
+	"\x12storage_class_name\x18\x02 \x01(\tR\x10storageClassName\"@\n" +
+	"\vVolumeMount\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
+	"\n" +
+	"mount_path\x18\x02 \x01(\tR\tmountPath\"\xd4\x01\n" +
+	"\rSandboxAssets\x129\n" +
+	"\rsandbox_class\x18\x01 \x01(\x0e2\x14.ateapi.SandboxClassR\fsandboxClass\x129\n" +
+	"\x06assets\x18\x02 \x03(\v2!.ateapi.SandboxAssets.AssetsEntryR\x06assets\x1aM\n" +
+	"\vAssetsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12(\n" +
+	"\x05value\x18\x02 \x01(\v2\x12.ateapi.ArchAssetsR\x05value:\x028\x01\"\x8e\x01\n" +
+	"\n" +
+	"ArchAssets\x123\n" +
+	"\x05files\x18\x01 \x03(\v2\x1d.ateapi.ArchAssets.FilesEntryR\x05files\x1aK\n" +
+	"\n" +
+	"FilesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12'\n" +
+	"\x05value\x18\x02 \x01(\v2\x11.ateapi.AssetFileR\x05value:\x028\x01\"5\n" +
+	"\tAssetFile\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12\x16\n" +
+	"\x06sha256\x18\x02 \x01(\tR\x06sha256\"E\n" +
 	"\x15CreateAtespaceRequest\x12,\n" +
 	"\batespace\x18\x01 \x01(\v2\x10.ateapi.AtespaceR\batespace\"C\n" +
 	"\x12GetAtespaceRequest\x12-\n" +
@@ -3194,7 +5234,38 @@ const file_ateapi_proto_rawDesc = "" +
 	"\tatespaces\x18\x01 \x03(\v2\x10.ateapi.AtespaceR\tatespaces\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"F\n" +
 	"\x15DeleteAtespaceRequest\x12-\n" +
-	"\batespace\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\batespace\":\n" +
+	"\batespace\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\batespace\"Z\n" +
+	"\x1aCreateActorTemplateRequest\x12<\n" +
+	"\x0eactor_template\x18\x01 \x01(\v2\x15.ateapi.ActorTemplateR\ractorTemplate\"S\n" +
+	"\x17GetActorTemplateRequest\x128\n" +
+	"\x0eactor_template\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\ractorTemplate\"\x97\x01\n" +
+	"\x1aUpdateActorTemplateRequest\x12<\n" +
+	"\x0eactor_template\x18\x01 \x01(\v2\x15.ateapi.ActorTemplateR\ractorTemplate\x12;\n" +
+	"\vupdate_mask\x18\x02 \x01(\v2\x1a.google.protobuf.FieldMaskR\n" +
+	"updateMask\"W\n" +
+	"\x19ListActorTemplatesRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\"\x84\x01\n" +
+	"\x1aListActorTemplatesResponse\x12>\n" +
+	"\x0factor_templates\x18\x01 \x03(\v2\x15.ateapi.ActorTemplateR\x0eactorTemplates\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"V\n" +
+	"\x1aDeleteActorTemplateRequest\x128\n" +
+	"\x0eactor_template\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\ractorTemplate\"w\n" +
+	"!CreateActorTemplateVersionRequest\x12R\n" +
+	"\x16actor_template_version\x18\x01 \x01(\v2\x1c.ateapi.ActorTemplateVersionR\x14actorTemplateVersion\"i\n" +
+	"\x1eGetActorTemplateVersionRequest\x12G\n" +
+	"\x16actor_template_version\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x14actorTemplateVersion\"\x85\x01\n" +
+	" ListActorTemplateVersionsRequest\x12%\n" +
+	"\x0eactor_template\x18\x01 \x01(\tR\ractorTemplate\x12\x1b\n" +
+	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x03 \x01(\tR\tpageToken\"\xa1\x01\n" +
+	"!ListActorTemplateVersionsResponse\x12T\n" +
+	"\x17actor_template_versions\x18\x01 \x03(\v2\x1c.ateapi.ActorTemplateVersionR\x15actorTemplateVersions\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"l\n" +
+	"!DeleteActorTemplateVersionRequest\x12G\n" +
+	"\x16actor_template_version\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x14actorTemplateVersion\":\n" +
 	"\x0fGetActorRequest\x12'\n" +
 	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"|\n" +
 	"\x12CreateActorRequest\x12#\n" +
@@ -3312,11 +5383,18 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x1bSNAPSHOT_CONTENT_SCOPE_DATA\x10\x02*f\n" +
 	"\x15ActorSnapshotTagScope\x12%\n" +
 	"!ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE\x10\x00\x12&\n" +
-	"\"ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED\x10\x01*k\n" +
+	"\"ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED\x10\x01*b\n" +
+	"\fSandboxClass\x12\x1d\n" +
+	"\x19SANDBOX_CLASS_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14SANDBOX_CLASS_GVISOR\x10\x01\x12\x19\n" +
+	"\x15SANDBOX_CLASS_MICROVM\x10\x02*d\n" +
+	"\fResumeSource\x12\x1d\n" +
+	"\x19RESUME_SOURCE_UNSPECIFIED\x10\x00\x12\x1b\n" +
+	"\x17RESUME_SOURCE_COLD_BOOT\x10\x01\x12\x18\n" +
+	"\x14RESUME_SOURCE_GOLDEN\x10\x02*k\n" +
 	"\x17ActorCertificatePurpose\x12)\n" +
 	"%ACTOR_CERTIFICATE_PURPOSE_UNSPECIFIED\x10\x00\x12%\n" +
-	"!ACTOR_CERTIFICATE_PURPOSE_ATUNNEL\x10\x012\xb3\n" +
-	"\n" +
+	"!ACTOR_CERTIFICATE_PURPOSE_ATUNNEL\x10\x012\x85\x11\n" +
 	"\aControl\x124\n" +
 	"\bGetActor\x12\x17.ateapi.GetActorRequest\x1a\r.ateapi.Actor\"\x00\x12:\n" +
 	"\vCreateActor\x12\x1a.ateapi.CreateActorRequest\x1a\r.ateapi.Actor\"\x00\x12:\n" +
@@ -3337,7 +5415,16 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x0eCreateAtespace\x12\x1d.ateapi.CreateAtespaceRequest\x1a\x10.ateapi.Atespace\"\x00\x12=\n" +
 	"\vGetAtespace\x12\x1a.ateapi.GetAtespaceRequest\x1a\x10.ateapi.Atespace\"\x00\x12N\n" +
 	"\rListAtespaces\x12\x1c.ateapi.ListAtespacesRequest\x1a\x1d.ateapi.ListAtespacesResponse\"\x00\x12C\n" +
-	"\x0eDeleteAtespace\x12\x1d.ateapi.DeleteAtespaceRequest\x1a\x10.ateapi.Atespace\"\x002N\n" +
+	"\x0eDeleteAtespace\x12\x1d.ateapi.DeleteAtespaceRequest\x1a\x10.ateapi.Atespace\"\x00\x12R\n" +
+	"\x13CreateActorTemplate\x12\".ateapi.CreateActorTemplateRequest\x1a\x15.ateapi.ActorTemplate\"\x00\x12L\n" +
+	"\x10GetActorTemplate\x12\x1f.ateapi.GetActorTemplateRequest\x1a\x15.ateapi.ActorTemplate\"\x00\x12R\n" +
+	"\x13UpdateActorTemplate\x12\".ateapi.UpdateActorTemplateRequest\x1a\x15.ateapi.ActorTemplate\"\x00\x12]\n" +
+	"\x12ListActorTemplates\x12!.ateapi.ListActorTemplatesRequest\x1a\".ateapi.ListActorTemplatesResponse\"\x00\x12R\n" +
+	"\x13DeleteActorTemplate\x12\".ateapi.DeleteActorTemplateRequest\x1a\x15.ateapi.ActorTemplate\"\x00\x12g\n" +
+	"\x1aCreateActorTemplateVersion\x12).ateapi.CreateActorTemplateVersionRequest\x1a\x1c.ateapi.ActorTemplateVersion\"\x00\x12a\n" +
+	"\x17GetActorTemplateVersion\x12&.ateapi.GetActorTemplateVersionRequest\x1a\x1c.ateapi.ActorTemplateVersion\"\x00\x12r\n" +
+	"\x19ListActorTemplateVersions\x12(.ateapi.ListActorTemplateVersionsRequest\x1a).ateapi.ListActorTemplateVersionsResponse\"\x00\x12g\n" +
+	"\x1aDeleteActorTemplateVersion\x12).ateapi.DeleteActorTemplateVersionRequest\x1a\x1c.ateapi.ActorTemplateVersion\"\x002N\n" +
 	"\x05Debug\x12E\n" +
 	"\n" +
 	"DebugClear\x12\x19.ateapi.DebugClearRequest\x1a\x1a.ateapi.DebugClearResponse\"\x002\x8a\x01\n" +
@@ -3357,167 +5444,261 @@ func file_ateapi_proto_rawDescGZIP() []byte {
 	return file_ateapi_proto_rawDescData
 }
 
-var file_ateapi_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_ateapi_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
+var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 80)
 var file_ateapi_proto_goTypes = []any{
-	(SnapshotContentScope)(0),             // 0: ateapi.SnapshotContentScope
-	(ActorSnapshotTagScope)(0),            // 1: ateapi.ActorSnapshotTagScope
-	(ActorCertificatePurpose)(0),          // 2: ateapi.ActorCertificatePurpose
-	(ExternalVolume_Status)(0),            // 3: ateapi.ExternalVolume.Status
-	(Actor_Status)(0),                     // 4: ateapi.Actor.Status
-	(Worker_State)(0),                     // 5: ateapi.Worker.State
-	(*LocalSnapshotInfo)(nil),             // 6: ateapi.LocalSnapshotInfo
-	(*Selector)(nil),                      // 7: ateapi.Selector
-	(*ResourceMetadata)(nil),              // 8: ateapi.ResourceMetadata
-	(*ExternalVolume)(nil),                // 9: ateapi.ExternalVolume
-	(*Actor)(nil),                         // 10: ateapi.Actor
-	(*WorkerAssignment)(nil),              // 11: ateapi.WorkerAssignment
-	(*ActorSnapshot)(nil),                 // 12: ateapi.ActorSnapshot
-	(*ActorSnapshotTag)(nil),              // 13: ateapi.ActorSnapshotTag
-	(*Atespace)(nil),                      // 14: ateapi.Atespace
-	(*ObjectRef)(nil),                     // 15: ateapi.ObjectRef
-	(*ActorSnapshotRef)(nil),              // 16: ateapi.ActorSnapshotRef
-	(*CreateAtespaceRequest)(nil),         // 17: ateapi.CreateAtespaceRequest
-	(*GetAtespaceRequest)(nil),            // 18: ateapi.GetAtespaceRequest
-	(*ListAtespacesRequest)(nil),          // 19: ateapi.ListAtespacesRequest
-	(*ListAtespacesResponse)(nil),         // 20: ateapi.ListAtespacesResponse
-	(*DeleteAtespaceRequest)(nil),         // 21: ateapi.DeleteAtespaceRequest
-	(*GetActorRequest)(nil),               // 22: ateapi.GetActorRequest
-	(*CreateActorRequest)(nil),            // 23: ateapi.CreateActorRequest
-	(*UpdateActorRequest)(nil),            // 24: ateapi.UpdateActorRequest
-	(*SuspendActorRequest)(nil),           // 25: ateapi.SuspendActorRequest
-	(*SuspendActorResponse)(nil),          // 26: ateapi.SuspendActorResponse
-	(*PauseActorRequest)(nil),             // 27: ateapi.PauseActorRequest
-	(*PauseActorResponse)(nil),            // 28: ateapi.PauseActorResponse
-	(*ResumeActorRequest)(nil),            // 29: ateapi.ResumeActorRequest
-	(*ResumeActorResponse)(nil),           // 30: ateapi.ResumeActorResponse
-	(*DeleteActorRequest)(nil),            // 31: ateapi.DeleteActorRequest
-	(*GetActorSnapshotRequest)(nil),       // 32: ateapi.GetActorSnapshotRequest
-	(*ListActorSnapshotsRequest)(nil),     // 33: ateapi.ListActorSnapshotsRequest
-	(*ListActorSnapshotsResponse)(nil),    // 34: ateapi.ListActorSnapshotsResponse
-	(*TagActorSnapshotRequest)(nil),       // 35: ateapi.TagActorSnapshotRequest
-	(*UpdateActorSnapshotTagRequest)(nil), // 36: ateapi.UpdateActorSnapshotTagRequest
-	(*DeleteActorSnapshotTagRequest)(nil), // 37: ateapi.DeleteActorSnapshotTagRequest
-	(*ListWorkersRequest)(nil),            // 38: ateapi.ListWorkersRequest
-	(*ListWorkersResponse)(nil),           // 39: ateapi.ListWorkersResponse
-	(*ListActorsRequest)(nil),             // 40: ateapi.ListActorsRequest
-	(*ListActorsResponse)(nil),            // 41: ateapi.ListActorsResponse
-	(*Worker)(nil),                        // 42: ateapi.Worker
-	(*Assignment)(nil),                    // 43: ateapi.Assignment
-	(*KubeNamespacedObjectRef)(nil),       // 44: ateapi.KubeNamespacedObjectRef
-	(*DebugClearRequest)(nil),             // 45: ateapi.DebugClearRequest
-	(*DebugClearResponse)(nil),            // 46: ateapi.DebugClearResponse
-	(*MintJWTRequest)(nil),                // 47: ateapi.MintJWTRequest
-	(*MintJWTResponse)(nil),               // 48: ateapi.MintJWTResponse
-	(*MintCertRequest)(nil),               // 49: ateapi.MintCertRequest
-	(*MintCertResponse)(nil),              // 50: ateapi.MintCertResponse
-	nil,                                   // 51: ateapi.Selector.MatchLabelsEntry
-	nil,                                   // 52: ateapi.ExternalVolume.VolumeContextEntry
-	nil,                                   // 53: ateapi.Worker.LabelsEntry
-	(*timestamppb.Timestamp)(nil),         // 54: google.protobuf.Timestamp
-	(*fieldmaskpb.FieldMask)(nil),         // 55: google.protobuf.FieldMask
+	(SnapshotContentScope)(0),                 // 0: ateapi.SnapshotContentScope
+	(ActorSnapshotTagScope)(0),                // 1: ateapi.ActorSnapshotTagScope
+	(SandboxClass)(0),                         // 2: ateapi.SandboxClass
+	(ResumeSource)(0),                         // 3: ateapi.ResumeSource
+	(ActorCertificatePurpose)(0),              // 4: ateapi.ActorCertificatePurpose
+	(ExternalVolume_Status)(0),                // 5: ateapi.ExternalVolume.Status
+	(Actor_Status)(0),                         // 6: ateapi.Actor.Status
+	(ActorTemplateVersionStatus_State)(0),     // 7: ateapi.ActorTemplateVersionStatus.State
+	(Worker_State)(0),                         // 8: ateapi.Worker.State
+	(*LocalSnapshotInfo)(nil),                 // 9: ateapi.LocalSnapshotInfo
+	(*Selector)(nil),                          // 10: ateapi.Selector
+	(*ResourceMetadata)(nil),                  // 11: ateapi.ResourceMetadata
+	(*ExternalVolume)(nil),                    // 12: ateapi.ExternalVolume
+	(*Actor)(nil),                             // 13: ateapi.Actor
+	(*WorkerAssignment)(nil),                  // 14: ateapi.WorkerAssignment
+	(*ActorSnapshot)(nil),                     // 15: ateapi.ActorSnapshot
+	(*ActorSnapshotTag)(nil),                  // 16: ateapi.ActorSnapshotTag
+	(*Atespace)(nil),                          // 17: ateapi.Atespace
+	(*ObjectRef)(nil),                         // 18: ateapi.ObjectRef
+	(*ActorSnapshotRef)(nil),                  // 19: ateapi.ActorSnapshotRef
+	(*ActorTemplate)(nil),                     // 20: ateapi.ActorTemplate
+	(*ActorTemplateSpec)(nil),                 // 21: ateapi.ActorTemplateSpec
+	(*ActorTemplateVersion)(nil),              // 22: ateapi.ActorTemplateVersion
+	(*ActorTemplateVersionSpec)(nil),          // 23: ateapi.ActorTemplateVersionSpec
+	(*SandboxConfig)(nil),                     // 24: ateapi.SandboxConfig
+	(*SnapshotsConfig)(nil),                   // 25: ateapi.SnapshotsConfig
+	(*OnResumeConfig)(nil),                    // 26: ateapi.OnResumeConfig
+	(*ActorTemplateVersionStatus)(nil),        // 27: ateapi.ActorTemplateVersionStatus
+	(*Container)(nil),                         // 28: ateapi.Container
+	(*EnvVar)(nil),                            // 29: ateapi.EnvVar
+	(*ContainerReadyz)(nil),                   // 30: ateapi.ContainerReadyz
+	(*HTTPGetAction)(nil),                     // 31: ateapi.HTTPGetAction
+	(*Volume)(nil),                            // 32: ateapi.Volume
+	(*DurableDirVolumeSource)(nil),            // 33: ateapi.DurableDirVolumeSource
+	(*ExternalVolumeTemplate)(nil),            // 34: ateapi.ExternalVolumeTemplate
+	(*VolumeMount)(nil),                       // 35: ateapi.VolumeMount
+	(*SandboxAssets)(nil),                     // 36: ateapi.SandboxAssets
+	(*ArchAssets)(nil),                        // 37: ateapi.ArchAssets
+	(*AssetFile)(nil),                         // 38: ateapi.AssetFile
+	(*CreateAtespaceRequest)(nil),             // 39: ateapi.CreateAtespaceRequest
+	(*GetAtespaceRequest)(nil),                // 40: ateapi.GetAtespaceRequest
+	(*ListAtespacesRequest)(nil),              // 41: ateapi.ListAtespacesRequest
+	(*ListAtespacesResponse)(nil),             // 42: ateapi.ListAtespacesResponse
+	(*DeleteAtespaceRequest)(nil),             // 43: ateapi.DeleteAtespaceRequest
+	(*CreateActorTemplateRequest)(nil),        // 44: ateapi.CreateActorTemplateRequest
+	(*GetActorTemplateRequest)(nil),           // 45: ateapi.GetActorTemplateRequest
+	(*UpdateActorTemplateRequest)(nil),        // 46: ateapi.UpdateActorTemplateRequest
+	(*ListActorTemplatesRequest)(nil),         // 47: ateapi.ListActorTemplatesRequest
+	(*ListActorTemplatesResponse)(nil),        // 48: ateapi.ListActorTemplatesResponse
+	(*DeleteActorTemplateRequest)(nil),        // 49: ateapi.DeleteActorTemplateRequest
+	(*CreateActorTemplateVersionRequest)(nil), // 50: ateapi.CreateActorTemplateVersionRequest
+	(*GetActorTemplateVersionRequest)(nil),    // 51: ateapi.GetActorTemplateVersionRequest
+	(*ListActorTemplateVersionsRequest)(nil),  // 52: ateapi.ListActorTemplateVersionsRequest
+	(*ListActorTemplateVersionsResponse)(nil), // 53: ateapi.ListActorTemplateVersionsResponse
+	(*DeleteActorTemplateVersionRequest)(nil), // 54: ateapi.DeleteActorTemplateVersionRequest
+	(*GetActorRequest)(nil),                   // 55: ateapi.GetActorRequest
+	(*CreateActorRequest)(nil),                // 56: ateapi.CreateActorRequest
+	(*UpdateActorRequest)(nil),                // 57: ateapi.UpdateActorRequest
+	(*SuspendActorRequest)(nil),               // 58: ateapi.SuspendActorRequest
+	(*SuspendActorResponse)(nil),              // 59: ateapi.SuspendActorResponse
+	(*PauseActorRequest)(nil),                 // 60: ateapi.PauseActorRequest
+	(*PauseActorResponse)(nil),                // 61: ateapi.PauseActorResponse
+	(*ResumeActorRequest)(nil),                // 62: ateapi.ResumeActorRequest
+	(*ResumeActorResponse)(nil),               // 63: ateapi.ResumeActorResponse
+	(*DeleteActorRequest)(nil),                // 64: ateapi.DeleteActorRequest
+	(*GetActorSnapshotRequest)(nil),           // 65: ateapi.GetActorSnapshotRequest
+	(*ListActorSnapshotsRequest)(nil),         // 66: ateapi.ListActorSnapshotsRequest
+	(*ListActorSnapshotsResponse)(nil),        // 67: ateapi.ListActorSnapshotsResponse
+	(*TagActorSnapshotRequest)(nil),           // 68: ateapi.TagActorSnapshotRequest
+	(*UpdateActorSnapshotTagRequest)(nil),     // 69: ateapi.UpdateActorSnapshotTagRequest
+	(*DeleteActorSnapshotTagRequest)(nil),     // 70: ateapi.DeleteActorSnapshotTagRequest
+	(*ListWorkersRequest)(nil),                // 71: ateapi.ListWorkersRequest
+	(*ListWorkersResponse)(nil),               // 72: ateapi.ListWorkersResponse
+	(*ListActorsRequest)(nil),                 // 73: ateapi.ListActorsRequest
+	(*ListActorsResponse)(nil),                // 74: ateapi.ListActorsResponse
+	(*Worker)(nil),                            // 75: ateapi.Worker
+	(*Assignment)(nil),                        // 76: ateapi.Assignment
+	(*KubeNamespacedObjectRef)(nil),           // 77: ateapi.KubeNamespacedObjectRef
+	(*DebugClearRequest)(nil),                 // 78: ateapi.DebugClearRequest
+	(*DebugClearResponse)(nil),                // 79: ateapi.DebugClearResponse
+	(*MintJWTRequest)(nil),                    // 80: ateapi.MintJWTRequest
+	(*MintJWTResponse)(nil),                   // 81: ateapi.MintJWTResponse
+	(*MintCertRequest)(nil),                   // 82: ateapi.MintCertRequest
+	(*MintCertResponse)(nil),                  // 83: ateapi.MintCertResponse
+	nil,                                       // 84: ateapi.Selector.MatchLabelsEntry
+	nil,                                       // 85: ateapi.ExternalVolume.VolumeContextEntry
+	nil,                                       // 86: ateapi.SandboxAssets.AssetsEntry
+	nil,                                       // 87: ateapi.ArchAssets.FilesEntry
+	nil,                                       // 88: ateapi.Worker.LabelsEntry
+	(*timestamppb.Timestamp)(nil),             // 89: google.protobuf.Timestamp
+	(*fieldmaskpb.FieldMask)(nil),             // 90: google.protobuf.FieldMask
 }
 var file_ateapi_proto_depIdxs = []int32{
-	0,  // 0: ateapi.LocalSnapshotInfo.content_scope:type_name -> ateapi.SnapshotContentScope
-	51, // 1: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
-	54, // 2: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
-	54, // 3: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
-	3,  // 4: ateapi.ExternalVolume.status:type_name -> ateapi.ExternalVolume.Status
-	52, // 5: ateapi.ExternalVolume.volume_context:type_name -> ateapi.ExternalVolume.VolumeContextEntry
-	8,  // 6: ateapi.Actor.metadata:type_name -> ateapi.ResourceMetadata
-	4,  // 7: ateapi.Actor.status:type_name -> ateapi.Actor.Status
-	11, // 8: ateapi.Actor.worker_assignment:type_name -> ateapi.WorkerAssignment
-	7,  // 9: ateapi.Actor.worker_selector:type_name -> ateapi.Selector
-	15, // 10: ateapi.Actor.latest_snapshot:type_name -> ateapi.ObjectRef
-	6,  // 11: ateapi.Actor.local_snapshot_info:type_name -> ateapi.LocalSnapshotInfo
-	9,  // 12: ateapi.Actor.actor_volumes:type_name -> ateapi.ExternalVolume
-	8,  // 13: ateapi.ActorSnapshot.metadata:type_name -> ateapi.ResourceMetadata
-	15, // 14: ateapi.ActorSnapshot.source_actor:type_name -> ateapi.ObjectRef
-	0,  // 15: ateapi.ActorSnapshot.content_scope:type_name -> ateapi.SnapshotContentScope
-	8,  // 16: ateapi.ActorSnapshotTag.metadata:type_name -> ateapi.ResourceMetadata
-	15, // 17: ateapi.ActorSnapshotTag.snapshot:type_name -> ateapi.ObjectRef
-	1,  // 18: ateapi.ActorSnapshotTag.scope:type_name -> ateapi.ActorSnapshotTagScope
-	8,  // 19: ateapi.Atespace.metadata:type_name -> ateapi.ResourceMetadata
-	15, // 20: ateapi.ActorSnapshotRef.snapshot:type_name -> ateapi.ObjectRef
-	15, // 21: ateapi.ActorSnapshotRef.tag:type_name -> ateapi.ObjectRef
-	14, // 22: ateapi.CreateAtespaceRequest.atespace:type_name -> ateapi.Atespace
-	15, // 23: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
-	14, // 24: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
-	15, // 25: ateapi.DeleteAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
-	15, // 26: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
-	10, // 27: ateapi.CreateActorRequest.actor:type_name -> ateapi.Actor
-	16, // 28: ateapi.CreateActorRequest.source_snapshot:type_name -> ateapi.ActorSnapshotRef
-	10, // 29: ateapi.UpdateActorRequest.actor:type_name -> ateapi.Actor
-	55, // 30: ateapi.UpdateActorRequest.update_mask:type_name -> google.protobuf.FieldMask
-	15, // 31: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
-	10, // 32: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
-	15, // 33: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
-	10, // 34: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
-	15, // 35: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
-	10, // 36: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
-	15, // 37: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
-	16, // 38: ateapi.GetActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
-	12, // 39: ateapi.ListActorSnapshotsResponse.snapshots:type_name -> ateapi.ActorSnapshot
-	16, // 40: ateapi.TagActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
-	13, // 41: ateapi.TagActorSnapshotRequest.tag:type_name -> ateapi.ActorSnapshotTag
-	13, // 42: ateapi.UpdateActorSnapshotTagRequest.tag:type_name -> ateapi.ActorSnapshotTag
-	55, // 43: ateapi.UpdateActorSnapshotTagRequest.update_mask:type_name -> google.protobuf.FieldMask
-	15, // 44: ateapi.DeleteActorSnapshotTagRequest.tag:type_name -> ateapi.ObjectRef
-	42, // 45: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
-	10, // 46: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
-	43, // 47: ateapi.Worker.assignment:type_name -> ateapi.Assignment
-	53, // 48: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
-	5,  // 49: ateapi.Worker.state:type_name -> ateapi.Worker.State
-	44, // 50: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	15, // 51: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
-	2,  // 52: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
-	22, // 53: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	23, // 54: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	24, // 55: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	25, // 56: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	27, // 57: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	29, // 58: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	31, // 59: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	32, // 60: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
-	33, // 61: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
-	35, // 62: ateapi.Control.TagActorSnapshot:input_type -> ateapi.TagActorSnapshotRequest
-	36, // 63: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
-	37, // 64: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
-	38, // 65: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	40, // 66: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	17, // 67: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	18, // 68: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	19, // 69: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	21, // 70: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	45, // 71: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
-	47, // 72: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	49, // 73: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	10, // 74: ateapi.Control.GetActor:output_type -> ateapi.Actor
-	10, // 75: ateapi.Control.CreateActor:output_type -> ateapi.Actor
-	10, // 76: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
-	26, // 77: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	28, // 78: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	30, // 79: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	10, // 80: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
-	12, // 81: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
-	34, // 82: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
-	13, // 83: ateapi.Control.TagActorSnapshot:output_type -> ateapi.ActorSnapshotTag
-	13, // 84: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	13, // 85: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	39, // 86: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	41, // 87: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	14, // 88: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
-	14, // 89: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
-	20, // 90: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	14, // 91: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
-	46, // 92: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
-	48, // 93: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	50, // 94: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	74, // [74:95] is the sub-list for method output_type
-	53, // [53:74] is the sub-list for method input_type
-	53, // [53:53] is the sub-list for extension type_name
-	53, // [53:53] is the sub-list for extension extendee
-	0,  // [0:53] is the sub-list for field type_name
+	0,   // 0: ateapi.LocalSnapshotInfo.content_scope:type_name -> ateapi.SnapshotContentScope
+	84,  // 1: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
+	89,  // 2: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
+	89,  // 3: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
+	5,   // 4: ateapi.ExternalVolume.status:type_name -> ateapi.ExternalVolume.Status
+	85,  // 5: ateapi.ExternalVolume.volume_context:type_name -> ateapi.ExternalVolume.VolumeContextEntry
+	11,  // 6: ateapi.Actor.metadata:type_name -> ateapi.ResourceMetadata
+	6,   // 7: ateapi.Actor.status:type_name -> ateapi.Actor.Status
+	14,  // 8: ateapi.Actor.worker_assignment:type_name -> ateapi.WorkerAssignment
+	10,  // 9: ateapi.Actor.worker_selector:type_name -> ateapi.Selector
+	18,  // 10: ateapi.Actor.latest_snapshot:type_name -> ateapi.ObjectRef
+	9,   // 11: ateapi.Actor.local_snapshot_info:type_name -> ateapi.LocalSnapshotInfo
+	12,  // 12: ateapi.Actor.actor_volumes:type_name -> ateapi.ExternalVolume
+	11,  // 13: ateapi.ActorSnapshot.metadata:type_name -> ateapi.ResourceMetadata
+	18,  // 14: ateapi.ActorSnapshot.source_actor:type_name -> ateapi.ObjectRef
+	0,   // 15: ateapi.ActorSnapshot.content_scope:type_name -> ateapi.SnapshotContentScope
+	11,  // 16: ateapi.ActorSnapshotTag.metadata:type_name -> ateapi.ResourceMetadata
+	18,  // 17: ateapi.ActorSnapshotTag.snapshot:type_name -> ateapi.ObjectRef
+	1,   // 18: ateapi.ActorSnapshotTag.scope:type_name -> ateapi.ActorSnapshotTagScope
+	11,  // 19: ateapi.Atespace.metadata:type_name -> ateapi.ResourceMetadata
+	18,  // 20: ateapi.ActorSnapshotRef.snapshot:type_name -> ateapi.ObjectRef
+	18,  // 21: ateapi.ActorSnapshotRef.tag:type_name -> ateapi.ObjectRef
+	11,  // 22: ateapi.ActorTemplate.metadata:type_name -> ateapi.ResourceMetadata
+	21,  // 23: ateapi.ActorTemplate.spec:type_name -> ateapi.ActorTemplateSpec
+	10,  // 24: ateapi.ActorTemplateSpec.worker_selector:type_name -> ateapi.Selector
+	18,  // 25: ateapi.ActorTemplateSpec.default_version_on_create:type_name -> ateapi.ObjectRef
+	11,  // 26: ateapi.ActorTemplateVersion.metadata:type_name -> ateapi.ResourceMetadata
+	18,  // 27: ateapi.ActorTemplateVersion.actor_template:type_name -> ateapi.ObjectRef
+	23,  // 28: ateapi.ActorTemplateVersion.spec:type_name -> ateapi.ActorTemplateVersionSpec
+	27,  // 29: ateapi.ActorTemplateVersion.status:type_name -> ateapi.ActorTemplateVersionStatus
+	28,  // 30: ateapi.ActorTemplateVersionSpec.containers:type_name -> ateapi.Container
+	32,  // 31: ateapi.ActorTemplateVersionSpec.volumes:type_name -> ateapi.Volume
+	25,  // 32: ateapi.ActorTemplateVersionSpec.snapshots_config:type_name -> ateapi.SnapshotsConfig
+	24,  // 33: ateapi.ActorTemplateVersionSpec.sandbox_config:type_name -> ateapi.SandboxConfig
+	2,   // 34: ateapi.SandboxConfig.sandbox_class:type_name -> ateapi.SandboxClass
+	0,   // 35: ateapi.SnapshotsConfig.on_pause:type_name -> ateapi.SnapshotContentScope
+	0,   // 36: ateapi.SnapshotsConfig.on_commit:type_name -> ateapi.SnapshotContentScope
+	26,  // 37: ateapi.SnapshotsConfig.on_resume:type_name -> ateapi.OnResumeConfig
+	3,   // 38: ateapi.OnResumeConfig.from_data:type_name -> ateapi.ResumeSource
+	18,  // 39: ateapi.ActorTemplateVersionStatus.golden_snapshot:type_name -> ateapi.ObjectRef
+	7,   // 40: ateapi.ActorTemplateVersionStatus.state:type_name -> ateapi.ActorTemplateVersionStatus.State
+	36,  // 41: ateapi.ActorTemplateVersionStatus.resolved_sandbox:type_name -> ateapi.SandboxAssets
+	29,  // 42: ateapi.Container.env:type_name -> ateapi.EnvVar
+	30,  // 43: ateapi.Container.readyz:type_name -> ateapi.ContainerReadyz
+	35,  // 44: ateapi.Container.volume_mounts:type_name -> ateapi.VolumeMount
+	31,  // 45: ateapi.ContainerReadyz.http_get:type_name -> ateapi.HTTPGetAction
+	33,  // 46: ateapi.Volume.durable_dir:type_name -> ateapi.DurableDirVolumeSource
+	34,  // 47: ateapi.Volume.external_volume_template:type_name -> ateapi.ExternalVolumeTemplate
+	2,   // 48: ateapi.SandboxAssets.sandbox_class:type_name -> ateapi.SandboxClass
+	86,  // 49: ateapi.SandboxAssets.assets:type_name -> ateapi.SandboxAssets.AssetsEntry
+	87,  // 50: ateapi.ArchAssets.files:type_name -> ateapi.ArchAssets.FilesEntry
+	17,  // 51: ateapi.CreateAtespaceRequest.atespace:type_name -> ateapi.Atespace
+	18,  // 52: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
+	17,  // 53: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
+	18,  // 54: ateapi.DeleteAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
+	20,  // 55: ateapi.CreateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
+	18,  // 56: ateapi.GetActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
+	20,  // 57: ateapi.UpdateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
+	90,  // 58: ateapi.UpdateActorTemplateRequest.update_mask:type_name -> google.protobuf.FieldMask
+	20,  // 59: ateapi.ListActorTemplatesResponse.actor_templates:type_name -> ateapi.ActorTemplate
+	18,  // 60: ateapi.DeleteActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
+	22,  // 61: ateapi.CreateActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ActorTemplateVersion
+	18,  // 62: ateapi.GetActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ObjectRef
+	22,  // 63: ateapi.ListActorTemplateVersionsResponse.actor_template_versions:type_name -> ateapi.ActorTemplateVersion
+	18,  // 64: ateapi.DeleteActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ObjectRef
+	18,  // 65: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 66: ateapi.CreateActorRequest.actor:type_name -> ateapi.Actor
+	19,  // 67: ateapi.CreateActorRequest.source_snapshot:type_name -> ateapi.ActorSnapshotRef
+	13,  // 68: ateapi.UpdateActorRequest.actor:type_name -> ateapi.Actor
+	90,  // 69: ateapi.UpdateActorRequest.update_mask:type_name -> google.protobuf.FieldMask
+	18,  // 70: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 71: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
+	18,  // 72: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 73: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
+	18,  // 74: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 75: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
+	18,  // 76: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
+	19,  // 77: ateapi.GetActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
+	15,  // 78: ateapi.ListActorSnapshotsResponse.snapshots:type_name -> ateapi.ActorSnapshot
+	19,  // 79: ateapi.TagActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
+	16,  // 80: ateapi.TagActorSnapshotRequest.tag:type_name -> ateapi.ActorSnapshotTag
+	16,  // 81: ateapi.UpdateActorSnapshotTagRequest.tag:type_name -> ateapi.ActorSnapshotTag
+	90,  // 82: ateapi.UpdateActorSnapshotTagRequest.update_mask:type_name -> google.protobuf.FieldMask
+	18,  // 83: ateapi.DeleteActorSnapshotTagRequest.tag:type_name -> ateapi.ObjectRef
+	75,  // 84: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
+	13,  // 85: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
+	76,  // 86: ateapi.Worker.assignment:type_name -> ateapi.Assignment
+	88,  // 87: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
+	8,   // 88: ateapi.Worker.state:type_name -> ateapi.Worker.State
+	77,  // 89: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
+	18,  // 90: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
+	4,   // 91: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
+	37,  // 92: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
+	38,  // 93: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
+	55,  // 94: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	56,  // 95: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	57,  // 96: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	58,  // 97: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	60,  // 98: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	62,  // 99: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	64,  // 100: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	65,  // 101: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
+	66,  // 102: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
+	68,  // 103: ateapi.Control.TagActorSnapshot:input_type -> ateapi.TagActorSnapshotRequest
+	69,  // 104: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
+	70,  // 105: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
+	71,  // 106: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	73,  // 107: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	39,  // 108: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	40,  // 109: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	41,  // 110: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	43,  // 111: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	44,  // 112: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
+	45,  // 113: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
+	46,  // 114: ateapi.Control.UpdateActorTemplate:input_type -> ateapi.UpdateActorTemplateRequest
+	47,  // 115: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
+	49,  // 116: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
+	50,  // 117: ateapi.Control.CreateActorTemplateVersion:input_type -> ateapi.CreateActorTemplateVersionRequest
+	51,  // 118: ateapi.Control.GetActorTemplateVersion:input_type -> ateapi.GetActorTemplateVersionRequest
+	52,  // 119: ateapi.Control.ListActorTemplateVersions:input_type -> ateapi.ListActorTemplateVersionsRequest
+	54,  // 120: ateapi.Control.DeleteActorTemplateVersion:input_type -> ateapi.DeleteActorTemplateVersionRequest
+	78,  // 121: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
+	80,  // 122: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	82,  // 123: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	13,  // 124: ateapi.Control.GetActor:output_type -> ateapi.Actor
+	13,  // 125: ateapi.Control.CreateActor:output_type -> ateapi.Actor
+	13,  // 126: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
+	59,  // 127: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	61,  // 128: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	63,  // 129: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	13,  // 130: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
+	15,  // 131: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
+	67,  // 132: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
+	16,  // 133: ateapi.Control.TagActorSnapshot:output_type -> ateapi.ActorSnapshotTag
+	16,  // 134: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	16,  // 135: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	72,  // 136: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	74,  // 137: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	17,  // 138: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
+	17,  // 139: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
+	42,  // 140: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	17,  // 141: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
+	20,  // 142: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
+	20,  // 143: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
+	20,  // 144: ateapi.Control.UpdateActorTemplate:output_type -> ateapi.ActorTemplate
+	48,  // 145: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
+	20,  // 146: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
+	22,  // 147: ateapi.Control.CreateActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	22,  // 148: ateapi.Control.GetActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	53,  // 149: ateapi.Control.ListActorTemplateVersions:output_type -> ateapi.ListActorTemplateVersionsResponse
+	22,  // 150: ateapi.Control.DeleteActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	79,  // 151: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
+	81,  // 152: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	83,  // 153: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	124, // [124:154] is the sub-list for method output_type
+	94,  // [94:124] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }
@@ -3529,13 +5710,20 @@ func file_ateapi_proto_init() {
 		(*ActorSnapshotRef_Snapshot)(nil),
 		(*ActorSnapshotRef_Tag)(nil),
 	}
+	file_ateapi_proto_msgTypes[20].OneofWrappers = []any{
+		(*EnvVar_Value)(nil),
+	}
+	file_ateapi_proto_msgTypes[23].OneofWrappers = []any{
+		(*Volume_DurableDir)(nil),
+		(*Volume_ExternalVolumeTemplate)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateapi_proto_rawDesc), len(file_ateapi_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   48,
+			NumEnums:      9,
+			NumMessages:   80,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -21,13 +21,14 @@
 package ateapipb
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -821,8 +821,10 @@ type Actor struct {
 	ActorTemplate string `protobuf:"bytes,13,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
 	// actor_template_version pins the ActorTemplateVersion this actor runs.
 	// Optional at CreateActor (the server resolves the template's
-	// default_version_on_create when unset); always stored resolved and
-	// immutable thereafter. Non-empty iff actor_template is set.
+	// default_version_on_create when unset); always stored resolved. May be
+	// re-pinned via UpdateActor or ResumeActor while the actor is SUSPENDED or
+	// CRASHED; takes effect at the next resume. Non-empty iff actor_template is
+	// set.
 	ActorTemplateVersion string       `protobuf:"bytes,14,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
 	Status               Actor_Status `protobuf:"varint,4,opt,name=status,proto3,enum=ateapi.Actor_Status" json:"status,omitempty"`
 	// worker_assignment points at the worker currently hosting this Actor.
@@ -1071,8 +1073,12 @@ type ActorSnapshot struct {
 	ActorTemplateUid       string                 `protobuf:"bytes,7,opt,name=actor_template_uid,json=actorTemplateUid,proto3" json:"actor_template_uid,omitempty"`
 	ContentScope           SnapshotContentScope   `protobuf:"varint,8,opt,name=content_scope,json=contentScope,proto3,enum=ateapi.SnapshotContentScope" json:"content_scope,omitempty"`
 	SnapshotUri            string                 `protobuf:"bytes,9,opt,name=snapshot_uri,json=snapshotUri,proto3" json:"snapshot_uri,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// The ActorTemplateVersion the source actor was pinned to when this
+	// snapshot was taken. Empty for CRD-path actors and for snapshots written
+	// before this field existed.
+	ActorTemplateVersion string `protobuf:"bytes,10,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ActorSnapshot) Reset() {
@@ -1164,6 +1170,13 @@ func (x *ActorSnapshot) GetContentScope() SnapshotContentScope {
 func (x *ActorSnapshot) GetSnapshotUri() string {
 	if x != nil {
 		return x.SnapshotUri
+	}
+	return ""
+}
+
+func (x *ActorSnapshot) GetActorTemplateVersion() string {
+	if x != nil {
+		return x.ActorTemplateVersion
 	}
 	return ""
 }
@@ -3578,6 +3591,8 @@ type UpdateActorRequest struct {
 	//
 	// Only the following fields are supported:
 	//   - worker_selector
+	//   - actor_template_version (SUSPENDED or CRASHED actors only; the pin
+	//     takes effect at the next resume)
 	UpdateMask    *fieldmaskpb.FieldMask `protobuf:"bytes,2,opt,name=update_mask,json=updateMask,proto3" json:"update_mask,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3807,9 +3822,15 @@ type ResumeActorRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Actor *ObjectRef             `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
 	// If true, skip golden snapshot and boot the workload from scratch.
-	Boot          bool `protobuf:"varint,2,opt,name=boot,proto3" json:"boot,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Boot bool `protobuf:"varint,2,opt,name=boot,proto3" json:"boot,omitempty"`
+	// Optional. Re-pins the actor to this ActorTemplateVersion before resuming:
+	// the actor restores with the new version's spec while its durable-dir data
+	// is preserved. Only valid for actors created from a control-plane
+	// ActorTemplate, in SUSPENDED or CRASHED status. A no-op when it equals the
+	// current pin.
+	ActorTemplateVersion string `protobuf:"bytes,3,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ResumeActorRequest) Reset() {
@@ -3854,6 +3875,13 @@ func (x *ResumeActorRequest) GetBoot() bool {
 		return x.Boot
 	}
 	return false
+}
+
+func (x *ResumeActorRequest) GetActorTemplateVersion() string {
+	if x != nil {
+		return x.ActorTemplateVersion
+	}
+	return ""
 }
 
 type ResumeActorResponse struct {
@@ -5154,7 +5182,7 @@ const file_ateapi_proto_rawDesc = "" +
 	"\n" +
 	"worker_pod\x18\x03 \x01(\tR\tworkerPod\x12$\n" +
 	"\x0eworker_pod_uid\x18\x04 \x01(\tR\fworkerPodUid\x12\"\n" +
-	"\rworker_pod_ip\x18\x05 \x01(\tR\vworkerPodIp\"\xd5\x03\n" +
+	"\rworker_pod_ip\x18\x05 \x01(\tR\vworkerPodIp\"\x8b\x04\n" +
 	"\rActorSnapshot\x124\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x18.ateapi.ResourceMetadataR\bmetadata\x124\n" +
 	"\fsource_actor\x18\x02 \x01(\v2\x11.ateapi.ObjectRefR\vsourceActor\x12(\n" +
@@ -5164,7 +5192,9 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x13actor_template_name\x18\x06 \x01(\tR\x11actorTemplateName\x12,\n" +
 	"\x12actor_template_uid\x18\a \x01(\tR\x10actorTemplateUid\x12A\n" +
 	"\rcontent_scope\x18\b \x01(\x0e2\x1c.ateapi.SnapshotContentScopeR\fcontentScope\x12!\n" +
-	"\fsnapshot_uri\x18\t \x01(\tR\vsnapshotUri\"\xac\x01\n" +
+	"\fsnapshot_uri\x18\t \x01(\tR\vsnapshotUri\x124\n" +
+	"\x16actor_template_version\x18\n" +
+	" \x01(\tR\x14actorTemplateVersion\"\xac\x01\n" +
 	"\x10ActorSnapshotTag\x124\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x18.ateapi.ResourceMetadataR\bmetadata\x12-\n" +
 	"\bsnapshot\x18\x02 \x01(\v2\x11.ateapi.ObjectRefR\bsnapshot\x123\n" +
@@ -5331,10 +5361,11 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x11PauseActorRequest\x12'\n" +
 	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"9\n" +
 	"\x12PauseActorResponse\x12#\n" +
-	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"Q\n" +
+	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\"\x87\x01\n" +
 	"\x12ResumeActorRequest\x12'\n" +
 	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\x12\x12\n" +
-	"\x04boot\x18\x02 \x01(\bR\x04boot\"T\n" +
+	"\x04boot\x18\x02 \x01(\bR\x04boot\x124\n" +
+	"\x16actor_template_version\x18\x03 \x01(\tR\x14actorTemplateVersion\"T\n" +
 	"\x13ResumeActorResponse\x12#\n" +
 	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\x12\x18\n" +
 	"\aresumed\x18\x02 \x01(\bR\aresumed\"=\n" +

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -78,6 +78,36 @@ service Control {
   // Delete an empty Atespace. Rejects (FailedPrecondition) if any Actors or
   // ActorSnapshotTags remain.
   rpc DeleteAtespace(DeleteAtespaceRequest) returns (Atespace) {}
+
+  rpc CreateActorTemplate(CreateActorTemplateRequest) returns (ActorTemplate) {}
+
+  // Get an ActorTemplate by name.
+  rpc GetActorTemplate(GetActorTemplateRequest) returns (ActorTemplate) {}
+
+  // Update mutable fields on an existing ActorTemplate.
+  rpc UpdateActorTemplate(UpdateActorTemplateRequest) returns (ActorTemplate) {}
+
+  rpc ListActorTemplates(ListActorTemplatesRequest) returns (ListActorTemplatesResponse) {}
+
+  // Delete an ActorTemplate. Rejects (FailedPrecondition) while any of its
+  // ActorTemplateVersions exist.
+  rpc DeleteActorTemplate(DeleteActorTemplateRequest) returns (ActorTemplate) {}
+
+  // Create a new ActorTemplateVersion under an existing ActorTemplate
+  // (FailedPrecondition if the parent does not exist).
+  rpc CreateActorTemplateVersion(CreateActorTemplateVersionRequest) returns (ActorTemplateVersion) {}
+
+  // Get an ActorTemplateVersion by name.
+  rpc GetActorTemplateVersion(GetActorTemplateVersionRequest) returns (ActorTemplateVersion) {}
+
+  // List ActorTemplateVersions, optionally filtered to one ActorTemplate.
+  rpc ListActorTemplateVersions(ListActorTemplateVersionsRequest) returns (ListActorTemplateVersionsResponse) {}
+
+  // Delete an ActorTemplateVersion together with its golden actor and golden
+  // snapshot in the reserved ate-golden atespace. Rejects (FailedPrecondition)
+  // while the version is its parent's default_version_on_create or while any
+  // Actor pins it.
+  rpc DeleteActorTemplateVersion(DeleteActorTemplateVersionRequest) returns (ActorTemplateVersion) {}
 }
 
 message LocalSnapshotInfo {
@@ -276,6 +306,264 @@ message ActorSnapshotRef {
   }
 }
 
+// SandboxClass selects the sandbox runtime family. Snapshots are not portable
+// across classes.
+enum SandboxClass {
+  SANDBOX_CLASS_UNSPECIFIED = 0;
+  SANDBOX_CLASS_GVISOR = 1;
+  SANDBOX_CLASS_MICROVM = 2;
+}
+
+// ActorTemplate groups the versions of one actor application and carries the
+// version-independent placement policy.
+message ActorTemplate {
+  // Common resource metadata: name, uid, version, timestamps.
+  ResourceMetadata metadata = 1;
+
+  ActorTemplateSpec spec = 2;
+}
+
+message ActorTemplateSpec {
+  // worker_selector restricts which worker pools actors from this template
+  // may use.
+  Selector worker_selector = 1;
+
+  // default_version_on_create names the ActorTemplateVersion used by
+  // CreateActor calls that do not pin a version. If unset, CreateActor
+  // without an explicit version fails with FailedPrecondition.
+  ObjectRef default_version_on_create = 2;
+}
+
+// ActorTemplateVersion is one immutable released version of an ActorTemplate:
+// the workload definition plus everything that affects snapshot validity.
+// Global-scoped: metadata.atespace is always empty and metadata.name must be
+// globally unique (by convention "<template-name>-<version>").
+message ActorTemplateVersion {
+  // Common resource metadata: name, uid, version, timestamps.
+  ResourceMetadata metadata = 1;
+
+  // actor_template is the parent ActorTemplate. Required at creation and
+  // immutable.
+  ObjectRef actor_template = 2;
+
+  // spec is immutable after creation.
+  ActorTemplateVersionSpec spec = 3;
+
+  ActorTemplateVersionStatus status = 4;
+}
+
+message ActorTemplateVersionSpec {
+  // pause_image is the container to use as the root sandbox container.
+  string pause_image = 1;
+
+  repeated Container containers = 2;
+
+  repeated Volume volumes = 3;
+
+  SnapshotsConfig snapshots_config = 4;
+
+  // sandbox_config selects the sandbox runtime this version's actors run on.
+  // Required. Resolved and frozen into status.resolved_sandbox at creation
+  // time.
+  SandboxConfig sandbox_config = 5;
+
+  // cpu class will be specified here in the future.
+}
+
+// SandboxConfig selects the sandbox runtime for an ActorTemplateVersion.
+message SandboxConfig {
+  // sandbox_class selects the sandbox runtime family.
+  // Required; must not be UNSPECIFIED.
+  SandboxClass sandbox_class = 1;
+
+  // config_name names the cluster-scoped SandboxConfig Kubernetes object
+  // supplying the sandbox binaries. Required; must match sandbox_class.
+  string config_name = 2;
+}
+
+message SnapshotsConfig {
+  // on_pause selects what is captured during pause actor.
+  SnapshotContentScope on_pause = 1;
+
+  // on_commit selects what captures.
+  // Must be a subset of on_pause: FULL allows FULL or DATA, DATA allows DATA.
+  SnapshotContentScope on_commit = 2;
+
+  // on_resume selects, per snapshot situation, what supplies the guest state
+  // at resume. Unset means the defaults documented on OnResumeConfig.
+  OnResumeConfig on_resume = 3;
+
+  // storage_location is the base object-storage URI snapshots of actors on
+  // this version are stored under. Required.
+  string storage_location = 4;
+}
+
+// ResumeSource selects what supplies the guest state when an actor is resumed
+// from one of the snapshot situations named by OnResumeConfig's fields.
+enum ResumeSource {
+  RESUME_SOURCE_UNSPECIFIED = 0;
+  // Starts the actor's containers afresh from the OCI image, with the
+  // durable-dir volumes pre-populated from the snapshot.
+  RESUME_SOURCE_COLD_BOOT = 1;
+  // Restores with the version's golden snapshot and the actor's own
+  // durable data.
+  RESUME_SOURCE_GOLDEN = 2;
+}
+
+// OnResumeConfig selects, per snapshot situation, what supplies the guest
+// state at resume. Each field names what is being resumed FROM; the value
+// names the boot source. Full snapshots that are still valid always restore
+// from their own content and are not configurable here.
+message OnResumeConfig {
+  // from_data applies when the resume uses a DATA-scope snapshot (from
+  // on_pause or on_commit).
+  ResumeSource from_data = 1;
+}
+
+message ActorTemplateVersionStatus {
+  // golden_snapshot points at the ActorSnapshot, in the reserved ate-golden
+  // system atespace, built for this version by ate-api. Set once state is
+  // READY.
+  ObjectRef golden_snapshot = 1;
+
+  // State machine, mirroring the ActorTemplateVersion CRD PhaseType:
+  // INITIAL -> RESUME_GOLDEN_ACTOR -> WAIT_GOLDEN_ACTOR -> {READY | FAILED}.
+  // READY and FAILED are terminal; the version is only usable once READY.
+  enum State {
+    STATE_UNSPECIFIED = 0;
+    STATE_INITIAL = 1;
+    STATE_RESUME_GOLDEN_ACTOR = 2;
+    STATE_WAIT_GOLDEN_ACTOR = 3;
+    STATE_READY = 4;
+    STATE_FAILED = 5;
+  }
+  State state = 2;
+
+  // resolved_sandbox is the referenced SandboxConfig's content frozen at
+  // creation time.
+  SandboxAssets resolved_sandbox = 3;
+
+  // message is a human-readable explanation of the current state, most
+  // useful when state is FAILED.
+  string message = 4;
+}
+
+// Container is a single application container of an ActorTemplateVersion.
+message Container {
+  string name = 1;
+
+  string image = 2;
+
+  // Entrypoint array; when set, the image's ENTRYPOINT and CMD are both
+  // ignored and the process argv is command + args. Unlike Kubernetes,
+  // $(VAR_NAME) references are NOT expanded.
+  repeated string command = 3;
+
+  // Arguments to the entrypoint; the image's CMD is used if unset (unless
+  // command is set, which discards the image's CMD).
+  repeated string args = 4;
+
+  repeated EnvVar env = 5;
+
+  // readyz is an optional HTTP readiness probe; when set the actor is not
+  // ready until the endpoint returns 200.
+  ContainerReadyz readyz = 6;
+
+  repeated VolumeMount volume_mounts = 7;
+}
+
+// EnvVar supplies one environment variable to a container. Values are not
+// expanded with Kubernetes-style $(VAR) references.
+message EnvVar {
+  // name may be any printable ASCII character except '='.
+  string name = 1;
+
+  // Exactly one source must be set.
+  oneof source {
+    // Literal value.
+    string value = 2;
+  }
+}
+
+// ContainerReadyz configures the readiness signal for a container.
+message ContainerReadyz {
+  // http_get specifies the HTTP request to perform. Required.
+  HTTPGetAction http_get = 1;
+
+  // timeout_seconds bounds how long to poll http_get before failing the
+  // actor start. 0 means the server-applied default (30s).
+  int32 timeout_seconds = 2;
+}
+
+// HTTPGetAction describes an HTTP GET against the container's interior IP.
+message HTTPGetAction {
+  // path defaults to "/readyz".
+  string path = 1;
+
+  int32 port = 2;
+}
+
+message Volume {
+  // name of the volume. Must be a DNS label.
+  string name = 1;
+
+  // Exactly one source must be set.
+  oneof source {
+    DurableDirVolumeSource durable_dir = 2;
+    ExternalVolumeTemplate external_volume_template = 3;
+  }
+}
+
+// DurableDirVolumeSource is a durable directory on rootfs that persists
+// across resumes and participates in snapshots.
+message DurableDirVolumeSource {}
+
+// ExternalVolumeTemplate provisions an external volume per actor; the volume
+// lives only as long as the actor. Not supported with SANDBOX_CLASS_MICROVM.
+message ExternalVolumeTemplate {
+  // capacity of the volume to create, in Kubernetes resource.Quantity string
+  // form (e.g. "10Gi"). Required.
+  string capacity = 1;
+
+  // storage_class_name names the cluster-scoped Kubernetes StorageClass to
+  // create the volume from. Required.
+  string storage_class_name = 2;
+}
+
+// VolumeMount mounts a named Volume into a container.
+message VolumeMount {
+  // name must match the name of a Volume.
+  string name = 1;
+
+  // mount_path within the container. Must be a clean absolute Unix path.
+  string mount_path = 2;
+}
+
+// SandboxAssets is the frozen description of the sandbox binaries an actor
+// boots with: a class plus content-addressed files keyed first by
+// architecture and then by asset name, mirroring the SandboxConfig
+// CRD schema.
+message SandboxAssets {
+  SandboxClass sandbox_class = 1;
+  // assets maps architecture (GOARCH, e.g. "amd64") to that arch's files.
+  map<string, ArchAssets> assets = 2;
+}
+
+message ArchAssets {
+  // files maps asset name (e.g. "gvisor", "kata-kernel") to its file.
+  map<string, AssetFile> files = 1;
+}
+
+// AssetFile is one content-addressed file atelet fetches for a sandbox
+// runtime.
+message AssetFile {
+  // URL to download the asset from (e.g. a gs:// URL).
+  string url = 1;
+
+  // Lower-case hex SHA256 naming the cached file and verifying the download.
+  string sha256 = 2;
+}
+
 message CreateAtespaceRequest {
   // The atespace to create.
   Atespace atespace = 1;
@@ -306,6 +594,95 @@ message ListAtespacesResponse {
 
 message DeleteAtespaceRequest {
   ObjectRef atespace = 1;
+}
+
+message CreateActorTemplateRequest {
+  // The actor template to create. Server-assigned metadata (uid, version,
+  // timestamps) is ignored.
+  ActorTemplate actor_template = 1;
+}
+
+message GetActorTemplateRequest {
+  ObjectRef actor_template = 1;
+}
+
+// Request to update mutable fields on an existing ActorTemplate.
+message UpdateActorTemplateRequest {
+  // The actor template to update.
+  // actor_template.metadata.name identifies which resource to update.
+  // actor_template.metadata.version and actor_template.metadata.uid are
+  // optional preconditions and zero values skip the check.
+  ActorTemplate actor_template = 1;
+
+  // The set of fields to update. Required.
+  //
+  // Only the following fields are supported:
+  //   - spec.worker_selector
+  //   - spec.default_version_on_create
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+message ListActorTemplatesRequest {
+  // Requested page size; the server may return fewer, or occasionally
+  // slightly more. If unspecified, defaults to a server-chosen value;
+  // values above 1000 are coerced to 1000.
+  int32 page_size = 1;
+
+  // Pagination token from a previous ListActorTemplates response.
+  // Omit or leave empty for the first request.
+  string page_token = 2;
+}
+
+message ListActorTemplatesResponse {
+  // The page of actor templates. This list may be empty even if there are
+  // more results.
+  repeated ActorTemplate actor_templates = 1;
+
+  // Pagination token for the next page. Empty if this is the last page.
+  string next_page_token = 2;
+}
+
+message DeleteActorTemplateRequest {
+  ObjectRef actor_template = 1;
+}
+
+message CreateActorTemplateVersionRequest {
+  // The actor template version to create. Server-assigned metadata (uid,
+  // version, timestamps) is ignored, as is status: the server initializes
+  // new versions to STATE_INITIAL.
+  ActorTemplateVersion actor_template_version = 1;
+}
+
+message GetActorTemplateVersionRequest {
+  ObjectRef actor_template_version = 1;
+}
+
+message ListActorTemplateVersionsRequest {
+  // The parent ActorTemplate whose versions to list, by name. Empty lists
+  // versions across all templates.
+  string actor_template = 1;
+
+  // Requested page size; the server may return fewer, or occasionally
+  // slightly more. If unspecified, defaults to a server-chosen value;
+  // values above 1000 are coerced to 1000.
+  int32 page_size = 2;
+
+  // Pagination token from a previous ListActorTemplateVersions response.
+  // Omit or leave empty for the first request.
+  string page_token = 3;
+}
+
+message ListActorTemplateVersionsResponse {
+  // The page of actor template versions. This list may be empty even if
+  // there are more results.
+  repeated ActorTemplateVersion actor_template_versions = 1;
+
+  // Pagination token for the next page. Empty if this is the last page.
+  string next_page_token = 2;
+}
+
+message DeleteActorTemplateVersionRequest {
+  ObjectRef actor_template_version = 1;
 }
 
 message GetActorRequest {

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -201,6 +201,17 @@ message Actor {
   string actor_template_namespace = 2;
   string actor_template_name = 3;
 
+  // actor_template names the control-plane ActorTemplate (global-scoped) this
+  // actor runs from. Exactly one of actor_template or
+  // (actor_template_namespace, actor_template_name) is set.
+  string actor_template = 13;
+
+  // actor_template_version pins the ActorTemplateVersion this actor runs.
+  // Optional at CreateActor (the server resolves the template's
+  // default_version_on_create when unset); always stored resolved and
+  // immutable thereafter. Non-empty iff actor_template is set.
+  string actor_template_version = 14;
+
   enum Status {
     STATUS_UNSPECIFIED = 0;
     STATUS_RESUMING = 1;
@@ -447,6 +458,15 @@ message ActorTemplateVersionStatus {
   // message is a human-readable explanation of the current state, most
   // useful when state is FAILED.
   string message = 4;
+
+  // golden_actor points at the actor, in the reserved ate-golden system
+  // atespace, being built to produce golden_snapshot. Set while the build is
+  // in progress; the actor is deleted once the snapshot is taken.
+  ObjectRef golden_actor = 5;
+
+  // take_golden_snapshot_at is when the WAIT_GOLDEN_ACTOR warmup elapses and
+  // the golden snapshot is taken.
+  google.protobuf.Timestamp take_golden_snapshot_at = 6;
 }
 
 // Container is a single application container of an ActorTemplateVersion.

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -208,8 +208,10 @@ message Actor {
 
   // actor_template_version pins the ActorTemplateVersion this actor runs.
   // Optional at CreateActor (the server resolves the template's
-  // default_version_on_create when unset); always stored resolved and
-  // immutable thereafter. Non-empty iff actor_template is set.
+  // default_version_on_create when unset); always stored resolved. May be
+  // re-pinned via UpdateActor or ResumeActor while the actor is SUSPENDED or
+  // CRASHED; takes effect at the next resume. Non-empty iff actor_template is
+  // set.
   string actor_template_version = 14;
 
   enum Status {
@@ -283,6 +285,11 @@ message ActorSnapshot {
   string actor_template_uid = 7;
   SnapshotContentScope content_scope = 8;
   string snapshot_uri = 9;
+
+  // The ActorTemplateVersion the source actor was pinned to when this
+  // snapshot was taken. Empty for CRD-path actors and for snapshots written
+  // before this field existed.
+  string actor_template_version = 10;
 }
 
 // ActorSnapshotTag is an immutable, Atespace-owned alias and retention pin.
@@ -734,6 +741,8 @@ message UpdateActorRequest {
   //
   // Only the following fields are supported:
   //   - worker_selector
+  //   - actor_template_version (SUSPENDED or CRASHED actors only; the pin
+  //     takes effect at the next resume)
   google.protobuf.FieldMask update_mask = 2;
 }
 
@@ -758,6 +767,13 @@ message ResumeActorRequest {
 
   // If true, skip golden snapshot and boot the workload from scratch.
   bool boot = 2;
+
+  // Optional. Re-pins the actor to this ActorTemplateVersion before resuming:
+  // the actor restores with the new version's spec while its durable-dir data
+  // is preserved. Only valid for actors created from a control-plane
+  // ActorTemplate, in SUSPENDED or CRASHED status. A no-op when it equals the
+  // current pin.
+  string actor_template_version = 3;
 }
 
 message ResumeActorResponse {

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -103,10 +103,11 @@ service Control {
   // List ActorTemplateVersions, optionally filtered to one ActorTemplate.
   rpc ListActorTemplateVersions(ListActorTemplateVersionsRequest) returns (ListActorTemplateVersionsResponse) {}
 
-  // Delete an ActorTemplateVersion together with its golden actor and golden
-  // snapshot in the reserved ate-golden atespace. Rejects (FailedPrecondition)
-  // while the version is its parent's default_version_on_create or while any
-  // Actor pins it.
+  // Delete an ActorTemplateVersion together with its golden snapshot in the
+  // reserved ate-golden atespace. Rejects (FailedPrecondition) while the
+  // version is its parent's default_version_on_create. Once actors carry
+  // version pins and the golden state machine lands, this will also reject
+  // while any Actor pins the version, and clean up the golden actor.
   rpc DeleteActorTemplateVersion(DeleteActorTemplateVersionRequest) returns (ActorTemplateVersion) {}
 }
 
@@ -330,7 +331,7 @@ message ActorTemplateSpec {
 
   // default_version_on_create names the ActorTemplateVersion used by
   // CreateActor calls that do not pin a version. If unset, CreateActor
-  // without an explicit version fails with FailedPrecondition.
+  // without an explicit version fails with FailedPrecondition. 
   ObjectRef default_version_on_create = 2;
 }
 

--- a/pkg/proto/ateapipb/ateapi_grpc.pb.go
+++ b/pkg/proto/ateapipb/ateapi_grpc.pb.go
@@ -33,24 +33,33 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Control_GetActor_FullMethodName               = "/ateapi.Control/GetActor"
-	Control_CreateActor_FullMethodName            = "/ateapi.Control/CreateActor"
-	Control_UpdateActor_FullMethodName            = "/ateapi.Control/UpdateActor"
-	Control_SuspendActor_FullMethodName           = "/ateapi.Control/SuspendActor"
-	Control_PauseActor_FullMethodName             = "/ateapi.Control/PauseActor"
-	Control_ResumeActor_FullMethodName            = "/ateapi.Control/ResumeActor"
-	Control_DeleteActor_FullMethodName            = "/ateapi.Control/DeleteActor"
-	Control_GetActorSnapshot_FullMethodName       = "/ateapi.Control/GetActorSnapshot"
-	Control_ListActorSnapshots_FullMethodName     = "/ateapi.Control/ListActorSnapshots"
-	Control_TagActorSnapshot_FullMethodName       = "/ateapi.Control/TagActorSnapshot"
-	Control_UpdateActorSnapshotTag_FullMethodName = "/ateapi.Control/UpdateActorSnapshotTag"
-	Control_DeleteActorSnapshotTag_FullMethodName = "/ateapi.Control/DeleteActorSnapshotTag"
-	Control_ListWorkers_FullMethodName            = "/ateapi.Control/ListWorkers"
-	Control_ListActors_FullMethodName             = "/ateapi.Control/ListActors"
-	Control_CreateAtespace_FullMethodName         = "/ateapi.Control/CreateAtespace"
-	Control_GetAtespace_FullMethodName            = "/ateapi.Control/GetAtespace"
-	Control_ListAtespaces_FullMethodName          = "/ateapi.Control/ListAtespaces"
-	Control_DeleteAtespace_FullMethodName         = "/ateapi.Control/DeleteAtespace"
+	Control_GetActor_FullMethodName                   = "/ateapi.Control/GetActor"
+	Control_CreateActor_FullMethodName                = "/ateapi.Control/CreateActor"
+	Control_UpdateActor_FullMethodName                = "/ateapi.Control/UpdateActor"
+	Control_SuspendActor_FullMethodName               = "/ateapi.Control/SuspendActor"
+	Control_PauseActor_FullMethodName                 = "/ateapi.Control/PauseActor"
+	Control_ResumeActor_FullMethodName                = "/ateapi.Control/ResumeActor"
+	Control_DeleteActor_FullMethodName                = "/ateapi.Control/DeleteActor"
+	Control_GetActorSnapshot_FullMethodName           = "/ateapi.Control/GetActorSnapshot"
+	Control_ListActorSnapshots_FullMethodName         = "/ateapi.Control/ListActorSnapshots"
+	Control_TagActorSnapshot_FullMethodName           = "/ateapi.Control/TagActorSnapshot"
+	Control_UpdateActorSnapshotTag_FullMethodName     = "/ateapi.Control/UpdateActorSnapshotTag"
+	Control_DeleteActorSnapshotTag_FullMethodName     = "/ateapi.Control/DeleteActorSnapshotTag"
+	Control_ListWorkers_FullMethodName                = "/ateapi.Control/ListWorkers"
+	Control_ListActors_FullMethodName                 = "/ateapi.Control/ListActors"
+	Control_CreateAtespace_FullMethodName             = "/ateapi.Control/CreateAtespace"
+	Control_GetAtespace_FullMethodName                = "/ateapi.Control/GetAtespace"
+	Control_ListAtespaces_FullMethodName              = "/ateapi.Control/ListAtespaces"
+	Control_DeleteAtespace_FullMethodName             = "/ateapi.Control/DeleteAtespace"
+	Control_CreateActorTemplate_FullMethodName        = "/ateapi.Control/CreateActorTemplate"
+	Control_GetActorTemplate_FullMethodName           = "/ateapi.Control/GetActorTemplate"
+	Control_UpdateActorTemplate_FullMethodName        = "/ateapi.Control/UpdateActorTemplate"
+	Control_ListActorTemplates_FullMethodName         = "/ateapi.Control/ListActorTemplates"
+	Control_DeleteActorTemplate_FullMethodName        = "/ateapi.Control/DeleteActorTemplate"
+	Control_CreateActorTemplateVersion_FullMethodName = "/ateapi.Control/CreateActorTemplateVersion"
+	Control_GetActorTemplateVersion_FullMethodName    = "/ateapi.Control/GetActorTemplateVersion"
+	Control_ListActorTemplateVersions_FullMethodName  = "/ateapi.Control/ListActorTemplateVersions"
+	Control_DeleteActorTemplateVersion_FullMethodName = "/ateapi.Control/DeleteActorTemplateVersion"
 )
 
 // ControlClient is the client API for Control service.
@@ -97,6 +106,27 @@ type ControlClient interface {
 	// Delete an empty Atespace. Rejects (FailedPrecondition) if any Actors or
 	// ActorSnapshotTags remain.
 	DeleteAtespace(ctx context.Context, in *DeleteAtespaceRequest, opts ...grpc.CallOption) (*Atespace, error)
+	CreateActorTemplate(ctx context.Context, in *CreateActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error)
+	// Get an ActorTemplate by name.
+	GetActorTemplate(ctx context.Context, in *GetActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error)
+	// Update mutable fields on an existing ActorTemplate.
+	UpdateActorTemplate(ctx context.Context, in *UpdateActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error)
+	ListActorTemplates(ctx context.Context, in *ListActorTemplatesRequest, opts ...grpc.CallOption) (*ListActorTemplatesResponse, error)
+	// Delete an ActorTemplate. Rejects (FailedPrecondition) while any of its
+	// ActorTemplateVersions exist.
+	DeleteActorTemplate(ctx context.Context, in *DeleteActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error)
+	// Create a new ActorTemplateVersion under an existing ActorTemplate
+	// (FailedPrecondition if the parent does not exist).
+	CreateActorTemplateVersion(ctx context.Context, in *CreateActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error)
+	// Get an ActorTemplateVersion by name.
+	GetActorTemplateVersion(ctx context.Context, in *GetActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error)
+	// List ActorTemplateVersions, optionally filtered to one ActorTemplate.
+	ListActorTemplateVersions(ctx context.Context, in *ListActorTemplateVersionsRequest, opts ...grpc.CallOption) (*ListActorTemplateVersionsResponse, error)
+	// Delete an ActorTemplateVersion together with its golden actor and golden
+	// snapshot in the reserved ate-golden atespace. Rejects (FailedPrecondition)
+	// while the version is its parent's default_version_on_create or while any
+	// Actor pins it.
+	DeleteActorTemplateVersion(ctx context.Context, in *DeleteActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error)
 }
 
 type controlClient struct {
@@ -287,6 +317,96 @@ func (c *controlClient) DeleteAtespace(ctx context.Context, in *DeleteAtespaceRe
 	return out, nil
 }
 
+func (c *controlClient) CreateActorTemplate(ctx context.Context, in *CreateActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplate)
+	err := c.cc.Invoke(ctx, Control_CreateActorTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) GetActorTemplate(ctx context.Context, in *GetActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplate)
+	err := c.cc.Invoke(ctx, Control_GetActorTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) UpdateActorTemplate(ctx context.Context, in *UpdateActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplate)
+	err := c.cc.Invoke(ctx, Control_UpdateActorTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) ListActorTemplates(ctx context.Context, in *ListActorTemplatesRequest, opts ...grpc.CallOption) (*ListActorTemplatesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListActorTemplatesResponse)
+	err := c.cc.Invoke(ctx, Control_ListActorTemplates_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) DeleteActorTemplate(ctx context.Context, in *DeleteActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplate)
+	err := c.cc.Invoke(ctx, Control_DeleteActorTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) CreateActorTemplateVersion(ctx context.Context, in *CreateActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplateVersion)
+	err := c.cc.Invoke(ctx, Control_CreateActorTemplateVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) GetActorTemplateVersion(ctx context.Context, in *GetActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplateVersion)
+	err := c.cc.Invoke(ctx, Control_GetActorTemplateVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) ListActorTemplateVersions(ctx context.Context, in *ListActorTemplateVersionsRequest, opts ...grpc.CallOption) (*ListActorTemplateVersionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListActorTemplateVersionsResponse)
+	err := c.cc.Invoke(ctx, Control_ListActorTemplateVersions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) DeleteActorTemplateVersion(ctx context.Context, in *DeleteActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplateVersion)
+	err := c.cc.Invoke(ctx, Control_DeleteActorTemplateVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ControlServer is the server API for Control service.
 // All implementations must embed UnimplementedControlServer
 // for forward compatibility.
@@ -331,6 +451,27 @@ type ControlServer interface {
 	// Delete an empty Atespace. Rejects (FailedPrecondition) if any Actors or
 	// ActorSnapshotTags remain.
 	DeleteAtespace(context.Context, *DeleteAtespaceRequest) (*Atespace, error)
+	CreateActorTemplate(context.Context, *CreateActorTemplateRequest) (*ActorTemplate, error)
+	// Get an ActorTemplate by name.
+	GetActorTemplate(context.Context, *GetActorTemplateRequest) (*ActorTemplate, error)
+	// Update mutable fields on an existing ActorTemplate.
+	UpdateActorTemplate(context.Context, *UpdateActorTemplateRequest) (*ActorTemplate, error)
+	ListActorTemplates(context.Context, *ListActorTemplatesRequest) (*ListActorTemplatesResponse, error)
+	// Delete an ActorTemplate. Rejects (FailedPrecondition) while any of its
+	// ActorTemplateVersions exist.
+	DeleteActorTemplate(context.Context, *DeleteActorTemplateRequest) (*ActorTemplate, error)
+	// Create a new ActorTemplateVersion under an existing ActorTemplate
+	// (FailedPrecondition if the parent does not exist).
+	CreateActorTemplateVersion(context.Context, *CreateActorTemplateVersionRequest) (*ActorTemplateVersion, error)
+	// Get an ActorTemplateVersion by name.
+	GetActorTemplateVersion(context.Context, *GetActorTemplateVersionRequest) (*ActorTemplateVersion, error)
+	// List ActorTemplateVersions, optionally filtered to one ActorTemplate.
+	ListActorTemplateVersions(context.Context, *ListActorTemplateVersionsRequest) (*ListActorTemplateVersionsResponse, error)
+	// Delete an ActorTemplateVersion together with its golden actor and golden
+	// snapshot in the reserved ate-golden atespace. Rejects (FailedPrecondition)
+	// while the version is its parent's default_version_on_create or while any
+	// Actor pins it.
+	DeleteActorTemplateVersion(context.Context, *DeleteActorTemplateVersionRequest) (*ActorTemplateVersion, error)
 	mustEmbedUnimplementedControlServer()
 }
 
@@ -394,6 +535,33 @@ func (UnimplementedControlServer) ListAtespaces(context.Context, *ListAtespacesR
 }
 func (UnimplementedControlServer) DeleteAtespace(context.Context, *DeleteAtespaceRequest) (*Atespace, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteAtespace not implemented")
+}
+func (UnimplementedControlServer) CreateActorTemplate(context.Context, *CreateActorTemplateRequest) (*ActorTemplate, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateActorTemplate not implemented")
+}
+func (UnimplementedControlServer) GetActorTemplate(context.Context, *GetActorTemplateRequest) (*ActorTemplate, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetActorTemplate not implemented")
+}
+func (UnimplementedControlServer) UpdateActorTemplate(context.Context, *UpdateActorTemplateRequest) (*ActorTemplate, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateActorTemplate not implemented")
+}
+func (UnimplementedControlServer) ListActorTemplates(context.Context, *ListActorTemplatesRequest) (*ListActorTemplatesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListActorTemplates not implemented")
+}
+func (UnimplementedControlServer) DeleteActorTemplate(context.Context, *DeleteActorTemplateRequest) (*ActorTemplate, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteActorTemplate not implemented")
+}
+func (UnimplementedControlServer) CreateActorTemplateVersion(context.Context, *CreateActorTemplateVersionRequest) (*ActorTemplateVersion, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateActorTemplateVersion not implemented")
+}
+func (UnimplementedControlServer) GetActorTemplateVersion(context.Context, *GetActorTemplateVersionRequest) (*ActorTemplateVersion, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetActorTemplateVersion not implemented")
+}
+func (UnimplementedControlServer) ListActorTemplateVersions(context.Context, *ListActorTemplateVersionsRequest) (*ListActorTemplateVersionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListActorTemplateVersions not implemented")
+}
+func (UnimplementedControlServer) DeleteActorTemplateVersion(context.Context, *DeleteActorTemplateVersionRequest) (*ActorTemplateVersion, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteActorTemplateVersion not implemented")
 }
 func (UnimplementedControlServer) mustEmbedUnimplementedControlServer() {}
 func (UnimplementedControlServer) testEmbeddedByValue()                 {}
@@ -740,6 +908,168 @@ func _Control_DeleteAtespace_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Control_CreateActorTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateActorTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).CreateActorTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_CreateActorTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).CreateActorTemplate(ctx, req.(*CreateActorTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_GetActorTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetActorTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).GetActorTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_GetActorTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).GetActorTemplate(ctx, req.(*GetActorTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_UpdateActorTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateActorTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).UpdateActorTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_UpdateActorTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).UpdateActorTemplate(ctx, req.(*UpdateActorTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_ListActorTemplates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListActorTemplatesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).ListActorTemplates(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_ListActorTemplates_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).ListActorTemplates(ctx, req.(*ListActorTemplatesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_DeleteActorTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteActorTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).DeleteActorTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_DeleteActorTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).DeleteActorTemplate(ctx, req.(*DeleteActorTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_CreateActorTemplateVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateActorTemplateVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).CreateActorTemplateVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_CreateActorTemplateVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).CreateActorTemplateVersion(ctx, req.(*CreateActorTemplateVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_GetActorTemplateVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetActorTemplateVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).GetActorTemplateVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_GetActorTemplateVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).GetActorTemplateVersion(ctx, req.(*GetActorTemplateVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_ListActorTemplateVersions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListActorTemplateVersionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).ListActorTemplateVersions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_ListActorTemplateVersions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).ListActorTemplateVersions(ctx, req.(*ListActorTemplateVersionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_DeleteActorTemplateVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteActorTemplateVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).DeleteActorTemplateVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_DeleteActorTemplateVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).DeleteActorTemplateVersion(ctx, req.(*DeleteActorTemplateVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Control_ServiceDesc is the grpc.ServiceDesc for Control service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -818,6 +1148,42 @@ var Control_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteAtespace",
 			Handler:    _Control_DeleteAtespace_Handler,
+		},
+		{
+			MethodName: "CreateActorTemplate",
+			Handler:    _Control_CreateActorTemplate_Handler,
+		},
+		{
+			MethodName: "GetActorTemplate",
+			Handler:    _Control_GetActorTemplate_Handler,
+		},
+		{
+			MethodName: "UpdateActorTemplate",
+			Handler:    _Control_UpdateActorTemplate_Handler,
+		},
+		{
+			MethodName: "ListActorTemplates",
+			Handler:    _Control_ListActorTemplates_Handler,
+		},
+		{
+			MethodName: "DeleteActorTemplate",
+			Handler:    _Control_DeleteActorTemplate_Handler,
+		},
+		{
+			MethodName: "CreateActorTemplateVersion",
+			Handler:    _Control_CreateActorTemplateVersion_Handler,
+		},
+		{
+			MethodName: "GetActorTemplateVersion",
+			Handler:    _Control_GetActorTemplateVersion_Handler,
+		},
+		{
+			MethodName: "ListActorTemplateVersions",
+			Handler:    _Control_ListActorTemplateVersions_Handler,
+		},
+		{
+			MethodName: "DeleteActorTemplateVersion",
+			Handler:    _Control_DeleteActorTemplateVersion_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/proto/ateapipb/ateapi_grpc.pb.go
+++ b/pkg/proto/ateapipb/ateapi_grpc.pb.go
@@ -122,10 +122,11 @@ type ControlClient interface {
 	GetActorTemplateVersion(ctx context.Context, in *GetActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error)
 	// List ActorTemplateVersions, optionally filtered to one ActorTemplate.
 	ListActorTemplateVersions(ctx context.Context, in *ListActorTemplateVersionsRequest, opts ...grpc.CallOption) (*ListActorTemplateVersionsResponse, error)
-	// Delete an ActorTemplateVersion together with its golden actor and golden
-	// snapshot in the reserved ate-golden atespace. Rejects (FailedPrecondition)
-	// while the version is its parent's default_version_on_create or while any
-	// Actor pins it.
+	// Delete an ActorTemplateVersion together with its golden snapshot in the
+	// reserved ate-golden atespace. Rejects (FailedPrecondition) while the
+	// version is its parent's default_version_on_create. Once actors carry
+	// version pins and the golden state machine lands, this will also reject
+	// while any Actor pins the version, and clean up the golden actor.
 	DeleteActorTemplateVersion(ctx context.Context, in *DeleteActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error)
 }
 
@@ -467,10 +468,11 @@ type ControlServer interface {
 	GetActorTemplateVersion(context.Context, *GetActorTemplateVersionRequest) (*ActorTemplateVersion, error)
 	// List ActorTemplateVersions, optionally filtered to one ActorTemplate.
 	ListActorTemplateVersions(context.Context, *ListActorTemplateVersionsRequest) (*ListActorTemplateVersionsResponse, error)
-	// Delete an ActorTemplateVersion together with its golden actor and golden
-	// snapshot in the reserved ate-golden atespace. Rejects (FailedPrecondition)
-	// while the version is its parent's default_version_on_create or while any
-	// Actor pins it.
+	// Delete an ActorTemplateVersion together with its golden snapshot in the
+	// reserved ate-golden atespace. Rejects (FailedPrecondition) while the
+	// version is its parent's default_version_on_create. Once actors carry
+	// version pins and the golden state machine lands, this will also reject
+	// while any Actor pins the version, and clean up the golden actor.
 	DeleteActorTemplateVersion(context.Context, *DeleteActorTemplateVersionRequest) (*ActorTemplateVersion, error)
 	mustEmbedUnimplementedControlServer()
 }


### PR DESCRIPTION
Introduce AT/ATV messages and CRUD RPCs in ateapipb per the M2 versioning proposal (issue #477): both resources are global-scoped, all snapshot-affecting fields live in the immutable ActorTemplateVersion, and the referenced SandboxConfig is resolved and frozen into the version's status at ATV creation.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
