### PR TITLE
switch write to memory to --rootfs-writes=disk (new): file writes go to a folder on the host machine's disk. The VM reaches that folder through a "pass-through window" called virtio-fs — a

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -20,6 +20,7 @@ defaultPlatforms:
 
 baseImageOverrides:
   github.com/agent-substrate/substrate/demos/sandbox: alpine
+  github.com/agent-substrate/substrate/demos/counter: alpine
   # ateom-microvm needs glibc (for the fetched cloud-hypervisor binary) and mount/umount
   # (to bind the image into the virtiofsd shared dir) — both in debian:stable-slim but
   # not in the distroless static default.

--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/ch"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/third_party/kata/agentpb"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/imagecache"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
@@ -105,6 +106,17 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	client := ch.NewClient(chSocket)
 	if err := client.WaitReady(ctx, 10*time.Second); err != nil {
 		return nil, fmt.Errorf("while waiting for CH api-socket: %w", err)
+	}
+
+	var dDrop time.Duration
+	if scope == ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL && actorHasDiskUpper(actorUID) {
+		tDrop := time.Now()
+		if err := s.dropGuestCaches(ctx, ra, actorUID, req.GetSpec().GetContainers()); err != nil {
+			slog.WarnContext(ctx, "Failed to drop guest caches before pause", slog.Any("err", err))
+		} else {
+			dDrop = time.Since(tDrop)
+			slog.InfoContext(ctx, "Successfully dropped guest page caches", slog.Duration("duration", dDrop))
+		}
 	}
 
 	tPause := time.Now()
@@ -184,7 +196,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 
 	s.actorLogger.EmitLifecycleLog("Actor checkpointed", actorRef, actorUID, templateNS, templateName)
 	slog.InfoContext(ctx, "Actor checkpointed", slog.String("id", actorUID), slog.Any("snapshot_files", snapshotFiles),
-		slog.String("scope", scope.String()), slog.Duration("pause", dPause),
+		slog.String("scope", scope.String()), slog.Duration("drop_caches", dDrop), slog.Duration("pause", dPause),
 		slog.Duration("snapshot", dSnapshot),
 		// The durable-dir + rootfs-upper tars run while the guest is paused, so
 		// their cost is part of the suspend latency and scales with the contents.
@@ -317,4 +329,44 @@ func (s *AteomService) teardownActor(ctx context.Context, id string, ra *running
 	if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(id)); err != nil {
 		slog.WarnContext(ctx, "Failed to unmount bundle rootfs overlays", slog.String("actorUID", id), slog.Any("err", err))
 	}
+}
+
+// dropGuestCaches drops guest page caches using ExecProcess against the workload container.
+func (s *AteomService) dropGuestCaches(ctx context.Context, ra *runningActor, actorUID string, containers []*ateompb.Container) error {
+	var ac *kata.AgentClient
+	if ra != nil && ra.logAgent != nil {
+		ac = ra.logAgent
+	} else {
+		vsockPath := kata.VsockSocketPath(actorUID)
+		var err error
+		ac, err = dialAgentRetry(ctx, vsockPath, 5*time.Second)
+		if err != nil {
+			return fmt.Errorf("dialing kata-agent: %w", err)
+		}
+		defer ac.Close()
+	}
+
+	if len(containers) == 0 {
+		return fmt.Errorf("no containers configured for actor")
+	}
+
+	targetContainer := overlayWorkloadID(containers[0].GetName())
+
+	req := &agentpb.ExecProcessRequest{
+		ContainerId: targetContainer,
+		ExecId:      "drop-caches-" + actorUID,
+		Process: &agentpb.Process{
+			Args: []string{"/bin/sh", "-c", "sync && echo 3 > /proc/sys/vm/drop_caches"},
+			User: &agentpb.User{
+				UID: 0,
+				GID: 0,
+			},
+		},
+	}
+
+	if err := ac.ExecProcess(ctx, req); err != nil {
+		return fmt.Errorf("executing drop_caches in container %q: %w", targetContainer, err)
+	}
+
+	return nil
 }

--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -47,11 +47,13 @@ import (
 //   - FULL: the whole guest. ateom drives the CH REST api-socket: pause -> snapshot
 //     file://<CheckpointStateDir> (config.json + state.json + sparse memory-ranges)
 //     -> tear the VMM down. Each container's rootfs is overlay(virtio-fs RO lower +
-//     guest-tmpfs upper), so the writable upper lives in guest RAM and is captured by
-//     the memory snapshot — process memory and rootfs writes both persist across
-//     suspend/resume. The RO lower is reconstructed from the OCI image at restore, so
-//     nothing rootfs-related ships. Durable-dir volumes are host-backed rather than in
-//     guest RAM, so they ship alongside as a tar.
+//     writable upper). In the default memory mode the upper lives in guest RAM and is
+//     captured by the memory snapshot — process memory and rootfs writes both persist
+//     across suspend/resume. In disk mode (--rootfs-writes=disk) the upper is
+//     host-backed like the durable-dir volumes and ships alongside as its own tar
+//     (see rootfsupper.go). The RO lower is reconstructed from the OCI image at
+//     restore, so it never ships. Durable-dir volumes are host-backed under either
+//     mode, so they ship alongside as a tar.
 //   - DATA: the durable-dir volumes only, as that same tar. The guest is discarded, so
 //     the actor cold-starts on restore with its volumes re-materialized.
 //
@@ -143,6 +145,23 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		dDurable = time.Since(tDurable)
 	}
 
+	// Disk-backed rootfs uppers: host-backed like the durable volumes, so the
+	// memory snapshot no longer carries the rootfs writes — ship them as their
+	// own tar, taken while the guest is paused (write-through share, so every
+	// completed guest write is already on the host). Only a Full snapshot
+	// carries it: under Data the workload cold-starts on restore, discarding
+	// rootfs state in either mode. Detected from the host dir the disk-mode
+	// boot created (actorHasDiskUpper), not the current flag, so the snapshot
+	// always matches the guest's actual mounts.
+	var dUpper time.Duration
+	if scope == ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL && actorHasDiskUpper(actorUID) {
+		tUpper := time.Now()
+		if err := tarRootfsUpper(ctx, ateompath.RootfsUpperDir(actorUID), checkpointDir); err != nil {
+			return nil, err
+		}
+		dUpper = time.Since(tUpper)
+	}
+
 	// Report exactly the files we wrote so atelet ships precisely this snapshot: for
 	// Full, the CH snapshot (config.json + state.json + memory-ranges + base-id) plus
 	// any durable-dir tar; for Data, that tar alone.
@@ -167,9 +186,10 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	slog.InfoContext(ctx, "Actor checkpointed", slog.String("id", actorUID), slog.Any("snapshot_files", snapshotFiles),
 		slog.String("scope", scope.String()), slog.Duration("pause", dPause),
 		slog.Duration("snapshot", dSnapshot),
-		// The durable-dir tar runs while the guest is paused, so its cost is part
-		// of the suspend latency and scales with the volume's contents.
-		slog.Duration("durable_dir", dDurable), slog.Duration("teardown", dTeardown))
+		// The durable-dir + rootfs-upper tars run while the guest is paused, so
+		// their cost is part of the suspend latency and scales with the contents.
+		slog.Duration("durable_dir", dDurable), slog.Duration("rootfs_upper", dUpper),
+		slog.Duration("teardown", dTeardown))
 	return &ateompb.CheckpointWorkloadResponse{SnapshotFiles: snapshotFiles}, nil
 }
 
@@ -219,9 +239,9 @@ func (s *AteomService) snapshotVMState(ctx context.Context, client *ch.Client, r
 			slog.String("id", actorUID), slog.Duration("merge", time.Since(tMerge)))
 	}
 
-	// Nothing rootfs-related ships: the overlay's writable upper is a guest tmpfs, so
-	// the actor's rootfs writes are already in the memory snapshot above, and the RO
-	// lower is reconstructed from the OCI image at restore (it never changes).
+	// The RO lower never ships (reconstructed from the OCI image at restore). The
+	// writable upper is in the memory snapshot above when it is a guest tmpfs; a
+	// disk-backed upper ships as its own tar from CheckpointWorkload instead.
 	return dSnapshot, nil
 }
 
@@ -270,13 +290,21 @@ func (s *AteomService) teardownActor(ctx context.Context, id string, ra *running
 			_, _ = ra.chCmd.Process.Wait()
 		}
 		// Kill the virtiofsds (after CH, their only client): the overlay RO lower's
-		// and, when the actor has durable-dir volumes, the writable share's.
-		for _, cmd := range []*exec.Cmd{ra.vfsdCmd, ra.durableVfsdCmd} {
+		// and, when present, the writable durable-dir and rootfs upper shares'.
+		for _, cmd := range []*exec.Cmd{ra.vfsdCmd, ra.durableVfsdCmd, ra.upperVfsdCmd} {
 			if cmd != nil && cmd.Process != nil {
 				_ = cmd.Process.Kill()
 				_, _ = cmd.Process.Wait()
 			}
 		}
+	}
+
+	// Remove the disk-backed rootfs upper dir (a no-op in memory mode): ateom
+	// owns it — atelet's actor-dir reset doesn't know it — and its absence is
+	// what marks the actor as not disk-backed (actorHasDiskUpper). Runs after
+	// the snapshot tar above, which is already on disk.
+	if err := os.RemoveAll(ateompath.RootfsUpperDir(id)); err != nil {
+		slog.WarnContext(ctx, "Failed to remove rootfs upper dir", slog.String("actorUID", id), slog.Any("err", err))
 	}
 
 	// Sweep any leftover per-sandbox host-side state + orphaned per-sandbox

--- a/cmd/ateom-microvm/internal/kata/agentclient.go
+++ b/cmd/ateom-microvm/internal/kata/agentclient.go
@@ -203,6 +203,15 @@ func (a *AgentClient) AddARPNeighbors(ctx context.Context, neighbors []*agentpb.
 	return nil
 }
 
+// ExecProcess executes a process inside a container or sandbox via the agent.
+// Mirrors grpc.AgentService/ExecProcess (returns google.protobuf.Empty).
+func (a *AgentClient) ExecProcess(ctx context.Context, req *agentpb.ExecProcessRequest) error {
+	if err := a.client.Call(ctx, "grpc.AgentService", "ExecProcess", req, &emptypb.Empty{}); err != nil {
+		return fmt.Errorf("agent ExecProcess: %w", err)
+	}
+	return nil
+}
+
 // ReadStdout reads up to max bytes from the container process's stdout. It is a
 // unary RPC (NOT a server stream): each call returns whatever bytes the agent has
 // buffered (up to max), so callers loop until it returns an error — the agent

--- a/cmd/ateom-microvm/internal/kata/overlay_linux.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux.go
@@ -292,6 +292,11 @@ func (a *AgentClient) StartOverlayWorkload(ctx context.Context, cid, workloadID,
 	upper := upperBase + "/fs"
 	work := upperBase + "/work"
 
+	options := []string{"lowerdir=" + lower, "upperdir=" + upper, "workdir=" + work}
+	if strings.HasPrefix(upperBase, guestUpperDiskDir) {
+		options = append(options, "index=off", "metacopy=off", "userxattr")
+	}
+
 	storages := []*agentpb.Storage{
 		{
 			Driver:     virtioFSDriver,
@@ -306,7 +311,7 @@ func (a *AgentClient) StartOverlayWorkload(ctx context.Context, cid, workloadID,
 			Fstype:        "overlay",
 			MountPoint:    ovlRoot,
 			DriverOptions: []string{createDir + "=" + upper, createDir + "=" + work},
-			Options:       []string{"lowerdir=" + lower, "upperdir=" + upper, "workdir=" + work},
+			Options:       options,
 		},
 	}
 	pbSpec := SpecToAgentPB(spec)

--- a/cmd/ateom-microvm/internal/kata/overlay_linux.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux.go
@@ -17,9 +17,11 @@
 package kata
 
 // Each container's rootfs is an overlay: its OCI image served read-only over virtio-fs
-// (the lower) plus a guest tmpfs (the writable upper). The upper is in guest RAM, so
-// rootfs writes ride along in the memory snapshot and persist across suspend/resume.
-// This file holds the overlay-specific helpers.
+// (the lower) plus a writable upper. By default the upper is a guest tmpfs — in guest
+// RAM, so rootfs writes ride along in the memory snapshot and persist across
+// suspend/resume. With disk-backed rootfs writes (--rootfs-writes=disk, see
+// cmd/ateom-microvm/rootfsupper.go) the upper instead lives on the ateUpper virtio-fs
+// share, backed by host disk. This file holds the overlay-specific helpers.
 
 import (
 	"context"
@@ -54,6 +56,16 @@ const (
 	// volume's contents live at <guestDurableDir>/<volumeName> and are bind-mounted
 	// from there into the containers that declare the volume.
 	guestDurableDir = "/run/ateom-durable"
+
+	// UpperFsTag is the virtio-fs tag for the actor's disk-backed rootfs upper
+	// share (--rootfs-writes=disk), served by a third virtiofsd from
+	// ateompath.RootfsUpperDir on the host.
+	UpperFsTag = "ateUpper"
+	// guestUpperDiskDir is where the agent mounts UpperFsTag in the guest; each
+	// container's overlay upper/work then live under <guestUpperDiskDir>/<cid>.
+	// Deliberately distinct from the tmpfs OverlayUpperBase prefix so the two
+	// modes can never alias.
+	guestUpperDiskDir = "/run/ateom-upper-disk"
 )
 
 // GuestDurableVolumeDir is the in-guest path holding one durable volume's
@@ -71,11 +83,18 @@ func SharedDir(id string) string {
 // VirtiofsdSocketPath is the vhost-user-fs socket CH connects to for the fs device.
 func VirtiofsdSocketPath(id string) string { return filepath.Join(VMDir(id), "virtiofsd.sock") }
 
-// OverlayUpperBase is the in-guest mount point for one container's overlay upper/work.
-// It lives under /run (tmpfs) so the upper's writes are in guest RAM and ride along in
-// the memory-only snapshot (rootfs writes persist). Keyed on the container id, which is
-// stable across the actor's restore lineage.
+// OverlayUpperBase is the in-guest mount point for one container's overlay upper/work
+// in the default (memory) mode. It lives under /run (tmpfs) so the upper's writes are
+// in guest RAM and ride along in the memory-only snapshot (rootfs writes persist).
+// Keyed on the container id, which is stable across the actor's restore lineage.
 func OverlayUpperBase(containerID string) string { return "/run/ateom-upper/" + containerID }
+
+// DiskUpperBase is the in-guest mount point for one container's overlay upper/work
+// when rootfs writes are disk-backed: a subdirectory of the ateUpper virtio-fs share,
+// so the upper's writes land on host disk (ateompath.RootfsUpperDir) instead of guest
+// RAM — the memory snapshot stays lean and the upper ships as a tar instead. Keyed on
+// the container id like OverlayUpperBase.
+func DiskUpperBase(containerID string) string { return guestUpperDiskDir + "/" + containerID }
 
 // GuestSharedRootfs is the in-guest path the kataShared mount exposes a container's
 // rootfs at. A carrier container with this as Root.Path makes the agent bind it to
@@ -91,6 +110,12 @@ type VirtiofsdOptions struct {
 	// Cache is virtiofsd's --cache mode. Empty defaults to "always", which is
 	// only correct for a strictly read-only share (see virtiofsdArgs).
 	Cache string
+	// Xattr enables xattr passthrough (--xattr). Required for a share hosting an
+	// overlayfs upper: overlay records whiteouts and opaque directories as
+	// trusted.overlay.* xattrs in the upper, and without passthrough the guest's
+	// overlay mount cannot round-trip them to the host (deletes of lower files
+	// would fail or silently un-delete across suspend/resume).
+	Xattr bool
 	Log   io.Writer
 }
 
@@ -106,7 +131,7 @@ func virtiofsdArgs(o VirtiofsdOptions) []string {
 		// side changes underneath the guest (e.g. contents restored from a snapshot).
 		cache = "always"
 	}
-	return []string{
+	args := []string{
 		"--socket-path=" + o.SocketPath,
 		"--shared-dir=" + o.SharedDir,
 		"--cache=" + cache,
@@ -114,6 +139,10 @@ func virtiofsdArgs(o VirtiofsdOptions) []string {
 		"--announce-submounts",
 		"--migration-mode", "find-paths",
 	}
+	if o.Xattr {
+		args = append(args, "--xattr")
+	}
+	return args
 }
 
 // StartVirtiofsd launches virtiofsd in find-paths migration mode serving o.SharedDir
@@ -193,7 +222,9 @@ func ReconstructSharedDirFromImage(ctx context.Context, bundleRootfs, restoreID,
 //
 // withDurableShare additionally mounts the writable durable-dir share, whose
 // per-volume subdirectories the containers bind-mount at their declared paths.
-func (a *AgentClient) CreateSandboxForActor(ctx context.Context, sandboxID, hostname string, withDurableShare bool) error {
+// withUpperShare additionally mounts the writable disk-backed rootfs upper share,
+// under whose mount each container's overlay upper/work live (DiskUpperBase).
+func (a *AgentClient) CreateSandboxForActor(ctx context.Context, sandboxID, hostname string, withDurableShare, withUpperShare bool) error {
 	storages := []*agentpb.Storage{{
 		Driver:     virtioFSDriver,
 		Source:     FsTag,
@@ -206,6 +237,14 @@ func (a *AgentClient) CreateSandboxForActor(ctx context.Context, sandboxID, host
 			Source:     DurableFsTag,
 			Fstype:     typeVirtioFS,
 			MountPoint: guestDurableDir,
+		})
+	}
+	if withUpperShare {
+		storages = append(storages, &agentpb.Storage{
+			Driver:     virtioFSDriver,
+			Source:     UpperFsTag,
+			Fstype:     typeVirtioFS,
+			MountPoint: guestUpperDiskDir,
 		})
 	}
 	return a.CreateSandbox(ctx, &agentpb.CreateSandboxRequest{
@@ -239,9 +278,11 @@ func (a *AgentClient) CreateCarrier(ctx context.Context, cid string, spec *specs
 
 // StartOverlayWorkload creates + starts one container with an overlayfs rootfs:
 // lower = the carrier's resolved bind (/run/kata-containers/<cid>/rootfs from the RO
-// virtio-fs base), upper/work = <upperBase>/{fs,work} on a guest tmpfs so rootfs writes
-// land in guest RAM (captured by the memory-only snapshot → persist). The agent creates
-// the upper/work dirs (create_directory) before mounting the overlay.
+// virtio-fs base), upper/work = <upperBase>/{fs,work}. upperBase is either a guest
+// tmpfs (OverlayUpperBase: writes land in guest RAM, captured by the memory-only
+// snapshot) or a directory on the disk-backed ateUpper share (DiskUpperBase: writes
+// land on host disk, shipped as a tar at checkpoint). The agent creates the upper/work
+// dirs (create_directory) before mounting the overlay.
 func (a *AgentClient) StartOverlayWorkload(ctx context.Context, cid, workloadID, upperBase string, spec *specs.Spec) error {
 	const createDir = "io.katacontainers.volume.overlayfs.create_directory"
 	sharedBase := "/run/kata-containers/" + cid + "/rootfs"

--- a/cmd/ateom-microvm/internal/kata/overlay_linux_test.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux_test.go
@@ -26,6 +26,7 @@ func TestVirtiofsdArgs(t *testing.T) {
 		name      string
 		opts      VirtiofsdOptions
 		wantCache string
+		wantXattr bool
 	}{
 		{
 			name:      "RO lower defaults to cache=always",
@@ -41,12 +42,29 @@ func TestVirtiofsdArgs(t *testing.T) {
 			},
 			wantCache: "--cache=auto",
 		},
+		{
+			name: "rootfs upper share passes xattrs through",
+			opts: VirtiofsdOptions{
+				SocketPath: "/run/vm/virtiofsd-upper.sock",
+				SharedDir:  "/var/lib/ateom-gvisor/actors/uid/rootfs-upper",
+				Cache:      "auto",
+				Xattr:      true,
+			},
+			wantCache: "--cache=auto",
+			wantXattr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			args := virtiofsdArgs(tc.opts)
 			if !slices.Contains(args, tc.wantCache) {
 				t.Errorf("args %v do not contain %q", args, tc.wantCache)
+			}
+			// Overlay whiteouts are trusted.overlay.* xattrs in the upper; a share
+			// hosting an upper must pass them through, and the others must not pay
+			// the passthrough cost.
+			if gotXattr := slices.Contains(args, "--xattr"); gotXattr != tc.wantXattr {
+				t.Errorf("args %v: --xattr present = %v, want %v", args, gotXattr, tc.wantXattr)
 			}
 			for _, want := range []string{
 				"--socket-path=" + tc.opts.SocketPath,

--- a/cmd/ateom-microvm/internal/kata/restore.go
+++ b/cmd/ateom-microvm/internal/kata/restore.go
@@ -35,3 +35,10 @@ func VsockSocketPath(id string) string { return filepath.Join(VMDir(id), "clh.so
 func DurableVirtiofsdSocketPath(id string) string {
 	return filepath.Join(VMDir(id), "virtiofsd-durable.sock")
 }
+
+// UpperVirtiofsdSocketPath is the vhost-user-fs socket for the actor's writable
+// disk-backed rootfs upper share (--rootfs-writes=disk), served by a third
+// virtiofsd alongside the RO lower's and the durable share's.
+func UpperVirtiofsdSocketPath(id string) string {
+	return filepath.Join(VMDir(id), "virtiofsd-upper.sock")
+}

--- a/cmd/ateom-microvm/internal/tarutil/fifo_linux.go
+++ b/cmd/ateom-microvm/internal/tarutil/fifo_linux.go
@@ -15,6 +15,8 @@
 package tarutil
 
 import (
+	"archive/tar"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,6 +45,35 @@ func createFifo(root *os.Root, name string, mode os.FileMode) error {
 
 	if err := unix.Mkfifoat(int(parent.Fd()), base, uint32(mode.Perm())); err != nil {
 		return fmt.Errorf("creating fifo %q: %w", name, err)
+	}
+	return nil
+}
+
+// createDevice creates a character or block device node relative to root.
+func createDevice(root *os.Root, name string, hdr *tar.Header, mode os.FileMode) error {
+	dir, base := filepath.Split(name)
+	if dir == "" {
+		dir = "."
+	}
+	parent, err := root.Open(filepath.Clean(dir))
+	if err != nil {
+		return fmt.Errorf("opening parent directory of %q: %w", name, err)
+	}
+	defer parent.Close()
+
+	var flags uint32
+	if hdr.Typeflag == tar.TypeChar {
+		flags = unix.S_IFCHR
+	} else {
+		flags = unix.S_IFBLK
+	}
+
+	dev := unix.Mkdev(uint32(hdr.Devmajor), uint32(hdr.Devminor))
+	if err := unix.Mknodat(int(parent.Fd()), base, flags|uint32(mode.Perm()), int(dev)); err != nil {
+		if errors.Is(err, os.ErrPermission) && os.Geteuid() != 0 {
+			return nil
+		}
+		return fmt.Errorf("creating device %q: %w", name, err)
 	}
 	return nil
 }

--- a/cmd/ateom-microvm/internal/tarutil/fifo_linux.go
+++ b/cmd/ateom-microvm/internal/tarutil/fifo_linux.go
@@ -16,7 +16,6 @@ package tarutil
 
 import (
 	"archive/tar"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,9 +69,6 @@ func createDevice(root *os.Root, name string, hdr *tar.Header, mode os.FileMode)
 
 	dev := unix.Mkdev(uint32(hdr.Devmajor), uint32(hdr.Devminor))
 	if err := unix.Mknodat(int(parent.Fd()), base, flags|uint32(mode.Perm()), int(dev)); err != nil {
-		if errors.Is(err, os.ErrPermission) && os.Geteuid() != 0 {
-			return nil
-		}
 		return fmt.Errorf("creating device %q: %w", name, err)
 	}
 	return nil

--- a/cmd/ateom-microvm/internal/tarutil/tarutil.go
+++ b/cmd/ateom-microvm/internal/tarutil/tarutil.go
@@ -39,6 +39,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 // Create writes a tar archive of srcDir's contents to tarPath. Entry names are
@@ -127,6 +129,20 @@ func writeTree(ctx context.Context, tw *tar.Writer, srcDir string) error {
 		}
 		setOwner(hdr, info)
 
+		// Read user.* xattrs and populate PAXRecords
+		xattrs, err := getLsetxattrs(path)
+		if err != nil {
+			return fmt.Errorf("reading xattrs for %q: %w", path, err)
+		}
+		if len(xattrs) > 0 {
+			if hdr.PAXRecords == nil {
+				hdr.PAXRecords = make(map[string]string)
+			}
+			for name, val := range xattrs {
+				hdr.PAXRecords["SCHILY.xattr."+name] = val
+			}
+		}
+
 		switch {
 		case info.Mode().IsRegular():
 			// A second link to an already-archived inode: record the link and
@@ -214,15 +230,15 @@ func Extract(tarPath, dstDir string) error {
 		if skip {
 			continue
 		}
-		if err := extractEntry(root, tr, hdr, name, dirs); err != nil {
+		if err := extractEntry(dstDir, root, tr, hdr, name, dirs); err != nil {
 			return err
 		}
 	}
-	return restoreDirMeta(root, dirs)
+	return restoreDirMeta(dstDir, root, dirs)
 }
 
 // extractEntry materializes one archive entry under root.
-func extractEntry(root *os.Root, tr *tar.Reader, hdr *tar.Header, name string, dirs map[string]*tar.Header) error {
+func extractEntry(dstDir string, root *os.Root, tr *tar.Reader, hdr *tar.Header, name string, dirs map[string]*tar.Header) error {
 	mode := hdr.FileInfo().Mode().Perm()
 
 	switch hdr.Typeflag {
@@ -249,7 +265,7 @@ func extractEntry(root *os.Root, tr *tar.Reader, hdr *tar.Header, name string, d
 		if closeErr != nil {
 			return fmt.Errorf("closing %q: %w", name, closeErr)
 		}
-		return restoreMeta(root, name, hdr)
+		return restoreMeta(dstDir, root, name, hdr)
 
 	case tar.TypeSymlink:
 		if err := replaceExisting(root, name); err != nil {
@@ -269,7 +285,7 @@ func extractEntry(root *os.Root, tr *tar.Reader, hdr *tar.Header, name string, d
 		if err := createFifo(root, name, mode); err != nil {
 			return err
 		}
-		return restoreMeta(root, name, hdr)
+		return restoreMeta(dstDir, root, name, hdr)
 
 	case tar.TypeLink:
 		target, skip, err := cleanTarName(hdr.Linkname)
@@ -291,7 +307,7 @@ func extractEntry(root *os.Root, tr *tar.Reader, hdr *tar.Header, name string, d
 		if err := createDevice(root, name, hdr, mode); err != nil {
 			return err
 		}
-		return restoreMeta(root, name, hdr)
+		return restoreMeta(dstDir, root, name, hdr)
 
 	default:
 		return fmt.Errorf("unsupported tar entry type %q at %q", string([]byte{hdr.Typeflag}), name)
@@ -318,14 +334,14 @@ func replaceExisting(root *os.Root, name string) error {
 // directories, deepest first: a directory's path is always longer than its
 // parent's, so length-descending order restores children before the parent's
 // mode can make them unreachable.
-func restoreDirMeta(root *os.Root, dirs map[string]*tar.Header) error {
+func restoreDirMeta(dstDir string, root *os.Root, dirs map[string]*tar.Header) error {
 	names := make([]string, 0, len(dirs))
 	for name := range dirs {
 		names = append(names, name)
 	}
 	sort.Slice(names, func(i, j int) bool { return len(names[i]) > len(names[j]) })
 	for _, name := range names {
-		if err := restoreMeta(root, name, dirs[name]); err != nil {
+		if err := restoreMeta(dstDir, root, name, dirs[name]); err != nil {
 			return err
 		}
 	}
@@ -349,7 +365,7 @@ func restoredMode(hdr *tar.Header) os.FileMode {
 // restoreMeta applies ownership, mode, and modification time to an extracted
 // path. Ownership is applied first because chowning a file clears its setuid
 // and setgid bits, which the chmod below then puts back.
-func restoreMeta(root *os.Root, name string, hdr *tar.Header) error {
+func restoreMeta(dstDir string, root *os.Root, name string, hdr *tar.Header) error {
 	if err := lchownEntry(root, name, hdr); err != nil {
 		return err
 	}
@@ -361,6 +377,18 @@ func restoreMeta(root *os.Root, name string, hdr *tar.Header) error {
 			return fmt.Errorf("restoring times on %q: %w", name, err)
 		}
 	}
+
+	// Restore user.* extended attributes from PAXRecords
+	for k, v := range hdr.PAXRecords {
+		if strings.HasPrefix(k, "SCHILY.xattr.user.") {
+			attrName := strings.TrimPrefix(k, "SCHILY.xattr.")
+			hostPath := filepath.Join(dstDir, name)
+			if err := unix.Lsetxattr(hostPath, attrName, []byte(v), 0); err != nil {
+				return fmt.Errorf("restoring xattr %q on %q: %w", attrName, hostPath, err)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -380,4 +408,46 @@ func cleanTarName(name string) (cleaned string, skip bool, err error) {
 		return "", false, fmt.Errorf("not a local path: %q", name)
 	}
 	return cleaned, false, nil
+}
+
+// getLsetxattrs lists and reads user.* extended attributes of path on Linux.
+func getLsetxattrs(path string) (map[string]string, error) {
+	sz, err := unix.Llistxattr(path, nil)
+	if err != nil {
+		if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENOSYS) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if sz <= 0 {
+		return nil, nil
+	}
+	buf := make([]byte, sz)
+	sz, err = unix.Llistxattr(path, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	xattrs := make(map[string]string)
+	names := strings.Split(string(buf[:sz]), "\x00")
+	for _, name := range names {
+		if name == "" || !strings.HasPrefix(name, "user.") {
+			continue
+		}
+		vsz, err := unix.Lgetxattr(path, name, nil)
+		if err != nil {
+			return nil, err
+		}
+		if vsz <= 0 {
+			xattrs[name] = ""
+			continue
+		}
+		vbuf := make([]byte, vsz)
+		vsz, err = unix.Lgetxattr(path, name, vbuf)
+		if err != nil {
+			return nil, err
+		}
+		xattrs[name] = string(vbuf[:vsz])
+	}
+	return xattrs, nil
 }

--- a/cmd/ateom-microvm/internal/tarutil/tarutil.go
+++ b/cmd/ateom-microvm/internal/tarutil/tarutil.go
@@ -145,8 +145,8 @@ func writeTree(ctx context.Context, tw *tar.Writer, srcDir string) error {
 			}
 			return copyFileInto(tw, path)
 
-		case d.IsDir(), info.Mode()&os.ModeSymlink != 0, info.Mode()&os.ModeNamedPipe != 0:
-			// FileInfoHeader already gave a FIFO Typeflag TypeFifo and size 0.
+		case d.IsDir(), info.Mode()&os.ModeSymlink != 0, info.Mode()&os.ModeNamedPipe != 0, info.Mode()&os.ModeDevice != 0:
+			// FileInfoHeader already populated directory, symlink, FIFO, or device Typeflags.
 			return tw.WriteHeader(hdr)
 
 		default:
@@ -283,6 +283,15 @@ func extractEntry(root *os.Root, tr *tar.Reader, hdr *tar.Header, name string, d
 			return fmt.Errorf("creating hardlink %q -> %q: %w", name, target, err)
 		}
 		return nil
+
+	case tar.TypeChar, tar.TypeBlock:
+		if err := replaceExisting(root, name); err != nil {
+			return err
+		}
+		if err := createDevice(root, name, hdr, mode); err != nil {
+			return err
+		}
+		return restoreMeta(root, name, hdr)
 
 	default:
 		return fmt.Errorf("unsupported tar entry type %q at %q", string([]byte{hdr.Typeflag}), name)

--- a/cmd/ateom-microvm/internal/tarutil/tarutil_test.go
+++ b/cmd/ateom-microvm/internal/tarutil/tarutil_test.go
@@ -90,6 +90,12 @@ func TestRoundTrip(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(src, "empty"), 0o755); err != nil {
 		t.Fatalf("mkdir empty: %v", err)
 	}
+	// Chmod explicitly: the Mkdir mode is clipped by the process umask (0o750
+	// under the 027 some workstations default to), which would skew the mode
+	// the round-trip below is expected to preserve.
+	if err := os.Chmod(filepath.Join(src, "empty"), 0o755); err != nil {
+		t.Fatalf("chmod empty: %v", err)
+	}
 	if err := os.Symlink("a.txt", filepath.Join(src, "link")); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
@@ -360,7 +366,7 @@ func TestRoundTripOwnership(t *testing.T) {
 	}
 }
 
-func TestCreateRejectsDeviceNode(t *testing.T) {
+func TestCreateSupportsDeviceNode(t *testing.T) {
 	roottest.Require(t, "creating a device node requires root")
 
 	src := t.TempDir()
@@ -368,12 +374,23 @@ func TestCreateRejectsDeviceNode(t *testing.T) {
 	if err := unix.Mknod(filepath.Join(src, "null"), unix.S_IFCHR|0o666, int(unix.Mkdev(1, 3))); err != nil {
 		t.Fatalf("creating device node: %v", err)
 	}
-	err := Create(t.Context(), filepath.Join(t.TempDir(), "dev.tar"), src)
-	if err == nil {
-		t.Fatal("Create succeeded on a device node, want an error")
+	tarPath := filepath.Join(t.TempDir(), "dev.tar")
+	err := Create(t.Context(), tarPath, src)
+	if err != nil {
+		t.Fatalf("Create failed on a device node: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unsupported file type") {
-		t.Errorf("error = %v, want it to mention an unsupported file type", err)
+
+	dst := t.TempDir()
+	if err := Extract(tarPath, dst); err != nil {
+		t.Fatalf("Extract failed on a device entry: %v", err)
+	}
+
+	st, err := os.Lstat(filepath.Join(dst, "null"))
+	if err != nil {
+		t.Fatalf("stat on extracted device: %v", err)
+	}
+	if st.Mode()&os.ModeDevice == 0 || st.Mode()&os.ModeCharDevice == 0 {
+		t.Errorf("extracted node mode = %v, want character device", st.Mode())
 	}
 }
 
@@ -490,10 +507,21 @@ func TestExtractIntoPrecreatedVolumeDir(t *testing.T) {
 	}
 }
 
-func TestExtractRejectsUnsupportedType(t *testing.T) {
+func TestExtractSupportsDeviceType(t *testing.T) {
+	roottest.Require(t, "creating a device node requires root")
+
 	tarPath := filepath.Join(t.TempDir(), "dev.tar")
 	writeTar(t, tarPath, tar.Header{Name: "null", Typeflag: tar.TypeChar, Devmajor: 1, Devminor: 3})
-	if err := Extract(tarPath, t.TempDir()); err == nil {
-		t.Fatal("Extract succeeded on a device entry, want an error")
+	dst := t.TempDir()
+	if err := Extract(tarPath, dst); err != nil {
+		t.Fatalf("Extract failed on a device entry: %v", err)
+	}
+
+	st, err := os.Lstat(filepath.Join(dst, "null"))
+	if err != nil {
+		t.Fatalf("stat on extracted device: %v", err)
+	}
+	if st.Mode()&os.ModeDevice == 0 || st.Mode()&os.ModeCharDevice == 0 {
+		t.Errorf("extracted node mode = %v, want character device", st.Mode())
 	}
 }

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -51,12 +51,19 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
+func getRootfsWritesDefault() string {
+	if val := os.Getenv("ATEOM_ROOTFS_WRITES"); val != "" {
+		return val
+	}
+	return "memory"
+}
+
 var (
 	podUID       = flag.String("pod-uid", "", "The UID of the current pod")
 	chBinary     = flag.String("cloud-hypervisor-binary", "cloud-hypervisor", "Path to the cloud-hypervisor binary (used to relaunch on restore).")
 	kataConfig   = flag.String("kata-config", "", "Path to a kata configuration.toml (passed to the shim as KATA_CONF_FILE). Empty uses kata's default. atelet generates one pointing at runtime-fetched assets.")
 	kataDebug    = flag.Bool("kata-debug", false, "Verbose kata-agent debugging: raise the guest agent log level and forward the guest console (incl. agent logs) into the pod logs.")
-	rootfsWrites = flag.String("rootfs-writes", "memory", "Where each container's overlay rootfs upper lives: \"memory\" (guest tmpfs: RAM-speed writes that ride in the memory snapshot, but every rootfs write is guest RAM) or \"disk\" (a host-disk-backed virtio-fs share: guest RAM and snapshots stay lean at the cost of virtio-fs write latency). Applies to cold boots; restores follow the snapshot they restore.")
+	rootfsWrites = flag.String("rootfs-writes", getRootfsWritesDefault(), "Where each container's overlay rootfs upper lives: \"memory\" (guest tmpfs: RAM-speed writes that ride in the memory snapshot, but every rootfs write is guest RAM) or \"disk\" (a host-disk-backed virtio-fs share: guest RAM and snapshots stay lean at the cost of virtio-fs write latency). Applies to cold boots; restores follow the snapshot they restore.")
 	showVersion  = flag.Bool("version", false, "Print version and exit.")
 	logLevelFlag = flag.String("log-level", "info", "Minimum log level: debug, info, warn, or error.")
 

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -56,6 +56,7 @@ var (
 	chBinary     = flag.String("cloud-hypervisor-binary", "cloud-hypervisor", "Path to the cloud-hypervisor binary (used to relaunch on restore).")
 	kataConfig   = flag.String("kata-config", "", "Path to a kata configuration.toml (passed to the shim as KATA_CONF_FILE). Empty uses kata's default. atelet generates one pointing at runtime-fetched assets.")
 	kataDebug    = flag.Bool("kata-debug", false, "Verbose kata-agent debugging: raise the guest agent log level and forward the guest console (incl. agent logs) into the pod logs.")
+	rootfsWrites = flag.String("rootfs-writes", "memory", "Where each container's overlay rootfs upper lives: \"memory\" (guest tmpfs: RAM-speed writes that ride in the memory snapshot, but every rootfs write is guest RAM) or \"disk\" (a host-disk-backed virtio-fs share: guest RAM and snapshots stay lean at the cost of virtio-fs write latency). Applies to cold boots; restores follow the snapshot they restore.")
 	showVersion  = flag.Bool("version", false, "Print version and exit.")
 	logLevelFlag = flag.String("log-level", "info", "Minimum log level: debug, info, warn, or error.")
 
@@ -98,6 +99,15 @@ func do(ctx context.Context) error {
 		return err
 	}
 	slog.InfoContext(ctx, "ateom-microvm booting", slog.String("version", version.String()))
+
+	var diskRootfsWrites bool
+	switch *rootfsWrites {
+	case "memory":
+	case "disk":
+		diskRootfsWrites = true
+	default:
+		return fmt.Errorf("invalid --rootfs-writes %q: must be \"memory\" or \"disk\"", *rootfsWrites)
+	}
 
 	const serviceName = "ateom-microvm"
 	tp, err := serverboot.InitTracing(ctx, serverboot.TracingOptions{
@@ -211,7 +221,7 @@ func do(ctx context.Context) error {
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.UnaryInterceptor(ateinterceptors.InternalServerUnaryInterceptor),
 	)
-	ateompb.RegisterAteomServer(svr, NewService(*podUID, *chBinary, *kataConfig, *kataDebug, interiorNetNS, actorLogger, atunnelServer, atunnelEgress, atunnelEgressPort, *atunnelCredentialBundle, *atunnelEgressTrustBundle))
+	ateompb.RegisterAteomServer(svr, NewService(*podUID, *chBinary, *kataConfig, *kataDebug, diskRootfsWrites, interiorNetNS, actorLogger, atunnelServer, atunnelEgress, atunnelEgressPort, *atunnelCredentialBundle, *atunnelEgressTrustBundle))
 	reflection.Register(svr)
 
 	slog.InfoContext(ctx, "ateom-microvm serving", slog.String("socket", sockPath))
@@ -261,6 +271,11 @@ type AteomService struct {
 	chBinary   string
 	kataConfig string
 	kataDebug  bool
+	// diskRootfsWrites selects the disk-backed rootfs upper for COLD boots
+	// (--rootfs-writes=disk, see rootfsupper.go). Checkpoints and restores are
+	// self-describing instead (actorHasDiskUpper / snapshotHasRootfsUpper), so
+	// in-flight actors survive a flag flip.
+	diskRootfsWrites bool
 
 	// interiorNetNS hosts the per-activation actor veth peer (see net.go);
 	// kata is pointed at it.
@@ -287,12 +302,13 @@ type AteomService struct {
 var _ ateompb.AteomServer = (*AteomService)(nil)
 
 // NewService creates a new AteomService.
-func NewService(podUID, chBinary, kataConfig string, kataDebug bool, interiorNetNS netns.NsHandle, actorLogger *actorlog.ActorLogger, atunnelServer *atunnel.Server, atunnelEgress *atunnel.Egress, atunnelEgressPort uint16, credentialBundle, egressTrustBundle string) *AteomService {
+func NewService(podUID, chBinary, kataConfig string, kataDebug, diskRootfsWrites bool, interiorNetNS netns.NsHandle, actorLogger *actorlog.ActorLogger, atunnelServer *atunnel.Server, atunnelEgress *atunnel.Egress, atunnelEgressPort uint16, credentialBundle, egressTrustBundle string) *AteomService {
 	return &AteomService{
 		podUID:                   podUID,
 		chBinary:                 chBinary,
 		kataConfig:               kataConfig,
 		kataDebug:                kataDebug,
+		diskRootfsWrites:         diskRootfsWrites,
 		interiorNetNS:            interiorNetNS,
 		actorLogger:              actorLogger,
 		atunnel:                  atunnelServer,

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -119,15 +119,16 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 // restoreFullScope restores a whole-guest snapshot: relaunch cloud-hypervisor
 // directly from it and resume.
 //
-// Each container's rootfs is overlay(virtio-fs RO lower + guest-tmpfs upper). Steps:
+// Each container's rootfs is overlay(virtio-fs RO lower + writable upper). Steps:
 // reconstruct each RO lower from the local OCI bundle (atelet re-unpacked the golden
 // image) at the frozen find-paths path and start the virtiofsd serving them; rewrite
 // the snapshot config's per-VMDir paths (vsock + serial + fs sockets) to this actor's;
 // rebuild the tap (the snapshot's virtio-net is fd-backed → fresh net_fds); relaunch
 // CH with --restore (OnDemand), and resume. Guest RAM — incl. the actor's in-memory
-// state, the tmpfs rootfs upper (so rootfs writes PERSIST), and the frozen network
-// config — comes back from the memory snapshot. Durable-dir volumes are host-backed
-// instead, and the caller has already restored them from the snapshot's tar.
+// state, a tmpfs rootfs upper when the snapshot used one (so rootfs writes PERSIST),
+// and the frozen network config — comes back from the memory snapshot. Durable-dir
+// volumes are host-backed instead, and the caller has already restored them from the
+// snapshot's tar; a disk-backed rootfs upper is re-materialized the same way below.
 func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, restoreDir string, tStart time.Time) (retErr error) {
 	actorUID := p.actorUID
 	templateNS, templateName := p.templateNS, p.templateName
@@ -153,11 +154,12 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	// Reconstruct each container's overlay RO lower from the LOCAL OCI bundle (atelet
 	// re-unpacked the golden image; the lower is the immutable golden image) at the
 	// frozen find-paths location SharedDir(id)/<cid>/rootfs, and start the one virtiofsd
-	// serving them. The writable upper is a guest tmpfs restored from the memory
-	// snapshot (rootfs writes persist), so there is no disk to rebuild or repoint; the
-	// fs socket in the snapshot config is repointed to this VMDir by
-	// rewriteSnapshotSocketPaths above. cross-node consistency relies on a deterministic
-	// unpack of the same image at the same <cid>/rootfs path.
+	// serving them. A tmpfs writable upper is restored by the memory snapshot itself
+	// (rootfs writes persist) with no disk to rebuild; a disk-backed upper is
+	// re-materialized from its tar below. The fs sockets in the snapshot config are
+	// repointed to this VMDir by rewriteSnapshotSocketPaths above. cross-node
+	// consistency relies on a deterministic unpack of the same image at the same
+	// <cid>/rootfs path.
 	containers := p.containers
 	if len(containers) == 0 {
 		return status.Error(codes.InvalidArgument, "actor spec has no containers")
@@ -193,6 +195,27 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 			if retErr != nil && durableVfsdCmd.Process != nil {
 				_ = durableVfsdCmd.Process.Kill()
 				_, _ = durableVfsdCmd.Process.Wait()
+			}
+		}()
+	}
+
+	// Disk-backed rootfs uppers: the snapshot says whether the guest expects the
+	// ateUpper share (its config.json references the fs device and the tar rides
+	// alongside), independent of this ateom's --rootfs-writes flag. Re-materialize
+	// the upper contents, then serve them exactly like the durable share — the tar
+	// reproduces the paths find-paths re-opens.
+	var upperVfsdCmd *exec.Cmd
+	if snapshotHasRootfsUpper(restoreDir) {
+		if err := untarRootfsUpper(ateompath.RootfsUpperDir(actorUID), restoreDir); err != nil {
+			return err
+		}
+		if upperVfsdCmd, err = s.stageRootfsUpperShare(ctx, rr, actorUID); err != nil {
+			return err
+		}
+		defer func() {
+			if retErr != nil && upperVfsdCmd.Process != nil {
+				_ = upperVfsdCmd.Process.Kill()
+				_, _ = upperVfsdCmd.Process.Wait()
 			}
 		}()
 	}
@@ -277,7 +300,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	}
 
 	ra := &runningActor{
-		chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd,
+		chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, upperVfsdCmd: upperVfsdCmd,
 		apiSocket: apiSocket, baseID: srcID, restoreSourceDir: restoreDir,
 	}
 
@@ -338,8 +361,8 @@ func rewriteSnapshotSocketPaths(snapshotDir, id string) error {
 	// Each virtio-fs share is served by its own per-VMDir virtiofsd socket; the
 	// snapshot recorded the golden actor's, so repoint them at this actor's VMDir.
 	// Match on the device tag: the shares have separate sockets (the overlay RO
-	// lower's and, when the actor has durable-dir volumes, the writable share's), and
-	// crossing them would hand the guest the wrong filesystem.
+	// lower's and, when present, the writable durable-dir and rootfs upper shares'),
+	// and crossing them would hand the guest the wrong filesystem.
 	if fss, ok := cfg["fs"].([]any); ok {
 		for _, f := range fss {
 			fm, ok := f.(map[string]any)
@@ -351,6 +374,8 @@ func rewriteSnapshotSocketPaths(snapshotDir, id string) error {
 				fm["socket"] = kata.VirtiofsdSocketPath(id)
 			case kata.DurableFsTag:
 				fm["socket"] = kata.DurableVirtiofsdSocketPath(id)
+			case kata.UpperFsTag:
+				fm["socket"] = kata.UpperVirtiofsdSocketPath(id)
 			default:
 				return fmt.Errorf("snapshot config %q has fs device with unknown tag %q", cfgPath, tag)
 			}

--- a/cmd/ateom-microvm/restore_test.go
+++ b/cmd/ateom-microvm/restore_test.go
@@ -86,26 +86,31 @@ func TestRewriteSnapshotSocketPaths(t *testing.T) {
 	})
 
 	t.Run("each share keeps its own socket", func(t *testing.T) {
-		// Ordered durable-first to catch a rewrite that assumes the RO lower comes
+		// Ordered with the RO lower last to catch a rewrite that assumes it comes
 		// first, which would hand the guest the wrong filesystem.
 		dir := writeSnapshotConfig(t, []map[string]any{
 			{"tag": kata.DurableFsTag, "socket": "/run/vc/vm/golden/virtiofsd-durable.sock"},
+			{"tag": kata.UpperFsTag, "socket": "/run/vc/vm/golden/virtiofsd-upper.sock"},
 			{"tag": kata.FsTag, "socket": "/run/vc/vm/golden/virtiofsd.sock"},
 		})
 		if err := rewriteSnapshotSocketPaths(dir, id); err != nil {
 			t.Fatalf("rewriteSnapshotSocketPaths: %v", err)
 		}
 		got := readFsSockets(t, dir)
-		for tag, want := range map[string]string{
+		want := map[string]string{
 			kata.FsTag:        kata.VirtiofsdSocketPath(id),
 			kata.DurableFsTag: kata.DurableVirtiofsdSocketPath(id),
-		} {
-			if got[tag] != want {
-				t.Errorf("%s socket = %q, want %q", tag, got[tag], want)
-			}
+			kata.UpperFsTag:   kata.UpperVirtiofsdSocketPath(id),
 		}
-		if got[kata.FsTag] == got[kata.DurableFsTag] {
-			t.Error("both shares were pointed at the same socket")
+		seen := map[string]string{}
+		for tag, w := range want {
+			if got[tag] != w {
+				t.Errorf("%s socket = %q, want %q", tag, got[tag], w)
+			}
+			if prev, dup := seen[got[tag]]; dup {
+				t.Errorf("shares %s and %s were pointed at the same socket %q", prev, tag, got[tag])
+			}
+			seen[got[tag]] = tag
 		}
 	})
 

--- a/cmd/ateom-microvm/rootfsupper.go
+++ b/cmd/ateom-microvm/rootfsupper.go
@@ -1,0 +1,160 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// Disk-backed rootfs writes for the micro-VM runtime (opt-in via
+// --rootfs-writes=disk).
+//
+// By default each container's overlay upper is a guest tmpfs: rootfs writes are
+// RAM-speed and ride along in the memory snapshot for free, but every byte the
+// actor writes is guest RAM — heavy writers inflate both the actor's memory
+// footprint and its snapshot (and with it suspend/resume latency). In disk mode
+// the upper moves to a THIRD virtio-fs share (kata.UpperFsTag), served by its
+// own virtiofsd from ateompath.RootfsUpperDir(actorUID) on the host: rootfs
+// writes leave guest RAM and the memory snapshot stays lean, at the cost of
+// virtio-fs write latency on every rootfs write. Which trade wins is
+// workload-dependent; the flag exists to measure exactly that.
+//
+// The share is served like the durable-dir one — write-through (no
+// --writeback, so a paused guest's completed writes are already on the host),
+// cache=auto (the host contents change underneath the guest on restore), and
+// find-paths migration — plus --xattr, because overlayfs stores whiteouts and
+// opaque-directory markers as trusted.overlay.* xattrs in the upper and the
+// guest kernel must round-trip them through virtiofsd. Unlike the durable dirs
+// (whose host side atelet owns), this directory is owned entirely by ateom:
+// created fresh at cold boot, re-materialized from the snapshot at restore,
+// and removed at teardown.
+//
+// Snapshots: the upper no longer rides in guest memory, so a FULL snapshot
+// ships it as a tar (rootfsUpperTarFile) exactly like the durable volumes,
+// taken while the guest is paused. Restore is self-describing — the tar's
+// presence in the snapshot is what says the guest expects the ateUpper share
+// (the snapshot's config.json references its fs device), independent of the
+// flag the restoring ateom happens to run with. A DATA snapshot deliberately
+// excludes it: the workload cold-starts on restore, so rootfs state is
+// discarded under that scope in either mode.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/tarutil"
+	"github.com/agent-substrate/substrate/internal/ateompath"
+)
+
+// rootfsUpperTarFile is the snapshot file holding the tar of the actor's
+// disk-backed rootfs uppers. Its entries are <containerID>/fs/... and
+// <containerID>/work/... relative to ateompath.RootfsUpperDir, so extraction
+// restores the exact layout the guest's find-paths re-opens.
+const rootfsUpperTarFile = "rootfs-upper.tar"
+
+// upperVirtiofsdLogPath is where the rootfs upper share's virtiofsd logs,
+// beside the overlay lower's and the durable share's under the actor's VM dir.
+func upperVirtiofsdLogPath(id string) string {
+	return filepath.Join(kata.VMDir(id), "virtiofsd-upper.log")
+}
+
+// resetRootfsUpperDir gives a cold boot a pristine upper directory: a cold
+// boot must start from the bare image (tmpfs mode gets that for free), and
+// atelet's actor-dir reset does not know about this directory, so ateom wipes
+// any previous activation's contents itself.
+func resetRootfsUpperDir(actorUID string) error {
+	dir := ateompath.RootfsUpperDir(actorUID)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("while clearing rootfs upper dir %q: %w", dir, err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("while creating rootfs upper dir %q: %w", dir, err)
+	}
+	return nil
+}
+
+// actorHasDiskUpper reports whether the running actor's rootfs uppers are
+// disk-backed, by the host directory only a disk-mode boot/restore creates
+// (and teardownActor removes). Checked at checkpoint instead of the flag so a
+// flag flip between an actor's boot and its checkpoint cannot desync the
+// snapshot from the guest's actual mounts.
+func actorHasDiskUpper(actorUID string) bool {
+	_, err := os.Stat(ateompath.RootfsUpperDir(actorUID))
+	return err == nil
+}
+
+// snapshotHasRootfsUpper reports whether a snapshot carries disk-backed rootfs
+// uppers — i.e. whether its guest expects the ateUpper share on restore.
+func snapshotHasRootfsUpper(snapshotDir string) bool {
+	_, err := os.Stat(filepath.Join(snapshotDir, rootfsUpperTarFile))
+	return err == nil
+}
+
+// stageRootfsUpperShare starts the virtiofsd serving the actor's disk-backed
+// rootfs uppers. The caller has already created (cold boot) or re-materialized
+// (restore) the host directory.
+//
+// The returned cmd outlives this call (CH talks to it for the VM's lifetime);
+// the caller owns it (tracked on runningActor, killed in teardownActor).
+func (s *AteomService) stageRootfsUpperShare(ctx context.Context, rr resolvedRuntime, actorUID string) (*exec.Cmd, error) {
+	shared := ateompath.RootfsUpperDir(actorUID)
+	if _, err := os.Stat(shared); err != nil {
+		return nil, fmt.Errorf("while checking rootfs upper dir %q: %w", shared, err)
+	}
+	log, _ := os.OpenFile(upperVirtiofsdLogPath(actorUID), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	cmd, err := kata.StartVirtiofsd(ctx, kata.VirtiofsdOptions{
+		Binary:     rr.virtiofsd,
+		SocketPath: kata.UpperVirtiofsdSocketPath(actorUID),
+		SharedDir:  shared,
+		Cache:      "auto",
+		Xattr:      true,
+		Log:        log,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("while starting rootfs upper virtiofsd: %w", err)
+	}
+	return cmd, nil
+}
+
+// tarRootfsUpper archives the actor's disk-backed rootfs uppers (dir) into the
+// checkpoint directory. The caller must have paused the guest first: virtiofsd
+// is write-through, so a completed guest write is on the host by then, but a
+// running guest could still add more after the walk.
+func tarRootfsUpper(ctx context.Context, dir, checkpointDir string) error {
+	if err := tarutil.Create(ctx, filepath.Join(checkpointDir, rootfsUpperTarFile), dir); err != nil {
+		return fmt.Errorf("while archiving rootfs uppers from %q: %w", dir, err)
+	}
+	return nil
+}
+
+// untarRootfsUpper restores the disk-backed rootfs uppers from a snapshot into
+// the actor's host directory. It must run before the upper share's virtiofsd
+// starts, so the guest never observes the directory mid-restore. The directory
+// is recreated from scratch: nothing else owns it, and stale contents from a
+// previous activation would corrupt the overlay state find-paths re-opens.
+func untarRootfsUpper(dir, snapshotDir string) error {
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("while clearing rootfs upper dir %q: %w", dir, err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("while creating rootfs upper dir %q: %w", dir, err)
+	}
+	if err := tarutil.Extract(filepath.Join(snapshotDir, rootfsUpperTarFile), dir); err != nil {
+		return fmt.Errorf("while restoring rootfs uppers into %q: %w", dir, err)
+	}
+	return nil
+}

--- a/cmd/ateom-microvm/rootfsupper_test.go
+++ b/cmd/ateom-microvm/rootfsupper_test.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// upperDirWith returns a rootfs upper directory laid out the way the guest
+// agent builds one: <containerID>/{fs,work} per container, with the given
+// files under fs/ (paths relative to it).
+func upperDirWith(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, content := range files {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("creating %q: %v", filepath.Dir(p), err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %q: %v", rel, err)
+		}
+	}
+	return dir
+}
+
+func TestRootfsUpperRoundTrip(t *testing.T) {
+	// Checkpoint: every container's upper/work, archived while the guest is
+	// paused. The layout under the dir is exactly what find-paths re-opens.
+	files := map[string]string{
+		"app_ovl/fs/home/agent/notes.txt": "rootfs write",
+		"app_ovl/work/index":              "",
+		"sidecar_ovl/fs/var/log/s.log":    "sidecar write",
+	}
+	src := upperDirWith(t, files)
+	checkpointDir := t.TempDir()
+	if err := tarRootfsUpper(t.Context(), src, checkpointDir); err != nil {
+		t.Fatalf("tarRootfsUpper: %v", err)
+	}
+	if !snapshotHasRootfsUpper(checkpointDir) {
+		t.Fatalf("snapshotHasRootfsUpper(%q) = false after tarRootfsUpper", checkpointDir)
+	}
+
+	// Restore: onto a directory holding a stale previous activation's contents,
+	// which must not leak into the restored overlay state.
+	dst := upperDirWith(t, map[string]string{"app_ovl/fs/stale.txt": "stale"})
+	if err := untarRootfsUpper(dst, checkpointDir); err != nil {
+		t.Fatalf("untarRootfsUpper: %v", err)
+	}
+	for rel, want := range files {
+		got, err := os.ReadFile(filepath.Join(dst, rel))
+		if err != nil {
+			t.Errorf("reading restored %q: %v", rel, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("restored %q = %q, want %q", rel, got, want)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dst, "app_ovl/fs/stale.txt")); !os.IsNotExist(err) {
+		t.Errorf("stale pre-restore content survived untarRootfsUpper (stat err = %v), want it wiped", err)
+	}
+}
+
+// A snapshot without the tar is a memory-mode snapshot: restore must not stage
+// the ateUpper share (the guest has no fs device for it).
+func TestSnapshotHasRootfsUpperAbsent(t *testing.T) {
+	if snapshotHasRootfsUpper(t.TempDir()) {
+		t.Error("snapshotHasRootfsUpper() = true for a snapshot without the tar")
+	}
+}

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -65,6 +65,10 @@ type runningActor struct {
 	// durable-dir volumes. nil when the actor declares none. Owned and torn down
 	// exactly like vfsdCmd.
 	durableVfsdCmd *exec.Cmd
+	// upperVfsdCmd is the third virtiofsd, serving the actor's disk-backed
+	// rootfs uppers (see rootfsupper.go). nil in the default memory mode. Owned
+	// and torn down exactly like vfsdCmd.
+	upperVfsdCmd *exec.Cmd
 	// apiSocket is the CH api-socket for this ateom-owned VMM.
 	apiSocket string
 
@@ -124,7 +128,8 @@ func overlayWorkloadID(name string) string { return name + "_ovl" }
 // actorContainer is one of the actor's containers prepared for the shared micro-VM:
 // its name (also the kata containerID + the overlay lower's find-paths subdir), the
 // host OCI bundle rootfs that backs the RO lower, and its OCI spec. The writable
-// overlay upper is a guest tmpfs (OverlayUpperBase(name)), so there is no host disk.
+// overlay upper is a guest tmpfs (OverlayUpperBase(name)) by default, or a directory
+// on the disk-backed ateUpper share (DiskUpperBase(name)) under --rootfs-writes=disk.
 type actorContainer struct {
 	name         string
 	bundleRootfs string
@@ -372,6 +377,26 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 		}()
 	}
 
+	// Disk-backed rootfs uppers (opt-in): a third writable virtio-fs share,
+	// served from a per-actor host directory ateom prepares itself (pristine —
+	// a cold boot starts from the bare image). See rootfsupper.go.
+	diskUpper := s.diskRootfsWrites
+	var upperVfsdCmd *exec.Cmd
+	if diskUpper {
+		if err := resetRootfsUpperDir(actorUID); err != nil {
+			return err
+		}
+		if upperVfsdCmd, err = s.stageRootfsUpperShare(ctx, rr, actorUID); err != nil {
+			return err
+		}
+		defer func() {
+			if retErr != nil && upperVfsdCmd.Process != nil {
+				_ = upperVfsdCmd.Process.Kill()
+				_, _ = upperVfsdCmd.Process.Wait()
+			}
+		}()
+	}
+
 	// Launch a bare VMM (CH + api-socket); ateom owns this process for teardown.
 	apiSocket := filepath.Join(kata.VMDir(actorUID), "clh-api.sock")
 	chCmd, client, err := ch.LaunchVMM(ctx, ch.LaunchVMMOptions{
@@ -395,7 +420,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	// writable upper is a guest tmpfs). serialLog is also read on a failed agent dial
 	// below, so keep it here.
 	serialLog := filepath.Join(kata.VMDir(actorUID), "serial.log")
-	vmCfg := buildVMConfig(actorUID, kernel, image, kparams, serialLog, memMiB, vcpus, durable)
+	vmCfg := buildVMConfig(actorUID, kernel, image, kparams, serialLog, memMiB, vcpus, durable, diskUpper)
 	if err := client.CreateVM(ctx, vmCfg); err != nil {
 		return fmt.Errorf("while creating VM: %w", err)
 	}
@@ -449,7 +474,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	}()
 
 	// Post-boot kata-agent setup: sandbox, guest networking, start each container.
-	if err := s.startActorContainers(ctx, ac, actorUID, vsockPath, ctrs, durable); err != nil {
+	if err := s.startActorContainers(ctx, ac, actorUID, vsockPath, ctrs, durable, diskUpper); err != nil {
 		return err
 	}
 
@@ -458,7 +483,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 		return fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
-	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, apiSocket: apiSocket, baseID: actorUID, logAgent: ac}
+	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, upperVfsdCmd: upperVfsdCmd, apiSocket: apiSocket, baseID: actorUID, logAgent: ac}
 	if err := s.activateActorNetworking(p.actorRef.Atespace, p.actorRef.Name, p.actorVersion, p.egressGatewayAddress); err != nil {
 		return err
 	}
@@ -571,7 +596,8 @@ func (s *AteomService) guestConfig(rr resolvedRuntime) (memMiB, vcpus int, kpara
 //
 // withDurable adds a second virtio-fs device for the actor's writable durable-dir
 // volumes (see durable.go), served by its own virtiofsd on the same PCI segment.
-func buildVMConfig(id, kernel, image, kparams, serialLog string, memMiB, vcpus int, withDurable bool) ch.VmConfig {
+// withUpper adds a third for the disk-backed rootfs uppers (see rootfsupper.go).
+func buildVMConfig(id, kernel, image, kparams, serialLog string, memMiB, vcpus int, withDurable, withUpper bool) ch.VmConfig {
 	console := "ttyS0"
 	if runtime.GOARCH == "arm64" {
 		console = "ttyAMA0"
@@ -589,7 +615,7 @@ func buildVMConfig(id, kernel, image, kparams, serialLog string, memMiB, vcpus i
 		Disks: []ch.DiskConfig{
 			{Path: image, Readonly: true, ImageType: "Raw", NumQueues: int32(vcpus), QueueSize: 1024},
 		},
-		Fs:       buildFsConfigs(id, withDurable),
+		Fs:       buildFsConfigs(id, withDurable, withUpper),
 		Platform: &ch.PlatformConfig{NumPciSegments: 2},
 		Rng:      &ch.RngConfig{Src: "/dev/urandom"},
 		Serial:   &ch.ConsoleConfig{Mode: "File", File: serialLog},
@@ -598,9 +624,10 @@ func buildVMConfig(id, kernel, image, kparams, serialLog string, memMiB, vcpus i
 }
 
 // buildFsConfigs returns the VM's virtio-fs devices: the overlay RO lower's
-// share, plus the writable durable-dir share when the actor has one. Both sit on
-// PCI segment 1 (the segment buildVMConfig reserves for virtio-fs).
-func buildFsConfigs(id string, withDurable bool) []ch.FsConfig {
+// share, plus the writable durable-dir share when the actor has one, plus the
+// writable disk-backed rootfs upper share when rootfs writes go to disk. All
+// sit on PCI segment 1 (the segment buildVMConfig reserves for virtio-fs).
+func buildFsConfigs(id string, withDurable, withUpper bool) []ch.FsConfig {
 	fs := []ch.FsConfig{{
 		Tag: kata.FsTag, Socket: kata.VirtiofsdSocketPath(id),
 		NumQueues: 1, QueueSize: 1024, PciSegment: 1,
@@ -608,6 +635,12 @@ func buildFsConfigs(id string, withDurable bool) []ch.FsConfig {
 	if withDurable {
 		fs = append(fs, ch.FsConfig{
 			Tag: kata.DurableFsTag, Socket: kata.DurableVirtiofsdSocketPath(id),
+			NumQueues: 1, QueueSize: 1024, PciSegment: 1,
+		})
+	}
+	if withUpper {
+		fs = append(fs, ch.FsConfig{
+			Tag: kata.UpperFsTag, Socket: kata.UpperVirtiofsdSocketPath(id),
 			NumQueues: 1, QueueSize: 1024, PciSegment: 1,
 		})
 	}
@@ -621,12 +654,14 @@ func buildFsConfigs(id string, withDurable bool) []ch.FsConfig {
 //
 // durable says the actor has durable-dir volumes: the sandbox then also mounts
 // the writable durable share, and each container binds the volumes it declared.
-func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentClient, id, vsockPath string, ctrs []actorContainer, durable bool) error {
+// diskUpper says rootfs writes are disk-backed: the sandbox then also mounts the
+// writable upper share, and each container's overlay upper/work live under it.
+func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentClient, id, vsockPath string, ctrs []actorContainer, durable, diskUpper bool) error {
 	// Establish the agent sandbox + the kataShared virtio-fs mount (the RO base for
 	// every container's overlay lower). All containers share it, so use the first
 	// container's hostname.
 	sbCtx, sbCancel := context.WithTimeout(ctx, 20*time.Second)
-	err := ac.CreateSandboxForActor(sbCtx, id, ctrs[0].spec.Hostname, durable)
+	err := ac.CreateSandboxForActor(sbCtx, id, ctrs[0].spec.Hostname, durable, diskUpper)
 	sbCancel()
 	if err != nil {
 		return fmt.Errorf("while creating agent sandbox: %w", err)
@@ -644,7 +679,7 @@ func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentC
 	}
 
 	for _, c := range ctrs {
-		if err := startOverlayContainer(ctx, ac, vsockPath, c); err != nil {
+		if err := startOverlayContainer(ctx, ac, vsockPath, c, diskUpper); err != nil {
 			return err
 		}
 	}
@@ -652,14 +687,15 @@ func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentC
 }
 
 // startOverlayContainer brings up one container's rootfs as overlay(virtio-fs RO
-// lower + guest-tmpfs upper): a carrier container (id == name) eager-binds the RO base
+// lower + writable upper): a carrier container (id == name) eager-binds the RO base
 // to /run/kata-containers/<name>/rootfs, then the workload (id == <name>_ovl) overlays
-// it with a tmpfs upper. On failure it dumps the guest overlay state.
+// it with the upper — a guest tmpfs by default, or a directory on the disk-backed
+// ateUpper share when diskUpper. On failure it dumps the guest overlay state.
 //
 // With a durable-dir volume, the WORKLOAD also binds it at the container's declared
 // mount paths. The carrier deliberately does not: its rootfs is the read-only lower,
 // where the agent could not create a missing mount point.
-func startOverlayContainer(ctx context.Context, ac *kata.AgentClient, vsockPath string, c actorContainer) error {
+func startOverlayContainer(ctx context.Context, ac *kata.AgentClient, vsockPath string, c actorContainer, diskUpper bool) error {
 	carrierCtx, carrierCancel := context.WithTimeout(ctx, 30*time.Second)
 	err := ac.CreateCarrier(carrierCtx, c.name, c.spec)
 	carrierCancel()
@@ -670,6 +706,9 @@ func startOverlayContainer(ctx context.Context, ac *kata.AgentClient, vsockPath 
 	}
 
 	upperBase := kata.OverlayUpperBase(c.name)
+	if diskUpper {
+		upperBase = kata.DiskUpperBase(c.name)
+	}
 	wlCtx, wlCancel := context.WithTimeout(ctx, 30*time.Second)
 	err = ac.StartOverlayWorkload(wlCtx, c.name, overlayWorkloadID(c.name), upperBase, workloadSpec(c))
 	wlCancel()
@@ -753,6 +792,7 @@ func logGuestBootDiagnostics(ctx context.Context, actorUID, serialLog string) {
 		{"serial", serialLog},
 		{"virtiofsd", virtiofsdLogPath(actorUID)},
 		{"virtiofsd-durable", durableVirtiofsdLogPath(actorUID)},
+		{"virtiofsd-upper", upperVirtiofsdLogPath(actorUID)},
 	} {
 		b, err := os.ReadFile(l.path)
 		if err != nil || len(b) == 0 {

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -132,7 +132,7 @@ spec:
       workload: counter-microvm
   snapshotsConfig:
     onPause: Full
-    onCommit: Data
+    onCommit: Full
     onResume:
       # A Data snapshot resumes by combining the durable data with the golden
       # snapshot's guest state (memory + fs delta) instead of cold-booting.

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -132,7 +132,7 @@ spec:
       workload: counter-microvm
   snapshotsConfig:
     onPause: Full
-    onCommit: Full
+    onCommit: Data
     onResume:
       # A Data snapshot resumes by combining the durable data with the golden
       # snapshot's guest state (memory + fs delta) instead of cold-booting.

--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -159,6 +159,19 @@ func DurableDirVolumeMountPoint(actorUID, volumeName string) string {
 	)
 }
 
+// RootfsUpperDir is the host directory backing the actor's disk-backed rootfs
+// overlay uppers (ateom-microvm's --rootfs-writes=disk mode): one subdirectory
+// per container, served into the guest over virtio-fs so rootfs writes land on
+// host disk instead of guest RAM. Unlike the durable-dir volumes it is owned
+// entirely by ateom (created at cold boot, archived at checkpoint, removed at
+// teardown); atelet never touches it.
+func RootfsUpperDir(actorUID string) string {
+	return filepath.Join(
+		ActorPath(actorUID),
+		"rootfs-upper",
+	)
+}
+
 // RestoreStateDir is the local directory to use to restore an actor from a
 // checkpoint downloaded from GCS.
 //


### PR DESCRIPTION
[POC}


 #### The problem we're trying to solve

  Substrate runs AI agents inside tiny virtual machines (micro-VMs). Each agent thinks it has its own computer with its own disk. But here's the catch: that "disk" is 
  fake — it's actually the VM's RAM. Every file the agent writes (logs, downloaded packages, code checkouts) is really sitting in memory.

  That was a deliberate choice because it's fast, but it has two costs:

  1. RAM is expensive and limited. An agent that writes 2 GB of files eats 2 GB of RAM. Substrate's whole business is packing many agents onto one machine — RAM-hungry
  agents ruin that math.
  2. Snapshots get fat. When Substrate "pauses" an idle agent, it saves the VM's memory to a file (a snapshot) so it can resume later. If the memory is stuffed with
  file data, snapshots are bigger, and pausing/resuming gets slower.

  Ben's suggestion: what if agent file writes went to the host machine's actual disk instead of RAM? Disk is cheap and plentiful. The catch: disk writes are slower.
  Nobody knows yet if the trade is worth it — that's your investigation.

 #### What we just built

  A switch. The runtime now has a flag with two positions:

  - --rootfs-writes=memory (the default, unchanged): file writes go to RAM. Fast, expensive.
  - --rootfs-writes=disk (new): file writes go to a folder on the host machine's disk. The VM reaches that folder through a "pass-through window" called virtio-fs — a
  standard mechanism for letting a VM read/write a host folder. Conveniently, Substrate already used this exact mechanism for another feature (durable volumes), so we
  copied a proven pattern rather than inventing one.
