### PR TITLE
api: surface status.observedGeneration on WorkerPool and ActorTemplate

### DIFF
--- a/cmd/atecontroller/internal/controllers/actortemplate_controller.go
+++ b/cmd/atecontroller/internal/controllers/actortemplate_controller.go
@@ -78,6 +78,11 @@ func (r *ActorTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	// Record the generation this reconcile observed so consumers can detect
+	// whether the controller has caught up to the latest spec. The per-phase
+	// Status().Update() calls below persist this value.
+	at.Status.ObservedGeneration = at.Generation
+
 	switch at.Status.Phase {
 	case atev1alpha1.PhaseInitial:
 		actorName := string(at.UID)

--- a/cmd/atecontroller/internal/controllers/workerpool_controller.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller.go
@@ -130,9 +130,10 @@ func (r *WorkerPoolReconciler) syncStatus(ctx context.Context, wp *atev1alpha1.W
 	}
 
 	want := atev1alpha1.WorkerPoolStatus{
-		Replicas:      dep.Status.Replicas,
-		ReadyReplicas: dep.Status.ReadyReplicas,
-		Selector:      selector.String(),
+		ObservedGeneration: wp.Generation,
+		Replicas:           dep.Status.Replicas,
+		ReadyReplicas:      dep.Status.ReadyReplicas,
+		Selector:           selector.String(),
 	}
 	if equality.Semantic.DeepEqual(wp.Status, want) {
 		return nil

--- a/manifests/ate-install/generated/ate.dev_actortemplates.yaml
+++ b/manifests/ate-install/generated/ate.dev_actortemplates.yaml
@@ -488,6 +488,17 @@ spec:
                 type: string
               goldenSnapshot:
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent generation observed for this
+                  ActorTemplate. It corresponds to the ActorTemplate's .metadata.generation,
+                  which is updated on mutation by the API server. The ActorTemplate spec is
+                  immutable, so in practice this transitions 0 -> 1 once the controller first
+                  reconciles the object, letting consumers distinguish an unobserved
+                  ActorTemplate (0) from a reconciled one.
+                format: int64
+                minimum: 0
+                type: integer
               phase:
                 description: Phase of the actor template.
                 type: string

--- a/manifests/ate-install/generated/ate.dev_workerpools.yaml
+++ b/manifests/ate-install/generated/ate.dev_workerpools.yaml
@@ -433,6 +433,16 @@ spec:
           status:
             description: status is the observed state of WorkerPool
             properties:
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent generation observed for this
+                  WorkerPool. It corresponds to the WorkerPool's .metadata.generation, which
+                  is updated on mutation by the API server. When observedGeneration lags
+                  .metadata.generation, the controller has not yet reconciled the latest
+                  spec, so consumers can detect a stale/in-progress status.
+                format: int64
+                minimum: 0
+                type: integer
               readyReplicas:
                 description: ReadyReplicas is the number of ready worker pods.
                 format: int32

--- a/pkg/api/v1alpha1/actortemplate_types.go
+++ b/pkg/api/v1alpha1/actortemplate_types.go
@@ -362,6 +362,16 @@ type ActorTemplateSpec struct {
 
 // TODO: add validation
 type ActorTemplateStatus struct {
+	// ObservedGeneration is the most recent generation observed for this
+	// ActorTemplate. It corresponds to the ActorTemplate's .metadata.generation,
+	// which is updated on mutation by the API server. The ActorTemplate spec is
+	// immutable, so in practice this transitions 0 -> 1 once the controller first
+	// reconciles the object, letting consumers distinguish an unobserved
+	// ActorTemplate (0) from a reconciled one.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Phase of the actor template.
 	// +optional
 	Phase PhaseType `json:"phase,omitempty"`

--- a/pkg/api/v1alpha1/workerpool_types.go
+++ b/pkg/api/v1alpha1/workerpool_types.go
@@ -91,6 +91,15 @@ type WorkerPoolSpec struct {
 }
 
 type WorkerPoolStatus struct {
+	// ObservedGeneration is the most recent generation observed for this
+	// WorkerPool. It corresponds to the WorkerPool's .metadata.generation, which
+	// is updated on mutation by the API server. When observedGeneration lags
+	// .metadata.generation, the controller has not yet reconciled the latest
+	// spec, so consumers can detect a stale/in-progress status.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Replicas is the total number of worker pods.
 	// +kubebuilder:validation:Minimum=0
 	// +optional


### PR DESCRIPTION
Adds an int64 `status.observedGeneration` to both CRDs and sets it in their reconcilers, so consumers can detect whether the controller has reconciled the latest spec — standard k8s status hygiene.

- **WorkerPool** — `syncStatus` sets `want.ObservedGeneration = wp.Generation`; the existing `equality.Semantic.DeepEqual` gate makes a generation change trigger a status write correctly.
- **ActorTemplate** — sets `at.Status.ObservedGeneration = at.Generation` once after the deletion guard, so all three phase-transition `Status().Update()` calls persist it. The spec is immutable (`XValidation: self == oldSelf`), so in practice this transitions `0 → 1` on first reconcile — distinguishing an unobserved template from a reconciled one.

CRD yamls are hand-mirrored to controller-gen's alphabetical ordering — worth a `make generate manifests` in CI to confirm zero drift. `go build ./...`, `go vet`, and the controller test suite pass locally.