### PR TITLE
Fix benchmarking auth bitrot; add microvm

### DIFF
--- a/benchmarking/automation/manifests/runner-job.yaml.tmpl
+++ b/benchmarking/automation/manifests/runner-job.yaml.tmpl
@@ -30,7 +30,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: benchmarking-permissions
+  name: automated-benchmarking-permissions
   namespace: ate-system
 subjects:
 - kind: ServiceAccount

--- a/benchmarking/automation/manifests/runner-job.yaml.tmpl
+++ b/benchmarking/automation/manifests/runner-job.yaml.tmpl
@@ -27,6 +27,20 @@ metadata:
   name: benchmark-runner
   namespace: benchmarking
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: benchmarking-permissions
+  namespace: ate-system
+subjects:
+- kind: ServiceAccount
+  name: benchmark-runner
+  namespace: benchmarking
+roleRef:
+  kind: Role
+  name: atelet-endpointslices
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/benchmarking/deploy_locust.sh
+++ b/benchmarking/deploy_locust.sh
@@ -18,7 +18,7 @@
 #   --deploy:  workloads/deploy.sh --deploy -> locust/build_and_push.sh -> locust/deploy.sh --deploy
 #   --delete:  locust/deploy.sh --delete -> workloads/deploy.sh --delete (reverse order)
 #
-# Worker count is forwarded to workloads/deploy.sh.
+# Worker count and sandbox class are forwarded to workloads/deploy.sh.
 
 set -o errexit -o nounset -o pipefail
 
@@ -26,17 +26,20 @@ ROOT="$(git rev-parse --show-toplevel)"
 BENCHMARKING_DIR="${ROOT}/benchmarking"
 
 WORKER_COUNT=1
+SANDBOX_CLASS=gvisor
 SKIP_BUILD=0
 
 usage() {
   echo "Usage: $0 [options]"
   echo ""
   echo "Options:"
-  echo "  --deploy             Deploy workloads, build/push locust image, then deploy locust"
-  echo "  --delete             Delete locust and then workloads"
-  echo "  --worker-count N     Number of WorkerPool replicas (default: 1)"
-  echo "  --skip-build         Skip locust image build/push (use the existing :latest image)"
-  echo "  -h|--help            Show this help message"
+  echo "  --deploy                Deploy workloads, build/push locust image, then deploy locust"
+  echo "  --delete                Delete locust and then workloads"
+  echo "  --worker-count N        Number of WorkerPool replicas (default: 1)"
+  echo "  --sandbox-class CLASS   Sandbox runtime for the WorkerPool: gvisor | microvm (default: gvisor)."
+  echo "                          microvm requires hack/install-microvm-deps.sh --install to have run."
+  echo "  --skip-build            Skip locust image build/push (use the existing :latest image)"
+  echo "  -h|--help               Show this help message"
   echo ""
   echo "Environment:"
   echo "  PROJECT_ID, BUCKET_NAME, etc. are read from .ate-dev-env.sh by the"
@@ -55,6 +58,8 @@ while [[ "$#" -gt 0 ]]; do
     --delete) action="delete" ;;
     --worker-count) shift; WORKER_COUNT="$1" ;;
     --worker-count=*) WORKER_COUNT="${1#*=}" ;;
+    --sandbox-class) shift; SANDBOX_CLASS="$1" ;;
+    --sandbox-class=*) SANDBOX_CLASS="${1#*=}" ;;
     --skip-build) SKIP_BUILD=1 ;;
     -h|--help) usage; exit 0 ;;
     *)
@@ -66,9 +71,20 @@ while [[ "$#" -gt 0 ]]; do
   shift
 done
 
+case "${SANDBOX_CLASS}" in
+  gvisor|microvm) ;;
+  *)
+    echo "Error: --sandbox-class must be gvisor or microvm, got '${SANDBOX_CLASS}'" >&2
+    exit 1
+    ;;
+esac
+
 if [[ "${action}" == "deploy" ]]; then
-  echo "=== Deploying benchmark workloads (worker_count=${WORKER_COUNT}) ==="
-  "${BENCHMARKING_DIR}/workloads/deploy.sh" --deploy --worker-count "${WORKER_COUNT}"
+  echo "=== Deploying benchmark workloads (worker_count=${WORKER_COUNT}, sandbox_class=${SANDBOX_CLASS}) ==="
+  "${BENCHMARKING_DIR}/workloads/deploy.sh" \
+    --deploy \
+    --worker-count "${WORKER_COUNT}" \
+    --sandbox-class "${SANDBOX_CLASS}"
 
   if [[ "${SKIP_BUILD}" -eq 0 ]]; then
     echo

--- a/benchmarking/locust/manifests/locust.yaml
+++ b/benchmarking/locust/manifests/locust.yaml
@@ -55,7 +55,6 @@ spec:
         - "/app/tests/glutton.py"
         - "--master"
         - "--master-bind-host=0.0.0.0"
-        - "--class-picker"
         env:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317

--- a/benchmarking/locust/manifests/locust.yaml
+++ b/benchmarking/locust/manifests/locust.yaml
@@ -52,7 +52,7 @@ spec:
         - "-m"
         - "locust"
         - "-f"
-        - "/app/tests"
+        - "/app/tests/glutton.py"
         - "--master"
         - "--master-bind-host=0.0.0.0"
         - "--class-picker"
@@ -73,39 +73,8 @@ spec:
         - name: servicedns-ca
           mountPath: /run/servicedns-ca
           readOnly: true
-        - name: podidentity
-          mountPath: /run/podidentity.podcert.ate.dev
-          readOnly: true
-        resources:
-          requests:
-            cpu: "500m"
-            memory: "512Mi"
-
-      - name: locust-python-worker
-        image: us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest
-        imagePullPolicy: Always
-        args:
-        - "-m"
-        - "locust"
-        - "-f"
-        - "/app/tests"
-        - "--worker"
-        # Literal IPv4, not "localhost". The master binds 0.0.0.0:5557, which
-        # is IPv4-only; locust sets ZMQ_IPV6 on the worker socket whenever the
-        # master host resolves to anything AF_INET6, and the pod's /etc/hosts
-        # maps localhost to ::1 as well as 127.0.0.1. The worker would then
-        # dial [::1]:5557 and retry forever against a silent master.
-        - "--master-host=127.0.0.1"
-        env:
-        - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
-        # Skips the GluttonUser stub declaration so the master never assigns
-        # GluttonUser spawns to this worker — boomer owns that class.
-        - name: LOCUST_NO_GLUTTON_USER
-          value: "1"
-        volumeMounts:
-        - name: servicedns-ca
-          mountPath: /run/servicedns-ca
+        - name: ateapi-token
+          mountPath: /run/ateapi-token
           readOnly: true
         - name: podidentity
           mountPath: /run/podidentity.podcert.ate.dev
@@ -114,6 +83,43 @@ spec:
           requests:
             cpu: "500m"
             memory: "512Mi"
+      # Python and boomer workers do not play nicely together, leaving this in for reference.
+      # - name: locust-python-worker
+      #   image: us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest
+      #   imagePullPolicy: Always
+      #   args:
+      #   - "-m"
+      #   - "locust"
+      #   - "-f"
+      #   - "/app/tests"
+      #   - "--worker"
+      #   # Literal IPv4, not "localhost". The master binds 0.0.0.0:5557, which
+      #   # is IPv4-only; locust sets ZMQ_IPV6 on the worker socket whenever the
+      #   # master host resolves to anything AF_INET6, and the pod's /etc/hosts
+      #   # maps localhost to ::1 as well as 127.0.0.1. The worker would then
+      #   # dial [::1]:5557 and retry forever against a silent master.
+      #   - "--master-host=127.0.0.1"
+      #   env:
+      #   - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      #     value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
+      #   # Skips the GluttonUser stub declaration so the master never assigns
+      #   # GluttonUser spawns to this worker — boomer owns that class.
+      #   - name: LOCUST_NO_GLUTTON_USER
+      #     value: "1"
+      #   volumeMounts:
+      #   - name: servicedns-ca
+      #     mountPath: /run/servicedns-ca
+      #     readOnly: true
+      #   - name: ateapi-token
+      #     mountPath: /run/ateapi-token
+      #     readOnly: true
+      #   - name: podidentity
+      #     mountPath: /run/podidentity.podcert.ate.dev
+      #     readOnly: true
+      #   resources:
+      #     requests:
+      #       cpu: "500m"
+      #       memory: "512Mi"
 
       - name: boomer-glutton
         # Same image as the master/worker — the boomer-glutton Go binary is
@@ -140,6 +146,9 @@ spec:
         - name: servicedns-ca
           mountPath: /run/servicedns-ca
           readOnly: true
+        - name: ateapi-token
+          mountPath: /run/ateapi-token
+          readOnly: true
         - name: podidentity
           mountPath: /run/podidentity.podcert.ate.dev
           readOnly: true
@@ -158,6 +167,13 @@ spec:
                 matchLabels:
                   podcert.ate.dev/canarying: live
               path: ca.crt
+      - name: ateapi-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: api.ate-system.svc
+              expirationSeconds: 3600
+              path: token
       # The benchmark's own client identity, presented to ateapi. Its
       # interceptor rejects calls carrying no credential, taking identity from
       # an mTLS client cert or, failing that, a Bearer token. Use the cert:
@@ -193,3 +209,17 @@ spec:
     protocol: TCP
     port: 8001
     targetPort: 8001
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: benchmarking-permissions
+  namespace: ate-system
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: benchmarking
+roleRef:
+  kind: Role
+  name: atelet-endpointslices
+  apiGroup: rbac.authorization.k8s.io

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -90,6 +90,8 @@ function usage() {
   echo "  --deploy-benchmarks                    Deploy workloads + locust load test stack"
   echo "  --delete-benchmarks                    Delete the locust stack and workloads"
   echo "  --benchmark-worker-count N             Number of WorkerPool replicas (default: 1)"
+  echo "  --benchmark-sandbox-class CLASS        Sandbox runtime for the benchmark WorkerPool: gvisor | microvm (default: gvisor)."
+  echo "                                         microvm requires hack/install-microvm-deps.sh --install to have run."
   echo ""
   for demo_name in "${ATE_DEMOS[@]}"; do
     echo "Demo: ${demo_name}"
@@ -638,13 +640,26 @@ delete_atenet() {
 }
 
 deploy_benchmarks() {
-  log_step "deploy_benchmarks (worker_count=${BENCHMARK_WORKER_COUNT})"
-  "${ROOT}/benchmarking/deploy_locust.sh" --deploy --worker-count "${BENCHMARK_WORKER_COUNT}"
+  log_step "deploy_benchmarks (worker_count=${BENCHMARK_WORKER_COUNT}, sandbox_class=${BENCHMARK_SANDBOX_CLASS})"
+  # The microvm SandboxConfig lives outside --deploy-ate-system's default set
+  # (which only installs gvisor-default); the workloads deploy references it
+  # by name and would fail if we skipped this.
+  if [[ "${BENCHMARK_SANDBOX_CLASS}" == "microvm" ]]; then
+    "${ROOT}/hack/install-microvm-deps.sh" --install
+  fi
+  "${ROOT}/benchmarking/deploy_locust.sh" \
+    --deploy \
+    --worker-count "${BENCHMARK_WORKER_COUNT}" \
+    --sandbox-class "${BENCHMARK_SANDBOX_CLASS}"
 }
 
 delete_benchmarks() {
-  log_step "delete_benchmarks"
+  log_step "delete_benchmarks (sandbox_class=${BENCHMARK_SANDBOX_CLASS})"
   "${ROOT}/benchmarking/deploy_locust.sh" --delete
+  # only tear down the microvm SandboxConfig if the caller opted into microvm.
+  if [[ "${BENCHMARK_SANDBOX_CLASS}" == "microvm" ]]; then
+    "${ROOT}/hack/install-microvm-deps.sh" --delete
+  fi
 }
 
 delete_all() {
@@ -678,6 +693,7 @@ done
 # treats them as no-ops since the value is already captured here.
 SETUP_CSI=false
 BENCHMARK_WORKER_COUNT=1
+BENCHMARK_SANDBOX_CLASS=gvisor
 prescan_args=("$@")
 for ((i = 0; i < ${#prescan_args[@]}; i++)); do
   case "${prescan_args[i]}" in
@@ -703,12 +719,29 @@ for ((i = 0; i < ${#prescan_args[@]}; i++)); do
     --benchmark-worker-count=*)
       BENCHMARK_WORKER_COUNT="${prescan_args[i]#*=}"
       ;;
+    --benchmark-sandbox-class)
+      if (( i + 1 >= ${#prescan_args[@]} )); then
+        echo "Error: --benchmark-sandbox-class requires gvisor or microvm" >&2
+        exit 1
+      fi
+      BENCHMARK_SANDBOX_CLASS="${prescan_args[$((i + 1))]}"
+      ;;
+    --benchmark-sandbox-class=*)
+      BENCHMARK_SANDBOX_CLASS="${prescan_args[i]#*=}"
+      ;;
     --setup-csi)
       SETUP_CSI=true
       ;;
   esac
 done
 atenet_router >/dev/null
+case "${BENCHMARK_SANDBOX_CLASS}" in
+  gvisor|microvm) ;;
+  *)
+    echo "Error: --benchmark-sandbox-class must be gvisor or microvm, got '${BENCHMARK_SANDBOX_CLASS}'" >&2
+    exit 1
+    ;;
+esac
 
 while [[ "$#" -gt 0 ]]; do
   # Run ${demo}_cmdline if it exists. If it returns 0, then we successfully
@@ -767,6 +800,8 @@ while [[ "$#" -gt 0 ]]; do
     # dispatch loop's `*)` unknown-option branch doesn't reject it.
     --benchmark-worker-count) shift ;;
     --benchmark-worker-count=*) ;;
+    --benchmark-sandbox-class) shift ;;
+    --benchmark-sandbox-class=*) ;;
 
     --create-jwt-authority-pool-secret) create_jwt_authority_pool_secret ;;
     --create-actor-id-ca-pool-secret) create_actor_id_ca_pool_secret ;;


### PR DESCRIPTION
Benchmarking needed updates to fix auth bitrot and to enable readint endpointslices. Also streamlined the ability to manually benchmark microvm and removed Python Locust workers by default to simplify self-serve benchmarking.

