### PR TITLE
manifests: stop pinning the control plane and DNS to IPv4

### DIFF
--- a/manifests/ate-install/ate-api-server.yaml
+++ b/manifests/ate-install/ate-api-server.yaml
@@ -92,7 +92,6 @@ spec:
       - name: ate-api-server
         image: ko://github.com/agent-substrate/substrate/cmd/ateapi
         args:
-          - "--grpc-listen-addr=0.0.0.0:443"
           - "--grpc-server-cred-bundle=/run/servicedns.podcert.ate.dev/credential-bundle.pem"
           - --redis-cluster-address=@env
           - --redis-ca-certs=/etc/valkey-ca/ca.crt
@@ -243,6 +242,8 @@ spec:
   # Headless (i.e. `clusterIP: None`) services make DNS return one A record per
   # ready pod so gRPC clients can load balance client-side.
   clusterIP: None
+  # Prefer, not Require: Require fails Service creation on a single-stack cluster.
+  ipFamilyPolicy: PreferDualStack
   selector:
     app: ate-api-server
   ports:

--- a/manifests/ate-install/atenet-dns.yaml
+++ b/manifests/ate-install/atenet-dns.yaml
@@ -167,6 +167,8 @@ spec:
   selector:
     app: dns
   type: ClusterIP
+  # Prefer, not Require: Require fails Service creation on a single-stack cluster.
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: dns
     port: 53


### PR DESCRIPTION
Two of the three Services on the actor request path were reachable over IPv4 only, for two different reasons.

**`ate-api-server` pinned its listener to the IPv4 wildcard.** The Deployment passed `--grpc-listen-addr=0.0.0.0:443`, overriding the `":443"` that `cmd/ateapi/main.go` already defaults to. The bare form binds every family the host has; the IPv4 wildcard binds one. The override dates to the initial commit and `git log -S` turns up no rationale for it, so this drops the flag rather than rewriting it to `[::]:443`.

**The `dns` and `api` Services carried no `ipFamilyPolicy`,** which the API server defaults to `SingleStack` — an IPv4 ClusterIP and nothing else on a dual-stack cluster. Both now set `PreferDualStack`, not `RequireDualStack`, since `Require` fails Service creation outright on the single-stack clusters CI runs. `api` is headless, so there the policy governs EndpointSlice families and therefore the per-pod DNS records that client-side gRPC load balancing depends on, not a VIP.

The `atenet-router` Service needs the same treatment and is handled separately, alongside the Envoy listener change it is useless without.

## Testing

No unit tests here, deliberately. Neither invariant is visible to a unit test of the affected binary — the binary is fine either way and only the deployed cluster breaks. An earlier revision asserted them by parsing the shipped YAML in a test-only `internal/installmanifests` package; that was dropped at review request in favour of exercising the real thing.

Coverage comes from running the e2e suite against a dual-stack cluster, which is a separate change: it adds an `ip-family` axis to the `e2e-test-matrix` workflow and a `TestDataPathServicesAreDualStack` that reads the cluster'''s families off the node pod CIDRs and **fails**, rather than skips, when a data-path Service has fewer families than the cluster can give it.

Locally on this branch: `go build ./...`, `go vet`, and `hack/verify/{boilerplate,gofmt,go-modules}.sh` pass.

## Compatibility

No behavior change on an IPv4-only cluster: `PreferDualStack` degrades silently, and `":443"` and `"0.0.0.0:443"` bind the same socket when the host has no IPv6.