### PR TITLE
atecontroller: reclaim golden actor on ActorTemplate delete

### DIFF
--- a/cmd/atecontroller/internal/controllers/actortemplate_controller.go
+++ b/cmd/atecontroller/internal/controllers/actortemplate_controller.go
@@ -30,10 +30,23 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
 	GoldenSnapshotCreationReason = "GoldenSnapshotCreation"
+
+	// goldenActorFinalizer gates ActorTemplate deletion on reclaiming the
+	// underlying golden actor (and its snapshot). Without it, deleting an
+	// ActorTemplate orphans the golden actor in substrate's store and its
+	// snapshot blobs in object storage, with no path to reach them again once
+	// status.GoldenActorID is gone with the CR.
+	goldenActorFinalizer = "ate.dev/golden-actor-cleanup"
+
+	// goldenActorDeleteRetry is the requeue delay used while waiting for a
+	// still-running golden actor to reach a deletable (suspended) state during
+	// finalization.
+	goldenActorDeleteRetry = 5 * time.Second
 
 	// goldenSnapshotWarmup is the default wall-clock delay between resuming
 	// the golden actor and taking its snapshot, used as a coarse "give the
@@ -73,8 +86,34 @@ func (r *ActorTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to get actor template %q: %w", req.NamespacedName, err)
 	}
 
-	// Handle deletion
+	// Handle deletion: run golden-actor cleanup while the finalizer is held,
+	// then release it so the CR can be garbage-collected.
 	if !at.GetDeletionTimestamp().IsZero() {
+		if !controllerutil.ContainsFinalizer(at, goldenActorFinalizer) {
+			return ctrl.Result{}, nil
+		}
+		requeue, err := r.cleanupGoldenActor(ctx, at)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if requeue {
+			// Golden actor was not yet deletable (e.g. still running); it has
+			// been asked to suspend. Retry the delete on the next pass.
+			return ctrl.Result{RequeueAfter: goldenActorDeleteRetry}, nil
+		}
+		controllerutil.RemoveFinalizer(at, goldenActorFinalizer)
+		if err := r.Update(ctx, at); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure the cleanup finalizer is present before any golden actor exists,
+	// so a delete that races template setup still triggers reclamation.
+	if controllerutil.AddFinalizer(at, goldenActorFinalizer) {
+		if err := r.Update(ctx, at); err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -185,6 +224,43 @@ func (r *ActorTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	default:
 		return ctrl.Result{}, fmt.Errorf("unrecognized phase %q", at.Status.Phase)
+	}
+}
+
+// cleanupGoldenActor reclaims the golden actor backing a deleted ActorTemplate.
+// It returns requeue=true when the actor could not be deleted yet because it is
+// not in a deletable state (DeleteActor requires SUSPENDED/CRASHED); in that
+// case it asks the actor to suspend and the caller retries. Deletion is
+// idempotent: a golden actor that was never created or is already gone is
+// treated as success.
+func (r *ActorTemplateReconciler) cleanupGoldenActor(ctx context.Context, at *atev1alpha1.ActorTemplate) (requeue bool, err error) {
+	actorName := at.Status.GoldenActorID
+	if actorName == "" {
+		// The golden actor was never created (template deleted before the first
+		// reconcile persisted GoldenActorID) — nothing to reclaim.
+		return false, nil
+	}
+
+	ref := &ateapipb.ObjectRef{Atespace: resources.GoldenActorAtespace, Name: actorName}
+
+	_, err = r.AteClient.DeleteActor(ctx, &ateapipb.DeleteActorRequest{Actor: ref})
+	if err == nil {
+		return false, nil
+	}
+	switch status.Code(err) {
+	case codes.NotFound:
+		// Already reclaimed — idempotent success.
+		return false, nil
+	case codes.FailedPrecondition:
+		// The golden actor is not in a deletable status (typically still
+		// running, e.g. the template was deleted mid-lifecycle). Suspend it so
+		// a subsequent pass can delete it.
+		if _, serr := r.AteClient.SuspendActor(ctx, &ateapipb.SuspendActorRequest{Actor: ref}); serr != nil {
+			return false, fmt.Errorf("while suspending golden actor %q for deletion: %w", actorName, serr)
+		}
+		return true, nil
+	default:
+		return false, fmt.Errorf("while deleting golden actor %q: %w", actorName, err)
 	}
 }
 

--- a/cmd/atecontroller/internal/controllers/actortemplate_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/actortemplate_controller_test.go
@@ -98,6 +98,8 @@ type mockControlClient struct {
 	ateapipb.ControlClient
 	createAtespaceFn func(ctx context.Context, req *ateapipb.CreateAtespaceRequest, opts ...grpc.CallOption) (*ateapipb.Atespace, error)
 	createActorFn    func(ctx context.Context, req *ateapipb.CreateActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error)
+	deleteActorFn    func(ctx context.Context, req *ateapipb.DeleteActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error)
+	suspendActorFn   func(ctx context.Context, req *ateapipb.SuspendActorRequest, opts ...grpc.CallOption) (*ateapipb.SuspendActorResponse, error)
 }
 
 func (m *mockControlClient) CreateAtespace(ctx context.Context, req *ateapipb.CreateAtespaceRequest, opts ...grpc.CallOption) (*ateapipb.Atespace, error) {
@@ -114,6 +116,20 @@ func (m *mockControlClient) CreateActor(ctx context.Context, req *ateapipb.Creat
 	return &ateapipb.Actor{}, nil
 }
 
+func (m *mockControlClient) DeleteActor(ctx context.Context, req *ateapipb.DeleteActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
+	if m.deleteActorFn != nil {
+		return m.deleteActorFn(ctx, req, opts...)
+	}
+	return &ateapipb.Actor{}, nil
+}
+
+func (m *mockControlClient) SuspendActor(ctx context.Context, req *ateapipb.SuspendActorRequest, opts ...grpc.CallOption) (*ateapipb.SuspendActorResponse, error) {
+	if m.suspendActorFn != nil {
+		return m.suspendActorFn(ctx, req, opts...)
+	}
+	return &ateapipb.SuspendActorResponse{}, nil
+}
+
 func TestActorTemplateReconciler_Reconcile_PhaseInitial(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := atev1alpha1.AddToScheme(scheme); err != nil {
@@ -126,9 +142,10 @@ func TestActorTemplateReconciler_Reconcile_PhaseInitial(t *testing.T) {
 	t.Run("creates golden actor using template UID", func(t *testing.T) {
 		template := &atev1alpha1.ActorTemplate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-template",
-				Namespace: "default",
-				UID:       types.UID(templateUID),
+				Name:       "my-template",
+				Namespace:  "default",
+				UID:        types.UID(templateUID),
+				Finalizers: []string{goldenActorFinalizer},
 			},
 			Status: atev1alpha1.ActorTemplateStatus{
 				Phase: atev1alpha1.PhaseInitial,
@@ -185,9 +202,10 @@ func TestActorTemplateReconciler_Reconcile_PhaseInitial(t *testing.T) {
 	t.Run("handles AlreadyExists error when golden actor was created on prior attempt", func(t *testing.T) {
 		template := &atev1alpha1.ActorTemplate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-template-retry",
-				Namespace: "default",
-				UID:       types.UID(templateUID),
+				Name:       "my-template-retry",
+				Namespace:  "default",
+				UID:        types.UID(templateUID),
+				Finalizers: []string{goldenActorFinalizer},
 			},
 			Status: atev1alpha1.ActorTemplateStatus{
 				Phase: atev1alpha1.PhaseInitial,
@@ -231,4 +249,248 @@ func TestActorTemplateReconciler_Reconcile_PhaseInitial(t *testing.T) {
 			t.Errorf("status.Phase = %q, want %q", reconciledTemplate.Status.Phase, atev1alpha1.PhaseResumeGoldenActor)
 		}
 	})
+}
+
+func TestActorTemplateReconciler_Reconcile_InstallsFinalizer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := atev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	template := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "needs-finalizer",
+			Namespace: "default",
+			UID:       types.UID("uid-install"),
+		},
+		Status: atev1alpha1.ActorTemplateStatus{Phase: atev1alpha1.PhaseInitial},
+	}
+
+	fakeK8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&atev1alpha1.ActorTemplate{}).
+		WithObjects(template).
+		Build()
+
+	var createActorCalled bool
+	fakeAteClient := &mockControlClient{
+		createActorFn: func(ctx context.Context, req *ateapipb.CreateActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
+			createActorCalled = true
+			return &ateapipb.Actor{}, nil
+		},
+	}
+
+	reconciler := &ActorTemplateReconciler{Client: fakeK8sClient, Scheme: scheme, AteClient: fakeAteClient}
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "needs-finalizer", Namespace: "default"}}
+
+	if _, err := reconciler.Reconcile(ctx, req); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	// First reconcile only installs the finalizer and returns early — no golden
+	// actor is created yet, and the phase is untouched.
+	if createActorCalled {
+		t.Errorf("CreateActor called on the finalizer-install reconcile; want deferred to the next pass")
+	}
+	got := &atev1alpha1.ActorTemplate{}
+	if err := fakeK8sClient.Get(ctx, req.NamespacedName, got); err != nil {
+		t.Fatalf("failed to get template: %v", err)
+	}
+	if len(got.Finalizers) != 1 || got.Finalizers[0] != goldenActorFinalizer {
+		t.Errorf("finalizers = %v, want [%q]", got.Finalizers, goldenActorFinalizer)
+	}
+	if got.Status.Phase != atev1alpha1.PhaseInitial {
+		t.Errorf("status.Phase = %q, want %q (unchanged)", got.Status.Phase, atev1alpha1.PhaseInitial)
+	}
+}
+
+func TestActorTemplateReconciler_Reconcile_Deletion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := atev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	newDeletingTemplate := func(name, goldenActorID string) *atev1alpha1.ActorTemplate {
+		return &atev1alpha1.ActorTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       name,
+				Namespace:  "default",
+				UID:        types.UID("uid-" + name),
+				Finalizers: []string{goldenActorFinalizer},
+			},
+			Status: atev1alpha1.ActorTemplateStatus{
+				Phase:         atev1alpha1.PhaseReady,
+				GoldenActorID: goldenActorID,
+			},
+		}
+	}
+
+	t.Run("deletes suspended golden actor and releases finalizer", func(t *testing.T) {
+		template := newDeletingTemplate("del-suspended", "uid-12345")
+		fakeK8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&atev1alpha1.ActorTemplate{}).
+			WithObjects(template).
+			Build()
+
+		var deletedName string
+		var suspendCalled bool
+		fakeAteClient := &mockControlClient{
+			deleteActorFn: func(ctx context.Context, req *ateapipb.DeleteActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
+				deletedName = req.GetActor().GetName()
+				return &ateapipb.Actor{}, nil
+			},
+			suspendActorFn: func(ctx context.Context, req *ateapipb.SuspendActorRequest, opts ...grpc.CallOption) (*ateapipb.SuspendActorResponse, error) {
+				suspendCalled = true
+				return &ateapipb.SuspendActorResponse{}, nil
+			},
+		}
+
+		reconciler := &ActorTemplateReconciler{Client: fakeK8sClient, Scheme: scheme, AteClient: fakeAteClient}
+		ctx := context.Background()
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "del-suspended", Namespace: "default"}}
+
+		if err := fakeK8sClient.Delete(ctx, template); err != nil {
+			t.Fatalf("failed to mark template for deletion: %v", err)
+		}
+		res, err := reconciler.Reconcile(ctx, req)
+		if err != nil {
+			t.Fatalf("Reconcile returned error: %v", err)
+		}
+		if !res.IsZero() {
+			t.Errorf("unexpected requeue result: %v", res)
+		}
+		if deletedName != "uid-12345" {
+			t.Errorf("DeleteActor called with name %q, want %q", deletedName, "uid-12345")
+		}
+		if suspendCalled {
+			t.Errorf("SuspendActor should not be called for an already-deletable actor")
+		}
+		got := &atev1alpha1.ActorTemplate{}
+		if err := fakeK8sClient.Get(ctx, req.NamespacedName, got); err == nil {
+			t.Errorf("template still present after finalizer removal; want deleted (finalizers=%v)", got.Finalizers)
+		}
+	})
+
+	t.Run("suspends running golden actor and requeues", func(t *testing.T) {
+		template := newDeletingTemplate("del-running", "uid-running")
+		fakeK8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&atev1alpha1.ActorTemplate{}).
+			WithObjects(template).
+			Build()
+
+		var suspendedName string
+		fakeAteClient := &mockControlClient{
+			deleteActorFn: func(ctx context.Context, req *ateapipb.DeleteActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
+				return nil, status.Error(codes.FailedPrecondition, "actor is not in a deletable state")
+			},
+			suspendActorFn: func(ctx context.Context, req *ateapipb.SuspendActorRequest, opts ...grpc.CallOption) (*ateapipb.SuspendActorResponse, error) {
+				suspendedName = req.GetActor().GetName()
+				return &ateapipb.SuspendActorResponse{}, nil
+			},
+		}
+
+		reconciler := &ActorTemplateReconciler{Client: fakeK8sClient, Scheme: scheme, AteClient: fakeAteClient}
+		ctx := context.Background()
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "del-running", Namespace: "default"}}
+
+		if err := fakeK8sClient.Delete(ctx, template); err != nil {
+			t.Fatalf("failed to mark template for deletion: %v", err)
+		}
+		res, err := reconciler.Reconcile(ctx, req)
+		if err != nil {
+			t.Fatalf("Reconcile returned error: %v", err)
+		}
+		if res.RequeueAfter != goldenActorDeleteRetry {
+			t.Errorf("RequeueAfter = %v, want %v", res.RequeueAfter, goldenActorDeleteRetry)
+		}
+		if suspendedName != "uid-running" {
+			t.Errorf("SuspendActor called with name %q, want %q", suspendedName, "uid-running")
+		}
+		// Finalizer must still be held so the retry pass can delete the actor.
+		got := &atev1alpha1.ActorTemplate{}
+		if err := fakeK8sClient.Get(ctx, req.NamespacedName, got); err != nil {
+			t.Fatalf("template unexpectedly gone before actor was reclaimed: %v", err)
+		}
+		if !controllerContainsFinalizer(got, goldenActorFinalizer) {
+			t.Errorf("finalizer released before golden actor was reclaimed; finalizers=%v", got.Finalizers)
+		}
+	})
+
+	t.Run("treats already-gone golden actor as success", func(t *testing.T) {
+		template := newDeletingTemplate("del-notfound", "uid-gone")
+		fakeK8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&atev1alpha1.ActorTemplate{}).
+			WithObjects(template).
+			Build()
+
+		fakeAteClient := &mockControlClient{
+			deleteActorFn: func(ctx context.Context, req *ateapipb.DeleteActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
+				return nil, status.Error(codes.NotFound, "actor already gone")
+			},
+		}
+
+		reconciler := &ActorTemplateReconciler{Client: fakeK8sClient, Scheme: scheme, AteClient: fakeAteClient}
+		ctx := context.Background()
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "del-notfound", Namespace: "default"}}
+
+		if err := fakeK8sClient.Delete(ctx, template); err != nil {
+			t.Fatalf("failed to mark template for deletion: %v", err)
+		}
+		if _, err := reconciler.Reconcile(ctx, req); err != nil {
+			t.Fatalf("Reconcile returned error: %v", err)
+		}
+		got := &atev1alpha1.ActorTemplate{}
+		if err := fakeK8sClient.Get(ctx, req.NamespacedName, got); err == nil {
+			t.Errorf("template still present after idempotent delete; want deleted (finalizers=%v)", got.Finalizers)
+		}
+	})
+
+	t.Run("releases finalizer when no golden actor was ever created", func(t *testing.T) {
+		template := newDeletingTemplate("del-nogolden", "")
+		fakeK8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&atev1alpha1.ActorTemplate{}).
+			WithObjects(template).
+			Build()
+
+		var deleteCalled bool
+		fakeAteClient := &mockControlClient{
+			deleteActorFn: func(ctx context.Context, req *ateapipb.DeleteActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
+				deleteCalled = true
+				return &ateapipb.Actor{}, nil
+			},
+		}
+
+		reconciler := &ActorTemplateReconciler{Client: fakeK8sClient, Scheme: scheme, AteClient: fakeAteClient}
+		ctx := context.Background()
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "del-nogolden", Namespace: "default"}}
+
+		if err := fakeK8sClient.Delete(ctx, template); err != nil {
+			t.Fatalf("failed to mark template for deletion: %v", err)
+		}
+		if _, err := reconciler.Reconcile(ctx, req); err != nil {
+			t.Fatalf("Reconcile returned error: %v", err)
+		}
+		if deleteCalled {
+			t.Errorf("DeleteActor called for a template with no GoldenActorID")
+		}
+		got := &atev1alpha1.ActorTemplate{}
+		if err := fakeK8sClient.Get(ctx, req.NamespacedName, got); err == nil {
+			t.Errorf("template still present after finalizer removal; want deleted (finalizers=%v)", got.Finalizers)
+		}
+	})
+}
+
+// controllerContainsFinalizer reports whether obj carries the named finalizer.
+func controllerContainsFinalizer(obj metav1.Object, finalizer string) bool {
+	for _, f := range obj.GetFinalizers() {
+		if f == finalizer {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
The ActorTemplate controller declares the `actortemplates/finalizers` RBAC verb but installs no finalizer, so deleting an ActorTemplate lets the CR be GC'd immediately while the backing golden actor + snapshot blobs live on in the store — unreclaimable once `status.GoldenActorID` is gone with the CR.

This adds an `ate.dev/golden-actor-cleanup` finalizer:
- **Installed on first reconcile** (before the golden actor is created), so a delete that races template setup still triggers reclamation.
- On delete, `cleanupGoldenActor` runs while the finalizer is held, then releases it:
  - **Idempotent** — `NotFound` (already reclaimed) or empty `GoldenActorID` (actor never created) → success.
  - **SUSPENDED-precondition aware** — `DeleteActor` requires `SUSPENDED`/`CRASHED`; a template deleted mid-lifecycle may have a `RUNNING` golden actor (`FailedPrecondition`), so we `SuspendActor` + requeue (5s) rather than deadlock the CR's deletion.

Tests: mock extended with `DeleteActor`/`SuspendActor`; new cases for finalizer-install, delete-when-suspended, delete-when-running (suspend+requeue), delete-when-NotFound, delete-when-no-GoldenActorID. `go build ./...`, `go vet`, and the controller test suite pass locally.