### PR TITLE
atecontroller: serve health probes

### DIFF
--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -144,7 +144,8 @@ func main() {
 	ateapiClient := ateapipb.NewControlClient(ateapiConn)
 
 	mgr, err := ctrl.NewManager(k8sConfig, ctrl.Options{
-		Scheme: scheme,
+		Scheme:                 scheme,
+		HealthProbeBindAddress: ":8081",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/manifests/ate-install/ate-controller.yaml
+++ b/manifests/ate-install/ate-controller.yaml
@@ -133,6 +133,19 @@ spec:
         - name: healthz
           containerPort: 8081
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         # Controller's own client identity presented to ateapi.
         - name: "podidentity"


### PR DESCRIPTION
Fixes #843

Adds `HealthProbeBindAddress` to allow serving readiness and liveness probes for atecontroller.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
