### PR TITLE
Support suspending a PAUSED actor without waking it

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -181,6 +181,10 @@ type FakeAteletServer struct {
 	RestoreRequest *ateletpb.RestoreRequest
 	FailRestore    error
 	RestoreDelay   time.Duration
+
+	UploadCalled  bool
+	UploadRequest *ateletpb.UploadPausedCheckpointRequest
+	FailUpload    error
 }
 
 func (f *FakeAteletServer) Reset() {
@@ -198,6 +202,22 @@ func (f *FakeAteletServer) Reset() {
 	f.RestoreRequest = nil
 	f.FailRestore = nil
 	f.RestoreDelay = 0
+
+	f.UploadCalled = false
+	f.UploadRequest = nil
+	f.FailUpload = nil
+}
+
+func (f *FakeAteletServer) UploadPausedCheckpoint(ctx context.Context, req *ateletpb.UploadPausedCheckpointRequest) (*ateletpb.UploadPausedCheckpointResponse, error) {
+	f.Lock.Lock()
+	defer f.Lock.Unlock()
+
+	f.UploadCalled = true
+	f.UploadRequest = proto.Clone(req).(*ateletpb.UploadPausedCheckpointRequest)
+	if f.FailUpload != nil {
+		return nil, f.FailUpload
+	}
+	return &ateletpb.UploadPausedCheckpointResponse{}, nil
 }
 
 func (f *FakeAteletServer) Run(ctx context.Context, req *ateletpb.RunRequest) (*ateletpb.RunResponse, error) {
@@ -3580,4 +3600,165 @@ func TestDeleteAtespace_NotFound(t *testing.T) {
 func assertValidateErr(t *testing.T, got field.ErrorList, want field.ErrorList) {
 	t.Helper()
 	field.ErrorMatcher{}.ByType().ByField().ByValue().Test(t, want, got)
+}
+
+// TestSuspendActor_FromPaused suspends a PAUSED actor end-to-end: instead of
+// checkpointing a running workload, ateapi asks the atelet on the node
+// holding the pause snapshot to upload it, then finalizes the actor with a
+// durable ActorSnapshot and no node pinning left behind.
+func TestSuspendActor_FromPaused(t *testing.T) {
+	ns := namespaceForTest("ns-suspend-paused")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	name := "id1"
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      "tmpl1",
+	}})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+	if _, err := tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	}); err != nil {
+		t.Fatalf("PauseActor failed: %v", err)
+	}
+	paused, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	// Drop the pause's Checkpoint call so the suspend's atelet traffic is
+	// observable in isolation.
+	tc.fakeAtelet.Reset()
+
+	suspended, err := tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+
+	if !tc.fakeAtelet.UploadCalled {
+		t.Fatal("expected atelet UploadPausedCheckpoint to be called")
+	}
+	if tc.fakeAtelet.CheckpointCalled {
+		t.Error("atelet Checkpoint called for a paused actor; there is no workload to checkpoint")
+	}
+	upload := tc.fakeAtelet.UploadRequest
+	if got, want := upload.GetLocalSnapshotName(), paused.GetLocalSnapshotInfo().GetSnapshotName(); got != want {
+		t.Errorf("upload local_snapshot_name = %q, want the pause snapshot %q", got, want)
+	}
+	if got, want := upload.GetAtespace(), testAtespace; got != want {
+		t.Errorf("upload atespace = %q, want %q", got, want)
+	}
+	if got := upload.GetDesiredScope(); got != ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL {
+		t.Errorf("upload desired_scope = %v, want FULL (template default)", got)
+	}
+
+	actor := suspended.GetActor()
+	if actor.GetStatus() != ateapipb.Actor_STATUS_SUSPENDED {
+		t.Errorf("status = %v, want SUSPENDED", actor.GetStatus())
+	}
+	if actor.GetLocalSnapshotInfo() != nil {
+		t.Errorf("LocalSnapshotInfo = %v, want cleared (node pinning must not survive suspend)", actor.GetLocalSnapshotInfo())
+	}
+	ref := actor.GetLatestSnapshot()
+	if ref.GetName() == "" {
+		t.Fatalf("SuspendActor returned no ActorSnapshot reference: %v", suspended)
+	}
+	snapshot, err := tc.client.GetActorSnapshot(context.Background(), &ateapipb.GetActorSnapshotRequest{
+		Snapshot: &ateapipb.ActorSnapshotRef{Reference: &ateapipb.ActorSnapshotRef_Snapshot{Snapshot: ref}},
+	})
+	if err != nil {
+		t.Fatalf("GetActorSnapshot failed: %v", err)
+	}
+	if got, want := snapshot.GetSnapshotUri(), upload.GetDestinationSnapshotUri(); got != want {
+		t.Errorf("snapshot URI = %q, want the upload destination %q", got, want)
+	}
+	if got := snapshot.GetContentScope(); got != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL {
+		t.Errorf("snapshot ContentScope = %v, want FULL", got)
+	}
+}
+
+// TestSuspendActor_FromPaused_RetryAfterUploadFailure exercises client-driven
+// forward recovery on the paused path: a failed upload leaves the actor
+// SUSPENDING with its local snapshot record intact, and a retry completes the
+// suspend against the same destination.
+func TestSuspendActor_FromPaused_RetryAfterUploadFailure(t *testing.T) {
+	ns := namespaceForTest("ns-suspend-paused-retry")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	name := "id1"
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      "tmpl1",
+	}})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+	if _, err := tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	}); err != nil {
+		t.Fatalf("PauseActor failed: %v", err)
+	}
+
+	tc.fakeAtelet.Reset()
+	tc.fakeAtelet.FailUpload = status.Error(codes.Unavailable, "injected upload failure")
+	if _, err := tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	}); err == nil {
+		t.Fatal("SuspendActor succeeded despite failing upload")
+	}
+
+	stuck, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if stuck.GetStatus() != ateapipb.Actor_STATUS_SUSPENDING {
+		t.Fatalf("status after failed upload = %v, want SUSPENDING (retryable)", stuck.GetStatus())
+	}
+	if stuck.GetLocalSnapshotInfo() == nil {
+		t.Fatal("LocalSnapshotInfo cleared by a failed upload; the retry could never find the snapshot")
+	}
+	firstDestination := tc.fakeAtelet.UploadRequest.GetDestinationSnapshotUri()
+
+	tc.fakeAtelet.Lock.Lock()
+	tc.fakeAtelet.FailUpload = nil
+	tc.fakeAtelet.Lock.Unlock()
+	retried, err := tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("SuspendActor retry failed: %v", err)
+	}
+	if got := retried.GetActor().GetStatus(); got != ateapipb.Actor_STATUS_SUSPENDED {
+		t.Errorf("status after retry = %v, want SUSPENDED", got)
+	}
+	if got := tc.fakeAtelet.UploadRequest.GetDestinationSnapshotUri(); got != firstDestination {
+		t.Errorf("retry destination = %q, want the original %q (idempotent upload target)", got, firstDestination)
+	}
 }

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -114,6 +114,11 @@ func (w *ActorWorkflow) ensureMarkedPausing(ctx context.Context, actorRef resour
 	if actor.GetStatus() != ateapipb.Actor_STATUS_RUNNING {
 		return nil, status.Errorf(codes.FailedPrecondition, "MarkPausing prerequisite not met for Actor: %s (got: %v, want %s)", actorRef, actor.GetStatus(), ateapipb.Actor_STATUS_RUNNING)
 	}
+	// By design a golden actor cannot be paused — it can only be suspended
+	// (committed).
+	if actorRef.Atespace == resources.GoldenActorAtespace {
+		return nil, status.Errorf(codes.FailedPrecondition, "actors in atespace %q are golden actors, which cannot be paused", actorRef.Atespace)
+	}
 
 	snapshotName := resources.NewSnapshotName()
 	updated, err := w.store.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {

--- a/cmd/ateapi/internal/controlapi/workflow_pause_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause_test.go
@@ -336,3 +336,18 @@ func TestPauseActor_CrashesWhenPausingActorMissingWorkerPod(t *testing.T) {
 		t.Errorf("stored status = %v, want %v", got.GetStatus(), ateapipb.Actor_STATUS_CRASHED)
 	}
 }
+
+// TestEnsureMarkedPausing_GoldenAtespaceRejected verifies golden actors
+// cannot be paused: by design they can only be suspended (committed).
+func TestEnsureMarkedPausing_GoldenAtespaceRejected(t *testing.T) {
+	st, cleanup := storetest.SetupTestStore(t)
+	defer cleanup()
+	w := newTestActorWorkflow(t, st, "ns", "tmpl1")
+
+	_, err := w.ensureMarkedPausing(context.Background(),
+		resources.ActorRef{Atespace: resources.GoldenActorAtespace, Name: "golden-1"},
+		&ateapipb.Actor{Status: ateapipb.Actor_STATUS_RUNNING})
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Fatalf("status.Code = %v (err %v), want FailedPrecondition", got, err)
+	}
+}

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -31,9 +31,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// SuspendActor executes the workflow to suspend a running actor. Idempotent:
-// a re-entered workflow fast-forwards past the steps a previous attempt
-// completed, deriving progress from the persisted actor alone.
+// SuspendActor executes the workflow to suspend a running or paused actor:
+// a running actor is checkpointed on its worker, a paused actor's node-local
+// snapshot is uploaded. Idempotent: a re-entered workflow fast-forwards past
+// the steps a previous attempt completed, deriving progress from the
+// persisted actor alone.
 func (w *ActorWorkflow) SuspendActor(ctx context.Context, actorRef resources.ActorRef) (_ *ateapipb.Actor, err error) {
 	start := time.Now()
 	var actor *ateapipb.Actor
@@ -61,12 +63,20 @@ func (w *ActorWorkflow) SuspendActor(ctx context.Context, actorRef resources.Act
 		// left to do.
 		return actor, nil
 	}
+	// Decided before marking: once SUSPENDING is committed, the loaded status
+	// alone can no longer tell the two origins apart.
+	fromPaused := isPausedOriginSuspend(actor)
 	var marked *ateapipb.Actor
 	if marked, err = w.ensureMarkedSuspending(lockCtx, actorRef, actor, actorTemplate); err != nil {
 		return nil, err
 	}
 	actor = marked
-	if wireSnapshotScope, err = w.ensureAteletSuspended(lockCtx, actorRef, actor, actorTemplate); err != nil {
+	if fromPaused {
+		wireSnapshotScope, err = w.ensurePausedSnapshotUploaded(lockCtx, actorRef, actor, actorTemplate)
+	} else {
+		wireSnapshotScope, err = w.ensureAteletSuspended(lockCtx, actorRef, actor, actorTemplate)
+	}
+	if err != nil {
 		return nil, err
 	}
 	if err = w.ensureVolumesDetached(lockCtx, actor, actorTemplate, "DetachVolumes", ateattr.OperationSuspend); err != nil {
@@ -96,11 +106,11 @@ func (w *ActorWorkflow) loadActorForSuspend(ctx context.Context, actorRef resour
 	return actor, actorTemplate, nil
 }
 
-// ensureMarkedSuspending transitions a RUNNING actor to SUSPENDING, minting
-// the in-progress snapshot location and recording the actor version the
-// snapshot will capture. Skips when a previous attempt already marked the
-// actor; the persisted location and source version then stay authoritative
-// for the rest of the workflow.
+// ensureMarkedSuspending transitions a RUNNING or PAUSED actor to
+// SUSPENDING, minting the in-progress snapshot location and recording the
+// actor version the snapshot will capture. Skips when a previous attempt
+// already marked the actor; the persisted location and source version then
+// stay authoritative for the rest of the workflow.
 func (w *ActorWorkflow) ensureMarkedSuspending(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "MarkSuspending")
 	defer func() { err = done(err) }()
@@ -109,8 +119,16 @@ func (w *ActorWorkflow) ensureMarkedSuspending(ctx context.Context, actorRef res
 		markSkipped(ctx, "actor already SUSPENDING")
 		return actor, nil
 	}
-	if actor.GetStatus() != ateapipb.Actor_STATUS_RUNNING {
-		return nil, status.Errorf(codes.FailedPrecondition, "MarkSuspending prerequisite not met for Actor: %s (got: %v, want %s)", actorRef, actor.GetStatus(), ateapipb.Actor_STATUS_RUNNING)
+	if got := actor.GetStatus(); got != ateapipb.Actor_STATUS_RUNNING && got != ateapipb.Actor_STATUS_PAUSED {
+		return nil, status.Errorf(codes.FailedPrecondition, "MarkSuspending prerequisite not met for Actor: %s (got: %v, want %s or %s)", actorRef, got, ateapipb.Actor_STATUS_RUNNING, ateapipb.Actor_STATUS_PAUSED)
+	}
+	// A paused-origin suspend uploads what the pause captured; it cannot
+	// fabricate the memory a Full commit needs from a Data-only capture.
+	// Reject before leaving PAUSED so the actor stays resumable.
+	if actor.GetStatus() == ateapipb.Actor_STATUS_PAUSED &&
+		pausedContentScope(actor.GetLocalSnapshotInfo(), actorTemplate) == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA &&
+		commitSnapshotScope(actorRef.Atespace, actorTemplate) == atev1alpha1.SnapshotScopeFull {
+		return nil, status.Errorf(codes.FailedPrecondition, "actor %s paused with a %s snapshot; the template commits %s, which a paused-origin suspend cannot produce", actorRef, atev1alpha1.SnapshotScopeData, atev1alpha1.SnapshotScopeFull)
 	}
 
 	name := resources.NewSnapshotName()
@@ -147,6 +165,30 @@ func commitSnapshotScope(atespace string, tmpl *atev1alpha1.ActorTemplate) atev1
 		return atev1alpha1.SnapshotScopeFull
 	}
 	return tmpl.Spec.SnapshotsConfig.OnCommit
+}
+
+// pausedContentScope returns the scope a paused actor's local snapshot was
+// captured with: the value recorded at pause finalization, or — for actors
+// paused before content_scope existed — the template's onPause, the same
+// derivation resume uses for local snapshots.
+func pausedContentScope(local *ateapipb.LocalSnapshotInfo, tmpl *atev1alpha1.ActorTemplate) ateapipb.SnapshotContentScope {
+	if scope := local.GetContentScope(); scope != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED {
+		return scope
+	}
+	return toActorSnapshotContentScope(tmpl.Spec.SnapshotsConfig.OnPause)
+}
+
+// isPausedOriginSuspend reports whether the suspend must upload a PAUSED
+// actor's node-local snapshot instead of checkpointing a running workload.
+// A LocalSnapshotInfo alone does not mean paused-origin: resume never clears
+// it, so a RUNNING actor resumed from pause still carries a stale one. The
+// nil worker assignment disambiguates — running-origin suspends keep their
+// assignment until finalize, paused actors never have one.
+func isPausedOriginSuspend(actor *ateapipb.Actor) bool {
+	return actor.GetStatus() == ateapipb.Actor_STATUS_PAUSED ||
+		(actor.GetStatus() == ateapipb.Actor_STATUS_SUSPENDING &&
+			actor.GetWorkerAssignment() == nil &&
+			actor.GetLocalSnapshotInfo() != nil)
 }
 
 // ensureAteletSuspended checkpoints the workload to the actor's persisted
@@ -214,6 +256,58 @@ func (w *ActorWorkflow) ensureAteletSuspended(ctx context.Context, actorRef reso
 
 	_, err = client.Checkpoint(ctx, req)
 	return wireSnapshotScope, maybeCrashActor(ctx, w.store, actorRef, err, "while checkpointing workload", ateattr.OperationSuspend)
+}
+
+// ensurePausedSnapshotUploaded suspends a PAUSED actor by telling the atelet
+// on the node holding the local pause snapshot to upload it to the actor's
+// persisted in-progress snapshot location; no workload runs, so there is no
+// ateom to checkpoint. Retries re-send the same semantic request: the
+// destination is minted once and the upload overwrites deterministic object
+// names, with the remote manifest as the commit marker.
+func (w *ActorWorkflow) ensurePausedSnapshotUploaded(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (wireSnapshotScope string, err error) {
+	ctx, done := stepSpan(ctx, "UploadPausedCheckpoint")
+	defer func() { err = done(err) }()
+
+	local := actor.GetLocalSnapshotInfo()
+	if len(local.GetNodeVmsWithLocalSnapshots()) == 0 {
+		// Without the node the snapshot can never be found (mirrors
+		// FinalizePaused, which crashes rather than record an unknown node).
+		if err := crashActor(ctx, w.store, actorRef, ateattr.OperationSuspend, ateattr.ReasonCorruptedAssignment); err != nil {
+			slog.ErrorContext(ctx, "Failed to crash actor", slog.String("err", err.Error()))
+		}
+		return "", fmt.Errorf("actor is CRASHED because it was suspending a paused snapshot with no node recorded")
+	}
+
+	ateletConn, err := w.dialer.DialForAteletOnNode(local.GetNodeVmsWithLocalSnapshots()[0])
+	if err != nil {
+		// No atelet on the node is indistinguishable from an atelet restart or
+		// informer lag, and the snapshot bytes may still be on its disk: stay
+		// retryable rather than crash.
+		return "", fmt.Errorf("while getting atelet conn for node %q: %w", local.GetNodeVmsWithLocalSnapshots()[0], err)
+	}
+	client := ateletpb.NewAteomHerderClient(ateletConn)
+
+	snapshotURI, err := inProgressSnapshotURI(actorTemplate, actor.GetMetadata().GetAtespace(), actor.GetInProgressSnapshotName())
+	if err != nil {
+		return "", err
+	}
+
+	req := &ateletpb.UploadPausedCheckpointRequest{
+		Atespace:               actor.GetMetadata().GetAtespace(),
+		ActorName:              actor.GetMetadata().GetName(),
+		ActorUid:               actor.GetMetadata().GetUid(),
+		ActorTemplateNamespace: actor.GetActorTemplateNamespace(),
+		ActorTemplateName:      actor.GetActorTemplateName(),
+		LocalSnapshotName:      local.GetSnapshotName(),
+		DestinationSnapshotUri: snapshotURI.String(),
+		// The commit scope, like a running-origin suspend; atelet converts
+		// from the captured scope in the snapshot's manifest where possible.
+		DesiredScope: toAteletSnapshotScope(commitSnapshotScope(actor.GetMetadata().GetAtespace(), actorTemplate)),
+	}
+	wireSnapshotScope = ateattr.SnapshotScopeValue(req.DesiredScope)
+
+	_, err = client.UploadPausedCheckpoint(ctx, req)
+	return wireSnapshotScope, maybeCrashActor(ctx, w.store, actorRef, err, "while uploading paused snapshot", ateattr.OperationSuspend)
 }
 
 func inProgressSnapshotURI(actorTemplate *atev1alpha1.ActorTemplate, atespace, name string) (resources.SnapshotURI, error) {

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -16,6 +16,7 @@ package controlapi
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
@@ -23,11 +24,13 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
 	"github.com/agent-substrate/substrate/internal/resources"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -109,15 +112,6 @@ func TestSuspendActorWorkflow_RejectedAndIdempotentPaths(t *testing.T) {
 		wantStatus ateapipb.Actor_Status
 	}{
 		{
-			// The state machine's PAUSED->SUSPENDED commit edge is rejected
-			// (suspending needs a live worker to checkpoint from) and the
-			// actor's status is left untouched.
-			name:       "paused rejected",
-			seedStatus: ateapipb.Actor_STATUS_PAUSED,
-			wantErr:    true,
-			wantStatus: ateapipb.Actor_STATUS_PAUSED,
-		},
-		{
 			// Suspending a SUSPENDED actor succeeds idempotently via
 			// IsComplete fast-forward without calling atelet.
 			name:       "newly created suspended succeeds",
@@ -160,13 +154,16 @@ func TestSuspendActorWorkflow_RejectedAndIdempotentPaths(t *testing.T) {
 }
 
 // TestEnsureMarkedSuspending_StatusMatrix verifies the suspend edge's status
-// gating against every actor status: RUNNING takes the edge, SUSPENDING skips
-// (a previous attempt already marked the actor), everything else is rejected
-// with FailedPrecondition. SUSPENDED is rejected here because the
-// orchestrator early-returns before this step for a fully suspended actor.
+// gating against every actor status: RUNNING takes the edge (checkpoint the
+// workload), PAUSED takes it too (upload the node-local pause snapshot),
+// SUSPENDING skips (a previous attempt already marked the actor), everything
+// else is rejected with FailedPrecondition. SUSPENDED is rejected here
+// because the orchestrator early-returns before this step for a fully
+// suspended actor.
 func TestEnsureMarkedSuspending_StatusMatrix(t *testing.T) {
 	allowed := map[ateapipb.Actor_Status]bool{
 		ateapipb.Actor_STATUS_RUNNING:    true,
+		ateapipb.Actor_STATUS_PAUSED:     true,
 		ateapipb.Actor_STATUS_SUSPENDING: true, // skipped, not re-marked
 	}
 
@@ -233,10 +230,12 @@ func newTestPersistence(t *testing.T) store.Interface {
 }
 
 // newDanglingDialer returns a dialer whose informer cache has no pods, so
-// DialForWorker returns ErrWorkerPodNotFound.
+// DialForWorker returns ErrWorkerPodNotFound and DialForAteletOnNode returns
+// ErrNoAteletOnNode.
 func newDanglingDialer() *AteletDialer {
 	empty := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
 		byNamespaceAndName: func(obj any) ([]string, error) { return nil, nil },
+		byNode:             func(obj any) ([]string, error) { return nil, nil },
 	})
 	return NewAteletDialer(empty, empty, "", "")
 }
@@ -518,5 +517,181 @@ func TestCommitSnapshotScope(t *testing.T) {
 				t.Errorf("commitSnapshotScope(%q, onCommit=%s) = %s, want %s", tc.atespace, tc.onCommit, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestIsPausedOriginSuspend pins the paused-origin discriminator:
+// LocalSnapshotInfo alone must not select the paused path, because resume
+// leaves it stale on RUNNING actors; only PAUSED status, or SUSPENDING with
+// no worker assignment, means the suspend uploads a local snapshot.
+func TestIsPausedOriginSuspend(t *testing.T) {
+	assignment := &ateapipb.WorkerAssignment{WorkerNamespace: "ns", WorkerPool: "pool", WorkerPod: "pod-1"}
+	localInfo := &ateapipb.LocalSnapshotInfo{SnapshotName: "snap", NodeVmsWithLocalSnapshots: []string{"node1"}}
+	tests := []struct {
+		name  string
+		actor *ateapipb.Actor
+		want  bool
+	}{
+		{"paused actor", &ateapipb.Actor{Status: ateapipb.Actor_STATUS_PAUSED, LocalSnapshotInfo: localInfo}, true},
+		{"suspending retry of a paused-origin suspend", &ateapipb.Actor{Status: ateapipb.Actor_STATUS_SUSPENDING, LocalSnapshotInfo: localInfo}, true},
+		{"running actor with stale local snapshot info", &ateapipb.Actor{Status: ateapipb.Actor_STATUS_RUNNING, LocalSnapshotInfo: localInfo, WorkerAssignment: assignment}, false},
+		{"suspending retry of a running-origin suspend with stale local snapshot info", &ateapipb.Actor{Status: ateapipb.Actor_STATUS_SUSPENDING, LocalSnapshotInfo: localInfo, WorkerAssignment: assignment}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPausedOriginSuspend(tc.actor); got != tc.want {
+				t.Errorf("isPausedOriginSuspend = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnsureMarkedSuspending_PausedScopeRejection verifies a paused-origin
+// suspend is rejected before the actor leaves PAUSED when the pause captured
+// Data but the template commits Full: an upload cannot fabricate memory.
+func TestEnsureMarkedSuspending_PausedScopeRejection(t *testing.T) {
+	tmpl := func(onPause, onCommit atev1alpha1.SnapshotScope) *atev1alpha1.ActorTemplate {
+		return &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{
+			SnapshotsConfig: atev1alpha1.SnapshotsConfig{OnPause: onPause, OnCommit: onCommit, Location: "gs://snapshots"},
+		}}
+	}
+	tests := []struct {
+		name     string
+		captured ateapipb.SnapshotContentScope
+		tmpl     *atev1alpha1.ActorTemplate
+		wantErr  bool
+	}{
+		{"data capture cannot commit full", ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA, tmpl(atev1alpha1.SnapshotScopeData, atev1alpha1.SnapshotScopeFull), true},
+		{"data capture commits data", ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA, tmpl(atev1alpha1.SnapshotScopeData, atev1alpha1.SnapshotScopeData), false},
+		{"full capture commits full", ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL, tmpl(atev1alpha1.SnapshotScopeFull, atev1alpha1.SnapshotScopeFull), false},
+		{"full capture commits data via conversion", ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL, tmpl(atev1alpha1.SnapshotScopeFull, atev1alpha1.SnapshotScopeData), false},
+		// Actors paused before content_scope existed fall back to the
+		// template's onPause.
+		{"unset capture falls back to onPause", ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED, tmpl(atev1alpha1.SnapshotScopeData, atev1alpha1.SnapshotScopeFull), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			persistence := newTestPersistence(t)
+			w := &ActorWorkflow{store: persistence}
+
+			actorRef := resources.ActorRef{Atespace: "team-a", Name: "actor-1"}
+			actor, err := persistence.CreateActor(ctx, &ateapipb.Actor{
+				Metadata:          &ateapipb.ResourceMetadata{Atespace: actorRef.Atespace, Name: actorRef.Name},
+				Status:            ateapipb.Actor_STATUS_PAUSED,
+				LocalSnapshotInfo: &ateapipb.LocalSnapshotInfo{SnapshotName: "snap", NodeVmsWithLocalSnapshots: []string{"node1"}, ContentScope: tc.captured},
+			})
+			if err != nil {
+				t.Fatalf("CreateActor: %v", err)
+			}
+
+			_, err = w.ensureMarkedSuspending(ctx, actorRef, actor, tc.tmpl)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("ensureMarkedSuspending = %v, wantErr %t", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				if got := status.Code(err); got != codes.FailedPrecondition {
+					t.Errorf("status.Code = %v, want FailedPrecondition", got)
+				}
+			}
+		})
+	}
+}
+
+// TestEnsurePausedSnapshotUploaded_Preconditions covers the paused branch's
+// failure handling: a lost node record crashes the actor (the snapshot can
+// never be found), while an unreachable atelet stays retryable (the bytes
+// are likely still on the node's disk).
+func TestEnsurePausedSnapshotUploaded_Preconditions(t *testing.T) {
+	t.Run("no node recorded crashes", func(t *testing.T) {
+		ctx := context.Background()
+		persistence := newTestPersistence(t)
+		w := &ActorWorkflow{store: persistence, dialer: newDanglingDialer()}
+
+		created, err := persistence.CreateActor(ctx, &ateapipb.Actor{
+			Metadata:          &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "actor-1"},
+			Status:            ateapipb.Actor_STATUS_SUSPENDING,
+			LocalSnapshotInfo: &ateapipb.LocalSnapshotInfo{SnapshotName: "snap"},
+		})
+		if err != nil {
+			t.Fatalf("CreateActor: %v", err)
+		}
+
+		if _, err := w.ensurePausedSnapshotUploaded(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, created, &atev1alpha1.ActorTemplate{}); err == nil {
+			t.Fatal("ensurePausedSnapshotUploaded = nil, want error for missing node record")
+		}
+
+		stored, err := persistence.GetActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"})
+		if err != nil {
+			t.Fatalf("GetActor: %v", err)
+		}
+		if stored.GetStatus() != ateapipb.Actor_STATUS_CRASHED {
+			t.Errorf("status = %v, want CRASHED", stored.GetStatus())
+		}
+	})
+
+	t.Run("no atelet on node stays retryable", func(t *testing.T) {
+		ctx := context.Background()
+		persistence := newTestPersistence(t)
+		w := &ActorWorkflow{store: persistence, dialer: newDanglingDialer()}
+
+		created, err := persistence.CreateActor(ctx, &ateapipb.Actor{
+			Metadata:               &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "actor-1"},
+			Status:                 ateapipb.Actor_STATUS_SUSPENDING,
+			InProgressSnapshotName: "snap-dest",
+			LocalSnapshotInfo:      &ateapipb.LocalSnapshotInfo{SnapshotName: "snap", NodeVmsWithLocalSnapshots: []string{"node1"}},
+		})
+		if err != nil {
+			t.Fatalf("CreateActor: %v", err)
+		}
+
+		tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"}}}
+		_, err = w.ensurePausedSnapshotUploaded(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, created, tmpl)
+		if !errors.Is(err, ErrNoAteletOnNode) {
+			t.Fatalf("ensurePausedSnapshotUploaded = %v, want ErrNoAteletOnNode", err)
+		}
+
+		stored, err := persistence.GetActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"})
+		if err != nil {
+			t.Fatalf("GetActor: %v", err)
+		}
+		if stored.GetStatus() != ateapipb.Actor_STATUS_SUSPENDING {
+			t.Errorf("status = %v, want SUSPENDING (retryable, not crashed)", stored.GetStatus())
+		}
+	})
+}
+
+// TestSuspendActor_PausedWithoutLocalSnapshotCrashes verifies a PAUSED actor
+// whose LocalSnapshotInfo is missing (corrupted store state: nothing records
+// where the pause snapshot lives) is crashed by the suspend workflow rather
+// than left flapping between PAUSED and SUSPENDING.
+func TestSuspendActor_PausedWithoutLocalSnapshotCrashes(t *testing.T) {
+	ctx := context.Background()
+	st, cleanup := storetest.SetupTestStore(t)
+	defer cleanup()
+
+	// The template needs a snapshot location: MarkSuspending validates the
+	// destination URI before the workflow reaches the crash under test.
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := indexer.Add(&atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "tmpl1"},
+		Spec:       atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"}},
+	}); err != nil {
+		t.Fatalf("add template to indexer: %v", err)
+	}
+	w := NewActorWorkflow(st, nil, nil, listersv1alpha1.NewActorTemplateLister(indexer), nil, nil, nil, nil, nil, "", nil)
+
+	seedWorkflowActor(t, ctx, st, resources.ActorRef{Atespace: "team-a", Name: "id1"}, "ns", "tmpl1", ateapipb.Actor_STATUS_PAUSED)
+
+	if _, err := w.SuspendActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}); err == nil {
+		t.Fatal("SuspendActor succeeded, want error for PAUSED actor with no local snapshot record")
+	}
+
+	got, err := st.GetActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if got.GetStatus() != ateapipb.Actor_STATUS_CRASHED {
+		t.Errorf("stored status = %v, want %v", got.GetStatus(), ateapipb.Actor_STATUS_CRASHED)
 	}
 }

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -629,7 +629,7 @@ func toAteomSnapshotScope(scope ateletpb.SnapshotScope) ateompb.SnapshotScope {
 }
 
 func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string, rec *sandboxAssetsRecord) error {
-	localCheckpointPath := filepath.Join(ateompath.LocalCheckpointsDir(req.GetActorUid()), req.GetLocalConfig().GetSnapshotName())
+	localCheckpointPath := ateompath.LocalSnapshotDir(req.GetActorUid(), req.GetLocalConfig().GetSnapshotName())
 	if err := os.MkdirAll(localCheckpointPath, 0o700); err != nil {
 		return fmt.Errorf("while creating local checkpoint directory: %w", err)
 	}
@@ -662,13 +662,20 @@ func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletp
 	if err != nil {
 		return err
 	}
+	return s.uploadSnapshot(ctx, uri, checkpointDir, rec, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+}
 
-	// Upload exactly the files ateom reported (each zstd-compressed).
+// uploadSnapshot uploads rec's snapshot files from srcDir to uri (each
+// zstd-compressed, concurrently), then the marshaled manifest. The manifest
+// goes last, never in parallel: its presence is the commit marker — readers
+// assume every file it lists is already present. A crash mid-upload thus
+// leaves only orphaned files, never a manifest pointing at files that never
+// landed; retries overwrite the deterministic object names.
+func (s *AteomHerder) uploadSnapshot(ctx context.Context, uri resources.SnapshotURI, srcDir string, rec *sandboxAssetsRecord, templateNamespace, templateName string) error {
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, fileName := range rec.SnapshotFiles {
-		fileName := fileName
-		local := filepath.Join(checkpointDir, fileName)
-		recordSnapshotSize(ctx, fileName, local, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+		local := filepath.Join(srcDir, fileName)
+		recordSnapshotSize(ctx, fileName, local, templateNamespace, templateName)
 		g.Go(func() error {
 			objectURI, err := uri.ObjectURI(fileName + ".zstd")
 			if err != nil {
@@ -684,7 +691,6 @@ func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletp
 		return err
 	}
 
-	// Write the self-describing snapshot manifest last.
 	manifest, err := json.Marshal(rec)
 	if err != nil {
 		return fmt.Errorf("while marshaling snapshot manifest: %w", err)
@@ -728,7 +734,7 @@ func (s *AteomHerder) UploadPausedCheckpoint(ctx context.Context, req *ateletpb.
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	localDir := filepath.Join(ateompath.LocalCheckpointsDir(req.GetActorUid()), req.GetLocalSnapshotName())
+	localDir := ateompath.LocalSnapshotDir(req.GetActorUid(), req.GetLocalSnapshotName())
 
 	tPersist := time.Now()
 	sandboxClass, err := s.uploadLocalCheckpointDir(ctx, req, localDir, uri)
@@ -763,16 +769,18 @@ func (s *AteomHerder) uploadLocalCheckpointDir(ctx context.Context, req *ateletp
 		// means the whole snapshot is committed and this retry already
 		// succeeded. Absent on both sides, the paused actor's state is
 		// unrecoverable.
-		if _, fetchErr := ategcs.FetchFromGCS(ctx, s.gcsClient, manifestURI); fetchErr == nil {
+		_, fetchErr := ategcs.FetchFromGCS(ctx, s.gcsClient, manifestURI)
+		if fetchErr == nil {
 			slog.InfoContext(ctx, "Local snapshot already uploaded and pruned; nothing to do", slog.String("snapshot_uri", req.GetDestinationSnapshotUri()))
 			return "", nil
-		} else if errors.Is(fetchErr, ateerrors.ReasonFailedGetExternalObject) {
+		}
+		if errors.Is(fetchErr, ateerrors.ReasonFailedGetExternalObject) {
 			return "", ateerrors.NewGRPCError(ctx, codes.DataLoss, ateerrors.ReasonLocalSnapshotGone, ateerrors.ActorCrashedMetadata(),
 				fmt.Errorf("local snapshot %q is gone and no uploaded copy exists: %w", req.GetLocalSnapshotName(), fetchErr))
-		} else {
-			return "", fmt.Errorf("while probing for an already-uploaded snapshot manifest: %w", fetchErr)
 		}
-	} else if err != nil {
+		return "", fmt.Errorf("while probing for an already-uploaded snapshot manifest: %w", fetchErr)
+	}
+	if err != nil {
 		return "", wrapFileSystemErr("while reading local snapshot manifest", err)
 	}
 
@@ -798,41 +806,8 @@ func (s *AteomHerder) uploadLocalCheckpointDir(ctx context.Context, req *ateletp
 			return rec.SandboxClass, err
 		}
 	}
-	files := rec.SnapshotFiles
 
-	// Upload the snapshot files concurrently, each zstd-compressed; the
-	// manifest follows separately below.
-	g, gCtx := errgroup.WithContext(ctx)
-	for _, fileName := range files {
-		local := filepath.Join(localDir, fileName)
-		recordSnapshotSize(ctx, fileName, local, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
-		g.Go(func() error {
-			objectURI, err := uri.ObjectURI(fileName + ".zstd")
-			if err != nil {
-				return fmt.Errorf("while addressing %s in GCS: %w", fileName, err)
-			}
-			if err := ategcs.SendLocalFileToGCSWithZstd(gCtx, s.gcsClient, objectURI, local); err != nil {
-				return fmt.Errorf("while uploading %s to GCS: %w", fileName, err)
-			}
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		return rec.SandboxClass, err
-	}
-
-	updatedManifest, err := json.Marshal(rec)
-	if err != nil {
-		return rec.SandboxClass, fmt.Errorf("while marshaling snapshot manifest: %w", err)
-	}
-	// The manifest goes last, never in parallel: its presence is the commit
-	// marker — readers assume every file it lists is already present. A crash
-	// mid-upload thus leaves only orphaned files, never a manifest pointing
-	// at files that never landed.
-	if err := ategcs.SendBytesToGCS(ctx, s.gcsClient, manifestURI, updatedManifest); err != nil {
-		return rec.SandboxClass, fmt.Errorf("while uploading snapshot manifest: %w", err)
-	}
-	return rec.SandboxClass, nil
+	return rec.SandboxClass, s.uploadSnapshot(ctx, uri, localDir, rec, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
 }
 
 // narrowFullCaptureToData rewrites rec so a FULL capture uploads as a DATA
@@ -939,9 +914,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			return nil, ateerrors.CrashIfReason(ctx, fmt.Errorf("while unmarshalling sandbox record: %w", err), ateerrors.ReasonInvalidSandboxAsset)
 		}
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-		localCheckpointDir := ateompath.LocalCheckpointsDir(actorUID)
-		snapshotName := req.GetLocalConfig().GetSnapshotName()
-		manifest, err := os.ReadFile(filepath.Join(localCheckpointDir, snapshotName, sandboxManifestName))
+		manifest, err := os.ReadFile(filepath.Join(ateompath.LocalSnapshotDir(actorUID, req.GetLocalConfig().GetSnapshotName()), sandboxManifestName))
 		if err != nil {
 			if isTerminalFileSystemErr(err) {
 				return nil, ateerrors.NewGRPCError(ctx, codes.DataLoss, ateerrors.ReasonTerminalFileSystemError, ateerrors.ActorCrashedMetadata(), err)

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"syscall"
 	"time"
@@ -49,6 +50,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/substratex509"
 	"github.com/agent-substrate/substrate/internal/version"
 	"github.com/agent-substrate/substrate/internal/volume"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/client/clientset/versioned"
 	"github.com/agent-substrate/substrate/pkg/client/informers/externalversions"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
@@ -695,6 +697,169 @@ func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletp
 		return fmt.Errorf("while uploading snapshot manifest: %w", err)
 	}
 	return nil
+}
+
+// UploadPausedCheckpoint copies a paused actor's local checkpoint to object
+// storage. It drives no ateom — the actor's sandbox is gone; the checkpoint
+// files and their self-describing manifest already sit under the actor's
+// local-checkpoints directory, written by an earlier local Checkpoint (pause).
+func (s *AteomHerder) UploadPausedCheckpoint(ctx context.Context, req *ateletpb.UploadPausedCheckpointRequest) (_ *ateletpb.UploadPausedCheckpointResponse, err error) {
+	if err := validateUploadPausedCheckpointRequest(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	tStart := time.Now()
+	var dPersist time.Duration
+	op := snapshotOp{
+		templateNamespace: req.GetActorTemplateNamespace(),
+		templateName:      req.GetActorTemplateName(),
+		// Always the actor's durable latest: golden actors are never paused
+		// (validation above rejects the golden atespace).
+		kind:  ateattr.SnapshotKindLatest,
+		scope: ateattr.SnapshotScopeValue(req.GetDesiredScope()),
+	}
+	defer func() {
+		s.instruments.recordCheckpoint(ctx, op, err,
+			phase{ateattr.SnapshotPhasePersist, dPersist},
+			phase{ateattr.SnapshotPhaseTotal, time.Since(tStart)})
+	}()
+
+	uri, err := resources.ParseSnapshotURI(req.GetDestinationSnapshotUri())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	localDir := filepath.Join(ateompath.LocalCheckpointsDir(req.GetActorUid()), req.GetLocalSnapshotName())
+
+	tPersist := time.Now()
+	sandboxClass, err := s.uploadLocalCheckpointDir(ctx, req, localDir, uri)
+	dPersist = time.Since(tPersist)
+	op.sandboxClass = sandboxClass
+	if err != nil {
+		op.failedPhase = ateattr.SnapshotPhasePersist
+		return nil, err
+	}
+
+	// The uploaded snapshot supersedes every local pause snapshot of this
+	// actor; free the node's disk (best-effort, like Checkpoint).
+	pruneLocalCheckpoints(ctx, req.GetActorUid())
+
+	return &ateletpb.UploadPausedCheckpointResponse{}, nil
+}
+
+// uploadLocalCheckpointDir uploads the local checkpoint in localDir to uri,
+// converting the captured scope to the requested one where possible. It
+// returns the sandbox class recorded in the snapshot manifest (empty when the
+// manifest was not read). Parameterized by localDir for tests.
+func (s *AteomHerder) uploadLocalCheckpointDir(ctx context.Context, req *ateletpb.UploadPausedCheckpointRequest, localDir string, uri resources.SnapshotURI) (string, error) {
+	manifestURI, err := uri.ObjectURI(sandboxManifestName)
+	if err != nil {
+		return "", fmt.Errorf("while addressing snapshot manifest in GCS: %w", err)
+	}
+
+	manifest, err := os.ReadFile(filepath.Join(localDir, sandboxManifestName))
+	if errors.Is(err, os.ErrNotExist) {
+		// The local snapshot is gone. A previous invocation may have uploaded
+		// and pruned it: the remote manifest is uploaded last, so its presence
+		// means the whole snapshot is committed and this retry already
+		// succeeded. Absent on both sides, the paused actor's state is
+		// unrecoverable.
+		if _, fetchErr := ategcs.FetchFromGCS(ctx, s.gcsClient, manifestURI); fetchErr == nil {
+			slog.InfoContext(ctx, "Local snapshot already uploaded and pruned; nothing to do", slog.String("snapshot_uri", req.GetDestinationSnapshotUri()))
+			return "", nil
+		} else if errors.Is(fetchErr, ateerrors.ReasonFailedGetExternalObject) {
+			return "", ateerrors.NewGRPCError(ctx, codes.DataLoss, ateerrors.ReasonLocalSnapshotGone, ateerrors.ActorCrashedMetadata(),
+				fmt.Errorf("local snapshot %q is gone and no uploaded copy exists: %w", req.GetLocalSnapshotName(), fetchErr))
+		} else {
+			return "", fmt.Errorf("while probing for an already-uploaded snapshot manifest: %w", fetchErr)
+		}
+	} else if err != nil {
+		return "", wrapFileSystemErr("while reading local snapshot manifest", err)
+	}
+
+	rec, err := unmarshalSandboxRecord(manifest)
+	if err != nil {
+		return "", ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonInvalidSandboxAsset)
+	}
+
+	capturedScope := rec.Scope
+	if capturedScope == "" {
+		return rec.SandboxClass, status.Errorf(codes.FailedPrecondition, "local snapshot %q has no scope recorded in its manifest (written by an older atelet); resume and pause the actor again before suspending it", req.GetLocalSnapshotName())
+	}
+	desiredScope := ateattr.SnapshotScopeValue(req.GetDesiredScope())
+
+	switch {
+	case capturedScope == desiredScope:
+	case capturedScope == ateattr.SnapshotScopeData && desiredScope == ateattr.SnapshotScopeFull:
+		// The control plane rejects this before marking SUSPENDING; reaching
+		// it here means the template changed mid-flight or store state drifted.
+		return rec.SandboxClass, status.Errorf(codes.FailedPrecondition, "pause snapshot captured %s; cannot upload it as %s (memory was never captured)", capturedScope, desiredScope)
+	default: // captured FULL, DATA wanted
+		if err := narrowFullCaptureToData(rec); err != nil {
+			return rec.SandboxClass, err
+		}
+	}
+	files := rec.SnapshotFiles
+
+	// Upload the snapshot files concurrently, each zstd-compressed; the
+	// manifest follows separately below.
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, fileName := range files {
+		local := filepath.Join(localDir, fileName)
+		recordSnapshotSize(ctx, fileName, local, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+		g.Go(func() error {
+			objectURI, err := uri.ObjectURI(fileName + ".zstd")
+			if err != nil {
+				return fmt.Errorf("while addressing %s in GCS: %w", fileName, err)
+			}
+			if err := ategcs.SendLocalFileToGCSWithZstd(gCtx, s.gcsClient, objectURI, local); err != nil {
+				return fmt.Errorf("while uploading %s to GCS: %w", fileName, err)
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return rec.SandboxClass, err
+	}
+
+	updatedManifest, err := json.Marshal(rec)
+	if err != nil {
+		return rec.SandboxClass, fmt.Errorf("while marshaling snapshot manifest: %w", err)
+	}
+	// The manifest goes last, never in parallel: its presence is the commit
+	// marker — readers assume every file it lists is already present. A crash
+	// mid-upload thus leaves only orphaned files, never a manifest pointing
+	// at files that never landed.
+	if err := ategcs.SendBytesToGCS(ctx, s.gcsClient, manifestURI, updatedManifest); err != nil {
+		return rec.SandboxClass, fmt.Errorf("while uploading snapshot manifest: %w", err)
+	}
+	return rec.SandboxClass, nil
+}
+
+// narrowFullCaptureToData rewrites rec so a FULL capture uploads as a DATA
+// snapshot. Each sandbox class owns one branch: micro-VM durable data is a
+// self-contained tar that can be carved out of the full file set; gVisor's
+// full checkpoint is monolithic until split checkpoints land.
+func narrowFullCaptureToData(rec *sandboxAssetsRecord) error {
+	switch atev1alpha1.SandboxClass(rec.SandboxClass) {
+	case atev1alpha1.SandboxClassMicroVM:
+		if !slices.Contains(rec.SnapshotFiles, ateompath.DurableDirTarFile) {
+			// No durable-dir volumes were attached at pause: this snapshot
+			// holds no data, and never will — not retryable.
+			return status.Errorf(codes.FailedPrecondition, "full micro-VM capture has no %s; the actor has no durable data to upload as %s", ateompath.DurableDirTarFile, ateattr.SnapshotScopeData)
+		}
+		rec.SnapshotFiles = []string{ateompath.DurableDirTarFile}
+		rec.Scope = ateattr.SnapshotScopeData
+		return nil
+
+	case atev1alpha1.SandboxClassGvisor:
+		// TODO(#790): split-checkpoint runsc will let a full gVisor checkpoint
+		// yield its durable data; implement this branch when it lands.
+		return status.Errorf(codes.Unimplemented, "gVisor cannot extract durable data from a full checkpoint yet (see #790)")
+
+	default:
+		// The manifest's class is unvalidated input from disk/object storage.
+		return status.Errorf(codes.FailedPrecondition, "unknown sandbox class %q in snapshot manifest", rec.SandboxClass)
+	}
 }
 
 func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest) (resp *ateletpb.RestoreResponse, err error) {
@@ -1546,6 +1711,37 @@ func validateSnapshotScope(scope ateletpb.SnapshotScope) error {
 	default:
 		return fmt.Errorf("invalid snapshot scope: %v", scope)
 	}
+}
+
+func validateUploadPausedCheckpointRequest(req *ateletpb.UploadPausedCheckpointRequest) error {
+	var errs field.ErrorList
+	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
+	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
+	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
+	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
+	}
+	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
+		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
+	}
+	errs = append(errs, resources.ValidateResourceName(req.GetLocalSnapshotName(), field.NewPath("local_snapshot_name"))...)
+	// Golden actors are never paused (the golden flow commits a running
+	// actor), so never promote a paused checkpoint to a golden snapshot.
+	if req.GetAtespace() == resources.GoldenActorAtespace {
+		errs = append(errs, field.Forbidden(field.NewPath("atespace"), fmt.Sprintf("atespace %q holds golden actors, which are never paused", req.GetAtespace())))
+	}
+	if _, err := resources.ParseSnapshotURI(req.GetDestinationSnapshotUri()); err != nil {
+		errs = append(errs, field.Invalid(field.NewPath("destination_snapshot_uri"), req.GetDestinationSnapshotUri(), err.Error()))
+	}
+	// Uploads only ever produce FULL or DATA snapshots; DATA_ON_GOLDEN is a
+	// restore-time combination.
+	switch req.GetDesiredScope() {
+	case ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL, ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA:
+	default:
+		errs = append(errs, field.NotSupported(field.NewPath("desired_scope"), req.GetDesiredScope(),
+			[]string{ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL.String(), ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA.String()}))
+	}
+	return errs.ToAggregate()
 }
 
 // writeFileAtomic writes data to path by writing a temp file in the same

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -25,7 +25,9 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -35,6 +37,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/internal/serverboot"
 	"github.com/google/go-cmp/cmp"
 	"github.com/klauspost/compress/zstd"
@@ -1214,5 +1217,333 @@ func TestCopyFilePreservesHolesUserspace(t *testing.T) {
 	if dstAlloc > srcAlloc*4 {
 		t.Errorf("userspace copy allocated %d bytes for a %d-byte source: holes were filled in",
 			dstAlloc, srcAlloc)
+	}
+}
+
+// recordingObjectStorage serves gets from and records puts into one map, so
+// upload tests can assert exactly which objects landed.
+type recordingObjectStorage struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+	putErr  error
+}
+
+func (r *recordingObjectStorage) GetObject(_ context.Context, bucket, object string) (io.ReadCloser, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	b, ok := r.objects[bucket+"/"+object]
+	if !ok {
+		return nil, fmt.Errorf("%w: Bucket:%q, Object:%q", ateerrors.ReasonFailedGetExternalObject, bucket, object)
+	}
+	return io.NopCloser(bytes.NewReader(b)), nil
+}
+
+func (r *recordingObjectStorage) PutObject(_ context.Context, bucket, object string, reader io.Reader) error {
+	if r.putErr != nil {
+		return r.putErr
+	}
+	b, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.objects == nil {
+		r.objects = map[string][]byte{}
+	}
+	r.objects[bucket+"/"+object] = b
+	return nil
+}
+
+func (r *recordingObjectStorage) keys() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	keys := make([]string, 0, len(r.objects))
+	for k := range r.objects {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// writeLocalSnapshot lays a local pause snapshot out in dir: the given files
+// plus the marshaled manifest beside them.
+func writeLocalSnapshot(t *testing.T, dir string, rec sandboxAssetsRecord, contents map[string]string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("creating snapshot dir: %v", err)
+	}
+	for name, body := range contents {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("writing snapshot file %s: %v", name, err)
+		}
+	}
+	manifest, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshaling manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, sandboxManifestName), manifest, 0o600); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+}
+
+func validUploadPausedCheckpointRequest() *ateletpb.UploadPausedCheckpointRequest {
+	return &ateletpb.UploadPausedCheckpointRequest{
+		Atespace:               "ate-demo",
+		ActorName:              "counter-1",
+		ActorUid:               "123e4567-e89b-12d3-a456-426614174000",
+		ActorTemplateNamespace: "ate-demo",
+		ActorTemplateName:      "counter",
+		LocalSnapshotName:      "pause-snap-1",
+		DestinationSnapshotUri: "gs://bucket/root/snapshots/ate-demo/snap-1",
+		DesiredScope:           ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL,
+	}
+}
+
+func TestUploadLocalCheckpointDir(t *testing.T) {
+	ctx := context.Background()
+	uri, err := resources.ParseSnapshotURI("gs://bucket/root/snapshots/ate-demo/snap-1")
+	if err != nil {
+		t.Fatalf("ParseSnapshotURI: %v", err)
+	}
+	fullRec := func(class string) sandboxAssetsRecord {
+		return sandboxAssetsRecord{
+			SandboxClass:  class,
+			SnapshotFiles: []string{"config.json", "memory-ranges", ateompath.DurableDirTarFile},
+			Scope:         ateattr.SnapshotScopeFull,
+		}
+	}
+
+	remoteManifest := func(t *testing.T, store *recordingObjectStorage) sandboxAssetsRecord {
+		t.Helper()
+		b, ok := store.objects["bucket/root/snapshots/ate-demo/snap-1/manifest.json"]
+		if !ok {
+			t.Fatal("no manifest uploaded")
+		}
+		rec, err := unmarshalSandboxRecord(b)
+		if err != nil {
+			t.Fatalf("parsing uploaded manifest: %v", err)
+		}
+		return *rec
+	}
+
+	t.Run("matching scope uploads all files", func(t *testing.T) {
+		store := &recordingObjectStorage{}
+		s := &AteomHerder{gcsClient: store}
+		dir := filepath.Join(t.TempDir(), "pause-snap-1")
+		writeLocalSnapshot(t, dir, fullRec("microvm"), map[string]string{
+			"config.json": "cfg", "memory-ranges": "mem", ateompath.DurableDirTarFile: "data",
+		})
+
+		if _, err := s.uploadLocalCheckpointDir(ctx, validUploadPausedCheckpointRequest(), dir, uri); err != nil {
+			t.Fatalf("uploadLocalCheckpointDir: %v", err)
+		}
+		want := []string{
+			"bucket/root/snapshots/ate-demo/snap-1/config.json.zstd",
+			"bucket/root/snapshots/ate-demo/snap-1/durable-dir.tar.zstd",
+			"bucket/root/snapshots/ate-demo/snap-1/manifest.json",
+			"bucket/root/snapshots/ate-demo/snap-1/memory-ranges.zstd",
+		}
+		if got := store.keys(); !slices.Equal(got, want) {
+			t.Errorf("uploaded objects = %v, want %v", got, want)
+		}
+		if rec := remoteManifest(t, store); rec.Scope != ateattr.SnapshotScopeFull {
+			t.Errorf("uploaded manifest scope = %q, want %q", rec.Scope, ateattr.SnapshotScopeFull)
+		}
+	})
+
+	t.Run("microvm full capture uploads durable tar alone as data", func(t *testing.T) {
+		store := &recordingObjectStorage{}
+		s := &AteomHerder{gcsClient: store}
+		dir := filepath.Join(t.TempDir(), "pause-snap-1")
+		writeLocalSnapshot(t, dir, fullRec("microvm"), map[string]string{
+			"config.json": "cfg", "memory-ranges": "mem", ateompath.DurableDirTarFile: "data",
+		})
+
+		req := validUploadPausedCheckpointRequest()
+		req.DesiredScope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
+		if _, err := s.uploadLocalCheckpointDir(ctx, req, dir, uri); err != nil {
+			t.Fatalf("uploadLocalCheckpointDir: %v", err)
+		}
+		want := []string{
+			"bucket/root/snapshots/ate-demo/snap-1/durable-dir.tar.zstd",
+			"bucket/root/snapshots/ate-demo/snap-1/manifest.json",
+		}
+		if got := store.keys(); !slices.Equal(got, want) {
+			t.Errorf("uploaded objects = %v, want %v", got, want)
+		}
+		rec := remoteManifest(t, store)
+		if rec.Scope != ateattr.SnapshotScopeData {
+			t.Errorf("uploaded manifest scope = %q, want %q", rec.Scope, ateattr.SnapshotScopeData)
+		}
+		if want := []string{ateompath.DurableDirTarFile}; !slices.Equal(rec.SnapshotFiles, want) {
+			t.Errorf("uploaded manifest files = %v, want %v", rec.SnapshotFiles, want)
+		}
+	})
+
+	t.Run("gvisor full capture cannot become data yet", func(t *testing.T) {
+		s := &AteomHerder{gcsClient: &recordingObjectStorage{}}
+		dir := filepath.Join(t.TempDir(), "pause-snap-1")
+		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
+			SandboxClass:  "gvisor",
+			SnapshotFiles: []string{"checkpoint.img"},
+			Scope:         ateattr.SnapshotScopeFull,
+		}, map[string]string{"checkpoint.img": "img"})
+
+		req := validUploadPausedCheckpointRequest()
+		req.DesiredScope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
+		_, err := s.uploadLocalCheckpointDir(ctx, req, dir, uri)
+		if got := status.Code(err); got != codes.Unimplemented {
+			t.Fatalf("status.Code = %v (err %v), want Unimplemented", got, err)
+		}
+	})
+
+	t.Run("microvm full capture without durable tar has no data", func(t *testing.T) {
+		s := &AteomHerder{gcsClient: &recordingObjectStorage{}}
+		dir := filepath.Join(t.TempDir(), "pause-snap-1")
+		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
+			SandboxClass:  "microvm",
+			SnapshotFiles: []string{"config.json", "memory-ranges"},
+			Scope:         ateattr.SnapshotScopeFull,
+		}, map[string]string{"config.json": "cfg", "memory-ranges": "mem"})
+
+		req := validUploadPausedCheckpointRequest()
+		req.DesiredScope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
+		_, err := s.uploadLocalCheckpointDir(ctx, req, dir, uri)
+		if got := status.Code(err); got != codes.FailedPrecondition {
+			t.Fatalf("status.Code = %v (err %v), want FailedPrecondition", got, err)
+		}
+	})
+
+	t.Run("unknown sandbox class cannot convert", func(t *testing.T) {
+		s := &AteomHerder{gcsClient: &recordingObjectStorage{}}
+		dir := filepath.Join(t.TempDir(), "pause-snap-1")
+		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
+			SandboxClass:  "mystery",
+			SnapshotFiles: []string{ateompath.DurableDirTarFile},
+			Scope:         ateattr.SnapshotScopeFull,
+		}, map[string]string{ateompath.DurableDirTarFile: "data"})
+
+		req := validUploadPausedCheckpointRequest()
+		req.DesiredScope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
+		_, err := s.uploadLocalCheckpointDir(ctx, req, dir, uri)
+		if got := status.Code(err); got != codes.FailedPrecondition {
+			t.Fatalf("status.Code = %v (err %v), want FailedPrecondition", got, err)
+		}
+	})
+
+	t.Run("data capture cannot become full", func(t *testing.T) {
+		s := &AteomHerder{gcsClient: &recordingObjectStorage{}}
+		dir := filepath.Join(t.TempDir(), "pause-snap-1")
+		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
+			SandboxClass:  "microvm",
+			SnapshotFiles: []string{ateompath.DurableDirTarFile},
+			Scope:         ateattr.SnapshotScopeData,
+		}, map[string]string{ateompath.DurableDirTarFile: "data"})
+
+		_, err := s.uploadLocalCheckpointDir(ctx, validUploadPausedCheckpointRequest(), dir, uri)
+		if got := status.Code(err); got != codes.FailedPrecondition {
+			t.Fatalf("status.Code = %v (err %v), want FailedPrecondition", got, err)
+		}
+	})
+
+	t.Run("manifest without scope is rejected", func(t *testing.T) {
+		store := &recordingObjectStorage{}
+		s := &AteomHerder{gcsClient: store}
+		dir := filepath.Join(t.TempDir(), "pause-snap-1")
+		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
+			SandboxClass:  "microvm",
+			SnapshotFiles: []string{ateompath.DurableDirTarFile},
+		}, map[string]string{ateompath.DurableDirTarFile: "data"})
+
+		req := validUploadPausedCheckpointRequest()
+		req.DesiredScope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
+		_, err := s.uploadLocalCheckpointDir(ctx, req, dir, uri)
+		if got := status.Code(err); got != codes.FailedPrecondition {
+			t.Fatalf("status.Code = %v (err %v), want FailedPrecondition for a scope-less manifest", got, err)
+		}
+		if ateerrors.ActorCrashRequested(err) {
+			t.Error("scope-less manifest requests an actor crash; the actor is still resumable")
+		}
+		if len(store.keys()) != 0 {
+			t.Errorf("objects uploaded despite rejection: %v", store.keys())
+		}
+	})
+
+	t.Run("gone locally but already uploaded succeeds", func(t *testing.T) {
+		store := &recordingObjectStorage{objects: map[string][]byte{
+			"bucket/root/snapshots/ate-demo/snap-1/manifest.json": []byte(`{"sandboxClass":"microvm"}`),
+		}}
+		s := &AteomHerder{gcsClient: store}
+
+		if _, err := s.uploadLocalCheckpointDir(ctx, validUploadPausedCheckpointRequest(), filepath.Join(t.TempDir(), "never-created"), uri); err != nil {
+			t.Fatalf("uploadLocalCheckpointDir: %v", err)
+		}
+	})
+
+	t.Run("gone locally and remotely crashes the actor", func(t *testing.T) {
+		s := &AteomHerder{gcsClient: &recordingObjectStorage{}}
+
+		_, err := s.uploadLocalCheckpointDir(ctx, validUploadPausedCheckpointRequest(), filepath.Join(t.TempDir(), "never-created"), uri)
+		if got := status.Code(err); got != codes.DataLoss {
+			t.Fatalf("status.Code = %v (err %v), want DataLoss", got, err)
+		}
+		if !ateerrors.ActorCrashRequested(err) {
+			t.Error("error does not request an actor crash")
+		}
+		if got := ateerrors.ExtractReason(err); got != string(ateerrors.ReasonLocalSnapshotGone) {
+			t.Errorf("reason = %q, want %q", got, ateerrors.ReasonLocalSnapshotGone)
+		}
+	})
+
+	t.Run("upload failure is a plain retryable error", func(t *testing.T) {
+		s := &AteomHerder{gcsClient: &recordingObjectStorage{putErr: errors.New("boom")}}
+		dir := filepath.Join(t.TempDir(), "pause-snap-1")
+		writeLocalSnapshot(t, dir, fullRec("microvm"), map[string]string{
+			"config.json": "cfg", "memory-ranges": "mem", ateompath.DurableDirTarFile: "data",
+		})
+
+		_, err := s.uploadLocalCheckpointDir(ctx, validUploadPausedCheckpointRequest(), dir, uri)
+		if err == nil {
+			t.Fatal("uploadLocalCheckpointDir succeeded, want error")
+		}
+		if ateerrors.ActorCrashRequested(err) {
+			t.Error("upload failure requests an actor crash; must stay retryable")
+		}
+	})
+}
+
+func TestValidateUploadPausedCheckpointRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ateletpb.UploadPausedCheckpointRequest)
+		wantErr bool
+	}{
+		{"valid", func(*ateletpb.UploadPausedCheckpointRequest) {}, false},
+		{"valid data scope", func(r *ateletpb.UploadPausedCheckpointRequest) {
+			r.DesiredScope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
+		}, false},
+		{"invalid atespace", func(r *ateletpb.UploadPausedCheckpointRequest) { r.Atespace = "../escape" }, true},
+		{"golden atespace rejected", func(r *ateletpb.UploadPausedCheckpointRequest) { r.Atespace = resources.GoldenActorAtespace }, true},
+		{"invalid actor name", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorName = "UPPER" }, true},
+		{"invalid actor uid", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorUid = "" }, true},
+		{"invalid template namespace", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorTemplateNamespace = "no/slashes" }, true},
+		{"invalid snapshot name", func(r *ateletpb.UploadPausedCheckpointRequest) { r.LocalSnapshotName = "../escape" }, true},
+		{"invalid snapshot uri", func(r *ateletpb.UploadPausedCheckpointRequest) { r.DestinationSnapshotUri = "not-a-uri" }, true},
+		{"unspecified scope", func(r *ateletpb.UploadPausedCheckpointRequest) {
+			r.DesiredScope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_UNSPECIFIED
+		}, true},
+		{"data-on-golden scope", func(r *ateletpb.UploadPausedCheckpointRequest) {
+			r.DesiredScope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN
+		}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validUploadPausedCheckpointRequest()
+			tc.mutate(req)
+			if err := validateUploadPausedCheckpointRequest(req); (err != nil) != tc.wantErr {
+				t.Errorf("validateUploadPausedCheckpointRequest err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/cmd/ateom-microvm/durable.go
+++ b/cmd/ateom-microvm/durable.go
@@ -57,7 +57,9 @@ import (
 // durableTarFile is the snapshot file holding the tar of the actor's durable-dir
 // volumes. Its entries are <volumeName>/... relative to
 // ateompath.DurableDirVolumeMountsDir, so extraction restores the same layout.
-const durableTarFile = "durable-dir.tar"
+// The name is shared with atelet, which uses it to carve durable data out of a
+// FULL snapshot's file set when uploading a paused checkpoint as DATA.
+const durableTarFile = ateompath.DurableDirTarFile
 
 // hasDurableVolumes reports whether any container mounts a durable-dir volume.
 func hasDurableVolumes(containers []*ateompb.Container) bool {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -394,6 +394,10 @@ stateDiagram-v2
     RESUMING --> RUNNING : restore / boot complete
     RUNNING --> SUSPENDING : SuspendActor
     SUSPENDING --> SUSPENDED : checkpoint complete
+    RUNNING --> PAUSING : PauseActor
+    PAUSING --> PAUSED : node-local checkpoint complete
+    PAUSED --> RESUMING : ResumeActor (pinned to the snapshot's node)
+    PAUSED --> SUSPENDING : SuspendActor (uploads the node-local snapshot)
     SUSPENDED --> [*] : DeleteActor
 ```
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -74,8 +74,10 @@ because they change too frequently for etcd.
 
 ## Lifecycle
 
-- **Suspend**: hibernate a running Actor by checkpointing it to a snapshot and
-  freeing its Worker. The requested snapshots are uploaded to external storage.
+- **Suspend**: hibernate a running or paused Actor into a durable snapshot in
+  external storage. A running Actor is checkpointed on its Worker (which is
+  then freed); a paused Actor's node-local snapshot is uploaded as-is, ending
+  its node pinning.
 
 - **Pause**: a short-term checkpoint of a running Actor. Snapshot files remain
   on the node VM, and the following Resume is prioritized onto the node VM

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -76,8 +76,8 @@ because they change too frequently for etcd.
 
 - **Suspend**: hibernate a running or paused Actor into a durable snapshot in
   external storage. A running Actor is checkpointed on its Worker (which is
-  then freed); a paused Actor's node-local snapshot is uploaded as-is, ending
-  its node pinning.
+  then freed); a paused Actor's node-local snapshot is uploaded — narrowed to
+  the commit scope when the pause captured more — ending its node pinning.
 
 - **Pause**: a short-term checkpoint of a running Actor. Snapshot files remain
   on the node VM, and the following Resume is prioritized onto the node VM

--- a/internal/ateerrors/ateerrors.go
+++ b/internal/ateerrors/ateerrors.go
@@ -55,6 +55,11 @@ const (
 	// image defines no ENTRYPOINT/CMD and the ActorTemplate sets no command/args).
 	ReasonInvalidContainerConfig Reason = "INVALID_CONTAINER_CONFIG"
 
+	// ReasonLocalSnapshotGone marks a paused actor whose local snapshot is
+	// missing from the node it was recorded on and absent from object storage:
+	// its state is unrecoverable.
+	ReasonLocalSnapshotGone Reason = "LOCAL_SNAPSHOT_GONE"
+
 	// Control-plane failure reasons for ate.actor.crashes metric.
 	ReasonCorruptedAssignment Reason = "CORRUPTED_ASSIGNMENT"
 	ReasonWorkerReassigned    Reason = "WORKER_REASSIGNED"
@@ -71,6 +76,7 @@ var AllReasons = []Reason{
 	ReasonInvalidObjectURL,
 	ReasonFailedGetExternalObject,
 	ReasonInvalidContainerConfig,
+	ReasonLocalSnapshotGone,
 	ReasonCorruptedAssignment,
 	ReasonWorkerReassigned,
 	ReasonWorkerPodGone,

--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -155,6 +155,13 @@ func LocalCheckpointsDir(actorUID string) string {
 	)
 }
 
+// DurableDirTarFile is the snapshot file holding the tar of a micro-VM
+// actor's durable-dir volumes (entries are <volumeName>/... relative to
+// DurableDirVolumeMountsDir). Written by ateom-microvm at checkpoint; a DATA
+// snapshot consists of this file alone, so atelet uses the name to carve the
+// durable data out of a FULL snapshot's file set.
+const DurableDirTarFile = "durable-dir.tar"
+
 // DurableDirVolumeMountsDir is the directory where individual durable-dir
 // volumes are mounted.
 func DurableDirVolumeMountsDir(actorUID string) string {

--- a/internal/ateompath/ateompath.go
+++ b/internal/ateompath/ateompath.go
@@ -155,6 +155,12 @@ func LocalCheckpointsDir(actorUID string) string {
 	)
 }
 
+// LocalSnapshotDir is the directory holding one named local (pause) snapshot
+// of an actor: the checkpoint files plus their manifest.
+func LocalSnapshotDir(actorUID, snapshotName string) string {
+	return filepath.Join(LocalCheckpointsDir(actorUID), snapshotName)
+}
+
 // DurableDirTarFile is the snapshot file holding the tar of a micro-VM
 // actor's durable-dir volumes (entries are <volumeName>/... relative to
 // DurableDirVolumeMountsDir). Written by ateom-microvm at checkpoint; a DATA

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -276,12 +276,56 @@ func TestDurableDirLifecycle(t *testing.T) {
 				microVMOnly:              true,
 			},
 		},
+		{
+			// Suspend from PAUSED with matching Full scopes.
+			name: "onCommit:Full, onPause:Full, suspend from PAUSED",
+			tc: actorLifecycleTestCase{
+				onCommit:                 v1alpha1.SnapshotScopeFull,
+				onPause:                  v1alpha1.SnapshotScopeFull,
+				wantMemoryAfterPause:     2,
+				wantFileAfterPause:       2,
+				wantMemoryAfterSuspend:   3,
+				wantFileAfterSuspend:     3,
+				wantSnapshotContentScope: ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
+				suspendWhilePaused:       true,
+			},
+		},
+		{
+			// Suspend from PAUSED with matching Data scopes.
+			name: "onCommit:Data, onPause:Data, suspend from PAUSED",
+			tc: actorLifecycleTestCase{
+				onCommit:                 v1alpha1.SnapshotScopeData,
+				onPause:                  v1alpha1.SnapshotScopeData,
+				wantMemoryAfterPause:     1,
+				wantFileAfterPause:       2,
+				wantMemoryAfterSuspend:   1,
+				wantFileAfterSuspend:     3,
+				wantSnapshotContentScope: ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA,
+				suspendWhilePaused:       true,
+			},
+		},
+		{
+			// Suspend from PAUSED with scope conversion.
+			// mircoVM already implemnted, while gVisor is blocked by #790:
+			name: "onCommit:Data, onPause:Full, suspend from PAUSED",
+			tc: actorLifecycleTestCase{
+				onCommit:                 v1alpha1.SnapshotScopeData,
+				onPause:                  v1alpha1.SnapshotScopeFull,
+				wantMemoryAfterPause:     2,
+				wantFileAfterPause:       2,
+				wantMemoryAfterSuspend:   1,
+				wantFileAfterSuspend:     3,
+				wantSnapshotContentScope: ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA,
+				suspendWhilePaused:       true,
+				microVMOnly:              true,
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.tc.microVMOnly && !isMicroVMEnvironment() {
-				t.Skipf("Skipping %s: the Golden resume source is micro-VM only", test.name)
+				t.Skipf("Skipping %s: micro-VM-only case (Golden resume source, or durable-data extraction from a Full capture)", test.name)
 			}
 			t.Parallel()
 			runActorLifecycleTestCase(t, "durabledir-lifecycle", createActorTemplate, test.tc)
@@ -416,6 +460,13 @@ type actorLifecycleTestCase struct {
 	// microVMOnly skips the case outside the micro-VM environment (e.g.
 	// fromData: Golden is rejected by the CRD CEL rules on gVisor).
 	microVMOnly bool
+
+	// suspendWhilePaused pauses the actor again before the suspend step, so
+	// the suspend runs from PAUSED: it must upload the node-local pause
+	// snapshot instead of checkpointing a running workload. The counter
+	// expectations are unchanged — both origins capture the state after the
+	// second call.
+	suspendWhilePaused bool
 }
 
 func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(context.Context, *testing.T, *e2e.Clients, *e2e.Namespace, v1alpha1.SnapshotScope, v1alpha1.SnapshotScope, v1alpha1.ResumeSource) (*v1alpha1.ActorTemplate, error), tc actorLifecycleTestCase) {
@@ -505,6 +556,15 @@ func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(
 	//
 	// Suspending the actor
 	//
+	if tc.suspendWhilePaused {
+		t.Logf("Pausing Actor %q before suspending...", actorID)
+		if _, err := clients.SubstrateAPI.PauseActor(ctx, &ateapipb.PauseActorRequest{
+			Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
+		}); err != nil {
+			t.Fatalf("failed to pause Actor before suspend: %v", err)
+		}
+		waitForActorStatus(ctx, t, clients, actorID, ateapipb.Actor_STATUS_PAUSED)
+	}
 	t.Logf("Suspending Actor %q...", actorID)
 	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
@@ -512,6 +572,20 @@ func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(
 		t.Fatalf("failed to suspend Actor: %v", err)
 	}
 	waitForActorStatus(ctx, t, clients, actorID, ateapipb.Actor_STATUS_SUSPENDED)
+
+	if tc.suspendWhilePaused {
+		// The suspend must end the node pinning: a suspended actor's snapshot
+		// lives in object storage, not on a node.
+		suspendedActor, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
+			Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
+		})
+		if err != nil {
+			t.Fatalf("failed to get suspended Actor: %v", err)
+		}
+		if suspendedActor.GetLocalSnapshotInfo() != nil {
+			t.Errorf("suspended Actor still carries LocalSnapshotInfo: %v", suspendedActor.GetLocalSnapshotInfo())
+		}
+	}
 
 	if tc.wantSnapshotContentScope != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED {
 		validateSnapshotContentScope(ctx, t, clients, actorID, tc.wantSnapshotContentScope)

--- a/internal/proto/ateletpb/atelet.pb.go
+++ b/internal/proto/ateletpb/atelet.pb.go
@@ -1507,6 +1507,151 @@ func (*CheckpointResponse) Descriptor() ([]byte, []int) {
 	return file_atelet_proto_rawDescGZIP(), []int{20}
 }
 
+type UploadPausedCheckpointRequest struct {
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Atespace  string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid  string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	// For metrics attribution, like on CheckpointRequest.
+	ActorTemplateNamespace string `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
+	ActorTemplateName      string `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	// The local checkpoint to upload: LocalSnapshotInfo.snapshot_name recorded
+	// at pause time.
+	LocalSnapshotName string `protobuf:"bytes,6,opt,name=local_snapshot_name,json=localSnapshotName,proto3" json:"local_snapshot_name,omitempty"`
+	// Destination object-storage URI (the actor's in-progress snapshot URI).
+	DestinationSnapshotUri string `protobuf:"bytes,7,opt,name=destination_snapshot_uri,json=destinationSnapshotUri,proto3" json:"destination_snapshot_uri,omitempty"`
+	// Scope the uploaded snapshot must have (the commit scope; FULL or DATA).
+	// The scope the pause checkpoint captured is not sent: atelet reads it from
+	// the local snapshot's own manifest, which is authoritative. When they
+	// differ, atelet converts where possible (micro-VM FULL capture to a DATA
+	// upload by selecting the durable-dir tar) and rejects otherwise.
+	DesiredScope  SnapshotScope `protobuf:"varint,8,opt,name=desired_scope,json=desiredScope,proto3,enum=atelet.SnapshotScope" json:"desired_scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UploadPausedCheckpointRequest) Reset() {
+	*x = UploadPausedCheckpointRequest{}
+	mi := &file_atelet_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UploadPausedCheckpointRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UploadPausedCheckpointRequest) ProtoMessage() {}
+
+func (x *UploadPausedCheckpointRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_atelet_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UploadPausedCheckpointRequest.ProtoReflect.Descriptor instead.
+func (*UploadPausedCheckpointRequest) Descriptor() ([]byte, []int) {
+	return file_atelet_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *UploadPausedCheckpointRequest) GetAtespace() string {
+	if x != nil {
+		return x.Atespace
+	}
+	return ""
+}
+
+func (x *UploadPausedCheckpointRequest) GetActorName() string {
+	if x != nil {
+		return x.ActorName
+	}
+	return ""
+}
+
+func (x *UploadPausedCheckpointRequest) GetActorUid() string {
+	if x != nil {
+		return x.ActorUid
+	}
+	return ""
+}
+
+func (x *UploadPausedCheckpointRequest) GetActorTemplateNamespace() string {
+	if x != nil {
+		return x.ActorTemplateNamespace
+	}
+	return ""
+}
+
+func (x *UploadPausedCheckpointRequest) GetActorTemplateName() string {
+	if x != nil {
+		return x.ActorTemplateName
+	}
+	return ""
+}
+
+func (x *UploadPausedCheckpointRequest) GetLocalSnapshotName() string {
+	if x != nil {
+		return x.LocalSnapshotName
+	}
+	return ""
+}
+
+func (x *UploadPausedCheckpointRequest) GetDestinationSnapshotUri() string {
+	if x != nil {
+		return x.DestinationSnapshotUri
+	}
+	return ""
+}
+
+func (x *UploadPausedCheckpointRequest) GetDesiredScope() SnapshotScope {
+	if x != nil {
+		return x.DesiredScope
+	}
+	return SnapshotScope_SNAPSHOT_SCOPE_UNSPECIFIED
+}
+
+type UploadPausedCheckpointResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UploadPausedCheckpointResponse) Reset() {
+	*x = UploadPausedCheckpointResponse{}
+	mi := &file_atelet_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UploadPausedCheckpointResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UploadPausedCheckpointResponse) ProtoMessage() {}
+
+func (x *UploadPausedCheckpointResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_atelet_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UploadPausedCheckpointResponse.ProtoReflect.Descriptor instead.
+func (*UploadPausedCheckpointResponse) Descriptor() ([]byte, []int) {
+	return file_atelet_proto_rawDescGZIP(), []int{22}
+}
+
 type RestoreRequest struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
@@ -1544,7 +1689,7 @@ type RestoreRequest struct {
 
 func (x *RestoreRequest) Reset() {
 	*x = RestoreRequest{}
-	mi := &file_atelet_proto_msgTypes[21]
+	mi := &file_atelet_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1556,7 +1701,7 @@ func (x *RestoreRequest) String() string {
 func (*RestoreRequest) ProtoMessage() {}
 
 func (x *RestoreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[21]
+	mi := &file_atelet_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1569,7 +1714,7 @@ func (x *RestoreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreRequest.ProtoReflect.Descriptor instead.
 func (*RestoreRequest) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{21}
+	return file_atelet_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *RestoreRequest) GetTargetAteomUid() string {
@@ -1698,7 +1843,7 @@ type RestoreResponse struct {
 
 func (x *RestoreResponse) Reset() {
 	*x = RestoreResponse{}
-	mi := &file_atelet_proto_msgTypes[22]
+	mi := &file_atelet_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1710,7 +1855,7 @@ func (x *RestoreResponse) String() string {
 func (*RestoreResponse) ProtoMessage() {}
 
 func (x *RestoreResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_atelet_proto_msgTypes[22]
+	mi := &file_atelet_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1723,7 +1868,7 @@ func (x *RestoreResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreResponse.ProtoReflect.Descriptor instead.
 func (*RestoreResponse) Descriptor() ([]byte, []int) {
-	return file_atelet_proto_rawDescGZIP(), []int{22}
+	return file_atelet_proto_rawDescGZIP(), []int{24}
 }
 
 var File_atelet_proto protoreflect.FileDescriptor
@@ -1831,7 +1976,18 @@ const file_atelet_proto_rawDesc = "" +
 	" \x01(\v2'.atelet.ExternalCheckpointConfigurationH\x00R\x0eexternalConfig\x12+\n" +
 	"\x05scope\x18\v \x01(\x0e2\x15.atelet.SnapshotScopeR\x05scopeB\b\n" +
 	"\x06config\"\x14\n" +
-	"\x12CheckpointResponse\"\xae\x05\n" +
+	"\x12CheckpointResponse\"\x87\x03\n" +
+	"\x1dUploadPausedCheckpointRequest\x12\x1a\n" +
+	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
+	"\n" +
+	"actor_name\x18\x02 \x01(\tR\tactorName\x12\x1b\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x128\n" +
+	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12.\n" +
+	"\x13local_snapshot_name\x18\x06 \x01(\tR\x11localSnapshotName\x128\n" +
+	"\x18destination_snapshot_uri\x18\a \x01(\tR\x16destinationSnapshotUri\x12:\n" +
+	"\rdesired_scope\x18\b \x01(\x0e2\x15.atelet.SnapshotScopeR\fdesiredScope\" \n" +
+	"\x1eUploadPausedCheckpointResponse\"\xae\x05\n" +
 	"\x0eRestoreRequest\x12(\n" +
 	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
 	"\batespace\x18\x02 \x01(\tR\batespace\x12\x1d\n" +
@@ -1866,12 +2022,13 @@ const file_atelet_proto_rawDesc = "" +
 	"\x13SNAPSHOT_SCOPE_DATA\x10\x02\x12!\n" +
 	"\x1dSNAPSHOT_SCOPE_DATA_ON_GOLDEN\x10\x032w\n" +
 	"\x10CredentialBroker\x12c\n" +
-	"\x14MintActorCertificate\x12#.atelet.MintActorCertificateRequest\x1a$.atelet.MintActorCertificateResponse\"\x002\xc4\x01\n" +
+	"\x14MintActorCertificate\x12#.atelet.MintActorCertificateRequest\x1a$.atelet.MintActorCertificateResponse\"\x002\xaf\x02\n" +
 	"\vAteomHerder\x120\n" +
 	"\x03Run\x12\x12.atelet.RunRequest\x1a\x13.atelet.RunResponse\"\x00\x12E\n" +
 	"\n" +
 	"Checkpoint\x12\x19.atelet.CheckpointRequest\x1a\x1a.atelet.CheckpointResponse\"\x00\x12<\n" +
-	"\aRestore\x12\x16.atelet.RestoreRequest\x1a\x17.atelet.RestoreResponse\"\x00B>Z<github.com/agent-substrate/substrate/internal/proto/ateletpbb\x06proto3"
+	"\aRestore\x12\x16.atelet.RestoreRequest\x1a\x17.atelet.RestoreResponse\"\x00\x12i\n" +
+	"\x16UploadPausedCheckpoint\x12%.atelet.UploadPausedCheckpointRequest\x1a&.atelet.UploadPausedCheckpointResponse\"\x00B>Z<github.com/agent-substrate/substrate/internal/proto/ateletpbb\x06proto3"
 
 var (
 	file_atelet_proto_rawDescOnce sync.Once
@@ -1886,7 +2043,7 @@ func file_atelet_proto_rawDescGZIP() []byte {
 }
 
 var file_atelet_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_atelet_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_atelet_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_atelet_proto_goTypes = []any{
 	(VolumeType)(0),                         // 0: atelet.VolumeType
 	(CheckpointType)(0),                     // 1: atelet.CheckpointType
@@ -1912,21 +2069,23 @@ var file_atelet_proto_goTypes = []any{
 	(*ExternalCheckpointConfiguration)(nil), // 21: atelet.ExternalCheckpointConfiguration
 	(*CheckpointRequest)(nil),               // 22: atelet.CheckpointRequest
 	(*CheckpointResponse)(nil),              // 23: atelet.CheckpointResponse
-	(*RestoreRequest)(nil),                  // 24: atelet.RestoreRequest
-	(*RestoreResponse)(nil),                 // 25: atelet.RestoreResponse
-	nil,                                     // 26: atelet.ArchAssets.FilesEntry
-	nil,                                     // 27: atelet.SandboxAssets.AssetsEntry
-	nil,                                     // 28: atelet.ExternalVolumeSource.VolumeContextEntry
+	(*UploadPausedCheckpointRequest)(nil),   // 24: atelet.UploadPausedCheckpointRequest
+	(*UploadPausedCheckpointResponse)(nil),  // 25: atelet.UploadPausedCheckpointResponse
+	(*RestoreRequest)(nil),                  // 26: atelet.RestoreRequest
+	(*RestoreResponse)(nil),                 // 27: atelet.RestoreResponse
+	nil,                                     // 28: atelet.ArchAssets.FilesEntry
+	nil,                                     // 29: atelet.SandboxAssets.AssetsEntry
+	nil,                                     // 30: atelet.ExternalVolumeSource.VolumeContextEntry
 }
 var file_atelet_proto_depIdxs = []int32{
 	10, // 0: atelet.RunRequest.spec:type_name -> atelet.WorkloadSpec
 	9,  // 1: atelet.RunRequest.sandbox_assets:type_name -> atelet.SandboxAssets
 	6,  // 2: atelet.RunRequest.egress_gateway:type_name -> atelet.EgressGateway
-	26, // 3: atelet.ArchAssets.files:type_name -> atelet.ArchAssets.FilesEntry
-	27, // 4: atelet.SandboxAssets.assets:type_name -> atelet.SandboxAssets.AssetsEntry
+	28, // 3: atelet.ArchAssets.files:type_name -> atelet.ArchAssets.FilesEntry
+	29, // 4: atelet.SandboxAssets.assets:type_name -> atelet.SandboxAssets.AssetsEntry
 	15, // 5: atelet.WorkloadSpec.containers:type_name -> atelet.Container
 	13, // 6: atelet.WorkloadSpec.volumes:type_name -> atelet.Volume
-	28, // 7: atelet.ExternalVolumeSource.volume_context:type_name -> atelet.ExternalVolumeSource.VolumeContextEntry
+	30, // 7: atelet.ExternalVolumeSource.volume_context:type_name -> atelet.ExternalVolumeSource.VolumeContextEntry
 	0,  // 8: atelet.Volume.type:type_name -> atelet.VolumeType
 	11, // 9: atelet.Volume.durable_dir:type_name -> atelet.DurableDirVolume
 	12, // 10: atelet.Volume.external:type_name -> atelet.ExternalVolumeSource
@@ -1939,27 +2098,30 @@ var file_atelet_proto_depIdxs = []int32{
 	20, // 17: atelet.CheckpointRequest.local_config:type_name -> atelet.LocalCheckpointConfiguration
 	21, // 18: atelet.CheckpointRequest.external_config:type_name -> atelet.ExternalCheckpointConfiguration
 	2,  // 19: atelet.CheckpointRequest.scope:type_name -> atelet.SnapshotScope
-	10, // 20: atelet.RestoreRequest.spec:type_name -> atelet.WorkloadSpec
-	1,  // 21: atelet.RestoreRequest.type:type_name -> atelet.CheckpointType
-	20, // 22: atelet.RestoreRequest.local_config:type_name -> atelet.LocalCheckpointConfiguration
-	21, // 23: atelet.RestoreRequest.external_config:type_name -> atelet.ExternalCheckpointConfiguration
-	2,  // 24: atelet.RestoreRequest.scope:type_name -> atelet.SnapshotScope
-	6,  // 25: atelet.RestoreRequest.egress_gateway:type_name -> atelet.EgressGateway
-	7,  // 26: atelet.ArchAssets.FilesEntry.value:type_name -> atelet.AssetFile
-	8,  // 27: atelet.SandboxAssets.AssetsEntry.value:type_name -> atelet.ArchAssets
-	3,  // 28: atelet.CredentialBroker.MintActorCertificate:input_type -> atelet.MintActorCertificateRequest
-	5,  // 29: atelet.AteomHerder.Run:input_type -> atelet.RunRequest
-	22, // 30: atelet.AteomHerder.Checkpoint:input_type -> atelet.CheckpointRequest
-	24, // 31: atelet.AteomHerder.Restore:input_type -> atelet.RestoreRequest
-	4,  // 32: atelet.CredentialBroker.MintActorCertificate:output_type -> atelet.MintActorCertificateResponse
-	19, // 33: atelet.AteomHerder.Run:output_type -> atelet.RunResponse
-	23, // 34: atelet.AteomHerder.Checkpoint:output_type -> atelet.CheckpointResponse
-	25, // 35: atelet.AteomHerder.Restore:output_type -> atelet.RestoreResponse
-	32, // [32:36] is the sub-list for method output_type
-	28, // [28:32] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	2,  // 20: atelet.UploadPausedCheckpointRequest.desired_scope:type_name -> atelet.SnapshotScope
+	10, // 21: atelet.RestoreRequest.spec:type_name -> atelet.WorkloadSpec
+	1,  // 22: atelet.RestoreRequest.type:type_name -> atelet.CheckpointType
+	20, // 23: atelet.RestoreRequest.local_config:type_name -> atelet.LocalCheckpointConfiguration
+	21, // 24: atelet.RestoreRequest.external_config:type_name -> atelet.ExternalCheckpointConfiguration
+	2,  // 25: atelet.RestoreRequest.scope:type_name -> atelet.SnapshotScope
+	6,  // 26: atelet.RestoreRequest.egress_gateway:type_name -> atelet.EgressGateway
+	7,  // 27: atelet.ArchAssets.FilesEntry.value:type_name -> atelet.AssetFile
+	8,  // 28: atelet.SandboxAssets.AssetsEntry.value:type_name -> atelet.ArchAssets
+	3,  // 29: atelet.CredentialBroker.MintActorCertificate:input_type -> atelet.MintActorCertificateRequest
+	5,  // 30: atelet.AteomHerder.Run:input_type -> atelet.RunRequest
+	22, // 31: atelet.AteomHerder.Checkpoint:input_type -> atelet.CheckpointRequest
+	26, // 32: atelet.AteomHerder.Restore:input_type -> atelet.RestoreRequest
+	24, // 33: atelet.AteomHerder.UploadPausedCheckpoint:input_type -> atelet.UploadPausedCheckpointRequest
+	4,  // 34: atelet.CredentialBroker.MintActorCertificate:output_type -> atelet.MintActorCertificateResponse
+	19, // 35: atelet.AteomHerder.Run:output_type -> atelet.RunResponse
+	23, // 36: atelet.AteomHerder.Checkpoint:output_type -> atelet.CheckpointResponse
+	27, // 37: atelet.AteomHerder.Restore:output_type -> atelet.RestoreResponse
+	25, // 38: atelet.AteomHerder.UploadPausedCheckpoint:output_type -> atelet.UploadPausedCheckpointResponse
+	34, // [34:39] is the sub-list for method output_type
+	29, // [29:34] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_atelet_proto_init() }
@@ -1976,7 +2138,7 @@ func file_atelet_proto_init() {
 		(*CheckpointRequest_LocalConfig)(nil),
 		(*CheckpointRequest_ExternalConfig)(nil),
 	}
-	file_atelet_proto_msgTypes[21].OneofWrappers = []any{
+	file_atelet_proto_msgTypes[23].OneofWrappers = []any{
 		(*RestoreRequest_LocalConfig)(nil),
 		(*RestoreRequest_ExternalConfig)(nil),
 	}
@@ -1986,7 +2148,7 @@ func file_atelet_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_atelet_proto_rawDesc), len(file_atelet_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   26,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/internal/proto/ateletpb/atelet.proto
+++ b/internal/proto/ateletpb/atelet.proto
@@ -50,6 +50,12 @@ service AteomHerder {
 
   // Restore restores a workload from checkpoint onto an ateom.
   rpc Restore(RestoreRequest) returns (RestoreResponse) {}
+
+  // UploadPausedCheckpoint copies a local (pause) checkpoint from this node's
+  // disk to object storage. Unlike Checkpoint it drives no ateom: the actor is
+  // paused, its sandbox is gone; the checkpoint files plus their manifest
+  // already sit under the actor's local-checkpoints directory.
+  rpc UploadPausedCheckpoint(UploadPausedCheckpointRequest) returns (UploadPausedCheckpointResponse) {}
 }
 
 message RunRequest {
@@ -248,6 +254,33 @@ message CheckpointRequest {
 }
 
 message CheckpointResponse {
+}
+
+message UploadPausedCheckpointRequest {
+  string atespace = 1;
+  string actor_name = 2;
+  string actor_uid = 3;
+
+  // For metrics attribution, like on CheckpointRequest.
+  string actor_template_namespace = 4;
+  string actor_template_name = 5;
+
+  // The local checkpoint to upload: LocalSnapshotInfo.snapshot_name recorded
+  // at pause time.
+  string local_snapshot_name = 6;
+
+  // Destination object-storage URI (the actor's in-progress snapshot URI).
+  string destination_snapshot_uri = 7;
+
+  // Scope the uploaded snapshot must have (the commit scope; FULL or DATA).
+  // The scope the pause checkpoint captured is not sent: atelet reads it from
+  // the local snapshot's own manifest, which is authoritative. When they
+  // differ, atelet converts where possible (micro-VM FULL capture to a DATA
+  // upload by selecting the durable-dir tar) and rejects otherwise.
+  SnapshotScope desired_scope = 8;
+}
+
+message UploadPausedCheckpointResponse {
 }
 
 message RestoreRequest {

--- a/internal/proto/ateletpb/atelet_grpc.pb.go
+++ b/internal/proto/ateletpb/atelet_grpc.pb.go
@@ -139,9 +139,10 @@ var CredentialBroker_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	AteomHerder_Run_FullMethodName        = "/atelet.AteomHerder/Run"
-	AteomHerder_Checkpoint_FullMethodName = "/atelet.AteomHerder/Checkpoint"
-	AteomHerder_Restore_FullMethodName    = "/atelet.AteomHerder/Restore"
+	AteomHerder_Run_FullMethodName                    = "/atelet.AteomHerder/Run"
+	AteomHerder_Checkpoint_FullMethodName             = "/atelet.AteomHerder/Checkpoint"
+	AteomHerder_Restore_FullMethodName                = "/atelet.AteomHerder/Restore"
+	AteomHerder_UploadPausedCheckpoint_FullMethodName = "/atelet.AteomHerder/UploadPausedCheckpoint"
 )
 
 // AteomHerderClient is the client API for AteomHerder service.
@@ -157,6 +158,11 @@ type AteomHerderClient interface {
 	Checkpoint(ctx context.Context, in *CheckpointRequest, opts ...grpc.CallOption) (*CheckpointResponse, error)
 	// Restore restores a workload from checkpoint onto an ateom.
 	Restore(ctx context.Context, in *RestoreRequest, opts ...grpc.CallOption) (*RestoreResponse, error)
+	// UploadPausedCheckpoint copies a local (pause) checkpoint from this node's
+	// disk to object storage. Unlike Checkpoint it drives no ateom: the actor is
+	// paused, its sandbox is gone; the checkpoint files plus their manifest
+	// already sit under the actor's local-checkpoints directory.
+	UploadPausedCheckpoint(ctx context.Context, in *UploadPausedCheckpointRequest, opts ...grpc.CallOption) (*UploadPausedCheckpointResponse, error)
 }
 
 type ateomHerderClient struct {
@@ -197,6 +203,16 @@ func (c *ateomHerderClient) Restore(ctx context.Context, in *RestoreRequest, opt
 	return out, nil
 }
 
+func (c *ateomHerderClient) UploadPausedCheckpoint(ctx context.Context, in *UploadPausedCheckpointRequest, opts ...grpc.CallOption) (*UploadPausedCheckpointResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UploadPausedCheckpointResponse)
+	err := c.cc.Invoke(ctx, AteomHerder_UploadPausedCheckpoint_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AteomHerderServer is the server API for AteomHerder service.
 // All implementations must embed UnimplementedAteomHerderServer
 // for forward compatibility.
@@ -210,6 +226,11 @@ type AteomHerderServer interface {
 	Checkpoint(context.Context, *CheckpointRequest) (*CheckpointResponse, error)
 	// Restore restores a workload from checkpoint onto an ateom.
 	Restore(context.Context, *RestoreRequest) (*RestoreResponse, error)
+	// UploadPausedCheckpoint copies a local (pause) checkpoint from this node's
+	// disk to object storage. Unlike Checkpoint it drives no ateom: the actor is
+	// paused, its sandbox is gone; the checkpoint files plus their manifest
+	// already sit under the actor's local-checkpoints directory.
+	UploadPausedCheckpoint(context.Context, *UploadPausedCheckpointRequest) (*UploadPausedCheckpointResponse, error)
 	mustEmbedUnimplementedAteomHerderServer()
 }
 
@@ -228,6 +249,9 @@ func (UnimplementedAteomHerderServer) Checkpoint(context.Context, *CheckpointReq
 }
 func (UnimplementedAteomHerderServer) Restore(context.Context, *RestoreRequest) (*RestoreResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Restore not implemented")
+}
+func (UnimplementedAteomHerderServer) UploadPausedCheckpoint(context.Context, *UploadPausedCheckpointRequest) (*UploadPausedCheckpointResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UploadPausedCheckpoint not implemented")
 }
 func (UnimplementedAteomHerderServer) mustEmbedUnimplementedAteomHerderServer() {}
 func (UnimplementedAteomHerderServer) testEmbeddedByValue()                     {}
@@ -304,6 +328,24 @@ func _AteomHerder_Restore_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AteomHerder_UploadPausedCheckpoint_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UploadPausedCheckpointRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AteomHerderServer).UploadPausedCheckpoint(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AteomHerder_UploadPausedCheckpoint_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AteomHerderServer).UploadPausedCheckpoint(ctx, req.(*UploadPausedCheckpointRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AteomHerder_ServiceDesc is the grpc.ServiceDesc for AteomHerder service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -322,6 +364,10 @@ var AteomHerder_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Restore",
 			Handler:    _AteomHerder_Restore_Handler,
+		},
+		{
+			MethodName: "UploadPausedCheckpoint",
+			Handler:    _AteomHerder_UploadPausedCheckpoint_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -32,7 +32,8 @@ service Control {
   // Update mutable fields on an existing Actor.
   rpc UpdateActor(UpdateActorRequest) returns (Actor) {}
 
-  // Suspend a given actor to a new snapshot.
+  // Suspend a given actor to a new snapshot. A running actor is checkpointed
+  // on its worker; a paused actor's node-local snapshot is uploaded as-is.
   rpc SuspendActor(SuspendActorRequest) returns (SuspendActorResponse) {}
 
   // Pause a given actor and keep its snapshots on node VM.

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -33,7 +33,8 @@ service Control {
   rpc UpdateActor(UpdateActorRequest) returns (Actor) {}
 
   // Suspend a given actor to a new snapshot. A running actor is checkpointed
-  // on its worker; a paused actor's node-local snapshot is uploaded as-is.
+  // on its worker; a paused actor's node-local snapshot is uploaded, narrowed
+  // to the template's commit scope where required (Full capture, Data commit).
   rpc SuspendActor(SuspendActorRequest) returns (SuspendActorResponse) {}
 
   // Pause a given actor and keep its snapshots on node VM.

--- a/pkg/proto/ateapipb/ateapi_grpc.pb.go
+++ b/pkg/proto/ateapipb/ateapi_grpc.pb.go
@@ -65,7 +65,8 @@ type ControlClient interface {
 	CreateActor(ctx context.Context, in *CreateActorRequest, opts ...grpc.CallOption) (*Actor, error)
 	// Update mutable fields on an existing Actor.
 	UpdateActor(ctx context.Context, in *UpdateActorRequest, opts ...grpc.CallOption) (*Actor, error)
-	// Suspend a given actor to a new snapshot.
+	// Suspend a given actor to a new snapshot. A running actor is checkpointed
+	// on its worker; a paused actor's node-local snapshot is uploaded as-is.
 	SuspendActor(ctx context.Context, in *SuspendActorRequest, opts ...grpc.CallOption) (*SuspendActorResponse, error)
 	// Pause a given actor and keep its snapshots on node VM.
 	PauseActor(ctx context.Context, in *PauseActorRequest, opts ...grpc.CallOption) (*PauseActorResponse, error)
@@ -299,7 +300,8 @@ type ControlServer interface {
 	CreateActor(context.Context, *CreateActorRequest) (*Actor, error)
 	// Update mutable fields on an existing Actor.
 	UpdateActor(context.Context, *UpdateActorRequest) (*Actor, error)
-	// Suspend a given actor to a new snapshot.
+	// Suspend a given actor to a new snapshot. A running actor is checkpointed
+	// on its worker; a paused actor's node-local snapshot is uploaded as-is.
 	SuspendActor(context.Context, *SuspendActorRequest) (*SuspendActorResponse, error)
 	// Pause a given actor and keep its snapshots on node VM.
 	PauseActor(context.Context, *PauseActorRequest) (*PauseActorResponse, error)

--- a/pkg/proto/ateapipb/ateapi_grpc.pb.go
+++ b/pkg/proto/ateapipb/ateapi_grpc.pb.go
@@ -66,7 +66,8 @@ type ControlClient interface {
 	// Update mutable fields on an existing Actor.
 	UpdateActor(ctx context.Context, in *UpdateActorRequest, opts ...grpc.CallOption) (*Actor, error)
 	// Suspend a given actor to a new snapshot. A running actor is checkpointed
-	// on its worker; a paused actor's node-local snapshot is uploaded as-is.
+	// on its worker; a paused actor's node-local snapshot is uploaded, narrowed
+	// to the template's commit scope where required (Full capture, Data commit).
 	SuspendActor(ctx context.Context, in *SuspendActorRequest, opts ...grpc.CallOption) (*SuspendActorResponse, error)
 	// Pause a given actor and keep its snapshots on node VM.
 	PauseActor(ctx context.Context, in *PauseActorRequest, opts ...grpc.CallOption) (*PauseActorResponse, error)
@@ -301,7 +302,8 @@ type ControlServer interface {
 	// Update mutable fields on an existing Actor.
 	UpdateActor(context.Context, *UpdateActorRequest) (*Actor, error)
 	// Suspend a given actor to a new snapshot. A running actor is checkpointed
-	// on its worker; a paused actor's node-local snapshot is uploaded as-is.
+	// on its worker; a paused actor's node-local snapshot is uploaded, narrowed
+	// to the template's commit scope where required (Full capture, Data commit).
 	SuspendActor(context.Context, *SuspendActorRequest) (*SuspendActorResponse, error)
 	// Pause a given actor and keep its snapshots on node VM.
 	PauseActor(context.Context, *PauseActorRequest) (*PauseActorResponse, error)


### PR DESCRIPTION
Part of #791 — the last planned piece of the [implementation plan](https://github.com/agent-substrate/substrate/issues/791#issuecomment-5226674097) (after #810, #812, #813). #791 stays open until #817 (gVisor Full-capture → Data-commit conversion, blocked on #790) is done; this PR covers micro-VM fully and gVisor for scope-matched suspends. Also part of the actor state machine (#119) and a prerequisite for system upgrade flows (#473).

`SuspendActor` now accepts a PAUSED actor: instead of checkpointing a running workload, ateapi dials the atelet on the node holding the pause snapshot and has it upload the node-local files to object storage, then finalizes as usual — durable `ActorSnapshot`, `SUSPENDED` status, node pinning cleared.

Two commits, reviewable independently:

## Commit 1 — atelet: `UploadPausedCheckpoint` RPC (dead code until commit 2)

- New `AteomHerder` RPC: a pure disk→object-storage copy driven by the snapshot's self-describing manifest — no ateom involved (the sandbox is gone).
- **Scope conversion** dispatches per sandbox class (`narrowFullCaptureToData`): a micro-VM FULL capture narrows to a DATA upload by carving out `durable-dir.tar` (constant hoisted to `ateompath`, shared with ateom-microvm); gVisor returns `Unimplemented` until split checkpoints land (#790); DATA can never widen to FULL; a scope-less manifest (older atelet) is rejected rather than guessed at.
- **Idempotent retry**: local files gone + remote manifest present ⇒ a previous invocation committed, succeed; gone on both sides ⇒ unrecoverable (`LOCAL_SNAPSHOT_GONE`, crashes the actor). Upload failures stay plain retryable errors; the manifest uploads last as the commit marker, never in parallel.
- The golden atespace is rejected at validation (fully on the `field.ErrorList` framework): golden actors are never paused.

## Commit 2 — control plane: enable suspend from PAUSED

- `FromPaused` discriminator: PAUSED status, or SUSPENDING with no worker assignment and a `LocalSnapshotInfo` — the field alone is stale on resumed-from-pause RUNNING actors, so the nil-assignment conjunct is load-bearing.
- `MarkSuspendingStep` accepts PAUSED and rejects a Data-captured pause against a Full commit *before* the actor leaves PAUSED (an upload cannot fabricate memory), using the `content_scope` recorded at pause (#812) with an `onPause` fallback.
- `CallAteletSuspendStep` paused branch dials by node (`DialForAteletOnNode`, #813): missing node record ⇒ crash (the snapshot can never be found); unreachable atelet ⇒ retryable; atelet's `LOCAL_SNAPSHOT_GONE` ⇒ crash via `maybeCrashActor`. `FinalizeSuspendedStep` needed no changes thanks to the #813 hoist.
- Root-cause guard: `MarkPausingStep` rejects pausing golden-atespace actors.
- Docs: pause states + the new `PAUSED → SUSPENDING` edge in the architecture state diagram; glossary Suspend entry covers both origins.

## Tests

- **atelet unit**: 10 upload-helper subtests (conversion matrix, idempotency probe, data-loss crash, retryable upload failure) via a recording object-storage fake; validation table.
- **control-plane unit**: discriminator table, scope-rejection table (incl. onPause fallback), paused preconditions (no node ⇒ CRASHED, no atelet ⇒ `ErrNoAteletOnNode` + still SUSPENDING), golden-pause rejection, prerequisite matrix updated.
- **functional (envtest)**: `TestSuspendActor_FromPaused` (upload called with the pause snapshot name, no Checkpoint RPC, SUSPENDED, pinning cleared, ActorSnapshot at the upload destination) + retry-after-failed-upload (same destination on retry).
- **e2e (demo suite)**: the lifecycle driver gains a suspend-from-PAUSED mode; three durable-dir cases — Full/Full, Data/Data, and the micro-VM Full→Data extraction — assert memory/file counters survive the full pause→suspend→resume journey and the node pinning is gone.

`go test -race ./...` clean (except the pre-existing macOS-only `internal/atunnel` unix-socket-path failures, untouched by this PR), `gofmt`/`go vet` clean, protos regenerated via `hack/protoc.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

