### PR TITLE
Make UpdateWorker follow substrate API guidelines

### DIFF
--- a/cmd/ateapi/internal/controlapi/crash.go
+++ b/cmd/ateapi/internal/controlapi/crash.go
@@ -130,8 +130,11 @@ func releaseWorker(ctx context.Context, st store.Interface, actor *ateapipb.Acto
 		return sandboxClass, nil
 	}
 
-	worker.Assignment = nil
-	if err := st.UpdateWorker(ctx, worker, worker.GetVersion()); err != nil {
+	_, err = st.UpdateWorker(ctx, worker.GetWorkerNamespace(), worker.GetWorkerPool(), worker.GetWorkerPod(), store.WithWorkerPrecondition(worker, func(toUpdate *ateapipb.Worker) error {
+		toUpdate.Assignment = nil
+		return nil
+	}))
+	if err != nil {
 		return sandboxClass, fmt.Errorf("while releasing worker: %w", err)
 	}
 	return sandboxClass, nil

--- a/cmd/ateapi/internal/controlapi/crash_test.go
+++ b/cmd/ateapi/internal/controlapi/crash_test.go
@@ -491,3 +491,80 @@ func assertCrashMetricDatapoint(t *testing.T, reader *sdkmetric.ManualReader, wa
 	t.Errorf("did not find ate.actor.crashes metric with attrs: opName=%q, reason=%q, tmplNS=%q, tmplName=%q, workerPool=%q, sandboxClass=%q",
 		wantOpName, wantReason, wantTmplNS, wantTmplName, wantWorkerPool, wantSandboxClass)
 }
+
+// TestReleaseWorker_PodReplaceRace checks that a release is not applied to a
+// worker whose pod was replaced between the caller's read and its write. The
+// recreated record reuses the pod name and resets to version 1, so only the pod
+// uid can tell the two pods apart.
+func TestReleaseWorker_PodReplaceRace(t *testing.T) {
+	ctx := context.Background()
+	persistence, cleanup := storetest.SetupTestStore(t)
+	t.Cleanup(cleanup)
+
+	actor, err := persistence.CreateActor(ctx, &ateapipb.Actor{
+		Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "actor-1"},
+		Status:   ateapipb.Actor_STATUS_RUNNING,
+		WorkerAssignment: &ateapipb.WorkerAssignment{
+			WorkerNamespace: "ns",
+			WorkerPool:      "pool",
+			WorkerPod:       "pod",
+			WorkerPodUid:    "pod-uid-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActor: %v", err)
+	}
+
+	// Pod A: the worker the caller reads, holding this actor's claim.
+	if err := persistence.CreateWorker(ctx, &ateapipb.Worker{
+		WorkerNamespace: "ns",
+		WorkerPool:      "pool",
+		WorkerPod:       "pod",
+		WorkerPodUid:    "pod-uid-1",
+		Assignment: &ateapipb.Assignment{
+			Actor:    &ateapipb.ObjectRef{Atespace: "team-a", Name: "actor-1"},
+			ActorUid: actor.GetMetadata().GetUid(),
+		},
+	}); err != nil {
+		t.Fatalf("CreateWorker: %v", err)
+	}
+
+	// A racing syncer replaces pod A with pod B under the same name, and another
+	// actor claims the replacement.
+	racing := &conflictInjectingStore{
+		Interface: persistence,
+		inject: func() {
+			if err := persistence.DeleteWorker(ctx, "ns", "pool", "pod"); err != nil {
+				t.Errorf("Racing writer: DeleteWorker: %v", err)
+				return
+			}
+			if err := persistence.CreateWorker(ctx, &ateapipb.Worker{
+				WorkerNamespace: "ns",
+				WorkerPool:      "pool",
+				WorkerPod:       "pod",
+				WorkerPodUid:    "pod-uid-2",
+				Assignment: &ateapipb.Assignment{
+					Actor:    &ateapipb.ObjectRef{Atespace: "team-a", Name: "other-actor"},
+					ActorUid: "other-actor-uid",
+				},
+			}); err != nil {
+				t.Errorf("Racing writer: CreateWorker: %v", err)
+			}
+		},
+	}
+
+	// The uid conflict returns an error
+	if _, err = releaseWorker(ctx, racing, actor); err == nil {
+		t.Errorf("releaseWorker()=nil, want %v", err)
+	}
+
+	stored, err := persistence.GetWorker(ctx, "ns", "pool", "pod")
+	if err != nil {
+		t.Fatalf("GetWorker: %v", err)
+	}
+	// The version reset to 1 along with the pod, so a version guard alone would
+	// have waved the release through and freed a worker another actor owns.
+	if got := stored.GetAssignment().GetActorUid(); got != "other-actor-uid" {
+		t.Errorf("assignment actor uid = %q, want %q: the release landed on the replacement pod", got, "other-actor-uid")
+	}
+}

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/ateredis"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
@@ -2729,8 +2730,11 @@ func TestResumeActor_CrashesIfAssignedWorkerIsDraining(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetWorker(%s) failed: %v", assignedPod, err)
 	}
-	assigned.State = ateapipb.Worker_STATE_DRAINING
-	if err := tc.persistence.UpdateWorker(context.Background(), assigned, assigned.GetVersion()); err != nil {
+	_, err = tc.persistence.UpdateWorker(context.Background(), ns, "pool1", assignedPod, store.WithWorkerPrecondition(assigned, func(toUpdate *ateapipb.Worker) error {
+		toUpdate.State = ateapipb.Worker_STATE_DRAINING
+		return nil
+	}))
+	if err != nil {
 		t.Fatalf("marking worker %s draining failed: %v", assignedPod, err)
 	}
 

--- a/cmd/ateapi/internal/controlapi/syncer.go
+++ b/cmd/ateapi/internal/controlapi/syncer.go
@@ -246,18 +246,15 @@ func (s *WorkerPoolSyncer) createOrUpdateWorker(ctx context.Context, key workerK
 	changed := false
 	if w.Ip != pod.Status.PodIP {
 		// TODO: I don't think this is possible, but handling this case so we can log it just in case we can reproduce it.
-		slog.InfoContext(ctx, "Syncer: updating worker in store (IP changed)", slog.String("worker", key.namespace+"/"+key.name))
-		w.Ip = pod.Status.PodIP
+		slog.WarnContext(ctx, "Syncer: updating worker in store (IP changed). This should never happen", slog.String("worker", key.namespace+"/"+key.name))
 		changed = true
 	}
 	if w.SandboxClass != string(pool.Spec.SandboxClass) {
 		slog.InfoContext(ctx, "Syncer: updating worker in store (SandboxClass changed)", slog.String("worker", key.namespace+"/"+key.name))
-		w.SandboxClass = string(pool.Spec.SandboxClass)
 		changed = true
 	}
 	if !maps.Equal(w.Labels, pool.GetLabels()) {
 		slog.InfoContext(ctx, "Syncer: updating worker in store (labels changed)", slog.String("worker", key.namespace+"/"+key.name))
-		w.Labels = pool.GetLabels()
 		changed = true
 	}
 	if !changed {
@@ -266,32 +263,45 @@ func (s *WorkerPoolSyncer) createOrUpdateWorker(ctx context.Context, key workerK
 
 	// ErrVersionConflict requeues the key; the retry re-fetches the worker at
 	// its new version.
-	return s.persistence.UpdateWorker(ctx, w, w.Version)
+	_, err = s.persistence.UpdateWorker(ctx, key.namespace, key.pool, key.name, store.WithWorkerPrecondition(w, func(toUpdate *ateapipb.Worker) error {
+		toUpdate.Ip = pod.Status.PodIP
+		toUpdate.SandboxClass = string(pool.Spec.SandboxClass)
+		toUpdate.Labels = maps.Clone(pool.GetLabels())
+		return nil
+	}))
+	return err
 }
 
 func isWorkerEligible(pod *corev1.Pod) bool {
 	return pod.Status.PodIP != ""
 }
 
+// errWorkerAlreadyDraining aborts a markWorkerDraining mutation that finds the
+// transition already done, so the store writes nothing and publishes no event.
+var errWorkerAlreadyDraining = errors.New("worker is already draining")
+
 // markWorkerDraining transitions a worker to STATE_DRAINING so the scheduler
 // stops routing new actors to it while its pod is Terminating. If the worker is
 // already gone or already draining there is nothing more to do — the Pod
-// Deleted event will clean up the record. A version conflict is returned so the
-// caller requeues and retries against the updated record.
+// Deleted event will clean up the record.
 func (s *WorkerPoolSyncer) markWorkerDraining(ctx context.Context, namespace, pool, podName string) error {
-	worker, err := s.persistence.GetWorker(ctx, namespace, pool, podName)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return nil
+	// The state is read and written inside one transaction, so the transition needs
+	// no precondition: it is decided against the very worker the write lands on.
+	_, err := s.persistence.UpdateWorker(ctx, namespace, pool, podName, func(toUpdate *ateapipb.Worker) error {
+		if toUpdate.GetState() == ateapipb.Worker_STATE_DRAINING {
+			return errWorkerAlreadyDraining
 		}
-		return err
-	}
-	if worker.GetState() == ateapipb.Worker_STATE_DRAINING {
+		toUpdate.State = ateapipb.Worker_STATE_DRAINING
+		return nil
+	})
+	if errors.Is(err, store.ErrNotFound) || errors.Is(err, errWorkerAlreadyDraining) {
 		return nil
 	}
-	slog.InfoContext(ctx, "Syncer: marking worker draining (pod deleting)", slog.String("worker", namespace+"/"+podName))
-	worker.State = ateapipb.Worker_STATE_DRAINING
-	return s.persistence.UpdateWorker(ctx, worker, worker.GetVersion())
+	if err != nil {
+		return err
+	}
+	slog.InfoContext(ctx, "Syncer: marked worker draining (pod deleting)", slog.String("worker", namespace+"/"+podName))
+	return nil
 }
 
 // reconcileDeadWorker cleans up a worker whose pod is gone. It releases the

--- a/cmd/ateapi/internal/controlapi/syncer_test.go
+++ b/cmd/ateapi/internal/controlapi/syncer_test.go
@@ -271,16 +271,17 @@ func TestSyncer_DeleteBoundWorker_ClearsActor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create actor: %v", err)
 	}
-	w, _ := persistence.GetWorker(ctx, ns, pool, pod)
-	w.Assignment = &ateapipb.Assignment{
-		ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
-			Namespace: ns,
-			Name:      "tmpl",
-		},
-		Actor:    &ateapipb.ObjectRef{Atespace: createdActor.GetMetadata().GetAtespace(), Name: createdActor.GetMetadata().GetName()},
-		ActorUid: createdActor.GetMetadata().GetUid(),
-	}
-	if err := persistence.UpdateWorker(ctx, w, w.Version); err != nil {
+	if _, err := persistence.UpdateWorker(ctx, ns, pool, pod, func(toUpdate *ateapipb.Worker) error {
+		toUpdate.Assignment = &ateapipb.Assignment{
+			ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
+				Namespace: ns,
+				Name:      "tmpl",
+			},
+			Actor:    &ateapipb.ObjectRef{Atespace: createdActor.GetMetadata().GetAtespace(), Name: createdActor.GetMetadata().GetName()},
+			ActorUid: createdActor.GetMetadata().GetUid(),
+		}
+		return nil
+	}); err != nil {
 		t.Fatalf("update worker: %v", err)
 	}
 
@@ -828,14 +829,14 @@ func TestReleaseActorOnDeadWorker_StatusTransitions(t *testing.T) {
 type conflictStore struct {
 	store.Interface
 	conflictTriggered atomic.Bool
-	onUpdate          func(ctx context.Context, worker *ateapipb.Worker)
+	onUpdate          func(ctx context.Context, namespace, pool, pod string)
 }
 
-func (c *conflictStore) UpdateWorker(ctx context.Context, worker *ateapipb.Worker, expectedVersion int64) error {
+func (c *conflictStore) UpdateWorker(ctx context.Context, namespace, pool, pod string, mutate func(*ateapipb.Worker) error) (*ateapipb.Worker, error) {
 	if c.onUpdate != nil && c.conflictTriggered.CompareAndSwap(false, true) {
-		c.onUpdate(ctx, worker)
+		c.onUpdate(ctx, namespace, pool, pod)
 	}
-	return c.Interface.UpdateWorker(ctx, worker, expectedVersion)
+	return c.Interface.UpdateWorker(ctx, namespace, pool, pod, mutate)
 }
 
 func TestSyncer_UpdateWorker_RetryOnVersionConflict(t *testing.T) {
@@ -929,11 +930,11 @@ func TestSyncer_UpdateWorker_RetryOnVersionConflict(t *testing.T) {
 	}
 
 	// Configure conflictStore to inject a concurrent version bump in Redis when the syncer calls UpdateWorker.
-	cs.onUpdate = func(c context.Context, w *ateapipb.Worker) {
-		if cw, err := cs.Interface.GetWorker(c, ns, poolName, podName); err == nil {
-			cw.NodeName = "node2"
-			_ = cs.Interface.UpdateWorker(c, cw, cw.Version)
-		}
+	cs.onUpdate = func(c context.Context, namespace, pool, pod string) {
+		_, _ = cs.Interface.UpdateWorker(c, namespace, pool, pod, func(toUpdate *ateapipb.Worker) error {
+			toUpdate.NodeName = "node2"
+			return nil
+		})
 	}
 
 	// Touch the pod ONCE in K8s so the syncer reconciles it. The first reconcile's

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -228,10 +228,17 @@ func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef reso
 
 			if wass := worker.Assignment; wass != nil {
 				if wass.GetActorUid() == latestActor.GetMetadata().GetUid() {
-					worker.Assignment = nil
-					if err := w.store.UpdateWorker(ctx, worker, worker.Version); err != nil {
+					_, err := w.store.UpdateWorker(ctx, worker.GetWorkerNamespace(), worker.GetWorkerPool(), worker.GetWorkerPod(), store.WithWorkerPrecondition(worker, func(toUpdate *ateapipb.Worker) error {
+						toUpdate.Assignment = nil
+						return nil
+					}))
+					if err != nil {
 						if errors.Is(err, store.ErrVersionConflict) {
 							return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
+						}
+						if errors.Is(err, store.ErrUIDConflict) {
+							return nil, status.Errorf(codes.Aborted, "worker %s/%s/%s not found with uid %s",
+								worker.GetWorkerNamespace(), worker.GetWorkerPool(), worker.GetWorkerPod(), worker.GetWorkerPodUid())
 						}
 						return nil, err
 					}

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -30,7 +30,6 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -386,13 +385,14 @@ func (w *ActorWorkflow) validateAssignedWorker(ctx context.Context, actorRef res
 	}
 	if !w.scheduler.Applies(worker, constraints) {
 		slog.ErrorContext(ctx, "crashing actor because previously assigned worker is not eligible anymore")
-		release := proto.Clone(worker).(*ateapipb.Worker)
-		release.Assignment = nil
 		// If that worker's pool is no longer eligible (e.g. the actor's
 		// worker_selector was updated after the failed attempt), release it back
 		// to the free pool instead of leaving it claimed forever — nothing else
 		// reclaims a healthy worker whose actor moved on to a different pool.
-		if err := w.store.UpdateWorker(ctx, release, release.Version); err != nil {
+		if _, err := w.store.UpdateWorker(ctx, worker.GetWorkerNamespace(), worker.GetWorkerPool(), worker.GetWorkerPod(), store.WithWorkerPrecondition(worker, func(toUpdate *ateapipb.Worker) error {
+			toUpdate.Assignment = nil
+			return nil
+		})); err != nil {
 			return nil, fmt.Errorf("while releasing stale worker assignment: %w", err)
 		}
 		if cerr := crashActor(ctx, w.store, actorRef, ateattr.OperationResume, ateattr.ReasonCorruptedAssignment); cerr != nil {
@@ -456,10 +456,6 @@ func (w *ActorWorkflow) assignWorkerAttempt(ctx context.Context, actorRef resour
 			assignedWorker = worker
 			break
 		}
-		// Workers() returns pointers directly from the cache so we need to clone before
-		// mutating so that the cache is not corrupted if UpdateWorker fails.
-		releaseWorker := proto.Clone(worker).(*ateapipb.Worker)
-		releaseWorker.Assignment = nil
 		// The claimed worker is no longer eligible (e.g. the actor's
 		// worker_selector changed after the failed attempt); release it back
 		// to the free pool — nothing else reclaims a healthy worker whose
@@ -467,12 +463,15 @@ func (w *ActorWorkflow) assignWorkerAttempt(ctx context.Context, actorRef resour
 		go func(release *ateapipb.Worker) {
 			bgCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			if err := w.store.UpdateWorker(bgCtx, release, release.Version); err != nil {
+			if _, err := w.store.UpdateWorker(bgCtx, release.GetWorkerNamespace(), release.GetWorkerPool(), release.GetWorkerPod(), store.WithWorkerPrecondition(release, func(toUpdate *ateapipb.Worker) error {
+				toUpdate.Assignment = nil
+				return nil
+			})); err != nil {
 				slog.ErrorContext(bgCtx, "Failed to release stale worker assignment",
 					slog.String("worker", release.GetWorkerNamespace()+"/"+release.GetWorkerPod()),
 					slog.Any("err", err))
 			}
-		}(releaseWorker)
+		}(worker)
 	}
 	if assignedWorker == nil {
 		pickedWorker, err := w.scheduler.Schedule(ctx, constraints)
@@ -488,10 +487,7 @@ func (w *ActorWorkflow) assignWorkerAttempt(ctx context.Context, actorRef resour
 		slog.InfoContext(ctx, "Picked worker", slog.Any("worker", pickedWorker.String()))
 	}
 
-	// Workers() returns pointers directly from the cache so we need to clone before
-	// mutating so that the cache is not corrupted if UpdateWorker fails.
-	assignedWorker = proto.Clone(assignedWorker).(*ateapipb.Worker)
-	assignedWorker.Assignment = &ateapipb.Assignment{
+	claim := &ateapipb.Assignment{
 		ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
 			Namespace: actor.GetActorTemplateNamespace(),
 			Name:      actor.GetActorTemplateName(),
@@ -503,7 +499,11 @@ func (w *ActorWorkflow) assignWorkerAttempt(ctx context.Context, actorRef resour
 		ActorUid: actor.GetMetadata().GetUid(),
 	}
 
-	if err := w.store.UpdateWorker(ctx, assignedWorker, assignedWorker.Version); err != nil {
+	assignedWorker, err = w.store.UpdateWorker(ctx, assignedWorker.GetWorkerNamespace(), assignedWorker.GetWorkerPool(), assignedWorker.GetWorkerPod(), store.WithWorkerPrecondition(assignedWorker, func(toUpdate *ateapipb.Worker) error {
+		toUpdate.Assignment = claim
+		return nil
+	}))
+	if err != nil {
 		return nil, nil, err
 	}
 

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -223,20 +223,15 @@ func TestAssignWorkerAttempt_RetryAfterConflictPicksFreshWorker(t *testing.T) {
 		}
 	}
 
-	// Snapshot the contested worker at the version the failed attempt saw.
-	beforeClaim, err := persistence.GetWorker(ctx, "worker-ns", "pool", "contested-pod")
-	if err != nil {
-		t.Fatalf("GetWorker: %v", err)
-	}
-
 	// A concurrent resume of another actor wins the contested worker, bumping
 	// its stored version past the failed attempt's snapshot.
-	claimed := proto.Clone(beforeClaim).(*ateapipb.Worker)
-	claimed.Assignment = &ateapipb.Assignment{
-		Actor:    &ateapipb.ObjectRef{Atespace: "team-a", Name: "other"},
-		ActorUid: "other-actor-uid",
-	}
-	if err := persistence.UpdateWorker(ctx, claimed, claimed.GetVersion()); err != nil {
+	if _, err := persistence.UpdateWorker(ctx, "worker-ns", "pool", "contested-pod", func(toUpdate *ateapipb.Worker) error {
+		toUpdate.Assignment = &ateapipb.Assignment{
+			Actor:    &ateapipb.ObjectRef{Atespace: "team-a", Name: "other"},
+			ActorUid: "other-actor-uid",
+		}
+		return nil
+	}); err != nil {
 		t.Fatalf("UpdateWorker (concurrent claim): %v", err)
 	}
 
@@ -311,6 +306,11 @@ func (c *conflictInjectingStore) UpdateActor(ctx context.Context, actorRef resou
 func (c *conflictInjectingStore) UpdateActorSnapshotTag(ctx context.Context, atespace, name string, mutate func(*ateapipb.ActorSnapshotTag) error) (*ateapipb.ActorSnapshotTag, error) {
 	c.once.Do(c.inject)
 	return c.Interface.UpdateActorSnapshotTag(ctx, atespace, name, mutate)
+}
+
+func (c *conflictInjectingStore) UpdateWorker(ctx context.Context, namespace, pool, pod string, mutate func(*ateapipb.Worker) error) (*ateapipb.Worker, error) {
+	c.once.Do(c.inject)
+	return c.Interface.UpdateWorker(ctx, namespace, pool, pod, mutate)
 }
 
 // seedAssignFixture stores one free gvisor worker and a SUSPENDED actor and

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -356,10 +356,17 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 			// Only free it if it still belongs to us
 			if wass := worker.Assignment; wass != nil {
 				if wass.GetActorUid() == latestActor.GetMetadata().GetUid() {
-					worker.Assignment = nil
-					if err := w.store.UpdateWorker(ctx, worker, worker.Version); err != nil {
+					_, err := w.store.UpdateWorker(ctx, worker.GetWorkerNamespace(), worker.GetWorkerPool(), workerPod, store.WithWorkerPrecondition(worker, func(toUpdate *ateapipb.Worker) error {
+						toUpdate.Assignment = nil
+						return nil
+					}))
+					if err != nil {
 						if errors.Is(err, store.ErrVersionConflict) {
 							return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")
+						}
+						if errors.Is(err, store.ErrUIDConflict) {
+							return nil, status.Errorf(codes.Aborted, "worker %s/%s/%s not found with uid %s",
+								worker.GetWorkerNamespace(), worker.GetWorkerPool(), workerPod, worker.GetWorkerPodUid())
 						}
 						return nil, err
 					}

--- a/cmd/ateapi/internal/store/atepg/atepg.go
+++ b/cmd/ateapi/internal/store/atepg/atepg.go
@@ -1264,36 +1264,47 @@ func unmarshalWorkerEvent(payload string) (store.WorkerEvent, error) {
 	return store.WorkerEvent{Type: store.WorkerEventType(env.Type), Worker: worker}, nil
 }
 
-// writeAndNotify runs fn inside a transaction, then--only if fn reports a
-// change worth notifying--calls pg_notify in the same transaction so
-// delivery happens if and only if the transaction commits.
-func (p *Persistence) writeAndNotify(ctx context.Context, eventType store.WorkerEventType, worker *ateapipb.Worker, fn func(ctx context.Context, tx pgx.Tx) (notify bool, err error)) error {
+// writeAndNotify runs fn inside a transaction, then--only if fn returns a
+// worker worth notifying about--calls pg_notify in the same transaction so
+// delivery happens if and only if the transaction commits. fn returns the
+// worker the write produced, or nil when there is nothing to announce; that
+// worker is what writeAndNotify returns once the transaction commits.
+func (p *Persistence) writeAndNotify(ctx context.Context, eventType store.WorkerEventType, fn func(ctx context.Context, tx pgx.Tx) (*ateapipb.Worker, error)) (*ateapipb.Worker, error) {
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("beginning transaction: %w", err)
+		return nil, fmt.Errorf("beginning transaction: %w", err)
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // no-op once committed
 
-	notify, err := fn(ctx, tx)
+	worker, err := fn(ctx, tx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if notify {
-		payload, err := marshalWorkerEvent(eventType, worker)
-		if err != nil {
-			return fmt.Errorf("marshaling worker event: %w", err)
-		}
-		if len(payload) > maxNotifyPayloadBytes {
-			return fmt.Errorf("worker event payload of %d bytes exceeds PostgreSQL NOTIFY limit of %d bytes", len(payload), maxNotifyPayloadBytes)
-		}
-		if _, err := tx.Exec(ctx, `SELECT pg_notify($1, $2)`, workerChangeChannel, string(payload)); err != nil {
-			return fmt.Errorf("notifying worker change: %w", err)
+	if worker != nil {
+		if err := notifyWorkerEvent(ctx, tx, eventType, worker); err != nil {
+			return nil, err
 		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("committing transaction: %w", err)
+		return nil, fmt.Errorf("committing transaction: %w", err)
+	}
+	return worker, nil
+}
+
+// notifyWorkerEvent queues a worker change notification inside tx, so delivery
+// happens if and only if the transaction commits.
+func notifyWorkerEvent(ctx context.Context, tx pgx.Tx, eventType store.WorkerEventType, worker *ateapipb.Worker) error {
+	payload, err := marshalWorkerEvent(eventType, worker)
+	if err != nil {
+		return fmt.Errorf("marshaling worker event: %w", err)
+	}
+	if len(payload) > maxNotifyPayloadBytes {
+		return fmt.Errorf("worker event payload of %d bytes exceeds PostgreSQL NOTIFY limit of %d bytes", len(payload), maxNotifyPayloadBytes)
+	}
+	if _, err := tx.Exec(ctx, `SELECT pg_notify($1, $2)`, workerChangeChannel, string(payload)); err != nil {
+		return fmt.Errorf("notifying worker change: %w", err)
 	}
 	return nil
 }
@@ -1307,15 +1318,15 @@ func (p *Persistence) CreateWorker(ctx context.Context, worker *ateapipb.Worker)
 		return fmt.Errorf("marshaling worker: %w", err)
 	}
 
-	err = p.writeAndNotify(ctx, store.WorkerEventCreated, dbWorker, func(ctx context.Context, tx pgx.Tx) (bool, error) {
+	_, err = p.writeAndNotify(ctx, store.WorkerEventCreated, func(ctx context.Context, tx pgx.Tx) (*ateapipb.Worker, error) {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO workers (worker_namespace, worker_pool, worker_pod, version, proto)
 			VALUES ($1, $2, $3, $4, $5)`,
 			dbWorker.GetWorkerNamespace(), dbWorker.GetWorkerPool(), dbWorker.GetWorkerPod(), dbWorker.GetVersion(), protoBytes)
 		if err != nil {
-			return false, err
+			return nil, err
 		}
-		return true, nil
+		return dbWorker, nil
 	})
 	if err != nil {
 		if isUniqueViolation(err) {
@@ -1347,48 +1358,71 @@ func (p *Persistence) GetWorker(ctx context.Context, namespace, poolName, pod st
 	return getWorkerRow(ctx, p.pool, namespace, poolName, pod)
 }
 
-func (p *Persistence) UpdateWorker(ctx context.Context, worker *ateapipb.Worker, expectedVersion int64) error {
-	namespace, poolName, pod := worker.GetWorkerNamespace(), worker.GetWorkerPool(), worker.GetWorkerPod()
-
-	dbWorker := proto.Clone(worker).(*ateapipb.Worker)
-	dbWorker.Version = expectedVersion + 1
-
-	protoBytes, err := proto.Marshal(dbWorker)
-	if err != nil {
-		return fmt.Errorf("marshaling worker: %w", err)
+func validateUpdateWorkerMutation(storedWorker, mutatedWorker *ateapipb.Worker) error {
+	if stored, mutated := storedWorker.GetWorkerNamespace(), mutatedWorker.GetWorkerNamespace(); stored != mutated {
+		return fmt.Errorf("worker_namespace is immutable: mutation changed it from %q to %q", stored, mutated)
 	}
+	if stored, mutated := storedWorker.GetWorkerPool(), mutatedWorker.GetWorkerPool(); stored != mutated {
+		return fmt.Errorf("worker_pool is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	if stored, mutated := storedWorker.GetWorkerPod(), mutatedWorker.GetWorkerPod(); stored != mutated {
+		return fmt.Errorf("worker_pod is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	if stored, mutated := storedWorker.GetIp(), mutatedWorker.GetIp(); stored != mutated {
+		return fmt.Errorf("ip is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	return nil
+}
 
-	return p.writeAndNotify(ctx, store.WorkerEventUpdated, dbWorker, func(ctx context.Context, tx pgx.Tx) (bool, error) {
-		var returned []byte
+func (p *Persistence) UpdateWorker(ctx context.Context, namespace, poolName, pod string, mutate func(toUpdate *ateapipb.Worker) error) (*ateapipb.Worker, error) {
+	return p.writeAndNotify(ctx, store.WorkerEventUpdated, func(ctx context.Context, tx pgx.Tx) (*ateapipb.Worker, error) {
+		var protoBytes []byte
 		err := tx.QueryRow(ctx, `
+			SELECT proto FROM workers
+			WHERE worker_namespace = $1 AND worker_pool = $2 AND worker_pod = $3
+			FOR UPDATE`, namespace, poolName, pod).Scan(&protoBytes)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, store.ErrNotFound
+			}
+			return nil, fmt.Errorf("selecting worker %s/%s/%s for update: %w", namespace, poolName, pod, err)
+		}
+		currentWorker := &ateapipb.Worker{}
+		if err := proto.Unmarshal(protoBytes, currentWorker); err != nil {
+			return nil, fmt.Errorf("unmarshaling worker: %w", err)
+		}
+
+		// Snapshot the stored state before handing the worker to mutate.
+		// mutate is free to edit anything it is given.
+		workerBeforeMutation := proto.Clone(currentWorker).(*ateapipb.Worker)
+		if err := mutate(currentWorker); err != nil {
+			return nil, err
+		}
+		if err := validateUpdateWorkerMutation(workerBeforeMutation, currentWorker); err != nil {
+			return nil, err
+		}
+		// The stored version is authoritative; derive the next one from it,
+		// discarding whatever mutate made of it.
+		currentWorker.Version = workerBeforeMutation.GetVersion() + 1
+
+		updatedBytes, err := proto.Marshal(currentWorker)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling worker: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `
 			UPDATE workers
 			SET version = $1, proto = $2
-			WHERE worker_namespace = $3 AND worker_pool = $4 AND worker_pod = $5
-			  AND version = $6
-			RETURNING proto`,
-			dbWorker.GetVersion(), protoBytes, namespace, poolName, pod, expectedVersion,
-		).Scan(&returned)
-		if err == nil {
-			return true, nil
+			WHERE worker_namespace = $3 AND worker_pool = $4 AND worker_pod = $5`,
+			currentWorker.GetVersion(), updatedBytes, namespace, poolName, pod); err != nil {
+			return nil, fmt.Errorf("updating worker %s/%s/%s: %w", namespace, poolName, pod, err)
 		}
-		if !errors.Is(err, pgx.ErrNoRows) {
-			return false, fmt.Errorf("updating worker %s/%s/%s: %w", namespace, poolName, pod, err)
-		}
-
-		current, getErr := getWorkerRow(ctx, tx, namespace, poolName, pod)
-		if getErr != nil {
-			return false, getErr
-		}
-		if current.GetVersion() != expectedVersion {
-			return false, store.ErrVersionConflict
-		}
-		return false, fmt.Errorf("update worker %s/%s/%s: no row matched but current state is otherwise consistent", namespace, poolName, pod)
+		return currentWorker, nil
 	})
 }
 
 func (p *Persistence) DeleteWorker(ctx context.Context, namespace, poolName, pod string) error {
 	deletedEvent := &ateapipb.Worker{WorkerNamespace: namespace, WorkerPod: pod}
-	return p.writeAndNotify(ctx, store.WorkerEventDeleted, deletedEvent, func(ctx context.Context, tx pgx.Tx) (bool, error) {
+	_, err := p.writeAndNotify(ctx, store.WorkerEventDeleted, func(ctx context.Context, tx pgx.Tx) (*ateapipb.Worker, error) {
 		var protoBytes []byte
 		err := tx.QueryRow(ctx, `
 			DELETE FROM workers
@@ -1397,12 +1431,13 @@ func (p *Persistence) DeleteWorker(ctx context.Context, namespace, poolName, pod
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				// Idempotent: nothing existed, so nothing to notify either.
-				return false, nil
+				return nil, nil
 			}
-			return false, fmt.Errorf("deleting worker %s/%s/%s: %w", namespace, poolName, pod, err)
+			return nil, fmt.Errorf("deleting worker %s/%s/%s: %w", namespace, poolName, pod, err)
 		}
-		return true, nil
+		return deletedEvent, nil
 	})
+	return err
 }
 
 func (p *Persistence) ListWorkers(ctx context.Context, pageSize int32, pageTokenStr string) ([]*ateapipb.Worker, string, error) {

--- a/cmd/ateapi/internal/store/atepg/atepg_test.go
+++ b/cmd/ateapi/internal/store/atepg/atepg_test.go
@@ -284,6 +284,81 @@ func TestWorkerNotification_OnlyAfterCommit(t *testing.T) {
 	}
 }
 
+// TestUpdateWorker_ConcurrentUpdatesSerialize pins the SELECT ... FOR UPDATE in
+// UpdateWorker. Two updaters race on the same row, each editing a different
+// field. The row lock is what makes the loser re-read the winner's committed
+// proto before applying its own mutation; without it both would compute their
+// write from version 1 and whoever committed last would silently drop the
+// other's field.
+func TestUpdateWorker_ConcurrentUpdatesAreSerialized(t *testing.T) {
+	s := setupPostgresStore(t).(*Persistence)
+	ctx := context.Background()
+
+	if err := s.CreateWorker(ctx, &ateapipb.Worker{
+		WorkerNamespace: "ns",
+		WorkerPool:      "pool",
+		WorkerPod:       "pod",
+		State:           ateapipb.Worker_STATE_ACTIVE,
+	}); err != nil {
+		t.Fatalf("CreateWorker failed: %v", err)
+	}
+
+	// Both updaters block on this until each has been given the go-ahead, so
+	// they contend for the row lock rather than running one after the other.
+	start := make(chan struct{})
+	mutations := []struct {
+		name   string
+		mutate func(toUpdate *ateapipb.Worker)
+	}{
+		{
+			name:   "sets node name",
+			mutate: func(toUpdate *ateapipb.Worker) { toUpdate.NodeName = "node-1" },
+		},
+		{
+			name:   "sets state",
+			mutate: func(toUpdate *ateapipb.Worker) { toUpdate.State = ateapipb.Worker_STATE_DRAINING },
+		},
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(mutations))
+	for i, m := range mutations {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, errs[i] = s.UpdateWorker(ctx, "ns", "pool", "pod", func(toUpdate *ateapipb.Worker) error {
+				m.mutate(toUpdate)
+				return nil
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("UpdateWorker that %s failed: %v", mutations[i].name, err)
+		}
+	}
+
+	got, err := s.GetWorker(ctx, "ns", "pool", "pod")
+	if err != nil {
+		t.Fatalf("GetWorker failed: %v", err)
+	}
+	// Version 3 -> 2 updates should've occurred.
+	if got.GetVersion() != 3 {
+		t.Errorf("version = %d, want 3: both updates must advance it in turn", got.GetVersion())
+	}
+	// Both fields survive only if the second updater reads the first's commit.
+	if got.GetNodeName() != "node-1" {
+		t.Errorf("node_name = %q, want %q: a concurrent update clobbered it", got.GetNodeName(), "node-1")
+	}
+	if got.GetState() != ateapipb.Worker_STATE_DRAINING {
+		t.Errorf("state = %v, want %v: a concurrent update clobbered it", got.GetState(), ateapipb.Worker_STATE_DRAINING)
+	}
+}
+
 func TestListActors_InvalidPageToken(t *testing.T) {
 	s := setupPostgresStore(t).(*Persistence)
 	ctx := context.Background()

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -65,6 +65,10 @@ import (
 // globalAtespace in Substrate is represented by "".
 const globalAtespace = ""
 
+// updateMaxAttempts bounds how many times an updater re-runs its
+// read-modify-write after a concurrent writer invalidates the transaction.
+const updateMaxAttempts = 5
+
 type workerPubSubMsg struct {
 	Type   int    `json:"t"`
 	Worker string `json:"w"` // protojson-encoded Worker
@@ -883,14 +887,9 @@ func validateUpdateActorSnapshotTagMutation(storedTag, mutatedTag *ateapipb.Acto
 	return nil
 }
 
-// updateActorSnapshotTagMaxAttempts bounds how many times UpdateActorSnapshotTag
-// re-runs its read-modify-write after a concurrent writer invalidates the
-// transaction.
-const updateActorSnapshotTagMaxAttempts = 5
-
 func (s *Persistence) UpdateActorSnapshotTag(ctx context.Context, atespace, name string, mutate func(*ateapipb.ActorSnapshotTag) error) (*ateapipb.ActorSnapshotTag, error) {
 	tagKey := actorSnapshotTagDBKey(atespace, name)
-	for range updateActorSnapshotTagMaxAttempts {
+	for range updateMaxAttempts {
 		var dbTag *ateapipb.ActorSnapshotTag
 		var abortErr error
 
@@ -1021,66 +1020,92 @@ func (s *Persistence) GetWorker(ctx context.Context, namespace, pool, pod string
 	return worker, nil
 }
 
-func (s *Persistence) UpdateWorker(ctx context.Context, worker *ateapipb.Worker, expectedVersion int64) error {
-	dbKey := workerDBKey(worker.GetWorkerNamespace(), worker.GetWorkerPool(), worker.GetWorkerPod())
+func validateUpdateWorkerMutation(storedWorker, mutatedWorker *ateapipb.Worker) error {
+	if stored, mutated := storedWorker.GetWorkerNamespace(), mutatedWorker.GetWorkerNamespace(); stored != mutated {
+		return fmt.Errorf("worker_namespace is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	if stored, mutated := storedWorker.GetWorkerPool(), mutatedWorker.GetWorkerPool(); stored != mutated {
+		return fmt.Errorf("worker_pool is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	if stored, mutated := storedWorker.GetWorkerPod(), mutatedWorker.GetWorkerPod(); stored != mutated {
+		return fmt.Errorf("worker_pod is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	if stored, mutated := storedWorker.GetIp(), mutatedWorker.GetIp(); stored != mutated {
+		return fmt.Errorf("ip is immutable: mutation changed it from %q to %q", stored, mutated)
+	}
+	return nil
+}
 
-	// Clone because we will update the version field, and we don't want to
-	// stomp the caller's copy.
-	dbWorker := proto.Clone(worker).(*ateapipb.Worker)
+func (s *Persistence) UpdateWorker(ctx context.Context, namespace, pool, pod string, mutate func(*ateapipb.Worker) error) (*ateapipb.Worker, error) {
+	dbKey := workerDBKey(namespace, pool, pod)
+	for range updateMaxAttempts {
+		var dbWorker *ateapipb.Worker
+		var abortErr error
 
-	err := s.rdb.Watch(ctx, func(tx *redis.Tx) error {
-		currentVal, err := tx.Get(ctx, dbKey).Bytes()
-		if err != nil {
-			if errors.Is(err, redis.Nil) {
-				return store.ErrNotFound
+		err := s.rdb.Watch(ctx, func(tx *redis.Tx) error {
+			currentVal, err := tx.Get(ctx, dbKey).Bytes()
+			if err != nil {
+				if errors.Is(err, redis.Nil) {
+					return store.ErrNotFound
+				}
+				return fmt.Errorf("while getting worker: %w", err)
 			}
-			return fmt.Errorf("while getting worker: %w", err)
-		}
 
-		currentWorker := &ateapipb.Worker{}
-		if err := protojson.Unmarshal(currentVal, currentWorker); err != nil {
-			return fmt.Errorf("in protojson.Unmarshal: %w", err)
-		}
+			currentWorker := &ateapipb.Worker{}
+			if err := protojson.Unmarshal(currentVal, currentWorker); err != nil {
+				return fmt.Errorf("in protojson.Unmarshal: %w", err)
+			}
 
-		if currentWorker.GetVersion() != expectedVersion {
-			return store.ErrVersionConflict
-		}
-		dbWorker.Version = currentWorker.GetVersion() + 1
-		if currentWorker.GetWorkerNamespace() != dbWorker.GetWorkerNamespace() {
-			return fmt.Errorf("worker_namespace is immutable")
-		}
-		if currentWorker.GetWorkerPool() != dbWorker.GetWorkerPool() {
-			return fmt.Errorf("worker_pool is immutable")
-		}
-		if currentWorker.GetWorkerPod() != dbWorker.GetWorkerPod() {
-			return fmt.Errorf("worker_pod is immutable")
-		}
-		if currentWorker.GetIp() != dbWorker.GetIp() {
-			return fmt.Errorf("ip is immutable")
-		}
-		newVal, err := protojson.Marshal(dbWorker)
-		if err != nil {
-			return fmt.Errorf("in protojson.Marshal: %w", err)
-		}
+			// Snapshot the stored state before handing the worker to mutate.
+			// mutate is free to edit anything it is given.
+			workerBeforeMutation := proto.Clone(currentWorker).(*ateapipb.Worker)
+			if err := mutate(currentWorker); err != nil {
+				abortErr = err
+				return err
+			}
+			if err := validateUpdateWorkerMutation(workerBeforeMutation, currentWorker); err != nil {
+				abortErr = err
+				return err
+			}
+			// The stored version is authoritative; derive the next one from it,
+			// discarding whatever mutate made of it.
+			currentWorker.Version = workerBeforeMutation.GetVersion() + 1
 
-		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-			pipe.Set(ctx, dbKey, newVal, 0)
+			newVal, err := protojson.Marshal(currentWorker)
+			if err != nil {
+				return fmt.Errorf("in protojson.Marshal: %w", err)
+			}
+
+			if _, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, dbKey, newVal, 0)
+				return nil
+			}); err != nil {
+				return err
+			}
+			dbWorker = currentWorker
 			return nil
-		})
-		return err
-	}, dbKey)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return store.ErrNotFound
+		}, dbKey)
+
+		switch {
+		case err == nil:
+			s.publishWorkerEvent(ctx, store.WorkerEventUpdated, dbWorker)
+			return dbWorker, nil
+		case abortErr != nil:
+			return nil, abortErr
+		case errors.Is(err, store.ErrNotFound):
+			return nil, store.ErrNotFound
+		case errors.Is(err, redis.TxFailedErr):
+			// A concurrent write landed between WATCH and EXEC, so mutate never
+			// saw it. Re-read and run it against the newer state.
+			continue
+		default:
+			return nil, fmt.Errorf("while executing update worker transaction: %w", err)
 		}
-		if errors.Is(err, store.ErrVersionConflict) || errors.Is(err, redis.TxFailedErr) {
-			return store.ErrVersionConflict
-		}
-		return fmt.Errorf("while executing update worker transaction: %w", err)
 	}
 
-	s.publishWorkerEvent(ctx, store.WorkerEventUpdated, dbWorker)
-	return nil
+	// Only the TxFailedErr branch continues the loop, so getting here means every
+	// attempt lost the race.
+	return nil, store.ErrVersionConflict
 }
 
 func (s *Persistence) DeleteWorker(ctx context.Context, namespace, pool, pod string) error {
@@ -1154,10 +1179,6 @@ func validateUpdateActorMutation(storedActor, mutatedActor *ateapipb.Actor) erro
 	}
 	return nil
 }
-
-// updateMaxAttempts bounds how many times UpdateActor or UpdateActorTemplate re-runs its
-// read-modify-write after a concurrent writer invalidates the transaction.
-const updateMaxAttempts = 5
 
 func (s *Persistence) UpdateActor(ctx context.Context, actorRef resources.ActorRef, mutate func(*ateapipb.Actor) error) (*ateapipb.Actor, error) {
 	dbKey := actorDBKey(actorRef)

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -502,21 +502,6 @@ func TestUpdateActor_RejectsStaleVersion(t *testing.T) {
 
 }
 
-func TestUpdateWorker_NotFound(t *testing.T) {
-	mr, s, ctx := setupTest(t)
-	defer mr.Close()
-
-	worker := &ateapipb.Worker{
-		WorkerNamespace: "default",
-		WorkerPool:      "pool-1",
-		WorkerPod:       "non-existent",
-	}
-	err := s.UpdateWorker(ctx, worker, 1)
-	if !errors.Is(err, store.ErrNotFound) {
-		t.Errorf("expected store.ErrNotFound, got %v", err)
-	}
-}
-
 func TestGetWorker_NotFound(t *testing.T) {
 	_, s, ctx := setupTest(t)
 
@@ -598,7 +583,11 @@ func TestUpdateWorker_Success(t *testing.T) {
 		ActorUid: "actor-1-uid",
 	}
 
-	if err := s.UpdateWorker(ctx, worker, 1); err != nil {
+	updated, err := s.UpdateWorker(ctx, "default", "pool-1", "pod-1", func(toUpdate *ateapipb.Worker) error {
+		toUpdate.Assignment = worker.GetAssignment()
+		return nil
+	})
+	if err != nil {
 		t.Fatalf("UpdateWorker failed: %v", err)
 	}
 
@@ -612,6 +601,9 @@ func TestUpdateWorker_Success(t *testing.T) {
 	}
 
 	worker.Version = 2
+	if diff := cmp.Diff(worker, updated, protocmp.Transform()); diff != "" {
+		t.Errorf("UpdateWorker returned unexpected worker (-want +got):\n%s", diff)
+	}
 	if diff := cmp.Diff(worker, got, protocmp.Transform()); diff != "" {
 		t.Errorf("UpdateWorker yielded unexpected state in DB (-want +got):\n%s", diff)
 	}
@@ -1212,23 +1204,104 @@ func TestUpdateWorker_Conflict(t *testing.T) {
 	}
 
 	// Update instance 1
-	worker1.Assignment = &ateapipb.Assignment{
-		Actor:    &ateapipb.ObjectRef{Atespace: "team-a", Name: "actor-1"},
-		ActorUid: "actor-1-uid",
-	}
-	err = s.UpdateWorker(ctx, worker1, worker1.Version)
+	_, err = s.UpdateWorker(ctx, "default", "pool-1", "pod-1", store.WithWorkerPrecondition(worker1, func(toUpdate *ateapipb.Worker) error {
+		toUpdate.Assignment = &ateapipb.Assignment{
+			Actor:    &ateapipb.ObjectRef{Atespace: "team-a", Name: "actor-1"},
+			ActorUid: "actor-1-uid",
+		}
+		return nil
+	}))
 	if err != nil {
 		t.Fatalf("UpdateWorker failed: %v", err)
 	}
 
-	// Try to update instance 2
-	worker2.Assignment = &ateapipb.Assignment{
-		Actor:    &ateapipb.ObjectRef{Atespace: "team-a", Name: "actor-2"},
-		ActorUid: "actor-2-uid",
-	}
-	err = s.UpdateWorker(ctx, worker2, worker2.Version)
+	// Try to update instance 2, which is pinned on the version instance 1 moved.
+	_, err = s.UpdateWorker(ctx, "default", "pool-1", "pod-1", store.WithWorkerPrecondition(worker2, func(toUpdate *ateapipb.Worker) error {
+		toUpdate.Assignment = &ateapipb.Assignment{
+			Actor:    &ateapipb.ObjectRef{Atespace: "team-a", Name: "actor-2"},
+			ActorUid: "actor-2-uid",
+		}
+		return nil
+	}))
 	if !errors.Is(err, store.ErrVersionConflict) {
 		t.Errorf("expected ErrVersionConflict, got %v", err)
+	}
+}
+
+// seedWorker stores a worker under the given pod name and pod uid, and returns
+// it as the store holds it.
+func seedWorker(t *testing.T, s *Persistence, ctx context.Context, pod, podUID string) *ateapipb.Worker {
+	t.Helper()
+	if err := s.CreateWorker(ctx, &ateapipb.Worker{
+		WorkerNamespace: "default",
+		WorkerPool:      "pool-1",
+		WorkerPod:       pod,
+		WorkerPodUid:    podUID,
+		Ip:              "10.0.0.1",
+		State:           ateapipb.Worker_STATE_ACTIVE,
+	}); err != nil {
+		t.Fatalf("CreateWorker(%s) failed: %v", pod, err)
+	}
+	stored, err := s.GetWorker(ctx, "default", "pool-1", pod)
+	if err != nil {
+		t.Fatalf("GetWorker(%s) failed: %v", pod, err)
+	}
+	return stored
+}
+
+func TestUpdateWorker_RetriesOnConcurrentWrite(t *testing.T) {
+	mr, s, ctx := setupTest(t)
+	seedWorker(t, s, ctx, "pod-1", "pod-uid-1")
+	workerKey := workerDBKey("default", "pool-1", "pod-1")
+
+	// A separate client, so its write lands outside the transaction's connection.
+	otherClient := redis.NewClusterClient(&redis.ClusterOptions{Addrs: []string{mr.Addr()}})
+	t.Cleanup(func() { otherClient.Close() })
+
+	attempts := 0
+	interceptor := &watchInterceptor{redisClient: s.rdb, before: func() {
+		// Only the first attempt races. We do this to make sure the second retry
+		// will succeed.
+		if attempts > 0 {
+			return
+		}
+		concurrent, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
+		if err != nil {
+			t.Errorf("GetWorker for concurrent write failed: %v", err)
+			return
+		}
+		// The retry must carry the concurrent scheduling decision forward, not
+		// revert it to what the first attempt read.
+		concurrent.NodeName = "node-2"
+		val, err := protojson.Marshal(concurrent)
+		if err != nil {
+			t.Errorf("protojson.Marshal failed: %v", err)
+			return
+		}
+		if err := otherClient.Set(ctx, workerKey, val, 0).Err(); err != nil {
+			t.Errorf("concurrent Set failed: %v", err)
+		}
+	}}
+	racing := &Persistence{rdb: interceptor, lockTTL: defaultLockTTL}
+
+	updated, err := racing.UpdateWorker(ctx, "default", "pool-1", "pod-1", func(toUpdate *ateapipb.Worker) error {
+		attempts++
+		toUpdate.State = ateapipb.Worker_STATE_DRAINING
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateWorker failed: %v", err)
+	}
+	if attempts < 2 {
+		t.Errorf("mutate ran %d times, want at least 2: the first write is racey and must be rejected", attempts)
+	}
+	if got, want := updated.GetState(), ateapipb.Worker_STATE_DRAINING; got != want {
+		t.Errorf("state = %v, want %v", got, want)
+	}
+	// The concurrent tx moved the worker to node-2. That change should survive
+	// instead of being reverted by a mutation computed against the older state.
+	if got := updated.GetNodeName(); got != "node-2" {
+		t.Errorf("node_name = %q, want %q: the retry clobbered the concurrent write", got, "node-2")
 	}
 }
 

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -190,8 +190,20 @@ type Interface interface {
 	// Registers a new idle worker. Returns ErrAlreadyExists if already registered.
 	CreateWorker(ctx context.Context, worker *ateapipb.Worker) error
 
-	// Updates worker state with optimistic concurrency check. Returns ErrNotFound if missing, or ErrVersionConflict on version mismatch.
-	UpdateWorker(ctx context.Context, worker *ateapipb.Worker, expectedVersion int64) error
+	// UpdateWorker performs a transactional read-modify-write on the worker
+	// addressed by namespace, pool and pod, and returns the stored Worker with its
+	// version advanced.
+	//
+	// mutate receives the stored worker and edits it in place. The mutated worker
+	// is written iff mutate returns nil. A mutate that must only land on the worker
+	// the caller observed wraps itself in WithWorkerPrecondition.
+	//
+	// mutate may run more than once, because the store retries when a concurrent
+	// write invalidates the transaction.
+	//
+	// Returns ErrNotFound if missing, ErrVersionConflict if the retry budget is
+	// exhausted, or the mutate's error verbatim otherwise.
+	UpdateWorker(ctx context.Context, namespace, pool, pod string, mutate func(toUpdate *ateapipb.Worker) error) (*ateapipb.Worker, error)
 
 	// Removes a worker. Idempotent: does nothing if worker is not found.
 	DeleteWorker(ctx context.Context, namespace, pool, pod string) error
@@ -222,18 +234,18 @@ const (
 	AnyVersion int64 = 0
 )
 
-// checkPrecondition reports whether md still describes the object the caller
-// observed, pinned on the uid and version it read, each waivable with AnyUID or
-// AnyVersion. Version guards against concurrent writes, uid against
-// atespace/name re-use across object lifecycles.
+// checkPrecondition reports whether the stored uid and version still describe
+// the object the caller observed, pinned on the uid and version it read, each
+// waivable with AnyUID or AnyVersion. Version guards against concurrent writes,
+// uid against atespace/name re-use across object lifecycles.
 //
 // Returns ErrUIDConflict or ErrVersionConflict, which the update surfaces
 // verbatim.
-func checkPrecondition(md *ateapipb.ResourceMetadata, uid string, version int64) error {
-	if uid != AnyUID && uid != md.GetUid() {
+func checkPrecondition(storedUID string, storedVersion int64, uid string, version int64) error {
+	if uid != AnyUID && uid != storedUID {
 		return ErrUIDConflict
 	}
-	if version != AnyVersion && version != md.GetVersion() {
+	if version != AnyVersion && version != storedVersion {
 		return ErrVersionConflict
 	}
 	return nil
@@ -255,7 +267,25 @@ type hasResourceMetadata interface {
 func WithPrecondition[T hasResourceMetadata](observed T, mutate func(stored T) error) func(stored T) error {
 	uid, version := observed.GetMetadata().GetUid(), observed.GetMetadata().GetVersion()
 	return func(stored T) error {
-		if err := checkPrecondition(stored.GetMetadata(), uid, version); err != nil {
+		md := stored.GetMetadata()
+		if err := checkPrecondition(md.GetUid(), md.GetVersion(), uid, version); err != nil {
+			return err
+		}
+		return mutate(stored)
+	}
+}
+
+// WithWorkerPrecondition is WithPrecondition for Worker, which carries its
+// identity in flat fields rather than in a ResourceMetadata. It pins on the
+// worker's pod uid, which changes when a pod is deleted and recreated under the
+// same name, and on its version.
+//
+// An observed worker carrying no pod uid or version pins nothing. To pin one of
+// the two and waive the other, pass an observed worker carrying only the field
+// to pin.
+func WithWorkerPrecondition(observed *ateapipb.Worker, mutate func(stored *ateapipb.Worker) error) func(stored *ateapipb.Worker) error {
+	return func(stored *ateapipb.Worker) error {
+		if err := checkPrecondition(stored.GetWorkerPodUid(), stored.GetVersion(), observed.GetWorkerPodUid(), observed.GetVersion()); err != nil {
 			return err
 		}
 		return mutate(stored)

--- a/cmd/ateapi/internal/store/store_test.go
+++ b/cmd/ateapi/internal/store/store_test.go
@@ -145,3 +145,113 @@ func TestWithPrecondition(t *testing.T) {
 		})
 	}
 }
+
+func TestWithWorkerPrecondition(t *testing.T) {
+	const (
+		storedUID = "stored-pod-uid"
+		staleUID  = "stale-pod-uid"
+		storedVer = int64(7)
+		staleVer  = int64(6)
+	)
+	// The worker the transaction reads, which the mutation is checked against.
+	stored := &ateapipb.Worker{
+		WorkerNamespace: "worker-ns",
+		WorkerPool:      "pool-1",
+		WorkerPod:       "pod-1",
+		WorkerPodUid:    storedUID,
+		Version:         storedVer,
+	}
+	errMutate := errors.New("mutate failed")
+
+	tests := []struct {
+		name               string
+		preconditionWorker *ateapipb.Worker
+		mutateErr          error
+		wantErr            error
+		wantMutated        bool
+	}{
+		{
+			name:               "the observed worker is still the stored one",
+			preconditionWorker: stored,
+			wantErr:            nil,
+			wantMutated:        true,
+		},
+		{
+			name:               "the mutate error is surfaced verbatim",
+			preconditionWorker: stored,
+			mutateErr:          errMutate,
+			wantErr:            errMutate,
+			wantMutated:        true,
+		},
+		{
+			name:               "an unguarded observed worker pins nothing",
+			preconditionWorker: &ateapipb.Worker{WorkerNamespace: "worker-ns", WorkerPool: "pool-1", WorkerPod: "pod-1"},
+			wantErr:            nil,
+			wantMutated:        true,
+		},
+		{
+			name:               "pod uid guarded, version waived, tolerates the moved version",
+			preconditionWorker: &ateapipb.Worker{WorkerPodUid: storedUID, Version: AnyVersion},
+			wantErr:            nil,
+			wantMutated:        true,
+		},
+		{
+			name:               "version guarded, pod uid waived, tolerates the new pod",
+			preconditionWorker: &ateapipb.Worker{WorkerPodUid: AnyUID, Version: storedVer},
+			wantErr:            nil,
+			wantMutated:        true,
+		},
+		{
+			name:               "the pod name now addresses a replaced pod",
+			preconditionWorker: &ateapipb.Worker{WorkerPodUid: staleUID, Version: storedVer},
+			wantErr:            ErrUIDConflict,
+			wantMutated:        false,
+		},
+		{
+			name:               "the version moved under the caller",
+			preconditionWorker: &ateapipb.Worker{WorkerPodUid: storedUID, Version: staleVer},
+			wantErr:            ErrVersionConflict,
+			wantMutated:        false,
+		},
+		{
+			name:               "pod uid guarded, version waived, still catches the replaced pod",
+			preconditionWorker: &ateapipb.Worker{WorkerPodUid: staleUID, Version: AnyVersion},
+			wantErr:            ErrUIDConflict,
+			wantMutated:        false,
+		},
+		{
+			name:               "version guarded, pod uid waived, still catches the moved version",
+			preconditionWorker: &ateapipb.Worker{WorkerPodUid: AnyUID, Version: staleVer},
+			wantErr:            ErrVersionConflict,
+			wantMutated:        false,
+		},
+		{
+			// The pod uid is reported first: a replaced pod makes the version
+			// meaningless, and it is the failure a retry can never resolve.
+			name:               "both stale reports the pod uid conflict",
+			preconditionWorker: &ateapipb.Worker{WorkerPodUid: staleUID, Version: staleVer},
+			wantErr:            ErrUIDConflict,
+			wantMutated:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mutated := false
+			mutate := WithWorkerPrecondition(tt.preconditionWorker, func(toUpdate *ateapipb.Worker) error {
+				mutated = true
+				if toUpdate != stored {
+					t.Errorf("mutate got worker %v, want the stored one", toUpdate)
+				}
+				return tt.mutateErr
+			})
+
+			if err := mutate(stored); !errors.Is(err, tt.wantErr) {
+				t.Errorf("mutate(stored) = %v, want one matching %v", err, tt.wantErr)
+			}
+			if mutated != tt.wantMutated {
+				t.Errorf("mutate ran = %t, want %t", mutated, tt.wantMutated)
+			}
+		})
+	}
+}

--- a/cmd/ateapi/internal/store/storecontract/contract.go
+++ b/cmd/ateapi/internal/store/storecontract/contract.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,6 +78,28 @@ func actorNameSet(actors []*ateapipb.Actor) map[string]bool {
 		set[a.GetMetadata().GetName()] = true
 	}
 	return set
+}
+
+// seedWorker stores a worker under the given pod name and pod uid, and returns
+// it as the store holds it.
+func seedWorker(t *testing.T, s store.Interface, pod, podUID string) *ateapipb.Worker {
+	t.Helper()
+	ctx := context.Background()
+	if err := s.CreateWorker(ctx, &ateapipb.Worker{
+		WorkerNamespace: "default",
+		WorkerPool:      "pool-1",
+		WorkerPod:       pod,
+		WorkerPodUid:    podUID,
+		Ip:              "10.0.0.1",
+		State:           ateapipb.Worker_STATE_ACTIVE,
+	}); err != nil {
+		t.Fatalf("CreateWorker(%s) failed: %v", pod, err)
+	}
+	stored, err := s.GetWorker(ctx, "default", "pool-1", pod)
+	if err != nil {
+		t.Fatalf("GetWorker(%s) failed: %v", pod, err)
+	}
+	return stored
 }
 
 func receiveEvent(t *testing.T, ch <-chan store.WorkerEvent) store.WorkerEvent {
@@ -401,81 +424,7 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		}
 	})
 
-	t.Run("UpdateWorker_Success", func(t *testing.T) {
-		s := setup(t)
-		ctx := context.Background()
-
-		worker := &ateapipb.Worker{WorkerNamespace: "default", WorkerPool: "pool-1", WorkerPod: "pod-1"}
-		if err := s.CreateWorker(ctx, worker); err != nil {
-			t.Fatalf("CreateWorker failed: %v", err)
-		}
-
-		// Subscribe after create so the create event doesn't pollute the channel.
-		watch, err := s.WatchWorkers(ctx)
-		if err != nil {
-			t.Fatalf("WatchWorkers failed: %v", err)
-		}
-		defer watch.Close()
-
-		worker.Assignment = &ateapipb.Assignment{
-			ActorTemplate: &ateapipb.KubeNamespacedObjectRef{Namespace: "default", Name: "test-template"},
-			Actor:         &ateapipb.ObjectRef{Name: "session-1"},
-		}
-		if err := s.UpdateWorker(ctx, worker, 1); err != nil {
-			t.Fatalf("UpdateWorker failed: %v", err)
-		}
-
-		got, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
-		if err != nil {
-			t.Fatalf("GetWorker failed: %v", err)
-		}
-		if got.Version != 2 {
-			t.Errorf("expected version 2, got %d", got.Version)
-		}
-
-		worker.Version = 2
-		if diff := cmp.Diff(worker, got, protocmp.Transform()); diff != "" {
-			t.Errorf("UpdateWorker yielded unexpected state in DB (-want +got):\n%s", diff)
-		}
-
-		event := receiveEvent(t, watch.Events)
-		if event.Type != store.WorkerEventUpdated {
-			t.Errorf("expected WorkerEventUpdated, got %v", event.Type)
-		}
-		if diff := cmp.Diff(worker, event.Worker, protocmp.Transform()); diff != "" {
-			t.Errorf("updated event worker mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("UpdateWorker_Conflict", func(t *testing.T) {
-		s := setup(t)
-		ctx := context.Background()
-
-		worker := &ateapipb.Worker{WorkerNamespace: "default", WorkerPool: "pool-1", WorkerPod: "pod-1"}
-		if err := s.CreateWorker(ctx, worker); err != nil {
-			t.Fatalf("CreateWorker failed: %v", err)
-		}
-
-		worker1, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
-		if err != nil {
-			t.Fatalf("GetWorker failed: %v", err)
-		}
-		worker2, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
-		if err != nil {
-			t.Fatalf("GetWorker failed: %v", err)
-		}
-
-		worker1.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ObjectRef{Name: "session-1"}}
-		if err := s.UpdateWorker(ctx, worker1, worker1.Version); err != nil {
-			t.Fatalf("UpdateWorker failed: %v", err)
-		}
-
-		worker2.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ObjectRef{Name: "session-2"}}
-		err = s.UpdateWorker(ctx, worker2, worker2.Version)
-		if !errors.Is(err, store.ErrVersionConflict) {
-			t.Errorf("expected ErrVersionConflict, got %v", err)
-		}
-	})
+	runUpdateWorkerContractTests(t, setup)
 
 	t.Run("DeleteWorker", func(t *testing.T) {
 		s := setup(t)
@@ -1500,6 +1449,275 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		}
 		if len(global) != 6 {
 			t.Errorf("global ListActorSnapshots returned %d snapshots, want 6", len(global))
+		}
+	})
+}
+
+// runUpdateWorkerContractTests covers UpdateWorker's contract
+func runUpdateWorkerContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
+	t.Helper()
+
+	t.Run("UpdateWorker_Success", func(t *testing.T) {
+		s := setup(t)
+		ctx := context.Background()
+
+		worker := &ateapipb.Worker{WorkerNamespace: "default", WorkerPool: "pool-1", WorkerPod: "pod-1"}
+		if err := s.CreateWorker(ctx, worker); err != nil {
+			t.Fatalf("CreateWorker failed: %v", err)
+		}
+
+		// Subscribe after create so the create event doesn't pollute the channel.
+		watch, err := s.WatchWorkers(ctx)
+		if err != nil {
+			t.Fatalf("WatchWorkers failed: %v", err)
+		}
+		defer watch.Close()
+
+		assignment := &ateapipb.Assignment{
+			ActorTemplate: &ateapipb.KubeNamespacedObjectRef{Namespace: "default", Name: "test-template"},
+			Actor:         &ateapipb.ObjectRef{Name: "session-1"},
+		}
+		updated, err := s.UpdateWorker(ctx, "default", "pool-1", "pod-1", func(toUpdate *ateapipb.Worker) error {
+			toUpdate.Assignment = assignment
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("UpdateWorker failed: %v", err)
+		}
+
+		got, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
+		if err != nil {
+			t.Fatalf("GetWorker failed: %v", err)
+		}
+		if got.Version != 2 {
+			t.Errorf("expected version 2, got %d", got.Version)
+		}
+
+		worker.Assignment = assignment
+		worker.Version = 2
+		if diff := cmp.Diff(worker, got, protocmp.Transform()); diff != "" {
+			t.Errorf("UpdateWorker yielded unexpected state in DB (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(worker, updated, protocmp.Transform()); diff != "" {
+			t.Errorf("UpdateWorker returned unexpected worker (-want +got):\n%s", diff)
+		}
+
+		event := receiveEvent(t, watch.Events)
+		if event.Type != store.WorkerEventUpdated {
+			t.Errorf("expected WorkerEventUpdated, got %v", event.Type)
+		}
+		if diff := cmp.Diff(worker, event.Worker, protocmp.Transform()); diff != "" {
+			t.Errorf("updated event worker mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("UpdateWorker_Conflict", func(t *testing.T) {
+		s := setup(t)
+		ctx := context.Background()
+
+		worker := &ateapipb.Worker{WorkerNamespace: "default", WorkerPool: "pool-1", WorkerPod: "pod-1"}
+		if err := s.CreateWorker(ctx, worker); err != nil {
+			t.Fatalf("CreateWorker failed: %v", err)
+		}
+
+		worker1, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
+		if err != nil {
+			t.Fatalf("GetWorker failed: %v", err)
+		}
+		staleWorker1, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
+		if err != nil {
+			t.Fatalf("GetWorker failed: %v", err)
+		}
+
+		// Update the worker off the first read, moving the version worker2 is
+		// pinned on.
+		_, err = s.UpdateWorker(ctx, "default", "pool-1", "pod-1", store.WithWorkerPrecondition(worker1, func(toUpdate *ateapipb.Worker) error {
+			toUpdate.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ObjectRef{Name: "session-1"}}
+			return nil
+		}))
+		if err != nil {
+			t.Fatalf("UpdateWorker failed: %v", err)
+		}
+
+		_, err = s.UpdateWorker(ctx, "default", "pool-1", "pod-1", store.WithWorkerPrecondition(staleWorker1, func(toUpdate *ateapipb.Worker) error {
+			t.Error("mutate() ran past its precondition once the pinned version had moved")
+			toUpdate.Assignment = &ateapipb.Assignment{Actor: &ateapipb.ObjectRef{Name: "session-2"}}
+			return nil
+		}))
+		if !errors.Is(err, store.ErrVersionConflict) {
+			t.Errorf("expected ErrVersionConflict, got %v", err)
+		}
+		// The pod uid still matches, so this is not the replaced-pod failure:
+		// callers key their retry decision off the difference.
+		if errors.Is(err, store.ErrUIDConflict) {
+			t.Errorf("UpdateWorker error = %v, want no store.ErrUIDConflict match: the pod is unchanged", err)
+		}
+	})
+
+	t.Run("UpdateWorker_NotFound", func(t *testing.T) {
+		s := setup(t)
+		ctx := context.Background()
+
+		_, err := s.UpdateWorker(ctx, "default", "pool-1", "non-existent", func(*ateapipb.Worker) error {
+			t.Error("mutate() ran for a worker that does not exist")
+			return nil
+		})
+		if !errors.Is(err, store.ErrNotFound) {
+			t.Errorf("UpdateWorker error = %v, want one matching store.ErrNotFound", err)
+		}
+	})
+
+	t.Run("UpdateWorker_RejectsStaleUID", func(t *testing.T) {
+		s := setup(t)
+		ctx := context.Background()
+
+		original := seedWorker(t, s, "pod-1", "pod-uid-1")
+		if err := s.DeleteWorker(ctx, "default", "pool-1", "pod-1"); err != nil {
+			t.Fatalf("DeleteWorker failed: %v", err)
+		}
+		// k8s can reuse the pod name but never the pod uid.
+		recreated := seedWorker(t, s, "pod-1", "pod-uid-2")
+		// The version reset to 1 along with the pod, so a version guard alone
+		// would have waved this write through. Only the pod uid distinguishes
+		// the pods.
+		if recreated.GetVersion() != 1 {
+			t.Fatalf("recreated version = %d, want 1: the version cannot tell the pods apart", recreated.GetVersion())
+		}
+
+		// Pins the pod alone: the observed worker carries the original pod uid
+		// and no version.
+		pinOriginalUID := &ateapipb.Worker{WorkerPodUid: original.GetWorkerPodUid(), Version: store.AnyVersion}
+		_, err := s.UpdateWorker(ctx, "default", "pool-1", "pod-1", store.WithWorkerPrecondition(pinOriginalUID, func(toUpdate *ateapipb.Worker) error {
+			t.Error("mutate() ran past its precondition once the pinned pod was gone")
+			toUpdate.State = ateapipb.Worker_STATE_DRAINING
+			return nil
+		}))
+		if !errors.Is(err, store.ErrUIDConflict) {
+			t.Errorf("UpdateWorker error = %v, want one matching store.ErrUIDConflict", err)
+		}
+
+		stored, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
+		if err != nil {
+			t.Fatalf("GetWorker failed: %v", err)
+		}
+		if diff := cmp.Diff(recreated, stored, protocmp.Transform()); diff != "" {
+			t.Errorf("The rejected update still wrote (-recreated +stored):\n%s", diff)
+		}
+	})
+
+	t.Run("UpdateWorker_MutateErrorIsNotRetried", func(t *testing.T) {
+		s := setup(t)
+		ctx := context.Background()
+
+		created := seedWorker(t, s, "pod-1", "pod-uid-1")
+		mutationError := errors.New("mutation error")
+
+		callsToMutateFn := 0
+		_, err := s.UpdateWorker(ctx, "default", "pool-1", "pod-1", func(toUpdate *ateapipb.Worker) error {
+			callsToMutateFn++
+			toUpdate.State = ateapipb.Worker_STATE_DRAINING
+			return fmt.Errorf("worker pool-1/pod-1: %w", mutationError)
+		})
+		// The error must arrive intact.
+		if !errors.Is(err, mutationError) {
+			t.Errorf("UpdateWorker error = %v, want one wrapping mutationError", err)
+		}
+		// Mutation errors are non-retriable.
+		if callsToMutateFn != 1 {
+			t.Errorf("mutate ran %d times, want exactly 1 (a rejected mutation must not be retried)", callsToMutateFn)
+		}
+
+		got, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
+		if err != nil {
+			t.Fatalf("GetWorker failed: %v", err)
+		}
+		if diff := cmp.Diff(created, got, protocmp.Transform()); diff != "" {
+			t.Errorf("aborted mutation was persisted (-created +got):\n%s", diff)
+		}
+	})
+
+	t.Run("UpdateWorker_DiscardsServerOwnedFieldEdits", func(t *testing.T) {
+		s := setup(t)
+		ctx := context.Background()
+
+		created := seedWorker(t, s, "pod-1", "pod-uid-1")
+		updated, err := s.UpdateWorker(ctx, "default", "pool-1", "pod-1", func(toUpdate *ateapipb.Worker) error {
+			// The version is server-owned: a closure must not be able to change it.
+			toUpdate.Version = 99
+			toUpdate.State = ateapipb.Worker_STATE_DRAINING
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("UpdateWorker failed: %v", err)
+		}
+
+		if got, want := updated.GetVersion(), created.GetVersion()+1; got != want {
+			t.Errorf("version = %d, want %d (one past the stored version, not the forged value)", got, want)
+		}
+		if got, want := updated.GetState(), ateapipb.Worker_STATE_DRAINING; got != want {
+			t.Errorf("state = %v, want %v: discarding the version edit must not discard the mutation", got, want)
+		}
+	})
+
+	// UpdateWorker_RejectsImmutableFieldChange covers the fields a mutation may
+	// not touch. Unlike the server-owned version, which is silently restored,
+	// these fail the call: a caller that re-addressed a worker or changed the IP
+	// the atetunnel dials asked for something the store cannot do, and must hear
+	// about it.
+	t.Run("UpdateWorker_RejectsImmutableFieldChange", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			mutate    func(toUpdate *ateapipb.Worker)
+			wantField string
+		}{
+			{
+				name:      "worker namespace",
+				mutate:    func(toUpdate *ateapipb.Worker) { toUpdate.WorkerNamespace = "other-namespace" },
+				wantField: "worker_namespace",
+			},
+			{
+				name:      "worker pool",
+				mutate:    func(toUpdate *ateapipb.Worker) { toUpdate.WorkerPool = "other-pool" },
+				wantField: "worker_pool",
+			},
+			{
+				name:      "worker pod",
+				mutate:    func(toUpdate *ateapipb.Worker) { toUpdate.WorkerPod = "other-pod" },
+				wantField: "worker_pod",
+			},
+			{
+				name:      "ip",
+				mutate:    func(toUpdate *ateapipb.Worker) { toUpdate.Ip = "10.0.0.2" },
+				wantField: "ip",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				s := setup(t)
+				ctx := context.Background()
+
+				created := seedWorker(t, s, "pod-1", "pod-uid-1")
+				_, err := s.UpdateWorker(ctx, "default", "pool-1", "pod-1", func(toUpdate *ateapipb.Worker) error {
+					// Paired with a legitimate edit, so the rejection cannot be
+					// mistaken for a no-op mutation.
+					toUpdate.State = ateapipb.Worker_STATE_DRAINING
+					tt.mutate(toUpdate)
+					return nil
+				})
+				// The message must name the offending field: the closure is
+				// buggy, and whoever has to fix it only has this error to go on.
+				if want := tt.wantField + " is immutable"; err == nil || !strings.Contains(err.Error(), want) {
+					t.Errorf("UpdateWorker changing %s = %v, want an error containing %q", tt.name, err, want)
+				}
+
+				got, err := s.GetWorker(ctx, "default", "pool-1", "pod-1")
+				if err != nil {
+					t.Fatalf("GetWorker failed: %v", err)
+				}
+				if diff := cmp.Diff(created, got, protocmp.Transform()); diff != "" {
+					t.Errorf("rejected mutation was persisted anyway (-created +got):\n%s", diff)
+				}
+			})
 		}
 	})
 }


### PR DESCRIPTION
UpdateWorker was the last Update method in the storage layer still taking the whole Worker as both identity and payload, the version as a positional argument, and returning only an error.

It now takes (namespace, pool, pod) plus a mutate
closure, matching GetWorker and its two Update (matching the other UpdateXYZ) and returns the worker that was stored

https://github.com/agent-substrate/substrate/issues/732
https://github.com/agent-substrate/substrate/issues/763

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
