### PR TITLE
Only register demo-autoscaled-workerpool when running on kind clusters

### DIFF
--- a/hack/install-demo-autoscaled-workerpool.sh
+++ b/hack/install-demo-autoscaled-workerpool.sh
@@ -16,11 +16,11 @@
 #
 # This is sourced as part of install-ate.sh. Do not run directly.
 
-ATE_DEMOS+=(demo-autoscaled-workerpool) # register demo-autoscaled-workerpool
-
-demo-autoscaled-workerpool_usage() {
-  echo "  --deploy-demo-autoscaled-workerpool            Deploy autoscaled-workerpool demo (HPA + prometheus-adapter + counter workload)"
-}
+# This demo is kind-only: it ships its own prometheus-adapter and a kind
+# specific HPA.
+if [[ "${ATE_INSTALL_KIND:-false}" == "true" ]]; then
+  ATE_DEMOS+=(demo-autoscaled-workerpool) # register demo-autoscaled-workerpool
+fi
 
 demo-autoscaled-workerpool_cmdline() {
   case "${1}" in


### PR DESCRIPTION
This was breaking 

`hack/install-ate.sh --delete-all` with `--delete-demo-autoscaled-workerpool is not supported on GKE`

Also removed the custom usage message for --deploy-demo-autoscaled-workerpool. This was duplicate with the default message:

Before:

```
Demo: demo-autoscaled-workerpool

  --deploy-demo-autoscaled-workerpool                         Deploy demo-autoscaled-workerpool
  --delete-demo-autoscaled-workerpool                         Delete demo-autoscaled-workerpool
  --deploy-demo-autoscaled-workerpool            Deploy autoscaled-workerpool demo (HPA + prometheus-adapter + counter workload)
```

After:

```
Demo: demo-autoscaled-workerpool

  --deploy-demo-autoscaled-workerpool                         Deploy demo-autoscaled-workerpool
  --delete-demo-autoscaled-workerpool                         Delete demo-autoscaled-workerpool
```

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
