### PR TITLE
test: increase timeouts on flaky e2e and syncer tests

### DIFF
--- a/cmd/ateapi/internal/controlapi/syncer_test.go
+++ b/cmd/ateapi/internal/controlapi/syncer_test.go
@@ -949,7 +949,9 @@ func TestSyncer_UpdateWorker_RetryOnVersionConflict(t *testing.T) {
 	}
 
 	// Verify that the worker in Redis eventually gets updated to the new SandboxClass despite the version conflict.
-	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+	// 15s: the syncer's rate-limiting work queue adds backoff between retries; on a loaded
+	// CI runner the second attempt can take longer than the previous 5s window allowed.
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		w, err := persistence.GetWorker(ctx, ns, poolName, podName)
 		if err != nil {
 			if errors.Is(err, store.ErrNotFound) {

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -1018,7 +1018,7 @@ func hasStorageClass(ctx context.Context, clients *e2e.Clients, name string) boo
 func waitForActorStatus(ctx context.Context, t *testing.T, clients *e2e.Clients, actorName string, expectedStatus ateapipb.Actor_Status) {
 	t.Helper()
 	t.Logf("Waiting for Actor %q to be %v...", actorName, expectedStatus)
-	timeout := 60 * time.Second
+	timeout := 120 * time.Second
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		resp, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
@@ -1038,7 +1038,9 @@ func waitForActorStatus(ctx context.Context, t *testing.T, clients *e2e.Clients,
 func callActor(t *testing.T, actorRef resources.ActorRef) (string, error) {
 	t.Helper()
 
-	deadline := time.Now().Add(30 * time.Second)
+	// 90s: actor reaches STATUS_RUNNING before xDS routes are fully propagated
+	// in atenet-router. The extra headroom covers the route-sync lag on loaded runners.
+	deadline := time.Now().Add(90 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
 		resp, err := callActorOnce(t, actorRef)


### PR DESCRIPTION
Fixes #799

## What changed and why

### `internal/e2e/suites/demo/demo_test.go`

- `callActor` deadline: **30s → 90s**
- `waitForActorStatus` timeout: **60s → 120s**

`TestActorLifecycle`, `TestDurableDirLifecycle`, and `TestMultipleDurableDirLifecycle` were failing with:
```
failed to call actor again: timed out waiting for actor response: unexpected status code: 503
```
The actor reaches `STATUS_RUNNING` before atenet-router's xDS routes are fully propagated. `callActor` was already retrying, but the 30s deadline was exhausted before the route-sync completed on a loaded CI runner. The same xDS propagation lag was fixed for the networking ingress tests in #724 — this applies the same principle to the demo suite.

### `cmd/ateapi/internal/controlapi/syncer_test.go`

- Final assertion `PollUntilContextTimeout`: **5s → 15s**

`TestSyncer_UpdateWorker_RetryOnVersionConflict` polls for the worker to reflect a new `SandboxClass` after a version conflict retry. The syncer's rate-limiting work queue adds backoff between reconcile attempts; on a loaded runner the second attempt occasionally lands after the 5s window closed.

## Checklist

- [x] Issue is linked above
- [x] Tests pass locally (`go test ./...`)
- [x] Documentation updated if behavior changed (N/A — test-only change)

## Not addressed in this PR

`TestLoaderConcurrentHandshakes` (2 failures in sample) — failure logs were unavailable (run was re-triggered before logs could be retrieved). Tracked in #799 for follow-up once a reproduction is captured.