### PR TITLE
benchmarking: enable Managed OpenTelemetry on the benchmark test cluster

### DIFF
--- a/benchmarking/automation/README.md
+++ b/benchmarking/automation/README.md
@@ -75,15 +75,16 @@ default is `0 3 * * *`, 3am UTC).
 
 ## Test cluster prerequisites
 
-Create the test cluster with the substrate-required beta APIs and Workload
-Identity enabled. The control plane must be on Kubernetes 1.36+ so
-`certificates.k8s.io/v1beta1` is available:
+Create the test cluster with the substrate-required beta APIs, Workload
+Identity, and Managed OpenTelemetry enabled. The control plane must be on
+Kubernetes 1.36+ so `certificates.k8s.io/v1beta1` is available:
 
 ```bash
 gcloud container clusters create <CLUSTER_NAME> \
   --location=<CLUSTER_LOCATION> \
   --num-nodes=5 \
   --workload-pool=<PROJECT_ID>.svc.id.goog \
+  --managed-otel-scope=COLLECTION_AND_INSTRUMENTATION_COMPONENTS \
   --enable-kubernetes-unstable-apis=certificates.k8s.io/v1beta1/podcertificaterequests,certificates.k8s.io/v1beta1/clustertrustbundles
 ```
 


### PR DESCRIPTION
The automation's test-cluster creation command did not enable Managed OpenTelemetry, but the ate-otel-config ConfigMap applied by hack/install-ate.sh and the runner Job both target opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317. Without the addon that name does not resolve and all benchmark telemetry is dropped.
