### PR TITLE
Add ActorTemplate and ActorTemplateVersion as substrate resources

### DIFF
--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -138,6 +138,112 @@ func (ActorSnapshotTagScope) EnumDescriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{1}
 }
 
+// SandboxClass selects the sandbox runtime family. Snapshots are not portable
+// across classes.
+type SandboxClass int32
+
+const (
+	SandboxClass_SANDBOX_CLASS_UNSPECIFIED SandboxClass = 0
+	SandboxClass_SANDBOX_CLASS_GVISOR      SandboxClass = 1
+	SandboxClass_SANDBOX_CLASS_MICROVM     SandboxClass = 2
+)
+
+// Enum value maps for SandboxClass.
+var (
+	SandboxClass_name = map[int32]string{
+		0: "SANDBOX_CLASS_UNSPECIFIED",
+		1: "SANDBOX_CLASS_GVISOR",
+		2: "SANDBOX_CLASS_MICROVM",
+	}
+	SandboxClass_value = map[string]int32{
+		"SANDBOX_CLASS_UNSPECIFIED": 0,
+		"SANDBOX_CLASS_GVISOR":      1,
+		"SANDBOX_CLASS_MICROVM":     2,
+	}
+)
+
+func (x SandboxClass) Enum() *SandboxClass {
+	p := new(SandboxClass)
+	*p = x
+	return p
+}
+
+func (x SandboxClass) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SandboxClass) Descriptor() protoreflect.EnumDescriptor {
+	return file_ateapi_proto_enumTypes[2].Descriptor()
+}
+
+func (SandboxClass) Type() protoreflect.EnumType {
+	return &file_ateapi_proto_enumTypes[2]
+}
+
+func (x SandboxClass) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SandboxClass.Descriptor instead.
+func (SandboxClass) EnumDescriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{2}
+}
+
+// ResumeSource selects what supplies the guest state when an actor is resumed
+// from one of the snapshot situations named by OnResumeConfig's fields.
+type ResumeSource int32
+
+const (
+	ResumeSource_RESUME_SOURCE_UNSPECIFIED ResumeSource = 0
+	// Starts the actor's containers afresh from the OCI image, with the
+	// durable-dir volumes pre-populated from the snapshot.
+	ResumeSource_RESUME_SOURCE_COLD_BOOT ResumeSource = 1
+	// Restores with the version's golden snapshot and the actor's own
+	// durable data.
+	ResumeSource_RESUME_SOURCE_GOLDEN ResumeSource = 2
+)
+
+// Enum value maps for ResumeSource.
+var (
+	ResumeSource_name = map[int32]string{
+		0: "RESUME_SOURCE_UNSPECIFIED",
+		1: "RESUME_SOURCE_COLD_BOOT",
+		2: "RESUME_SOURCE_GOLDEN",
+	}
+	ResumeSource_value = map[string]int32{
+		"RESUME_SOURCE_UNSPECIFIED": 0,
+		"RESUME_SOURCE_COLD_BOOT":   1,
+		"RESUME_SOURCE_GOLDEN":      2,
+	}
+)
+
+func (x ResumeSource) Enum() *ResumeSource {
+	p := new(ResumeSource)
+	*p = x
+	return p
+}
+
+func (x ResumeSource) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ResumeSource) Descriptor() protoreflect.EnumDescriptor {
+	return file_ateapi_proto_enumTypes[3].Descriptor()
+}
+
+func (ResumeSource) Type() protoreflect.EnumType {
+	return &file_ateapi_proto_enumTypes[3]
+}
+
+func (x ResumeSource) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ResumeSource.Descriptor instead.
+func (ResumeSource) EnumDescriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{3}
+}
+
 type ActorCertificatePurpose int32
 
 const (
@@ -168,11 +274,11 @@ func (x ActorCertificatePurpose) String() string {
 }
 
 func (ActorCertificatePurpose) Descriptor() protoreflect.EnumDescriptor {
-	return file_ateapi_proto_enumTypes[2].Descriptor()
+	return file_ateapi_proto_enumTypes[4].Descriptor()
 }
 
 func (ActorCertificatePurpose) Type() protoreflect.EnumType {
-	return &file_ateapi_proto_enumTypes[2]
+	return &file_ateapi_proto_enumTypes[4]
 }
 
 func (x ActorCertificatePurpose) Number() protoreflect.EnumNumber {
@@ -181,7 +287,7 @@ func (x ActorCertificatePurpose) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ActorCertificatePurpose.Descriptor instead.
 func (ActorCertificatePurpose) EnumDescriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{2}
+	return file_ateapi_proto_rawDescGZIP(), []int{4}
 }
 
 type ExternalVolume_Status int32
@@ -223,11 +329,11 @@ func (x ExternalVolume_Status) String() string {
 }
 
 func (ExternalVolume_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_ateapi_proto_enumTypes[3].Descriptor()
+	return file_ateapi_proto_enumTypes[5].Descriptor()
 }
 
 func (ExternalVolume_Status) Type() protoreflect.EnumType {
-	return &file_ateapi_proto_enumTypes[3]
+	return &file_ateapi_proto_enumTypes[5]
 }
 
 func (x ExternalVolume_Status) Number() protoreflect.EnumNumber {
@@ -290,11 +396,11 @@ func (x Actor_Status) String() string {
 }
 
 func (Actor_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_ateapi_proto_enumTypes[4].Descriptor()
+	return file_ateapi_proto_enumTypes[6].Descriptor()
 }
 
 func (Actor_Status) Type() protoreflect.EnumType {
-	return &file_ateapi_proto_enumTypes[4]
+	return &file_ateapi_proto_enumTypes[6]
 }
 
 func (x Actor_Status) Number() protoreflect.EnumNumber {
@@ -304,6 +410,67 @@ func (x Actor_Status) Number() protoreflect.EnumNumber {
 // Deprecated: Use Actor_Status.Descriptor instead.
 func (Actor_Status) EnumDescriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{4, 0}
+}
+
+// State machine, mirroring the ActorTemplateVersion CRD PhaseType:
+// INITIAL -> RESUME_GOLDEN_ACTOR -> WAIT_GOLDEN_ACTOR -> {READY | FAILED}.
+// READY and FAILED are terminal; the version is only usable once READY.
+type ActorTemplateVersionStatus_State int32
+
+const (
+	ActorTemplateVersionStatus_STATE_UNSPECIFIED         ActorTemplateVersionStatus_State = 0
+	ActorTemplateVersionStatus_STATE_INITIAL             ActorTemplateVersionStatus_State = 1
+	ActorTemplateVersionStatus_STATE_RESUME_GOLDEN_ACTOR ActorTemplateVersionStatus_State = 2
+	ActorTemplateVersionStatus_STATE_WAIT_GOLDEN_ACTOR   ActorTemplateVersionStatus_State = 3
+	ActorTemplateVersionStatus_STATE_READY               ActorTemplateVersionStatus_State = 4
+	ActorTemplateVersionStatus_STATE_FAILED              ActorTemplateVersionStatus_State = 5
+)
+
+// Enum value maps for ActorTemplateVersionStatus_State.
+var (
+	ActorTemplateVersionStatus_State_name = map[int32]string{
+		0: "STATE_UNSPECIFIED",
+		1: "STATE_INITIAL",
+		2: "STATE_RESUME_GOLDEN_ACTOR",
+		3: "STATE_WAIT_GOLDEN_ACTOR",
+		4: "STATE_READY",
+		5: "STATE_FAILED",
+	}
+	ActorTemplateVersionStatus_State_value = map[string]int32{
+		"STATE_UNSPECIFIED":         0,
+		"STATE_INITIAL":             1,
+		"STATE_RESUME_GOLDEN_ACTOR": 2,
+		"STATE_WAIT_GOLDEN_ACTOR":   3,
+		"STATE_READY":               4,
+		"STATE_FAILED":              5,
+	}
+)
+
+func (x ActorTemplateVersionStatus_State) Enum() *ActorTemplateVersionStatus_State {
+	p := new(ActorTemplateVersionStatus_State)
+	*p = x
+	return p
+}
+
+func (x ActorTemplateVersionStatus_State) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ActorTemplateVersionStatus_State) Descriptor() protoreflect.EnumDescriptor {
+	return file_ateapi_proto_enumTypes[7].Descriptor()
+}
+
+func (ActorTemplateVersionStatus_State) Type() protoreflect.EnumType {
+	return &file_ateapi_proto_enumTypes[7]
+}
+
+func (x ActorTemplateVersionStatus_State) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ActorTemplateVersionStatus_State.Descriptor instead.
+func (ActorTemplateVersionStatus_State) EnumDescriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{18, 0}
 }
 
 type Worker_State int32
@@ -339,11 +506,11 @@ func (x Worker_State) String() string {
 }
 
 func (Worker_State) Descriptor() protoreflect.EnumDescriptor {
-	return file_ateapi_proto_enumTypes[5].Descriptor()
+	return file_ateapi_proto_enumTypes[8].Descriptor()
 }
 
 func (Worker_State) Type() protoreflect.EnumType {
-	return &file_ateapi_proto_enumTypes[5]
+	return &file_ateapi_proto_enumTypes[8]
 }
 
 func (x Worker_State) Number() protoreflect.EnumNumber {
@@ -352,7 +519,7 @@ func (x Worker_State) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Worker_State.Descriptor instead.
 func (Worker_State) EnumDescriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{36, 0}
+	return file_ateapi_proto_rawDescGZIP(), []int{66, 0}
 }
 
 type LocalSnapshotInfo struct {
@@ -1226,6 +1393,1223 @@ func (*ActorSnapshotRef_Snapshot) isActorSnapshotRef_Reference() {}
 
 func (*ActorSnapshotRef_Tag) isActorSnapshotRef_Reference() {}
 
+// ActorTemplate groups the versions of one actor application and carries the
+// version-independent placement policy.
+type ActorTemplate struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Common resource metadata: name, uid, version, timestamps.
+	Metadata      *ResourceMetadata  `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Spec          *ActorTemplateSpec `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActorTemplate) Reset() {
+	*x = ActorTemplate{}
+	mi := &file_ateapi_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplate) ProtoMessage() {}
+
+func (x *ActorTemplate) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplate.ProtoReflect.Descriptor instead.
+func (*ActorTemplate) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ActorTemplate) GetMetadata() *ResourceMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ActorTemplate) GetSpec() *ActorTemplateSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+type ActorTemplateSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// worker_selector restricts which worker pools actors from this template
+	// may use.
+	WorkerSelector *Selector `protobuf:"bytes,1,opt,name=worker_selector,json=workerSelector,proto3" json:"worker_selector,omitempty"`
+	// default_version_on_create names the ActorTemplateVersion used by
+	// CreateActor calls that do not pin a version. If unset, CreateActor
+	// without an explicit version fails with FailedPrecondition.
+	DefaultVersionOnCreate *ObjectRef `protobuf:"bytes,2,opt,name=default_version_on_create,json=defaultVersionOnCreate,proto3" json:"default_version_on_create,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *ActorTemplateSpec) Reset() {
+	*x = ActorTemplateSpec{}
+	mi := &file_ateapi_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplateSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplateSpec) ProtoMessage() {}
+
+func (x *ActorTemplateSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplateSpec.ProtoReflect.Descriptor instead.
+func (*ActorTemplateSpec) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ActorTemplateSpec) GetWorkerSelector() *Selector {
+	if x != nil {
+		return x.WorkerSelector
+	}
+	return nil
+}
+
+func (x *ActorTemplateSpec) GetDefaultVersionOnCreate() *ObjectRef {
+	if x != nil {
+		return x.DefaultVersionOnCreate
+	}
+	return nil
+}
+
+// ActorTemplateVersion is one immutable released version of an ActorTemplate:
+// the workload definition plus everything that affects snapshot validity.
+// Global-scoped: metadata.atespace is always empty and metadata.name must be
+// globally unique (by convention "<template-name>-<version>").
+type ActorTemplateVersion struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Common resource metadata: name, uid, version, timestamps.
+	Metadata *ResourceMetadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// actor_template is the parent ActorTemplate. Required at creation and
+	// immutable.
+	ActorTemplate *ObjectRef `protobuf:"bytes,2,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	// spec is immutable after creation.
+	Spec          *ActorTemplateVersionSpec   `protobuf:"bytes,3,opt,name=spec,proto3" json:"spec,omitempty"`
+	Status        *ActorTemplateVersionStatus `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActorTemplateVersion) Reset() {
+	*x = ActorTemplateVersion{}
+	mi := &file_ateapi_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplateVersion) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplateVersion) ProtoMessage() {}
+
+func (x *ActorTemplateVersion) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplateVersion.ProtoReflect.Descriptor instead.
+func (*ActorTemplateVersion) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ActorTemplateVersion) GetMetadata() *ResourceMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersion) GetActorTemplate() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersion) GetSpec() *ActorTemplateVersionSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersion) GetStatus() *ActorTemplateVersionStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+type ActorTemplateVersionSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// pause_image is the container to use as the root sandbox container.
+	PauseImage      string           `protobuf:"bytes,1,opt,name=pause_image,json=pauseImage,proto3" json:"pause_image,omitempty"`
+	Containers      []*Container     `protobuf:"bytes,2,rep,name=containers,proto3" json:"containers,omitempty"`
+	Volumes         []*Volume        `protobuf:"bytes,3,rep,name=volumes,proto3" json:"volumes,omitempty"`
+	SnapshotsConfig *SnapshotsConfig `protobuf:"bytes,4,opt,name=snapshots_config,json=snapshotsConfig,proto3" json:"snapshots_config,omitempty"`
+	// sandbox_config selects the sandbox runtime this version's actors run on.
+	// Required. Resolved and frozen into status.resolved_sandbox at creation
+	// time.
+	SandboxConfig *SandboxConfig `protobuf:"bytes,5,opt,name=sandbox_config,json=sandboxConfig,proto3" json:"sandbox_config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActorTemplateVersionSpec) Reset() {
+	*x = ActorTemplateVersionSpec{}
+	mi := &file_ateapi_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplateVersionSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplateVersionSpec) ProtoMessage() {}
+
+func (x *ActorTemplateVersionSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplateVersionSpec.ProtoReflect.Descriptor instead.
+func (*ActorTemplateVersionSpec) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ActorTemplateVersionSpec) GetPauseImage() string {
+	if x != nil {
+		return x.PauseImage
+	}
+	return ""
+}
+
+func (x *ActorTemplateVersionSpec) GetContainers() []*Container {
+	if x != nil {
+		return x.Containers
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionSpec) GetVolumes() []*Volume {
+	if x != nil {
+		return x.Volumes
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionSpec) GetSnapshotsConfig() *SnapshotsConfig {
+	if x != nil {
+		return x.SnapshotsConfig
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionSpec) GetSandboxConfig() *SandboxConfig {
+	if x != nil {
+		return x.SandboxConfig
+	}
+	return nil
+}
+
+// SandboxConfig selects the sandbox runtime for an ActorTemplateVersion.
+type SandboxConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// sandbox_class selects the sandbox runtime family.
+	// Required; must not be UNSPECIFIED.
+	SandboxClass SandboxClass `protobuf:"varint,1,opt,name=sandbox_class,json=sandboxClass,proto3,enum=ateapi.SandboxClass" json:"sandbox_class,omitempty"`
+	// config_name names the cluster-scoped SandboxConfig Kubernetes object
+	// supplying the sandbox binaries. Required; must match sandbox_class.
+	ConfigName    string `protobuf:"bytes,2,opt,name=config_name,json=configName,proto3" json:"config_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxConfig) Reset() {
+	*x = SandboxConfig{}
+	mi := &file_ateapi_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxConfig) ProtoMessage() {}
+
+func (x *SandboxConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxConfig.ProtoReflect.Descriptor instead.
+func (*SandboxConfig) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *SandboxConfig) GetSandboxClass() SandboxClass {
+	if x != nil {
+		return x.SandboxClass
+	}
+	return SandboxClass_SANDBOX_CLASS_UNSPECIFIED
+}
+
+func (x *SandboxConfig) GetConfigName() string {
+	if x != nil {
+		return x.ConfigName
+	}
+	return ""
+}
+
+type SnapshotsConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// on_pause selects what is captured during pause actor.
+	OnPause SnapshotContentScope `protobuf:"varint,1,opt,name=on_pause,json=onPause,proto3,enum=ateapi.SnapshotContentScope" json:"on_pause,omitempty"`
+	// on_commit selects what captures.
+	// Must be a subset of on_pause: FULL allows FULL or DATA, DATA allows DATA.
+	OnCommit SnapshotContentScope `protobuf:"varint,2,opt,name=on_commit,json=onCommit,proto3,enum=ateapi.SnapshotContentScope" json:"on_commit,omitempty"`
+	// on_resume selects, per snapshot situation, what supplies the guest state
+	// at resume. Unset means the defaults documented on OnResumeConfig.
+	OnResume *OnResumeConfig `protobuf:"bytes,3,opt,name=on_resume,json=onResume,proto3" json:"on_resume,omitempty"`
+	// storage_location is the base object-storage URI snapshots of actors on
+	// this version are stored under. Required.
+	StorageLocation string `protobuf:"bytes,4,opt,name=storage_location,json=storageLocation,proto3" json:"storage_location,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *SnapshotsConfig) Reset() {
+	*x = SnapshotsConfig{}
+	mi := &file_ateapi_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotsConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotsConfig) ProtoMessage() {}
+
+func (x *SnapshotsConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotsConfig.ProtoReflect.Descriptor instead.
+func (*SnapshotsConfig) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *SnapshotsConfig) GetOnPause() SnapshotContentScope {
+	if x != nil {
+		return x.OnPause
+	}
+	return SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED
+}
+
+func (x *SnapshotsConfig) GetOnCommit() SnapshotContentScope {
+	if x != nil {
+		return x.OnCommit
+	}
+	return SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED
+}
+
+func (x *SnapshotsConfig) GetOnResume() *OnResumeConfig {
+	if x != nil {
+		return x.OnResume
+	}
+	return nil
+}
+
+func (x *SnapshotsConfig) GetStorageLocation() string {
+	if x != nil {
+		return x.StorageLocation
+	}
+	return ""
+}
+
+// OnResumeConfig selects, per snapshot situation, what supplies the guest
+// state at resume. Each field names what is being resumed FROM; the value
+// names the boot source. Full snapshots that are still valid always restore
+// from their own content and are not configurable here.
+type OnResumeConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// from_data applies when the resume uses a DATA-scope snapshot (from
+	// on_pause or on_commit).
+	FromData      ResumeSource `protobuf:"varint,1,opt,name=from_data,json=fromData,proto3,enum=ateapi.ResumeSource" json:"from_data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OnResumeConfig) Reset() {
+	*x = OnResumeConfig{}
+	mi := &file_ateapi_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OnResumeConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OnResumeConfig) ProtoMessage() {}
+
+func (x *OnResumeConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OnResumeConfig.ProtoReflect.Descriptor instead.
+func (*OnResumeConfig) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *OnResumeConfig) GetFromData() ResumeSource {
+	if x != nil {
+		return x.FromData
+	}
+	return ResumeSource_RESUME_SOURCE_UNSPECIFIED
+}
+
+type ActorTemplateVersionStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// golden_snapshot points at the ActorSnapshot, in the reserved ate-golden
+	// system atespace, built for this version by ate-api. Set once state is
+	// READY.
+	GoldenSnapshot *ObjectRef                       `protobuf:"bytes,1,opt,name=golden_snapshot,json=goldenSnapshot,proto3" json:"golden_snapshot,omitempty"`
+	State          ActorTemplateVersionStatus_State `protobuf:"varint,2,opt,name=state,proto3,enum=ateapi.ActorTemplateVersionStatus_State" json:"state,omitempty"`
+	// resolved_sandbox is the referenced SandboxConfig's content frozen at
+	// creation time.
+	ResolvedSandbox *SandboxAssets `protobuf:"bytes,3,opt,name=resolved_sandbox,json=resolvedSandbox,proto3" json:"resolved_sandbox,omitempty"`
+	// message is a human-readable explanation of the current state, most
+	// useful when state is FAILED.
+	Message       string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActorTemplateVersionStatus) Reset() {
+	*x = ActorTemplateVersionStatus{}
+	mi := &file_ateapi_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActorTemplateVersionStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActorTemplateVersionStatus) ProtoMessage() {}
+
+func (x *ActorTemplateVersionStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActorTemplateVersionStatus.ProtoReflect.Descriptor instead.
+func (*ActorTemplateVersionStatus) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ActorTemplateVersionStatus) GetGoldenSnapshot() *ObjectRef {
+	if x != nil {
+		return x.GoldenSnapshot
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionStatus) GetState() ActorTemplateVersionStatus_State {
+	if x != nil {
+		return x.State
+	}
+	return ActorTemplateVersionStatus_STATE_UNSPECIFIED
+}
+
+func (x *ActorTemplateVersionStatus) GetResolvedSandbox() *SandboxAssets {
+	if x != nil {
+		return x.ResolvedSandbox
+	}
+	return nil
+}
+
+func (x *ActorTemplateVersionStatus) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+// Container is a single application container of an ActorTemplateVersion.
+type Container struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Image string                 `protobuf:"bytes,2,opt,name=image,proto3" json:"image,omitempty"`
+	// Entrypoint array; when set, the image's ENTRYPOINT and CMD are both
+	// ignored and the process argv is command + args. Unlike Kubernetes,
+	// $(VAR_NAME) references are NOT expanded.
+	Command []string `protobuf:"bytes,3,rep,name=command,proto3" json:"command,omitempty"`
+	// Arguments to the entrypoint; the image's CMD is used if unset (unless
+	// command is set, which discards the image's CMD).
+	Args []string  `protobuf:"bytes,4,rep,name=args,proto3" json:"args,omitempty"`
+	Env  []*EnvVar `protobuf:"bytes,5,rep,name=env,proto3" json:"env,omitempty"`
+	// readyz is an optional HTTP readiness probe; when set the actor is not
+	// ready until the endpoint returns 200.
+	Readyz        *ContainerReadyz `protobuf:"bytes,6,opt,name=readyz,proto3" json:"readyz,omitempty"`
+	VolumeMounts  []*VolumeMount   `protobuf:"bytes,7,rep,name=volume_mounts,json=volumeMounts,proto3" json:"volume_mounts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Container) Reset() {
+	*x = Container{}
+	mi := &file_ateapi_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Container) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Container) ProtoMessage() {}
+
+func (x *Container) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Container.ProtoReflect.Descriptor instead.
+func (*Container) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *Container) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Container) GetImage() string {
+	if x != nil {
+		return x.Image
+	}
+	return ""
+}
+
+func (x *Container) GetCommand() []string {
+	if x != nil {
+		return x.Command
+	}
+	return nil
+}
+
+func (x *Container) GetArgs() []string {
+	if x != nil {
+		return x.Args
+	}
+	return nil
+}
+
+func (x *Container) GetEnv() []*EnvVar {
+	if x != nil {
+		return x.Env
+	}
+	return nil
+}
+
+func (x *Container) GetReadyz() *ContainerReadyz {
+	if x != nil {
+		return x.Readyz
+	}
+	return nil
+}
+
+func (x *Container) GetVolumeMounts() []*VolumeMount {
+	if x != nil {
+		return x.VolumeMounts
+	}
+	return nil
+}
+
+// EnvVar supplies one environment variable to a container. Values are not
+// expanded with Kubernetes-style $(VAR) references.
+type EnvVar struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name may be any printable ASCII character except '='.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Exactly one source must be set.
+	//
+	// Types that are valid to be assigned to Source:
+	//
+	//	*EnvVar_Value
+	Source        isEnvVar_Source `protobuf_oneof:"source"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnvVar) Reset() {
+	*x = EnvVar{}
+	mi := &file_ateapi_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnvVar) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnvVar) ProtoMessage() {}
+
+func (x *EnvVar) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnvVar.ProtoReflect.Descriptor instead.
+func (*EnvVar) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *EnvVar) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *EnvVar) GetSource() isEnvVar_Source {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *EnvVar) GetValue() string {
+	if x != nil {
+		if x, ok := x.Source.(*EnvVar_Value); ok {
+			return x.Value
+		}
+	}
+	return ""
+}
+
+type isEnvVar_Source interface {
+	isEnvVar_Source()
+}
+
+type EnvVar_Value struct {
+	// Literal value.
+	Value string `protobuf:"bytes,2,opt,name=value,proto3,oneof"`
+}
+
+func (*EnvVar_Value) isEnvVar_Source() {}
+
+// ContainerReadyz configures the readiness signal for a container.
+type ContainerReadyz struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// http_get specifies the HTTP request to perform. Required.
+	HttpGet *HTTPGetAction `protobuf:"bytes,1,opt,name=http_get,json=httpGet,proto3" json:"http_get,omitempty"`
+	// timeout_seconds bounds how long to poll http_get before failing the
+	// actor start. 0 means the server-applied default (30s).
+	TimeoutSeconds int32 `protobuf:"varint,2,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ContainerReadyz) Reset() {
+	*x = ContainerReadyz{}
+	mi := &file_ateapi_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContainerReadyz) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerReadyz) ProtoMessage() {}
+
+func (x *ContainerReadyz) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerReadyz.ProtoReflect.Descriptor instead.
+func (*ContainerReadyz) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ContainerReadyz) GetHttpGet() *HTTPGetAction {
+	if x != nil {
+		return x.HttpGet
+	}
+	return nil
+}
+
+func (x *ContainerReadyz) GetTimeoutSeconds() int32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
+}
+
+// HTTPGetAction describes an HTTP GET against the container's interior IP.
+type HTTPGetAction struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// path defaults to "/readyz".
+	Path          string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Port          int32  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HTTPGetAction) Reset() {
+	*x = HTTPGetAction{}
+	mi := &file_ateapi_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HTTPGetAction) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HTTPGetAction) ProtoMessage() {}
+
+func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HTTPGetAction.ProtoReflect.Descriptor instead.
+func (*HTTPGetAction) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *HTTPGetAction) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *HTTPGetAction) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+type Volume struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name of the volume. Must be a DNS label.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Exactly one source must be set.
+	//
+	// Types that are valid to be assigned to Source:
+	//
+	//	*Volume_DurableDir
+	//	*Volume_ExternalVolumeTemplate
+	Source        isVolume_Source `protobuf_oneof:"source"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Volume) Reset() {
+	*x = Volume{}
+	mi := &file_ateapi_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Volume) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Volume) ProtoMessage() {}
+
+func (x *Volume) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Volume.ProtoReflect.Descriptor instead.
+func (*Volume) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *Volume) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Volume) GetSource() isVolume_Source {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *Volume) GetDurableDir() *DurableDirVolumeSource {
+	if x != nil {
+		if x, ok := x.Source.(*Volume_DurableDir); ok {
+			return x.DurableDir
+		}
+	}
+	return nil
+}
+
+func (x *Volume) GetExternalVolumeTemplate() *ExternalVolumeTemplate {
+	if x != nil {
+		if x, ok := x.Source.(*Volume_ExternalVolumeTemplate); ok {
+			return x.ExternalVolumeTemplate
+		}
+	}
+	return nil
+}
+
+type isVolume_Source interface {
+	isVolume_Source()
+}
+
+type Volume_DurableDir struct {
+	DurableDir *DurableDirVolumeSource `protobuf:"bytes,2,opt,name=durable_dir,json=durableDir,proto3,oneof"`
+}
+
+type Volume_ExternalVolumeTemplate struct {
+	ExternalVolumeTemplate *ExternalVolumeTemplate `protobuf:"bytes,3,opt,name=external_volume_template,json=externalVolumeTemplate,proto3,oneof"`
+}
+
+func (*Volume_DurableDir) isVolume_Source() {}
+
+func (*Volume_ExternalVolumeTemplate) isVolume_Source() {}
+
+// DurableDirVolumeSource is a durable directory on rootfs that persists
+// across resumes and participates in snapshots.
+type DurableDirVolumeSource struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DurableDirVolumeSource) Reset() {
+	*x = DurableDirVolumeSource{}
+	mi := &file_ateapi_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DurableDirVolumeSource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DurableDirVolumeSource) ProtoMessage() {}
+
+func (x *DurableDirVolumeSource) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DurableDirVolumeSource.ProtoReflect.Descriptor instead.
+func (*DurableDirVolumeSource) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{24}
+}
+
+// ExternalVolumeTemplate provisions an external volume per actor; the volume
+// lives only as long as the actor. Not supported with SANDBOX_CLASS_MICROVM.
+type ExternalVolumeTemplate struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// capacity of the volume to create, in Kubernetes resource.Quantity string
+	// form (e.g. "10Gi"). Required.
+	Capacity string `protobuf:"bytes,1,opt,name=capacity,proto3" json:"capacity,omitempty"`
+	// storage_class_name names the cluster-scoped Kubernetes StorageClass to
+	// create the volume from. Required.
+	StorageClassName string `protobuf:"bytes,2,opt,name=storage_class_name,json=storageClassName,proto3" json:"storage_class_name,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ExternalVolumeTemplate) Reset() {
+	*x = ExternalVolumeTemplate{}
+	mi := &file_ateapi_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExternalVolumeTemplate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExternalVolumeTemplate) ProtoMessage() {}
+
+func (x *ExternalVolumeTemplate) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExternalVolumeTemplate.ProtoReflect.Descriptor instead.
+func (*ExternalVolumeTemplate) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *ExternalVolumeTemplate) GetCapacity() string {
+	if x != nil {
+		return x.Capacity
+	}
+	return ""
+}
+
+func (x *ExternalVolumeTemplate) GetStorageClassName() string {
+	if x != nil {
+		return x.StorageClassName
+	}
+	return ""
+}
+
+// VolumeMount mounts a named Volume into a container.
+type VolumeMount struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name must match the name of a Volume.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// mount_path within the container. Must be a clean absolute Unix path.
+	MountPath     string `protobuf:"bytes,2,opt,name=mount_path,json=mountPath,proto3" json:"mount_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VolumeMount) Reset() {
+	*x = VolumeMount{}
+	mi := &file_ateapi_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VolumeMount) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VolumeMount) ProtoMessage() {}
+
+func (x *VolumeMount) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VolumeMount.ProtoReflect.Descriptor instead.
+func (*VolumeMount) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *VolumeMount) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *VolumeMount) GetMountPath() string {
+	if x != nil {
+		return x.MountPath
+	}
+	return ""
+}
+
+// SandboxAssets is the frozen description of the sandbox binaries an actor
+// boots with: a class plus content-addressed files keyed first by
+// architecture and then by asset name, mirroring the SandboxConfig
+// CRD schema.
+type SandboxAssets struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	SandboxClass SandboxClass           `protobuf:"varint,1,opt,name=sandbox_class,json=sandboxClass,proto3,enum=ateapi.SandboxClass" json:"sandbox_class,omitempty"`
+	// assets maps architecture (GOARCH, e.g. "amd64") to that arch's files.
+	Assets        map[string]*ArchAssets `protobuf:"bytes,2,rep,name=assets,proto3" json:"assets,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxAssets) Reset() {
+	*x = SandboxAssets{}
+	mi := &file_ateapi_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxAssets) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxAssets) ProtoMessage() {}
+
+func (x *SandboxAssets) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxAssets.ProtoReflect.Descriptor instead.
+func (*SandboxAssets) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *SandboxAssets) GetSandboxClass() SandboxClass {
+	if x != nil {
+		return x.SandboxClass
+	}
+	return SandboxClass_SANDBOX_CLASS_UNSPECIFIED
+}
+
+func (x *SandboxAssets) GetAssets() map[string]*ArchAssets {
+	if x != nil {
+		return x.Assets
+	}
+	return nil
+}
+
+type ArchAssets struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// files maps asset name (e.g. "gvisor", "kata-kernel") to its file.
+	Files         map[string]*AssetFile `protobuf:"bytes,1,rep,name=files,proto3" json:"files,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ArchAssets) Reset() {
+	*x = ArchAssets{}
+	mi := &file_ateapi_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ArchAssets) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ArchAssets) ProtoMessage() {}
+
+func (x *ArchAssets) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ArchAssets.ProtoReflect.Descriptor instead.
+func (*ArchAssets) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *ArchAssets) GetFiles() map[string]*AssetFile {
+	if x != nil {
+		return x.Files
+	}
+	return nil
+}
+
+// AssetFile is one content-addressed file atelet fetches for a sandbox
+// runtime.
+type AssetFile struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// URL to download the asset from (e.g. a gs:// URL).
+	Url string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	// Lower-case hex SHA256 naming the cached file and verifying the download.
+	Sha256        string `protobuf:"bytes,2,opt,name=sha256,proto3" json:"sha256,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssetFile) Reset() {
+	*x = AssetFile{}
+	mi := &file_ateapi_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssetFile) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssetFile) ProtoMessage() {}
+
+func (x *AssetFile) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssetFile.ProtoReflect.Descriptor instead.
+func (*AssetFile) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *AssetFile) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *AssetFile) GetSha256() string {
+	if x != nil {
+		return x.Sha256
+	}
+	return ""
+}
+
 type CreateAtespaceRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The atespace to create.
@@ -1236,7 +2620,7 @@ type CreateAtespaceRequest struct {
 
 func (x *CreateAtespaceRequest) Reset() {
 	*x = CreateAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[11]
+	mi := &file_ateapi_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1248,7 +2632,7 @@ func (x *CreateAtespaceRequest) String() string {
 func (*CreateAtespaceRequest) ProtoMessage() {}
 
 func (x *CreateAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[11]
+	mi := &file_ateapi_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1261,7 +2645,7 @@ func (x *CreateAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*CreateAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{11}
+	return file_ateapi_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *CreateAtespaceRequest) GetAtespace() *Atespace {
@@ -1280,7 +2664,7 @@ type GetAtespaceRequest struct {
 
 func (x *GetAtespaceRequest) Reset() {
 	*x = GetAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[12]
+	mi := &file_ateapi_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1292,7 +2676,7 @@ func (x *GetAtespaceRequest) String() string {
 func (*GetAtespaceRequest) ProtoMessage() {}
 
 func (x *GetAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[12]
+	mi := &file_ateapi_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1305,7 +2689,7 @@ func (x *GetAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*GetAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{12}
+	return file_ateapi_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetAtespaceRequest) GetAtespace() *ObjectRef {
@@ -1330,7 +2714,7 @@ type ListAtespacesRequest struct {
 
 func (x *ListAtespacesRequest) Reset() {
 	*x = ListAtespacesRequest{}
-	mi := &file_ateapi_proto_msgTypes[13]
+	mi := &file_ateapi_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1342,7 +2726,7 @@ func (x *ListAtespacesRequest) String() string {
 func (*ListAtespacesRequest) ProtoMessage() {}
 
 func (x *ListAtespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[13]
+	mi := &file_ateapi_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1355,7 +2739,7 @@ func (x *ListAtespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAtespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListAtespacesRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{13}
+	return file_ateapi_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ListAtespacesRequest) GetPageSize() int32 {
@@ -1384,7 +2768,7 @@ type ListAtespacesResponse struct {
 
 func (x *ListAtespacesResponse) Reset() {
 	*x = ListAtespacesResponse{}
-	mi := &file_ateapi_proto_msgTypes[14]
+	mi := &file_ateapi_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1396,7 +2780,7 @@ func (x *ListAtespacesResponse) String() string {
 func (*ListAtespacesResponse) ProtoMessage() {}
 
 func (x *ListAtespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[14]
+	mi := &file_ateapi_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1409,7 +2793,7 @@ func (x *ListAtespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAtespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListAtespacesResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{14}
+	return file_ateapi_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ListAtespacesResponse) GetAtespaces() []*Atespace {
@@ -1435,7 +2819,7 @@ type DeleteAtespaceRequest struct {
 
 func (x *DeleteAtespaceRequest) Reset() {
 	*x = DeleteAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[15]
+	mi := &file_ateapi_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1447,7 +2831,7 @@ func (x *DeleteAtespaceRequest) String() string {
 func (*DeleteAtespaceRequest) ProtoMessage() {}
 
 func (x *DeleteAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[15]
+	mi := &file_ateapi_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1460,12 +2844,577 @@ func (x *DeleteAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{15}
+	return file_ateapi_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *DeleteAtespaceRequest) GetAtespace() *ObjectRef {
 	if x != nil {
 		return x.Atespace
+	}
+	return nil
+}
+
+type CreateActorTemplateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The actor template to create. Server-assigned metadata (uid, version,
+	// timestamps) is ignored.
+	ActorTemplate *ActorTemplate `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateActorTemplateRequest) Reset() {
+	*x = CreateActorTemplateRequest{}
+	mi := &file_ateapi_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateActorTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateActorTemplateRequest) ProtoMessage() {}
+
+func (x *CreateActorTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateActorTemplateRequest.ProtoReflect.Descriptor instead.
+func (*CreateActorTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *CreateActorTemplateRequest) GetActorTemplate() *ActorTemplate {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+type GetActorTemplateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ActorTemplate *ObjectRef             `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetActorTemplateRequest) Reset() {
+	*x = GetActorTemplateRequest{}
+	mi := &file_ateapi_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetActorTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetActorTemplateRequest) ProtoMessage() {}
+
+func (x *GetActorTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetActorTemplateRequest.ProtoReflect.Descriptor instead.
+func (*GetActorTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *GetActorTemplateRequest) GetActorTemplate() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+// Request to update mutable fields on an existing ActorTemplate.
+type UpdateActorTemplateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The actor template to update.
+	// actor_template.metadata.name identifies which resource to update.
+	// actor_template.metadata.version and actor_template.metadata.uid are
+	// optional preconditions and zero values skip the check.
+	ActorTemplate *ActorTemplate `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	// The set of fields to update. Required.
+	//
+	// Only the following fields are supported:
+	//   - spec.worker_selector
+	//   - spec.default_version_on_create
+	UpdateMask    *fieldmaskpb.FieldMask `protobuf:"bytes,2,opt,name=update_mask,json=updateMask,proto3" json:"update_mask,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateActorTemplateRequest) Reset() {
+	*x = UpdateActorTemplateRequest{}
+	mi := &file_ateapi_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateActorTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateActorTemplateRequest) ProtoMessage() {}
+
+func (x *UpdateActorTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateActorTemplateRequest.ProtoReflect.Descriptor instead.
+func (*UpdateActorTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *UpdateActorTemplateRequest) GetActorTemplate() *ActorTemplate {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+func (x *UpdateActorTemplateRequest) GetUpdateMask() *fieldmaskpb.FieldMask {
+	if x != nil {
+		return x.UpdateMask
+	}
+	return nil
+}
+
+type ListActorTemplatesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Requested page size; the server may return fewer, or occasionally
+	// slightly more. If unspecified, defaults to a server-chosen value;
+	// values above 1000 are coerced to 1000.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// Pagination token from a previous ListActorTemplates response.
+	// Omit or leave empty for the first request.
+	PageToken     string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListActorTemplatesRequest) Reset() {
+	*x = ListActorTemplatesRequest{}
+	mi := &file_ateapi_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListActorTemplatesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListActorTemplatesRequest) ProtoMessage() {}
+
+func (x *ListActorTemplatesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListActorTemplatesRequest.ProtoReflect.Descriptor instead.
+func (*ListActorTemplatesRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *ListActorTemplatesRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListActorTemplatesRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+type ListActorTemplatesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The page of actor templates. This list may be empty even if there are
+	// more results.
+	ActorTemplates []*ActorTemplate `protobuf:"bytes,1,rep,name=actor_templates,json=actorTemplates,proto3" json:"actor_templates,omitempty"`
+	// Pagination token for the next page. Empty if this is the last page.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListActorTemplatesResponse) Reset() {
+	*x = ListActorTemplatesResponse{}
+	mi := &file_ateapi_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListActorTemplatesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListActorTemplatesResponse) ProtoMessage() {}
+
+func (x *ListActorTemplatesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListActorTemplatesResponse.ProtoReflect.Descriptor instead.
+func (*ListActorTemplatesResponse) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *ListActorTemplatesResponse) GetActorTemplates() []*ActorTemplate {
+	if x != nil {
+		return x.ActorTemplates
+	}
+	return nil
+}
+
+func (x *ListActorTemplatesResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+type DeleteActorTemplateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ActorTemplate *ObjectRef             `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteActorTemplateRequest) Reset() {
+	*x = DeleteActorTemplateRequest{}
+	mi := &file_ateapi_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteActorTemplateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteActorTemplateRequest) ProtoMessage() {}
+
+func (x *DeleteActorTemplateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteActorTemplateRequest.ProtoReflect.Descriptor instead.
+func (*DeleteActorTemplateRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *DeleteActorTemplateRequest) GetActorTemplate() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return nil
+}
+
+type CreateActorTemplateVersionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The actor template version to create. Server-assigned metadata (uid,
+	// version, timestamps) is ignored, as is status: the server initializes
+	// new versions to STATE_INITIAL.
+	ActorTemplateVersion *ActorTemplateVersion `protobuf:"bytes,1,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *CreateActorTemplateVersionRequest) Reset() {
+	*x = CreateActorTemplateVersionRequest{}
+	mi := &file_ateapi_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateActorTemplateVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateActorTemplateVersionRequest) ProtoMessage() {}
+
+func (x *CreateActorTemplateVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateActorTemplateVersionRequest.ProtoReflect.Descriptor instead.
+func (*CreateActorTemplateVersionRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *CreateActorTemplateVersionRequest) GetActorTemplateVersion() *ActorTemplateVersion {
+	if x != nil {
+		return x.ActorTemplateVersion
+	}
+	return nil
+}
+
+type GetActorTemplateVersionRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	ActorTemplateVersion *ObjectRef             `protobuf:"bytes,1,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *GetActorTemplateVersionRequest) Reset() {
+	*x = GetActorTemplateVersionRequest{}
+	mi := &file_ateapi_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetActorTemplateVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetActorTemplateVersionRequest) ProtoMessage() {}
+
+func (x *GetActorTemplateVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetActorTemplateVersionRequest.ProtoReflect.Descriptor instead.
+func (*GetActorTemplateVersionRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *GetActorTemplateVersionRequest) GetActorTemplateVersion() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplateVersion
+	}
+	return nil
+}
+
+type ListActorTemplateVersionsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The parent ActorTemplate whose versions to list, by name. Empty lists
+	// versions across all templates.
+	ActorTemplate string `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
+	// Requested page size; the server may return fewer, or occasionally
+	// slightly more. If unspecified, defaults to a server-chosen value;
+	// values above 1000 are coerced to 1000.
+	PageSize int32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// Pagination token from a previous ListActorTemplateVersions response.
+	// Omit or leave empty for the first request.
+	PageToken     string `protobuf:"bytes,3,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListActorTemplateVersionsRequest) Reset() {
+	*x = ListActorTemplateVersionsRequest{}
+	mi := &file_ateapi_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListActorTemplateVersionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListActorTemplateVersionsRequest) ProtoMessage() {}
+
+func (x *ListActorTemplateVersionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListActorTemplateVersionsRequest.ProtoReflect.Descriptor instead.
+func (*ListActorTemplateVersionsRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *ListActorTemplateVersionsRequest) GetActorTemplate() string {
+	if x != nil {
+		return x.ActorTemplate
+	}
+	return ""
+}
+
+func (x *ListActorTemplateVersionsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListActorTemplateVersionsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+type ListActorTemplateVersionsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The page of actor template versions. This list may be empty even if
+	// there are more results.
+	ActorTemplateVersions []*ActorTemplateVersion `protobuf:"bytes,1,rep,name=actor_template_versions,json=actorTemplateVersions,proto3" json:"actor_template_versions,omitempty"`
+	// Pagination token for the next page. Empty if this is the last page.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListActorTemplateVersionsResponse) Reset() {
+	*x = ListActorTemplateVersionsResponse{}
+	mi := &file_ateapi_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListActorTemplateVersionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListActorTemplateVersionsResponse) ProtoMessage() {}
+
+func (x *ListActorTemplateVersionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListActorTemplateVersionsResponse.ProtoReflect.Descriptor instead.
+func (*ListActorTemplateVersionsResponse) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *ListActorTemplateVersionsResponse) GetActorTemplateVersions() []*ActorTemplateVersion {
+	if x != nil {
+		return x.ActorTemplateVersions
+	}
+	return nil
+}
+
+func (x *ListActorTemplateVersionsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+type DeleteActorTemplateVersionRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	ActorTemplateVersion *ObjectRef             `protobuf:"bytes,1,opt,name=actor_template_version,json=actorTemplateVersion,proto3" json:"actor_template_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *DeleteActorTemplateVersionRequest) Reset() {
+	*x = DeleteActorTemplateVersionRequest{}
+	mi := &file_ateapi_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteActorTemplateVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteActorTemplateVersionRequest) ProtoMessage() {}
+
+func (x *DeleteActorTemplateVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteActorTemplateVersionRequest.ProtoReflect.Descriptor instead.
+func (*DeleteActorTemplateVersionRequest) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *DeleteActorTemplateVersionRequest) GetActorTemplateVersion() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplateVersion
 	}
 	return nil
 }
@@ -1479,7 +3428,7 @@ type GetActorRequest struct {
 
 func (x *GetActorRequest) Reset() {
 	*x = GetActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[16]
+	mi := &file_ateapi_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1491,7 +3440,7 @@ func (x *GetActorRequest) String() string {
 func (*GetActorRequest) ProtoMessage() {}
 
 func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[16]
+	mi := &file_ateapi_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1504,7 +3453,7 @@ func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorRequest.ProtoReflect.Descriptor instead.
 func (*GetActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{16}
+	return file_ateapi_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GetActorRequest) GetActor() *ObjectRef {
@@ -1527,7 +3476,7 @@ type CreateActorRequest struct {
 
 func (x *CreateActorRequest) Reset() {
 	*x = CreateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[17]
+	mi := &file_ateapi_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1539,7 +3488,7 @@ func (x *CreateActorRequest) String() string {
 func (*CreateActorRequest) ProtoMessage() {}
 
 func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[17]
+	mi := &file_ateapi_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1552,7 +3501,7 @@ func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateActorRequest.ProtoReflect.Descriptor instead.
 func (*CreateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{17}
+	return file_ateapi_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CreateActorRequest) GetActor() *Actor {
@@ -1591,7 +3540,7 @@ type UpdateActorRequest struct {
 
 func (x *UpdateActorRequest) Reset() {
 	*x = UpdateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[18]
+	mi := &file_ateapi_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1603,7 +3552,7 @@ func (x *UpdateActorRequest) String() string {
 func (*UpdateActorRequest) ProtoMessage() {}
 
 func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[18]
+	mi := &file_ateapi_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1616,7 +3565,7 @@ func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorRequest.ProtoReflect.Descriptor instead.
 func (*UpdateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{18}
+	return file_ateapi_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *UpdateActorRequest) GetActor() *Actor {
@@ -1642,7 +3591,7 @@ type SuspendActorRequest struct {
 
 func (x *SuspendActorRequest) Reset() {
 	*x = SuspendActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[19]
+	mi := &file_ateapi_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1654,7 +3603,7 @@ func (x *SuspendActorRequest) String() string {
 func (*SuspendActorRequest) ProtoMessage() {}
 
 func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[19]
+	mi := &file_ateapi_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1667,7 +3616,7 @@ func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorRequest.ProtoReflect.Descriptor instead.
 func (*SuspendActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{19}
+	return file_ateapi_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *SuspendActorRequest) GetActor() *ObjectRef {
@@ -1686,7 +3635,7 @@ type SuspendActorResponse struct {
 
 func (x *SuspendActorResponse) Reset() {
 	*x = SuspendActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[20]
+	mi := &file_ateapi_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1698,7 +3647,7 @@ func (x *SuspendActorResponse) String() string {
 func (*SuspendActorResponse) ProtoMessage() {}
 
 func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[20]
+	mi := &file_ateapi_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1711,7 +3660,7 @@ func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorResponse.ProtoReflect.Descriptor instead.
 func (*SuspendActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{20}
+	return file_ateapi_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *SuspendActorResponse) GetActor() *Actor {
@@ -1730,7 +3679,7 @@ type PauseActorRequest struct {
 
 func (x *PauseActorRequest) Reset() {
 	*x = PauseActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[21]
+	mi := &file_ateapi_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1742,7 +3691,7 @@ func (x *PauseActorRequest) String() string {
 func (*PauseActorRequest) ProtoMessage() {}
 
 func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[21]
+	mi := &file_ateapi_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1755,7 +3704,7 @@ func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorRequest.ProtoReflect.Descriptor instead.
 func (*PauseActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{21}
+	return file_ateapi_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *PauseActorRequest) GetActor() *ObjectRef {
@@ -1774,7 +3723,7 @@ type PauseActorResponse struct {
 
 func (x *PauseActorResponse) Reset() {
 	*x = PauseActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1786,7 +3735,7 @@ func (x *PauseActorResponse) String() string {
 func (*PauseActorResponse) ProtoMessage() {}
 
 func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1799,7 +3748,7 @@ func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorResponse.ProtoReflect.Descriptor instead.
 func (*PauseActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{22}
+	return file_ateapi_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *PauseActorResponse) GetActor() *Actor {
@@ -1820,7 +3769,7 @@ type ResumeActorRequest struct {
 
 func (x *ResumeActorRequest) Reset() {
 	*x = ResumeActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1832,7 +3781,7 @@ func (x *ResumeActorRequest) String() string {
 func (*ResumeActorRequest) ProtoMessage() {}
 
 func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1845,7 +3794,7 @@ func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorRequest.ProtoReflect.Descriptor instead.
 func (*ResumeActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{23}
+	return file_ateapi_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ResumeActorRequest) GetActor() *ObjectRef {
@@ -1874,7 +3823,7 @@ type ResumeActorResponse struct {
 
 func (x *ResumeActorResponse) Reset() {
 	*x = ResumeActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1886,7 +3835,7 @@ func (x *ResumeActorResponse) String() string {
 func (*ResumeActorResponse) ProtoMessage() {}
 
 func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1899,7 +3848,7 @@ func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorResponse.ProtoReflect.Descriptor instead.
 func (*ResumeActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{24}
+	return file_ateapi_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ResumeActorResponse) GetActor() *Actor {
@@ -1925,7 +3874,7 @@ type DeleteActorRequest struct {
 
 func (x *DeleteActorRequest) Reset() {
 	*x = DeleteActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1937,7 +3886,7 @@ func (x *DeleteActorRequest) String() string {
 func (*DeleteActorRequest) ProtoMessage() {}
 
 func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1950,7 +3899,7 @@ func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorRequest.ProtoReflect.Descriptor instead.
 func (*DeleteActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{25}
+	return file_ateapi_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *DeleteActorRequest) GetActor() *ObjectRef {
@@ -1969,7 +3918,7 @@ type GetActorSnapshotRequest struct {
 
 func (x *GetActorSnapshotRequest) Reset() {
 	*x = GetActorSnapshotRequest{}
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1981,7 +3930,7 @@ func (x *GetActorSnapshotRequest) String() string {
 func (*GetActorSnapshotRequest) ProtoMessage() {}
 
 func (x *GetActorSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1994,7 +3943,7 @@ func (x *GetActorSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*GetActorSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{26}
+	return file_ateapi_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetActorSnapshotRequest) GetSnapshot() *ActorSnapshotRef {
@@ -2015,7 +3964,7 @@ type ListActorSnapshotsRequest struct {
 
 func (x *ListActorSnapshotsRequest) Reset() {
 	*x = ListActorSnapshotsRequest{}
-	mi := &file_ateapi_proto_msgTypes[27]
+	mi := &file_ateapi_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2027,7 +3976,7 @@ func (x *ListActorSnapshotsRequest) String() string {
 func (*ListActorSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListActorSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[27]
+	mi := &file_ateapi_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2040,7 +3989,7 @@ func (x *ListActorSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListActorSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{27}
+	return file_ateapi_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ListActorSnapshotsRequest) GetAtespace() string {
@@ -2074,7 +4023,7 @@ type ListActorSnapshotsResponse struct {
 
 func (x *ListActorSnapshotsResponse) Reset() {
 	*x = ListActorSnapshotsResponse{}
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2086,7 +4035,7 @@ func (x *ListActorSnapshotsResponse) String() string {
 func (*ListActorSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListActorSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2099,7 +4048,7 @@ func (x *ListActorSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListActorSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{28}
+	return file_ateapi_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ListActorSnapshotsResponse) GetSnapshots() []*ActorSnapshot {
@@ -2126,7 +4075,7 @@ type TagActorSnapshotRequest struct {
 
 func (x *TagActorSnapshotRequest) Reset() {
 	*x = TagActorSnapshotRequest{}
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2138,7 +4087,7 @@ func (x *TagActorSnapshotRequest) String() string {
 func (*TagActorSnapshotRequest) ProtoMessage() {}
 
 func (x *TagActorSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2151,7 +4100,7 @@ func (x *TagActorSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TagActorSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*TagActorSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{29}
+	return file_ateapi_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *TagActorSnapshotRequest) GetSnapshot() *ActorSnapshotRef {
@@ -2189,7 +4138,7 @@ type UpdateActorSnapshotTagRequest struct {
 
 func (x *UpdateActorSnapshotTagRequest) Reset() {
 	*x = UpdateActorSnapshotTagRequest{}
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2201,7 +4150,7 @@ func (x *UpdateActorSnapshotTagRequest) String() string {
 func (*UpdateActorSnapshotTagRequest) ProtoMessage() {}
 
 func (x *UpdateActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2214,7 +4163,7 @@ func (x *UpdateActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorSnapshotTagRequest.ProtoReflect.Descriptor instead.
 func (*UpdateActorSnapshotTagRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{30}
+	return file_ateapi_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *UpdateActorSnapshotTagRequest) GetTag() *ActorSnapshotTag {
@@ -2240,7 +4189,7 @@ type DeleteActorSnapshotTagRequest struct {
 
 func (x *DeleteActorSnapshotTagRequest) Reset() {
 	*x = DeleteActorSnapshotTagRequest{}
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2252,7 +4201,7 @@ func (x *DeleteActorSnapshotTagRequest) String() string {
 func (*DeleteActorSnapshotTagRequest) ProtoMessage() {}
 
 func (x *DeleteActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2265,7 +4214,7 @@ func (x *DeleteActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorSnapshotTagRequest.ProtoReflect.Descriptor instead.
 func (*DeleteActorSnapshotTagRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{31}
+	return file_ateapi_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *DeleteActorSnapshotTagRequest) GetTag() *ObjectRef {
@@ -2290,7 +4239,7 @@ type ListWorkersRequest struct {
 
 func (x *ListWorkersRequest) Reset() {
 	*x = ListWorkersRequest{}
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2302,7 +4251,7 @@ func (x *ListWorkersRequest) String() string {
 func (*ListWorkersRequest) ProtoMessage() {}
 
 func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2315,7 +4264,7 @@ func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkersRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{32}
+	return file_ateapi_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ListWorkersRequest) GetPageSize() int32 {
@@ -2344,7 +4293,7 @@ type ListWorkersResponse struct {
 
 func (x *ListWorkersResponse) Reset() {
 	*x = ListWorkersResponse{}
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2356,7 +4305,7 @@ func (x *ListWorkersResponse) String() string {
 func (*ListWorkersResponse) ProtoMessage() {}
 
 func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2369,7 +4318,7 @@ func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkersResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{33}
+	return file_ateapi_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListWorkersResponse) GetWorkers() []*Worker {
@@ -2405,7 +4354,7 @@ type ListActorsRequest struct {
 
 func (x *ListActorsRequest) Reset() {
 	*x = ListActorsRequest{}
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2417,7 +4366,7 @@ func (x *ListActorsRequest) String() string {
 func (*ListActorsRequest) ProtoMessage() {}
 
 func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2430,7 +4379,7 @@ func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsRequest.ProtoReflect.Descriptor instead.
 func (*ListActorsRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{34}
+	return file_ateapi_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ListActorsRequest) GetAtespace() string {
@@ -2466,7 +4415,7 @@ type ListActorsResponse struct {
 
 func (x *ListActorsResponse) Reset() {
 	*x = ListActorsResponse{}
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2478,7 +4427,7 @@ func (x *ListActorsResponse) String() string {
 func (*ListActorsResponse) ProtoMessage() {}
 
 func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2491,7 +4440,7 @@ func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsResponse.ProtoReflect.Descriptor instead.
 func (*ListActorsResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{35}
+	return file_ateapi_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ListActorsResponse) GetActors() []*Actor {
@@ -2527,7 +4476,7 @@ type Worker struct {
 
 func (x *Worker) Reset() {
 	*x = Worker{}
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2539,7 +4488,7 @@ func (x *Worker) String() string {
 func (*Worker) ProtoMessage() {}
 
 func (x *Worker) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2552,7 +4501,7 @@ func (x *Worker) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Worker.ProtoReflect.Descriptor instead.
 func (*Worker) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{36}
+	return file_ateapi_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *Worker) GetWorkerNamespace() string {
@@ -2643,7 +4592,7 @@ type Assignment struct {
 
 func (x *Assignment) Reset() {
 	*x = Assignment{}
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2655,7 +4604,7 @@ func (x *Assignment) String() string {
 func (*Assignment) ProtoMessage() {}
 
 func (x *Assignment) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2668,7 +4617,7 @@ func (x *Assignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Assignment.ProtoReflect.Descriptor instead.
 func (*Assignment) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{37}
+	return file_ateapi_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *Assignment) GetActorTemplate() *KubeNamespacedObjectRef {
@@ -2702,7 +4651,7 @@ type KubeNamespacedObjectRef struct {
 
 func (x *KubeNamespacedObjectRef) Reset() {
 	*x = KubeNamespacedObjectRef{}
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2714,7 +4663,7 @@ func (x *KubeNamespacedObjectRef) String() string {
 func (*KubeNamespacedObjectRef) ProtoMessage() {}
 
 func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2727,7 +4676,7 @@ func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeNamespacedObjectRef.ProtoReflect.Descriptor instead.
 func (*KubeNamespacedObjectRef) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{38}
+	return file_ateapi_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *KubeNamespacedObjectRef) GetNamespace() string {
@@ -2752,7 +4701,7 @@ type DebugClearRequest struct {
 
 func (x *DebugClearRequest) Reset() {
 	*x = DebugClearRequest{}
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2764,7 +4713,7 @@ func (x *DebugClearRequest) String() string {
 func (*DebugClearRequest) ProtoMessage() {}
 
 func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2777,7 +4726,7 @@ func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearRequest.ProtoReflect.Descriptor instead.
 func (*DebugClearRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{39}
+	return file_ateapi_proto_rawDescGZIP(), []int{69}
 }
 
 type DebugClearResponse struct {
@@ -2788,7 +4737,7 @@ type DebugClearResponse struct {
 
 func (x *DebugClearResponse) Reset() {
 	*x = DebugClearResponse{}
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2800,7 +4749,7 @@ func (x *DebugClearResponse) String() string {
 func (*DebugClearResponse) ProtoMessage() {}
 
 func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2813,7 +4762,7 @@ func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearResponse.ProtoReflect.Descriptor instead.
 func (*DebugClearResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{40}
+	return file_ateapi_proto_rawDescGZIP(), []int{70}
 }
 
 type MintJWTRequest struct {
@@ -2828,7 +4777,7 @@ type MintJWTRequest struct {
 
 func (x *MintJWTRequest) Reset() {
 	*x = MintJWTRequest{}
-	mi := &file_ateapi_proto_msgTypes[41]
+	mi := &file_ateapi_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2840,7 +4789,7 @@ func (x *MintJWTRequest) String() string {
 func (*MintJWTRequest) ProtoMessage() {}
 
 func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[41]
+	mi := &file_ateapi_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2853,7 +4802,7 @@ func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTRequest.ProtoReflect.Descriptor instead.
 func (*MintJWTRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{41}
+	return file_ateapi_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *MintJWTRequest) GetAudience() []string {
@@ -2914,7 +4863,7 @@ type MintJWTResponse struct {
 
 func (x *MintJWTResponse) Reset() {
 	*x = MintJWTResponse{}
-	mi := &file_ateapi_proto_msgTypes[42]
+	mi := &file_ateapi_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2926,7 +4875,7 @@ func (x *MintJWTResponse) String() string {
 func (*MintJWTResponse) ProtoMessage() {}
 
 func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[42]
+	mi := &file_ateapi_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2939,7 +4888,7 @@ func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTResponse.ProtoReflect.Descriptor instead.
 func (*MintJWTResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{42}
+	return file_ateapi_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *MintJWTResponse) GetActorJwt() string {
@@ -2971,7 +4920,7 @@ type MintCertRequest struct {
 
 func (x *MintCertRequest) Reset() {
 	*x = MintCertRequest{}
-	mi := &file_ateapi_proto_msgTypes[43]
+	mi := &file_ateapi_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2983,7 +4932,7 @@ func (x *MintCertRequest) String() string {
 func (*MintCertRequest) ProtoMessage() {}
 
 func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[43]
+	mi := &file_ateapi_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2996,7 +4945,7 @@ func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertRequest.ProtoReflect.Descriptor instead.
 func (*MintCertRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{43}
+	return file_ateapi_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *MintCertRequest) GetWorkerNamespace() string {
@@ -3053,7 +5002,7 @@ type MintCertResponse struct {
 
 func (x *MintCertResponse) Reset() {
 	*x = MintCertResponse{}
-	mi := &file_ateapi_proto_msgTypes[44]
+	mi := &file_ateapi_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3065,7 +5014,7 @@ func (x *MintCertResponse) String() string {
 func (*MintCertResponse) ProtoMessage() {}
 
 func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[44]
+	mi := &file_ateapi_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3078,7 +5027,7 @@ func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertResponse.ProtoReflect.Descriptor instead.
 func (*MintCertResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{44}
+	return file_ateapi_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *MintCertResponse) GetActorCertificates() [][]byte {
@@ -3181,7 +5130,98 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x10ActorSnapshotRef\x12/\n" +
 	"\bsnapshot\x18\x01 \x01(\v2\x11.ateapi.ObjectRefH\x00R\bsnapshot\x12%\n" +
 	"\x03tag\x18\x02 \x01(\v2\x11.ateapi.ObjectRefH\x00R\x03tagB\v\n" +
-	"\treference\"E\n" +
+	"\treference\"t\n" +
+	"\rActorTemplate\x124\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x18.ateapi.ResourceMetadataR\bmetadata\x12-\n" +
+	"\x04spec\x18\x02 \x01(\v2\x19.ateapi.ActorTemplateSpecR\x04spec\"\x9c\x01\n" +
+	"\x11ActorTemplateSpec\x129\n" +
+	"\x0fworker_selector\x18\x01 \x01(\v2\x10.ateapi.SelectorR\x0eworkerSelector\x12L\n" +
+	"\x19default_version_on_create\x18\x02 \x01(\v2\x11.ateapi.ObjectRefR\x16defaultVersionOnCreate\"\xf8\x01\n" +
+	"\x14ActorTemplateVersion\x124\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x18.ateapi.ResourceMetadataR\bmetadata\x128\n" +
+	"\x0eactor_template\x18\x02 \x01(\v2\x11.ateapi.ObjectRefR\ractorTemplate\x124\n" +
+	"\x04spec\x18\x03 \x01(\v2 .ateapi.ActorTemplateVersionSpecR\x04spec\x12:\n" +
+	"\x06status\x18\x04 \x01(\v2\".ateapi.ActorTemplateVersionStatusR\x06status\"\x9a\x02\n" +
+	"\x18ActorTemplateVersionSpec\x12\x1f\n" +
+	"\vpause_image\x18\x01 \x01(\tR\n" +
+	"pauseImage\x121\n" +
+	"\n" +
+	"containers\x18\x02 \x03(\v2\x11.ateapi.ContainerR\n" +
+	"containers\x12(\n" +
+	"\avolumes\x18\x03 \x03(\v2\x0e.ateapi.VolumeR\avolumes\x12B\n" +
+	"\x10snapshots_config\x18\x04 \x01(\v2\x17.ateapi.SnapshotsConfigR\x0fsnapshotsConfig\x12<\n" +
+	"\x0esandbox_config\x18\x05 \x01(\v2\x15.ateapi.SandboxConfigR\rsandboxConfig\"k\n" +
+	"\rSandboxConfig\x129\n" +
+	"\rsandbox_class\x18\x01 \x01(\x0e2\x14.ateapi.SandboxClassR\fsandboxClass\x12\x1f\n" +
+	"\vconfig_name\x18\x02 \x01(\tR\n" +
+	"configName\"\xe5\x01\n" +
+	"\x0fSnapshotsConfig\x127\n" +
+	"\bon_pause\x18\x01 \x01(\x0e2\x1c.ateapi.SnapshotContentScopeR\aonPause\x129\n" +
+	"\ton_commit\x18\x02 \x01(\x0e2\x1c.ateapi.SnapshotContentScopeR\bonCommit\x123\n" +
+	"\ton_resume\x18\x03 \x01(\v2\x16.ateapi.OnResumeConfigR\bonResume\x12)\n" +
+	"\x10storage_location\x18\x04 \x01(\tR\x0fstorageLocation\"C\n" +
+	"\x0eOnResumeConfig\x121\n" +
+	"\tfrom_data\x18\x01 \x01(\x0e2\x14.ateapi.ResumeSourceR\bfromData\"\x87\x03\n" +
+	"\x1aActorTemplateVersionStatus\x12:\n" +
+	"\x0fgolden_snapshot\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x0egoldenSnapshot\x12>\n" +
+	"\x05state\x18\x02 \x01(\x0e2(.ateapi.ActorTemplateVersionStatus.StateR\x05state\x12@\n" +
+	"\x10resolved_sandbox\x18\x03 \x01(\v2\x15.ateapi.SandboxAssetsR\x0fresolvedSandbox\x12\x18\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\"\x90\x01\n" +
+	"\x05State\x12\x15\n" +
+	"\x11STATE_UNSPECIFIED\x10\x00\x12\x11\n" +
+	"\rSTATE_INITIAL\x10\x01\x12\x1d\n" +
+	"\x19STATE_RESUME_GOLDEN_ACTOR\x10\x02\x12\x1b\n" +
+	"\x17STATE_WAIT_GOLDEN_ACTOR\x10\x03\x12\x0f\n" +
+	"\vSTATE_READY\x10\x04\x12\x10\n" +
+	"\fSTATE_FAILED\x10\x05\"\xf0\x01\n" +
+	"\tContainer\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05image\x18\x02 \x01(\tR\x05image\x12\x18\n" +
+	"\acommand\x18\x03 \x03(\tR\acommand\x12\x12\n" +
+	"\x04args\x18\x04 \x03(\tR\x04args\x12 \n" +
+	"\x03env\x18\x05 \x03(\v2\x0e.ateapi.EnvVarR\x03env\x12/\n" +
+	"\x06readyz\x18\x06 \x01(\v2\x17.ateapi.ContainerReadyzR\x06readyz\x128\n" +
+	"\rvolume_mounts\x18\a \x03(\v2\x13.ateapi.VolumeMountR\fvolumeMounts\">\n" +
+	"\x06EnvVar\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x05value\x18\x02 \x01(\tH\x00R\x05valueB\b\n" +
+	"\x06source\"l\n" +
+	"\x0fContainerReadyz\x120\n" +
+	"\bhttp_get\x18\x01 \x01(\v2\x15.ateapi.HTTPGetActionR\ahttpGet\x12'\n" +
+	"\x0ftimeout_seconds\x18\x02 \x01(\x05R\x0etimeoutSeconds\"7\n" +
+	"\rHTTPGetAction\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\"\xc5\x01\n" +
+	"\x06Volume\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12A\n" +
+	"\vdurable_dir\x18\x02 \x01(\v2\x1e.ateapi.DurableDirVolumeSourceH\x00R\n" +
+	"durableDir\x12Z\n" +
+	"\x18external_volume_template\x18\x03 \x01(\v2\x1e.ateapi.ExternalVolumeTemplateH\x00R\x16externalVolumeTemplateB\b\n" +
+	"\x06source\"\x18\n" +
+	"\x16DurableDirVolumeSource\"b\n" +
+	"\x16ExternalVolumeTemplate\x12\x1a\n" +
+	"\bcapacity\x18\x01 \x01(\tR\bcapacity\x12,\n" +
+	"\x12storage_class_name\x18\x02 \x01(\tR\x10storageClassName\"@\n" +
+	"\vVolumeMount\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
+	"\n" +
+	"mount_path\x18\x02 \x01(\tR\tmountPath\"\xd4\x01\n" +
+	"\rSandboxAssets\x129\n" +
+	"\rsandbox_class\x18\x01 \x01(\x0e2\x14.ateapi.SandboxClassR\fsandboxClass\x129\n" +
+	"\x06assets\x18\x02 \x03(\v2!.ateapi.SandboxAssets.AssetsEntryR\x06assets\x1aM\n" +
+	"\vAssetsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12(\n" +
+	"\x05value\x18\x02 \x01(\v2\x12.ateapi.ArchAssetsR\x05value:\x028\x01\"\x8e\x01\n" +
+	"\n" +
+	"ArchAssets\x123\n" +
+	"\x05files\x18\x01 \x03(\v2\x1d.ateapi.ArchAssets.FilesEntryR\x05files\x1aK\n" +
+	"\n" +
+	"FilesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12'\n" +
+	"\x05value\x18\x02 \x01(\v2\x11.ateapi.AssetFileR\x05value:\x028\x01\"5\n" +
+	"\tAssetFile\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12\x16\n" +
+	"\x06sha256\x18\x02 \x01(\tR\x06sha256\"E\n" +
 	"\x15CreateAtespaceRequest\x12,\n" +
 	"\batespace\x18\x01 \x01(\v2\x10.ateapi.AtespaceR\batespace\"C\n" +
 	"\x12GetAtespaceRequest\x12-\n" +
@@ -3194,7 +5234,38 @@ const file_ateapi_proto_rawDesc = "" +
 	"\tatespaces\x18\x01 \x03(\v2\x10.ateapi.AtespaceR\tatespaces\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"F\n" +
 	"\x15DeleteAtespaceRequest\x12-\n" +
-	"\batespace\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\batespace\":\n" +
+	"\batespace\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\batespace\"Z\n" +
+	"\x1aCreateActorTemplateRequest\x12<\n" +
+	"\x0eactor_template\x18\x01 \x01(\v2\x15.ateapi.ActorTemplateR\ractorTemplate\"S\n" +
+	"\x17GetActorTemplateRequest\x128\n" +
+	"\x0eactor_template\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\ractorTemplate\"\x97\x01\n" +
+	"\x1aUpdateActorTemplateRequest\x12<\n" +
+	"\x0eactor_template\x18\x01 \x01(\v2\x15.ateapi.ActorTemplateR\ractorTemplate\x12;\n" +
+	"\vupdate_mask\x18\x02 \x01(\v2\x1a.google.protobuf.FieldMaskR\n" +
+	"updateMask\"W\n" +
+	"\x19ListActorTemplatesRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\"\x84\x01\n" +
+	"\x1aListActorTemplatesResponse\x12>\n" +
+	"\x0factor_templates\x18\x01 \x03(\v2\x15.ateapi.ActorTemplateR\x0eactorTemplates\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"V\n" +
+	"\x1aDeleteActorTemplateRequest\x128\n" +
+	"\x0eactor_template\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\ractorTemplate\"w\n" +
+	"!CreateActorTemplateVersionRequest\x12R\n" +
+	"\x16actor_template_version\x18\x01 \x01(\v2\x1c.ateapi.ActorTemplateVersionR\x14actorTemplateVersion\"i\n" +
+	"\x1eGetActorTemplateVersionRequest\x12G\n" +
+	"\x16actor_template_version\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x14actorTemplateVersion\"\x85\x01\n" +
+	" ListActorTemplateVersionsRequest\x12%\n" +
+	"\x0eactor_template\x18\x01 \x01(\tR\ractorTemplate\x12\x1b\n" +
+	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x03 \x01(\tR\tpageToken\"\xa1\x01\n" +
+	"!ListActorTemplateVersionsResponse\x12T\n" +
+	"\x17actor_template_versions\x18\x01 \x03(\v2\x1c.ateapi.ActorTemplateVersionR\x15actorTemplateVersions\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"l\n" +
+	"!DeleteActorTemplateVersionRequest\x12G\n" +
+	"\x16actor_template_version\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x14actorTemplateVersion\":\n" +
 	"\x0fGetActorRequest\x12'\n" +
 	"\x05actor\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\"|\n" +
 	"\x12CreateActorRequest\x12#\n" +
@@ -3312,11 +5383,18 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x1bSNAPSHOT_CONTENT_SCOPE_DATA\x10\x02*f\n" +
 	"\x15ActorSnapshotTagScope\x12%\n" +
 	"!ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE\x10\x00\x12&\n" +
-	"\"ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED\x10\x01*k\n" +
+	"\"ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED\x10\x01*b\n" +
+	"\fSandboxClass\x12\x1d\n" +
+	"\x19SANDBOX_CLASS_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14SANDBOX_CLASS_GVISOR\x10\x01\x12\x19\n" +
+	"\x15SANDBOX_CLASS_MICROVM\x10\x02*d\n" +
+	"\fResumeSource\x12\x1d\n" +
+	"\x19RESUME_SOURCE_UNSPECIFIED\x10\x00\x12\x1b\n" +
+	"\x17RESUME_SOURCE_COLD_BOOT\x10\x01\x12\x18\n" +
+	"\x14RESUME_SOURCE_GOLDEN\x10\x02*k\n" +
 	"\x17ActorCertificatePurpose\x12)\n" +
 	"%ACTOR_CERTIFICATE_PURPOSE_UNSPECIFIED\x10\x00\x12%\n" +
-	"!ACTOR_CERTIFICATE_PURPOSE_ATUNNEL\x10\x012\xb3\n" +
-	"\n" +
+	"!ACTOR_CERTIFICATE_PURPOSE_ATUNNEL\x10\x012\x85\x11\n" +
 	"\aControl\x124\n" +
 	"\bGetActor\x12\x17.ateapi.GetActorRequest\x1a\r.ateapi.Actor\"\x00\x12:\n" +
 	"\vCreateActor\x12\x1a.ateapi.CreateActorRequest\x1a\r.ateapi.Actor\"\x00\x12:\n" +
@@ -3337,7 +5415,16 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x0eCreateAtespace\x12\x1d.ateapi.CreateAtespaceRequest\x1a\x10.ateapi.Atespace\"\x00\x12=\n" +
 	"\vGetAtespace\x12\x1a.ateapi.GetAtespaceRequest\x1a\x10.ateapi.Atespace\"\x00\x12N\n" +
 	"\rListAtespaces\x12\x1c.ateapi.ListAtespacesRequest\x1a\x1d.ateapi.ListAtespacesResponse\"\x00\x12C\n" +
-	"\x0eDeleteAtespace\x12\x1d.ateapi.DeleteAtespaceRequest\x1a\x10.ateapi.Atespace\"\x002N\n" +
+	"\x0eDeleteAtespace\x12\x1d.ateapi.DeleteAtespaceRequest\x1a\x10.ateapi.Atespace\"\x00\x12R\n" +
+	"\x13CreateActorTemplate\x12\".ateapi.CreateActorTemplateRequest\x1a\x15.ateapi.ActorTemplate\"\x00\x12L\n" +
+	"\x10GetActorTemplate\x12\x1f.ateapi.GetActorTemplateRequest\x1a\x15.ateapi.ActorTemplate\"\x00\x12R\n" +
+	"\x13UpdateActorTemplate\x12\".ateapi.UpdateActorTemplateRequest\x1a\x15.ateapi.ActorTemplate\"\x00\x12]\n" +
+	"\x12ListActorTemplates\x12!.ateapi.ListActorTemplatesRequest\x1a\".ateapi.ListActorTemplatesResponse\"\x00\x12R\n" +
+	"\x13DeleteActorTemplate\x12\".ateapi.DeleteActorTemplateRequest\x1a\x15.ateapi.ActorTemplate\"\x00\x12g\n" +
+	"\x1aCreateActorTemplateVersion\x12).ateapi.CreateActorTemplateVersionRequest\x1a\x1c.ateapi.ActorTemplateVersion\"\x00\x12a\n" +
+	"\x17GetActorTemplateVersion\x12&.ateapi.GetActorTemplateVersionRequest\x1a\x1c.ateapi.ActorTemplateVersion\"\x00\x12r\n" +
+	"\x19ListActorTemplateVersions\x12(.ateapi.ListActorTemplateVersionsRequest\x1a).ateapi.ListActorTemplateVersionsResponse\"\x00\x12g\n" +
+	"\x1aDeleteActorTemplateVersion\x12).ateapi.DeleteActorTemplateVersionRequest\x1a\x1c.ateapi.ActorTemplateVersion\"\x002N\n" +
 	"\x05Debug\x12E\n" +
 	"\n" +
 	"DebugClear\x12\x19.ateapi.DebugClearRequest\x1a\x1a.ateapi.DebugClearResponse\"\x002\x8a\x01\n" +
@@ -3357,167 +5444,261 @@ func file_ateapi_proto_rawDescGZIP() []byte {
 	return file_ateapi_proto_rawDescData
 }
 
-var file_ateapi_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_ateapi_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
+var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 80)
 var file_ateapi_proto_goTypes = []any{
-	(SnapshotContentScope)(0),             // 0: ateapi.SnapshotContentScope
-	(ActorSnapshotTagScope)(0),            // 1: ateapi.ActorSnapshotTagScope
-	(ActorCertificatePurpose)(0),          // 2: ateapi.ActorCertificatePurpose
-	(ExternalVolume_Status)(0),            // 3: ateapi.ExternalVolume.Status
-	(Actor_Status)(0),                     // 4: ateapi.Actor.Status
-	(Worker_State)(0),                     // 5: ateapi.Worker.State
-	(*LocalSnapshotInfo)(nil),             // 6: ateapi.LocalSnapshotInfo
-	(*Selector)(nil),                      // 7: ateapi.Selector
-	(*ResourceMetadata)(nil),              // 8: ateapi.ResourceMetadata
-	(*ExternalVolume)(nil),                // 9: ateapi.ExternalVolume
-	(*Actor)(nil),                         // 10: ateapi.Actor
-	(*WorkerAssignment)(nil),              // 11: ateapi.WorkerAssignment
-	(*ActorSnapshot)(nil),                 // 12: ateapi.ActorSnapshot
-	(*ActorSnapshotTag)(nil),              // 13: ateapi.ActorSnapshotTag
-	(*Atespace)(nil),                      // 14: ateapi.Atespace
-	(*ObjectRef)(nil),                     // 15: ateapi.ObjectRef
-	(*ActorSnapshotRef)(nil),              // 16: ateapi.ActorSnapshotRef
-	(*CreateAtespaceRequest)(nil),         // 17: ateapi.CreateAtespaceRequest
-	(*GetAtespaceRequest)(nil),            // 18: ateapi.GetAtespaceRequest
-	(*ListAtespacesRequest)(nil),          // 19: ateapi.ListAtespacesRequest
-	(*ListAtespacesResponse)(nil),         // 20: ateapi.ListAtespacesResponse
-	(*DeleteAtespaceRequest)(nil),         // 21: ateapi.DeleteAtespaceRequest
-	(*GetActorRequest)(nil),               // 22: ateapi.GetActorRequest
-	(*CreateActorRequest)(nil),            // 23: ateapi.CreateActorRequest
-	(*UpdateActorRequest)(nil),            // 24: ateapi.UpdateActorRequest
-	(*SuspendActorRequest)(nil),           // 25: ateapi.SuspendActorRequest
-	(*SuspendActorResponse)(nil),          // 26: ateapi.SuspendActorResponse
-	(*PauseActorRequest)(nil),             // 27: ateapi.PauseActorRequest
-	(*PauseActorResponse)(nil),            // 28: ateapi.PauseActorResponse
-	(*ResumeActorRequest)(nil),            // 29: ateapi.ResumeActorRequest
-	(*ResumeActorResponse)(nil),           // 30: ateapi.ResumeActorResponse
-	(*DeleteActorRequest)(nil),            // 31: ateapi.DeleteActorRequest
-	(*GetActorSnapshotRequest)(nil),       // 32: ateapi.GetActorSnapshotRequest
-	(*ListActorSnapshotsRequest)(nil),     // 33: ateapi.ListActorSnapshotsRequest
-	(*ListActorSnapshotsResponse)(nil),    // 34: ateapi.ListActorSnapshotsResponse
-	(*TagActorSnapshotRequest)(nil),       // 35: ateapi.TagActorSnapshotRequest
-	(*UpdateActorSnapshotTagRequest)(nil), // 36: ateapi.UpdateActorSnapshotTagRequest
-	(*DeleteActorSnapshotTagRequest)(nil), // 37: ateapi.DeleteActorSnapshotTagRequest
-	(*ListWorkersRequest)(nil),            // 38: ateapi.ListWorkersRequest
-	(*ListWorkersResponse)(nil),           // 39: ateapi.ListWorkersResponse
-	(*ListActorsRequest)(nil),             // 40: ateapi.ListActorsRequest
-	(*ListActorsResponse)(nil),            // 41: ateapi.ListActorsResponse
-	(*Worker)(nil),                        // 42: ateapi.Worker
-	(*Assignment)(nil),                    // 43: ateapi.Assignment
-	(*KubeNamespacedObjectRef)(nil),       // 44: ateapi.KubeNamespacedObjectRef
-	(*DebugClearRequest)(nil),             // 45: ateapi.DebugClearRequest
-	(*DebugClearResponse)(nil),            // 46: ateapi.DebugClearResponse
-	(*MintJWTRequest)(nil),                // 47: ateapi.MintJWTRequest
-	(*MintJWTResponse)(nil),               // 48: ateapi.MintJWTResponse
-	(*MintCertRequest)(nil),               // 49: ateapi.MintCertRequest
-	(*MintCertResponse)(nil),              // 50: ateapi.MintCertResponse
-	nil,                                   // 51: ateapi.Selector.MatchLabelsEntry
-	nil,                                   // 52: ateapi.ExternalVolume.VolumeContextEntry
-	nil,                                   // 53: ateapi.Worker.LabelsEntry
-	(*timestamppb.Timestamp)(nil),         // 54: google.protobuf.Timestamp
-	(*fieldmaskpb.FieldMask)(nil),         // 55: google.protobuf.FieldMask
+	(SnapshotContentScope)(0),                 // 0: ateapi.SnapshotContentScope
+	(ActorSnapshotTagScope)(0),                // 1: ateapi.ActorSnapshotTagScope
+	(SandboxClass)(0),                         // 2: ateapi.SandboxClass
+	(ResumeSource)(0),                         // 3: ateapi.ResumeSource
+	(ActorCertificatePurpose)(0),              // 4: ateapi.ActorCertificatePurpose
+	(ExternalVolume_Status)(0),                // 5: ateapi.ExternalVolume.Status
+	(Actor_Status)(0),                         // 6: ateapi.Actor.Status
+	(ActorTemplateVersionStatus_State)(0),     // 7: ateapi.ActorTemplateVersionStatus.State
+	(Worker_State)(0),                         // 8: ateapi.Worker.State
+	(*LocalSnapshotInfo)(nil),                 // 9: ateapi.LocalSnapshotInfo
+	(*Selector)(nil),                          // 10: ateapi.Selector
+	(*ResourceMetadata)(nil),                  // 11: ateapi.ResourceMetadata
+	(*ExternalVolume)(nil),                    // 12: ateapi.ExternalVolume
+	(*Actor)(nil),                             // 13: ateapi.Actor
+	(*WorkerAssignment)(nil),                  // 14: ateapi.WorkerAssignment
+	(*ActorSnapshot)(nil),                     // 15: ateapi.ActorSnapshot
+	(*ActorSnapshotTag)(nil),                  // 16: ateapi.ActorSnapshotTag
+	(*Atespace)(nil),                          // 17: ateapi.Atespace
+	(*ObjectRef)(nil),                         // 18: ateapi.ObjectRef
+	(*ActorSnapshotRef)(nil),                  // 19: ateapi.ActorSnapshotRef
+	(*ActorTemplate)(nil),                     // 20: ateapi.ActorTemplate
+	(*ActorTemplateSpec)(nil),                 // 21: ateapi.ActorTemplateSpec
+	(*ActorTemplateVersion)(nil),              // 22: ateapi.ActorTemplateVersion
+	(*ActorTemplateVersionSpec)(nil),          // 23: ateapi.ActorTemplateVersionSpec
+	(*SandboxConfig)(nil),                     // 24: ateapi.SandboxConfig
+	(*SnapshotsConfig)(nil),                   // 25: ateapi.SnapshotsConfig
+	(*OnResumeConfig)(nil),                    // 26: ateapi.OnResumeConfig
+	(*ActorTemplateVersionStatus)(nil),        // 27: ateapi.ActorTemplateVersionStatus
+	(*Container)(nil),                         // 28: ateapi.Container
+	(*EnvVar)(nil),                            // 29: ateapi.EnvVar
+	(*ContainerReadyz)(nil),                   // 30: ateapi.ContainerReadyz
+	(*HTTPGetAction)(nil),                     // 31: ateapi.HTTPGetAction
+	(*Volume)(nil),                            // 32: ateapi.Volume
+	(*DurableDirVolumeSource)(nil),            // 33: ateapi.DurableDirVolumeSource
+	(*ExternalVolumeTemplate)(nil),            // 34: ateapi.ExternalVolumeTemplate
+	(*VolumeMount)(nil),                       // 35: ateapi.VolumeMount
+	(*SandboxAssets)(nil),                     // 36: ateapi.SandboxAssets
+	(*ArchAssets)(nil),                        // 37: ateapi.ArchAssets
+	(*AssetFile)(nil),                         // 38: ateapi.AssetFile
+	(*CreateAtespaceRequest)(nil),             // 39: ateapi.CreateAtespaceRequest
+	(*GetAtespaceRequest)(nil),                // 40: ateapi.GetAtespaceRequest
+	(*ListAtespacesRequest)(nil),              // 41: ateapi.ListAtespacesRequest
+	(*ListAtespacesResponse)(nil),             // 42: ateapi.ListAtespacesResponse
+	(*DeleteAtespaceRequest)(nil),             // 43: ateapi.DeleteAtespaceRequest
+	(*CreateActorTemplateRequest)(nil),        // 44: ateapi.CreateActorTemplateRequest
+	(*GetActorTemplateRequest)(nil),           // 45: ateapi.GetActorTemplateRequest
+	(*UpdateActorTemplateRequest)(nil),        // 46: ateapi.UpdateActorTemplateRequest
+	(*ListActorTemplatesRequest)(nil),         // 47: ateapi.ListActorTemplatesRequest
+	(*ListActorTemplatesResponse)(nil),        // 48: ateapi.ListActorTemplatesResponse
+	(*DeleteActorTemplateRequest)(nil),        // 49: ateapi.DeleteActorTemplateRequest
+	(*CreateActorTemplateVersionRequest)(nil), // 50: ateapi.CreateActorTemplateVersionRequest
+	(*GetActorTemplateVersionRequest)(nil),    // 51: ateapi.GetActorTemplateVersionRequest
+	(*ListActorTemplateVersionsRequest)(nil),  // 52: ateapi.ListActorTemplateVersionsRequest
+	(*ListActorTemplateVersionsResponse)(nil), // 53: ateapi.ListActorTemplateVersionsResponse
+	(*DeleteActorTemplateVersionRequest)(nil), // 54: ateapi.DeleteActorTemplateVersionRequest
+	(*GetActorRequest)(nil),                   // 55: ateapi.GetActorRequest
+	(*CreateActorRequest)(nil),                // 56: ateapi.CreateActorRequest
+	(*UpdateActorRequest)(nil),                // 57: ateapi.UpdateActorRequest
+	(*SuspendActorRequest)(nil),               // 58: ateapi.SuspendActorRequest
+	(*SuspendActorResponse)(nil),              // 59: ateapi.SuspendActorResponse
+	(*PauseActorRequest)(nil),                 // 60: ateapi.PauseActorRequest
+	(*PauseActorResponse)(nil),                // 61: ateapi.PauseActorResponse
+	(*ResumeActorRequest)(nil),                // 62: ateapi.ResumeActorRequest
+	(*ResumeActorResponse)(nil),               // 63: ateapi.ResumeActorResponse
+	(*DeleteActorRequest)(nil),                // 64: ateapi.DeleteActorRequest
+	(*GetActorSnapshotRequest)(nil),           // 65: ateapi.GetActorSnapshotRequest
+	(*ListActorSnapshotsRequest)(nil),         // 66: ateapi.ListActorSnapshotsRequest
+	(*ListActorSnapshotsResponse)(nil),        // 67: ateapi.ListActorSnapshotsResponse
+	(*TagActorSnapshotRequest)(nil),           // 68: ateapi.TagActorSnapshotRequest
+	(*UpdateActorSnapshotTagRequest)(nil),     // 69: ateapi.UpdateActorSnapshotTagRequest
+	(*DeleteActorSnapshotTagRequest)(nil),     // 70: ateapi.DeleteActorSnapshotTagRequest
+	(*ListWorkersRequest)(nil),                // 71: ateapi.ListWorkersRequest
+	(*ListWorkersResponse)(nil),               // 72: ateapi.ListWorkersResponse
+	(*ListActorsRequest)(nil),                 // 73: ateapi.ListActorsRequest
+	(*ListActorsResponse)(nil),                // 74: ateapi.ListActorsResponse
+	(*Worker)(nil),                            // 75: ateapi.Worker
+	(*Assignment)(nil),                        // 76: ateapi.Assignment
+	(*KubeNamespacedObjectRef)(nil),           // 77: ateapi.KubeNamespacedObjectRef
+	(*DebugClearRequest)(nil),                 // 78: ateapi.DebugClearRequest
+	(*DebugClearResponse)(nil),                // 79: ateapi.DebugClearResponse
+	(*MintJWTRequest)(nil),                    // 80: ateapi.MintJWTRequest
+	(*MintJWTResponse)(nil),                   // 81: ateapi.MintJWTResponse
+	(*MintCertRequest)(nil),                   // 82: ateapi.MintCertRequest
+	(*MintCertResponse)(nil),                  // 83: ateapi.MintCertResponse
+	nil,                                       // 84: ateapi.Selector.MatchLabelsEntry
+	nil,                                       // 85: ateapi.ExternalVolume.VolumeContextEntry
+	nil,                                       // 86: ateapi.SandboxAssets.AssetsEntry
+	nil,                                       // 87: ateapi.ArchAssets.FilesEntry
+	nil,                                       // 88: ateapi.Worker.LabelsEntry
+	(*timestamppb.Timestamp)(nil),             // 89: google.protobuf.Timestamp
+	(*fieldmaskpb.FieldMask)(nil),             // 90: google.protobuf.FieldMask
 }
 var file_ateapi_proto_depIdxs = []int32{
-	0,  // 0: ateapi.LocalSnapshotInfo.content_scope:type_name -> ateapi.SnapshotContentScope
-	51, // 1: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
-	54, // 2: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
-	54, // 3: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
-	3,  // 4: ateapi.ExternalVolume.status:type_name -> ateapi.ExternalVolume.Status
-	52, // 5: ateapi.ExternalVolume.volume_context:type_name -> ateapi.ExternalVolume.VolumeContextEntry
-	8,  // 6: ateapi.Actor.metadata:type_name -> ateapi.ResourceMetadata
-	4,  // 7: ateapi.Actor.status:type_name -> ateapi.Actor.Status
-	11, // 8: ateapi.Actor.worker_assignment:type_name -> ateapi.WorkerAssignment
-	7,  // 9: ateapi.Actor.worker_selector:type_name -> ateapi.Selector
-	15, // 10: ateapi.Actor.latest_snapshot:type_name -> ateapi.ObjectRef
-	6,  // 11: ateapi.Actor.local_snapshot_info:type_name -> ateapi.LocalSnapshotInfo
-	9,  // 12: ateapi.Actor.actor_volumes:type_name -> ateapi.ExternalVolume
-	8,  // 13: ateapi.ActorSnapshot.metadata:type_name -> ateapi.ResourceMetadata
-	15, // 14: ateapi.ActorSnapshot.source_actor:type_name -> ateapi.ObjectRef
-	0,  // 15: ateapi.ActorSnapshot.content_scope:type_name -> ateapi.SnapshotContentScope
-	8,  // 16: ateapi.ActorSnapshotTag.metadata:type_name -> ateapi.ResourceMetadata
-	15, // 17: ateapi.ActorSnapshotTag.snapshot:type_name -> ateapi.ObjectRef
-	1,  // 18: ateapi.ActorSnapshotTag.scope:type_name -> ateapi.ActorSnapshotTagScope
-	8,  // 19: ateapi.Atespace.metadata:type_name -> ateapi.ResourceMetadata
-	15, // 20: ateapi.ActorSnapshotRef.snapshot:type_name -> ateapi.ObjectRef
-	15, // 21: ateapi.ActorSnapshotRef.tag:type_name -> ateapi.ObjectRef
-	14, // 22: ateapi.CreateAtespaceRequest.atespace:type_name -> ateapi.Atespace
-	15, // 23: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
-	14, // 24: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
-	15, // 25: ateapi.DeleteAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
-	15, // 26: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
-	10, // 27: ateapi.CreateActorRequest.actor:type_name -> ateapi.Actor
-	16, // 28: ateapi.CreateActorRequest.source_snapshot:type_name -> ateapi.ActorSnapshotRef
-	10, // 29: ateapi.UpdateActorRequest.actor:type_name -> ateapi.Actor
-	55, // 30: ateapi.UpdateActorRequest.update_mask:type_name -> google.protobuf.FieldMask
-	15, // 31: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
-	10, // 32: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
-	15, // 33: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
-	10, // 34: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
-	15, // 35: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
-	10, // 36: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
-	15, // 37: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
-	16, // 38: ateapi.GetActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
-	12, // 39: ateapi.ListActorSnapshotsResponse.snapshots:type_name -> ateapi.ActorSnapshot
-	16, // 40: ateapi.TagActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
-	13, // 41: ateapi.TagActorSnapshotRequest.tag:type_name -> ateapi.ActorSnapshotTag
-	13, // 42: ateapi.UpdateActorSnapshotTagRequest.tag:type_name -> ateapi.ActorSnapshotTag
-	55, // 43: ateapi.UpdateActorSnapshotTagRequest.update_mask:type_name -> google.protobuf.FieldMask
-	15, // 44: ateapi.DeleteActorSnapshotTagRequest.tag:type_name -> ateapi.ObjectRef
-	42, // 45: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
-	10, // 46: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
-	43, // 47: ateapi.Worker.assignment:type_name -> ateapi.Assignment
-	53, // 48: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
-	5,  // 49: ateapi.Worker.state:type_name -> ateapi.Worker.State
-	44, // 50: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	15, // 51: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
-	2,  // 52: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
-	22, // 53: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	23, // 54: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	24, // 55: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	25, // 56: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	27, // 57: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	29, // 58: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	31, // 59: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	32, // 60: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
-	33, // 61: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
-	35, // 62: ateapi.Control.TagActorSnapshot:input_type -> ateapi.TagActorSnapshotRequest
-	36, // 63: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
-	37, // 64: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
-	38, // 65: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	40, // 66: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	17, // 67: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	18, // 68: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	19, // 69: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	21, // 70: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	45, // 71: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
-	47, // 72: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	49, // 73: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	10, // 74: ateapi.Control.GetActor:output_type -> ateapi.Actor
-	10, // 75: ateapi.Control.CreateActor:output_type -> ateapi.Actor
-	10, // 76: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
-	26, // 77: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	28, // 78: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	30, // 79: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	10, // 80: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
-	12, // 81: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
-	34, // 82: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
-	13, // 83: ateapi.Control.TagActorSnapshot:output_type -> ateapi.ActorSnapshotTag
-	13, // 84: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	13, // 85: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	39, // 86: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	41, // 87: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	14, // 88: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
-	14, // 89: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
-	20, // 90: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	14, // 91: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
-	46, // 92: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
-	48, // 93: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	50, // 94: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	74, // [74:95] is the sub-list for method output_type
-	53, // [53:74] is the sub-list for method input_type
-	53, // [53:53] is the sub-list for extension type_name
-	53, // [53:53] is the sub-list for extension extendee
-	0,  // [0:53] is the sub-list for field type_name
+	0,   // 0: ateapi.LocalSnapshotInfo.content_scope:type_name -> ateapi.SnapshotContentScope
+	84,  // 1: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
+	89,  // 2: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
+	89,  // 3: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
+	5,   // 4: ateapi.ExternalVolume.status:type_name -> ateapi.ExternalVolume.Status
+	85,  // 5: ateapi.ExternalVolume.volume_context:type_name -> ateapi.ExternalVolume.VolumeContextEntry
+	11,  // 6: ateapi.Actor.metadata:type_name -> ateapi.ResourceMetadata
+	6,   // 7: ateapi.Actor.status:type_name -> ateapi.Actor.Status
+	14,  // 8: ateapi.Actor.worker_assignment:type_name -> ateapi.WorkerAssignment
+	10,  // 9: ateapi.Actor.worker_selector:type_name -> ateapi.Selector
+	18,  // 10: ateapi.Actor.latest_snapshot:type_name -> ateapi.ObjectRef
+	9,   // 11: ateapi.Actor.local_snapshot_info:type_name -> ateapi.LocalSnapshotInfo
+	12,  // 12: ateapi.Actor.actor_volumes:type_name -> ateapi.ExternalVolume
+	11,  // 13: ateapi.ActorSnapshot.metadata:type_name -> ateapi.ResourceMetadata
+	18,  // 14: ateapi.ActorSnapshot.source_actor:type_name -> ateapi.ObjectRef
+	0,   // 15: ateapi.ActorSnapshot.content_scope:type_name -> ateapi.SnapshotContentScope
+	11,  // 16: ateapi.ActorSnapshotTag.metadata:type_name -> ateapi.ResourceMetadata
+	18,  // 17: ateapi.ActorSnapshotTag.snapshot:type_name -> ateapi.ObjectRef
+	1,   // 18: ateapi.ActorSnapshotTag.scope:type_name -> ateapi.ActorSnapshotTagScope
+	11,  // 19: ateapi.Atespace.metadata:type_name -> ateapi.ResourceMetadata
+	18,  // 20: ateapi.ActorSnapshotRef.snapshot:type_name -> ateapi.ObjectRef
+	18,  // 21: ateapi.ActorSnapshotRef.tag:type_name -> ateapi.ObjectRef
+	11,  // 22: ateapi.ActorTemplate.metadata:type_name -> ateapi.ResourceMetadata
+	21,  // 23: ateapi.ActorTemplate.spec:type_name -> ateapi.ActorTemplateSpec
+	10,  // 24: ateapi.ActorTemplateSpec.worker_selector:type_name -> ateapi.Selector
+	18,  // 25: ateapi.ActorTemplateSpec.default_version_on_create:type_name -> ateapi.ObjectRef
+	11,  // 26: ateapi.ActorTemplateVersion.metadata:type_name -> ateapi.ResourceMetadata
+	18,  // 27: ateapi.ActorTemplateVersion.actor_template:type_name -> ateapi.ObjectRef
+	23,  // 28: ateapi.ActorTemplateVersion.spec:type_name -> ateapi.ActorTemplateVersionSpec
+	27,  // 29: ateapi.ActorTemplateVersion.status:type_name -> ateapi.ActorTemplateVersionStatus
+	28,  // 30: ateapi.ActorTemplateVersionSpec.containers:type_name -> ateapi.Container
+	32,  // 31: ateapi.ActorTemplateVersionSpec.volumes:type_name -> ateapi.Volume
+	25,  // 32: ateapi.ActorTemplateVersionSpec.snapshots_config:type_name -> ateapi.SnapshotsConfig
+	24,  // 33: ateapi.ActorTemplateVersionSpec.sandbox_config:type_name -> ateapi.SandboxConfig
+	2,   // 34: ateapi.SandboxConfig.sandbox_class:type_name -> ateapi.SandboxClass
+	0,   // 35: ateapi.SnapshotsConfig.on_pause:type_name -> ateapi.SnapshotContentScope
+	0,   // 36: ateapi.SnapshotsConfig.on_commit:type_name -> ateapi.SnapshotContentScope
+	26,  // 37: ateapi.SnapshotsConfig.on_resume:type_name -> ateapi.OnResumeConfig
+	3,   // 38: ateapi.OnResumeConfig.from_data:type_name -> ateapi.ResumeSource
+	18,  // 39: ateapi.ActorTemplateVersionStatus.golden_snapshot:type_name -> ateapi.ObjectRef
+	7,   // 40: ateapi.ActorTemplateVersionStatus.state:type_name -> ateapi.ActorTemplateVersionStatus.State
+	36,  // 41: ateapi.ActorTemplateVersionStatus.resolved_sandbox:type_name -> ateapi.SandboxAssets
+	29,  // 42: ateapi.Container.env:type_name -> ateapi.EnvVar
+	30,  // 43: ateapi.Container.readyz:type_name -> ateapi.ContainerReadyz
+	35,  // 44: ateapi.Container.volume_mounts:type_name -> ateapi.VolumeMount
+	31,  // 45: ateapi.ContainerReadyz.http_get:type_name -> ateapi.HTTPGetAction
+	33,  // 46: ateapi.Volume.durable_dir:type_name -> ateapi.DurableDirVolumeSource
+	34,  // 47: ateapi.Volume.external_volume_template:type_name -> ateapi.ExternalVolumeTemplate
+	2,   // 48: ateapi.SandboxAssets.sandbox_class:type_name -> ateapi.SandboxClass
+	86,  // 49: ateapi.SandboxAssets.assets:type_name -> ateapi.SandboxAssets.AssetsEntry
+	87,  // 50: ateapi.ArchAssets.files:type_name -> ateapi.ArchAssets.FilesEntry
+	17,  // 51: ateapi.CreateAtespaceRequest.atespace:type_name -> ateapi.Atespace
+	18,  // 52: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
+	17,  // 53: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
+	18,  // 54: ateapi.DeleteAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
+	20,  // 55: ateapi.CreateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
+	18,  // 56: ateapi.GetActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
+	20,  // 57: ateapi.UpdateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
+	90,  // 58: ateapi.UpdateActorTemplateRequest.update_mask:type_name -> google.protobuf.FieldMask
+	20,  // 59: ateapi.ListActorTemplatesResponse.actor_templates:type_name -> ateapi.ActorTemplate
+	18,  // 60: ateapi.DeleteActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
+	22,  // 61: ateapi.CreateActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ActorTemplateVersion
+	18,  // 62: ateapi.GetActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ObjectRef
+	22,  // 63: ateapi.ListActorTemplateVersionsResponse.actor_template_versions:type_name -> ateapi.ActorTemplateVersion
+	18,  // 64: ateapi.DeleteActorTemplateVersionRequest.actor_template_version:type_name -> ateapi.ObjectRef
+	18,  // 65: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 66: ateapi.CreateActorRequest.actor:type_name -> ateapi.Actor
+	19,  // 67: ateapi.CreateActorRequest.source_snapshot:type_name -> ateapi.ActorSnapshotRef
+	13,  // 68: ateapi.UpdateActorRequest.actor:type_name -> ateapi.Actor
+	90,  // 69: ateapi.UpdateActorRequest.update_mask:type_name -> google.protobuf.FieldMask
+	18,  // 70: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 71: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
+	18,  // 72: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 73: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
+	18,  // 74: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 75: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
+	18,  // 76: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
+	19,  // 77: ateapi.GetActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
+	15,  // 78: ateapi.ListActorSnapshotsResponse.snapshots:type_name -> ateapi.ActorSnapshot
+	19,  // 79: ateapi.TagActorSnapshotRequest.snapshot:type_name -> ateapi.ActorSnapshotRef
+	16,  // 80: ateapi.TagActorSnapshotRequest.tag:type_name -> ateapi.ActorSnapshotTag
+	16,  // 81: ateapi.UpdateActorSnapshotTagRequest.tag:type_name -> ateapi.ActorSnapshotTag
+	90,  // 82: ateapi.UpdateActorSnapshotTagRequest.update_mask:type_name -> google.protobuf.FieldMask
+	18,  // 83: ateapi.DeleteActorSnapshotTagRequest.tag:type_name -> ateapi.ObjectRef
+	75,  // 84: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
+	13,  // 85: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
+	76,  // 86: ateapi.Worker.assignment:type_name -> ateapi.Assignment
+	88,  // 87: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
+	8,   // 88: ateapi.Worker.state:type_name -> ateapi.Worker.State
+	77,  // 89: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
+	18,  // 90: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
+	4,   // 91: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
+	37,  // 92: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
+	38,  // 93: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
+	55,  // 94: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	56,  // 95: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	57,  // 96: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	58,  // 97: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	60,  // 98: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	62,  // 99: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	64,  // 100: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	65,  // 101: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
+	66,  // 102: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
+	68,  // 103: ateapi.Control.TagActorSnapshot:input_type -> ateapi.TagActorSnapshotRequest
+	69,  // 104: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
+	70,  // 105: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
+	71,  // 106: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	73,  // 107: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	39,  // 108: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	40,  // 109: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	41,  // 110: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	43,  // 111: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	44,  // 112: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
+	45,  // 113: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
+	46,  // 114: ateapi.Control.UpdateActorTemplate:input_type -> ateapi.UpdateActorTemplateRequest
+	47,  // 115: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
+	49,  // 116: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
+	50,  // 117: ateapi.Control.CreateActorTemplateVersion:input_type -> ateapi.CreateActorTemplateVersionRequest
+	51,  // 118: ateapi.Control.GetActorTemplateVersion:input_type -> ateapi.GetActorTemplateVersionRequest
+	52,  // 119: ateapi.Control.ListActorTemplateVersions:input_type -> ateapi.ListActorTemplateVersionsRequest
+	54,  // 120: ateapi.Control.DeleteActorTemplateVersion:input_type -> ateapi.DeleteActorTemplateVersionRequest
+	78,  // 121: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
+	80,  // 122: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	82,  // 123: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	13,  // 124: ateapi.Control.GetActor:output_type -> ateapi.Actor
+	13,  // 125: ateapi.Control.CreateActor:output_type -> ateapi.Actor
+	13,  // 126: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
+	59,  // 127: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	61,  // 128: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	63,  // 129: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	13,  // 130: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
+	15,  // 131: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
+	67,  // 132: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
+	16,  // 133: ateapi.Control.TagActorSnapshot:output_type -> ateapi.ActorSnapshotTag
+	16,  // 134: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	16,  // 135: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	72,  // 136: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	74,  // 137: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	17,  // 138: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
+	17,  // 139: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
+	42,  // 140: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	17,  // 141: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
+	20,  // 142: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
+	20,  // 143: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
+	20,  // 144: ateapi.Control.UpdateActorTemplate:output_type -> ateapi.ActorTemplate
+	48,  // 145: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
+	20,  // 146: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
+	22,  // 147: ateapi.Control.CreateActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	22,  // 148: ateapi.Control.GetActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	53,  // 149: ateapi.Control.ListActorTemplateVersions:output_type -> ateapi.ListActorTemplateVersionsResponse
+	22,  // 150: ateapi.Control.DeleteActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	79,  // 151: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
+	81,  // 152: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	83,  // 153: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	124, // [124:154] is the sub-list for method output_type
+	94,  // [94:124] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }
@@ -3529,13 +5710,20 @@ func file_ateapi_proto_init() {
 		(*ActorSnapshotRef_Snapshot)(nil),
 		(*ActorSnapshotRef_Tag)(nil),
 	}
+	file_ateapi_proto_msgTypes[20].OneofWrappers = []any{
+		(*EnvVar_Value)(nil),
+	}
+	file_ateapi_proto_msgTypes[23].OneofWrappers = []any{
+		(*Volume_DurableDir)(nil),
+		(*Volume_ExternalVolumeTemplate)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateapi_proto_rawDesc), len(file_ateapi_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   48,
+			NumEnums:      9,
+			NumMessages:   80,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -78,6 +78,36 @@ service Control {
   // Delete an empty Atespace. Rejects (FailedPrecondition) if any Actors or
   // ActorSnapshotTags remain.
   rpc DeleteAtespace(DeleteAtespaceRequest) returns (Atespace) {}
+
+  rpc CreateActorTemplate(CreateActorTemplateRequest) returns (ActorTemplate) {}
+
+  // Get an ActorTemplate by name.
+  rpc GetActorTemplate(GetActorTemplateRequest) returns (ActorTemplate) {}
+
+  // Update mutable fields on an existing ActorTemplate.
+  rpc UpdateActorTemplate(UpdateActorTemplateRequest) returns (ActorTemplate) {}
+
+  rpc ListActorTemplates(ListActorTemplatesRequest) returns (ListActorTemplatesResponse) {}
+
+  // Delete an ActorTemplate. Rejects (FailedPrecondition) while any of its
+  // ActorTemplateVersions exist.
+  rpc DeleteActorTemplate(DeleteActorTemplateRequest) returns (ActorTemplate) {}
+
+  // Create a new ActorTemplateVersion under an existing ActorTemplate
+  // (FailedPrecondition if the parent does not exist).
+  rpc CreateActorTemplateVersion(CreateActorTemplateVersionRequest) returns (ActorTemplateVersion) {}
+
+  // Get an ActorTemplateVersion by name.
+  rpc GetActorTemplateVersion(GetActorTemplateVersionRequest) returns (ActorTemplateVersion) {}
+
+  // List ActorTemplateVersions, optionally filtered to one ActorTemplate.
+  rpc ListActorTemplateVersions(ListActorTemplateVersionsRequest) returns (ListActorTemplateVersionsResponse) {}
+
+  // Delete an ActorTemplateVersion together with its golden actor and golden
+  // snapshot in the reserved ate-golden atespace. Rejects (FailedPrecondition)
+  // while the version is its parent's default_version_on_create or while any
+  // Actor pins it.
+  rpc DeleteActorTemplateVersion(DeleteActorTemplateVersionRequest) returns (ActorTemplateVersion) {}
 }
 
 message LocalSnapshotInfo {
@@ -276,6 +306,264 @@ message ActorSnapshotRef {
   }
 }
 
+// SandboxClass selects the sandbox runtime family. Snapshots are not portable
+// across classes.
+enum SandboxClass {
+  SANDBOX_CLASS_UNSPECIFIED = 0;
+  SANDBOX_CLASS_GVISOR = 1;
+  SANDBOX_CLASS_MICROVM = 2;
+}
+
+// ActorTemplate groups the versions of one actor application and carries the
+// version-independent placement policy.
+message ActorTemplate {
+  // Common resource metadata: name, uid, version, timestamps.
+  ResourceMetadata metadata = 1;
+
+  ActorTemplateSpec spec = 2;
+}
+
+message ActorTemplateSpec {
+  // worker_selector restricts which worker pools actors from this template
+  // may use.
+  Selector worker_selector = 1;
+
+  // default_version_on_create names the ActorTemplateVersion used by
+  // CreateActor calls that do not pin a version. If unset, CreateActor
+  // without an explicit version fails with FailedPrecondition.
+  ObjectRef default_version_on_create = 2;
+}
+
+// ActorTemplateVersion is one immutable released version of an ActorTemplate:
+// the workload definition plus everything that affects snapshot validity.
+// Global-scoped: metadata.atespace is always empty and metadata.name must be
+// globally unique (by convention "<template-name>-<version>").
+message ActorTemplateVersion {
+  // Common resource metadata: name, uid, version, timestamps.
+  ResourceMetadata metadata = 1;
+
+  // actor_template is the parent ActorTemplate. Required at creation and
+  // immutable.
+  ObjectRef actor_template = 2;
+
+  // spec is immutable after creation.
+  ActorTemplateVersionSpec spec = 3;
+
+  ActorTemplateVersionStatus status = 4;
+}
+
+message ActorTemplateVersionSpec {
+  // pause_image is the container to use as the root sandbox container.
+  string pause_image = 1;
+
+  repeated Container containers = 2;
+
+  repeated Volume volumes = 3;
+
+  SnapshotsConfig snapshots_config = 4;
+
+  // sandbox_config selects the sandbox runtime this version's actors run on.
+  // Required. Resolved and frozen into status.resolved_sandbox at creation
+  // time.
+  SandboxConfig sandbox_config = 5;
+
+  // cpu class will be specified here in the future.
+}
+
+// SandboxConfig selects the sandbox runtime for an ActorTemplateVersion.
+message SandboxConfig {
+  // sandbox_class selects the sandbox runtime family.
+  // Required; must not be UNSPECIFIED.
+  SandboxClass sandbox_class = 1;
+
+  // config_name names the cluster-scoped SandboxConfig Kubernetes object
+  // supplying the sandbox binaries. Required; must match sandbox_class.
+  string config_name = 2;
+}
+
+message SnapshotsConfig {
+  // on_pause selects what is captured during pause actor.
+  SnapshotContentScope on_pause = 1;
+
+  // on_commit selects what captures.
+  // Must be a subset of on_pause: FULL allows FULL or DATA, DATA allows DATA.
+  SnapshotContentScope on_commit = 2;
+
+  // on_resume selects, per snapshot situation, what supplies the guest state
+  // at resume. Unset means the defaults documented on OnResumeConfig.
+  OnResumeConfig on_resume = 3;
+
+  // storage_location is the base object-storage URI snapshots of actors on
+  // this version are stored under. Required.
+  string storage_location = 4;
+}
+
+// ResumeSource selects what supplies the guest state when an actor is resumed
+// from one of the snapshot situations named by OnResumeConfig's fields.
+enum ResumeSource {
+  RESUME_SOURCE_UNSPECIFIED = 0;
+  // Starts the actor's containers afresh from the OCI image, with the
+  // durable-dir volumes pre-populated from the snapshot.
+  RESUME_SOURCE_COLD_BOOT = 1;
+  // Restores with the version's golden snapshot and the actor's own
+  // durable data.
+  RESUME_SOURCE_GOLDEN = 2;
+}
+
+// OnResumeConfig selects, per snapshot situation, what supplies the guest
+// state at resume. Each field names what is being resumed FROM; the value
+// names the boot source. Full snapshots that are still valid always restore
+// from their own content and are not configurable here.
+message OnResumeConfig {
+  // from_data applies when the resume uses a DATA-scope snapshot (from
+  // on_pause or on_commit).
+  ResumeSource from_data = 1;
+}
+
+message ActorTemplateVersionStatus {
+  // golden_snapshot points at the ActorSnapshot, in the reserved ate-golden
+  // system atespace, built for this version by ate-api. Set once state is
+  // READY.
+  ObjectRef golden_snapshot = 1;
+
+  // State machine, mirroring the ActorTemplateVersion CRD PhaseType:
+  // INITIAL -> RESUME_GOLDEN_ACTOR -> WAIT_GOLDEN_ACTOR -> {READY | FAILED}.
+  // READY and FAILED are terminal; the version is only usable once READY.
+  enum State {
+    STATE_UNSPECIFIED = 0;
+    STATE_INITIAL = 1;
+    STATE_RESUME_GOLDEN_ACTOR = 2;
+    STATE_WAIT_GOLDEN_ACTOR = 3;
+    STATE_READY = 4;
+    STATE_FAILED = 5;
+  }
+  State state = 2;
+
+  // resolved_sandbox is the referenced SandboxConfig's content frozen at
+  // creation time.
+  SandboxAssets resolved_sandbox = 3;
+
+  // message is a human-readable explanation of the current state, most
+  // useful when state is FAILED.
+  string message = 4;
+}
+
+// Container is a single application container of an ActorTemplateVersion.
+message Container {
+  string name = 1;
+
+  string image = 2;
+
+  // Entrypoint array; when set, the image's ENTRYPOINT and CMD are both
+  // ignored and the process argv is command + args. Unlike Kubernetes,
+  // $(VAR_NAME) references are NOT expanded.
+  repeated string command = 3;
+
+  // Arguments to the entrypoint; the image's CMD is used if unset (unless
+  // command is set, which discards the image's CMD).
+  repeated string args = 4;
+
+  repeated EnvVar env = 5;
+
+  // readyz is an optional HTTP readiness probe; when set the actor is not
+  // ready until the endpoint returns 200.
+  ContainerReadyz readyz = 6;
+
+  repeated VolumeMount volume_mounts = 7;
+}
+
+// EnvVar supplies one environment variable to a container. Values are not
+// expanded with Kubernetes-style $(VAR) references.
+message EnvVar {
+  // name may be any printable ASCII character except '='.
+  string name = 1;
+
+  // Exactly one source must be set.
+  oneof source {
+    // Literal value.
+    string value = 2;
+  }
+}
+
+// ContainerReadyz configures the readiness signal for a container.
+message ContainerReadyz {
+  // http_get specifies the HTTP request to perform. Required.
+  HTTPGetAction http_get = 1;
+
+  // timeout_seconds bounds how long to poll http_get before failing the
+  // actor start. 0 means the server-applied default (30s).
+  int32 timeout_seconds = 2;
+}
+
+// HTTPGetAction describes an HTTP GET against the container's interior IP.
+message HTTPGetAction {
+  // path defaults to "/readyz".
+  string path = 1;
+
+  int32 port = 2;
+}
+
+message Volume {
+  // name of the volume. Must be a DNS label.
+  string name = 1;
+
+  // Exactly one source must be set.
+  oneof source {
+    DurableDirVolumeSource durable_dir = 2;
+    ExternalVolumeTemplate external_volume_template = 3;
+  }
+}
+
+// DurableDirVolumeSource is a durable directory on rootfs that persists
+// across resumes and participates in snapshots.
+message DurableDirVolumeSource {}
+
+// ExternalVolumeTemplate provisions an external volume per actor; the volume
+// lives only as long as the actor. Not supported with SANDBOX_CLASS_MICROVM.
+message ExternalVolumeTemplate {
+  // capacity of the volume to create, in Kubernetes resource.Quantity string
+  // form (e.g. "10Gi"). Required.
+  string capacity = 1;
+
+  // storage_class_name names the cluster-scoped Kubernetes StorageClass to
+  // create the volume from. Required.
+  string storage_class_name = 2;
+}
+
+// VolumeMount mounts a named Volume into a container.
+message VolumeMount {
+  // name must match the name of a Volume.
+  string name = 1;
+
+  // mount_path within the container. Must be a clean absolute Unix path.
+  string mount_path = 2;
+}
+
+// SandboxAssets is the frozen description of the sandbox binaries an actor
+// boots with: a class plus content-addressed files keyed first by
+// architecture and then by asset name, mirroring the SandboxConfig
+// CRD schema.
+message SandboxAssets {
+  SandboxClass sandbox_class = 1;
+  // assets maps architecture (GOARCH, e.g. "amd64") to that arch's files.
+  map<string, ArchAssets> assets = 2;
+}
+
+message ArchAssets {
+  // files maps asset name (e.g. "gvisor", "kata-kernel") to its file.
+  map<string, AssetFile> files = 1;
+}
+
+// AssetFile is one content-addressed file atelet fetches for a sandbox
+// runtime.
+message AssetFile {
+  // URL to download the asset from (e.g. a gs:// URL).
+  string url = 1;
+
+  // Lower-case hex SHA256 naming the cached file and verifying the download.
+  string sha256 = 2;
+}
+
 message CreateAtespaceRequest {
   // The atespace to create.
   Atespace atespace = 1;
@@ -306,6 +594,95 @@ message ListAtespacesResponse {
 
 message DeleteAtespaceRequest {
   ObjectRef atespace = 1;
+}
+
+message CreateActorTemplateRequest {
+  // The actor template to create. Server-assigned metadata (uid, version,
+  // timestamps) is ignored.
+  ActorTemplate actor_template = 1;
+}
+
+message GetActorTemplateRequest {
+  ObjectRef actor_template = 1;
+}
+
+// Request to update mutable fields on an existing ActorTemplate.
+message UpdateActorTemplateRequest {
+  // The actor template to update.
+  // actor_template.metadata.name identifies which resource to update.
+  // actor_template.metadata.version and actor_template.metadata.uid are
+  // optional preconditions and zero values skip the check.
+  ActorTemplate actor_template = 1;
+
+  // The set of fields to update. Required.
+  //
+  // Only the following fields are supported:
+  //   - spec.worker_selector
+  //   - spec.default_version_on_create
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+message ListActorTemplatesRequest {
+  // Requested page size; the server may return fewer, or occasionally
+  // slightly more. If unspecified, defaults to a server-chosen value;
+  // values above 1000 are coerced to 1000.
+  int32 page_size = 1;
+
+  // Pagination token from a previous ListActorTemplates response.
+  // Omit or leave empty for the first request.
+  string page_token = 2;
+}
+
+message ListActorTemplatesResponse {
+  // The page of actor templates. This list may be empty even if there are
+  // more results.
+  repeated ActorTemplate actor_templates = 1;
+
+  // Pagination token for the next page. Empty if this is the last page.
+  string next_page_token = 2;
+}
+
+message DeleteActorTemplateRequest {
+  ObjectRef actor_template = 1;
+}
+
+message CreateActorTemplateVersionRequest {
+  // The actor template version to create. Server-assigned metadata (uid,
+  // version, timestamps) is ignored, as is status: the server initializes
+  // new versions to STATE_INITIAL.
+  ActorTemplateVersion actor_template_version = 1;
+}
+
+message GetActorTemplateVersionRequest {
+  ObjectRef actor_template_version = 1;
+}
+
+message ListActorTemplateVersionsRequest {
+  // The parent ActorTemplate whose versions to list, by name. Empty lists
+  // versions across all templates.
+  string actor_template = 1;
+
+  // Requested page size; the server may return fewer, or occasionally
+  // slightly more. If unspecified, defaults to a server-chosen value;
+  // values above 1000 are coerced to 1000.
+  int32 page_size = 2;
+
+  // Pagination token from a previous ListActorTemplateVersions response.
+  // Omit or leave empty for the first request.
+  string page_token = 3;
+}
+
+message ListActorTemplateVersionsResponse {
+  // The page of actor template versions. This list may be empty even if
+  // there are more results.
+  repeated ActorTemplateVersion actor_template_versions = 1;
+
+  // Pagination token for the next page. Empty if this is the last page.
+  string next_page_token = 2;
+}
+
+message DeleteActorTemplateVersionRequest {
+  ObjectRef actor_template_version = 1;
 }
 
 message GetActorRequest {

--- a/pkg/proto/ateapipb/ateapi_grpc.pb.go
+++ b/pkg/proto/ateapipb/ateapi_grpc.pb.go
@@ -33,24 +33,33 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Control_GetActor_FullMethodName               = "/ateapi.Control/GetActor"
-	Control_CreateActor_FullMethodName            = "/ateapi.Control/CreateActor"
-	Control_UpdateActor_FullMethodName            = "/ateapi.Control/UpdateActor"
-	Control_SuspendActor_FullMethodName           = "/ateapi.Control/SuspendActor"
-	Control_PauseActor_FullMethodName             = "/ateapi.Control/PauseActor"
-	Control_ResumeActor_FullMethodName            = "/ateapi.Control/ResumeActor"
-	Control_DeleteActor_FullMethodName            = "/ateapi.Control/DeleteActor"
-	Control_GetActorSnapshot_FullMethodName       = "/ateapi.Control/GetActorSnapshot"
-	Control_ListActorSnapshots_FullMethodName     = "/ateapi.Control/ListActorSnapshots"
-	Control_TagActorSnapshot_FullMethodName       = "/ateapi.Control/TagActorSnapshot"
-	Control_UpdateActorSnapshotTag_FullMethodName = "/ateapi.Control/UpdateActorSnapshotTag"
-	Control_DeleteActorSnapshotTag_FullMethodName = "/ateapi.Control/DeleteActorSnapshotTag"
-	Control_ListWorkers_FullMethodName            = "/ateapi.Control/ListWorkers"
-	Control_ListActors_FullMethodName             = "/ateapi.Control/ListActors"
-	Control_CreateAtespace_FullMethodName         = "/ateapi.Control/CreateAtespace"
-	Control_GetAtespace_FullMethodName            = "/ateapi.Control/GetAtespace"
-	Control_ListAtespaces_FullMethodName          = "/ateapi.Control/ListAtespaces"
-	Control_DeleteAtespace_FullMethodName         = "/ateapi.Control/DeleteAtespace"
+	Control_GetActor_FullMethodName                   = "/ateapi.Control/GetActor"
+	Control_CreateActor_FullMethodName                = "/ateapi.Control/CreateActor"
+	Control_UpdateActor_FullMethodName                = "/ateapi.Control/UpdateActor"
+	Control_SuspendActor_FullMethodName               = "/ateapi.Control/SuspendActor"
+	Control_PauseActor_FullMethodName                 = "/ateapi.Control/PauseActor"
+	Control_ResumeActor_FullMethodName                = "/ateapi.Control/ResumeActor"
+	Control_DeleteActor_FullMethodName                = "/ateapi.Control/DeleteActor"
+	Control_GetActorSnapshot_FullMethodName           = "/ateapi.Control/GetActorSnapshot"
+	Control_ListActorSnapshots_FullMethodName         = "/ateapi.Control/ListActorSnapshots"
+	Control_TagActorSnapshot_FullMethodName           = "/ateapi.Control/TagActorSnapshot"
+	Control_UpdateActorSnapshotTag_FullMethodName     = "/ateapi.Control/UpdateActorSnapshotTag"
+	Control_DeleteActorSnapshotTag_FullMethodName     = "/ateapi.Control/DeleteActorSnapshotTag"
+	Control_ListWorkers_FullMethodName                = "/ateapi.Control/ListWorkers"
+	Control_ListActors_FullMethodName                 = "/ateapi.Control/ListActors"
+	Control_CreateAtespace_FullMethodName             = "/ateapi.Control/CreateAtespace"
+	Control_GetAtespace_FullMethodName                = "/ateapi.Control/GetAtespace"
+	Control_ListAtespaces_FullMethodName              = "/ateapi.Control/ListAtespaces"
+	Control_DeleteAtespace_FullMethodName             = "/ateapi.Control/DeleteAtespace"
+	Control_CreateActorTemplate_FullMethodName        = "/ateapi.Control/CreateActorTemplate"
+	Control_GetActorTemplate_FullMethodName           = "/ateapi.Control/GetActorTemplate"
+	Control_UpdateActorTemplate_FullMethodName        = "/ateapi.Control/UpdateActorTemplate"
+	Control_ListActorTemplates_FullMethodName         = "/ateapi.Control/ListActorTemplates"
+	Control_DeleteActorTemplate_FullMethodName        = "/ateapi.Control/DeleteActorTemplate"
+	Control_CreateActorTemplateVersion_FullMethodName = "/ateapi.Control/CreateActorTemplateVersion"
+	Control_GetActorTemplateVersion_FullMethodName    = "/ateapi.Control/GetActorTemplateVersion"
+	Control_ListActorTemplateVersions_FullMethodName  = "/ateapi.Control/ListActorTemplateVersions"
+	Control_DeleteActorTemplateVersion_FullMethodName = "/ateapi.Control/DeleteActorTemplateVersion"
 )
 
 // ControlClient is the client API for Control service.
@@ -97,6 +106,27 @@ type ControlClient interface {
 	// Delete an empty Atespace. Rejects (FailedPrecondition) if any Actors or
 	// ActorSnapshotTags remain.
 	DeleteAtespace(ctx context.Context, in *DeleteAtespaceRequest, opts ...grpc.CallOption) (*Atespace, error)
+	CreateActorTemplate(ctx context.Context, in *CreateActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error)
+	// Get an ActorTemplate by name.
+	GetActorTemplate(ctx context.Context, in *GetActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error)
+	// Update mutable fields on an existing ActorTemplate.
+	UpdateActorTemplate(ctx context.Context, in *UpdateActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error)
+	ListActorTemplates(ctx context.Context, in *ListActorTemplatesRequest, opts ...grpc.CallOption) (*ListActorTemplatesResponse, error)
+	// Delete an ActorTemplate. Rejects (FailedPrecondition) while any of its
+	// ActorTemplateVersions exist.
+	DeleteActorTemplate(ctx context.Context, in *DeleteActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error)
+	// Create a new ActorTemplateVersion under an existing ActorTemplate
+	// (FailedPrecondition if the parent does not exist).
+	CreateActorTemplateVersion(ctx context.Context, in *CreateActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error)
+	// Get an ActorTemplateVersion by name.
+	GetActorTemplateVersion(ctx context.Context, in *GetActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error)
+	// List ActorTemplateVersions, optionally filtered to one ActorTemplate.
+	ListActorTemplateVersions(ctx context.Context, in *ListActorTemplateVersionsRequest, opts ...grpc.CallOption) (*ListActorTemplateVersionsResponse, error)
+	// Delete an ActorTemplateVersion together with its golden actor and golden
+	// snapshot in the reserved ate-golden atespace. Rejects (FailedPrecondition)
+	// while the version is its parent's default_version_on_create or while any
+	// Actor pins it.
+	DeleteActorTemplateVersion(ctx context.Context, in *DeleteActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error)
 }
 
 type controlClient struct {
@@ -287,6 +317,96 @@ func (c *controlClient) DeleteAtespace(ctx context.Context, in *DeleteAtespaceRe
 	return out, nil
 }
 
+func (c *controlClient) CreateActorTemplate(ctx context.Context, in *CreateActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplate)
+	err := c.cc.Invoke(ctx, Control_CreateActorTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) GetActorTemplate(ctx context.Context, in *GetActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplate)
+	err := c.cc.Invoke(ctx, Control_GetActorTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) UpdateActorTemplate(ctx context.Context, in *UpdateActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplate)
+	err := c.cc.Invoke(ctx, Control_UpdateActorTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) ListActorTemplates(ctx context.Context, in *ListActorTemplatesRequest, opts ...grpc.CallOption) (*ListActorTemplatesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListActorTemplatesResponse)
+	err := c.cc.Invoke(ctx, Control_ListActorTemplates_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) DeleteActorTemplate(ctx context.Context, in *DeleteActorTemplateRequest, opts ...grpc.CallOption) (*ActorTemplate, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplate)
+	err := c.cc.Invoke(ctx, Control_DeleteActorTemplate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) CreateActorTemplateVersion(ctx context.Context, in *CreateActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplateVersion)
+	err := c.cc.Invoke(ctx, Control_CreateActorTemplateVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) GetActorTemplateVersion(ctx context.Context, in *GetActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplateVersion)
+	err := c.cc.Invoke(ctx, Control_GetActorTemplateVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) ListActorTemplateVersions(ctx context.Context, in *ListActorTemplateVersionsRequest, opts ...grpc.CallOption) (*ListActorTemplateVersionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListActorTemplateVersionsResponse)
+	err := c.cc.Invoke(ctx, Control_ListActorTemplateVersions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *controlClient) DeleteActorTemplateVersion(ctx context.Context, in *DeleteActorTemplateVersionRequest, opts ...grpc.CallOption) (*ActorTemplateVersion, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActorTemplateVersion)
+	err := c.cc.Invoke(ctx, Control_DeleteActorTemplateVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ControlServer is the server API for Control service.
 // All implementations must embed UnimplementedControlServer
 // for forward compatibility.
@@ -331,6 +451,27 @@ type ControlServer interface {
 	// Delete an empty Atespace. Rejects (FailedPrecondition) if any Actors or
 	// ActorSnapshotTags remain.
 	DeleteAtespace(context.Context, *DeleteAtespaceRequest) (*Atespace, error)
+	CreateActorTemplate(context.Context, *CreateActorTemplateRequest) (*ActorTemplate, error)
+	// Get an ActorTemplate by name.
+	GetActorTemplate(context.Context, *GetActorTemplateRequest) (*ActorTemplate, error)
+	// Update mutable fields on an existing ActorTemplate.
+	UpdateActorTemplate(context.Context, *UpdateActorTemplateRequest) (*ActorTemplate, error)
+	ListActorTemplates(context.Context, *ListActorTemplatesRequest) (*ListActorTemplatesResponse, error)
+	// Delete an ActorTemplate. Rejects (FailedPrecondition) while any of its
+	// ActorTemplateVersions exist.
+	DeleteActorTemplate(context.Context, *DeleteActorTemplateRequest) (*ActorTemplate, error)
+	// Create a new ActorTemplateVersion under an existing ActorTemplate
+	// (FailedPrecondition if the parent does not exist).
+	CreateActorTemplateVersion(context.Context, *CreateActorTemplateVersionRequest) (*ActorTemplateVersion, error)
+	// Get an ActorTemplateVersion by name.
+	GetActorTemplateVersion(context.Context, *GetActorTemplateVersionRequest) (*ActorTemplateVersion, error)
+	// List ActorTemplateVersions, optionally filtered to one ActorTemplate.
+	ListActorTemplateVersions(context.Context, *ListActorTemplateVersionsRequest) (*ListActorTemplateVersionsResponse, error)
+	// Delete an ActorTemplateVersion together with its golden actor and golden
+	// snapshot in the reserved ate-golden atespace. Rejects (FailedPrecondition)
+	// while the version is its parent's default_version_on_create or while any
+	// Actor pins it.
+	DeleteActorTemplateVersion(context.Context, *DeleteActorTemplateVersionRequest) (*ActorTemplateVersion, error)
 	mustEmbedUnimplementedControlServer()
 }
 
@@ -394,6 +535,33 @@ func (UnimplementedControlServer) ListAtespaces(context.Context, *ListAtespacesR
 }
 func (UnimplementedControlServer) DeleteAtespace(context.Context, *DeleteAtespaceRequest) (*Atespace, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteAtespace not implemented")
+}
+func (UnimplementedControlServer) CreateActorTemplate(context.Context, *CreateActorTemplateRequest) (*ActorTemplate, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateActorTemplate not implemented")
+}
+func (UnimplementedControlServer) GetActorTemplate(context.Context, *GetActorTemplateRequest) (*ActorTemplate, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetActorTemplate not implemented")
+}
+func (UnimplementedControlServer) UpdateActorTemplate(context.Context, *UpdateActorTemplateRequest) (*ActorTemplate, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateActorTemplate not implemented")
+}
+func (UnimplementedControlServer) ListActorTemplates(context.Context, *ListActorTemplatesRequest) (*ListActorTemplatesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListActorTemplates not implemented")
+}
+func (UnimplementedControlServer) DeleteActorTemplate(context.Context, *DeleteActorTemplateRequest) (*ActorTemplate, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteActorTemplate not implemented")
+}
+func (UnimplementedControlServer) CreateActorTemplateVersion(context.Context, *CreateActorTemplateVersionRequest) (*ActorTemplateVersion, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateActorTemplateVersion not implemented")
+}
+func (UnimplementedControlServer) GetActorTemplateVersion(context.Context, *GetActorTemplateVersionRequest) (*ActorTemplateVersion, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetActorTemplateVersion not implemented")
+}
+func (UnimplementedControlServer) ListActorTemplateVersions(context.Context, *ListActorTemplateVersionsRequest) (*ListActorTemplateVersionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListActorTemplateVersions not implemented")
+}
+func (UnimplementedControlServer) DeleteActorTemplateVersion(context.Context, *DeleteActorTemplateVersionRequest) (*ActorTemplateVersion, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteActorTemplateVersion not implemented")
 }
 func (UnimplementedControlServer) mustEmbedUnimplementedControlServer() {}
 func (UnimplementedControlServer) testEmbeddedByValue()                 {}
@@ -740,6 +908,168 @@ func _Control_DeleteAtespace_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Control_CreateActorTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateActorTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).CreateActorTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_CreateActorTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).CreateActorTemplate(ctx, req.(*CreateActorTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_GetActorTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetActorTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).GetActorTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_GetActorTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).GetActorTemplate(ctx, req.(*GetActorTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_UpdateActorTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateActorTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).UpdateActorTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_UpdateActorTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).UpdateActorTemplate(ctx, req.(*UpdateActorTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_ListActorTemplates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListActorTemplatesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).ListActorTemplates(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_ListActorTemplates_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).ListActorTemplates(ctx, req.(*ListActorTemplatesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_DeleteActorTemplate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteActorTemplateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).DeleteActorTemplate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_DeleteActorTemplate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).DeleteActorTemplate(ctx, req.(*DeleteActorTemplateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_CreateActorTemplateVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateActorTemplateVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).CreateActorTemplateVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_CreateActorTemplateVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).CreateActorTemplateVersion(ctx, req.(*CreateActorTemplateVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_GetActorTemplateVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetActorTemplateVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).GetActorTemplateVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_GetActorTemplateVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).GetActorTemplateVersion(ctx, req.(*GetActorTemplateVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_ListActorTemplateVersions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListActorTemplateVersionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).ListActorTemplateVersions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_ListActorTemplateVersions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).ListActorTemplateVersions(ctx, req.(*ListActorTemplateVersionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Control_DeleteActorTemplateVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteActorTemplateVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ControlServer).DeleteActorTemplateVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Control_DeleteActorTemplateVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ControlServer).DeleteActorTemplateVersion(ctx, req.(*DeleteActorTemplateVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Control_ServiceDesc is the grpc.ServiceDesc for Control service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -818,6 +1148,42 @@ var Control_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteAtespace",
 			Handler:    _Control_DeleteAtespace_Handler,
+		},
+		{
+			MethodName: "CreateActorTemplate",
+			Handler:    _Control_CreateActorTemplate_Handler,
+		},
+		{
+			MethodName: "GetActorTemplate",
+			Handler:    _Control_GetActorTemplate_Handler,
+		},
+		{
+			MethodName: "UpdateActorTemplate",
+			Handler:    _Control_UpdateActorTemplate_Handler,
+		},
+		{
+			MethodName: "ListActorTemplates",
+			Handler:    _Control_ListActorTemplates_Handler,
+		},
+		{
+			MethodName: "DeleteActorTemplate",
+			Handler:    _Control_DeleteActorTemplate_Handler,
+		},
+		{
+			MethodName: "CreateActorTemplateVersion",
+			Handler:    _Control_CreateActorTemplateVersion_Handler,
+		},
+		{
+			MethodName: "GetActorTemplateVersion",
+			Handler:    _Control_GetActorTemplateVersion_Handler,
+		},
+		{
+			MethodName: "ListActorTemplateVersions",
+			Handler:    _Control_ListActorTemplateVersions_Handler,
+		},
+		{
+			MethodName: "DeleteActorTemplateVersion",
+			Handler:    _Control_DeleteActorTemplateVersion_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
Part of #477 . Adding both AT and ATV as global resources in substrate.

All ATV fields are immutable. SandboxConifg will be frozen into ATV at creation time.

- [ ] Tests pass

> - [ ] Appropriate changes to documentation are included in the PR. 

Not yet, will add documentation once we cut over from the the current CRD impl.

Demo: what the counter demo will look like with AT and ATV:

```
apiVersion: api.ate.dev/v1alpha1
kind: ActorTemplate
metadata:
  name: counter-atv
spec:
  workerSelector:
    matchLabels:
      workload: counter
  defaultVersionOnCreate:
    name: counter-atv-v1
---
apiVersion: api.ate.dev/v1alpha1
kind: ActorTemplateVersion
metadata:
  name: counter-atv-v1
actorTemplate:
  name: counter-atv
spec:
  pauseImage: "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
  containers:
  - name: counter
    image: ko://github.com/agent-substrate/substrate/demos/counter
    command:
    - /ko-app/counter
    env:
    - name: VERSION
      value: v1
    readyz:
      httpGet:
        path: /readyz
        port: 80
    volumeMounts:
    - name: data
      mountPath: /home/counter
  volumes:
  - name: data
    durableDir: {}
  snapshotsConfig:
    onPause: SNAPSHOT_CONTENT_SCOPE_FULL
    onCommit: SNAPSHOT_CONTENT_SCOPE_DATA
    storageLocation: gs://${BUCKET_NAME}/ate-demo-counter-atv/
  sandboxConfig:
    sandboxClass: SANDBOX_CLASS_GVISOR
    configName: gvisor-default
---
```