### PR TITLE
use FNV-1a as documented in rendezvous hashing

### DIFF
--- a/cmd/podcertcontroller/internal/rendezvous/rendezvous.go
+++ b/cmd/podcertcontroller/internal/rendezvous/rendezvous.go
@@ -275,7 +275,7 @@ func Hash(item string, replicas []string) string {
 }
 
 func fnvhash(key string) uint64 {
-	hasher := fnv.New64()
+	hasher := fnv.New64a()
 	_, _ = hasher.Write([]byte(key))
 	return hasher.Sum64()
 }


### PR DESCRIPTION
## Summary

The comment on Hasher states the implementation is based on FNV-1a, but fnvhash used fnv.New64() which is FNV-1. Switch to fnv.New64a() to match the documented algorithm and get better distribution.

## Why this is safe 

The hash function is used solely for live work assignment across controller replicas via rendezvous hashing. No hash values are persisted anywhere.