### PR TITLE
Add Actor egress policy Alloy model

### DIFF
--- a/docs/reviews/actor-egress-policy-model.als
+++ b/docs/reviews/actor-egress-policy-model.als
@@ -1,0 +1,206 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module actor_egress_policy
+
+// Bounded review model for the Actor Egress Policy Proposal.
+// This is an analysis artifact, not an implementation specification.
+
+sig Atespace {
+  defaultPolicy: lone Policy
+}
+
+sig Actor {
+  space: one Atespace,
+  actorPolicy: lone Policy
+}
+
+sig Host {}
+sig Address {}
+sig ProtectedAddress in Address {}
+sig Header {}
+
+sig Destination {
+  authority: lone Host,
+  address: one Address
+}
+
+sig Credential {
+  owner: one Atespace
+}
+
+sig Injection {
+  header: one Header,
+  credential: one Credential
+}
+
+sig Extension {}
+
+sig Policy {
+  rules: set Rule,
+  extensions: set Extension
+}
+
+abstract sig Rule {}
+one sig AllowAll extends Rule {}
+
+abstract sig HostRule extends Rule {
+  matchedHosts: set Host
+}
+
+sig ExactHostRule extends HostRule {
+  injections: set Injection
+}
+
+sig WildcardHostRule extends HostRule {}
+
+sig CIDRRule extends Rule {
+  addresses: set Address
+}
+
+// The effective-policy selection is replacement, not merging.
+fun effectivePolicy[a: Actor]: lone Policy {
+  { p: Policy |
+    p = a.actorPolicy or
+    (no a.actorPolicy and p = a.space.defaultPolicy)
+  }
+}
+
+pred ruleMatches[r: Rule, d: Destination] {
+  r = AllowAll or
+  (r in HostRule and some d.authority and d.authority in r.matchedHosts) or
+  (r in CIDRRule and d.address in r.addresses)
+}
+
+// The proposal explicitly protects hostname resolution from loopback,
+// link-local, and unspecified results, but does not apply that prohibition to
+// a directly matching CIDR rule.
+pred proposalPortableAllows[a: Actor, d: Destination] {
+  some p: effectivePolicy[a] |
+    some r: p.rules |
+      ruleMatches[r, d] and
+      (r not in HostRule or d.address not in ProtectedAddress)
+}
+
+fun policyInjections[p: set Policy]: set Injection {
+  (p.rules & ExactHostRule).injections
+}
+
+fun policyCredentials[p: set Policy]: set Credential {
+  policyInjections[p].credential
+}
+
+// CredentialReference.name is resolved within the Actor's Atespace.
+fact ScopedCredentialResolution {
+  all a: Actor |
+    all i: policyInjections[effectivePolicy[a]] |
+      i.credential.owner = a.space
+}
+
+// A Decision models an implementation that selects one matching OR rule as
+// the authorizing rule. The proposal does not state whether effects are taken
+// from one rule or the union of every matching rule.
+sig Decision {
+  actor: one Actor,
+  destination: one Destination,
+  selectedRule: one Rule
+}
+
+fact ValidDecision {
+  all d: Decision |
+    some p: effectivePolicy[d.actor] |
+      d.selectedRule in p.rules and
+      ruleMatches[d.selectedRule, d.destination]
+}
+
+fun decisionInjections[d: Decision]: set Injection {
+  (d.selectedRule & ExactHostRule).injections
+}
+
+sig PEP {
+  installed: Actor -> lone Policy,
+  healthyStream: set Actor,
+  validLease: set Actor,
+  installedCredentials: set Credential,
+  supportedExtensions: set Extension
+}
+
+// This reflects the proposal's local admission conditions. It intentionally
+// has no omniscient test that the installed version is still authoritative.
+pred proposalPEPMayAllow[pep: PEP, a: Actor, d: Destination] {
+  a in pep.healthyStream
+  a in pep.validLease
+  some pep.installed[a]
+  some r: pep.installed[a].rules | ruleMatches[r, d]
+  policyCredentials[pep.installed[a]] in pep.installedCredentials
+  pep.installed[a].extensions in pep.supportedExtensions
+}
+
+assert EffectiveSelectionIsUnique {
+  all a: Actor | lone effectivePolicy[a]
+}
+
+assert CredentialResolutionStaysInAtespace {
+  all a: Actor |
+    policyCredentials[effectivePolicy[a]].owner in a.space
+}
+
+// Expected counterexample: Actor replacement may be more permissive than the
+// Atespace default, which is expressly allowed by the proposal.
+assert AtespaceDefaultIsPermissionCeiling {
+  all a: Actor, d: Destination |
+    proposalPortableAllows[a, d] implies
+      (some a.space.defaultPolicy implies
+        some r: a.space.defaultPolicy.rules | ruleMatches[r, d])
+}
+
+// Expected counterexample: a directly allowed CIDR can contain a protected
+// address even though hostname rules reject the same resolved address.
+assert ProtectedDestinationsAlwaysDenied {
+  all a: Actor, d: Destination |
+    d.address in ProtectedAddress implies
+      not proposalPortableAllows[a, d]
+}
+
+// Expected counterexample: two matching OR rules can select different
+// injection effects for the same Actor and destination.
+assert MatchingEffectsAreDeterministic {
+  all disj x, y: Decision |
+    x.actor = y.actor and x.destination = y.destination implies
+      decisionInjections[x] = decisionInjections[y]
+}
+
+// Expected counterexample: stream and lease health alone cannot reveal a
+// committed policy version that has not yet reached the PEP.
+assert HealthyLeaseNeverUsesStalePolicy {
+  all pep: PEP, a: Actor, d: Destination |
+    proposalPEPMayAllow[pep, a, d] implies
+      pep.installed[a] = effectivePolicy[a]
+}
+
+// This should hold because unsupported extensions are excluded by the local
+// admission predicate.
+assert UnsupportedExtensionsFailClosed {
+  all pep: PEP, a: Actor, d: Destination |
+    proposalPEPMayAllow[pep, a, d] implies
+      pep.installed[a].extensions in pep.supportedExtensions
+}
+
+check EffectiveSelectionIsUnique for 5
+check CredentialResolutionStaysInAtespace for 5
+check AtespaceDefaultIsPermissionCeiling for 5
+check ProtectedDestinationsAlwaysDenied for 5
+check MatchingEffectsAreDeterministic for 5
+check HealthyLeaseNeverUsesStalePolicy for 5
+check UnsupportedExtensionsFailClosed for 5

--- a/docs/reviews/actor-egress-policy-model.md
+++ b/docs/reviews/actor-egress-policy-model.md
@@ -1,0 +1,137 @@
+# Actor Egress Policy Alloy Model
+
+This document explains how to use
+[`actor-egress-policy-model.als`](actor-egress-policy-model.als) to review the
+Actor Egress Policy proposal.
+
+The model is a bounded design-analysis artifact. It is not an implementation
+of the policy engine or a complete specification of its behavior.
+
+## Prerequisites
+
+Install the Alloy Analyzer. The model has been tested with Alloy Analyzer
+6.2.0.
+
+Open `actor-egress-policy-model.als` in the Alloy Analyzer desktop application.
+The commands at the bottom of the file will appear in the command selector.
+
+## Running the model
+
+Select a `check` command and click **Execute**. Run each command individually:
+
+```alloy
+check EffectiveSelectionIsUnique for 5
+check CredentialResolutionStaysInAtespace for 5
+check AtespaceDefaultIsPermissionCeiling for 5
+check ProtectedDestinationsAlwaysDenied for 5
+check MatchingEffectsAreDeterministic for 5
+check HealthyLeaseNeverUsesStalePolicy for 5
+check UnsupportedExtensionsFailClosed for 5
+```
+
+The `for 5` clause asks Alloy to search structures within a bounded scope of
+five atoms per top-level signature, subject to Alloy's normal scope rules.
+
+## Interpreting results
+
+Alloy reports one of two relevant outcomes for these commands:
+
+- **No counterexample found** means Alloy found no violation within the
+  selected scope.
+- A generated instance is a counterexample. Open it in the visualizer to see
+  the Actors, Atespaces, policies, rules, destinations, credentials, and PEP
+  state that violate the assertion.
+
+A counterexample is not necessarily a defect in the Alloy model. Several
+assertions intentionally test properties that the proposal does not guarantee.
+Those counterexamples make the resulting design consequence concrete.
+
+## Expected results
+
+| Assertion | Expected result | Meaning |
+|---|---|---|
+| `EffectiveSelectionIsUnique` | No counterexample | Replacement-based policy selection produces at most one effective policy. |
+| `CredentialResolutionStaysInAtespace` | No counterexample | Referenced credentials remain scoped to the Actor's Atespace. |
+| `AtespaceDefaultIsPermissionCeiling` | Counterexample | An Actor policy can be more permissive than the Atespace default, as the proposal permits. |
+| `ProtectedDestinationsAlwaysDenied` | Counterexample | The proposal's protected-address check applies to hostname rules but does not clearly cover every authorization path. |
+| `MatchingEffectsAreDeterministic` | Counterexample | Different matching rules can produce different credential-injection effects. |
+| `HealthyLeaseNeverUsesStalePolicy` | Counterexample | Stream and lease health alone do not prove that the installed policy is the latest committed policy. |
+| `UnsupportedExtensionsFailClosed` | No counterexample | The modeled PEP admission condition prevents use of unsupported extensions. |
+
+If a result differs from this table after changing the model, inspect the
+counterexample or confirm that the design change intentionally altered the
+invariant.
+
+## Inspecting a counterexample
+
+In the visualizer:
+
+1. Identify the `Actor` and its `Atespace`.
+2. Compare `actorPolicy` with `defaultPolicy` and determine which one
+   `effectivePolicy` selects.
+3. Inspect the selected policy's `rules` and `extensions`.
+4. Follow each `Decision` to its `destination` and `selectedRule`.
+5. For credential cases, follow `injections` to the `Credential` and its
+   owning Atespace.
+6. For delivery cases, compare `PEP.installed` with `effectivePolicy` and
+   inspect stream, lease, credential, and extension state.
+
+Use **New Instance** to ask Alloy for another counterexample. Different
+instances can reveal distinct ways that the same assertion fails.
+
+## Using the model during design review
+
+The normal workflow is:
+
+1. Translate a proposed requirement into a predicate, fact, or assertion.
+2. Run a `check` command to search for a counterexample.
+3. Decide whether the counterexample exposes a specification problem, an
+   accepted design consequence, or an inaccurate model assumption.
+4. Update the proposal or the model accordingly.
+5. Rerun every assertion to detect semantic regressions.
+
+For example, if the proposal defines how effects from overlapping rules are
+combined, update the rule-effect logic and rerun
+`MatchingEffectsAreDeterministic`. The desired outcome would then be no
+counterexample within the chosen scope.
+
+## Extending the model
+
+Use the following Alloy constructs according to intent:
+
+- A `sig` introduces a design entity or state object.
+- A `fact` encodes an unconditional assumption or required invariant. Use
+  facts sparingly because they can accidentally exclude the behavior being
+  investigated.
+- A `pred` defines reusable behavior or a condition that can be explored.
+- A `fun` computes a relation or set.
+- An `assert` states a property that should hold.
+- A `check` searches for a counterexample to an assertion.
+- A `run` searches for an instance satisfying a predicate and is useful for
+  confirming that the model still has valid instances.
+
+When adding an invariant, first consider whether it is already guaranteed by
+the proposal. If it is merely a desired property, encode it as an assertion
+before making it a fact. This allows Alloy to show whether the current design
+actually guarantees it.
+
+## Scope and limitations
+
+Alloy performs bounded analysis. "No counterexample found" means no violation
+was found within the selected scope. It is not a proof for every possible
+system size.
+
+The current model intentionally abstracts away:
+
+- DNS resolution and caching;
+- HTTP and TLS parsing;
+- cryptographic identity validation;
+- protobuf and xDS wire encoding;
+- datastore transactions and event delivery;
+- concurrency, timing, and performance; and
+- implementation-specific authorization.
+
+These areas require protocol review, threat analysis, testing, or additional
+state-machine models. Increase the scope or extend the model when a design
+question depends on more entities or behavior than the current abstraction
+represents.


### PR DESCRIPTION
## Summary

- add a bounded Alloy model for the Actor Egress Policy proposal
- check policy selection, credential scope, protected destinations, overlapping rule effects, stale policy state, and required extensions
- document how to run, interpret, and extend the model

## Why

The model provides a repeatable way to validate policy invariants, find counterexamples, and detect semantic regressions as the design evolves. It is a review artifact, not an implementation specification.

## Validation

- Alloy Analyzer 6.2.0 model execution
- `git diff --check origin/main...HEAD`
- verified expected counterexamples and assertions as documented in the companion guide
