### PR TITLE
atenet-router: raise actor-cluster circuit breakers

### DIFF
--- a/cmd/atenet/internal/router/cmd.go
+++ b/cmd/atenet/internal/router/cmd.go
@@ -79,7 +79,7 @@ func NewRouterCmd() *cobra.Command {
 	cmd.Flags().DurationVar(&cfg.ParkedRequest.RetryInterval, "parked-request-retry-interval", ingress.DefaultParkedRequestRetryInterval, "Delay before a parked request's first resume retry")
 	cmd.Flags().Float64Var(&cfg.ParkedRequest.RetryFactor, "parked-request-retry-factor", ingress.DefaultParkedRequestRetryFactor, "Multiplier applied to the retry delay after each attempt; must be >= 1")
 	cmd.Flags().Float64Var(&cfg.ParkedRequest.RetryJitter, "parked-request-retry-jitter", ingress.DefaultParkedRequestRetryJitter, "Random fraction in [0, 1) added to each retry delay to de-synchronize parked requests")
-	cmd.Flags().IntVar(&cfg.ExtProcMaxRequests, "extproc-max-requests", 0, "Circuit-breaker max_requests for Envoy's ext_proc cluster; 0 (the default) derives it as twice --parked-request-max (minimum 1024). Explicit values must be >= --parked-request-max: every parked request holds one slot for its full wait, and the excess is fast-path headroom")
+	cmd.Flags().IntVar(&cfg.ExtProcMaxRequests, "extproc-max-requests", 0, "Circuit-breaker ceiling for Envoy's ext_proc cluster, applied to max_requests and max_pending_requests alike; 0 (the default) derives it as twice --parked-request-max (minimum 1024). Explicit values must be >= --parked-request-max: every parked request holds one slot for its full wait, and the excess is fast-path headroom")
 	// Graceful shutdown knobs. The router sits behind a Service, so
 	// route-drain window is needed: after SIGTERM the readiness flip
 	// must propagate to the Service endpoints before the drain starts.

--- a/cmd/atenet/internal/router/xds.go
+++ b/cmd/atenet/internal/router/xds.go
@@ -111,10 +111,11 @@ const (
 // otherwise Envoy abandons a parked request (500) long before the router does.
 const defaultExtProcMessageTimeout = 5 * time.Second
 
-// defaultExtProcMaxRequests is the circuit-breaker max_requests set on the
-// ext_proc cluster: ingress.DefaultParkedRequestMax plus equal fast-path headroom, so a
-// full parking lot cannot starve the millisecond-scale header exchanges of
-// requests to already-running actors. See buildCluster.
+// defaultExtProcMaxRequests is the circuit-breaker ceiling set on the ext_proc
+// cluster, applied to both max_requests and max_pending_requests:
+// ingress.DefaultParkedRequestMax plus equal fast-path headroom, so a full
+// parking lot cannot starve the millisecond-scale header exchanges of requests
+// to already-running actors. See buildCluster.
 const defaultExtProcMaxRequests = 2048
 
 // defaultRouteTimeout is Envoy's end-to-end route timeout for workload traffic:
@@ -142,6 +143,12 @@ const defaultRouteTimeout = 10 * time.Second
 // override a route timeout above five minutes would never be reached. See
 // routeIdleTimeout.
 const envoyDefaultStreamIdleTimeout = 5 * time.Minute
+
+// actorClusterMaxConcurrency replaces Envoy's 1024 default, which is far below
+// what the router can carry. Kept under the ~28,232 ephemeral-port budget
+// (each in-flight HTTP/1.1 request holds one source port) so the breaker's
+// counted overflow trips before the kernel's opaque EADDRNOTAVAIL.
+const actorClusterMaxConcurrency = 20000
 
 // XdsServer implements an aggregated discovery service server for dynamic Envoy router nodes.
 type XdsServer struct {
@@ -184,10 +191,11 @@ type XdsServer struct {
 	// response. Must be >= the parking budget so parked requests aren't cut short.
 	extProcMessageTimeout time.Duration
 
-	// extProcMaxRequests is the circuit-breaker max_requests on the ext_proc
-	// cluster — the hard ceiling on concurrent requests held open against the
-	// router's processing server, parked requests included. Must be >= the
-	// parking lot size (enforced at startup in Run).
+	// extProcMaxRequests is the circuit-breaker ceiling on the ext_proc cluster
+	// — the hard limit on concurrent requests held open against the router's
+	// processing server, parked requests included. Applied to max_requests and
+	// max_pending_requests alike. Must be >= the parking lot size (enforced at
+	// startup in Run).
 	extProcMaxRequests uint32
 
 	// routeTimeout is Envoy's end-to-end timeout on the workload route. Actors
@@ -241,9 +249,10 @@ func (x *XdsServer) SetExtProcMessageTimeout(d time.Duration) {
 	}
 }
 
-// SetExtProcMaxRequests sets the circuit-breaker max_requests on the ext_proc
-// cluster. Size it to the parking lot plus fast-path headroom (validated in
-// Run()); a non-positive value leaves the default unchanged.
+// SetExtProcMaxRequests sets the circuit-breaker ceiling on the ext_proc
+// cluster, for max_requests and max_pending_requests together. Size it to the
+// parking lot plus fast-path headroom (validated in Run()); a non-positive
+// value leaves the default unchanged.
 func (x *XdsServer) SetExtProcMaxRequests(n int) {
 	x.mu.Lock()
 	defer x.mu.Unlock()
@@ -518,10 +527,14 @@ func (x *XdsServer) buildCluster() *clusterv3.Cluster {
 			Type: clusterv3.Cluster_STATIC,
 		},
 		LbPolicy: clusterv3.Cluster_ROUND_ROBIN,
+		// max_pending_requests rises with max_requests: a request is pending
+		// until the pool hands it a stream, and a shallower pending queue just
+		// moves the rejection.
 		CircuitBreakers: &clusterv3.CircuitBreakers{
 			Thresholds: []*clusterv3.CircuitBreakers_Thresholds{{
-				Priority:    corev3.RoutingPriority_DEFAULT,
-				MaxRequests: wrapperspb.UInt32(x.extProcMaxRequests),
+				Priority:           corev3.RoutingPriority_DEFAULT,
+				MaxRequests:        wrapperspb.UInt32(x.extProcMaxRequests),
+				MaxPendingRequests: wrapperspb.UInt32(x.extProcMaxRequests),
 			}},
 		},
 		LoadAssignment: &endpointv3.ClusterLoadAssignment{
@@ -751,6 +764,18 @@ func (x *XdsServer) buildOriginalDstCluster() *clusterv3.Cluster {
 					},
 				},
 			},
+		},
+		// Connections, pending and requests are lifted together: the upstream
+		// hop is HTTP/1.1, so capping any one below the others just moves
+		// where the queue forms. max_retries keeps Envoy's default — no route
+		// to this cluster sets a retry policy.
+		CircuitBreakers: &clusterv3.CircuitBreakers{
+			Thresholds: []*clusterv3.CircuitBreakers_Thresholds{{
+				Priority:           corev3.RoutingPriority_DEFAULT,
+				MaxConnections:     wrapperspb.UInt32(actorClusterMaxConcurrency),
+				MaxPendingRequests: wrapperspb.UInt32(actorClusterMaxConcurrency),
+				MaxRequests:        wrapperspb.UInt32(actorClusterMaxConcurrency),
+			}},
 		},
 	}
 


### PR DESCRIPTION
The actor cluster configured no circuit breakers, leaving Envoy's 1,024 default — a low ceiling for the one proxy carrying every actor's ingress. Under overload it surfaces as storms of instant 503s once concurrency crosses 1,024.

- Actor cluster: `max_connections`, `max_pending_requests` and `max_requests` rise to 20,000, kept under the ~28k ephemeral-port budget so overload trips a counted breaker instead of the kernel's opaque `EADDRNOTAVAIL`. `max_retries` keeps Envoy's default — nothing on this cluster retries.
- ext_proc cluster: the `--extproc-max-requests` ceiling now covers `max_pending_requests` as well as `max_requests`.

Tested with `go test ./cmd/atenet/internal/router/`.