### PR TITLE
kubectl-ate: show sandbox class in worker listings

### DIFF
--- a/cmd/kubectl-ate/internal/cmd/get_workers.go
+++ b/cmd/kubectl-ate/internal/cmd/get_workers.go
@@ -29,6 +29,7 @@ var (
 	getWorkerNamespaceFlag string
 	getWorkerAtespaceFlag  string
 	getWorkerSelectorFlag  string
+	getWorkerClassFlag     string
 )
 
 var getWorkersCmd = &cobra.Command{
@@ -43,6 +44,7 @@ func init() {
 	getWorkersCmd.Flags().StringVarP(&getWorkerNamespaceFlag, "namespace", "n", "", "Scope output to a specific Kubernetes namespace")
 	getWorkersCmd.Flags().StringVarP(&getWorkerAtespaceFlag, "atespace", "a", "", "Filter worker pods hosting actors in a specific atespace")
 	getWorkersCmd.Flags().StringVarP(&getWorkerSelectorFlag, "selector", "l", "", "Filter by worker pool labels")
+	getWorkersCmd.Flags().StringVar(&getWorkerClassFlag, "sandbox-class", "", "Filter by sandbox class (e.g. gvisor, microvm)")
 	getCmd.AddCommand(getWorkersCmd)
 }
 
@@ -52,6 +54,7 @@ type GetWorkersRunner struct {
 	namespace    string
 	atespace     string
 	selector     string
+	sandboxClass string
 	outputFmt    string
 	out          io.Writer
 }
@@ -61,7 +64,7 @@ func (r *GetWorkersRunner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	filtered, err := filterWorkers(workers, r.namespace, r.atespace, r.selector)
+	filtered, err := filterWorkers(workers, r.namespace, r.atespace, r.selector, r.sandboxClass)
 	if err != nil {
 		return err
 	}
@@ -86,6 +89,7 @@ func runGetWorkers(cmd *cobra.Command, args []string) error {
 		namespace:    getWorkerNamespaceFlag,
 		atespace:     getWorkerAtespaceFlag,
 		selector:     getWorkerSelectorFlag,
+		sandboxClass: getWorkerClassFlag,
 		outputFmt:    outputFmt,
 		out:          os.Stdout,
 	}

--- a/cmd/kubectl-ate/internal/cmd/get_workers_test.go
+++ b/cmd/kubectl-ate/internal/cmd/get_workers_test.go
@@ -29,6 +29,7 @@ func TestGetWorkersRunner_Filters(t *testing.T) {
 			WorkerNamespace: "ns-1",
 			WorkerPool:      "counter",
 			WorkerPod:       "pod-1",
+			SandboxClass:    "microvm",
 			Assignment: &ateapipb.Assignment{
 				ActorTemplate: &ateapipb.KubeNamespacedObjectRef{Namespace: "ns-1", Name: "counter"},
 				Actor:         &ateapipb.ObjectRef{Atespace: "space-a", Name: "actor-a"},
@@ -39,12 +40,14 @@ func TestGetWorkersRunner_Filters(t *testing.T) {
 			WorkerNamespace: "ns-1",
 			WorkerPool:      "other",
 			WorkerPod:       "pod-2",
+			SandboxClass:    "gvisor",
 			Labels:          map[string]string{"ate.dev/worker-pool": "other"},
 		},
 		{
 			WorkerNamespace: "ns-2",
 			WorkerPool:      "counter",
 			WorkerPod:       "pod-3",
+			SandboxClass:    "gvisor",
 			Assignment: &ateapipb.Assignment{
 				ActorTemplate: &ateapipb.KubeNamespacedObjectRef{Namespace: "ns-2", Name: "counter"},
 				Actor:         &ateapipb.ObjectRef{Atespace: "space-b", Name: "actor-b"},
@@ -53,10 +56,10 @@ func TestGetWorkersRunner_Filters(t *testing.T) {
 		},
 	}
 
-	header := "NAMESPACE   POOL      POD     STATUS     ASSIGNED ACTOR\n"
-	row1 := "ns-1        counter   pod-1   ASSIGNED   ns-1/counter/space-a/actor-a\n"
-	row2 := "ns-1        other     pod-2   FREE       <none>\n"
-	row3 := "ns-2        counter   pod-3   ASSIGNED   ns-2/counter/space-b/actor-b\n"
+	header := "NAMESPACE   POOL      CLASS     POD     STATUS     ASSIGNED ACTOR\n"
+	row1 := "ns-1        counter   microvm   pod-1   ASSIGNED   ns-1/counter/space-a/actor-a\n"
+	row2 := "ns-1        other     gvisor    pod-2   FREE       <none>\n"
+	row3 := "ns-2        counter   gvisor    pod-3   ASSIGNED   ns-2/counter/space-b/actor-b\n"
 
 	tests := []struct {
 		name      string
@@ -69,7 +72,7 @@ func TestGetWorkersRunner_Filters(t *testing.T) {
 		{name: "namespace", namespace: "ns-1", expected: header + row1 + row2},
 		{name: "atespace", atespace: "space-a", expected: header + row1},
 		// With no matching rows the tabwriter sizes columns to the header alone.
-		{name: "atespace excludes free workers", atespace: "no-such-space", expected: "NAMESPACE   POOL   POD   STATUS   ASSIGNED ACTOR\n"},
+		{name: "atespace excludes free workers", atespace: "no-such-space", expected: "NAMESPACE   POOL   CLASS   POD   STATUS   ASSIGNED ACTOR\n"},
 		{name: "selector", selector: "ate.dev/worker-pool=counter", expected: header + row1 + row3},
 		{name: "combined", namespace: "ns-1", selector: "ate.dev/worker-pool=counter", expected: header + row1},
 	}

--- a/cmd/kubectl-ate/internal/cmd/get_workers_test.go
+++ b/cmd/kubectl-ate/internal/cmd/get_workers_test.go
@@ -62,11 +62,12 @@ func TestGetWorkersRunner_Filters(t *testing.T) {
 	row3 := "ns-2        counter   gvisor    pod-3   ASSIGNED   ns-2/counter/space-b/actor-b\n"
 
 	tests := []struct {
-		name      string
-		namespace string
-		atespace  string
-		selector  string
-		expected  string
+		name         string
+		namespace    string
+		atespace     string
+		selector     string
+		sandboxClass string
+		expected     string
 	}{
 		{name: "no filter", expected: header + row1 + row2 + row3},
 		{name: "namespace", namespace: "ns-1", expected: header + row1 + row2},
@@ -74,6 +75,11 @@ func TestGetWorkersRunner_Filters(t *testing.T) {
 		// With no matching rows the tabwriter sizes columns to the header alone.
 		{name: "atespace excludes free workers", atespace: "no-such-space", expected: "NAMESPACE   POOL   CLASS   POD   STATUS   ASSIGNED ACTOR\n"},
 		{name: "selector", selector: "ate.dev/worker-pool=counter", expected: header + row1 + row3},
+		{name: "sandbox class", sandboxClass: "microvm", expected: header + row1},
+		// gvisor-only rows shrink the CLASS column to the widest survivor.
+		{name: "sandbox class gvisor", sandboxClass: "gvisor", expected: "NAMESPACE   POOL      CLASS    POD     STATUS     ASSIGNED ACTOR\n" +
+			"ns-1        other     gvisor   pod-2   FREE       <none>\n" +
+			"ns-2        counter   gvisor   pod-3   ASSIGNED   ns-2/counter/space-b/actor-b\n"},
 		{name: "combined", namespace: "ns-1", selector: "ate.dev/worker-pool=counter", expected: header + row1},
 	}
 
@@ -85,6 +91,7 @@ func TestGetWorkersRunner_Filters(t *testing.T) {
 				namespace:    test.namespace,
 				atespace:     test.atespace,
 				selector:     test.selector,
+				sandboxClass: test.sandboxClass,
 				outputFmt:    "table",
 				out:          &buf,
 			}

--- a/cmd/kubectl-ate/internal/cmd/top_workers.go
+++ b/cmd/kubectl-ate/internal/cmd/top_workers.go
@@ -34,6 +34,7 @@ var (
 	topWorkerNamespaceFlag string
 	topWorkerAtespaceFlag  string
 	topWorkerSelectorFlag  string
+	topWorkerClassFlag     string
 )
 
 var topWorkersCmd = &cobra.Command{
@@ -48,6 +49,7 @@ func init() {
 	topWorkersCmd.Flags().StringVarP(&topWorkerNamespaceFlag, "namespace", "n", "", "Scope output to a specific Kubernetes namespace")
 	topWorkersCmd.Flags().StringVarP(&topWorkerAtespaceFlag, "atespace", "a", "", "Filter worker pods hosting actors in a specific atespace")
 	topWorkersCmd.Flags().StringVarP(&topWorkerSelectorFlag, "selector", "l", "", "Filter by worker pool labels")
+	topWorkersCmd.Flags().StringVar(&topWorkerClassFlag, "sandbox-class", "", "Filter by sandbox class (e.g. gvisor, microvm)")
 	topCmd.AddCommand(topWorkersCmd)
 }
 
@@ -75,6 +77,7 @@ type TopWorkersRunner struct {
 	namespace        string
 	atespace         string
 	selector         string
+	sandboxClass     string
 	outputFmt        string
 	out              io.Writer
 }
@@ -84,7 +87,7 @@ func (r *TopWorkersRunner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	filtered, err := filterWorkers(allWorkers, r.namespace, r.atespace, r.selector)
+	filtered, err := filterWorkers(allWorkers, r.namespace, r.atespace, r.selector, r.sandboxClass)
 	if err != nil {
 		return err
 	}
@@ -210,6 +213,7 @@ func runTopWorkers(cmd *cobra.Command, args []string) error {
 		namespace:        topWorkerNamespaceFlag,
 		atespace:         topWorkerAtespaceFlag,
 		selector:         topWorkerSelectorFlag,
+		sandboxClass:     topWorkerClassFlag,
 		outputFmt:        outputFmt,
 		out:              os.Stdout,
 	}

--- a/cmd/kubectl-ate/internal/cmd/top_workers.go
+++ b/cmd/kubectl-ate/internal/cmd/top_workers.go
@@ -143,6 +143,7 @@ func (r *TopWorkersRunner) Run(ctx context.Context) error {
 		items = append(items, &printer.WorkerTopItem{
 			Pod:           podName,
 			Pool:          pool,
+			Class:         w.GetSandboxClass(),
 			Status:        status,
 			AssignedActor: assignedActor,
 			CPU:           cpuStr,

--- a/cmd/kubectl-ate/internal/cmd/top_workers_test.go
+++ b/cmd/kubectl-ate/internal/cmd/top_workers_test.go
@@ -59,6 +59,7 @@ func TestTopWorkersRunner_Success(t *testing.T) {
 			WorkerNamespace: "ate-demo-counter",
 			WorkerPool:      "counter",
 			WorkerPod:       "counter-worker-pool-7b9f8-x123",
+			SandboxClass:    "gvisor",
 			Assignment: &ateapipb.Assignment{
 				Actor: &ateapipb.ObjectRef{
 					Atespace: "ate-demo-counter",
@@ -71,6 +72,7 @@ func TestTopWorkersRunner_Success(t *testing.T) {
 			WorkerNamespace: "ate-demo-counter",
 			WorkerPool:      "counter",
 			WorkerPod:       "counter-worker-pool-7b9f8-y456",
+			SandboxClass:    "microvm",
 			Labels:          map[string]string{"ate.dev/worker-pool": "counter"},
 		},
 	}
@@ -120,9 +122,9 @@ func TestTopWorkersRunner_Success(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	expected := `NAME                             POOL      STATUS     ASSIGNED ACTOR                  CPU(CORES)   MEMORY(bytes)
-counter-worker-pool-7b9f8-x123   counter   ASSIGNED   ate-demo-counter/my-counter-1   342m         412Mi
-counter-worker-pool-7b9f8-y456   counter   FREE       <none>                          2m           64Mi
+	expected := `NAME                             POOL      CLASS     STATUS     ASSIGNED ACTOR                  CPU(CORES)   MEMORY(bytes)
+counter-worker-pool-7b9f8-x123   counter   gvisor    ASSIGNED   ate-demo-counter/my-counter-1   342m         412Mi
+counter-worker-pool-7b9f8-y456   counter   microvm   FREE       <none>                          2m           64Mi
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -135,6 +137,7 @@ func TestTopWorkersRunner_FilterNamespace(t *testing.T) {
 			WorkerNamespace: "ns-1",
 			WorkerPool:      "pool-1",
 			WorkerPod:       "pod-1",
+			SandboxClass:    "gvisor",
 		},
 		{
 			WorkerNamespace: "ns-2",
@@ -156,8 +159,8 @@ func TestTopWorkersRunner_FilterNamespace(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	expected := `NAME    POOL     STATUS   ASSIGNED ACTOR   CPU(CORES)            MEMORY(bytes)
-pod-1   pool-1   FREE     <none>           metrics unavailable   metrics unavailable
+	expected := `NAME    POOL     CLASS    STATUS   ASSIGNED ACTOR   CPU(CORES)            MEMORY(bytes)
+pod-1   pool-1   gvisor   FREE     <none>           metrics unavailable   metrics unavailable
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -170,6 +173,7 @@ func TestTopWorkersRunner_FilterAtespace(t *testing.T) {
 			WorkerNamespace: "ns-1",
 			WorkerPool:      "pool-1",
 			WorkerPod:       "pod-1",
+			SandboxClass:    "microvm",
 			Assignment: &ateapipb.Assignment{
 				Actor: &ateapipb.ObjectRef{Atespace: "space-a", Name: "actor-a"},
 			},
@@ -197,8 +201,8 @@ func TestTopWorkersRunner_FilterAtespace(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	expected := `NAME    POOL     STATUS     ASSIGNED ACTOR    CPU(CORES)            MEMORY(bytes)
-pod-1   pool-1   ASSIGNED   space-a/actor-a   metrics unavailable   metrics unavailable
+	expected := `NAME    POOL     CLASS     STATUS     ASSIGNED ACTOR    CPU(CORES)            MEMORY(bytes)
+pod-1   pool-1   microvm   ASSIGNED   space-a/actor-a   metrics unavailable   metrics unavailable
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -211,6 +215,7 @@ func TestTopWorkersRunner_FilterSelector(t *testing.T) {
 			WorkerNamespace: "ns-1",
 			WorkerPool:      "counter",
 			WorkerPod:       "pod-1",
+			SandboxClass:    "gvisor",
 			Labels:          map[string]string{"ate.dev/worker-pool": "counter"},
 		},
 		{
@@ -234,8 +239,8 @@ func TestTopWorkersRunner_FilterSelector(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	expected := `NAME    POOL      STATUS   ASSIGNED ACTOR   CPU(CORES)            MEMORY(bytes)
-pod-1   counter   FREE     <none>           metrics unavailable   metrics unavailable
+	expected := `NAME    POOL      CLASS    STATUS   ASSIGNED ACTOR   CPU(CORES)            MEMORY(bytes)
+pod-1   counter   gvisor   FREE     <none>           metrics unavailable   metrics unavailable
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -263,8 +268,8 @@ func TestTopWorkersRunner_MetricsUnavailable(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	expected := `NAME    POOL     STATUS   ASSIGNED ACTOR   CPU(CORES)            MEMORY(bytes)
-pod-1   pool-1   FREE     <none>           metrics unavailable   metrics unavailable
+	expected := `NAME    POOL     CLASS   STATUS   ASSIGNED ACTOR   CPU(CORES)            MEMORY(bytes)
+pod-1   pool-1           FREE     <none>           metrics unavailable   metrics unavailable
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)

--- a/cmd/kubectl-ate/internal/cmd/workers.go
+++ b/cmd/kubectl-ate/internal/cmd/workers.go
@@ -50,9 +50,9 @@ func listAllWorkers(ctx context.Context, lister WorkerLister) ([]*ateapipb.Worke
 }
 
 // filterWorkers filters workers by Kubernetes namespace, assigned-actor
-// atespace, and worker pool label selector. Empty values match everything;
-// an atespace filter only matches workers with an assigned actor.
-func filterWorkers(workers []*ateapipb.Worker, namespace, atespace, selector string) ([]*ateapipb.Worker, error) {
+// atespace, worker pool label selector, and sandbox class. Empty values match
+// everything; an atespace filter only matches workers with an assigned actor.
+func filterWorkers(workers []*ateapipb.Worker, namespace, atespace, selector, sandboxClass string) ([]*ateapipb.Worker, error) {
 	var labelSel labels.Selector
 	if selector != "" {
 		var err error
@@ -71,6 +71,9 @@ func filterWorkers(workers []*ateapipb.Worker, namespace, atespace, selector str
 			continue
 		}
 		if labelSel != nil && !labelSel.Matches(labels.Set(w.GetLabels())) {
+			continue
+		}
+		if sandboxClass != "" && w.GetSandboxClass() != sandboxClass {
 			continue
 		}
 		filtered = append(filtered, w)

--- a/cmd/kubectl-ate/internal/printer/printer.go
+++ b/cmd/kubectl-ate/internal/printer/printer.go
@@ -118,10 +118,11 @@ func PrintWorkersTo(out io.Writer, workers []*ateapipb.Worker, format string) er
 		return printProto(out, &ateapipb.ListWorkersResponse{Workers: workers}, format)
 	case "table":
 		w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
-		fmt.Fprintln(w, "NAMESPACE\tPOOL\tPOD\tSTATUS\tASSIGNED ACTOR")
+		fmt.Fprintln(w, "NAMESPACE\tPOOL\tCLASS\tPOD\tSTATUS\tASSIGNED ACTOR")
 		for _, worker := range workers {
 			ns := worker.GetWorkerNamespace()
 			pool := worker.GetWorkerPool()
+			class := worker.GetSandboxClass()
 			pod := worker.GetWorkerPod()
 
 			status := "FREE"
@@ -132,7 +133,7 @@ func PrintWorkersTo(out io.Writer, workers []*ateapipb.Worker, format string) er
 					wass.ActorTemplate.Namespace, wass.ActorTemplate.Name, wass.Actor.Atespace, wass.Actor.Name)
 			}
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ns, pool, pod, status, assignedActor)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", ns, pool, class, pod, status, assignedActor)
 		}
 		return w.Flush()
 	default:
@@ -144,6 +145,7 @@ func PrintWorkersTo(out io.Writer, workers []*ateapipb.Worker, format string) er
 type WorkerTopItem struct {
 	Pod           string `json:"pod" yaml:"pod"`
 	Pool          string `json:"pool" yaml:"pool"`
+	Class         string `json:"class,omitempty" yaml:"class,omitempty"`
 	Status        string `json:"status" yaml:"status"`
 	AssignedActor string `json:"assignedActor" yaml:"assignedActor"`
 	CPU           string `json:"cpu" yaml:"cpu"`
@@ -191,10 +193,10 @@ func PrintWorkerTopTo(out io.Writer, items []*WorkerTopItem, format string) erro
 // PrintWorkerTopTable prints worker top items as a formatted table.
 func PrintWorkerTopTable(out io.Writer, items []*WorkerTopItem) error {
 	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "NAME\tPOOL\tSTATUS\tASSIGNED ACTOR\tCPU(CORES)\tMEMORY(bytes)")
+	fmt.Fprintln(w, "NAME\tPOOL\tCLASS\tSTATUS\tASSIGNED ACTOR\tCPU(CORES)\tMEMORY(bytes)")
 	for _, item := range items {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			item.Pod, item.Pool, item.Status, item.AssignedActor, item.CPU, item.Memory)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			item.Pod, item.Pool, item.Class, item.Status, item.AssignedActor, item.CPU, item.Memory)
 	}
 	return w.Flush()
 }

--- a/cmd/kubectl-ate/internal/printer/printer_test.go
+++ b/cmd/kubectl-ate/internal/printer/printer_test.go
@@ -210,6 +210,7 @@ func TestPrintWorkersTo_Table(t *testing.T) {
 			WorkerNamespace: "default",
 			WorkerPool:      "pool-1",
 			WorkerPod:       "pod-1",
+			SandboxClass:    "gvisor",
 			Assignment: &ateapipb.Assignment{
 				ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
 					Namespace: "default",
@@ -228,8 +229,8 @@ func TestPrintWorkersTo_Table(t *testing.T) {
 	}
 	output := buf.String()
 
-	expected := `NAMESPACE   POOL     POD     STATUS     ASSIGNED ACTOR
-default     pool-1   pod-1   ASSIGNED   default/template-1/space-1/id-1
+	expected := `NAMESPACE   POOL     CLASS    POD     STATUS     ASSIGNED ACTOR
+default     pool-1   gvisor   pod-1   ASSIGNED   default/template-1/space-1/id-1
 `
 	if diff := cmp.Diff(expected, output); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -251,8 +252,8 @@ func TestPrintWorkersTo_Table_Free(t *testing.T) {
 	}
 	output := buf.String()
 
-	expected := `NAMESPACE   POOL     POD     STATUS   ASSIGNED ACTOR
-default     pool-1   pod-1   FREE     <none>
+	expected := `NAMESPACE   POOL     CLASS   POD     STATUS   ASSIGNED ACTOR
+default     pool-1           pod-1   FREE     <none>
 `
 	if diff := cmp.Diff(expected, output); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -283,10 +284,10 @@ func TestPrintWorkersTo_Table_Sorted(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := `NAMESPACE   POOL     POD     STATUS   ASSIGNED ACTOR
-default     pool-1   pod-a   FREE     <none>
-default     pool-1   pod-z   FREE     <none>
-other       pool-2   pod-1   FREE     <none>
+	expected := `NAMESPACE   POOL     CLASS   POD     STATUS   ASSIGNED ACTOR
+default     pool-1           pod-a   FREE     <none>
+default     pool-1           pod-z   FREE     <none>
+other       pool-2           pod-1   FREE     <none>
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -408,6 +409,7 @@ func TestPrintWorkerTopTo_Table(t *testing.T) {
 		{
 			Pod:           "counter-worker-pool-7b9f8-x123",
 			Pool:          "counter",
+			Class:         "gvisor",
 			Status:        "ASSIGNED",
 			AssignedActor: "default/counter-template/ate-demo-counter/my-counter-1",
 			CPU:           "342m",
@@ -417,6 +419,7 @@ func TestPrintWorkerTopTo_Table(t *testing.T) {
 		{
 			Pod:           "counter-worker-pool-7b9f8-y456",
 			Pool:          "counter",
+			Class:         "microvm",
 			Status:        "FREE",
 			AssignedActor: "<none>",
 			CPU:           "2m",
@@ -430,9 +433,9 @@ func TestPrintWorkerTopTo_Table(t *testing.T) {
 	}
 	output := buf.String()
 
-	expected := `NAME                             POOL      STATUS     ASSIGNED ACTOR                                           CPU(CORES)   MEMORY(bytes)
-counter-worker-pool-7b9f8-x123   counter   ASSIGNED   default/counter-template/ate-demo-counter/my-counter-1   342m         412Mi
-counter-worker-pool-7b9f8-y456   counter   FREE       <none>                                                   2m           64Mi
+	expected := `NAME                             POOL      CLASS     STATUS     ASSIGNED ACTOR                                           CPU(CORES)   MEMORY(bytes)
+counter-worker-pool-7b9f8-x123   counter   gvisor    ASSIGNED   default/counter-template/ate-demo-counter/my-counter-1   342m         412Mi
+counter-worker-pool-7b9f8-y456   counter   microvm   FREE       <none>                                                   2m           64Mi
 `
 	if diff := cmp.Diff(expected, output); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Adds a `CLASS` column (`gvisor` | `microvm`) and a `--sandbox-class` filter to `kubectl ate get workers` and `kubectl ate top workers`.

## Why

Nothing user-facing distinguishes worker sandbox classes today, and `top workers` is where that silence actively misleads: its CPU/MEMORY columns come from metrics-server, i.e. the **host-side worker pod**. A gVisor worker's pod usage roughly tracks its workload, but a micro-VM worker's memory reflects the guest's RAM (demand-paged toward a fixed allocation) rather than the workload — on a mixed-class cluster the table invites comparing numbers that are not comparable. This is the same source-comparability caveat `ateompb.StatsSource` documents for workload-side samples.

`ate.sandbox.class` is already one of the sanctioned low-cardinality metric-label keys in `internal/ateattr`, so this surfaces an established dimension rather than inventing one.

## What

- `printer.WorkerTopItem` gains `Class` (`json:"class,omitempty"`); both table printers gain a `CLASS` column after `POOL`.
- `top workers` populates it from `Worker.GetSandboxClass()` — the field is already on the `ListWorkers` response (`ateapi.proto` field 9), so there is **no server, proto, or RPC change**.
- `--sandbox-class` filters both commands, alongside the existing `-n` / `-a` / `-l` filters (shared `filterWorkers`).
- Column renders empty against a server that predates `sandbox_class`; pinned by the free-worker and metrics-unavailable test cases.

## Sample output

Against a dev cluster running one gVisor pool and one micro-VM pool (nested-virt GKE node pool), with one actor resumed onto a micro-VM worker:

```console
$ kubectl ate top workers
NAME                               POOL              CLASS     STATUS     ASSIGNED ACTOR                                               CPU(CORES)   MEMORY(bytes)
counter-5f74698959-6qnqk           counter           gvisor    FREE       <none>                                                       1m           6Mi
counter-5f74698959-fcw6j           counter           gvisor    FREE       <none>                                                       1m           7Mi
counter-5f74698959-hd6px           counter           gvisor    FREE       <none>                                                       1m           6Mi
counter-5f74698959-ptlrt           counter           gvisor    FREE       <none>                                                       1m           5Mi
counter-5f74698959-pzrqs           counter           gvisor    FREE       <none>                                                       1m           6Mi
counter-microvm-7c5f74d879-6mdxs   counter-microvm   microvm   FREE       <none>                                                       1m           6Mi
counter-microvm-7c5f74d879-z9qds   counter-microvm   microvm   ASSIGNED   ate-demo-counter-microvm/counter-microvm/demo/my-counter-1   5m           45Mi

$ kubectl ate top workers --sandbox-class=microvm
NAME                               POOL              CLASS     STATUS     ASSIGNED ACTOR                                               CPU(CORES)   MEMORY(bytes)
counter-microvm-7c5f74d879-6mdxs   counter-microvm   microvm   FREE       <none>                                                       1m           6Mi
counter-microvm-7c5f74d879-z9qds   counter-microvm   microvm   ASSIGNED   ate-demo-counter-microvm/counter-microvm/demo/my-counter-1   4m           45Mi
```

(The FREE micro-VM workers sit at ~6Mi because the VM only exists once a workload boots; the assigned worker's memory grows with the guest's touched pages.)

## Testing

- `go test ./cmd/kubectl-ate/...` — table expectations updated for both commands and the printer, including empty-class rendering and `--sandbox-class` filter cases for each command.
- Output above is from a live GKE cluster.
