### PR TITLE
ateomnet: create the actor veth peer inside the actor netns

### DIFF
--- a/internal/ateomnet/net.go
+++ b/internal/ateomnet/net.go
@@ -37,7 +37,6 @@ import (
 const (
 	HostVethName      = "ateom0"
 	ActorVethName     = "eth0"
-	ActorVethTempName = "ateom1"
 	HostVethCIDR      = "169.254.17.1/30"
 	ActorVethCIDR     = "169.254.17.2/30"
 	ActorVethGateway  = "169.254.17.1"
@@ -84,13 +83,12 @@ func MustParseMAC(s string) net.HardwareAddr {
 // ConfigureActorVeth configures the actor veth inside the interior netns.
 // It assumes it is already running inside the target network namespace.
 func ConfigureActorVeth(ctx context.Context) error {
-	// Run inside the gVisor interior netns after setupActorNetwork moves the
-	// veth peer there. gVisor reads link names, addresses, and routes from this
-	// namespace when the workload starts, so the peer is deliberately renamed to
-	// eth0 and configured like a normal container interface:
+	// Run inside the gVisor interior netns. SetupActorNetwork has already created
+	// the veth peer here, under its final name, so this only has to address it.
+	// gVisor reads link names, addresses, and routes from this namespace when the
+	// workload starts, so eth0 is configured like a normal container interface:
 	//
 	//   * lo is brought up for localhost behavior.
-	//   * the temporary veth peer is renamed to eth0.
 	//   * eth0 receives the actor-side /30 address.
 	//   * the default route points to the worker-side veth gateway.
 	loLink, err := netlink.LinkByName("lo")
@@ -101,16 +99,9 @@ func ConfigureActorVeth(ctx context.Context) error {
 		return fmt.Errorf("while bringing up lo in interior netns: %w", err)
 	}
 
-	actorLink, err := netlink.LinkByName(ActorVethTempName)
+	actorLink, err := netlink.LinkByName(ActorVethName)
 	if err != nil {
 		return fmt.Errorf("while acquiring actor veth in interior netns: %w", err)
-	}
-	if err := netlink.LinkSetName(actorLink, ActorVethName); err != nil {
-		return fmt.Errorf("while renaming actor veth to %q: %w", ActorVethName, err)
-	}
-	actorLink, err = netlink.LinkByName(ActorVethName)
-	if err != nil {
-		return fmt.Errorf("while reacquiring actor veth in interior netns: %w", err)
 	}
 
 	if err := netlink.AddrReplace(actorLink, ActorVethAddr); err != nil {
@@ -134,10 +125,10 @@ func ConfigureActorVeth(ctx context.Context) error {
 // Intentionally idempotent.
 func CleanupActorNetwork(ctx context.Context, interiorNetNS netns.NsHandle) error {
 	// Remove all per-activation network state owned by ateom. Deleting the
-	// worker-side veth also deletes its peer when the pair is still connected,
-	// but failed setup can leave the peer already moved into the actor netns.
-	// For that reason cleanup also enters the interior netns and deletes either
-	// the final actor interface name or the temporary peer name if present.
+	// worker-side veth also deletes its peer, but the pair is born with its peer
+	// already in the actor netns, so a setup that failed before the worker side
+	// was named can leave that peer behind on its own. For that reason cleanup
+	// also enters the interior netns and deletes the actor interface if present.
 	//
 	// This function is intentionally idempotent so it can run before setup, after
 	// checkpoint, and from setup failure cleanup without requiring the caller to
@@ -153,23 +144,21 @@ func CleanupActorNetwork(ctx context.Context, interiorNetNS netns.NsHandle) erro
 			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while deleting host veth: %w", err))
 			slog.WarnContext(ctx, "Failed to delete host veth; continuing actor netns cleanup", "err", err)
 		}
-	} else if _, ok := err.(netlink.LinkNotFoundError); !ok {
+	} else if _, notFound := errors.AsType[netlink.LinkNotFoundError](err); !notFound {
 		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while looking up host veth: %w", err))
 		slog.WarnContext(ctx, "Failed to look up host veth; continuing actor netns cleanup", "err", err)
 	}
 
 	if err := NetNSDo(ctx, interiorNetNS, func(_ context.Context) error {
-		for _, name := range []string{ActorVethName, ActorVethTempName} {
-			link, err := netlink.LinkByName(name)
-			if err == nil {
-				if err := netlink.LinkDel(link); err != nil {
-					return fmt.Errorf("while deleting interior veth %q: %w", name, err)
-				}
-				continue
+		link, err := netlink.LinkByName(ActorVethName)
+		if err == nil {
+			if err := netlink.LinkDel(link); err != nil {
+				return fmt.Errorf("while deleting interior veth %q: %w", ActorVethName, err)
 			}
-			if _, ok := err.(netlink.LinkNotFoundError); !ok {
-				return fmt.Errorf("while looking up interior veth %q: %w", name, err)
-			}
+			return nil
+		}
+		if _, notFound := errors.AsType[netlink.LinkNotFoundError](err); !notFound {
+			return fmt.Errorf("while looking up interior veth %q: %w", ActorVethName, err)
 		}
 		return nil
 	}); err != nil {
@@ -495,10 +484,10 @@ type NetworkConfig struct {
 // pod netns and the interior netns.
 func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
 	// Build a fresh point-to-point network between the worker pod netns and the
-	// gVisor interior netns. The worker side keeps the pod's real eth0, creates
-	// ateom0 as the gateway, and moves only the veth peer into the actor netns.
-	// The actor side renames that peer to eth0 and installs a default route via
-	// the worker-side veth address. This replaces the old behavior of moving the
+	// gVisor interior netns. The worker side keeps the pod's real eth0 and creates
+	// ateom0 as the gateway; the pair's peer is born inside the actor netns as
+	// eth0, where it gets the actor-side address and a default route via the
+	// worker-side veth address. This replaces the old behavior of moving the
 	// Kubernetes-provided eth0 out of the worker pod.
 	//
 	// The nftables rules installed here redirect actor TCP egress to atunnel
@@ -538,11 +527,20 @@ func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
 		}
 	}
 
+	// The peer is born in the interior netns under its final name. Do not replace
+	// this with the obvious "create locally, LinkSetNsFd across, rename to eth0":
+	// moving and renaming a netdev each cost an RCU grace period under the global
+	// RTNL lock, which is ~18ms vs ~3ms for all of SetupActorNetwork, on the
+	// resume path. Naming the peer here is safe because its name is resolved in
+	// its own netns, so it never collides with the pod's eth0.
 	veth := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: HostVethName,
 		},
-		PeerName: ActorVethTempName,
+		PeerName: ActorVethName,
+		// netlink.NsFd, not netns.NsHandle: only the netlink type is recognized
+		// as IFLA_NET_NS_FD on the peer, though both are file descriptors.
+		PeerNamespace: netlink.NsFd(int(cfg.InteriorNetNS)),
 	}
 	if len(cfg.HostVethHWAddr) > 0 {
 		veth.LinkAttrs.HardwareAddr = cfg.HostVethHWAddr
@@ -561,14 +559,6 @@ func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
 	}
 	if err := netlink.LinkSetUp(hostLink); err != nil {
 		return fmt.Errorf("while bringing up host veth: %w", err)
-	}
-
-	actorLink, err := netlink.LinkByName(ActorVethTempName)
-	if err != nil {
-		return fmt.Errorf("while getting actor veth peer: %w", err)
-	}
-	if err := netlink.LinkSetNsFd(actorLink, int(cfg.InteriorNetNS)); err != nil {
-		return fmt.Errorf("while moving actor veth peer into interior netns: %w", err)
 	}
 
 	if err := NetNSDo(ctx, cfg.InteriorNetNS, ConfigureActorVeth); err != nil {

--- a/internal/ateomnet/net_linux_test.go
+++ b/internal/ateomnet/net_linux_test.go
@@ -1,0 +1,311 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ateomnet
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/agent-substrate/substrate/internal/roottest"
+	"github.com/google/nftables"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+// withTestNetNS runs fn with the calling thread inside a throwaway netns
+// standing in for the worker pod's, and hands it a second throwaway netns
+// standing in for an actor's interior one.
+//
+// Both are anonymous (netns.New, not NewNamed) so the test leaves nothing behind
+// in /run/netns, and every link, sysctl, and nftables table SetupActorNetwork
+// touches is scoped to a namespace that disappears with the test rather than to
+// the machine running it.
+func withTestNetNS(t *testing.T, fn func(interior netns.NsHandle)) {
+	t.Helper()
+
+	// Locked for the whole body: netns is a per-thread property, so an unlocked
+	// goroutine could be rescheduled onto a thread still in the original
+	// namespace midway through. It also means a t.Fatal inside fn tears the
+	// thread down instead of returning it to the pool mis-configured.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	orig, err := netns.Get()
+	if err != nil {
+		t.Fatalf("getting current netns: %v", err)
+	}
+	defer orig.Close()
+	// Registered before the namespaces below so it runs after they are closed.
+	defer func() {
+		if err := netns.Set(orig); err != nil {
+			t.Errorf("restoring original netns: %v", err)
+		}
+	}()
+
+	pod, err := netns.New() // netns.New switches the thread into the new namespace
+	if err != nil {
+		t.Fatalf("creating pod netns: %v", err)
+	}
+	defer pod.Close()
+	interior, err := netns.New()
+	if err != nil {
+		t.Fatalf("creating interior netns: %v", err)
+	}
+	defer interior.Close()
+	if err := netns.Set(pod); err != nil {
+		t.Fatalf("entering pod netns: %v", err)
+	}
+
+	fn(interior)
+}
+
+// requireNftables skips when the kernel in this environment cannot serve the
+// nftables netlink API at all, which SetupActorNetwork needs and which is a
+// property of the machine rather than of the code under test.
+func requireNftables(t *testing.T) {
+	t.Helper()
+	c := &nftables.Conn{}
+	if _, err := c.ListTablesOfFamily(nftables.TableFamilyIPv4); err != nil {
+		t.Skipf("nftables unavailable in this environment: %v", err)
+	}
+}
+
+// linkByName returns the link, or nil when it does not exist.
+func linkByName(t *testing.T, name string) netlink.Link {
+	t.Helper()
+	link, err := netlink.LinkByName(name)
+	if err == nil {
+		return link
+	}
+	if _, ok := errors.AsType[netlink.LinkNotFoundError](err); ok {
+		return nil
+	}
+	t.Fatalf("looking up link %q: %v", name, err)
+	return nil
+}
+
+func hasAddr(t *testing.T, link netlink.Link, cidr string) bool {
+	t.Helper()
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+	if err != nil {
+		t.Fatalf("listing addresses of %q: %v", link.Attrs().Name, err)
+	}
+	want := MustParseAddr(cidr)
+	for _, addr := range addrs {
+		if addr.IPNet != nil && addr.IPNet.String() == want.IPNet.String() {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSetupActorNetworkFinalState pins the namespace state gVisor and the
+// micro-VM guest read after an activation: what links exist, where, with which
+// addresses and routes. It deliberately asserts the end state rather than the
+// sequence of netlink calls that produced it, so the setup path stays free to
+// get there differently (as it did when the veth peer stopped being created in
+// the pod netns and moved across).
+func TestSetupActorNetworkFinalState(t *testing.T) {
+	roottest.Require(t, "creating network namespaces, veth pairs, and nftables rules")
+	ctx := context.Background()
+
+	withTestNetNS(t, func(interior netns.NsHandle) {
+		requireNftables(t)
+
+		if err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
+			t.Fatalf("SetupActorNetwork: %v", err)
+		}
+
+		// Worker pod side: the gateway end of the point-to-point link.
+		host := linkByName(t, HostVethName)
+		if host == nil {
+			t.Fatalf("host veth %q missing from the pod netns", HostVethName)
+		}
+		if !hasAddr(t, host, HostVethCIDR) {
+			t.Errorf("host veth %q does not carry %s", HostVethName, HostVethCIDR)
+		}
+		if host.Attrs().Flags&1 == 0 { // net.FlagUp
+			t.Errorf("host veth %q is not up", HostVethName)
+		}
+
+		// The actor interface must exist ONLY in the interior netns. A peer left
+		// in the pod netns would mean the pair was built the old way, and worse,
+		// would collide with the pod's own eth0 on a real worker.
+		if stray := linkByName(t, ActorVethName); stray != nil {
+			t.Errorf("actor interface %q must not exist in the pod netns", ActorVethName)
+		}
+
+		if err := NetNSDo(ctx, interior, func(context.Context) error {
+			actor := linkByName(t, ActorVethName)
+			if actor == nil {
+				t.Fatalf("actor veth %q missing from the interior netns", ActorVethName)
+			}
+			if !hasAddr(t, actor, ActorVethCIDR) {
+				t.Errorf("actor veth %q does not carry %s", ActorVethName, ActorVethCIDR)
+			}
+			if actor.Attrs().Flags&1 == 0 {
+				t.Errorf("actor veth %q is not up", ActorVethName)
+			}
+
+			if lo := linkByName(t, "lo"); lo == nil {
+				t.Error("interior netns has no loopback")
+			} else if lo.Attrs().Flags&1 == 0 {
+				t.Error("interior loopback is not up")
+			}
+
+			routes, err := netlink.RouteList(actor, netlink.FAMILY_V4)
+			if err != nil {
+				t.Fatalf("listing interior routes: %v", err)
+			}
+			// A default route reports its destination either as nil or as an
+			// explicit 0.0.0.0/0, depending on how the kernel rendered it.
+			isDefault := func(route netlink.Route) bool {
+				if route.Dst == nil {
+					return true
+				}
+				ones, _ := route.Dst.Mask.Size()
+				return ones == 0
+			}
+			var haveDefault bool
+			for _, route := range routes {
+				if isDefault(route) && route.Gw.Equal(ActorVethGwIP) {
+					haveDefault = true
+				}
+			}
+			if !haveDefault {
+				t.Errorf("interior netns has no default route via %s, got %v", ActorVethGateway, routes)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("inspecting interior netns: %v", err)
+		}
+	})
+}
+
+// TestSetupActorNetworkIsRepeatable covers the activation cycle a reused worker
+// runs: set up, tear down, set up again. The second setup has to succeed against
+// whatever the first one left behind.
+func TestSetupActorNetworkIsRepeatable(t *testing.T) {
+	roottest.Require(t, "creating network namespaces, veth pairs, and nftables rules")
+	ctx := context.Background()
+
+	withTestNetNS(t, func(interior netns.NsHandle) {
+		requireNftables(t)
+
+		for i := range 3 {
+			if err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
+				t.Fatalf("SetupActorNetwork (activation %d): %v", i, err)
+			}
+			if linkByName(t, HostVethName) == nil {
+				t.Fatalf("host veth %q missing after activation %d", HostVethName, i)
+			}
+			if err := CleanupActorNetwork(ctx, interior); err != nil {
+				t.Fatalf("CleanupActorNetwork (activation %d): %v", i, err)
+			}
+		}
+
+		// Cleanup is idempotent: the extra call after the loop's last one must
+		// still succeed, and both ends must be gone.
+		if err := CleanupActorNetwork(ctx, interior); err != nil {
+			t.Fatalf("CleanupActorNetwork on an already-clean network: %v", err)
+		}
+		if stray := linkByName(t, HostVethName); stray != nil {
+			t.Errorf("host veth %q survived cleanup", HostVethName)
+		}
+		if err := NetNSDo(ctx, interior, func(context.Context) error {
+			if stray := linkByName(t, ActorVethName); stray != nil {
+				t.Errorf("actor veth %q survived cleanup", ActorVethName)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("inspecting interior netns: %v", err)
+		}
+	})
+}
+
+// TestSetupActorNetworkHostVethHWAddr covers the micro-VM requirement: a CH
+// snapshot freezes the guest's ARP entry for the gateway, so the worker-side
+// veth MAC has to be exactly the one the caller asked for, on every pod.
+func TestSetupActorNetworkHostVethHWAddr(t *testing.T) {
+	roottest.Require(t, "creating network namespaces, veth pairs, and nftables rules")
+	ctx := context.Background()
+
+	withTestNetNS(t, func(interior netns.NsHandle) {
+		requireNftables(t)
+
+		want := MustParseMAC("02:a8:1e:00:00:01")
+		if err := SetupActorNetwork(ctx, NetworkConfig{
+			InteriorNetNS:      interior,
+			HostVethHWAddr:     want,
+			SweepInteriorLinks: true,
+		}); err != nil {
+			t.Fatalf("SetupActorNetwork: %v", err)
+		}
+
+		host := linkByName(t, HostVethName)
+		if host == nil {
+			t.Fatalf("host veth %q missing from the pod netns", HostVethName)
+		}
+		if got := host.Attrs().HardwareAddr.String(); got != want.String() {
+			t.Errorf("host veth MAC = %s, want %s", got, want)
+		}
+	})
+}
+
+// TestSetupActorNetworkSweepsInteriorLinks covers the other half of the micro-VM
+// path: SweepInteriorLinks clears a previous activation's leftovers (kata's tap
+// device) before the new pair is created, and must not take the loopback or the
+// freshly created actor veth with it.
+func TestSetupActorNetworkSweepsInteriorLinks(t *testing.T) {
+	roottest.Require(t, "creating network namespaces, veth pairs, and nftables rules")
+	ctx := context.Background()
+
+	withTestNetNS(t, func(interior netns.NsHandle) {
+		requireNftables(t)
+
+		const leftover = "stale-tap0"
+		if err := NetNSDo(ctx, interior, func(context.Context) error {
+			return netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: leftover}})
+		}); err != nil {
+			t.Fatalf("planting a leftover interior link: %v", err)
+		}
+
+		if err := SetupActorNetwork(ctx, NetworkConfig{
+			InteriorNetNS:      interior,
+			SweepInteriorLinks: true,
+		}); err != nil {
+			t.Fatalf("SetupActorNetwork: %v", err)
+		}
+
+		if err := NetNSDo(ctx, interior, func(context.Context) error {
+			if stray := linkByName(t, leftover); stray != nil {
+				t.Errorf("leftover interior link %q was not swept", leftover)
+			}
+			if linkByName(t, ActorVethName) == nil {
+				t.Errorf("actor veth %q missing after a sweeping setup", ActorVethName)
+			}
+			if linkByName(t, "lo") == nil {
+				t.Error("sweep removed the interior loopback")
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("inspecting interior netns: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
`SetupActorNetwork` built the veth pair in the worker pod netns with the peer under a temporary name, moved the peer into the actor netns with LinkSetNsFd, and renamed it to eth0 on the far side. The temporary name existed only because the pod netns has an eth0 of its own for the peer to collide with.

Those two operations were 13.8ms of the 15.0ms of veth work: each drives a netdev unregister/register with an RCU grace period taken under the global RTNL lock. Neither parallelizes, so the fix is to not do them. Creating the pair with PeerName plus PeerNamespace has the peer born in the actor netns already called eth0, which costs neither: the name is resolved in the peer's namespace, so it never sees the pod's eth0.

Measured on the real function, 200 activations on a 6.8 kernel:

  before:  `SetupActorNetwork  mean=18.07ms  p50=17.83ms  p99=26.81ms`
  after:   `SetupActorNetwork  mean=2.96ms   p50=2.69ms   p99=5.72ms`

That is ~15ms off every actor resume, against a 100ms p95 activation target, since RestoreWorkload calls this before runsc restore. CleanupActorNetwork is unchanged at ~16ms; that cost is the veth delete and it lands on suspend.

The resulting namespace is identical, which is what the new tests assert: they pin the end state gVisor and the micro-VM guest read -- which links exist, in which namespace, with which addresses and routes -- rather than the sequence of netlink calls that produced it. They also cover repeated activation on a reused worker, cleanup idempotency, and the two micro-VM options (the fixed host veth MAC that keeps a restored guest's frozen ARP entry valid, and the interior link sweep). They run in throwaway anonymous namespaces, so they leave nothing behind on the machine, and are root-gated via internal/roottest like the other privileged tests.

`ActorVethTempName` goes away with its last user.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
