### PR TITLE
Allow force deleting an actor from any state.

### DIFF
--- a/cmd/ateapi/internal/actoridentity/actoridentity.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity.go
@@ -351,9 +351,8 @@ func (s *Server) authorizeActor(ctx context.Context, caller *ateletCaller, req *
 		return nil, resources.ActorRef{}, status.Error(codes.Internal, "failed to look up actor")
 	}
 
-	// Deletion is only entered from SUSPENDED or CRASHED, both of which
-	// have already released the worker, so the assignment check below would
-	// reject this too. It is kept for better visibility and logging.
+	// Refuse credential minting if the actor is being deleted. Under force deletion,
+	// an actor enters ACTOR_STATE_DELETING while its worker assignment is still active.
 	if actor.GetStatus().GetState() == ateapipb.ActorState_ACTOR_STATE_DELETING {
 		slog.WarnContext(ctx, "ActorIdentity refused: actor is being deleted", slog.Any("actor", actorRef))
 		return nil, resources.ActorRef{}, status.Error(codes.FailedPrecondition, "actor is being deleted")

--- a/cmd/ateapi/internal/actoridentity/actoridentity_test.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity_test.go
@@ -338,6 +338,10 @@ func TestMintCertAuthorization(t *testing.T) {
 			fixture:  runningOnNode(testNode),
 			wantCode: codes.OK,
 		},
+		"actor is in ACTOR_STATE_DELETING with active worker assignment": {
+			fixture:  actorFixture{state: ateapipb.ActorState_ACTOR_STATE_DELETING, workerNode: testNode},
+			wantCode: codes.FailedPrecondition,
+		},
 		"caller presented no certificate": {
 			noPeer:   true,
 			fixture:  runningOnNode(testNode),

--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -349,7 +349,7 @@ func (s *Service) DeleteActor(ctx context.Context, req *ateapipb.DeleteActorRequ
 	actorRef := resources.ActorRefFromObjectRef(req.GetActor())
 	setSpanActorRefAttributes(ctx, actorRef)
 
-	deleted, err = s.actorWorkflow.DeleteActor(ctx, actorRef)
+	deleted, err = s.actorWorkflow.DeleteActor(ctx, actorRef, req.GetAnyState())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -2775,7 +2775,7 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 		t.Fatalf("GetActor failed: %v", err)
 	}
 	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
-		t.Errorf("expected state CRASHED, got %v", getResp.GetStatus().GetState())
+		t.Errorf("expected status CRASHED, got %v", getResp.GetStatus())
 	}
 	if getResp.GetStatus().GetWorkerAssignment() != nil {
 		t.Errorf("expected worker_assignment to be cleared, got %v", getResp.GetStatus().GetWorkerAssignment())

--- a/cmd/ateapi/internal/controlapi/volumes.go
+++ b/cmd/ateapi/internal/controlapi/volumes.go
@@ -150,6 +150,10 @@ func deleteActorVolumes(ctx context.Context, registry VolumePluginRegistry, acto
 			continue
 		}
 		if err := plugin.DeleteVolume(ctx, volID); err != nil {
+			if status.Code(err) == codes.NotFound {
+				slog.WarnContext(ctx, "Volume not found during delete, assuming already deleted", slog.String("volume_id", volID))
+				continue
+			}
 			errs = append(errs, fmt.Errorf("failed to delete volume %q: %w", volID, err))
 		}
 	}
@@ -211,18 +215,38 @@ func detachActorVolumes(ctx context.Context, st detachActorVolumesStore, registr
 	}
 
 	ref := &ateapipb.ObjectRef{Atespace: actor.GetMetadata().GetAtespace(), Name: actor.GetMetadata().GetName()}
-	for _, vol := range getMountedActorVolumes(ctx, ref, actor.GetStatus().GetActorVolumes(), template) {
+	// If the template is available, only detach volumes that are actively mounted
+	// in the template's containers. If the template is missing/deleted, fall back to
+	// attempting detachment for all external volumes recorded on the actor so we do
+	// not orphan attached disks on the worker node.
+	volumesToDetach := actor.GetStatus().GetActorVolumes()
+	if template != nil {
+		volumesToDetach = getMountedActorVolumes(ctx, ref, actor.GetStatus().GetActorVolumes(), template)
+	}
+	// Collect errors for all volumes to detach, but continue processing so we attempt to detach all volumes.
+	var errs []error
+	for _, vol := range volumesToDetach {
+		// StorageVolumeId is only populated once the volume is provisioned.
+		// Skip volumes that were never created (e.g. failed during PENDING state).
+		if vol.GetStorageVolumeId() == "" {
+			slog.WarnContext(ctx, "Volume has no storage volume ID, skipping detach", slog.String("volume_name", vol.GetVolumeName()), slog.String("actor_id", actor.GetMetadata().GetName()))
+			continue
+		}
 		slog.InfoContext(ctx, "Detaching volume from node", slog.String("volume_id", vol.GetStorageVolumeId()), slog.String("node", node))
 		plugin, err := registry.GetPlugin(ctx, vol.GetVolumeType())
 		if err != nil {
-			return fmt.Errorf("failed to get volume plugin for %q: %w", vol.GetVolumeType(), err)
+			errs = append(errs, fmt.Errorf("failed to get volume plugin for %q: %w", vol.GetVolumeType(), err))
+			continue
 		}
-		err = plugin.DetachVolume(ctx, vol.GetStorageVolumeId(), node)
-		if err != nil {
-			return fmt.Errorf("failed to detach volume %q from node %q: %w", vol.GetStorageVolumeId(), node, err)
+		if err := plugin.DetachVolume(ctx, vol.GetStorageVolumeId(), node); err != nil {
+			if status.Code(err) == codes.NotFound {
+				slog.WarnContext(ctx, "Volume not found during detach, assuming already detached", slog.String("volume_id", vol.GetStorageVolumeId()), slog.String("node", node))
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to detach volume %q from node %q: %w", vol.GetStorageVolumeId(), node, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // detachActorVolumesStore enumerates the subset of store methods needed to

--- a/cmd/ateapi/internal/controlapi/workflow_delete.go
+++ b/cmd/ateapi/internal/controlapi/workflow_delete.go
@@ -18,16 +18,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/resources"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // DeleteActor executes the workflow to delete an actor. Idempotent.
-func (w *ActorWorkflow) DeleteActor(ctx context.Context, actorRef resources.ActorRef) (*ateapipb.Actor, error) {
+func (w *ActorWorkflow) DeleteActor(ctx context.Context, actorRef resources.ActorRef, anyState bool) (*ateapipb.Actor, error) {
 	ctx, lock, err := w.acquireActorLock(ctx, actorRef)
 	if err != nil {
 		return nil, err
@@ -38,11 +42,53 @@ func (w *ActorWorkflow) DeleteActor(ctx context.Context, actorRef resources.Acto
 	if err != nil {
 		return nil, err
 	}
-	if actor, err = w.ensureMarkedDeleting(ctx, actorRef, actor); err != nil {
+
+	if actor, err = w.ensureMarkedDeleting(ctx, actorRef, actor, anyState); err != nil {
 		return nil, err
 	}
+
+	// DeleteActor will attempt best-effort cleanup across all steps, collecting any errors.
+	// If any step fails, errors are returned so the caller can retry, and the actor record
+	// is retained in the store in the DELETING state.
+	// TODO: Ensure GC collects all the remaining resources if the cleanup fails.
+	var errs []error
+	actorTemplate := (*atev1alpha1.ActorTemplate)(nil)
+	if actor.GetActorTemplateNamespace() != "" && actor.GetActorTemplateName() != "" {
+		tmpl, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
+		if err != nil && !k8serrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("while fetching actor template: %w", err))
+		}
+		actorTemplate = tmpl
+	}
+
+	var atletTerminatedErr, volumesDetachedErr error
+	if err := w.ensureAteletTerminated(ctx, actorRef, actor, actorTemplate); err != nil {
+		atletTerminatedErr = fmt.Errorf("while terminating atelet: %w", err)
+		errs = append(errs, atletTerminatedErr)
+	}
+	if err := w.ensureVolumesDetachedForDelete(ctx, actor, actorTemplate); err != nil {
+		volumesDetachedErr = fmt.Errorf("while detaching volumes: %w", err)
+		errs = append(errs, volumesDetachedErr)
+	}
+
+	// Release worker if atelet termination and volume detachment did not fail.
+	if atletTerminatedErr == nil && volumesDetachedErr == nil {
+		if actor, err = w.ensureWorkerReleased(ctx, actorRef, actor); err != nil {
+			errs = append(errs, fmt.Errorf("while releasing worker: %w", err))
+		}
+	} else {
+		slog.WarnContext(ctx, "skipping releasing worker due to atelet termination or volume detachment failure",
+			slog.Any("actor", actorRef),
+			slog.Any("atletTerminatedErr", atletTerminatedErr),
+			slog.Any("volumesDetachedErr", volumesDetachedErr))
+	}
+
 	if err := w.ensureVolumesDeleted(ctx, actor); err != nil {
-		return nil, err
+		errs = append(errs, fmt.Errorf("while deleting volumes: %w", err))
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
 	}
 	return w.finalizeDeleted(ctx, actorRef)
 }
@@ -62,20 +108,177 @@ func (w *ActorWorkflow) loadActorForDelete(ctx context.Context, actorRef resourc
 	return actor, nil
 }
 
+// ensureAteletTerminated calls atelet to terminate the workload.
+func (w *ActorWorkflow) ensureAteletTerminated(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (err error) {
+	ctx, done := stepSpan(ctx, "CallAteletTerminate")
+	defer func() { err = done(err) }()
+
+	assignment := actor.GetStatus().GetWorkerAssignment()
+	if assignment == nil {
+		slog.InfoContext(ctx, "actor has no worker assignment, skipping atlet terminate request", slog.Any("actor", actorRef))
+		return nil
+	}
+
+	if workerName := assignment.GetWorker().GetName(); workerName != "" {
+		worker, err := w.store.GetWorker(ctx, workerName)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				slog.InfoContext(ctx, "worker not found in store, skipping atelet terminate request", slog.String("worker", workerName), slog.Any("actor", actorRef))
+				return nil
+			}
+			return fmt.Errorf("while checking worker assignment: %w", err)
+		}
+		wass := worker.GetStatus().GetAssignment()
+		if wass == nil || wass.GetActorUid() != actor.GetMetadata().GetUid() {
+			slog.InfoContext(ctx, "worker is no longer assigned to this actor, skipping atelet terminate request",
+				slog.String("worker", workerName),
+				slog.Any("actor", actorRef))
+			return nil
+		}
+	}
+
+	workerPodNs := assignment.GetWorkerNamespace()
+	workerPodName := assignment.GetWorkerPod()
+
+	conn, err := w.dialer.DialForWorker(workerPodNs, workerPodName)
+	if err != nil {
+		if errors.Is(err, ErrWorkerPodNotFound) {
+			slog.InfoContext(ctx, "worker pod not found, treating as terminated", slog.String("workerNamespace", workerPodNs), slog.String("workerPod", workerPodName))
+			return nil
+		}
+		return fmt.Errorf("while connecting to worker pod %s/%s: %w", workerPodNs, workerPodName, err)
+	}
+
+	client := ateletpb.NewAteomHerderClient(conn)
+
+	var workloadSpec *ateletpb.WorkloadSpec
+	if actorTemplate != nil {
+		spec, err := workloadSpecFromActorTemplate(actorTemplate, actor)
+		if err != nil {
+			return err
+		}
+		workloadSpec = spec
+	} else {
+		// When the template is missing/deleted, build a fallback workload spec with
+		// all external volumes recorded on the actor so atelet can unmount them on the node.
+		slog.WarnContext(ctx, "actor template not found, constructing fallback workload spec for atelet terminate",
+			slog.String("actor", actorRef.Name),
+			slog.String("templateNamespace", actor.GetActorTemplateNamespace()),
+			slog.String("templateName", actor.GetActorTemplateName()))
+		workloadSpec = &ateletpb.WorkloadSpec{}
+		for _, vol := range actor.GetStatus().GetActorVolumes() {
+			// StorageVolumeId is only populated once the volume is provisioned.
+			// Skip volumes that were never created (e.g. failed during PENDING state).
+			if vol.GetStorageVolumeId() != "" {
+				workloadSpec.Volumes = append(workloadSpec.Volumes, &ateletpb.Volume{
+					Name: vol.GetVolumeName(),
+					Source: &ateletpb.Volume_External{
+						External: &ateletpb.ExternalVolumeSource{
+							StorageVolumeId: vol.GetStorageVolumeId(),
+							VolumeType:      vol.GetVolumeType(),
+							VolumeContext:   vol.GetVolumeContext(),
+						},
+					},
+				})
+			}
+		}
+	}
+
+	req := &ateletpb.TerminateRequest{
+		TargetAteomUid:         assignment.GetWorkerPodUid(),
+		Atespace:               actor.GetMetadata().GetAtespace(),
+		ActorName:              actor.GetMetadata().GetName(),
+		ActorUid:               actor.GetMetadata().GetUid(),
+		ActorTemplateNamespace: actor.GetActorTemplateNamespace(),
+		ActorTemplateName:      actor.GetActorTemplateName(),
+		Spec:                   workloadSpec,
+	}
+
+	if _, err := client.Terminate(ctx, req); err != nil {
+		if status.Code(err) == codes.NotFound {
+			slog.InfoContext(ctx, "workload already terminated on atelet", slog.Any("actor", actorRef))
+			return nil
+		}
+		return fmt.Errorf("while terminating actor on atelet: %w", err)
+	}
+
+	return nil
+}
+
+// ensureVolumesDetachedForDelete detaches external volumes.
+func (w *ActorWorkflow) ensureVolumesDetachedForDelete(ctx context.Context, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (err error) {
+	ctx, done := stepSpan(ctx, "DetachVolumesForDelete")
+	defer func() { err = done(err) }()
+
+	return detachActorVolumes(ctx, w.store, w.pluginRegistry, actor, actorTemplate, "delete")
+}
+
+// ensureWorkerReleased releases the worker assigned to the actor.
+func (w *ActorWorkflow) ensureWorkerReleased(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor) (updated *ateapipb.Actor, err error) {
+	ctx, done := stepSpan(ctx, "ReleaseWorker")
+	defer func() { err = done(err) }()
+
+	if actor.GetStatus().GetWorkerAssignment() == nil {
+		markSkipped(ctx, "worker already released")
+		return actor, nil
+	}
+
+	latestActor, err := w.store.GetActor(ctx, actorRef)
+	if err != nil {
+		return nil, err
+	}
+
+	if latestActor.GetStatus().GetWorkerAssignment() != nil {
+		if _, err := releaseWorker(ctx, w.store, latestActor); err != nil {
+			return nil, err
+		}
+
+		latestActor, err = w.store.GetActor(ctx, actorRef)
+		if err != nil {
+			return nil, err
+		}
+
+		updatedActor, err := w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(latestActor), func(dbActor *ateapipb.Actor) error {
+			if dbActor.Status != nil {
+				dbActor.Status.LocalSnapshotInfo = nil
+				dbActor.Status.WorkerAssignment = nil
+			}
+			return nil
+		})
+		if err != nil {
+			if errors.Is(err, store.ErrVersionConflict) {
+				return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
+			}
+			return nil, err
+		}
+		latestActor = updatedActor
+	}
+	return latestActor, nil
+}
+
 // ensureMarkedDeleting transitions the actor and its volumes to DELETING and
 // persists the change, returning the stored copy. Skips when a previous
 // attempt already marked the actor.
-func (w *ActorWorkflow) ensureMarkedDeleting(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor) (_ *ateapipb.Actor, err error) {
+func (w *ActorWorkflow) ensureMarkedDeleting(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, anyState bool) (updated *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "MarkDeleting")
 	defer func() { err = done(err) }()
 
-	if actor.GetStatus().GetState() == ateapipb.ActorState_ACTOR_STATE_DELETING {
+	st := actor.GetStatus().GetState()
+	if st == ateapipb.ActorState_ACTOR_STATE_DELETING {
 		markSkipped(ctx, "actor already DELETING")
 		return actor, nil
 	}
-	if actor.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_SUSPENDED &&
-		actor.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
-		return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not in a deletable state (state: %v)", actorRef, actor.GetStatus().GetState())
+	shouldDelete := false
+	switch st {
+	case ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
+		ateapipb.ActorState_ACTOR_STATE_CRASHED:
+		shouldDelete = true
+	default:
+		// This allows deletion for any state
+		shouldDelete = anyState
+	}
+	if !shouldDelete {
+		return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not in a deletable state (state: %v)", actorRef, st)
 	}
 
 	storedActor, err := w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(actor), func(toUpdate *ateapipb.Actor) error {
@@ -95,10 +298,15 @@ func (w *ActorWorkflow) ensureMarkedDeleting(ctx context.Context, actorRef resou
 }
 
 // ensureVolumesDeleted removes the actor's external volumes. Volume deletion
-// is idempotent, so a re-entered workflow can safely run it again.
+// is idempotent, so a re-entered workflow can safely run it again. It assumes a no-op success if volume is not found
 func (w *ActorWorkflow) ensureVolumesDeleted(ctx context.Context, actor *ateapipb.Actor) (err error) {
 	ctx, done := stepSpan(ctx, "DeleteVolumes")
 	defer func() { err = done(err) }()
+
+	st := actor.GetStatus().GetState()
+	if st != ateapipb.ActorState_ACTOR_STATE_DELETING {
+		return status.Errorf(codes.FailedPrecondition, "DeleteVolumes prerequisite not met for Actor: %s (got: %v, want %s)", actor.GetMetadata().GetName(), st, ateapipb.ActorState_ACTOR_STATE_DELETING)
+	}
 
 	if err := deleteActorVolumes(ctx, w.pluginRegistry, actor.GetMetadata().GetUid(), actor.GetStatus().GetActorVolumes()); err != nil {
 		return status.Errorf(codes.Internal, "while deleting actor volumes: %v", err)

--- a/cmd/ateapi/internal/controlapi/workflow_delete_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_delete_test.go
@@ -27,37 +27,82 @@ import (
 
 func TestDeleteActorWorkflow_ExecutionPaths(t *testing.T) {
 	tests := []struct {
-		name      string
-		seedState ateapipb.ActorState
-		wantErr   bool
-		wantCode  codes.Code
+		name        string
+		seedState   ateapipb.ActorState
+		anyState    bool
+		missingTmpl bool
+		wantErr     bool
+		wantCode    codes.Code
 	}{
 		{
 			name:      "delete suspended actor succeeds",
 			seedState: ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
+			anyState:  false,
 			wantErr:   false,
 		},
 		{
 			name:      "delete crashed actor succeeds",
 			seedState: ateapipb.ActorState_ACTOR_STATE_CRASHED,
+			anyState:  false,
 			wantErr:   false,
 		},
 		{
 			name:      "delete deleting actor succeeds",
 			seedState: ateapipb.ActorState_ACTOR_STATE_DELETING,
+			anyState:  false,
 			wantErr:   false,
 		},
 		{
-			name:      "delete running actor rejected",
+			name:      "delete running actor rejected when not any_state",
 			seedState: ateapipb.ActorState_ACTOR_STATE_RUNNING,
+			anyState:  false,
 			wantErr:   true,
 			wantCode:  codes.FailedPrecondition,
 		},
 		{
-			name:      "delete paused actor rejected",
+			name:      "delete paused actor rejected when not any_state",
 			seedState: ateapipb.ActorState_ACTOR_STATE_PAUSED,
+			anyState:  false,
 			wantErr:   true,
 			wantCode:  codes.FailedPrecondition,
+		},
+		{
+			name:      "any_state delete suspended actor succeeds",
+			seedState: ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
+			anyState:  true,
+			wantErr:   false,
+		},
+		{
+			name:      "any_state delete running actor succeeds",
+			seedState: ateapipb.ActorState_ACTOR_STATE_RUNNING,
+			anyState:  true,
+			wantErr:   false,
+		},
+		{
+			name:      "any_state delete paused actor succeeds",
+			seedState: ateapipb.ActorState_ACTOR_STATE_PAUSED,
+			anyState:  true,
+			wantErr:   false,
+		},
+		{
+			name:      "any_state delete crashed actor succeeds",
+			seedState: ateapipb.ActorState_ACTOR_STATE_CRASHED,
+			anyState:  true,
+			wantErr:   false,
+		},
+		{
+			name:        "delete suspended actor with missing template succeeds",
+			seedState:   ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
+			anyState:    false,
+			missingTmpl: true,
+			wantErr:     false,
+		},
+		{
+			name:        "any_state delete suspended actor with missing template succeeds",
+			seedState:   ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
+			anyState:    true,
+			missingTmpl: true,
+			wantErr:     false,
 		},
 	}
 
@@ -69,9 +114,13 @@ func TestDeleteActorWorkflow_ExecutionPaths(t *testing.T) {
 			w := newTestActorWorkflow(t, st, "ns", "tmpl1")
 
 			actorRef := resources.ActorRef{Atespace: "team-a", Name: "id1"}
-			seedWorkflowActor(t, ctx, st, actorRef, "ns", "tmpl1", tc.seedState)
+			tmplName := "tmpl1"
+			if tc.missingTmpl {
+				tmplName = "missing-tmpl"
+			}
+			seedWorkflowActor(t, ctx, st, actorRef, "ns", tmplName, tc.seedState)
 
-			deleted, err := w.DeleteActor(ctx, actorRef)
+			deleted, err := w.DeleteActor(ctx, actorRef, tc.anyState)
 			if tc.wantErr {
 				if got := status.Code(err); got != tc.wantCode {
 					t.Fatalf("status.Code(err) = %v, want %v (err: %v)", got, tc.wantCode, err)
@@ -92,29 +141,60 @@ func TestDeleteActorWorkflow_ExecutionPaths(t *testing.T) {
 }
 
 func TestEnsureMarkedDeleting_StateMatrix(t *testing.T) {
-	allowed := map[ateapipb.ActorState]bool{
-		ateapipb.ActorState_ACTOR_STATE_SUSPENDED: true,
-		ateapipb.ActorState_ACTOR_STATE_CRASHED:   true,
-		ateapipb.ActorState_ACTOR_STATE_DELETING:  true, // skipped, not re-marked
+	tests := []struct {
+		name     string
+		anyState bool
+		allowed  map[ateapipb.ActorState]bool
+	}{
+		{
+			name:     "standard delete",
+			anyState: false,
+			allowed: map[ateapipb.ActorState]bool{
+				ateapipb.ActorState_ACTOR_STATE_SUSPENDED: true,
+				ateapipb.ActorState_ACTOR_STATE_CRASHED:   true,
+				ateapipb.ActorState_ACTOR_STATE_DELETING:  true, // skipped
+			},
+		},
+		{
+			name:     "any_state delete",
+			anyState: true,
+			allowed: map[ateapipb.ActorState]bool{
+				ateapipb.ActorState_ACTOR_STATE_UNSPECIFIED: true,
+				ateapipb.ActorState_ACTOR_STATE_RUNNING:     true,
+				ateapipb.ActorState_ACTOR_STATE_RESUMING:    true,
+				ateapipb.ActorState_ACTOR_STATE_SUSPENDING:  true,
+				ateapipb.ActorState_ACTOR_STATE_PAUSING:     true,
+				ateapipb.ActorState_ACTOR_STATE_PAUSED:      true,
+				ateapipb.ActorState_ACTOR_STATE_SUSPENDED:   true,
+				ateapipb.ActorState_ACTOR_STATE_CRASHED:     true,
+				ateapipb.ActorState_ACTOR_STATE_DELETING:    true, // skipped
+			},
+		},
 	}
 
-	for _, seedState := range allActorStates {
-		ctx := context.Background()
-		st, cleanup := storetest.SetupTestStore(t)
-		w := newTestActorWorkflow(t, st, "ns", "tmpl1")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, seedState := range allActorStates {
+				ctx := context.Background()
+				st, cleanup := storetest.SetupTestStore(t)
+				w := newTestActorWorkflow(t, st, "ns", "tmpl1")
 
-		actorRef := resources.ActorRef{Atespace: "team-a", Name: "id1"}
-		seedWorkflowActor(t, ctx, st, actorRef, "ns", "tmpl1", seedState)
-		actor, err := st.GetActor(ctx, actorRef)
-		if err != nil {
-			t.Fatalf("state %v: get seeded actor: %v", seedState, err)
-		}
+				actorRef := resources.ActorRef{Atespace: "team-a", Name: "id1"}
+				seedWorkflowActor(t, ctx, st, actorRef, "ns", "tmpl1", seedState)
+				actor, err := st.GetActor(ctx, actorRef)
+				if err != nil {
+					t.Fatalf("state %v: get seeded actor: %v", seedState, err)
+				}
 
-		updated, err := w.ensureMarkedDeleting(ctx, actorRef, actor)
-		assertPrerequisiteResult(t, seedState, err, allowed[seedState])
-		if err == nil && updated.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_DELETING {
-			t.Errorf("state %v: ensureMarkedDeleting returned actor in %v, want DELETING", seedState, updated.GetStatus().GetState())
-		}
-		cleanup()
+				updated, err := w.ensureMarkedDeleting(ctx, actorRef, actor, tc.anyState)
+				assertPrerequisiteResult(t, seedState, err, tc.allowed[seedState])
+				if err == nil && seedState != ateapipb.ActorState_ACTOR_STATE_DELETING {
+					if updated.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_DELETING {
+						t.Errorf("state %v: ensureMarkedDeleting returned actor in %v, want DELETING", seedState, updated.GetStatus().GetState())
+					}
+				}
+				cleanup()
+			}
+		})
 	}
 }

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -353,29 +353,10 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 		return nil, err
 	}
 
-	// 1. Free the worker (if the actor has one and it hasn't been freed yet)
-	if assignment := latestActor.GetStatus().GetWorkerAssignment(); assignment != nil {
-		workerPod := assignment.GetWorkerPod()
-
-		worker, err := w.store.GetWorker(ctx, assignment.GetWorker().GetName())
-		if err != nil {
-			if !errors.Is(err, store.ErrNotFound) {
-				return nil, fmt.Errorf("while getting worker for release: %w", err)
-			}
-			slog.WarnContext(ctx, "Worker already gone during finalize suspend, skipping release", "worker", workerPod)
-		} else {
-			// Only free it if it still belongs to us
-			if wass := worker.GetStatus().GetAssignment(); wass != nil {
-				if wass.GetActorUid() == latestActor.GetMetadata().GetUid() {
-					worker.Status.Assignment = nil
-					if err := w.store.UpdateWorker(ctx, worker, worker.GetMetadata().GetVersion()); err != nil {
-						if errors.Is(err, store.ErrVersionConflict) {
-							return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
-						}
-						return nil, err
-					}
-				}
-			}
+	// 1. Free the worker (if it hasn't been freed yet)
+	if latestActor.GetStatus().GetWorkerAssignment() != nil {
+		if _, err := releaseWorker(ctx, w.store, latestActor); err != nil {
+			return nil, err
 		}
 
 		// Re-fetch the actor now that the worker is freed.

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -1195,6 +1195,65 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	return &ateletpb.RestoreResponse{}, nil
 }
 
+// Terminate terminates any running workload on ateom, unmounts external volumes,
+// and resets actor directories on the node.
+func (s *AteomHerder) Terminate(ctx context.Context, req *ateletpb.TerminateRequest) (*ateletpb.TerminateResponse, error) {
+	if err := validateTerminateRequest(req); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
+	actorUID := req.GetActorUid()
+
+	var assetPaths map[string]string
+	sandboxRec, err := readSandboxRecord(actorUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read sandbox record during terminate (actor: %s, actorUID: %s): %w", actorRef, actorUID, err)
+	}
+	paths, err := s.ensureSandboxAssets(ctx, sandboxRec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure sandbox assets during terminate (actor: %s, actorUID: %s): %w", actorRef, actorUID, err)
+	}
+	assetPaths = paths
+
+	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial ateom for terminate (actor: %s, actorUID: %s): %w", actorRef, actorUID, err)
+	}
+
+	spec, err := buildAteomWorkloadSpec(req.GetSpec())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid workload spec: %v", err)
+	}
+	if _, err := client.TerminateWorkload(ctx, &ateompb.TerminateWorkloadRequest{
+		Atespace:               req.GetAtespace(),
+		ActorName:              req.GetActorName(),
+		ActorUid:               req.GetActorUid(),
+		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
+		ActorTemplateName:      req.GetActorTemplateName(),
+		RunscPath:              runscPathFor(assetPaths),
+		Spec:                   spec,
+	}); err != nil {
+		if status.Code(err) == codes.NotFound {
+			slog.InfoContext(ctx, "workload not found on ateom during terminate", slog.Any("actor", actorRef), slog.String("actorUID", actorUID))
+		} else {
+			return nil, fmt.Errorf("failed calling ateom.TerminateWorkload (actor: %s, actorUID: %s): %w", actorRef, actorUID, err)
+		}
+	}
+
+	// Unmount external volumes
+	if err := s.unmountExternalVolumes(ctx, actorUID, req.GetSpec().GetVolumes()); err != nil {
+		return nil, fmt.Errorf("failed to unmount external volumes during terminate (actor: %s, actorUID: %s): %w", actorRef, actorUID, err)
+	}
+
+	// Reset actor directories on the node
+	if err := resetActorDirs(actorUID); err != nil {
+		return nil, fmt.Errorf("failed to reset actor directories during terminate (actor: %s, actorUID: %s): %w", actorRef, actorUID, err)
+	}
+
+	return &ateletpb.TerminateResponse{}, nil
+}
+
 func (s *AteomHerder) copyLocalCheckpoint(ctx context.Context, snapshotName string, srcDir, dstDir string, files []string) error {
 	for _, fileName := range files {
 		if ctx.Err() != nil {
@@ -1862,6 +1921,30 @@ func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
 		return fmt.Errorf("golden_snapshot_uri is only valid with snapshot scope %s", ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN)
 	}
 	return nil
+}
+
+func validateTerminateRequest(req *ateletpb.TerminateRequest) error {
+	var errs field.ErrorList
+	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
+	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
+	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
+	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+	}
+	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
+	}
+	if len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+	if err := resources.ValidateAteomUID(req.GetTargetAteomUid()); err != nil {
+		return err
+	}
+	names := make([]string, 0, len(req.GetSpec().GetContainers()))
+	for _, ctr := range req.GetSpec().GetContainers() {
+		names = append(names, ctr.GetName())
+	}
+	return resources.ValidateContainerNames(names)
 }
 
 func validateSnapshotScope(scope ateletpb.SnapshotScope) error {

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -784,6 +784,41 @@ func TestRPCBoundariesReject(t *testing.T) {
 		})
 		wantInvalidArgument(t, "Restore", err)
 	})
+	t.Run("Terminate", func(t *testing.T) {
+		const okTargetAteomUID = "123e4567-e89b-12d3-a456-426614174001"
+		t.Run("invalid ateom UID", func(t *testing.T) {
+			_, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
+				Atespace: okAtespace, ActorName: okID,
+				ActorUid: okActorUID, ActorTemplateNamespace: "default", ActorTemplateName: "template",
+				TargetAteomUid: badUID, Spec: okSpec,
+			})
+			wantInvalidArgument(t, "Terminate", err)
+		})
+		t.Run("missing template namespace", func(t *testing.T) {
+			_, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
+				Atespace: okAtespace, ActorName: okID,
+				ActorUid: okActorUID, ActorTemplateName: "template",
+				TargetAteomUid: okTargetAteomUID, Spec: okSpec,
+			})
+			wantInvalidArgument(t, "Terminate", err)
+		})
+		t.Run("missing template name", func(t *testing.T) {
+			_, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
+				Atespace: okAtespace, ActorName: okID,
+				ActorUid: okActorUID, ActorTemplateNamespace: "default",
+				TargetAteomUid: okTargetAteomUID, Spec: okSpec,
+			})
+			wantInvalidArgument(t, "Terminate", err)
+		})
+		t.Run("missing target ateom UID", func(t *testing.T) {
+			_, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
+				Atespace: okAtespace, ActorName: okID,
+				ActorUid: okActorUID, ActorTemplateNamespace: "default", ActorTemplateName: "template",
+				Spec: okSpec,
+			})
+			wantInvalidArgument(t, "Terminate", err)
+		})
+	})
 }
 
 func TestBuildAteomWorkloadSpecForwardsReadyz(t *testing.T) {

--- a/cmd/atelet/volumes.go
+++ b/cmd/atelet/volumes.go
@@ -68,7 +68,7 @@ func (s *AteomHerder) unmountExternalVolumes(ctx context.Context, actorUID strin
 			continue
 		}
 		if err := plugin.UnmountVolume(ctx, ext.GetStorageVolumeId(), hostPath); err != nil {
-			if status.Code(err) == codes.NotFound {
+			if status.Code(err) == codes.NotFound || errors.Is(err, os.ErrNotExist) {
 				slog.WarnContext(ctx, "Volume not found during unmount, assuming already unmounted", slog.String("volume_id", ext.GetStorageVolumeId()), slog.Any("error", err))
 			} else {
 				errs = append(errs, fmt.Errorf("failed to unmount volume %q from %q: %w", ext.GetStorageVolumeId(), hostPath, err))

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -785,29 +785,13 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	// reporting its usage is then the honest answer.
 	s.activeActor.Store(nil)
 
-	// After checkpointing the sandbox root, runsc may no longer have a usable
-	// control server for state/delete calls. Keep this as best-effort cleanup:
-	// atelet resets the actor runsc, bundle, pidfile, and checkpoint
-	// directories after uploading the snapshot.
-	if err := rcmd.cleanupContainersAfterCheckpoint(ctx, req.GetSpec().GetContainers()); err != nil {
-		slog.WarnContext(ctx, "Failed to clean up runsc containers after checkpoint",
-			"actor", attribution.Ref,
-			"actorUID", req.GetActorUid(),
-			"err", err)
-	}
-
-	// Detach the overlay rootfs mounts before atelet wipes the bundle dirs
-	// (deleting a bundle out from under a live mount in this namespace would
-	// leave the mount orphaned until the pod restarts). Best-effort, same as
-	// the container cleanup above.
-	if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(req.GetActorUid())); err != nil {
-		slog.WarnContext(ctx, "Failed to unmount bundle rootfs overlays after checkpoint",
-			"actorUID", req.GetActorUid(),
-			"err", err)
-	}
-
-	if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
-		slog.WarnContext(ctx, "Failed to clean up actor network after checkpoint", slog.Any("err", err))
+	// Cleanup the containers after checkpointing.
+	// This is best-effort cleanup for actor containers that may have been left behind after checkpointing.
+	if err := s.terminateWorkload(ctx, attribution.Ref, attribution.UID, req.GetRunscPath(), req.GetSpec().GetContainers()); err != nil {
+		slog.WarnContext(ctx, "failed to terminate workload after checkpoint",
+			slog.String("actor", attribution.Ref.String()),
+			slog.String("actorUID", attribution.UID),
+			slog.Any("err", err))
 	}
 
 	// Report exactly the files runsc wrote so atelet ships precisely this set
@@ -840,7 +824,16 @@ func listSnapshotFiles(dir string) ([]string, error) {
 	return files, nil
 }
 
-func (r *runsc) cleanupContainersAfterCheckpoint(ctx context.Context, containers []*ateompb.Container) error {
+func (r *runsc) stopContainers(ctx context.Context, containers []*ateompb.Container) {
+	for _, ctr := range containers {
+		_ = r.cmdKill(ctx, ctr.GetName(), "SIGKILL")
+		_ = r.cmdWait(ctx, ctr.GetName())
+	}
+	_ = r.cmdKill(ctx, "pause", "SIGKILL")
+	_ = r.cmdWait(ctx, "pause")
+}
+
+func (r *runsc) cleanupContainers(ctx context.Context, containers []*ateompb.Container) error {
 	// Check state of all containers to mimic containerd.
 	//
 	// Without this, `runsc delete` occasionally throws an error.
@@ -1058,6 +1051,59 @@ func (s *AteomService) prepareActorEgress(ctx context.Context, actorUID string, 
 		return nil, fmt.Errorf("while configuring actor egress client: %w", err)
 	}
 	return &actorEgress{client: gatewayClient, certificateSource: certificateSource, expiresAt: expiresAt}, nil
+}
+
+func (s *AteomService) TerminateWorkload(ctx context.Context, req *ateompb.TerminateWorkloadRequest) (*ateompb.TerminateWorkloadResponse, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.activeActor.Store(nil)
+
+	attribution := ateomstats.ActorAttributionFromRequest(req)
+
+	if err := s.terminateWorkload(ctx, attribution.Ref, attribution.UID, req.GetRunscPath(), req.GetSpec().GetContainers()); err != nil {
+		return nil, fmt.Errorf("failed to terminate workload: %w", err)
+	}
+
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor terminated", attribution)
+	s.activeSession = nil
+
+	return &ateompb.TerminateWorkloadResponse{}, nil
+}
+
+func (s *AteomService) terminateWorkload(ctx context.Context, actorRef resources.ActorRef, actorUID, runscPath string, containers []*ateompb.Container) error {
+	var errs []error
+	if err := s.deactivateActorNetworking(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("while deactivating actor networking: %w", err))
+	}
+
+	rcmd := &runsc{
+		path:     runscPath,
+		actorUID: actorUID,
+	}
+
+	// Stop the containers before deleting them, to avoid leaving a live container with no bundle on disk. Best-effort: if the containers are already stopped, the delete will succeed anyway.
+	rcmd.stopContainers(ctx, containers)
+	// Keep this as best-effort cleanup:
+	// atelet resets the actor runsc, bundle, pidfile, and checkpoint
+	// directories after uploading the snapshot.
+	if err := rcmd.cleanupContainers(ctx, containers); err != nil {
+		errs = append(errs, fmt.Errorf("while cleaning up runsc containers: %w", err))
+	}
+
+	// Detach the overlay rootfs mounts before atelet wipes the bundle dirs
+	// (deleting a bundle out from under a live mount in this namespace would
+	// leave the mount orphaned until the pod restarts). Best-effort, same as
+	// the container cleanup above.
+	if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(actorUID)); err != nil {
+		errs = append(errs, fmt.Errorf("while unmounting bundle rootfs overlays: %w", err))
+	}
+
+	if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
+		errs = append(errs, fmt.Errorf("while cleaning up actor network: %w", err))
+	}
+
+	return errors.Join(errs...)
 }
 
 func (s *AteomService) activateActorNetworking(atespace, actorName string, egress *actorEgress) error {

--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -188,27 +189,13 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	// Tear down: the actor returns to "available". Best-effort; the snapshot is
 	// already on disk for atelet to ship.
 	tTeardown := time.Now()
-	s.teardownActor(ctx, actorUID, ra, client)
-	dTeardown := time.Since(tTeardown)
-	delete(s.running, actorUID)
-
-	// The guest is gone as of the teardown above, so the ateom is back to
-	// "available": there is nothing left to measure, and holding the attribution
-	// would let a later GetWorkloadStats report a checkpointed actor as though it
-	// were still running.
-	//
-	// Nothing above this point clears it, unlike the gVisor ateom, which clears
-	// as soon as its checkpoint call has taken the sandbox down. Here the guest
-	// is only paused until this teardown, so a checkpoint that failed earlier has
-	// left it present, and reporting its usage is then the honest answer. This is
-	// the same point at which the running entry goes away, which is what keeps
-	// the two views of "is an actor here" from disagreeing.
-	s.activeActor.Store(nil)
-
-	// Tear down the per-activation actor network.
-	if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
-		slog.WarnContext(ctx, "Failed to clean up actor network after checkpoint", slog.Any("err", err))
+	if err := s.terminateWorkload(ctx, actorUID); err != nil {
+		slog.WarnContext(ctx, "failed to terminate workload after checkpoint",
+			slog.String("actor", attribution.Ref.String()),
+			slog.String("actorUID", actorUID),
+			slog.Any("err", err))
 	}
+	dTeardown := time.Since(tTeardown)
 
 	s.actorLogger.EmitLifecycleLog(ctx, "Actor checkpointed", attribution)
 	slog.InfoContext(ctx, "Actor checkpointed", slog.String("id", actorUID), slog.Any("snapshot_files", snapshotFiles),
@@ -294,10 +281,9 @@ func listFiles(dir string) ([]string, error) {
 	return files, nil
 }
 
-// teardownActor stops the ateom-owned CH VMM for an actor. Best-effort: the
-// snapshot is already on disk, so this only needs to release resources. ra may be
+// teardownActor stops the ateom-owned CH VMM for an actor. ra may be
 // nil (e.g. ateom restarted and lost in-memory state).
-func (s *AteomService) teardownActor(ctx context.Context, id string, ra *runningActor, client *ch.Client) {
+func (s *AteomService) teardownActor(ctx context.Context, id string, ra *runningActor, client *ch.Client) error {
 	// Stop offering the guest to GetWorkloadStats first, before anything below
 	// makes it stop answering. Clearing it here rather than alongside the
 	// attribution is what keeps a poll that lands mid-teardown on the
@@ -305,11 +291,14 @@ func (s *AteomService) teardownActor(ctx context.Context, id string, ra *running
 	// closed connection as a failed read.
 	s.guestStats.Store(nil)
 
+	var errs []error
 	if client != nil {
 		tShutdown := time.Now()
 		shutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		if err := client.Shutdown(shutCtx); err != nil {
-			slog.WarnContext(ctx, "CH shutdown failed (continuing teardown)", slog.Any("err", err))
+			if !errors.Is(err, os.ErrNotExist) {
+				slog.WarnContext(ctx, "CH shutdown returned error during teardown", slog.Any("err", err))
+			}
 		}
 		cancel()
 		slog.InfoContext(ctx, "CH API shutdown done", slog.Duration("took", time.Since(tShutdown)))
@@ -353,8 +342,64 @@ func (s *AteomService) teardownActor(ctx context.Context, id string, ra *running
 
 	// Detach the bundle rootfs overlays composed in buildActorContainers, so
 	// atelet's bundle wipe doesn't strand live mounts in this namespace.
-	// Best-effort like the rest of teardown.
 	if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(id)); err != nil {
-		slog.WarnContext(ctx, "Failed to unmount bundle rootfs overlays", slog.String("actorUID", id), slog.Any("err", err))
+		if !errors.Is(err, os.ErrNotExist) {
+			errs = append(errs, fmt.Errorf("while unmounting bundle rootfs overlays: %w", err))
+		}
 	}
+	return errors.Join(errs...)
+}
+
+// TerminateWorkload stops the running actor, tears down its VMM, and cleans up
+// networking and overlays.
+func (s *AteomService) TerminateWorkload(ctx context.Context, req *ateompb.TerminateWorkloadRequest) (*ateompb.TerminateWorkloadResponse, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	attribution := ateomstats.ActorAttributionFromRequest(req)
+
+	if err := s.terminateWorkload(ctx, attribution.UID); err != nil {
+		return nil, fmt.Errorf("failed to terminate workload: %w", err)
+	}
+
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor terminated", attribution)
+
+	return &ateompb.TerminateWorkloadResponse{}, nil
+}
+
+func (s *AteomService) terminateWorkload(ctx context.Context, actorUID string) error {
+	var errs []error
+	if err := s.deactivateActorNetworking(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("while deactivating actor networking: %w", err))
+	}
+
+	ra := s.running[actorUID]
+	chSocket := kata.CLHSocketPath(actorUID)
+	if ra != nil && ra.apiSocket != "" {
+		chSocket = ra.apiSocket
+	}
+	client := ch.NewClient(chSocket)
+
+	if err := s.teardownActor(ctx, actorUID, ra, client); err != nil {
+		errs = append(errs, fmt.Errorf("while tearing down actor: %w", err))
+	}
+	delete(s.running, actorUID)
+
+	// The guest is gone as of the teardown above, so the ateom is back to
+	// "available": there is nothing left to measure, and holding the attribution
+	// would let a later GetWorkloadStats report a checkpointed actor as though it
+	// were still running.
+	//
+	// Nothing above this point clears it, unlike the gVisor ateom, which clears
+	// as soon as its checkpoint call has taken the sandbox down. Here the guest
+	// is only paused until this teardown, so a checkpoint that failed earlier has
+	// left it present, and reporting its usage is then the honest answer. This is
+	// the same point at which the running entry goes away, which is what keeps
+	// the two views of "is an actor here" from disagreeing.
+	s.activeActor.Store(nil)
+
+	if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
+		errs = append(errs, fmt.Errorf("while cleaning up actor network: %w", err))
+	}
+	return errors.Join(errs...)
 }

--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -168,8 +168,11 @@ kubectl ate resume actor my-actor -a <atespace>
 # Suspend an actor (snapshots its state to storage and frees the worker)
 kubectl ate suspend actor my-actor -a <atespace>
 
-# Delete an actor.
+# Delete an actor (by default, requires the actor to be SUSPENDED or CRASHED).
 kubectl ate delete actor my-actor -a <atespace>
+
+# Delete an actor from any state (e.g. RUNNING, PAUSED), terminating workloads and detaching volumes.
+kubectl ate delete actor my-actor -a <atespace> --any-state
 ```
 
 ### Actor Snapshots

--- a/cmd/kubectl-ate/internal/cmd/delete_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/delete_actor.go
@@ -24,6 +24,7 @@ import (
 )
 
 var deleteAtespaceFlag string
+var deleteActorAnyStateFlag bool
 
 var deleteActorCmd = &cobra.Command{
 	Use:   "actor <actor-name>",
@@ -39,7 +40,8 @@ var deleteActorCmd = &cobra.Command{
 
 		actorRef := resources.ActorRef{Atespace: deleteAtespaceFlag, Name: args[0]}
 		_, err = c.ControlClient.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
-			Actor: actorRef.ToObjectRef(),
+			Actor:    actorRef.ToObjectRef(),
+			AnyState: deleteActorAnyStateFlag,
 		})
 		if err != nil {
 			return err
@@ -53,5 +55,6 @@ var deleteActorCmd = &cobra.Command{
 func init() {
 	deleteActorCmd.Flags().StringVarP(&deleteAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
 	_ = deleteActorCmd.MarkFlagRequired("atespace")
+	deleteActorCmd.Flags().BoolVar(&deleteActorAnyStateFlag, "any-state", false, "Delete the actor from any state")
 	deleteCmd.AddCommand(deleteActorCmd)
 }

--- a/demos/claude-code-multiplex/ui/server.go
+++ b/demos/claude-code-multiplex/ui/server.go
@@ -208,6 +208,8 @@ func actorStateString(s ateapipb.ActorState) string {
 		return "Suspending"
 	case ateapipb.ActorState_ACTOR_STATE_SUSPENDED:
 		return "Suspended"
+	case ateapipb.ActorState_ACTOR_STATE_DELETING:
+		return "Deleting"
 	default:
 		return "?"
 	}

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -452,10 +452,10 @@ Hibernate a running actor, capturing its current RAM and disk state into a snaps
 *   **Response:** `SuspendActorResponse` containing the `Actor` object in `ACTOR_STATE_SUSPENDED`.
 
 #### `DeleteActor`
-Removes an actor from the registry.
-*   **Constraints:** Only actors in `ACTOR_STATE_SUSPENDED` can be deleted.
+Removes an actor from the registry and cleans up associated resources.
 *   **Request:** `DeleteActorRequest`
     *   `actor`: `ObjectRef` of the actor to delete. Delete takes no preconditions today, so it is last-writer-wins.
+    *   `any_state`: (Optional) If `true`, allows deleting the actor from any state (e.g. `RUNNING`, `PAUSED`), terminating active workloads, detaching volumes, and releasing worker allocations. By default (`false`), only actors in `ACTOR_STATE_SUSPENDED` or `ACTOR_STATE_CRASHED` (or already `ACTOR_STATE_DELETING`) can be deleted.
 *   **Response:** the deleted `Actor`, as it was immediately before removal.
 
 #### `GetActor` / `ListActors`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -464,9 +464,9 @@ including published tags, but leaves snapshot cleanup to garbage collection.
 
 ### Phase 4: Deletion
 
-Actors in `ACTOR_STATE_SUSPENDED` state can be deleted from the Control Plane.
-After deletion, the state of the actor (i.e., memory+disk snapshots) is garbage
-collected. The garbage collection process is not implemented yet.
+By default, only actors in `ACTOR_STATE_SUSPENDED` or `ACTOR_STATE_CRASHED` state can be deleted from the Control Plane. With the `any_state` flag enabled, an actor in any state (such as `ACTOR_STATE_RUNNING` or `ACTOR_STATE_PAUSED`) can be deleted directly; the workflow terminates the running containers on the worker, detaches mounted volumes, and frees the worker assignment before deleting the record.
+
+After deletion, the state of the actor (i.e., memory+disk snapshots) is garbage collected. The garbage collection process is not implemented yet.
 
 ## State Management & Persistence
 

--- a/internal/ateomstats/actorattribution.go
+++ b/internal/ateomstats/actorattribution.go
@@ -39,6 +39,7 @@ var (
 	_ attributionSource = (*ateompb.RunWorkloadRequest)(nil)
 	_ attributionSource = (*ateompb.RestoreWorkloadRequest)(nil)
 	_ attributionSource = (*ateompb.CheckpointWorkloadRequest)(nil)
+	_ attributionSource = (*ateompb.TerminateWorkloadRequest)(nil)
 )
 
 // ActorAttributionFromRequest extracts the attribution an ateom should retain

--- a/internal/ateomstats/actorattribution_test.go
+++ b/internal/ateomstats/actorattribution_test.go
@@ -66,8 +66,35 @@ func TestActorAttributionFromRequest(t *testing.T) {
 			want: fullAttribution,
 		},
 		{
+			name: "checkpoint request",
+			req: &ateompb.CheckpointWorkloadRequest{
+				Atespace:               "atespace-a",
+				ActorName:              "actor-b",
+				ActorUid:               "uid-c",
+				ActorTemplateNamespace: "template-ns-d",
+				ActorTemplateName:      "template-name-e",
+			},
+			want: fullAttribution,
+		},
+		{
+			name: "terminate request",
+			req: &ateompb.TerminateWorkloadRequest{
+				Atespace:               "atespace-a",
+				ActorName:              "actor-b",
+				ActorUid:               "uid-c",
+				ActorTemplateNamespace: "template-ns-d",
+				ActorTemplateName:      "template-name-e",
+			},
+			want: fullAttribution,
+		},
+		{
 			name: "empty run request",
 			req:  &ateompb.RunWorkloadRequest{},
+			want: resources.ActorAttribution{},
+		},
+		{
+			name: "empty terminate request",
+			req:  &ateompb.TerminateWorkloadRequest{},
 			want: resources.ActorAttribution{},
 		},
 		{
@@ -82,6 +109,16 @@ func TestActorAttributionFromRequest(t *testing.T) {
 		{
 			name: "nil restore request",
 			req:  (*ateompb.RestoreWorkloadRequest)(nil),
+			want: resources.ActorAttribution{},
+		},
+		{
+			name: "nil checkpoint request",
+			req:  (*ateompb.CheckpointWorkloadRequest)(nil),
+			want: resources.ActorAttribution{},
+		},
+		{
+			name: "nil terminate request",
+			req:  (*ateompb.TerminateWorkloadRequest)(nil),
 			want: resources.ActorAttribution{},
 		},
 	}

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,6 +71,14 @@ func TestActorLifecycle(t *testing.T) {
 		{
 			name: "SuspendResumeActor",
 			f:    suspendActor,
+		},
+		{
+			name: "DeleteActorAnyState",
+			f:    deleteActorAnyState,
+		},
+		{
+			name: "DeletePausedActorAnyState",
+			f:    deletePausedActorAnyState,
 		},
 	}
 
@@ -420,6 +430,77 @@ func TestExternalVolumeLifecycle(t *testing.T) {
 			t.Parallel()
 			runActorLifecycleTestCase(t, "extvol-lifecycle", createActorTemplateWithExternalVolume, test.tc)
 		})
+	}
+}
+
+func TestDeleteActorAnyStateWithExternalVolume(t *testing.T) {
+	if e2e.IsMicroVM() {
+		t.Skip("Skipping TestDeleteActorAnyStateWithExternalVolume for microVM environment")
+	}
+
+	ctx := context.Background()
+	clients := e2e.GetClients()
+	nsObj := e2e.CreateNamespace(t)
+
+	_, _ = clients.SubstrateAPI.CreateAtespace(ctx, &ateapipb.CreateAtespaceRequest{
+		Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: demoAtespace}},
+	})
+
+	at, err := createActorTemplateWithExternalVolume(ctx, t, clients, nsObj, v1alpha1.SnapshotScopeData, v1alpha1.SnapshotScopeData, v1alpha1.ResumeSourceColdBoot)
+	if err != nil {
+		t.Fatalf("failed to initialize ActorTemplate: %v", err)
+	}
+
+	actorName := "anystate-delete-extvol-" + nsObj.Name
+
+	t.Logf("Creating Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: demoAtespace, Name: actorName},
+		ActorTemplateNamespace: nsObj.Name,
+		ActorTemplateName:      at.Name,
+	}}); err != nil {
+		t.Fatalf("failed to create Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
+
+	t.Logf("Resuming Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); err != nil {
+		t.Fatalf("failed to resume Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_RUNNING)
+
+	// Verify volume exists in actor (status should be CREATED)
+	actor, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	})
+	if err != nil {
+		t.Fatalf("failed to get actor: %v", err)
+	}
+	if len(actor.GetStatus().GetActorVolumes()) == 0 {
+		t.Fatalf("expected actor to have volumes, got 0")
+	}
+	for _, vol := range actor.GetStatus().GetActorVolumes() {
+		if vol.Status != ateapipb.ExternalVolume_STATUS_CREATED {
+			t.Fatalf("expected volume %q to be CREATED, got %s", vol.VolumeName, vol.Status)
+		}
+	}
+
+	// Delete the running actor with any-state
+	t.Logf("Deleting running Actor %q with any-state...", actorName)
+	if _, err := clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
+		Actor:    &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+		AnyState: true,
+	}); err != nil {
+		t.Fatalf("failed to delete Actor with any-state: %v", err)
+	}
+
+	// Verify deletion in store
+	if _, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("expected actor %q to be NotFound after delete, got err: %v", actorName, err)
 	}
 }
 
@@ -860,6 +941,150 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
 	}); err == nil {
 		t.Fatalf("expected actor %q to be deleted, but it still exists", actorName)
+	}
+
+	return nil
+}
+
+func deleteActorAnyState(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *e2e.Namespace, at *v1alpha1.ActorTemplate) error {
+	actorName := "anystate-delete-actor-" + nsObj.Name
+
+	// 1. Creating an actor
+	t.Logf("Creating Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: demoAtespace, Name: actorName},
+		ActorTemplateNamespace: nsObj.Name,
+		ActorTemplateName:      at.Name,
+	}}); err != nil {
+		t.Fatalf("failed to create Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
+
+	// Verify that any-state delete on a SUSPENDED actor succeeds
+	t.Logf("Attempting any-state delete on suspended Actor %q (should succeed)...", actorName)
+	if _, err := clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
+		Actor:    &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+		AnyState: true,
+	}); err != nil {
+		t.Fatalf("expected any-state delete on suspended actor to succeed, got %v", err)
+	}
+
+	// 2. Re-creating and Resuming the actor
+	t.Logf("Re-creating Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: demoAtespace, Name: actorName},
+		ActorTemplateNamespace: nsObj.Name,
+		ActorTemplateName:      at.Name,
+	}}); err != nil {
+		t.Fatalf("failed to create Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
+
+	t.Logf("Resuming Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); err != nil {
+		t.Fatalf("failed to resume Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_RUNNING)
+
+	// 3. Call the actor to ensure workload is actively serving on worker
+	resp, err := callActor(t, resources.ActorRef{Atespace: demoAtespace, Name: actorName})
+	if err != nil {
+		t.Fatalf("failed to call actor: %v", err)
+	}
+	validateCounterResponse(t, resp, "after creation", 1, 1)
+
+	// 4. Attempt standard DeleteActor without any-state on running actor (should fail with FailedPrecondition)
+	t.Logf("Attempting standard delete on running Actor %q (should fail)...", actorName)
+	if _, err := clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
+		Actor:    &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+		AnyState: false,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition when standard deleting running actor, got %v", err)
+	}
+
+	// 5. Delete the running actor with any-state
+	t.Logf("Deleting running Actor %q with any-state...", actorName)
+	if _, err := clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
+		Actor:    &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+		AnyState: true,
+	}); err != nil {
+		t.Fatalf("failed to delete Actor with any-state: %v", err)
+	}
+
+	// 6. Verify deletion in store
+	if _, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("expected actor %q to be NotFound after delete, got err: %v", actorName, err)
+	}
+
+	// 7. Verify actor name can be immediately reused
+	t.Logf("Re-creating Actor %q to verify name reuse...", actorName)
+	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: demoAtespace, Name: actorName},
+		ActorTemplateNamespace: nsObj.Name,
+		ActorTemplateName:      at.Name,
+	}}); err != nil {
+		t.Fatalf("failed to recreate Actor: %v", err)
+	}
+	defer func() {
+		clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
+			Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+		})
+	}()
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
+
+	return nil
+}
+
+func deletePausedActorAnyState(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *e2e.Namespace, at *v1alpha1.ActorTemplate) error {
+	actorName := "anystate-delete-paused-actor-" + nsObj.Name
+
+	// 1. Creating an actor
+	t.Logf("Creating Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: demoAtespace, Name: actorName},
+		ActorTemplateNamespace: nsObj.Name,
+		ActorTemplateName:      at.Name,
+	}}); err != nil {
+		t.Fatalf("failed to create Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
+
+	// 2. Resuming the actor
+	t.Logf("Resuming Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); err != nil {
+		t.Fatalf("failed to resume Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_RUNNING)
+
+	// 3. Pausing the actor
+	t.Logf("Pausing Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.PauseActor(ctx, &ateapipb.PauseActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); err != nil {
+		t.Fatalf("failed to pause Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_PAUSED)
+
+	// 4. Delete the paused actor with any-state
+	t.Logf("Deleting paused Actor %q with any-state...", actorName)
+	if _, err := clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
+		Actor:    &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+		AnyState: true,
+	}); err != nil {
+		t.Fatalf("failed to delete Actor with any-state: %v", err)
+	}
+
+	// 5. Verify deletion in store
+	if _, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("expected actor %q to be NotFound after delete, got err: %v", actorName, err)
 	}
 
 	return nil

--- a/internal/proto/ateletpb/atelet.pb.go
+++ b/internal/proto/ateletpb/atelet.pb.go
@@ -305,6 +305,134 @@ func (x *MintActorCertificateResponse) GetActorCertificates() [][]byte {
 	return nil
 }
 
+type TerminateRequest struct {
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
+	Atespace               string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName              string                 `protobuf:"bytes,3,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid               string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateNamespace string                 `protobuf:"bytes,5,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *TerminateRequest) Reset() {
+	*x = TerminateRequest{}
+	mi := &file_atelet_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminateRequest) ProtoMessage() {}
+
+func (x *TerminateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_atelet_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminateRequest.ProtoReflect.Descriptor instead.
+func (*TerminateRequest) Descriptor() ([]byte, []int) {
+	return file_atelet_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *TerminateRequest) GetTargetAteomUid() string {
+	if x != nil {
+		return x.TargetAteomUid
+	}
+	return ""
+}
+
+func (x *TerminateRequest) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *TerminateRequest) GetActorName() string {
+	if x != nil {
+		return x.ActorName
+	}
+	return ""
+}
+
+func (x *TerminateRequest) GetActorUid() string {
+	if x != nil {
+		return x.ActorUid
+	}
+	return ""
+}
+
+func (x *TerminateRequest) GetActorTemplateNamespace() string {
+	if x != nil {
+		return x.ActorTemplateNamespace
+	}
+	return ""
+}
+
+func (x *TerminateRequest) GetActorTemplateName() string {
+	if x != nil {
+		return x.ActorTemplateName
+	}
+	return ""
+}
+
+func (x *TerminateRequest) GetSpec() *WorkloadSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+type TerminateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminateResponse) Reset() {
+	*x = TerminateResponse{}
+	mi := &file_atelet_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminateResponse) ProtoMessage() {}
+
+func (x *TerminateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_atelet_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminateResponse.ProtoReflect.Descriptor instead.
+func (*TerminateResponse) Descriptor() ([]byte, []int) {
+	return file_atelet_proto_rawDescGZIP(), []int{3}
+}
+
 type RunRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
@@ -331,7 +459,7 @@ type RunRequest struct {
 
 func (x *RunRequest) Reset() {
 	*x = RunRequest{}
-	mi := &file_atelet_proto_msgTypes[2]
+	mi := &file_atelet_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -343,7 +471,7 @@ func (x *RunRequest) String() string {
 func (*RunRequest) ProtoMessage() {}
 
 func (x *RunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[2]
+	mi := &file_atelet_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -356,7 +484,7 @@ func (x *RunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunRequest.ProtoReflect.Descriptor instead.
 func (*RunRequest) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{2}
+	return file_atelet_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *RunRequest) GetTargetAteomUid() string {
@@ -448,7 +576,7 @@ type EgressGateway struct {
 
 func (x *EgressGateway) Reset() {
 	*x = EgressGateway{}
-	mi := &file_atelet_proto_msgTypes[3]
+	mi := &file_atelet_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -460,7 +588,7 @@ func (x *EgressGateway) String() string {
 func (*EgressGateway) ProtoMessage() {}
 
 func (x *EgressGateway) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[3]
+	mi := &file_atelet_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -473,7 +601,7 @@ func (x *EgressGateway) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EgressGateway.ProtoReflect.Descriptor instead.
 func (*EgressGateway) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{3}
+	return file_atelet_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *EgressGateway) GetAddress() string {
@@ -497,7 +625,7 @@ type AssetFile struct {
 
 func (x *AssetFile) Reset() {
 	*x = AssetFile{}
-	mi := &file_atelet_proto_msgTypes[4]
+	mi := &file_atelet_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -509,7 +637,7 @@ func (x *AssetFile) String() string {
 func (*AssetFile) ProtoMessage() {}
 
 func (x *AssetFile) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[4]
+	mi := &file_atelet_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -522,7 +650,7 @@ func (x *AssetFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetFile.ProtoReflect.Descriptor instead.
 func (*AssetFile) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{4}
+	return file_atelet_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *AssetFile) GetUrl() string {
@@ -550,7 +678,7 @@ type ArchAssets struct {
 
 func (x *ArchAssets) Reset() {
 	*x = ArchAssets{}
-	mi := &file_atelet_proto_msgTypes[5]
+	mi := &file_atelet_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -562,7 +690,7 @@ func (x *ArchAssets) String() string {
 func (*ArchAssets) ProtoMessage() {}
 
 func (x *ArchAssets) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[5]
+	mi := &file_atelet_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -575,7 +703,7 @@ func (x *ArchAssets) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchAssets.ProtoReflect.Descriptor instead.
 func (*ArchAssets) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{5}
+	return file_atelet_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ArchAssets) GetFiles() map[string]*AssetFile {
@@ -605,7 +733,7 @@ type SandboxAssets struct {
 
 func (x *SandboxAssets) Reset() {
 	*x = SandboxAssets{}
-	mi := &file_atelet_proto_msgTypes[6]
+	mi := &file_atelet_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -617,7 +745,7 @@ func (x *SandboxAssets) String() string {
 func (*SandboxAssets) ProtoMessage() {}
 
 func (x *SandboxAssets) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[6]
+	mi := &file_atelet_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -630,7 +758,7 @@ func (x *SandboxAssets) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxAssets.ProtoReflect.Descriptor instead.
 func (*SandboxAssets) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{6}
+	return file_atelet_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *SandboxAssets) GetSandboxClass() string {
@@ -665,7 +793,7 @@ type WorkloadSpec struct {
 
 func (x *WorkloadSpec) Reset() {
 	*x = WorkloadSpec{}
-	mi := &file_atelet_proto_msgTypes[7]
+	mi := &file_atelet_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -677,7 +805,7 @@ func (x *WorkloadSpec) String() string {
 func (*WorkloadSpec) ProtoMessage() {}
 
 func (x *WorkloadSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[7]
+	mi := &file_atelet_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -690,7 +818,7 @@ func (x *WorkloadSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadSpec.ProtoReflect.Descriptor instead.
 func (*WorkloadSpec) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{7}
+	return file_atelet_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *WorkloadSpec) GetContainers() []*Container {
@@ -715,7 +843,7 @@ type DurableDirVolume struct {
 
 func (x *DurableDirVolume) Reset() {
 	*x = DurableDirVolume{}
-	mi := &file_atelet_proto_msgTypes[8]
+	mi := &file_atelet_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -727,7 +855,7 @@ func (x *DurableDirVolume) String() string {
 func (*DurableDirVolume) ProtoMessage() {}
 
 func (x *DurableDirVolume) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[8]
+	mi := &file_atelet_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -740,7 +868,7 @@ func (x *DurableDirVolume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DurableDirVolume.ProtoReflect.Descriptor instead.
 func (*DurableDirVolume) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{8}
+	return file_atelet_proto_rawDescGZIP(), []int{10}
 }
 
 type ExternalVolumeSource struct {
@@ -754,7 +882,7 @@ type ExternalVolumeSource struct {
 
 func (x *ExternalVolumeSource) Reset() {
 	*x = ExternalVolumeSource{}
-	mi := &file_atelet_proto_msgTypes[9]
+	mi := &file_atelet_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -766,7 +894,7 @@ func (x *ExternalVolumeSource) String() string {
 func (*ExternalVolumeSource) ProtoMessage() {}
 
 func (x *ExternalVolumeSource) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[9]
+	mi := &file_atelet_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -779,7 +907,7 @@ func (x *ExternalVolumeSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExternalVolumeSource.ProtoReflect.Descriptor instead.
 func (*ExternalVolumeSource) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{9}
+	return file_atelet_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ExternalVolumeSource) GetStorageVolumeId() string {
@@ -812,7 +940,7 @@ type ImageVolumeSource struct {
 
 func (x *ImageVolumeSource) Reset() {
 	*x = ImageVolumeSource{}
-	mi := &file_atelet_proto_msgTypes[10]
+	mi := &file_atelet_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -824,7 +952,7 @@ func (x *ImageVolumeSource) String() string {
 func (*ImageVolumeSource) ProtoMessage() {}
 
 func (x *ImageVolumeSource) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[10]
+	mi := &file_atelet_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -837,7 +965,7 @@ func (x *ImageVolumeSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageVolumeSource.ProtoReflect.Descriptor instead.
 func (*ImageVolumeSource) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{10}
+	return file_atelet_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ImageVolumeSource) GetReference() string {
@@ -859,7 +987,7 @@ type ActorMetadataItem struct {
 
 func (x *ActorMetadataItem) Reset() {
 	*x = ActorMetadataItem{}
-	mi := &file_atelet_proto_msgTypes[11]
+	mi := &file_atelet_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -871,7 +999,7 @@ func (x *ActorMetadataItem) String() string {
 func (*ActorMetadataItem) ProtoMessage() {}
 
 func (x *ActorMetadataItem) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[11]
+	mi := &file_atelet_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -884,7 +1012,7 @@ func (x *ActorMetadataItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActorMetadataItem.ProtoReflect.Descriptor instead.
 func (*ActorMetadataItem) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{11}
+	return file_atelet_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ActorMetadataItem) GetField() ActorMetadataField {
@@ -912,7 +1040,7 @@ type ActorMetadataDataSource struct {
 
 func (x *ActorMetadataDataSource) Reset() {
 	*x = ActorMetadataDataSource{}
-	mi := &file_atelet_proto_msgTypes[12]
+	mi := &file_atelet_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -924,7 +1052,7 @@ func (x *ActorMetadataDataSource) String() string {
 func (*ActorMetadataDataSource) ProtoMessage() {}
 
 func (x *ActorMetadataDataSource) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[12]
+	mi := &file_atelet_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -937,7 +1065,7 @@ func (x *ActorMetadataDataSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActorMetadataDataSource.ProtoReflect.Descriptor instead.
 func (*ActorMetadataDataSource) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{12}
+	return file_atelet_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ActorMetadataDataSource) GetItems() []*ActorMetadataItem {
@@ -959,7 +1087,7 @@ type SystemInfoDataSource struct {
 
 func (x *SystemInfoDataSource) Reset() {
 	*x = SystemInfoDataSource{}
-	mi := &file_atelet_proto_msgTypes[13]
+	mi := &file_atelet_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -971,7 +1099,7 @@ func (x *SystemInfoDataSource) String() string {
 func (*SystemInfoDataSource) ProtoMessage() {}
 
 func (x *SystemInfoDataSource) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[13]
+	mi := &file_atelet_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -984,7 +1112,7 @@ func (x *SystemInfoDataSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemInfoDataSource.ProtoReflect.Descriptor instead.
 func (*SystemInfoDataSource) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{13}
+	return file_atelet_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *SystemInfoDataSource) GetDataSource() isSystemInfoDataSource_DataSource {
@@ -1025,7 +1153,7 @@ type SystemInfoVolume struct {
 
 func (x *SystemInfoVolume) Reset() {
 	*x = SystemInfoVolume{}
-	mi := &file_atelet_proto_msgTypes[14]
+	mi := &file_atelet_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1037,7 +1165,7 @@ func (x *SystemInfoVolume) String() string {
 func (*SystemInfoVolume) ProtoMessage() {}
 
 func (x *SystemInfoVolume) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[14]
+	mi := &file_atelet_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1050,7 +1178,7 @@ func (x *SystemInfoVolume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemInfoVolume.ProtoReflect.Descriptor instead.
 func (*SystemInfoVolume) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{14}
+	return file_atelet_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SystemInfoVolume) GetDataSources() []*SystemInfoDataSource {
@@ -1076,7 +1204,7 @@ type Volume struct {
 
 func (x *Volume) Reset() {
 	*x = Volume{}
-	mi := &file_atelet_proto_msgTypes[15]
+	mi := &file_atelet_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1088,7 +1216,7 @@ func (x *Volume) String() string {
 func (*Volume) ProtoMessage() {}
 
 func (x *Volume) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[15]
+	mi := &file_atelet_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1101,7 +1229,7 @@ func (x *Volume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Volume.ProtoReflect.Descriptor instead.
 func (*Volume) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{15}
+	return file_atelet_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Volume) GetName() string {
@@ -1192,7 +1320,7 @@ type VolumeMount struct {
 
 func (x *VolumeMount) Reset() {
 	*x = VolumeMount{}
-	mi := &file_atelet_proto_msgTypes[16]
+	mi := &file_atelet_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1204,7 +1332,7 @@ func (x *VolumeMount) String() string {
 func (*VolumeMount) ProtoMessage() {}
 
 func (x *VolumeMount) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[16]
+	mi := &file_atelet_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1217,7 +1345,7 @@ func (x *VolumeMount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeMount.ProtoReflect.Descriptor instead.
 func (*VolumeMount) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{16}
+	return file_atelet_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *VolumeMount) GetName() string {
@@ -1250,7 +1378,7 @@ type Container struct {
 
 func (x *Container) Reset() {
 	*x = Container{}
-	mi := &file_atelet_proto_msgTypes[17]
+	mi := &file_atelet_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1262,7 +1390,7 @@ func (x *Container) String() string {
 func (*Container) ProtoMessage() {}
 
 func (x *Container) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[17]
+	mi := &file_atelet_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1275,7 +1403,7 @@ func (x *Container) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Container.ProtoReflect.Descriptor instead.
 func (*Container) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{17}
+	return file_atelet_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *Container) GetName() string {
@@ -1344,7 +1472,7 @@ type SecurityContext struct {
 
 func (x *SecurityContext) Reset() {
 	*x = SecurityContext{}
-	mi := &file_atelet_proto_msgTypes[18]
+	mi := &file_atelet_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1356,7 +1484,7 @@ func (x *SecurityContext) String() string {
 func (*SecurityContext) ProtoMessage() {}
 
 func (x *SecurityContext) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[18]
+	mi := &file_atelet_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1369,7 +1497,7 @@ func (x *SecurityContext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecurityContext.ProtoReflect.Descriptor instead.
 func (*SecurityContext) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{18}
+	return file_atelet_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SecurityContext) GetCapabilities() *Capabilities {
@@ -1391,7 +1519,7 @@ type Capabilities struct {
 
 func (x *Capabilities) Reset() {
 	*x = Capabilities{}
-	mi := &file_atelet_proto_msgTypes[19]
+	mi := &file_atelet_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1403,7 +1531,7 @@ func (x *Capabilities) String() string {
 func (*Capabilities) ProtoMessage() {}
 
 func (x *Capabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[19]
+	mi := &file_atelet_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1416,7 +1544,7 @@ func (x *Capabilities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Capabilities.ProtoReflect.Descriptor instead.
 func (*Capabilities) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{19}
+	return file_atelet_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *Capabilities) GetAdd() []string {
@@ -1443,7 +1571,7 @@ type EnvEntry struct {
 
 func (x *EnvEntry) Reset() {
 	*x = EnvEntry{}
-	mi := &file_atelet_proto_msgTypes[20]
+	mi := &file_atelet_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1455,7 +1583,7 @@ func (x *EnvEntry) String() string {
 func (*EnvEntry) ProtoMessage() {}
 
 func (x *EnvEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[20]
+	mi := &file_atelet_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1468,7 +1596,7 @@ func (x *EnvEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvEntry.ProtoReflect.Descriptor instead.
 func (*EnvEntry) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{20}
+	return file_atelet_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *EnvEntry) GetName() string {
@@ -1499,7 +1627,7 @@ type Readyz struct {
 
 func (x *Readyz) Reset() {
 	*x = Readyz{}
-	mi := &file_atelet_proto_msgTypes[21]
+	mi := &file_atelet_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1511,7 +1639,7 @@ func (x *Readyz) String() string {
 func (*Readyz) ProtoMessage() {}
 
 func (x *Readyz) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[21]
+	mi := &file_atelet_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1524,7 +1652,7 @@ func (x *Readyz) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Readyz.ProtoReflect.Descriptor instead.
 func (*Readyz) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{21}
+	return file_atelet_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *Readyz) GetHttpGet() *HTTPGetAction {
@@ -1554,7 +1682,7 @@ type HTTPGetAction struct {
 
 func (x *HTTPGetAction) Reset() {
 	*x = HTTPGetAction{}
-	mi := &file_atelet_proto_msgTypes[22]
+	mi := &file_atelet_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1566,7 +1694,7 @@ func (x *HTTPGetAction) String() string {
 func (*HTTPGetAction) ProtoMessage() {}
 
 func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[22]
+	mi := &file_atelet_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1579,7 +1707,7 @@ func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPGetAction.ProtoReflect.Descriptor instead.
 func (*HTTPGetAction) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{22}
+	return file_atelet_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *HTTPGetAction) GetPath() string {
@@ -1604,7 +1732,7 @@ type RunResponse struct {
 
 func (x *RunResponse) Reset() {
 	*x = RunResponse{}
-	mi := &file_atelet_proto_msgTypes[23]
+	mi := &file_atelet_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1616,7 +1744,7 @@ func (x *RunResponse) String() string {
 func (*RunResponse) ProtoMessage() {}
 
 func (x *RunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[23]
+	mi := &file_atelet_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1629,7 +1757,7 @@ func (x *RunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunResponse.ProtoReflect.Descriptor instead.
 func (*RunResponse) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{23}
+	return file_atelet_proto_rawDescGZIP(), []int{25}
 }
 
 type LocalCheckpointConfiguration struct {
@@ -1645,7 +1773,7 @@ type LocalCheckpointConfiguration struct {
 
 func (x *LocalCheckpointConfiguration) Reset() {
 	*x = LocalCheckpointConfiguration{}
-	mi := &file_atelet_proto_msgTypes[24]
+	mi := &file_atelet_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1657,7 +1785,7 @@ func (x *LocalCheckpointConfiguration) String() string {
 func (*LocalCheckpointConfiguration) ProtoMessage() {}
 
 func (x *LocalCheckpointConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[24]
+	mi := &file_atelet_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1670,7 +1798,7 @@ func (x *LocalCheckpointConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocalCheckpointConfiguration.ProtoReflect.Descriptor instead.
 func (*LocalCheckpointConfiguration) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{24}
+	return file_atelet_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *LocalCheckpointConfiguration) GetSnapshotName() string {
@@ -1691,7 +1819,7 @@ type ExternalCheckpointConfiguration struct {
 
 func (x *ExternalCheckpointConfiguration) Reset() {
 	*x = ExternalCheckpointConfiguration{}
-	mi := &file_atelet_proto_msgTypes[25]
+	mi := &file_atelet_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1703,7 +1831,7 @@ func (x *ExternalCheckpointConfiguration) String() string {
 func (*ExternalCheckpointConfiguration) ProtoMessage() {}
 
 func (x *ExternalCheckpointConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[25]
+	mi := &file_atelet_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1716,7 +1844,7 @@ func (x *ExternalCheckpointConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExternalCheckpointConfiguration.ProtoReflect.Descriptor instead.
 func (*ExternalCheckpointConfiguration) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{25}
+	return file_atelet_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ExternalCheckpointConfiguration) GetSnapshotUri() string {
@@ -1754,7 +1882,7 @@ type CheckpointRequest struct {
 
 func (x *CheckpointRequest) Reset() {
 	*x = CheckpointRequest{}
-	mi := &file_atelet_proto_msgTypes[26]
+	mi := &file_atelet_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1766,7 +1894,7 @@ func (x *CheckpointRequest) String() string {
 func (*CheckpointRequest) ProtoMessage() {}
 
 func (x *CheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[26]
+	mi := &file_atelet_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1779,7 +1907,7 @@ func (x *CheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckpointRequest.ProtoReflect.Descriptor instead.
 func (*CheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{26}
+	return file_atelet_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *CheckpointRequest) GetTargetAteomUid() string {
@@ -1894,7 +2022,7 @@ type CheckpointResponse struct {
 
 func (x *CheckpointResponse) Reset() {
 	*x = CheckpointResponse{}
-	mi := &file_atelet_proto_msgTypes[27]
+	mi := &file_atelet_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1906,7 +2034,7 @@ func (x *CheckpointResponse) String() string {
 func (*CheckpointResponse) ProtoMessage() {}
 
 func (x *CheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[27]
+	mi := &file_atelet_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1919,7 +2047,7 @@ func (x *CheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckpointResponse.ProtoReflect.Descriptor instead.
 func (*CheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{27}
+	return file_atelet_proto_rawDescGZIP(), []int{29}
 }
 
 type UploadPausedCheckpointRequest struct {
@@ -1947,7 +2075,7 @@ type UploadPausedCheckpointRequest struct {
 
 func (x *UploadPausedCheckpointRequest) Reset() {
 	*x = UploadPausedCheckpointRequest{}
-	mi := &file_atelet_proto_msgTypes[28]
+	mi := &file_atelet_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1959,7 +2087,7 @@ func (x *UploadPausedCheckpointRequest) String() string {
 func (*UploadPausedCheckpointRequest) ProtoMessage() {}
 
 func (x *UploadPausedCheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[28]
+	mi := &file_atelet_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1972,7 +2100,7 @@ func (x *UploadPausedCheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UploadPausedCheckpointRequest.ProtoReflect.Descriptor instead.
 func (*UploadPausedCheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{28}
+	return file_atelet_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *UploadPausedCheckpointRequest) GetAtespace() string {
@@ -2039,7 +2167,7 @@ type UploadPausedCheckpointResponse struct {
 
 func (x *UploadPausedCheckpointResponse) Reset() {
 	*x = UploadPausedCheckpointResponse{}
-	mi := &file_atelet_proto_msgTypes[29]
+	mi := &file_atelet_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2051,7 +2179,7 @@ func (x *UploadPausedCheckpointResponse) String() string {
 func (*UploadPausedCheckpointResponse) ProtoMessage() {}
 
 func (x *UploadPausedCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[29]
+	mi := &file_atelet_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2064,7 +2192,7 @@ func (x *UploadPausedCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UploadPausedCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*UploadPausedCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{29}
+	return file_atelet_proto_rawDescGZIP(), []int{31}
 }
 
 type RestoreRequest struct {
@@ -2110,7 +2238,7 @@ type RestoreRequest struct {
 
 func (x *RestoreRequest) Reset() {
 	*x = RestoreRequest{}
-	mi := &file_atelet_proto_msgTypes[30]
+	mi := &file_atelet_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2122,7 +2250,7 @@ func (x *RestoreRequest) String() string {
 func (*RestoreRequest) ProtoMessage() {}
 
 func (x *RestoreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[30]
+	mi := &file_atelet_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2135,7 +2263,7 @@ func (x *RestoreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreRequest.ProtoReflect.Descriptor instead.
 func (*RestoreRequest) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{30}
+	return file_atelet_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *RestoreRequest) GetTargetAteomUid() string {
@@ -2278,7 +2406,7 @@ type RestoreResponse struct {
 
 func (x *RestoreResponse) Reset() {
 	*x = RestoreResponse{}
-	mi := &file_atelet_proto_msgTypes[31]
+	mi := &file_atelet_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2290,7 +2418,7 @@ func (x *RestoreResponse) String() string {
 func (*RestoreResponse) ProtoMessage() {}
 
 func (x *RestoreResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[31]
+	mi := &file_atelet_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2303,7 +2431,7 @@ func (x *RestoreResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreResponse.ProtoReflect.Descriptor instead.
 func (*RestoreResponse) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{31}
+	return file_atelet_proto_rawDescGZIP(), []int{33}
 }
 
 var File_atelet_proto protoreflect.FileDescriptor
@@ -2315,7 +2443,17 @@ const file_atelet_proto_rawDesc = "" +
 	"\x1bcertificate_signing_request\x18\x01 \x01(\fR\x19certificateSigningRequest\x12,\n" +
 	"\x12expected_actor_uid\x18\x02 \x01(\tR\x10expectedActorUid\"M\n" +
 	"\x1cMintActorCertificateResponse\x12-\n" +
-	"\x12actor_certificates\x18\x01 \x03(\fR\x11actorCertificates\"\xf6\x03\n" +
+	"\x12actor_certificates\x18\x01 \x03(\fR\x11actorCertificates\"\xa8\x02\n" +
+	"\x10TerminateRequest\x12(\n" +
+	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
+	"\batespace\x18\x02 \x01(\tR\batespace\x12\x1d\n" +
+	"\n" +
+	"actor_name\x18\x03 \x01(\tR\tactorName\x12\x1b\n" +
+	"\tactor_uid\x18\x04 \x01(\tR\bactorUid\x128\n" +
+	"\x18actor_template_namespace\x18\x05 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x06 \x01(\tR\x11actorTemplateName\x12(\n" +
+	"\x04spec\x18\a \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\"\x13\n" +
+	"\x11TerminateResponse\"\xf6\x03\n" +
 	"\n" +
 	"RunRequest\x12(\n" +
 	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
@@ -2482,13 +2620,14 @@ const file_atelet_proto_rawDesc = "" +
 	"\x13SNAPSHOT_SCOPE_DATA\x10\x02\x12!\n" +
 	"\x1dSNAPSHOT_SCOPE_DATA_ON_GOLDEN\x10\x032w\n" +
 	"\x10CredentialBroker\x12c\n" +
-	"\x14MintActorCertificate\x12#.atelet.MintActorCertificateRequest\x1a$.atelet.MintActorCertificateResponse\"\x002\xaf\x02\n" +
+	"\x14MintActorCertificate\x12#.atelet.MintActorCertificateRequest\x1a$.atelet.MintActorCertificateResponse\"\x002\xf3\x02\n" +
 	"\vAteomHerder\x120\n" +
 	"\x03Run\x12\x12.atelet.RunRequest\x1a\x13.atelet.RunResponse\"\x00\x12E\n" +
 	"\n" +
 	"Checkpoint\x12\x19.atelet.CheckpointRequest\x1a\x1a.atelet.CheckpointResponse\"\x00\x12<\n" +
 	"\aRestore\x12\x16.atelet.RestoreRequest\x1a\x17.atelet.RestoreResponse\"\x00\x12i\n" +
-	"\x16UploadPausedCheckpoint\x12%.atelet.UploadPausedCheckpointRequest\x1a&.atelet.UploadPausedCheckpointResponse\"\x00B>Z<github.com/agent-substrate/substrate/internal/proto/ateletpbb\x06proto3"
+	"\x16UploadPausedCheckpoint\x12%.atelet.UploadPausedCheckpointRequest\x1a&.atelet.UploadPausedCheckpointResponse\"\x00\x12B\n" +
+	"\tTerminate\x12\x18.atelet.TerminateRequest\x1a\x19.atelet.TerminateResponse\"\x00B>Z<github.com/agent-substrate/substrate/internal/proto/ateletpbb\x06proto3"
 
 var (
 	file_atelet_proto_rawDescOnce sync.Once
@@ -2503,99 +2642,104 @@ func file_atelet_proto_rawDescGZIP() []byte {
 }
 
 var file_atelet_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_atelet_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_atelet_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_atelet_proto_goTypes = []any{
 	(ActorMetadataField)(0),                 // 0: atelet.ActorMetadataField
 	(CheckpointType)(0),                     // 1: atelet.CheckpointType
 	(SnapshotScope)(0),                      // 2: atelet.SnapshotScope
 	(*MintActorCertificateRequest)(nil),     // 3: atelet.MintActorCertificateRequest
 	(*MintActorCertificateResponse)(nil),    // 4: atelet.MintActorCertificateResponse
-	(*RunRequest)(nil),                      // 5: atelet.RunRequest
-	(*EgressGateway)(nil),                   // 6: atelet.EgressGateway
-	(*AssetFile)(nil),                       // 7: atelet.AssetFile
-	(*ArchAssets)(nil),                      // 8: atelet.ArchAssets
-	(*SandboxAssets)(nil),                   // 9: atelet.SandboxAssets
-	(*WorkloadSpec)(nil),                    // 10: atelet.WorkloadSpec
-	(*DurableDirVolume)(nil),                // 11: atelet.DurableDirVolume
-	(*ExternalVolumeSource)(nil),            // 12: atelet.ExternalVolumeSource
-	(*ImageVolumeSource)(nil),               // 13: atelet.ImageVolumeSource
-	(*ActorMetadataItem)(nil),               // 14: atelet.ActorMetadataItem
-	(*ActorMetadataDataSource)(nil),         // 15: atelet.ActorMetadataDataSource
-	(*SystemInfoDataSource)(nil),            // 16: atelet.SystemInfoDataSource
-	(*SystemInfoVolume)(nil),                // 17: atelet.SystemInfoVolume
-	(*Volume)(nil),                          // 18: atelet.Volume
-	(*VolumeMount)(nil),                     // 19: atelet.VolumeMount
-	(*Container)(nil),                       // 20: atelet.Container
-	(*SecurityContext)(nil),                 // 21: atelet.SecurityContext
-	(*Capabilities)(nil),                    // 22: atelet.Capabilities
-	(*EnvEntry)(nil),                        // 23: atelet.EnvEntry
-	(*Readyz)(nil),                          // 24: atelet.Readyz
-	(*HTTPGetAction)(nil),                   // 25: atelet.HTTPGetAction
-	(*RunResponse)(nil),                     // 26: atelet.RunResponse
-	(*LocalCheckpointConfiguration)(nil),    // 27: atelet.LocalCheckpointConfiguration
-	(*ExternalCheckpointConfiguration)(nil), // 28: atelet.ExternalCheckpointConfiguration
-	(*CheckpointRequest)(nil),               // 29: atelet.CheckpointRequest
-	(*CheckpointResponse)(nil),              // 30: atelet.CheckpointResponse
-	(*UploadPausedCheckpointRequest)(nil),   // 31: atelet.UploadPausedCheckpointRequest
-	(*UploadPausedCheckpointResponse)(nil),  // 32: atelet.UploadPausedCheckpointResponse
-	(*RestoreRequest)(nil),                  // 33: atelet.RestoreRequest
-	(*RestoreResponse)(nil),                 // 34: atelet.RestoreResponse
-	nil,                                     // 35: atelet.ArchAssets.FilesEntry
-	nil,                                     // 36: atelet.SandboxAssets.AssetsEntry
-	nil,                                     // 37: atelet.ExternalVolumeSource.VolumeContextEntry
+	(*TerminateRequest)(nil),                // 5: atelet.TerminateRequest
+	(*TerminateResponse)(nil),               // 6: atelet.TerminateResponse
+	(*RunRequest)(nil),                      // 7: atelet.RunRequest
+	(*EgressGateway)(nil),                   // 8: atelet.EgressGateway
+	(*AssetFile)(nil),                       // 9: atelet.AssetFile
+	(*ArchAssets)(nil),                      // 10: atelet.ArchAssets
+	(*SandboxAssets)(nil),                   // 11: atelet.SandboxAssets
+	(*WorkloadSpec)(nil),                    // 12: atelet.WorkloadSpec
+	(*DurableDirVolume)(nil),                // 13: atelet.DurableDirVolume
+	(*ExternalVolumeSource)(nil),            // 14: atelet.ExternalVolumeSource
+	(*ImageVolumeSource)(nil),               // 15: atelet.ImageVolumeSource
+	(*ActorMetadataItem)(nil),               // 16: atelet.ActorMetadataItem
+	(*ActorMetadataDataSource)(nil),         // 17: atelet.ActorMetadataDataSource
+	(*SystemInfoDataSource)(nil),            // 18: atelet.SystemInfoDataSource
+	(*SystemInfoVolume)(nil),                // 19: atelet.SystemInfoVolume
+	(*Volume)(nil),                          // 20: atelet.Volume
+	(*VolumeMount)(nil),                     // 21: atelet.VolumeMount
+	(*Container)(nil),                       // 22: atelet.Container
+	(*SecurityContext)(nil),                 // 23: atelet.SecurityContext
+	(*Capabilities)(nil),                    // 24: atelet.Capabilities
+	(*EnvEntry)(nil),                        // 25: atelet.EnvEntry
+	(*Readyz)(nil),                          // 26: atelet.Readyz
+	(*HTTPGetAction)(nil),                   // 27: atelet.HTTPGetAction
+	(*RunResponse)(nil),                     // 28: atelet.RunResponse
+	(*LocalCheckpointConfiguration)(nil),    // 29: atelet.LocalCheckpointConfiguration
+	(*ExternalCheckpointConfiguration)(nil), // 30: atelet.ExternalCheckpointConfiguration
+	(*CheckpointRequest)(nil),               // 31: atelet.CheckpointRequest
+	(*CheckpointResponse)(nil),              // 32: atelet.CheckpointResponse
+	(*UploadPausedCheckpointRequest)(nil),   // 33: atelet.UploadPausedCheckpointRequest
+	(*UploadPausedCheckpointResponse)(nil),  // 34: atelet.UploadPausedCheckpointResponse
+	(*RestoreRequest)(nil),                  // 35: atelet.RestoreRequest
+	(*RestoreResponse)(nil),                 // 36: atelet.RestoreResponse
+	nil,                                     // 37: atelet.ArchAssets.FilesEntry
+	nil,                                     // 38: atelet.SandboxAssets.AssetsEntry
+	nil,                                     // 39: atelet.ExternalVolumeSource.VolumeContextEntry
 }
 var file_atelet_proto_depIdxs = []int32{
-	10, // 0: atelet.RunRequest.spec:type_name -> atelet.WorkloadSpec
-	9,  // 1: atelet.RunRequest.sandbox_assets:type_name -> atelet.SandboxAssets
-	6,  // 2: atelet.RunRequest.egress_gateway:type_name -> atelet.EgressGateway
-	35, // 3: atelet.ArchAssets.files:type_name -> atelet.ArchAssets.FilesEntry
-	36, // 4: atelet.SandboxAssets.assets:type_name -> atelet.SandboxAssets.AssetsEntry
-	20, // 5: atelet.WorkloadSpec.containers:type_name -> atelet.Container
-	18, // 6: atelet.WorkloadSpec.volumes:type_name -> atelet.Volume
-	37, // 7: atelet.ExternalVolumeSource.volume_context:type_name -> atelet.ExternalVolumeSource.VolumeContextEntry
-	0,  // 8: atelet.ActorMetadataItem.field:type_name -> atelet.ActorMetadataField
-	14, // 9: atelet.ActorMetadataDataSource.items:type_name -> atelet.ActorMetadataItem
-	15, // 10: atelet.SystemInfoDataSource.actor_metadata:type_name -> atelet.ActorMetadataDataSource
-	16, // 11: atelet.SystemInfoVolume.data_sources:type_name -> atelet.SystemInfoDataSource
-	11, // 12: atelet.Volume.durable_dir:type_name -> atelet.DurableDirVolume
-	12, // 13: atelet.Volume.external:type_name -> atelet.ExternalVolumeSource
-	17, // 14: atelet.Volume.system_info:type_name -> atelet.SystemInfoVolume
-	13, // 15: atelet.Volume.image:type_name -> atelet.ImageVolumeSource
-	23, // 16: atelet.Container.env:type_name -> atelet.EnvEntry
-	24, // 17: atelet.Container.readyz:type_name -> atelet.Readyz
-	19, // 18: atelet.Container.volume_mounts:type_name -> atelet.VolumeMount
-	21, // 19: atelet.Container.security_context:type_name -> atelet.SecurityContext
-	22, // 20: atelet.SecurityContext.capabilities:type_name -> atelet.Capabilities
-	25, // 21: atelet.Readyz.http_get:type_name -> atelet.HTTPGetAction
-	10, // 22: atelet.CheckpointRequest.spec:type_name -> atelet.WorkloadSpec
-	1,  // 23: atelet.CheckpointRequest.type:type_name -> atelet.CheckpointType
-	27, // 24: atelet.CheckpointRequest.local_config:type_name -> atelet.LocalCheckpointConfiguration
-	28, // 25: atelet.CheckpointRequest.external_config:type_name -> atelet.ExternalCheckpointConfiguration
-	2,  // 26: atelet.CheckpointRequest.scope:type_name -> atelet.SnapshotScope
-	2,  // 27: atelet.UploadPausedCheckpointRequest.desired_scope:type_name -> atelet.SnapshotScope
-	10, // 28: atelet.RestoreRequest.spec:type_name -> atelet.WorkloadSpec
-	1,  // 29: atelet.RestoreRequest.type:type_name -> atelet.CheckpointType
-	27, // 30: atelet.RestoreRequest.local_config:type_name -> atelet.LocalCheckpointConfiguration
-	28, // 31: atelet.RestoreRequest.external_config:type_name -> atelet.ExternalCheckpointConfiguration
-	2,  // 32: atelet.RestoreRequest.scope:type_name -> atelet.SnapshotScope
-	6,  // 33: atelet.RestoreRequest.egress_gateway:type_name -> atelet.EgressGateway
-	7,  // 34: atelet.ArchAssets.FilesEntry.value:type_name -> atelet.AssetFile
-	8,  // 35: atelet.SandboxAssets.AssetsEntry.value:type_name -> atelet.ArchAssets
-	3,  // 36: atelet.CredentialBroker.MintActorCertificate:input_type -> atelet.MintActorCertificateRequest
-	5,  // 37: atelet.AteomHerder.Run:input_type -> atelet.RunRequest
-	29, // 38: atelet.AteomHerder.Checkpoint:input_type -> atelet.CheckpointRequest
-	33, // 39: atelet.AteomHerder.Restore:input_type -> atelet.RestoreRequest
-	31, // 40: atelet.AteomHerder.UploadPausedCheckpoint:input_type -> atelet.UploadPausedCheckpointRequest
-	4,  // 41: atelet.CredentialBroker.MintActorCertificate:output_type -> atelet.MintActorCertificateResponse
-	26, // 42: atelet.AteomHerder.Run:output_type -> atelet.RunResponse
-	30, // 43: atelet.AteomHerder.Checkpoint:output_type -> atelet.CheckpointResponse
-	34, // 44: atelet.AteomHerder.Restore:output_type -> atelet.RestoreResponse
-	32, // 45: atelet.AteomHerder.UploadPausedCheckpoint:output_type -> atelet.UploadPausedCheckpointResponse
-	41, // [41:46] is the sub-list for method output_type
-	36, // [36:41] is the sub-list for method input_type
-	36, // [36:36] is the sub-list for extension type_name
-	36, // [36:36] is the sub-list for extension extendee
-	0,  // [0:36] is the sub-list for field type_name
+	12, // 0: atelet.TerminateRequest.spec:type_name -> atelet.WorkloadSpec
+	12, // 1: atelet.RunRequest.spec:type_name -> atelet.WorkloadSpec
+	11, // 2: atelet.RunRequest.sandbox_assets:type_name -> atelet.SandboxAssets
+	8,  // 3: atelet.RunRequest.egress_gateway:type_name -> atelet.EgressGateway
+	37, // 4: atelet.ArchAssets.files:type_name -> atelet.ArchAssets.FilesEntry
+	38, // 5: atelet.SandboxAssets.assets:type_name -> atelet.SandboxAssets.AssetsEntry
+	22, // 6: atelet.WorkloadSpec.containers:type_name -> atelet.Container
+	20, // 7: atelet.WorkloadSpec.volumes:type_name -> atelet.Volume
+	39, // 8: atelet.ExternalVolumeSource.volume_context:type_name -> atelet.ExternalVolumeSource.VolumeContextEntry
+	0,  // 9: atelet.ActorMetadataItem.field:type_name -> atelet.ActorMetadataField
+	16, // 10: atelet.ActorMetadataDataSource.items:type_name -> atelet.ActorMetadataItem
+	17, // 11: atelet.SystemInfoDataSource.actor_metadata:type_name -> atelet.ActorMetadataDataSource
+	18, // 12: atelet.SystemInfoVolume.data_sources:type_name -> atelet.SystemInfoDataSource
+	13, // 13: atelet.Volume.durable_dir:type_name -> atelet.DurableDirVolume
+	14, // 14: atelet.Volume.external:type_name -> atelet.ExternalVolumeSource
+	19, // 15: atelet.Volume.system_info:type_name -> atelet.SystemInfoVolume
+	15, // 16: atelet.Volume.image:type_name -> atelet.ImageVolumeSource
+	25, // 17: atelet.Container.env:type_name -> atelet.EnvEntry
+	26, // 18: atelet.Container.readyz:type_name -> atelet.Readyz
+	21, // 19: atelet.Container.volume_mounts:type_name -> atelet.VolumeMount
+	23, // 20: atelet.Container.security_context:type_name -> atelet.SecurityContext
+	24, // 21: atelet.SecurityContext.capabilities:type_name -> atelet.Capabilities
+	27, // 22: atelet.Readyz.http_get:type_name -> atelet.HTTPGetAction
+	12, // 23: atelet.CheckpointRequest.spec:type_name -> atelet.WorkloadSpec
+	1,  // 24: atelet.CheckpointRequest.type:type_name -> atelet.CheckpointType
+	29, // 25: atelet.CheckpointRequest.local_config:type_name -> atelet.LocalCheckpointConfiguration
+	30, // 26: atelet.CheckpointRequest.external_config:type_name -> atelet.ExternalCheckpointConfiguration
+	2,  // 27: atelet.CheckpointRequest.scope:type_name -> atelet.SnapshotScope
+	2,  // 28: atelet.UploadPausedCheckpointRequest.desired_scope:type_name -> atelet.SnapshotScope
+	12, // 29: atelet.RestoreRequest.spec:type_name -> atelet.WorkloadSpec
+	1,  // 30: atelet.RestoreRequest.type:type_name -> atelet.CheckpointType
+	29, // 31: atelet.RestoreRequest.local_config:type_name -> atelet.LocalCheckpointConfiguration
+	30, // 32: atelet.RestoreRequest.external_config:type_name -> atelet.ExternalCheckpointConfiguration
+	2,  // 33: atelet.RestoreRequest.scope:type_name -> atelet.SnapshotScope
+	8,  // 34: atelet.RestoreRequest.egress_gateway:type_name -> atelet.EgressGateway
+	9,  // 35: atelet.ArchAssets.FilesEntry.value:type_name -> atelet.AssetFile
+	10, // 36: atelet.SandboxAssets.AssetsEntry.value:type_name -> atelet.ArchAssets
+	3,  // 37: atelet.CredentialBroker.MintActorCertificate:input_type -> atelet.MintActorCertificateRequest
+	7,  // 38: atelet.AteomHerder.Run:input_type -> atelet.RunRequest
+	31, // 39: atelet.AteomHerder.Checkpoint:input_type -> atelet.CheckpointRequest
+	35, // 40: atelet.AteomHerder.Restore:input_type -> atelet.RestoreRequest
+	33, // 41: atelet.AteomHerder.UploadPausedCheckpoint:input_type -> atelet.UploadPausedCheckpointRequest
+	5,  // 42: atelet.AteomHerder.Terminate:input_type -> atelet.TerminateRequest
+	4,  // 43: atelet.CredentialBroker.MintActorCertificate:output_type -> atelet.MintActorCertificateResponse
+	28, // 44: atelet.AteomHerder.Run:output_type -> atelet.RunResponse
+	32, // 45: atelet.AteomHerder.Checkpoint:output_type -> atelet.CheckpointResponse
+	36, // 46: atelet.AteomHerder.Restore:output_type -> atelet.RestoreResponse
+	34, // 47: atelet.AteomHerder.UploadPausedCheckpoint:output_type -> atelet.UploadPausedCheckpointResponse
+	6,  // 48: atelet.AteomHerder.Terminate:output_type -> atelet.TerminateResponse
+	43, // [43:49] is the sub-list for method output_type
+	37, // [37:43] is the sub-list for method input_type
+	37, // [37:37] is the sub-list for extension type_name
+	37, // [37:37] is the sub-list for extension extendee
+	0,  // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_atelet_proto_init() }
@@ -2603,21 +2747,21 @@ func file_atelet_proto_init() {
 	if File_atelet_proto != nil {
 		return
 	}
-	file_atelet_proto_msgTypes[2].OneofWrappers = []any{}
-	file_atelet_proto_msgTypes[13].OneofWrappers = []any{
+	file_atelet_proto_msgTypes[4].OneofWrappers = []any{}
+	file_atelet_proto_msgTypes[15].OneofWrappers = []any{
 		(*SystemInfoDataSource_ActorMetadata)(nil),
 	}
-	file_atelet_proto_msgTypes[15].OneofWrappers = []any{
+	file_atelet_proto_msgTypes[17].OneofWrappers = []any{
 		(*Volume_DurableDir)(nil),
 		(*Volume_External)(nil),
 		(*Volume_SystemInfo)(nil),
 		(*Volume_Image)(nil),
 	}
-	file_atelet_proto_msgTypes[26].OneofWrappers = []any{
+	file_atelet_proto_msgTypes[28].OneofWrappers = []any{
 		(*CheckpointRequest_LocalConfig)(nil),
 		(*CheckpointRequest_ExternalConfig)(nil),
 	}
-	file_atelet_proto_msgTypes[30].OneofWrappers = []any{
+	file_atelet_proto_msgTypes[32].OneofWrappers = []any{
 		(*RestoreRequest_LocalConfig)(nil),
 		(*RestoreRequest_ExternalConfig)(nil),
 	}
@@ -2627,7 +2771,7 @@ func file_atelet_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_atelet_proto_rawDesc), len(file_atelet_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   35,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/internal/proto/ateletpb/atelet.proto
+++ b/internal/proto/ateletpb/atelet.proto
@@ -56,6 +56,26 @@ service AteomHerder {
   // paused, its sandbox is gone; the checkpoint files plus their manifest
   // already sit under the actor's local-checkpoints directory.
   rpc UploadPausedCheckpoint(UploadPausedCheckpointRequest) returns (UploadPausedCheckpointResponse) {}
+
+  // Terminate tells atelet to terminate/kill any running workload for an actor,
+  // unmount its volumes, and clean up actor state on the node.
+  rpc Terminate(TerminateRequest) returns (TerminateResponse) {}
+}
+
+message TerminateRequest {
+  string target_ateom_uid = 1;
+
+  string atespace = 2;
+  string actor_name = 3;
+  string actor_uid = 4;
+
+  string actor_template_namespace = 5;
+  string actor_template_name = 6;
+
+  WorkloadSpec spec = 7;
+}
+
+message TerminateResponse {
 }
 
 message RunRequest {

--- a/internal/proto/ateletpb/atelet_grpc.pb.go
+++ b/internal/proto/ateletpb/atelet_grpc.pb.go
@@ -143,6 +143,7 @@ const (
 	AteomHerder_Checkpoint_FullMethodName             = "/atelet.AteomHerder/Checkpoint"
 	AteomHerder_Restore_FullMethodName                = "/atelet.AteomHerder/Restore"
 	AteomHerder_UploadPausedCheckpoint_FullMethodName = "/atelet.AteomHerder/UploadPausedCheckpoint"
+	AteomHerder_Terminate_FullMethodName              = "/atelet.AteomHerder/Terminate"
 )
 
 // AteomHerderClient is the client API for AteomHerder service.
@@ -163,6 +164,9 @@ type AteomHerderClient interface {
 	// paused, its sandbox is gone; the checkpoint files plus their manifest
 	// already sit under the actor's local-checkpoints directory.
 	UploadPausedCheckpoint(ctx context.Context, in *UploadPausedCheckpointRequest, opts ...grpc.CallOption) (*UploadPausedCheckpointResponse, error)
+	// Terminate tells atelet to terminate/kill any running workload for an actor,
+	// unmount its volumes, and clean up actor state on the node.
+	Terminate(ctx context.Context, in *TerminateRequest, opts ...grpc.CallOption) (*TerminateResponse, error)
 }
 
 type ateomHerderClient struct {
@@ -213,6 +217,16 @@ func (c *ateomHerderClient) UploadPausedCheckpoint(ctx context.Context, in *Uplo
 	return out, nil
 }
 
+func (c *ateomHerderClient) Terminate(ctx context.Context, in *TerminateRequest, opts ...grpc.CallOption) (*TerminateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TerminateResponse)
+	err := c.cc.Invoke(ctx, AteomHerder_Terminate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AteomHerderServer is the server API for AteomHerder service.
 // All implementations must embed UnimplementedAteomHerderServer
 // for forward compatibility.
@@ -231,6 +245,9 @@ type AteomHerderServer interface {
 	// paused, its sandbox is gone; the checkpoint files plus their manifest
 	// already sit under the actor's local-checkpoints directory.
 	UploadPausedCheckpoint(context.Context, *UploadPausedCheckpointRequest) (*UploadPausedCheckpointResponse, error)
+	// Terminate tells atelet to terminate/kill any running workload for an actor,
+	// unmount its volumes, and clean up actor state on the node.
+	Terminate(context.Context, *TerminateRequest) (*TerminateResponse, error)
 	mustEmbedUnimplementedAteomHerderServer()
 }
 
@@ -252,6 +269,9 @@ func (UnimplementedAteomHerderServer) Restore(context.Context, *RestoreRequest) 
 }
 func (UnimplementedAteomHerderServer) UploadPausedCheckpoint(context.Context, *UploadPausedCheckpointRequest) (*UploadPausedCheckpointResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UploadPausedCheckpoint not implemented")
+}
+func (UnimplementedAteomHerderServer) Terminate(context.Context, *TerminateRequest) (*TerminateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Terminate not implemented")
 }
 func (UnimplementedAteomHerderServer) mustEmbedUnimplementedAteomHerderServer() {}
 func (UnimplementedAteomHerderServer) testEmbeddedByValue()                     {}
@@ -346,6 +366,24 @@ func _AteomHerder_UploadPausedCheckpoint_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AteomHerder_Terminate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TerminateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AteomHerderServer).Terminate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AteomHerder_Terminate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AteomHerderServer).Terminate(ctx, req.(*TerminateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AteomHerder_ServiceDesc is the grpc.ServiceDesc for AteomHerder service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -368,6 +406,10 @@ var AteomHerder_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UploadPausedCheckpoint",
 			Handler:    _AteomHerder_UploadPausedCheckpoint_Handler,
+		},
+		{
+			MethodName: "Terminate",
+			Handler:    _AteomHerder_Terminate_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -268,6 +268,134 @@ func (NoSampleReason) EnumDescriptor() ([]byte, []int) {
 	return file_ateom_proto_rawDescGZIP(), []int{3}
 }
 
+type TerminateWorkloadRequest struct {
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName              string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid               string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateNamespace string                 `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	RunscPath              string                 `protobuf:"bytes,6,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *TerminateWorkloadRequest) Reset() {
+	*x = TerminateWorkloadRequest{}
+	mi := &file_ateom_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminateWorkloadRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminateWorkloadRequest) ProtoMessage() {}
+
+func (x *TerminateWorkloadRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateom_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminateWorkloadRequest.ProtoReflect.Descriptor instead.
+func (*TerminateWorkloadRequest) Descriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *TerminateWorkloadRequest) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *TerminateWorkloadRequest) GetActorName() string {
+	if x != nil {
+		return x.ActorName
+	}
+	return ""
+}
+
+func (x *TerminateWorkloadRequest) GetActorUid() string {
+	if x != nil {
+		return x.ActorUid
+	}
+	return ""
+}
+
+func (x *TerminateWorkloadRequest) GetActorTemplateNamespace() string {
+	if x != nil {
+		return x.ActorTemplateNamespace
+	}
+	return ""
+}
+
+func (x *TerminateWorkloadRequest) GetActorTemplateName() string {
+	if x != nil {
+		return x.ActorTemplateName
+	}
+	return ""
+}
+
+func (x *TerminateWorkloadRequest) GetRunscPath() string {
+	if x != nil {
+		return x.RunscPath
+	}
+	return ""
+}
+
+func (x *TerminateWorkloadRequest) GetSpec() *WorkloadSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+type TerminateWorkloadResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminateWorkloadResponse) Reset() {
+	*x = TerminateWorkloadResponse{}
+	mi := &file_ateom_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminateWorkloadResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminateWorkloadResponse) ProtoMessage() {}
+
+func (x *TerminateWorkloadResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ateom_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminateWorkloadResponse.ProtoReflect.Descriptor instead.
+func (*TerminateWorkloadResponse) Descriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{1}
+}
+
 type RunWorkloadRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
@@ -296,7 +424,7 @@ type RunWorkloadRequest struct {
 
 func (x *RunWorkloadRequest) Reset() {
 	*x = RunWorkloadRequest{}
-	mi := &file_ateom_proto_msgTypes[0]
+	mi := &file_ateom_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -308,7 +436,7 @@ func (x *RunWorkloadRequest) String() string {
 func (*RunWorkloadRequest) ProtoMessage() {}
 
 func (x *RunWorkloadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[0]
+	mi := &file_ateom_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -321,7 +449,7 @@ func (x *RunWorkloadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunWorkloadRequest.ProtoReflect.Descriptor instead.
 func (*RunWorkloadRequest) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{0}
+	return file_ateom_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *RunWorkloadRequest) GetAtespace() string {
@@ -413,7 +541,7 @@ type EgressGateway struct {
 
 func (x *EgressGateway) Reset() {
 	*x = EgressGateway{}
-	mi := &file_ateom_proto_msgTypes[1]
+	mi := &file_ateom_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -425,7 +553,7 @@ func (x *EgressGateway) String() string {
 func (*EgressGateway) ProtoMessage() {}
 
 func (x *EgressGateway) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[1]
+	mi := &file_ateom_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -438,7 +566,7 @@ func (x *EgressGateway) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EgressGateway.ProtoReflect.Descriptor instead.
 func (*EgressGateway) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{1}
+	return file_ateom_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *EgressGateway) GetAddress() string {
@@ -458,7 +586,7 @@ type WorkloadSpec struct {
 
 func (x *WorkloadSpec) Reset() {
 	*x = WorkloadSpec{}
-	mi := &file_ateom_proto_msgTypes[2]
+	mi := &file_ateom_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -470,7 +598,7 @@ func (x *WorkloadSpec) String() string {
 func (*WorkloadSpec) ProtoMessage() {}
 
 func (x *WorkloadSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[2]
+	mi := &file_ateom_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -483,7 +611,7 @@ func (x *WorkloadSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadSpec.ProtoReflect.Descriptor instead.
 func (*WorkloadSpec) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{2}
+	return file_ateom_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *WorkloadSpec) GetContainers() []*Container {
@@ -514,7 +642,7 @@ type Container struct {
 
 func (x *Container) Reset() {
 	*x = Container{}
-	mi := &file_ateom_proto_msgTypes[3]
+	mi := &file_ateom_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -526,7 +654,7 @@ func (x *Container) String() string {
 func (*Container) ProtoMessage() {}
 
 func (x *Container) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[3]
+	mi := &file_ateom_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -539,7 +667,7 @@ func (x *Container) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Container.ProtoReflect.Descriptor instead.
 func (*Container) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{3}
+	return file_ateom_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Container) GetName() string {
@@ -595,7 +723,7 @@ type VolumeMount struct {
 
 func (x *VolumeMount) Reset() {
 	*x = VolumeMount{}
-	mi := &file_ateom_proto_msgTypes[4]
+	mi := &file_ateom_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -607,7 +735,7 @@ func (x *VolumeMount) String() string {
 func (*VolumeMount) ProtoMessage() {}
 
 func (x *VolumeMount) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[4]
+	mi := &file_ateom_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -620,7 +748,7 @@ func (x *VolumeMount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeMount.ProtoReflect.Descriptor instead.
 func (*VolumeMount) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{4}
+	return file_ateom_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *VolumeMount) GetVolumeName() string {
@@ -651,7 +779,7 @@ type DurableDirVolumeMount struct {
 
 func (x *DurableDirVolumeMount) Reset() {
 	*x = DurableDirVolumeMount{}
-	mi := &file_ateom_proto_msgTypes[5]
+	mi := &file_ateom_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -663,7 +791,7 @@ func (x *DurableDirVolumeMount) String() string {
 func (*DurableDirVolumeMount) ProtoMessage() {}
 
 func (x *DurableDirVolumeMount) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[5]
+	mi := &file_ateom_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -676,7 +804,7 @@ func (x *DurableDirVolumeMount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DurableDirVolumeMount.ProtoReflect.Descriptor instead.
 func (*DurableDirVolumeMount) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{5}
+	return file_ateom_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *DurableDirVolumeMount) GetVolumeName() string {
@@ -709,7 +837,7 @@ type SystemInfoVolumeMount struct {
 
 func (x *SystemInfoVolumeMount) Reset() {
 	*x = SystemInfoVolumeMount{}
-	mi := &file_ateom_proto_msgTypes[6]
+	mi := &file_ateom_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -721,7 +849,7 @@ func (x *SystemInfoVolumeMount) String() string {
 func (*SystemInfoVolumeMount) ProtoMessage() {}
 
 func (x *SystemInfoVolumeMount) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[6]
+	mi := &file_ateom_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -734,7 +862,7 @@ func (x *SystemInfoVolumeMount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemInfoVolumeMount.ProtoReflect.Descriptor instead.
 func (*SystemInfoVolumeMount) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{6}
+	return file_ateom_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *SystemInfoVolumeMount) GetVolumeName() string {
@@ -766,7 +894,7 @@ type ImageVolumeMount struct {
 
 func (x *ImageVolumeMount) Reset() {
 	*x = ImageVolumeMount{}
-	mi := &file_ateom_proto_msgTypes[7]
+	mi := &file_ateom_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -778,7 +906,7 @@ func (x *ImageVolumeMount) String() string {
 func (*ImageVolumeMount) ProtoMessage() {}
 
 func (x *ImageVolumeMount) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[7]
+	mi := &file_ateom_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -791,7 +919,7 @@ func (x *ImageVolumeMount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageVolumeMount.ProtoReflect.Descriptor instead.
 func (*ImageVolumeMount) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{7}
+	return file_ateom_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ImageVolumeMount) GetVolumeName() string {
@@ -822,7 +950,7 @@ type Readyz struct {
 
 func (x *Readyz) Reset() {
 	*x = Readyz{}
-	mi := &file_ateom_proto_msgTypes[8]
+	mi := &file_ateom_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -834,7 +962,7 @@ func (x *Readyz) String() string {
 func (*Readyz) ProtoMessage() {}
 
 func (x *Readyz) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[8]
+	mi := &file_ateom_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -847,7 +975,7 @@ func (x *Readyz) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Readyz.ProtoReflect.Descriptor instead.
 func (*Readyz) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{8}
+	return file_ateom_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Readyz) GetHttpGet() *HTTPGetAction {
@@ -877,7 +1005,7 @@ type HTTPGetAction struct {
 
 func (x *HTTPGetAction) Reset() {
 	*x = HTTPGetAction{}
-	mi := &file_ateom_proto_msgTypes[9]
+	mi := &file_ateom_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -889,7 +1017,7 @@ func (x *HTTPGetAction) String() string {
 func (*HTTPGetAction) ProtoMessage() {}
 
 func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[9]
+	mi := &file_ateom_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -902,7 +1030,7 @@ func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPGetAction.ProtoReflect.Descriptor instead.
 func (*HTTPGetAction) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{9}
+	return file_ateom_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *HTTPGetAction) GetPath() string {
@@ -927,7 +1055,7 @@ type RunWorkloadResponse struct {
 
 func (x *RunWorkloadResponse) Reset() {
 	*x = RunWorkloadResponse{}
-	mi := &file_ateom_proto_msgTypes[10]
+	mi := &file_ateom_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -939,7 +1067,7 @@ func (x *RunWorkloadResponse) String() string {
 func (*RunWorkloadResponse) ProtoMessage() {}
 
 func (x *RunWorkloadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[10]
+	mi := &file_ateom_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -952,7 +1080,7 @@ func (x *RunWorkloadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunWorkloadResponse.ProtoReflect.Descriptor instead.
 func (*RunWorkloadResponse) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{10}
+	return file_ateom_proto_rawDescGZIP(), []int{12}
 }
 
 type CheckpointWorkloadRequest struct {
@@ -986,7 +1114,7 @@ type CheckpointWorkloadRequest struct {
 
 func (x *CheckpointWorkloadRequest) Reset() {
 	*x = CheckpointWorkloadRequest{}
-	mi := &file_ateom_proto_msgTypes[11]
+	mi := &file_ateom_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -998,7 +1126,7 @@ func (x *CheckpointWorkloadRequest) String() string {
 func (*CheckpointWorkloadRequest) ProtoMessage() {}
 
 func (x *CheckpointWorkloadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[11]
+	mi := &file_ateom_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1011,7 +1139,7 @@ func (x *CheckpointWorkloadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckpointWorkloadRequest.ProtoReflect.Descriptor instead.
 func (*CheckpointWorkloadRequest) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{11}
+	return file_ateom_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *CheckpointWorkloadRequest) GetAtespace() string {
@@ -1096,7 +1224,7 @@ type CheckpointWorkloadResponse struct {
 
 func (x *CheckpointWorkloadResponse) Reset() {
 	*x = CheckpointWorkloadResponse{}
-	mi := &file_ateom_proto_msgTypes[12]
+	mi := &file_ateom_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1108,7 +1236,7 @@ func (x *CheckpointWorkloadResponse) String() string {
 func (*CheckpointWorkloadResponse) ProtoMessage() {}
 
 func (x *CheckpointWorkloadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[12]
+	mi := &file_ateom_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1121,7 +1249,7 @@ func (x *CheckpointWorkloadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckpointWorkloadResponse.ProtoReflect.Descriptor instead.
 func (*CheckpointWorkloadResponse) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{12}
+	return file_ateom_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CheckpointWorkloadResponse) GetSnapshotFiles() []string {
@@ -1166,7 +1294,7 @@ type RestoreWorkloadRequest struct {
 
 func (x *RestoreWorkloadRequest) Reset() {
 	*x = RestoreWorkloadRequest{}
-	mi := &file_ateom_proto_msgTypes[13]
+	mi := &file_ateom_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1178,7 +1306,7 @@ func (x *RestoreWorkloadRequest) String() string {
 func (*RestoreWorkloadRequest) ProtoMessage() {}
 
 func (x *RestoreWorkloadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[13]
+	mi := &file_ateom_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1191,7 +1319,7 @@ func (x *RestoreWorkloadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreWorkloadRequest.ProtoReflect.Descriptor instead.
 func (*RestoreWorkloadRequest) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{13}
+	return file_ateom_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *RestoreWorkloadRequest) GetAtespace() string {
@@ -1300,7 +1428,7 @@ type RestoreWorkloadResponse struct {
 
 func (x *RestoreWorkloadResponse) Reset() {
 	*x = RestoreWorkloadResponse{}
-	mi := &file_ateom_proto_msgTypes[14]
+	mi := &file_ateom_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1312,7 +1440,7 @@ func (x *RestoreWorkloadResponse) String() string {
 func (*RestoreWorkloadResponse) ProtoMessage() {}
 
 func (x *RestoreWorkloadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[14]
+	mi := &file_ateom_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1325,7 +1453,7 @@ func (x *RestoreWorkloadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreWorkloadResponse.ProtoReflect.Descriptor instead.
 func (*RestoreWorkloadResponse) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{14}
+	return file_ateom_proto_rawDescGZIP(), []int{16}
 }
 
 type GetWorkloadStatsRequest struct {
@@ -1341,7 +1469,7 @@ type GetWorkloadStatsRequest struct {
 
 func (x *GetWorkloadStatsRequest) Reset() {
 	*x = GetWorkloadStatsRequest{}
-	mi := &file_ateom_proto_msgTypes[15]
+	mi := &file_ateom_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1353,7 +1481,7 @@ func (x *GetWorkloadStatsRequest) String() string {
 func (*GetWorkloadStatsRequest) ProtoMessage() {}
 
 func (x *GetWorkloadStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[15]
+	mi := &file_ateom_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1366,7 +1494,7 @@ func (x *GetWorkloadStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkloadStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetWorkloadStatsRequest) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{15}
+	return file_ateom_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetWorkloadStatsRequest) GetActorUid() string {
@@ -1430,7 +1558,7 @@ type WorkloadStatsSample struct {
 
 func (x *WorkloadStatsSample) Reset() {
 	*x = WorkloadStatsSample{}
-	mi := &file_ateom_proto_msgTypes[16]
+	mi := &file_ateom_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1442,7 +1570,7 @@ func (x *WorkloadStatsSample) String() string {
 func (*WorkloadStatsSample) ProtoMessage() {}
 
 func (x *WorkloadStatsSample) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[16]
+	mi := &file_ateom_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1455,7 +1583,7 @@ func (x *WorkloadStatsSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadStatsSample.ProtoReflect.Descriptor instead.
 func (*WorkloadStatsSample) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{16}
+	return file_ateom_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *WorkloadStatsSample) GetAtespace() string {
@@ -1551,7 +1679,7 @@ type GetWorkloadStatsResponse struct {
 
 func (x *GetWorkloadStatsResponse) Reset() {
 	*x = GetWorkloadStatsResponse{}
-	mi := &file_ateom_proto_msgTypes[17]
+	mi := &file_ateom_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1563,7 +1691,7 @@ func (x *GetWorkloadStatsResponse) String() string {
 func (*GetWorkloadStatsResponse) ProtoMessage() {}
 
 func (x *GetWorkloadStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[17]
+	mi := &file_ateom_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1576,7 +1704,7 @@ func (x *GetWorkloadStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkloadStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetWorkloadStatsResponse) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{17}
+	return file_ateom_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetWorkloadStatsResponse) GetSample() *WorkloadStatsSample {
@@ -1594,7 +1722,7 @@ type GetActiveWorkloadStatsRequest struct {
 
 func (x *GetActiveWorkloadStatsRequest) Reset() {
 	*x = GetActiveWorkloadStatsRequest{}
-	mi := &file_ateom_proto_msgTypes[18]
+	mi := &file_ateom_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1606,7 +1734,7 @@ func (x *GetActiveWorkloadStatsRequest) String() string {
 func (*GetActiveWorkloadStatsRequest) ProtoMessage() {}
 
 func (x *GetActiveWorkloadStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[18]
+	mi := &file_ateom_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1619,7 +1747,7 @@ func (x *GetActiveWorkloadStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActiveWorkloadStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetActiveWorkloadStatsRequest) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{18}
+	return file_ateom_proto_rawDescGZIP(), []int{20}
 }
 
 type GetActiveWorkloadStatsResponse struct {
@@ -1641,7 +1769,7 @@ type GetActiveWorkloadStatsResponse struct {
 
 func (x *GetActiveWorkloadStatsResponse) Reset() {
 	*x = GetActiveWorkloadStatsResponse{}
-	mi := &file_ateom_proto_msgTypes[19]
+	mi := &file_ateom_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1653,7 +1781,7 @@ func (x *GetActiveWorkloadStatsResponse) String() string {
 func (*GetActiveWorkloadStatsResponse) ProtoMessage() {}
 
 func (x *GetActiveWorkloadStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateom_proto_msgTypes[19]
+	mi := &file_ateom_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1666,7 +1794,7 @@ func (x *GetActiveWorkloadStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActiveWorkloadStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetActiveWorkloadStatsResponse) Descriptor() ([]byte, []int) {
-	return file_ateom_proto_rawDescGZIP(), []int{19}
+	return file_ateom_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetActiveWorkloadStatsResponse) GetResult() isGetActiveWorkloadStatsResponse_Result {
@@ -1714,7 +1842,18 @@ var File_ateom_proto protoreflect.FileDescriptor
 
 const file_ateom_proto_rawDesc = "" +
 	"\n" +
-	"\vateom.proto\x12\x05ateom\"\xdb\x04\n" +
+	"\vateom.proto\x12\x05ateom\"\xa4\x02\n" +
+	"\x18TerminateWorkloadRequest\x12\x1a\n" +
+	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
+	"\n" +
+	"actor_name\x18\x02 \x01(\tR\tactorName\x12\x1b\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x128\n" +
+	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12\x1d\n" +
+	"\n" +
+	"runsc_path\x18\x06 \x01(\tR\trunscPath\x12'\n" +
+	"\x04spec\x18\a \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\"\x1b\n" +
+	"\x19TerminateWorkloadResponse\"\xdb\x04\n" +
 	"\x12RunWorkloadRequest\x12\x1a\n" +
 	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
@@ -1856,13 +1995,14 @@ const file_ateom_proto_rawDesc = "" +
 	"\x0eNoSampleReason\x12 \n" +
 	"\x1cNO_SAMPLE_REASON_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cNO_SAMPLE_REASON_NO_WORKLOAD\x10\x01\x12'\n" +
-	"#NO_SAMPLE_REASON_NOT_MEASURABLE_YET\x10\x022\xc0\x03\n" +
+	"#NO_SAMPLE_REASON_NOT_MEASURABLE_YET\x10\x022\x9a\x04\n" +
 	"\x05Ateom\x12F\n" +
 	"\vRunWorkload\x12\x19.ateom.RunWorkloadRequest\x1a\x1a.ateom.RunWorkloadResponse\"\x00\x12[\n" +
 	"\x12CheckpointWorkload\x12 .ateom.CheckpointWorkloadRequest\x1a!.ateom.CheckpointWorkloadResponse\"\x00\x12R\n" +
 	"\x0fRestoreWorkload\x12\x1d.ateom.RestoreWorkloadRequest\x1a\x1e.ateom.RestoreWorkloadResponse\"\x00\x12U\n" +
 	"\x10GetWorkloadStats\x12\x1e.ateom.GetWorkloadStatsRequest\x1a\x1f.ateom.GetWorkloadStatsResponse\"\x00\x12g\n" +
-	"\x16GetActiveWorkloadStats\x12$.ateom.GetActiveWorkloadStatsRequest\x1a%.ateom.GetActiveWorkloadStatsResponse\"\x00B=Z;github.com/agent-substrate/substrate/internal/proto/ateompbb\x06proto3"
+	"\x16GetActiveWorkloadStats\x12$.ateom.GetActiveWorkloadStatsRequest\x1a%.ateom.GetActiveWorkloadStatsResponse\"\x00\x12X\n" +
+	"\x11TerminateWorkload\x12\x1f.ateom.TerminateWorkloadRequest\x1a .ateom.TerminateWorkloadResponse\"\x00B=Z;github.com/agent-substrate/substrate/internal/proto/ateompbb\x06proto3"
 
 var (
 	file_ateom_proto_rawDescOnce sync.Once
@@ -1877,74 +2017,79 @@ func file_ateom_proto_rawDescGZIP() []byte {
 }
 
 var file_ateom_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_ateom_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_ateom_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_ateom_proto_goTypes = []any{
 	(SnapshotScope)(0),                     // 0: ateom.SnapshotScope
 	(SandboxClass)(0),                      // 1: ateom.SandboxClass
 	(StatsSource)(0),                       // 2: ateom.StatsSource
 	(NoSampleReason)(0),                    // 3: ateom.NoSampleReason
-	(*RunWorkloadRequest)(nil),             // 4: ateom.RunWorkloadRequest
-	(*EgressGateway)(nil),                  // 5: ateom.EgressGateway
-	(*WorkloadSpec)(nil),                   // 6: ateom.WorkloadSpec
-	(*Container)(nil),                      // 7: ateom.Container
-	(*VolumeMount)(nil),                    // 8: ateom.VolumeMount
-	(*DurableDirVolumeMount)(nil),          // 9: ateom.DurableDirVolumeMount
-	(*SystemInfoVolumeMount)(nil),          // 10: ateom.SystemInfoVolumeMount
-	(*ImageVolumeMount)(nil),               // 11: ateom.ImageVolumeMount
-	(*Readyz)(nil),                         // 12: ateom.Readyz
-	(*HTTPGetAction)(nil),                  // 13: ateom.HTTPGetAction
-	(*RunWorkloadResponse)(nil),            // 14: ateom.RunWorkloadResponse
-	(*CheckpointWorkloadRequest)(nil),      // 15: ateom.CheckpointWorkloadRequest
-	(*CheckpointWorkloadResponse)(nil),     // 16: ateom.CheckpointWorkloadResponse
-	(*RestoreWorkloadRequest)(nil),         // 17: ateom.RestoreWorkloadRequest
-	(*RestoreWorkloadResponse)(nil),        // 18: ateom.RestoreWorkloadResponse
-	(*GetWorkloadStatsRequest)(nil),        // 19: ateom.GetWorkloadStatsRequest
-	(*WorkloadStatsSample)(nil),            // 20: ateom.WorkloadStatsSample
-	(*GetWorkloadStatsResponse)(nil),       // 21: ateom.GetWorkloadStatsResponse
-	(*GetActiveWorkloadStatsRequest)(nil),  // 22: ateom.GetActiveWorkloadStatsRequest
-	(*GetActiveWorkloadStatsResponse)(nil), // 23: ateom.GetActiveWorkloadStatsResponse
-	nil,                                    // 24: ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
-	nil,                                    // 25: ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
-	nil,                                    // 26: ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
+	(*TerminateWorkloadRequest)(nil),       // 4: ateom.TerminateWorkloadRequest
+	(*TerminateWorkloadResponse)(nil),      // 5: ateom.TerminateWorkloadResponse
+	(*RunWorkloadRequest)(nil),             // 6: ateom.RunWorkloadRequest
+	(*EgressGateway)(nil),                  // 7: ateom.EgressGateway
+	(*WorkloadSpec)(nil),                   // 8: ateom.WorkloadSpec
+	(*Container)(nil),                      // 9: ateom.Container
+	(*VolumeMount)(nil),                    // 10: ateom.VolumeMount
+	(*DurableDirVolumeMount)(nil),          // 11: ateom.DurableDirVolumeMount
+	(*SystemInfoVolumeMount)(nil),          // 12: ateom.SystemInfoVolumeMount
+	(*ImageVolumeMount)(nil),               // 13: ateom.ImageVolumeMount
+	(*Readyz)(nil),                         // 14: ateom.Readyz
+	(*HTTPGetAction)(nil),                  // 15: ateom.HTTPGetAction
+	(*RunWorkloadResponse)(nil),            // 16: ateom.RunWorkloadResponse
+	(*CheckpointWorkloadRequest)(nil),      // 17: ateom.CheckpointWorkloadRequest
+	(*CheckpointWorkloadResponse)(nil),     // 18: ateom.CheckpointWorkloadResponse
+	(*RestoreWorkloadRequest)(nil),         // 19: ateom.RestoreWorkloadRequest
+	(*RestoreWorkloadResponse)(nil),        // 20: ateom.RestoreWorkloadResponse
+	(*GetWorkloadStatsRequest)(nil),        // 21: ateom.GetWorkloadStatsRequest
+	(*WorkloadStatsSample)(nil),            // 22: ateom.WorkloadStatsSample
+	(*GetWorkloadStatsResponse)(nil),       // 23: ateom.GetWorkloadStatsResponse
+	(*GetActiveWorkloadStatsRequest)(nil),  // 24: ateom.GetActiveWorkloadStatsRequest
+	(*GetActiveWorkloadStatsResponse)(nil), // 25: ateom.GetActiveWorkloadStatsResponse
+	nil,                                    // 26: ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
+	nil,                                    // 27: ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
+	nil,                                    // 28: ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
 }
 var file_ateom_proto_depIdxs = []int32{
-	6,  // 0: ateom.RunWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	24, // 1: ateom.RunWorkloadRequest.runtime_asset_paths:type_name -> ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
-	5,  // 2: ateom.RunWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
-	7,  // 3: ateom.WorkloadSpec.containers:type_name -> ateom.Container
-	12, // 4: ateom.Container.readyz:type_name -> ateom.Readyz
-	9,  // 5: ateom.Container.durable_dir_volume_mounts:type_name -> ateom.DurableDirVolumeMount
-	8,  // 6: ateom.Container.csi_volume_mounts:type_name -> ateom.VolumeMount
-	10, // 7: ateom.Container.system_info_volume_mounts:type_name -> ateom.SystemInfoVolumeMount
-	11, // 8: ateom.Container.image_volume_mounts:type_name -> ateom.ImageVolumeMount
-	13, // 9: ateom.Readyz.http_get:type_name -> ateom.HTTPGetAction
-	6,  // 10: ateom.CheckpointWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	25, // 11: ateom.CheckpointWorkloadRequest.runtime_asset_paths:type_name -> ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
-	0,  // 12: ateom.CheckpointWorkloadRequest.scope:type_name -> ateom.SnapshotScope
-	6,  // 13: ateom.RestoreWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	26, // 14: ateom.RestoreWorkloadRequest.runtime_asset_paths:type_name -> ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
-	0,  // 15: ateom.RestoreWorkloadRequest.scope:type_name -> ateom.SnapshotScope
-	5,  // 16: ateom.RestoreWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
-	1,  // 17: ateom.WorkloadStatsSample.sandbox_class:type_name -> ateom.SandboxClass
-	2,  // 18: ateom.WorkloadStatsSample.source:type_name -> ateom.StatsSource
-	20, // 19: ateom.GetWorkloadStatsResponse.sample:type_name -> ateom.WorkloadStatsSample
-	20, // 20: ateom.GetActiveWorkloadStatsResponse.sample:type_name -> ateom.WorkloadStatsSample
-	3,  // 21: ateom.GetActiveWorkloadStatsResponse.no_sample_reason:type_name -> ateom.NoSampleReason
-	4,  // 22: ateom.Ateom.RunWorkload:input_type -> ateom.RunWorkloadRequest
-	15, // 23: ateom.Ateom.CheckpointWorkload:input_type -> ateom.CheckpointWorkloadRequest
-	17, // 24: ateom.Ateom.RestoreWorkload:input_type -> ateom.RestoreWorkloadRequest
-	19, // 25: ateom.Ateom.GetWorkloadStats:input_type -> ateom.GetWorkloadStatsRequest
-	22, // 26: ateom.Ateom.GetActiveWorkloadStats:input_type -> ateom.GetActiveWorkloadStatsRequest
-	14, // 27: ateom.Ateom.RunWorkload:output_type -> ateom.RunWorkloadResponse
-	16, // 28: ateom.Ateom.CheckpointWorkload:output_type -> ateom.CheckpointWorkloadResponse
-	18, // 29: ateom.Ateom.RestoreWorkload:output_type -> ateom.RestoreWorkloadResponse
-	21, // 30: ateom.Ateom.GetWorkloadStats:output_type -> ateom.GetWorkloadStatsResponse
-	23, // 31: ateom.Ateom.GetActiveWorkloadStats:output_type -> ateom.GetActiveWorkloadStatsResponse
-	27, // [27:32] is the sub-list for method output_type
-	22, // [22:27] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	8,  // 0: ateom.TerminateWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
+	8,  // 1: ateom.RunWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
+	26, // 2: ateom.RunWorkloadRequest.runtime_asset_paths:type_name -> ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
+	7,  // 3: ateom.RunWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
+	9,  // 4: ateom.WorkloadSpec.containers:type_name -> ateom.Container
+	14, // 5: ateom.Container.readyz:type_name -> ateom.Readyz
+	11, // 6: ateom.Container.durable_dir_volume_mounts:type_name -> ateom.DurableDirVolumeMount
+	10, // 7: ateom.Container.csi_volume_mounts:type_name -> ateom.VolumeMount
+	12, // 8: ateom.Container.system_info_volume_mounts:type_name -> ateom.SystemInfoVolumeMount
+	13, // 9: ateom.Container.image_volume_mounts:type_name -> ateom.ImageVolumeMount
+	15, // 10: ateom.Readyz.http_get:type_name -> ateom.HTTPGetAction
+	8,  // 11: ateom.CheckpointWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
+	27, // 12: ateom.CheckpointWorkloadRequest.runtime_asset_paths:type_name -> ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
+	0,  // 13: ateom.CheckpointWorkloadRequest.scope:type_name -> ateom.SnapshotScope
+	8,  // 14: ateom.RestoreWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
+	28, // 15: ateom.RestoreWorkloadRequest.runtime_asset_paths:type_name -> ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
+	0,  // 16: ateom.RestoreWorkloadRequest.scope:type_name -> ateom.SnapshotScope
+	7,  // 17: ateom.RestoreWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
+	1,  // 18: ateom.WorkloadStatsSample.sandbox_class:type_name -> ateom.SandboxClass
+	2,  // 19: ateom.WorkloadStatsSample.source:type_name -> ateom.StatsSource
+	22, // 20: ateom.GetWorkloadStatsResponse.sample:type_name -> ateom.WorkloadStatsSample
+	22, // 21: ateom.GetActiveWorkloadStatsResponse.sample:type_name -> ateom.WorkloadStatsSample
+	3,  // 22: ateom.GetActiveWorkloadStatsResponse.no_sample_reason:type_name -> ateom.NoSampleReason
+	6,  // 23: ateom.Ateom.RunWorkload:input_type -> ateom.RunWorkloadRequest
+	17, // 24: ateom.Ateom.CheckpointWorkload:input_type -> ateom.CheckpointWorkloadRequest
+	19, // 25: ateom.Ateom.RestoreWorkload:input_type -> ateom.RestoreWorkloadRequest
+	21, // 26: ateom.Ateom.GetWorkloadStats:input_type -> ateom.GetWorkloadStatsRequest
+	24, // 27: ateom.Ateom.GetActiveWorkloadStats:input_type -> ateom.GetActiveWorkloadStatsRequest
+	4,  // 28: ateom.Ateom.TerminateWorkload:input_type -> ateom.TerminateWorkloadRequest
+	16, // 29: ateom.Ateom.RunWorkload:output_type -> ateom.RunWorkloadResponse
+	18, // 30: ateom.Ateom.CheckpointWorkload:output_type -> ateom.CheckpointWorkloadResponse
+	20, // 31: ateom.Ateom.RestoreWorkload:output_type -> ateom.RestoreWorkloadResponse
+	23, // 32: ateom.Ateom.GetWorkloadStats:output_type -> ateom.GetWorkloadStatsResponse
+	25, // 33: ateom.Ateom.GetActiveWorkloadStats:output_type -> ateom.GetActiveWorkloadStatsResponse
+	5,  // 34: ateom.Ateom.TerminateWorkload:output_type -> ateom.TerminateWorkloadResponse
+	29, // [29:35] is the sub-list for method output_type
+	23, // [23:29] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_ateom_proto_init() }
@@ -1952,9 +2097,9 @@ func file_ateom_proto_init() {
 	if File_ateom_proto != nil {
 		return
 	}
-	file_ateom_proto_msgTypes[0].OneofWrappers = []any{}
-	file_ateom_proto_msgTypes[13].OneofWrappers = []any{}
-	file_ateom_proto_msgTypes[19].OneofWrappers = []any{
+	file_ateom_proto_msgTypes[2].OneofWrappers = []any{}
+	file_ateom_proto_msgTypes[15].OneofWrappers = []any{}
+	file_ateom_proto_msgTypes[21].OneofWrappers = []any{
 		(*GetActiveWorkloadStatsResponse_Sample)(nil),
 		(*GetActiveWorkloadStatsResponse_NoSampleReason)(nil),
 	}
@@ -1964,7 +2109,7 @@ func file_ateom_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateom_proto_rawDesc), len(file_ateom_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   23,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -98,6 +98,25 @@ service Ateom {
   // it is a pure read, safe on a timer, and does not touch the lifecycle
   // mutex.
   rpc GetActiveWorkloadStats(GetActiveWorkloadStatsRequest) returns (GetActiveWorkloadStatsResponse) {}
+
+  // TerminateWorkload stops and deletes container workloads and cleans up
+  // network and bundle overlays on ateom.
+  rpc TerminateWorkload(TerminateWorkloadRequest) returns (TerminateWorkloadResponse) {}
+}
+
+message TerminateWorkloadRequest {
+  string atespace = 1;
+  string actor_name = 2;
+  string actor_uid = 3;
+
+  string actor_template_namespace = 4;
+  string actor_template_name = 5;
+
+  string runsc_path = 6;
+  WorkloadSpec spec = 7;
+}
+
+message TerminateWorkloadResponse {
 }
 
 message RunWorkloadRequest {

--- a/internal/proto/ateompb/ateom_grpc.pb.go
+++ b/internal/proto/ateompb/ateom_grpc.pb.go
@@ -38,6 +38,7 @@ const (
 	Ateom_RestoreWorkload_FullMethodName        = "/ateom.Ateom/RestoreWorkload"
 	Ateom_GetWorkloadStats_FullMethodName       = "/ateom.Ateom/GetWorkloadStats"
 	Ateom_GetActiveWorkloadStats_FullMethodName = "/ateom.Ateom/GetActiveWorkloadStats"
+	Ateom_TerminateWorkload_FullMethodName      = "/ateom.Ateom/TerminateWorkload"
 )
 
 // AteomClient is the client API for Ateom service.
@@ -120,6 +121,9 @@ type AteomClient interface {
 	// it is a pure read, safe on a timer, and does not touch the lifecycle
 	// mutex.
 	GetActiveWorkloadStats(ctx context.Context, in *GetActiveWorkloadStatsRequest, opts ...grpc.CallOption) (*GetActiveWorkloadStatsResponse, error)
+	// TerminateWorkload stops and deletes container workloads and cleans up
+	// network and bundle overlays on ateom.
+	TerminateWorkload(ctx context.Context, in *TerminateWorkloadRequest, opts ...grpc.CallOption) (*TerminateWorkloadResponse, error)
 }
 
 type ateomClient struct {
@@ -174,6 +178,16 @@ func (c *ateomClient) GetActiveWorkloadStats(ctx context.Context, in *GetActiveW
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetActiveWorkloadStatsResponse)
 	err := c.cc.Invoke(ctx, Ateom_GetActiveWorkloadStats_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *ateomClient) TerminateWorkload(ctx context.Context, in *TerminateWorkloadRequest, opts ...grpc.CallOption) (*TerminateWorkloadResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TerminateWorkloadResponse)
+	err := c.cc.Invoke(ctx, Ateom_TerminateWorkload_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -260,6 +274,9 @@ type AteomServer interface {
 	// it is a pure read, safe on a timer, and does not touch the lifecycle
 	// mutex.
 	GetActiveWorkloadStats(context.Context, *GetActiveWorkloadStatsRequest) (*GetActiveWorkloadStatsResponse, error)
+	// TerminateWorkload stops and deletes container workloads and cleans up
+	// network and bundle overlays on ateom.
+	TerminateWorkload(context.Context, *TerminateWorkloadRequest) (*TerminateWorkloadResponse, error)
 	mustEmbedUnimplementedAteomServer()
 }
 
@@ -284,6 +301,9 @@ func (UnimplementedAteomServer) GetWorkloadStats(context.Context, *GetWorkloadSt
 }
 func (UnimplementedAteomServer) GetActiveWorkloadStats(context.Context, *GetActiveWorkloadStatsRequest) (*GetActiveWorkloadStatsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetActiveWorkloadStats not implemented")
+}
+func (UnimplementedAteomServer) TerminateWorkload(context.Context, *TerminateWorkloadRequest) (*TerminateWorkloadResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method TerminateWorkload not implemented")
 }
 func (UnimplementedAteomServer) mustEmbedUnimplementedAteomServer() {}
 func (UnimplementedAteomServer) testEmbeddedByValue()               {}
@@ -396,6 +416,24 @@ func _Ateom_GetActiveWorkloadStats_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Ateom_TerminateWorkload_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TerminateWorkloadRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AteomServer).TerminateWorkload(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Ateom_TerminateWorkload_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AteomServer).TerminateWorkload(ctx, req.(*TerminateWorkloadRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Ateom_ServiceDesc is the grpc.ServiceDesc for Ateom service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -422,6 +460,10 @@ var Ateom_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetActiveWorkloadStats",
 			Handler:    _Ateom_GetActiveWorkloadStats_Handler,
+		},
+		{
+			MethodName: "TerminateWorkload",
+			Handler:    _Ateom_TerminateWorkload_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -3576,6 +3576,7 @@ func (x *ResumeActorResponse) GetResumed() bool {
 type DeleteActorRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Actor         *ObjectRef             `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
+	AnyState      bool                   `protobuf:"varint,2,opt,name=any_state,json=anyState,proto3" json:"any_state,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3615,6 +3616,13 @@ func (x *DeleteActorRequest) GetActor() *ObjectRef {
 		return x.Actor
 	}
 	return nil
+}
+
+func (x *DeleteActorRequest) GetAnyState() bool {
+	if x != nil {
+		return x.AnyState
+	}
+	return false
 }
 
 type GetActorSnapshotRequest struct {
@@ -5426,9 +5434,10 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x04boot\x18\x02 \x01(\bR\x04boot\"T\n" +
 	"\x13ResumeActorResponse\x12#\n" +
 	"\x05actor\x18\x01 \x01(\v2\r.ateapi.ActorR\x05actor\x12\x18\n" +
-	"\aresumed\x18\x02 \x01(\bR\aresumed\"=\n" +
+	"\aresumed\x18\x02 \x01(\bR\aresumed\"Z\n" +
 	"\x12DeleteActorRequest\x12'\n" +
-	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"H\n" +
+	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\x12\x1b\n" +
+	"\tany_state\x18\x02 \x01(\bR\banyState\"H\n" +
 	"\x17GetActorSnapshotRequest\x12-\n" +
 	"\bsnapshot\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\bsnapshot\"A\n" +
 	"\x1aGetActorSnapshotTagRequest\x12#\n" +

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -720,6 +720,7 @@ message ResumeActorResponse {
 
 message DeleteActorRequest {
   ObjectRef actor = 1;
+  bool any_state = 2;
 }
 
 message GetActorSnapshotRequest {


### PR DESCRIPTION
Fixes #643 
                                                                                                                                                                                                                                                                                                                                                 
This feature introduces the ability to delete Substrate actors from any lifecycle state (e.g., RUNNING, PAUSED, PENDING), rather than requiring them to be hibernated into SUSPENDED (or CRASHED) beforehand.  This is crucial for cleaning up stuck or failed actors.
                                                                                                                                                                                                                                                                                                                                                                     
  #### 1. Control Plane & gRPC API (pkg/proto/ateapipb, ateapi)                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                     
  • DeleteActorRequest.any_state: Added a new boolean field any_state to DeleteActorRequest.                                                                                                                                                                                                                                                                         
      • When false (default): enforces the existing behavior where only actors in ACTOR_STATE_SUSPENDED or ACTOR_STATE_CRASHED (or already ACTOR_STATE_DELETING) can be deleted.                                                                                                                                                                                     
      • When true: allows deleting an actor in any state (e.g., RUNNING, PAUSED).                                                                                                                                                                                                                                                                                    
  • Orchestrated Cleanup Workflow (workflow_delete.go):                                                                                                                                                                                                                                                                                                              
         1. Transitions actor state to ACTOR_STATE_DELETING.                                                                                                                                                                                                                                                                                                            
         2. Calls atelet.Terminate to stop live workloads on the node.                                                                                                                                                                                                                                                                                                  
         3. Detaches external volumes from the worker node (with fallback logic using actor status if the ActorTemplate was deleted).                                                                                                                                                                                                                                   
         4. Releases the assigned physical worker Pod back to the WorkerPool.                                                                                                                                                                                                                                                                                           
         5. Deletes external storage volumes through the storage plugins.                                                                                                                                                                                                                                                                                               
         6. Finalizes removal of the actor from the persistence store.                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                     
  #### 2. Node Herder Agent (atelet)                                                                                                                                                                                                                                                                                                                                 
  • Terminate RPC (main.go): Added a new Terminate method to AteomHerder:                                                                                                                                                                                                                                                                                            
      • Calls ateom.TerminateWorkload on the target worker pod.                                                                                                                                                                                                                                                                                                      
      • Unmounts external volumes mounted for the actor on the node.                                                                                                                                                                                                                                                                                                 
      • Cleans up and resets actor runtime host directories (OCI bundles, checkpoints, pid files).                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                     
 #### 3. In-Pod Sandboxes (ateom-gvisor & ateom-microvm)                                                                                                                                                                                                                                                                                                            
  • TerminateWorkload RPC:                                                                                                                                                                                                                                                                                                                                           
      • gVisor (main.go): Stops and deletes active runsc containers, unmounts bundle rootfs overlays, and tears down the actor's interior network namespace.                                                                                                                                                                                                         
      • Micro-VM (checkpoint.go): Shuts down the Cloud Hypervisor VMM, unmounts bundle rootfs overlays, and cleans up the network namespace.                                                                                                                                                                                                                         
      • Emits an "Actor terminated" lifecycle log and clears the active actor attribution so the worker can host new workloads.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                     
  #### 4. CLI (kubectl-ate)                                                                                                                                                                                                                                                                                                                                          
  • --any-state Flag (delete_actor.go):                                                                                                                                                                                                                                                                                                                              
    kubectl-ate delete actor <actor-name> -a <atespace> --any-state                                                                                                             

  ──────                                                                                                                                                                                                                                                                                                                                                             
  ## Verification 
  [x] Changes tested in local with 
 ```
 • go build ./...: Passed                                                                                                                                                                                                                                                                                                                                       
    go test ./...: Passed (all unit and functional tests pass)                                                                                                                                                                                                                                                                                                   
    make lint: Passed (no lint errors) 
```
Detailed manual tests                                                                                                                                                                                                                                                                                                                                           
 ```                                                                                                                                                                                                                                                                                                                                                
  ### Scenario 1: Force Delete a Running Actor with --any-state                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                     
  1. Create the actor:                                                                                                                                                                                                                                                                                                                                               
    kubectl ate create actor manual-test-1 --template=ate-demo-counter-microvm/counter-microvm -a demo                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                     
  2. Resume the actor:                                                                                                                                                                                                                                                                                                                                               
    kubectl ate resume actor manual-test-1 -a demo                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                     
  3. Force delete the running actor:                                                                                                                                                                                                                                                                                                                                 
    kubectl ate delete actor manual-test-1 -a demo --any-state                                                                                                                                                                                                                                                                                                       
    actor "manual-test-1" deleted                                                                                                                                                                                                                                                                                                                                    
```                                                                                                                                                                                                                                                                                                                                                                   
  ──────                                                                                                                                                                                                                                                                                                                                                             
### Scenario 2: Standard Delete a Suspended Actor                                                                                                                                                                                                                                                                                                                  
```                                                                                                                                                                                                                                                                                                                                  
  1. Create the actor:                                                                                                                                                                                                                                                                                                                                               
    kubectl ate create actor manual-test-2 --template=ate-demo-counter-microvm/counter-microvm -a demo                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                     
  2. Resume the actor:                                                                                                                                                                                                                                                                                                                                               
    kubectl ate resume actor manual-test-2 -a demo                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                     
  3. Suspend the actor:                                                                                                                                                                                                                                                                                                                                              
    kubectl ate suspend actor manual-test-2 -a demo                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                     
  4. Standard delete the suspended actor:                                                                                                                                                                                                                                                                                                                            
    kubectl ate delete actor manual-test-2 -a demo                                                                                                                                                                                                                                                                                                                   
    actor "manual-test-2" deleted                                                                                                                                                                                                                                                                                                                                    
```
  ──────                                                                                                                                                                                                                                                                                                                                                             
 ### Unit & E2E Tests                                                                                                                                                                                                                                                                                                                                               
    # Unit & Functional Tests                                                                                                                                                                                                                                                                                                                                        
    go test ./cmd/ateapi/internal/controlapi -run "TestDeleteActorWorkflow|TestEnsureMarkedDeleting"                                                                                                                                                                                                                                                                 
    # E2E Tests                                                                                                                                                                                                                                                                                                                                                      
    E2E_TEMPLATE_NAMESPACE=ate-demo-counter-microvm E2E_TEMPLATE_NAME=counter-microvm ./hack/run-e2e-kind.sh ./internal/e2e/suites/demo -run TestActorLifecycle                                                                                                                                                                                                      
    ./hack/run-e2e-kind.sh ./internal/e2e/suites/demo -run TestForceDeleteActorWithExternalVolume 
```
- [ x] Appropriate changes to documentation are included in the PR
