### PR TITLE
Fix failed test TestUploadLocalCheckpointDir

### DIFF
--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -1320,6 +1320,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 	fullRec := func(class string) sandboxAssetsRecord {
 		return sandboxAssetsRecord{
 			SandboxClass:  class,
+			PauseImage:    "pause@sha256:abc",
 			SnapshotFiles: []string{"config.json", "memory-ranges", ateompath.DurableDirTarFile},
 			Scope:         ateattr.SnapshotScopeFull,
 		}
@@ -1397,6 +1398,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "gvisor",
+			PauseImage:    "pause@sha256:abc",
 			SnapshotFiles: []string{"checkpoint.img"},
 			Scope:         ateattr.SnapshotScopeFull,
 		}, map[string]string{"checkpoint.img": "img"})
@@ -1414,6 +1416,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "microvm",
+			PauseImage:    "pause@sha256:abc",
 			SnapshotFiles: []string{"config.json", "memory-ranges"},
 			Scope:         ateattr.SnapshotScopeFull,
 		}, map[string]string{"config.json": "cfg", "memory-ranges": "mem"})
@@ -1431,6 +1434,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "mystery",
+			PauseImage:    "pause@sha256:abc",
 			SnapshotFiles: []string{ateompath.DurableDirTarFile},
 			Scope:         ateattr.SnapshotScopeFull,
 		}, map[string]string{ateompath.DurableDirTarFile: "data"})
@@ -1448,6 +1452,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "microvm",
+			PauseImage:    "pause@sha256:abc",
 			SnapshotFiles: []string{ateompath.DurableDirTarFile},
 			Scope:         ateattr.SnapshotScopeData,
 		}, map[string]string{ateompath.DurableDirTarFile: "data"})
@@ -1464,6 +1469,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "microvm",
+			PauseImage:    "pause@sha256:abc",
 			SnapshotFiles: []string{ateompath.DurableDirTarFile},
 		}, map[string]string{ateompath.DurableDirTarFile: "data"})
 

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -49,6 +49,8 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+const testPauseImage = "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
+
 func TestSnapshotManifestActorMetadata(t *testing.T) {
 	rec := sandboxAssetsRecord{
 		Atespace:               "team-a",
@@ -73,7 +75,7 @@ func TestSnapshotManifestActorMetadata(t *testing.T) {
 // written before the scope field existed must still parse, reporting an empty
 // scope, and a scope-less record must not serialize a scope key at all.
 func TestSnapshotManifestScopeAbsent(t *testing.T) {
-	legacy := []byte(`{"sandboxClass":"gvisor","pauseImage":"pause@sha256:abc","snapshotFiles":["checkpoint.img"]}`)
+	legacy := []byte(`{"sandboxClass":"gvisor","pauseImage":"` + testPauseImage + `","snapshotFiles":["checkpoint.img"]}`)
 	rec, err := unmarshalSandboxRecord(legacy)
 	if err != nil {
 		t.Fatalf("unmarshalSandboxRecord(legacy manifest): %v", err)
@@ -1320,7 +1322,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 	fullRec := func(class string) sandboxAssetsRecord {
 		return sandboxAssetsRecord{
 			SandboxClass:  class,
-			PauseImage:    "pause@sha256:abc",
+			PauseImage:    testPauseImage,
 			SnapshotFiles: []string{"config.json", "memory-ranges", ateompath.DurableDirTarFile},
 			Scope:         ateattr.SnapshotScopeFull,
 		}
@@ -1398,7 +1400,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "gvisor",
-			PauseImage:    "pause@sha256:abc",
+			PauseImage:    testPauseImage,
 			SnapshotFiles: []string{"checkpoint.img"},
 			Scope:         ateattr.SnapshotScopeFull,
 		}, map[string]string{"checkpoint.img": "img"})
@@ -1416,7 +1418,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "microvm",
-			PauseImage:    "pause@sha256:abc",
+			PauseImage:    testPauseImage,
 			SnapshotFiles: []string{"config.json", "memory-ranges"},
 			Scope:         ateattr.SnapshotScopeFull,
 		}, map[string]string{"config.json": "cfg", "memory-ranges": "mem"})
@@ -1434,7 +1436,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "mystery",
-			PauseImage:    "pause@sha256:abc",
+			PauseImage:    testPauseImage,
 			SnapshotFiles: []string{ateompath.DurableDirTarFile},
 			Scope:         ateattr.SnapshotScopeFull,
 		}, map[string]string{ateompath.DurableDirTarFile: "data"})
@@ -1452,7 +1454,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "microvm",
-			PauseImage:    "pause@sha256:abc",
+			PauseImage:    testPauseImage,
 			SnapshotFiles: []string{ateompath.DurableDirTarFile},
 			Scope:         ateattr.SnapshotScopeData,
 		}, map[string]string{ateompath.DurableDirTarFile: "data"})
@@ -1469,7 +1471,7 @@ func TestUploadLocalCheckpointDir(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "pause-snap-1")
 		writeLocalSnapshot(t, dir, sandboxAssetsRecord{
 			SandboxClass:  "microvm",
-			PauseImage:    "pause@sha256:abc",
+			PauseImage:    testPauseImage,
 			SnapshotFiles: []string{ateompath.DurableDirTarFile},
 		}, map[string]string{ateompath.DurableDirTarFile: "data"})
 


### PR DESCRIPTION
Commit da8414bb made unmarshalSandboxRecord reject records without a pauseImage, fixing the test failure found in 
```
--- FAIL: TestUploadLocalCheckpointDir (0.01s)
    --- FAIL: TestUploadLocalCheckpointDir/matching_scope_uploads_all_files (0.00s)
    --- FAIL: TestUploadLocalCheckpointDir/microvm_full_capture_uploads_durable_tar_alone_as_data (0.00s)
    --- FAIL: TestUploadLocalCheckpointDir/gvisor_full_capture_cannot_become_data_yet (0.00s)
    --- FAIL: TestUploadLocalCheckpointDir/microvm_full_capture_without_durable_tar_has_no_data (0.00s)
    --- FAIL: TestUploadLocalCheckpointDir/unknown_sandbox_class_cannot_convert (0.00s)
    --- FAIL: TestUploadLocalCheckpointDir/data_capture_cannot_become_full (0.00s)
    --- FAIL: TestUploadLocalCheckpointDir/manifest_without_scope_is_rejected (0.00s)
    --- PASS: TestUploadLocalCheckpointDir/gone_locally_but_already_uploaded_succeeds (0.00s)
    --- PASS: TestUploadLocalCheckpointDir/gone_locally_and_remotely_crashes_the_actor (0.00s)
    --- FAIL: TestUploadLocalCheckpointDir/upload_failure_is_a_plain_retryable_error (0.00s)
```