### PR TITLE
Fix toctou race in UpdateActor

### DIFF
--- a/cmd/ateapi/internal/controlapi/crash.go
+++ b/cmd/ateapi/internal/controlapi/crash.go
@@ -75,14 +75,18 @@ func crashActor(ctx context.Context, st store.Interface, actorRef resources.Acto
 	// the counter itself is emitted only after the transition commits.
 	crashAttrs := ateattr.ActorMetricAttributes(actor, sandboxClass, opName, reason)
 
-	actor.Status = ateapipb.Actor_STATUS_CRASHED
+	_, err = st.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, actor.GetMetadata().GetUid(), actor.GetMetadata().GetVersion()); err != nil {
+			return err
+		}
+		dbActor.Status = ateapipb.Actor_STATUS_CRASHED
 
-	// InProgressSnapshotName and InProgressLocalSnapshotName are kept for
-	// debugging; failed workflow steps must never promote either of them to an
-	// ActorSnapshot or to LocalSnapshotInfo.
-	actor.WorkerAssignment = nil
-
-	_, err = st.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion())
+		// InProgressSnapshotName and InProgressLocalSnapshotName are kept for
+		// debugging; failed workflow steps must never promote either of them to an
+		// ActorSnapshot or to LocalSnapshotInfo.
+		dbActor.WorkerAssignment = nil
+		return nil
+	})
 	if err != nil {
 		errCollected = append(errCollected, fmt.Errorf("while marking actor crashed: %w", err))
 		return errors.Join(errCollected...)

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -2447,7 +2447,7 @@ func TestUpdateActor_Preconditions(t *testing.T) {
 	// The uid from the deleted lifecycle must be rejected, even though the
 	// atespace/name it was observed under still resolves.
 	_, err := update(&ateapipb.ResourceMetadata{Uid: staleUID}, "other-lifecycle")
-	assertGrpcError(t, err, codes.Aborted, fmt.Sprintf("Actor %s/%s has uid %s, not %s", testAtespace, testActorID, uid, staleUID))
+	assertGrpcError(t, err, codes.Aborted, fmt.Sprintf("actor %s/%s not found with uid %s", testAtespace, testActorID, staleUID))
 
 	// An unguarded update is last-writer-wins, and moves the resource past the
 	// version observed above.
@@ -2494,7 +2494,7 @@ func TestUpdateActor_NotFound(t *testing.T) {
 		Actor:      &ateapipb.Actor{Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "does-not-exist"}},
 		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"worker_selector"}},
 	})
-	assertGrpcError(t, err, codes.NotFound, "Actor test-atespace/does-not-exist not found")
+	assertGrpcError(t, err, codes.NotFound, "actor test-atespace/does-not-exist not found")
 }
 
 func TestUpdateActorSnapshotTag_Success(t *testing.T) {
@@ -3287,21 +3287,19 @@ func TestDeleteActor_Crashed(t *testing.T) {
 
 	createTemplate(t, tc, ns)
 
-	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
 		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "tmpl1",
-	}})
-	if err != nil {
+	}}); err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
 
-	actor, err := tc.persistence.GetActor(context.Background(), resources.ActorRef{Atespace: testAtespace, Name: "id1"})
-	if err != nil {
-		t.Fatalf("GetActor failed: %v", err)
-	}
-	actor.Status = ateapipb.Actor_STATUS_CRASHED
-	if _, err := tc.persistence.UpdateActor(context.Background(), actor, actor.GetMetadata().GetVersion()); err != nil {
+	actorRef := resources.ActorRef{Atespace: testAtespace, Name: "id1"}
+	if _, err := tc.persistence.UpdateActor(context.Background(), actorRef, func(dbActor *ateapipb.Actor) error {
+		dbActor.Status = ateapipb.Actor_STATUS_CRASHED
+		return nil
+	}); err != nil {
 		t.Fatalf("UpdateActor failed: %v", err)
 	}
 

--- a/cmd/ateapi/internal/controlapi/syncer.go
+++ b/cmd/ateapi/internal/controlapi/syncer.go
@@ -383,14 +383,18 @@ func (s *WorkerPoolSyncer) releaseActorOnDeadWorker(ctx context.Context, namespa
 	// Snapshot crash attributes before pod and pool pointers are cleared on actor.
 	crashAttrs := ateattr.ActorMetricAttributes(actor, worker.GetSandboxClass(), opName, ateattr.ReasonWorkerPodGone)
 
-	actor.Status = ateapipb.Actor_STATUS_CRASHED
-	actor.WorkerAssignment = nil
-	// Both in-progress checkpoints die with the worker: the durable one was
-	// never uploaded, the local one lived on the node that went away.
-	actor.InProgressSnapshotName = ""
-	actor.InProgressLocalSnapshotName = ""
-
-	_, err = s.persistence.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion())
+	_, err = s.persistence.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, actor.GetMetadata().GetUid(), actor.GetMetadata().GetVersion()); err != nil {
+			return err
+		}
+		dbActor.Status = ateapipb.Actor_STATUS_CRASHED
+		dbActor.WorkerAssignment = nil
+		// Both in-progress checkpoints die with the worker: the durable one was
+		// never uploaded, the local one lived on the node that went away.
+		dbActor.InProgressSnapshotName = ""
+		dbActor.InProgressLocalSnapshotName = ""
+		return nil
+	})
 
 	if err == nil && !wasAlreadyCrashed {
 		recordActorCrash(ctx, crashAttrs)

--- a/cmd/ateapi/internal/controlapi/update_actor.go
+++ b/cmd/ateapi/internal/controlapi/update_actor.go
@@ -41,30 +41,22 @@ func (s *Service) UpdateActor(ctx context.Context, req *ateapipb.UpdateActorRequ
 	actorRef := resources.ActorRefFromActor(in)
 	setSpanActorRefAttributes(ctx, actorRef)
 
-	actor, err := s.persistence.GetActor(ctx, actorRef)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Errorf(codes.NotFound, "Actor %s not found", actorRef)
+	updated, err := s.persistence.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, in.GetMetadata().GetUid(), in.GetMetadata().GetVersion()); err != nil {
+			return err
 		}
-		return nil, fmt.Errorf("while getting actor: %w", err)
-	}
-
-	// UID and version preconditions
-	if uid := in.GetMetadata().GetUid(); uid != "" && uid != actor.GetMetadata().GetUid() {
-		return nil, status.Errorf(codes.Aborted, "Actor %s has uid %s, not %s", actorRef, actor.GetMetadata().GetUid(), uid)
-	}
-
-	expectedVersion := actor.GetMetadata().GetVersion()
-	if version := in.GetMetadata().GetVersion(); version != 0 {
-		expectedVersion = version
-	}
-
-	applyUpdateMask(actor, in, req.GetUpdateMask(), actorMutableFields)
-
-	updated, err := s.persistence.UpdateActor(ctx, actor, expectedVersion)
+		applyUpdateMask(dbActor, in, req.GetUpdateMask(), actorMutableFields)
+		return nil
+	})
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
+		}
+		if errors.Is(err, store.ErrUIDConflict) {
+			return nil, status.Errorf(codes.Aborted, "actor %s/%s not found with uid %s", in.GetMetadata().GetAtespace(), in.GetMetadata().GetName(), in.GetMetadata().GetUid())
+		}
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "actor %s not found", actorRef)
 		}
 		return nil, fmt.Errorf("while updating actor: %w", err)
 	}

--- a/cmd/ateapi/internal/controlapi/update_actor_test.go
+++ b/cmd/ateapi/internal/controlapi/update_actor_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
 	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 )
 
@@ -215,6 +216,152 @@ func TestUpdateActor_FailedLookupStampsRefIdentityOnly(t *testing.T) {
 		if _, ok := attrs[k]; ok {
 			t.Errorf("unexpected %s on failed-update span", k)
 		}
+	}
+}
+
+// TestUpdateActor_DeleteRecreateRace checks that an update is not applied
+// if an actor was deleted and recreated during the update operation.
+func TestUpdateActor_DeleteRecreateRace(t *testing.T) {
+	ctx := context.Background()
+	persistence, cleanup := storetest.SetupTestStore(t)
+	t.Cleanup(cleanup)
+
+	actorRef := resources.ActorRef{Atespace: testAtespace, Name: testActorID}
+
+	// Actor A: what the client reads, and what its uid precondition names.
+	// Freshly created, so it sits at version 1.
+	original, err := persistence.CreateActor(ctx, &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+		ActorTemplateNamespace: "ns1",
+		ActorTemplateName:      "tmpl1",
+		Status:                 ateapipb.Actor_STATUS_RUNNING,
+		WorkerAssignment:       &ateapipb.WorkerAssignment{WorkerPod: "pod-a"},
+	})
+	if err != nil {
+		t.Fatalf("seed CreateActor: %v", err)
+	}
+
+	// A concurrent client deletes A and recreates the same atespace/name as a
+	// brand new actor B, in the window the handler used to leave open between
+	// its own read and the store's WATCH.
+	var recreated *ateapipb.Actor
+	racing := &conflictInjectingStore{
+		Interface: persistence,
+		inject: func() {
+			if _, err := persistence.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+				dbActor.Status = ateapipb.Actor_STATUS_DELETING
+				return nil
+			}); err != nil {
+				t.Fatalf("racing writer: mark deleting: %v", err)
+			}
+			if _, err := persistence.DeleteActor(ctx, actorRef); err != nil {
+				t.Fatalf("racing writer: DeleteActor: %v", err)
+			}
+			recreated, err = persistence.CreateActor(ctx, &ateapipb.Actor{
+				Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+				ActorTemplateNamespace: "ns1",
+				ActorTemplateName:      "tmpl1",
+				Status:                 ateapipb.Actor_STATUS_SUSPENDED,
+			})
+			if err != nil {
+				t.Fatalf("racing writer: recreate CreateActor: %v", err)
+			}
+		},
+	}
+	svc := &Service{persistence: racing}
+
+	// The client asserts "only update the actor with uid A".
+	_, err = svc.UpdateActor(ctx, &ateapipb.UpdateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata: &ateapipb.ResourceMetadata{
+				Atespace: testAtespace,
+				Name:     testActorID,
+				Uid:      original.GetMetadata().GetUid(),
+			},
+			WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"worker_selector"}},
+	})
+	if code := status.Code(err); code != codes.Aborted {
+		t.Errorf("UpdateActor error = %v (code %v), want code Aborted: the actor holding uid %s was deleted mid-update",
+			err, code, original.GetMetadata().GetUid())
+	}
+
+	stored, err := persistence.GetActor(ctx, actorRef)
+	if err != nil {
+		t.Fatalf("GetActor: %v", err)
+	}
+	if got, want := stored.GetMetadata().GetUid(), recreated.GetMetadata().GetUid(); got != want {
+		t.Fatalf("stored uid = %s, want recreated actor's uid %s", got, want)
+	}
+	// The stored record must still be actor B as its creator left it. Any of A's
+	// state showing up here is the clobber.
+	if got := stored.GetStatus(); got != ateapipb.Actor_STATUS_SUSPENDED {
+		t.Errorf("stored status = %v, want %v: recreated actor was overwritten with the deleted actor's state",
+			got, ateapipb.Actor_STATUS_SUSPENDED)
+	}
+	if got := stored.GetWorkerAssignment(); got != nil {
+		t.Errorf("stored worker_assignment = %v, want nil: recreated actor inherited the deleted actor's worker", got)
+	}
+	if got := stored.GetWorkerSelector(); got != nil {
+		t.Errorf("stored worker_selector = %v, want nil: update meant for the deleted actor was applied", got)
+	}
+}
+
+// TestUpdateActor_ConcurrentDisjointUpdates checks that concurrent write
+// to a disjoint field is resolved by the store and both fields survive the update.
+func TestUpdateActor_ConcurrentDisjointUpdates(t *testing.T) {
+	ctx := context.Background()
+	persistence, cleanup := storetest.SetupTestStore(t)
+	t.Cleanup(cleanup)
+
+	actorRef := resources.ActorRef{Atespace: testAtespace, Name: testActorID}
+
+	if _, err := persistence.CreateActor(ctx, &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+		ActorTemplateNamespace: "ns1",
+		ActorTemplateName:      "tmpl1",
+		Status:                 ateapipb.Actor_STATUS_RUNNING,
+	}); err != nil {
+		t.Fatalf("seed CreateActor: %v", err)
+	}
+
+	// A suspend workflow bumps status (a field that a later update operation will not touch)
+	// inside the handler's read-modify-write window.
+	racing := &conflictInjectingStore{
+		Interface: persistence,
+		inject: func() {
+			if _, err := persistence.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+				dbActor.Status = ateapipb.Actor_STATUS_SUSPENDING
+				return nil
+			}); err != nil {
+				t.Fatalf("racing writer: mark suspending: %v", err)
+			}
+		},
+	}
+	svc := &Service{persistence: racing}
+
+	// Update operation is changing the worker_selector field, not the actor's status (like the concurrent op)
+	if _, err := svc.UpdateActor(ctx, &ateapipb.UpdateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:       &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+			WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"worker_selector"}},
+	}); err != nil {
+		t.Fatalf("UpdateActor error = %v, want success: no version precondition was set, so the conflict is the server's to resolve", err)
+	}
+
+	stored, err := persistence.GetActor(ctx, actorRef)
+	if err != nil {
+		t.Fatalf("GetActor: %v", err)
+	}
+	// Both worker selector and status updates survive
+	if got := stored.GetWorkerSelector().GetMatchLabels()["tier"]; got != "paid" {
+		t.Errorf("stored worker_selector[tier] = %q, want %q", got, "paid")
+	}
+	if got := stored.GetStatus(); got != ateapipb.Actor_STATUS_SUSPENDING {
+		t.Errorf("stored status = %v, want %v: the concurrent writer's field must survive", got, ateapipb.Actor_STATUS_SUSPENDING)
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/workflow_delete.go
+++ b/cmd/ateapi/internal/controlapi/workflow_delete.go
@@ -78,11 +78,16 @@ func (w *ActorWorkflow) ensureMarkedDeleting(ctx context.Context, actorRef resou
 		return nil, status.Errorf(codes.FailedPrecondition, "Actor %s is not in a deletable status (status: %v)", actorRef, actor.GetStatus())
 	}
 
-	actor.Status = ateapipb.Actor_STATUS_DELETING
-	for _, vol := range actor.GetActorVolumes() {
-		vol.Status = ateapipb.ExternalVolume_STATUS_DELETING
-	}
-	updated, err := w.store.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion())
+	updated, err := w.store.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, actor.GetMetadata().GetUid(), actor.GetMetadata().GetVersion()); err != nil {
+			return err
+		}
+		dbActor.Status = ateapipb.Actor_STATUS_DELETING
+		for _, vol := range dbActor.GetActorVolumes() {
+			vol.Status = ateapipb.ExternalVolume_STATUS_DELETING
+		}
+		return nil
+	})
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -115,9 +115,15 @@ func (w *ActorWorkflow) ensureMarkedPausing(ctx context.Context, actorRef resour
 		return nil, status.Errorf(codes.FailedPrecondition, "MarkPausing prerequisite not met for Actor: %s (got: %v, want %s)", actorRef, actor.GetStatus(), ateapipb.Actor_STATUS_RUNNING)
 	}
 
-	actor.Status = ateapipb.Actor_STATUS_PAUSING
-	actor.InProgressLocalSnapshotName = resources.NewSnapshotName()
-	updated, err := w.store.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion())
+	snapshotName := resources.NewSnapshotName()
+	updated, err := w.store.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, actor.GetMetadata().GetUid(), actor.GetMetadata().GetVersion()); err != nil {
+			return err
+		}
+		dbActor.Status = ateapipb.Actor_STATUS_PAUSING
+		dbActor.InProgressLocalSnapshotName = snapshotName
+		return nil
+	})
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
@@ -237,36 +243,44 @@ func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef reso
 			return nil, err
 		}
 		wasAlreadyCrashed := latestActor.GetStatus() == ateapipb.Actor_STATUS_CRASHED
-		latestActor.Status = ateapipb.Actor_STATUS_PAUSED
+		newStatus := ateapipb.Actor_STATUS_PAUSED
 		if nodeName == "" {
 			// Without a node name we cannot record where the local snapshot lives,
 			// so the actor can never be resumed (the scheduler would search for a
 			// worker on an unknown node forever). Crash it instead of leaving it
 			// stuck in PAUSED.
 			slog.ErrorContext(ctx, "Node name not found during finalize pause, crashing actor", slog.Any("actor", actorRef))
-			latestActor.Status = ateapipb.Actor_STATUS_CRASHED
+			newStatus = ateapipb.Actor_STATUS_CRASHED
 		}
-		// TODO(dberkov) - what if InProgressLocalSnapshotName is empty? That shouldn't be possible.
-		if latestActor.InProgressLocalSnapshotName != "" {
-			localInfo := &ateapipb.LocalSnapshotInfo{
-				SnapshotName: latestActor.InProgressLocalSnapshotName,
-				ContentScope: toActorSnapshotContentScope(actorTemplate.Spec.SnapshotsConfig.OnPause),
-			}
-			if latestActor.Status != ateapipb.Actor_STATUS_CRASHED {
-				localInfo.NodeVmsWithLocalSnapshots = []string{nodeName}
-			}
-			latestActor.LocalSnapshotInfo = localInfo
-			latestActor.InProgressLocalSnapshotName = ""
-		}
+		contentScope := toActorSnapshotContentScope(actorTemplate.Spec.SnapshotsConfig.OnPause)
 		sandboxClass := ""
 		if worker != nil {
 			sandboxClass = worker.GetSandboxClass()
 		}
 		// Snapshot crash attributes before pod and pool pointers are cleared below.
+		latestActor.Status = newStatus
 		crashAttrs := ateattr.ActorMetricAttributes(latestActor, sandboxClass, ateattr.OperationPause, ateattr.ReasonCorruptedAssignment)
 
-		latestActor.WorkerAssignment = nil
-		updatedActor, err := w.store.UpdateActor(ctx, latestActor, latestActor.GetMetadata().GetVersion())
+		updatedActor, err := w.store.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+			if err := store.CheckActorPrecondition(dbActor, latestActor.GetMetadata().GetUid(), latestActor.GetMetadata().GetVersion()); err != nil {
+				return err
+			}
+			dbActor.Status = newStatus
+			// TODO(dberkov) - what if InProgressLocalSnapshotName is empty? That shouldn't be possible.
+			if dbActor.GetInProgressLocalSnapshotName() != "" {
+				localInfo := &ateapipb.LocalSnapshotInfo{
+					SnapshotName: dbActor.GetInProgressLocalSnapshotName(),
+					ContentScope: contentScope,
+				}
+				if newStatus != ateapipb.Actor_STATUS_CRASHED {
+					localInfo.NodeVmsWithLocalSnapshots = []string{nodeName}
+				}
+				dbActor.LocalSnapshotInfo = localInfo
+				dbActor.InProgressLocalSnapshotName = ""
+			}
+			dbActor.WorkerAssignment = nil
+			return nil
+		})
 		if err == nil && updatedActor.GetStatus() == ateapipb.Actor_STATUS_CRASHED && !wasAlreadyCrashed {
 			recordActorCrash(ctx, crashAttrs)
 		}

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -98,7 +98,7 @@ func (w *ActorWorkflow) ResumeActor(ctx context.Context, actorRef resources.Acto
 		return actor, false, nil
 	}
 	var created *ateapipb.Actor
-	if created, err = w.ensureVolumesCreated(lockCtx, actor, actorTemplate); err != nil {
+	if created, err = w.ensureVolumesCreated(lockCtx, actorRef, actor, actorTemplate); err != nil {
 		return nil, false, err
 	}
 	actor = created
@@ -235,7 +235,7 @@ func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resourc
 // ensureVolumesCreated provisions any initial actor volumes that are in
 // PENDING state, persisting the resulting volume state (even when creation
 // partially failed, so progress is not lost) and returning the stored copy.
-func (w *ActorWorkflow) ensureVolumesCreated(ctx context.Context, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (_ *ateapipb.Actor, err error) {
+func (w *ActorWorkflow) ensureVolumesCreated(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "CreateVolumes")
 	defer func() { err = done(err) }()
 
@@ -252,15 +252,23 @@ func (w *ActorWorkflow) ensureVolumesCreated(ctx context.Context, actor *ateapip
 	}
 
 	volumes, createErr := createActorVolumes(ctx, w.pluginRegistry, w.storageClassLister, actor.GetMetadata().GetUid(), actorTemplate, actor.GetActorVolumes())
-	actor.ActorVolumes = volumes
+	// createActorVolumes reports the state it got to even when it fails, so both
+	// paths persist the same field.
+	persistVolumes := func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, actor.GetMetadata().GetUid(), actor.GetMetadata().GetVersion()); err != nil {
+			return err
+		}
+		dbActor.ActorVolumes = volumes
+		return nil
+	}
 	if createErr != nil {
 		// Even if volume creation failed, we still want to persist any updated volume state.
-		if _, updateErr := w.store.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion()); updateErr != nil {
+		if _, updateErr := w.store.UpdateActor(ctx, actorRef, persistVolumes); updateErr != nil {
 			slog.ErrorContext(ctx, "failed to update actor volumes on volume creation failure in resume", slog.Any("error", updateErr))
 		}
 		return nil, createErr
 	}
-	updated, updateErr := w.store.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion())
+	updated, updateErr := w.store.UpdateActor(ctx, actorRef, persistVolumes)
 	if updateErr != nil {
 		if errors.Is(updateErr, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
@@ -502,10 +510,15 @@ func (w *ActorWorkflow) assignWorkerAttempt(ctx context.Context, actorRef resour
 		return nil, nil, err
 	}
 
-	actor.Status = ateapipb.Actor_STATUS_RESUMING
-	actor.WorkerAssignment = workerAssignmentFrom(assignedWorker)
-
-	updatedActor, err := w.store.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion())
+	newAssignment := workerAssignmentFrom(assignedWorker)
+	updatedActor, err := w.store.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, actor.GetMetadata().GetUid(), actor.GetMetadata().GetVersion()); err != nil {
+			return err
+		}
+		dbActor.Status = ateapipb.Actor_STATUS_RESUMING
+		dbActor.WorkerAssignment = newAssignment
+		return nil
+	})
 	if err != nil {
 		if !errors.Is(err, store.ErrVersionConflict) {
 			return nil, nil, err
@@ -722,8 +735,13 @@ func (w *ActorWorkflow) finalizeRunning(ctx context.Context, actorRef resources.
 		return nil, err
 	}
 
-	latestActor.Status = ateapipb.Actor_STATUS_RUNNING
-	updatedActor, err := w.store.UpdateActor(ctx, latestActor, latestActor.GetMetadata().GetVersion())
+	updatedActor, err := w.store.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, latestActor.GetMetadata().GetUid(), latestActor.GetMetadata().GetVersion()); err != nil {
+			return err
+		}
+		dbActor.Status = ateapipb.Actor_STATUS_RUNNING
+		return nil
+	})
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -303,9 +303,9 @@ type conflictInjectingStore struct {
 	inject func()
 }
 
-func (c *conflictInjectingStore) UpdateActor(ctx context.Context, actor *ateapipb.Actor, expectedVersion int64) (*ateapipb.Actor, error) {
+func (c *conflictInjectingStore) UpdateActor(ctx context.Context, actorRef resources.ActorRef, mutate func(*ateapipb.Actor) error) (*ateapipb.Actor, error) {
 	c.once.Do(c.inject)
-	return c.Interface.UpdateActor(ctx, actor, expectedVersion)
+	return c.Interface.UpdateActor(ctx, actorRef, mutate)
 }
 
 // seedAssignFixture stores one free gvisor worker and a SUSPENDED actor and
@@ -384,8 +384,13 @@ func TestAssignWorkerAttempt_ConflictRefreshesActor(t *testing.T) {
 					t.Errorf("inject GetActor: %v", err)
 					return
 				}
-				tc.mutate(fresh)
-				injected, err = persistence.UpdateActor(ctx, fresh, fresh.GetMetadata().GetVersion())
+				injected, err = persistence.UpdateActor(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, func(dbActor *ateapipb.Actor) error {
+					if err := store.CheckActorPrecondition(dbActor, store.AnyUID, fresh.GetMetadata().GetVersion()); err != nil {
+						return err
+					}
+					tc.mutate(dbActor)
+					return nil
+				})
 				if err != nil {
 					t.Errorf("inject UpdateActor: %v", err)
 				}

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -113,16 +113,21 @@ func (w *ActorWorkflow) ensureMarkedSuspending(ctx context.Context, actorRef res
 		return nil, status.Errorf(codes.FailedPrecondition, "MarkSuspending prerequisite not met for Actor: %s (got: %v, want %s)", actorRef, actor.GetStatus(), ateapipb.Actor_STATUS_RUNNING)
 	}
 
-	actor.Status = ateapipb.Actor_STATUS_SUSPENDING
-	actor.InProgressSnapshotSourceActorVersion = actor.GetMetadata().GetVersion()
 	name := resources.NewSnapshotName()
 	// Fail here rather than at checkpoint time if the template's location
 	// cannot produce a usable URI: nothing has been written yet.
 	if _, err := inProgressSnapshotURI(actorTemplate, actorRef.Atespace, name); err != nil {
 		return nil, err
 	}
-	actor.InProgressSnapshotName = name
-	updated, err := w.store.UpdateActor(ctx, actor, actor.GetMetadata().GetVersion())
+	updated, err := w.store.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, actor.GetMetadata().GetUid(), actor.GetMetadata().GetVersion()); err != nil {
+			return err
+		}
+		dbActor.Status = ateapipb.Actor_STATUS_SUSPENDING
+		dbActor.InProgressSnapshotSourceActorVersion = dbActor.GetMetadata().GetVersion()
+		dbActor.InProgressSnapshotName = name
+		return nil
+	})
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
@@ -281,9 +286,8 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 	// 2. Finalize the actor: record the snapshot and mark it SUSPENDED. This
 	// must run even with no worker assignment (nothing to free), or the actor
 	// would be left SUSPENDING forever with the workflow reporting success.
-	latestActor.Status = ateapipb.Actor_STATUS_SUSPENDED
-	if latestActor.InProgressSnapshotName != "" {
-		snapshotName := latestActor.InProgressSnapshotName
+	snapshotName := latestActor.GetInProgressSnapshotName()
+	if snapshotName != "" {
 		// The same inputs CallAteletSuspend used, so the recorded URI is
 		// where the bytes were actually written.
 		snapshotURI, err := inProgressSnapshotURI(actorTemplate, actorRef.Atespace, snapshotName)
@@ -306,13 +310,21 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 		if _, err := w.store.CreateActorSnapshot(ctx, snapshot); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
 			return nil, err
 		}
-		latestActor.LatestSnapshot = &ateapipb.ObjectRef{Atespace: actorRef.Atespace, Name: snapshotName}
-		latestActor.InProgressSnapshotName = ""
-		latestActor.InProgressSnapshotSourceActorVersion = 0
 	}
-	latestActor.WorkerAssignment = nil
-	latestActor.LocalSnapshotInfo = nil
-	updatedActor, err := w.store.UpdateActor(ctx, latestActor, latestActor.GetMetadata().GetVersion())
+	updatedActor, err := w.store.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, latestActor.GetMetadata().GetUid(), latestActor.GetMetadata().GetVersion()); err != nil {
+			return err
+		}
+		dbActor.Status = ateapipb.Actor_STATUS_SUSPENDED
+		if snapshotName != "" {
+			dbActor.LatestSnapshot = &ateapipb.ObjectRef{Atespace: actorRef.Atespace, Name: snapshotName}
+			dbActor.InProgressSnapshotName = ""
+			dbActor.InProgressSnapshotSourceActorVersion = 0
+		}
+		dbActor.WorkerAssignment = nil
+		dbActor.LocalSnapshotInfo = nil
+		return nil
+	})
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -754,70 +754,97 @@ func (s *Persistence) DeleteActor(ctx context.Context, actorRef resources.ActorR
 	return deleted, nil
 }
 
-func (s *Persistence) UpdateActor(ctx context.Context, actor *ateapipb.Actor, expectedVersion int64) (*ateapipb.Actor, error) {
-	dbKey := actorDBKey(resources.ActorRefFromActor(actor))
+// validateUpdateActorMutation reports whether an actor mutation left the fields it does
+// not own alone.
+func validateUpdateActorMutation(storedActor, mutatedActor *ateapipb.Actor) error {
+	if stored, mutated := storedActor.GetMetadata().GetAtespace(), mutatedActor.GetMetadata().GetAtespace(); stored != mutated {
+		return fmt.Errorf("metadata.atespace is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	if stored, mutated := storedActor.GetMetadata().GetName(), mutatedActor.GetMetadata().GetName(); stored != mutated {
+		return fmt.Errorf("metadata.name is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	if stored, mutated := storedActor.GetActorTemplateNamespace(), mutatedActor.GetActorTemplateNamespace(); stored != mutated {
+		return fmt.Errorf("actor_template_namespace is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	if stored, mutated := storedActor.GetActorTemplateName(), mutatedActor.GetActorTemplateName(); stored != mutated {
+		return fmt.Errorf("actor_template_name is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	return nil
+}
 
-	// Clone because we will update the version field, and we don't want to
-	// stomp the caller's copy.
-	dbActor := proto.Clone(actor).(*ateapipb.Actor)
+// updateActorMaxAttempts bounds how many times UpdateActor re-runs its
+// read-modify-write after a concurrent writer invalidates the transaction.
+const updateActorMaxAttempts = 5
 
-	err := s.rdb.Watch(ctx, func(tx *redis.Tx) error {
-		currentVal, err := tx.Get(ctx, dbKey).Bytes()
-		if err != nil {
-			if errors.Is(err, redis.Nil) {
-				return store.ErrNotFound
+func (s *Persistence) UpdateActor(ctx context.Context, actorRef resources.ActorRef, mutate func(*ateapipb.Actor) error) (*ateapipb.Actor, error) {
+	dbKey := actorDBKey(actorRef)
+	for range updateActorMaxAttempts {
+		var dbActor *ateapipb.Actor
+		var abortErr error
+
+		err := s.rdb.Watch(ctx, func(tx *redis.Tx) error {
+			currentVal, err := tx.Get(ctx, dbKey).Bytes()
+			if err != nil {
+				if errors.Is(err, redis.Nil) {
+					return store.ErrNotFound
+				}
+				return fmt.Errorf("while getting actor: %w", err)
 			}
-			return fmt.Errorf("while getting actor: %w", err)
-		}
 
-		currentActor := &ateapipb.Actor{}
-		if err := protojson.Unmarshal(currentVal, currentActor); err != nil {
-			return fmt.Errorf("in protojson.Unmarshal: %w", err)
-		}
+			currentActor := &ateapipb.Actor{}
+			if err := protojson.Unmarshal(currentVal, currentActor); err != nil {
+				return fmt.Errorf("in protojson.Unmarshal: %w", err)
+			}
 
-		if currentActor.GetMetadata().GetVersion() != expectedVersion {
-			return store.ErrVersionConflict
-		}
-		if currentActor.GetMetadata().GetName() != dbActor.GetMetadata().GetName() {
-			return fmt.Errorf("name is immutable")
-		}
-		if currentActor.GetMetadata().GetAtespace() != dbActor.GetMetadata().GetAtespace() {
-			return fmt.Errorf("atespace is immutable")
-		}
-		if currentActor.GetActorTemplateNamespace() != dbActor.GetActorTemplateNamespace() {
-			return fmt.Errorf("actor_template_namespace is immutable")
-		}
-		if currentActor.GetActorTemplateName() != dbActor.GetActorTemplateName() {
-			return fmt.Errorf("actor_template_name is immutable")
-		}
-		// The stored metadata is authoritative; derive the next metadata from it.
-		dbActor.Metadata = newUpdateMetadata(currentActor.GetMetadata())
+			// Snapshot the stored state before handing the actor to mutate.
+			// mutate is free to edit anything it is given.
+			actorBeforeMutation := proto.Clone(currentActor).(*ateapipb.Actor)
+			if err := mutate(currentActor); err != nil {
+				abortErr = err
+				return err
+			}
+			if err := validateUpdateActorMutation(actorBeforeMutation, currentActor); err != nil {
+				abortErr = err
+				return err
+			}
+			// The stored metadata is authoritative; derive the next metadata
+			// from it, discarding whatever mutate made of it.
+			currentActor.Metadata = newUpdateMetadata(actorBeforeMutation.GetMetadata())
 
-		newVal, err := protojson.Marshal(dbActor)
-		if err != nil {
-			return fmt.Errorf("in protojson.Marshal: %w", err)
-		}
+			newVal, err := protojson.Marshal(currentActor)
+			if err != nil {
+				return fmt.Errorf("in protojson.Marshal: %w", err)
+			}
 
-		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-			pipe.Set(ctx, dbKey, newVal, 0)
+			if _, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, dbKey, newVal, 0)
+				return nil
+			}); err != nil {
+				return err
+			}
+			dbActor = currentActor
 			return nil
-		})
-		return err
-	}, dbKey)
+		}, dbKey)
 
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		switch {
+		case err == nil:
+			return dbActor, nil
+		case abortErr != nil:
+			return nil, abortErr
+		case errors.Is(err, store.ErrNotFound):
 			return nil, store.ErrNotFound
+		case errors.Is(err, redis.TxFailedErr):
+			// A concurrent write landed between WATCH and EXEC, so mutate never
+			// saw it. Re-read and run it against the newer state.
+			continue
+		default:
+			return nil, fmt.Errorf("while executing update actor transaction: %w", err)
 		}
-		if errors.Is(err, store.ErrVersionConflict) || errors.Is(err, redis.TxFailedErr) {
-			return nil, store.ErrVersionConflict
-		}
-		return nil, fmt.Errorf("while executing update actor transaction: %w", err)
 	}
 
-	// dbActor is the persisted state (advanced version and update_time). The
-	// caller's input is left unmodified.
-	return dbActor, nil
+	// Only the TxFailedErr branch continues the loop, so getting here means every
+	// attempt lost the race.
+	return nil, store.ErrVersionConflict
 }
 
 func (s *Persistence) ListWorkers(ctx context.Context, pageSize int32, pageTokenStr string) ([]*ateapipb.Worker, string, error) {

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -27,6 +28,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/redis/go-redis/v9"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -141,24 +143,29 @@ func TestCreateActor_AlreadyExists(t *testing.T) {
 	}
 }
 
-func TestUpdateActor_Success(t *testing.T) {
-	_, s, ctx := setupTest(t)
-
-	actor := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: testAtespace},
+// newTestActor returns an unsaved actor for the UpdateActor tests.
+func newTestActor(name string) *ateapipb.Actor {
+	return &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
 		ActorTemplateNamespace: "default",
 		ActorTemplateName:      "test-template",
 		Status:                 ateapipb.Actor_STATUS_SUSPENDED,
 	}
+}
 
+func TestUpdateActor_Success(t *testing.T) {
+	_, s, ctx := setupTest(t)
+	actor := newTestActor("actor-1")
 	created, err := s.CreateActor(ctx, actor)
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
 
-	toUpdate := proto.Clone(created).(*ateapipb.Actor)
-	toUpdate.Status = ateapipb.Actor_STATUS_RUNNING
-	updated, err := s.UpdateActor(ctx, toUpdate, created.GetMetadata().GetVersion())
+	actorRef := resources.ActorRefFromActor(actor)
+	updated, err := s.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		dbActor.Status = ateapipb.Actor_STATUS_RUNNING
+		return nil
+	})
 	if err != nil {
 		t.Fatalf("UpdateActor failed: %v", err)
 	}
@@ -178,13 +185,8 @@ func TestUpdateActor_Success(t *testing.T) {
 		t.Errorf("create_time changed on update: got %v, want %v", updated.GetMetadata().GetCreateTime().AsTime(), created.GetMetadata().GetCreateTime().AsTime())
 	}
 
-	// The input must not be mutated.
-	if toUpdate.GetMetadata().GetVersion() != created.GetMetadata().GetVersion() {
-		t.Errorf("UpdateActor must not mutate its input; version changed to %d", toUpdate.GetMetadata().GetVersion())
-	}
-
 	// The returned resource is exactly what GetActor reads back.
-	got, err := s.GetActor(ctx, resources.ActorRefFromActor(actor))
+	got, err := s.GetActor(ctx, actorRef)
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
@@ -193,59 +195,311 @@ func TestUpdateActor_Success(t *testing.T) {
 	}
 }
 
-func TestUpdateActor_Conflict(t *testing.T) {
+func TestUpdateActor_MutateErrorAreNotRetried(t *testing.T) {
 	_, s, ctx := setupTest(t)
-
-	actor := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: testAtespace},
-		ActorTemplateNamespace: "default",
-		ActorTemplateName:      "test-template",
-		Status:                 ateapipb.Actor_STATUS_SUSPENDED,
-	}
-
-	_, err := s.CreateActor(ctx, actor)
+	actor := newTestActor("actor-1")
+	created, err := s.CreateActor(ctx, actor)
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
 
-	// Fetch instance 1
-	actor1, err := s.GetActor(ctx, resources.ActorRefFromActor(actor))
+	var mutationError = errors.New("mutation error")
+
+	actorRef := resources.ActorRefFromActor(actor)
+	callsToMutateFn := 0
+	_, err = s.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		callsToMutateFn++
+		dbActor.Status = ateapipb.Actor_STATUS_RUNNING
+		return fmt.Errorf("actor %s: %w", actorRef, mutationError)
+	})
+	// The error must arrive intact
+	if !errors.Is(err, mutationError) {
+		t.Errorf("UpdateActor error = %v, want one wrapping mutationError", err)
+	}
+	// Mutation errors are non-retriable
+	if callsToMutateFn != 1 {
+		t.Errorf("mutate ran %d times, want exactly 1 (a rejected precondition must not be retried)", callsToMutateFn)
+	}
+
+	got, err := s.GetActor(ctx, actorRef)
 	if err != nil {
 		t.Fatalf("GetActor failed: %v", err)
 	}
+	if diff := cmp.Diff(created, got, protocmp.Transform()); diff != "" {
+		t.Errorf("aborted mutation was persisted (-created +got):\n%s", diff)
+	}
+}
 
-	// Fetch instance 2 (stale after actor1 updates)
-	actor2, err := s.GetActor(ctx, resources.ActorRefFromActor(actor))
+func TestUpdateActor_DiscardsServerOwnedFieldsEdits(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	actor := newTestActor("actor-1")
+	created, err := s.CreateActor(ctx, actor)
 	if err != nil {
-		t.Fatalf("GetActor failed: %v", err)
+		t.Fatalf("CreateActor failed: %v", err)
 	}
 
-	// Update instance 1
-	actor1.Status = ateapipb.Actor_STATUS_RUNNING
-	_, err = s.UpdateActor(ctx, actor1, actor1.GetMetadata().GetVersion())
+	actorRef := resources.ActorRefFromActor(actor)
+	updated, err := s.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		// Metadata is server-owned: a closure must not be able to change it.
+		dbActor.Metadata.Uid = "forged-uid"
+		dbActor.Metadata.Version = 99
+		dbActor.Metadata.CreateTime = nil
+		dbActor.Metadata.UpdateTime = nil
+		dbActor.Status = ateapipb.Actor_STATUS_RUNNING
+		return nil
+	})
 	if err != nil {
 		t.Fatalf("UpdateActor failed: %v", err)
 	}
 
-	// Try to update instance 2 (which has stale version)
-	actor2.Status = ateapipb.Actor_STATUS_SUSPENDED
-	_, err = s.UpdateActor(ctx, actor2, actor2.GetMetadata().GetVersion())
-	if !errors.Is(err, store.ErrVersionConflict) {
-		t.Errorf("expected ErrVersionConflict, got %v", err)
+	if got := updated.GetMetadata().GetUid(); got != created.GetMetadata().GetUid() {
+		t.Errorf("uid = %q, want the server-assigned %q", got, created.GetMetadata().GetUid())
+	}
+	if got := updated.GetMetadata().GetVersion(); got != created.GetMetadata().GetVersion()+1 {
+		t.Errorf("version = %d, want %d (one past the stored version, not the forged value)", got, created.GetMetadata().GetVersion()+1)
+	}
+	if got := updated.GetMetadata().GetCreateTime(); got == nil || !got.AsTime().Equal(created.GetMetadata().GetCreateTime().AsTime()) {
+		t.Errorf("create_time = %v, want the creation value %v", got, created.GetMetadata().GetCreateTime())
+	}
+	if updated.GetStatus() != ateapipb.Actor_STATUS_RUNNING {
+		t.Errorf("status = %v, want RUNNING: discarding metadata edits must not discard the mutation", updated.GetStatus())
+	}
+}
+
+// TestUpdateActor_RejectsImmutableFieldChange covers the fields a mutation may
+// not touch. Unlike the server-owned metadata, which is silently restored,
+// these fail the call: a caller that renamed an actor or repointed its template
+// asked for something the store cannot do, and must hear about it.
+func TestUpdateActor_RejectsImmutableFieldChange(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(dbActor *ateapipb.Actor)
+		wantField string
+	}{
+		{
+			name:      "atespace",
+			mutate:    func(dbActor *ateapipb.Actor) { dbActor.Metadata.Atespace = "other-atespace" },
+			wantField: "metadata.atespace",
+		},
+		{
+			name:      "name",
+			mutate:    func(dbActor *ateapipb.Actor) { dbActor.Metadata.Name = "other-name" },
+			wantField: "metadata.name",
+		},
+		{
+			name:      "actor template namespace",
+			mutate:    func(dbActor *ateapipb.Actor) { dbActor.ActorTemplateNamespace = "other-ns" },
+			wantField: "actor_template_namespace",
+		},
+		{
+			name:      "actor template name",
+			mutate:    func(dbActor *ateapipb.Actor) { dbActor.ActorTemplateName = "other-template" },
+			wantField: "actor_template_name",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, s, ctx := setupTest(t)
+			actor := newTestActor("actor-1")
+			created, err := s.CreateActor(ctx, actor)
+			if err != nil {
+				t.Fatalf("CreateActor failed: %v", err)
+			}
+
+			actorRef := resources.ActorRefFromActor(actor)
+			_, err = s.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+				// Paired with a legitimate edit, so the rejection cannot be
+				// mistaken for a no-op mutation.
+				dbActor.Status = ateapipb.Actor_STATUS_RUNNING
+				tt.mutate(dbActor)
+				return nil
+			})
+			// The message must name the offending field: the closure is buggy,
+			// and whoever has to fix it only has this error to go on.
+			if want := tt.wantField + " is immutable"; err == nil || !strings.Contains(err.Error(), want) {
+				t.Errorf("UpdateActor changing %s = %v, want an error containing %q", tt.name, err, want)
+			}
+
+			got, err := s.GetActor(ctx, actorRef)
+			if err != nil {
+				t.Fatalf("GetActor failed: %v", err)
+			}
+			if diff := cmp.Diff(created, got, protocmp.Transform()); diff != "" {
+				t.Errorf("rejected mutation was persisted anyway (-created +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// watchInterceptor runs before each WATCH'd transaction body, so a test can
+// write the watched key from another connection and make EXEC fail the way a
+// real concurrent writer would.
+type watchInterceptor struct {
+	redisClient
+	before func()
+}
+
+func (w *watchInterceptor) Watch(ctx context.Context, fn func(*redis.Tx) error, keys ...string) error {
+	return w.redisClient.Watch(ctx, func(tx *redis.Tx) error {
+		w.before()
+		return fn(tx)
+	}, keys...)
+}
+
+func TestUpdateActor_RetriesOnConcurrentWrite(t *testing.T) {
+	mr, s, ctx := setupTest(t)
+	actor := newTestActor("actor-1")
+	if _, err := s.CreateActor(ctx, actor); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	actorRef := resources.ActorRefFromActor(actor)
+
+	// A separate client, so its write lands outside the transaction's connection.
+	otherClient := redis.NewClusterClient(&redis.ClusterOptions{Addrs: []string{mr.Addr()}})
+	t.Cleanup(func() { otherClient.Close() })
+
+	attempts := 0
+	interceptor := &watchInterceptor{redisClient: s.rdb, before: func() {
+		// Only the first attempt races. We do this to make sure the second retry
+		// will succeed.
+		if attempts > 0 {
+			return
+		}
+		concurrent, err := s.GetActor(ctx, actorRef)
+		if err != nil {
+			t.Errorf("GetActor for concurrent write failed: %v", err)
+			return
+		}
+		concurrent.WorkerSelector = &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}}
+		val, err := protojson.Marshal(concurrent)
+		if err != nil {
+			t.Errorf("protojson.Marshal failed: %v", err)
+			return
+		}
+		if err := otherClient.Set(ctx, actorDBKey(actorRef), val, 0).Err(); err != nil {
+			t.Errorf("concurrent Set failed: %v", err)
+		}
+	}}
+	racing := &Persistence{rdb: interceptor, lockTTL: defaultLockTTL}
+
+	updated, err := racing.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		attempts++
+		dbActor.Status = ateapipb.Actor_STATUS_RUNNING
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateActor failed: %v", err)
+	}
+	if attempts < 2 {
+		t.Errorf("mutate ran %d times, want at least 2: the firts write is racey and must be rejected", attempts)
+	}
+	if updated.GetStatus() != ateapipb.Actor_STATUS_RUNNING {
+		t.Errorf("status = %v, want RUNNING", updated.GetStatus())
+	}
+	// 1. The concurrent tx wrote "tier: paid" worker selector. This change should survive instead of
+	// being reverted by a mutation computed against the older state.
+	if got := updated.GetWorkerSelector().GetMatchLabels()["tier"]; got != "paid" {
+		t.Errorf("worker_selector[tier] = %q, want %q: the retry clobbered the concurrent write", got, "paid")
 	}
 }
 
 func TestUpdateActor_NotFound(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
-
-	actor := &ateapipb.Actor{
-		Metadata: &ateapipb.ResourceMetadata{Name: "non-existent", Atespace: testAtespace},
-	}
-	_, err := s.UpdateActor(ctx, actor, 1)
+	_, s, ctx := setupTest(t)
+	_, err := s.UpdateActor(ctx, resources.ActorRef{Atespace: testAtespace, Name: "non-existent"}, func(dbActor *ateapipb.Actor) error {
+		t.Error("mutate must not run for a missing actor")
+		return nil
+	})
 	if !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("expected store.ErrNotFound, got %v", err)
 	}
+}
+
+func TestUpdateActor_RejectsStaleUID(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	original, err := s.CreateActor(ctx, newTestActor("actor-1"))
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	actorRef := resources.ActorRefFromActor(original)
+	if _, err := s.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		dbActor.Status = ateapipb.Actor_STATUS_DELETING
+		return nil
+	}); err != nil {
+		t.Fatalf("marking actor deleting failed: %v", err)
+	}
+	if _, err := s.DeleteActor(ctx, actorRef); err != nil {
+		t.Fatalf("DeleteActor failed: %v", err)
+	}
+	recreated, err := s.CreateActor(ctx, newTestActor("actor-1"))
+	if err != nil {
+		t.Fatalf("recreate CreateActor failed: %v", err)
+	}
+	if recreated.GetMetadata().GetUid() == original.GetMetadata().GetUid() {
+		t.Fatalf("recreated actor reused uid %s, want a fresh one", recreated.GetMetadata().GetUid())
+	}
+
+	_, err = s.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, original.GetMetadata().GetUid(), store.AnyVersion); err != nil {
+			return err
+		}
+		t.Error("mutate ran past its precondition once the pinned incarnation was gone")
+		dbActor.Status = ateapipb.Actor_STATUS_RUNNING
+		return nil
+	})
+	if !errors.Is(err, store.ErrUIDConflict) {
+		t.Errorf("UpdateActor error = %v, want one matching store.ErrUIDConflict", err)
+	}
+
+	// The version guard was waived, so this is the incarnation failure alone.
+	if errors.Is(err, store.ErrVersionConflict) {
+		t.Errorf("UpdateActor error = %v, want no store.ErrVersionConflict match: no version was pinned", err)
+	}
+
+	stored, err := s.GetActor(ctx, actorRef)
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if got := stored.GetMetadata().GetVersion(); got != recreated.GetMetadata().GetVersion() {
+		t.Errorf("version = %d, want %d: the rejected update still wrote", got, recreated.GetMetadata().GetVersion())
+	}
+}
+
+func TestUpdateActor_RejectsStaleVersion(t *testing.T) {
+	_, s, ctx := setupTest(t)
+
+	created, err := s.CreateActor(ctx, newTestActor("actor-1"))
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	actorRef := resources.ActorRefFromActor(created)
+	staleVersion := created.GetMetadata().GetVersion()
+
+	if _, err := s.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		dbActor.Status = ateapipb.Actor_STATUS_RUNNING
+		return nil
+	}); err != nil {
+		t.Fatalf("UpdateActor failed: %v", err)
+	}
+
+	_, err = s.UpdateActor(ctx, actorRef, func(dbActor *ateapipb.Actor) error {
+		if err := store.CheckActorPrecondition(dbActor, created.GetMetadata().GetUid(), staleVersion); err != nil {
+			return err
+		}
+		t.Error("mutate ran past its precondition once the pinned version had moved")
+		dbActor.Status = ateapipb.Actor_STATUS_SUSPENDED
+		return nil
+	})
+	if !errors.Is(err, store.ErrVersionConflict) {
+		t.Errorf("UpdateActor error = %v, want one matching store.ErrVersionConflict", err)
+	}
+	// The uid still matches, so this is not the incarnation failure: callers key
+	// their retry decision off the difference.
+	if errors.Is(err, store.ErrUIDConflict) {
+		t.Errorf("UpdateActor error = %v, want no store.ErrUIDConflict match: the incarnation is unchanged", err)
+	}
+
 }
 
 func TestUpdateWorker_NotFound(t *testing.T) {

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -31,7 +31,9 @@ var (
 	// ErrAlreadyExists indicates that the object already exists in the DB.
 	ErrAlreadyExists = errors.New("persistence: already exists")
 
-	// ErrVersionConflict indicates an update's expected version did not match the stored one.
+	// ErrVersionConflict indicates a write lost to a concurrent one: either a
+	// precondition pinned a version the stored object is no longer at, or the
+	// store's own retry budget was exhausted losing the same race.
 	ErrVersionConflict = errors.New("persistence: version conflict")
 
 	// ErrFailedPrecondition indicates the object is not in the required state for the operation.
@@ -39,6 +41,11 @@ var (
 
 	// ErrLockConflict indicates that a distributed lock is already held by another client.
 	ErrLockConflict = errors.New("persistence: lock conflict")
+
+	// ErrUIDConflict indicates a precondition pinned a uid the stored object does
+	// not carry, meaning the name now addresses a different incarnation. Retrying
+	// can never resolve it.
+	ErrUIDConflict = errors.New("persistence: uid conflict")
 )
 
 // Interface defines the contract for the persistence layer storing actor state.
@@ -51,10 +58,19 @@ type Interface interface {
 	// mutated. Returns ErrAlreadyExists if key is taken.
 	CreateActor(ctx context.Context, actor *ateapipb.Actor) (*ateapipb.Actor, error)
 
-	// Updates actor state with optimistic concurrency check and returns the stored
-	// resource with advanced metadata (version, update_time). The input is not
-	// mutated. Returns ErrNotFound if missing, or ErrVersionConflict on version mismatch.
-	UpdateActor(ctx context.Context, actor *ateapipb.Actor, expectedVersion int64) (*ateapipb.Actor, error)
+	// UpdateActor performs a transactional read-modify-write and returns the updated
+	// actor with advanced metadata (version, update_time).
+	//
+	// mutate receives the stored actor and edits it in place. The mutated actor is
+	// written iff mutate returns nil. A mutate that must only land on the actor the
+	// caller observed guards itself with CheckActorPrecondition.
+	//
+	// mutate may run more than once, because the store retries when a concurrent
+	// write invalidates the transaction.
+	//
+	// Returns ErrNotFound if missing, ErrVersionConflict if the retry budget is
+	// exhausted, or the mutate's error verbatim otherwise.
+	UpdateActor(ctx context.Context, actorRef resources.ActorRef, mutate func(dbActor *ateapipb.Actor) error) (*ateapipb.Actor, error)
 
 	// Removes an actor and returns the deleted resource. Returns ErrNotFound if
 	// missing, or ErrFailedPrecondition if not suspended.
@@ -134,6 +150,33 @@ type Interface interface {
 
 	// DebugClearAll drop all data from the database. Useful for debugging / local testing/
 	DebugClearAll(ctx context.Context) error
+}
+
+const (
+	// AnyUID accepts whichever actor holds the atespace and name at write time.
+	AnyUID = ""
+	// AnyVersion accepts whatever revision the store is at.
+	AnyVersion int64 = 0
+)
+
+// CheckActorPrecondition reports whether dbActor is still the actor the caller
+// observed, pinned on the uid and version it read, each waivable with AnyUID or
+// AnyVersion. Version guards against concurrent writes, uid against actor
+// atespace/name re-use across actor lifecycles.
+//
+// Call it at the top of an UpdateActor mutation so the write is conditional on
+// the stored actor the transaction actually read, not on one read earlier
+// outside of it. Returns ErrUIDConflict or ErrVersionConflict, which UpdateActor
+// surfaces verbatim.
+func CheckActorPrecondition(dbActor *ateapipb.Actor, uid string, version int64) error {
+	md := dbActor.GetMetadata()
+	if uid != AnyUID && uid != md.GetUid() {
+		return ErrUIDConflict
+	}
+	if version != AnyVersion && version != md.GetVersion() {
+		return ErrVersionConflict
+	}
+	return nil
 }
 
 // WorkerEventType indicates the type of change to a Worker.

--- a/cmd/ateapi/internal/store/store_test.go
+++ b/cmd/ateapi/internal/store/store_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+)
+
+func TestCheckActorPrecondition(t *testing.T) {
+	const (
+		storedUID = "stored-uid"
+		staleUID  = "stale-uid"
+		storedVer = int64(7)
+		staleVer  = int64(6)
+	)
+	dbActor := &ateapipb.Actor{
+		Metadata: &ateapipb.ResourceMetadata{
+			Atespace: "test-atespace",
+			Name:     "actor-1",
+			Uid:      storedUID,
+			Version:  storedVer,
+		},
+	}
+
+	tests := []struct {
+		name    string
+		uid     string
+		version int64
+		wantErr error
+	}{
+		{
+			name:    "both waived",
+			uid:     AnyUID,
+			version: AnyVersion,
+			wantErr: nil,
+		},
+		{
+			name:    "both guarded and both match",
+			uid:     storedUID,
+			version: storedVer,
+			wantErr: nil,
+		},
+		{
+			name:    "uid guarded, version waived, tolerates the moved version",
+			uid:     storedUID,
+			version: AnyVersion,
+			wantErr: nil,
+		},
+		{
+			name:    "version guarded, uid waived, still catches the moved version",
+			uid:     AnyUID,
+			version: staleVer,
+			wantErr: ErrVersionConflict,
+		},
+		{
+			name:    "uid guarded, version waived, still catches the new incarnation",
+			uid:     staleUID,
+			version: AnyVersion,
+			wantErr: ErrUIDConflict,
+		},
+		{
+			// The uid is reported first: a new incarnation makes the version
+			// meaningless, and it is the failure a retry can never resolve.
+			name:    "both stale reports the uid conflict",
+			uid:     staleUID,
+			version: staleVer,
+			wantErr: ErrUIDConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckActorPrecondition(dbActor, tt.uid, tt.version)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("CheckActorPrecondition(dbActor, %q, %d) = %v, want one matching %v", tt.uid, tt.version, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
UpdateActor now takes an ActorRef, an ActorPrecondition, and a mutate callback. The store reads the stored actor inside the WATCH transaction, checks the precondition against that value, and hands it to mutate, which edits it in place.

The storage layer retries up to 5 times when a concurrent write invalidates it, re-running mutate against the newer state

I still need to migrate the other callers of store.UpdateActor to avoid calling GetActor outside of the closure function.

#763

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
