### PR TITLE
Fix unit tests failing due to restrictive umask

### DIFF
--- a/cmd/ateom-microvm/internal/tarutil/tarutil_test.go
+++ b/cmd/ateom-microvm/internal/tarutil/tarutil_test.go
@@ -87,8 +87,12 @@ func TestRoundTrip(t *testing.T) {
 		t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "ro"), 0o700) })
 	}
 	restoreWritable(src)
-	if err := os.Mkdir(filepath.Join(src, "empty"), 0o755); err != nil {
+	emptyDir := filepath.Join(src, "empty")
+	if err := os.Mkdir(emptyDir, 0o755); err != nil {
 		t.Fatalf("mkdir empty: %v", err)
+	}
+	if err := os.Chmod(emptyDir, 0o755); err != nil {
+		t.Fatalf("chmod empty: %v", err)
 	}
 	if err := os.Symlink("a.txt", filepath.Join(src, "link")); err != nil {
 		t.Fatalf("symlink: %v", err)

--- a/internal/imagecache/implicitdirs_test.go
+++ b/internal/imagecache/implicitdirs_test.go
@@ -144,6 +144,12 @@ func TestApplyDirFixups_SkipsShadowedPaths(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(rootfs, "afile"), nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
+	fiBefore, err := os.Lstat(filepath.Join(rootfs, "afile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedMode := fiBefore.Mode().Perm()
+
 	fixups := []dirFixup{
 		{Path: "missing", Mode: 0o700},
 		{Path: "afile", Mode: 0o700},
@@ -151,7 +157,7 @@ func TestApplyDirFixups_SkipsShadowedPaths(t *testing.T) {
 	if err := applyDirFixups(rootfs, fixups); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	if fi, _ := os.Lstat(filepath.Join(rootfs, "afile")); fi.Mode().Perm() != 0o644 {
-		t.Errorf("non-directory was chmodded: %v", fi.Mode())
+	if fi, _ := os.Lstat(filepath.Join(rootfs, "afile")); fi.Mode().Perm() != expectedMode {
+		t.Errorf("non-directory was chmodded: %v (expected %v)", fi.Mode().Perm(), expectedMode)
 	}
 }


### PR DESCRIPTION
Modify tests in imagecache and tarutil to pass in environments with restrictive umask (like 0027).

Fixes: #830 

TAG=agy
CONV=c647bc5d-fac0-49c8-96e1-2aeb3de188aa

- [ X] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
