### PR TITLE
Update gVisor release which supports multiple durable-dirs

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -879,18 +879,13 @@ func (s *AteomHerder) prepareOCIBundles(
 			"io.kubernetes.cri.container-type": "sandbox",
 			"io.kubernetes.cri.container-name": "pause",
 		}
-		// Declare the durable-dir volume to gVisor. The annotation key holds a
-		// single mount ("durabledir"), so this can express exactly ONE volume —
-		// a second would silently overwrite the first. The ActorTemplate CEL
-		// rules are what keep that from happening: they cap gVisor templates at
-		// one durable-dir volume (micro-VM templates, which ignore these
-		// annotations entirely, may declare any number).
-		// TODO(dberkov) needs to revisit this logic once gVisor supports multiple durable-dir volumes.
+		// Declare durable-dir volumes to gVisor. We use the volume name as the
+		// mount hint name to support multiple durable-dir volumes.
 		for _, vol := range spec.GetVolumes() {
 			if vol.GetType() == ateletpb.VolumeType_VOLUME_TYPE_DURABLE_DIR {
-				annotations["dev.gvisor.spec.mount.durabledir.type"] = "bind"
-				annotations["dev.gvisor.spec.mount.durabledir.share"] = "container"
-				annotations["dev.gvisor.spec.mount.durabledir.source"] = ateompath.DurableDirVolumeMountPoint(actorUID, vol.GetName())
+				annotations[fmt.Sprintf("dev.gvisor.spec.mount.%s.type", vol.GetName())] = "bind"
+				annotations[fmt.Sprintf("dev.gvisor.spec.mount.%s.share", vol.GetName())] = "container"
+				annotations[fmt.Sprintf("dev.gvisor.spec.mount.%s.source", vol.GetName())] = ateompath.DurableDirVolumeMountPoint(actorUID, vol.GetName())
 			}
 		}
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -215,12 +215,12 @@ spec:
   assets:
     amd64:
       gvisor:
-        url: "gs://gvisor/releases/release/20260727/x86_64/gvisor.tar.bz2"
-        sha256: "0ebce37235dcffad3a165aa86aad24a92ba887ab4c8c26f580db97eb373c39f9"
+        url: "gs://gvisor/releases/release/20260803/x86_64/gvisor.tar.bz2"
+        sha256: "9e7a5fcc2cbd28c9cd4af910a9327abcf07a8efcce242c285b860d79010c2db5"
     arm64:
       gvisor:
-        url: "gs://gvisor/releases/release/20260727/aarch64/gvisor.tar.bz2"
-        sha256: "4a54f2c5ace3da0d6b02cce384e6db253d1de8da55648ff96a0b560ef8e2a6c7"
+        url: "gs://gvisor/releases/release/20260803/aarch64/gvisor.tar.bz2"
+        sha256: "294d54dea2a18bcd2614a4b5072d6f32f0e8938f9e6e71c9e86b843c4a7b707b"
 ```
 
 ### Micro-VM SandboxConfig

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -294,10 +294,6 @@ func TestDurableDirLifecycle(t *testing.T) {
 // micro-VM runtime supports more than one — gVisor templates are still capped at
 // one by the ActorTemplate CEL rules, so the template would be rejected there.
 func TestMultipleDurableDirLifecycle(t *testing.T) {
-	if !isMicroVMEnvironment() {
-		t.Skip("Skipping TestMultipleDurableDirLifecycle: multiple DurableDir volumes are micro-VM only")
-	}
-
 	tests := []struct {
 		name string
 		tc   actorLifecycleTestCase
@@ -342,12 +338,16 @@ func TestMultipleDurableDirLifecycle(t *testing.T) {
 				wantFileAfterSuspend:     3,
 				checkSecondFileCounter:   true,
 				wantSnapshotContentScope: ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA,
+				microVMOnly:              true,
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.tc.microVMOnly && !isMicroVMEnvironment() {
+				t.Skipf("Skipping %s: the Golden resume source is micro-VM only", test.name)
+			}
 			t.Parallel()
 			runActorLifecycleTestCase(t, "multi-durabledir-lifecycle", createActorTemplateWithTwoDurableDirs, test.tc)
 		})

--- a/manifests/ate-install/generated/ate.dev_actortemplates.yaml
+++ b/manifests/ate-install/generated/ate.dev_actortemplates.yaml
@@ -460,17 +460,6 @@ spec:
             x-kubernetes-validations:
             - message: Spec is immutable
               rule: self == oldSelf
-            - message: Only one DurableDir-typed volume is supported when sandboxClass
-                is 'gvisor'
-              rule: (has(self.sandboxClass) && self.sandboxClass == 'microvm') ||
-                !has(self.volumes) || self.volumes.filter(v, has(v.durableDir)).size()
-                <= 1
-            - message: A container may mount only one DurableDir-typed volume when
-                sandboxClass is 'gvisor'
-              rule: (has(self.sandboxClass) && self.sandboxClass == 'microvm') ||
-                !has(self.containers) || self.containers.all(c, !has(c.volumeMounts)
-                || c.volumeMounts.filter(vm, has(self.volumes) && self.volumes.exists(v,
-                v.name == vm.name && has(v.durableDir))).size() <= 1)
             - message: All volumes defined in spec.volumes must be mounted by at least
                 one container
               rule: '!has(self.volumes) || self.volumes.all(v, has(self.containers)

--- a/manifests/ate-install/sandboxconfig-gvisor.yaml
+++ b/manifests/ate-install/sandboxconfig-gvisor.yaml
@@ -29,9 +29,9 @@ spec:
   assets:
     amd64:
       gvisor:
-        url: "gs://gvisor/releases/release/20260727/x86_64/gvisor.tar.bz2"
-        sha256: "0ebce37235dcffad3a165aa86aad24a92ba887ab4c8c26f580db97eb373c39f9"
+        url: "gs://gvisor/releases/release/20260803/x86_64/gvisor.tar.bz2"
+        sha256: "9e7a5fcc2cbd28c9cd4af910a9327abcf07a8efcce242c285b860d79010c2db5"
     arm64:
       gvisor:
-        url: "gs://gvisor/releases/release/20260727/aarch64/gvisor.tar.bz2"
-        sha256: "4a54f2c5ace3da0d6b02cce384e6db253d1de8da55648ff96a0b560ef8e2a6c7"
+        url: "gs://gvisor/releases/release/20260803/aarch64/gvisor.tar.bz2"
+        sha256: "294d54dea2a18bcd2614a4b5072d6f32f0e8938f9e6e71c9e86b843c4a7b707b"

--- a/pkg/api/v1alpha1/actortemplate_types.go
+++ b/pkg/api/v1alpha1/actortemplate_types.go
@@ -353,8 +353,6 @@ type SnapshotsConfig struct {
 
 // ActorTemplateSpec defined desired spec of an actor.
 //
-// +kubebuilder:validation:XValidation:rule="(has(self.sandboxClass) && self.sandboxClass == 'microvm') || !has(self.volumes) || self.volumes.filter(v, has(v.durableDir)).size() <= 1",message="Only one DurableDir-typed volume is supported when sandboxClass is 'gvisor'"
-// +kubebuilder:validation:XValidation:rule="(has(self.sandboxClass) && self.sandboxClass == 'microvm') || !has(self.containers) || self.containers.all(c, !has(c.volumeMounts) || c.volumeMounts.filter(vm, has(self.volumes) && self.volumes.exists(v, v.name == vm.name && has(v.durableDir))).size() <= 1)",message="A container may mount only one DurableDir-typed volume when sandboxClass is 'gvisor'"
 // +kubebuilder:validation:XValidation:rule="!has(self.volumes) || self.volumes.all(v, has(self.containers) && self.containers.exists(c, has(c.volumeMounts) && c.volumeMounts.exists(vm, vm.name == v.name)))",message="All volumes defined in spec.volumes must be mounted by at least one container"
 // +kubebuilder:validation:XValidation:rule="!has(self.sandboxClass) || self.sandboxClass != 'microvm' || !has(self.volumes) || !self.volumes.exists(v, has(v.externalVolumeTemplate))",message="ExternalVolumes are not supported when sandboxClass is 'microvm'"
 // +kubebuilder:validation:XValidation:rule="(has(self.sandboxClass) && self.sandboxClass == 'microvm') || !has(self.snapshotsConfig.onResume) || (has(self.snapshotsConfig.onResume.fromData) ? self.snapshotsConfig.onResume.fromData : 'ColdBoot') != 'Golden'",message="onResume.fromData: Golden is not supported when sandboxClass is 'gvisor'"

--- a/pkg/api/v1alpha1/actortemplate_validation_test.go
+++ b/pkg/api/v1alpha1/actortemplate_validation_test.go
@@ -673,7 +673,7 @@ func TestActorTemplateValidation(t *testing.T) {
 		},
 		wantErr: false,
 	}, {
-		name: "Volumes: 2 DurableDir volumes in template is invalid for gvisor",
+		name: "Volumes: 2 DurableDir volumes in template is valid",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.Volumes = []Volume{
 				{Name: "vol1", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
@@ -684,10 +684,9 @@ func TestActorTemplateValidation(t *testing.T) {
 				{Name: "vol2", MountPath: "/home2"},
 			}
 		},
-		wantErr: true,
-		errMsg:  "Only one DurableDir-typed volume is supported when sandboxClass is 'gvisor'",
+		wantErr: false,
 	}, {
-		name: "Volumes: 2 DurableDir volumes spread across containers is invalid for gvisor",
+		name: "Volumes: 2 DurableDir volumes spread across containers is valid",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.Volumes = []Volume{
 				{Name: "vol1", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
@@ -704,10 +703,9 @@ func TestActorTemplateValidation(t *testing.T) {
 				{Name: "vol1", MountPath: "/home1"},
 			}
 		},
-		wantErr: true,
-		errMsg:  "Only one DurableDir-typed volume is supported when sandboxClass is 'gvisor'",
+		wantErr: false,
 	}, {
-		name: "Volumes: same DurableDir volume mounted twice in one container is invalid for gvisor",
+		name: "Volumes: same DurableDir volume mounted twice in one container is valid",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.Volumes = []Volume{
 				{Name: "vol1", VolumeSource: VolumeSource{DurableDir: &DurableDirVolumeSource{}}},
@@ -717,8 +715,7 @@ func TestActorTemplateValidation(t *testing.T) {
 				{Name: "vol1", MountPath: "/home2"},
 			}
 		},
-		wantErr: true,
-		errMsg:  "A container may mount only one DurableDir-typed volume when sandboxClass is 'gvisor'",
+		wantErr: false,
 	}, {
 		name: "Volumes: same DurableDir volume mounted across two containers is valid",
 		mutate: func(at *ActorTemplate) {


### PR DESCRIPTION
- Update the gVisor release which has support for multiple durable-dirs.
- Modify the tests to run with gVisor (which were disabled before).
