### PR TITLE
Implement ActorTemplate CRUD in the control API

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor_template.go
+++ b/cmd/ateapi/internal/controlapi/actor_template.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/api/validate/content"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func (s *Service) CreateActorTemplate(ctx context.Context, req *ateapipb.CreateActorTemplateRequest) (*ateapipb.ActorTemplate, error) {
+	if errs := validateCreateActorTemplateRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	in := req.GetActorTemplate()
+	templateRef := resources.ActorTemplateRefFromActorTemplate(in)
+
+	exists, err := s.persistence.AtespaceExists(ctx, templateRef.Atespace)
+	if err != nil {
+		return nil, fmt.Errorf("while checking atespace: %w", err)
+	}
+	if !exists {
+		return nil, status.Errorf(codes.FailedPrecondition, "Atespace %s not found", templateRef.Atespace)
+	}
+
+	// Rebuild the template from the client-owned fields only: status is
+	// server-owned and ignored per the CreateActorTemplateRequest contract.
+	template := &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{
+			Atespace: templateRef.Atespace,
+			Name:     templateRef.Name,
+		},
+		WorkerSelector:  in.GetWorkerSelector(),
+		Containers:      in.GetContainers(),
+		Volumes:         in.GetVolumes(),
+		SnapshotsConfig: in.GetSnapshotsConfig(),
+		SandboxConfig:   in.GetSandboxConfig(),
+		Resources:       in.GetResources(),
+		Status:          &ateapipb.ActorTemplateStatus{Phase: ateapipb.ActorTemplatePhase_ACTOR_TEMPLATE_PHASE_INITIAL},
+	}
+	stored, err := s.persistence.CreateActorTemplate(ctx, template)
+	if err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			return nil, status.Errorf(codes.AlreadyExists, "ActorTemplate %s already exists", templateRef)
+		}
+		if errors.Is(err, store.ErrFailedPrecondition) {
+			return nil, status.Error(codes.FailedPrecondition, err.Error())
+		}
+		return nil, fmt.Errorf("while recording actor template: %w", err)
+	}
+
+	return stored, nil
+}
+
+func validateCreateActorTemplateRequest(req *ateapipb.CreateActorTemplateRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	template := req.GetActorTemplate()
+	templatePath := fldPath.Child("actor_template")
+	if template == nil {
+		errs = append(errs, field.Required(templatePath, ""))
+		return errs
+	}
+
+	// ActorTemplate is Atespaced: metadata.atespace and name are required + valid.
+	metaPath := templatePath.Child("metadata")
+	if val, p := template.GetMetadata().GetAtespace(), metaPath.Child("atespace"); val == "" {
+		errs = append(errs, field.Required(p, ""))
+	} else {
+		errs = append(errs, resources.ValidateResourceName(val, p)...)
+	}
+	if val, p := template.GetMetadata().GetName(), metaPath.Child("name"); val == "" {
+		errs = append(errs, field.Required(p, ""))
+	} else {
+		errs = append(errs, resources.ValidateResourceName(val, p)...)
+	}
+
+	if sel := template.GetWorkerSelector(); sel != nil {
+		errs = append(errs, validateSelector(sel, templatePath.Child("worker_selector"))...)
+	}
+
+	containersPath := templatePath.Child("containers")
+	if len(template.GetContainers()) == 0 {
+		errs = append(errs, field.Required(containersPath, ""))
+	}
+	for i, container := range template.GetContainers() {
+		if val, p := container.GetName(), containersPath.Index(i).Child("name"); val == "" {
+			errs = append(errs, field.Required(p, ""))
+		} else {
+			for _, msg := range content.IsDNS1123Label(val) {
+				errs = append(errs, field.Invalid(p, val, msg))
+			}
+		}
+		if container.GetImage() == "" {
+			errs = append(errs, field.Required(containersPath.Index(i).Child("image"), ""))
+		}
+	}
+
+	snapshotsPath := templatePath.Child("snapshots_config")
+	if snapshots := template.GetSnapshotsConfig(); snapshots == nil {
+		errs = append(errs, field.Required(snapshotsPath, ""))
+	} else {
+		if snapshots.GetStorageLocation() == "" {
+			errs = append(errs, field.Required(snapshotsPath.Child("storage_location"), ""))
+		}
+		// Mirrors the ActorTemplate CRD's CEL rule; UNSPECIFIED means FULL, so
+		// an unset on_commit over a DATA on_pause is rejected too.
+		if snapshots.GetOnPause() == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA &&
+			snapshots.GetOnCommit() != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA {
+			errs = append(errs, field.Invalid(snapshotsPath.Child("on_commit"), snapshots.GetOnCommit().String(), "must be a subset of on_pause"))
+		}
+	}
+
+	sandboxPath := templatePath.Child("sandbox_config")
+	if sandbox := template.GetSandboxConfig(); sandbox == nil {
+		errs = append(errs, field.Required(sandboxPath, ""))
+	} else {
+		if sandbox.GetSandboxClass() == ateapipb.SandboxClass_SANDBOX_CLASS_UNSPECIFIED {
+			errs = append(errs, field.Required(sandboxPath.Child("sandbox_class"), ""))
+		}
+		if sandbox.GetConfigName() == "" {
+			errs = append(errs, field.Required(sandboxPath.Child("config_name"), ""))
+		}
+	}
+
+	return errs
+}
+
+func (s *Service) GetActorTemplate(ctx context.Context, req *ateapipb.GetActorTemplateRequest) (*ateapipb.ActorTemplate, error) {
+	if errs := validateGetActorTemplateRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	templateRef := resources.ActorTemplateRefFromObjectRef(req.GetActorTemplate())
+	template, err := s.persistence.GetActorTemplate(ctx, templateRef)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, status.Errorf(codes.NotFound, "ActorTemplate %s not found", templateRef)
+	} else if err != nil {
+		return nil, fmt.Errorf("while getting actor template from DB: %w", err)
+	}
+
+	return template, nil
+}
+
+func validateGetActorTemplateRequest(req *ateapipb.GetActorTemplateRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.ActorTemplate, fldPath.Child("actor_template"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
+	}
+
+	return errs
+}
+
+func (s *Service) ListActorTemplates(ctx context.Context, req *ateapipb.ListActorTemplatesRequest) (*ateapipb.ListActorTemplatesResponse, error) {
+	if errs := validateListActorTemplatesRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	page, err := s.persistence.ListActorTemplates(ctx, req.GetAtespace(), store.ListOptions{PageSize: effectivePageSize(req.GetPageSize()), PageToken: req.GetPageToken()})
+	if err != nil {
+		return nil, fmt.Errorf("while listing actor templates in db: %w", err)
+	}
+	return &ateapipb.ListActorTemplatesResponse{
+		ActorTemplates: page.Items,
+		NextPageToken:  page.NextPageToken,
+	}, nil
+}
+
+func validateListActorTemplatesRequest(req *ateapipb.ListActorTemplatesRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	// An empty atespace is allowed here and means "all atespaces".
+	if val, fldPath := req.Atespace, fldPath.Child("atespace"); val != "" {
+		errs = append(errs, resources.ValidateResourceName(val, fldPath)...)
+	}
+
+	if val, fldPath := req.PageSize, fldPath.Child("page_size"); val < 0 {
+		errs = append(errs, field.Invalid(fldPath, val, "must be greater than or equal to 0"))
+	}
+
+	return errs
+}
+
+func (s *Service) DeleteActorTemplate(ctx context.Context, req *ateapipb.DeleteActorTemplateRequest) (*ateapipb.ActorTemplate, error) {
+	if errs := validateDeleteActorTemplateRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
+	}
+
+	templateRef := resources.ActorTemplateRefFromObjectRef(req.GetActorTemplate())
+	deleted, err := s.persistence.DeleteActorTemplate(ctx, templateRef)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "ActorTemplate %s not found", templateRef)
+		}
+		if errors.Is(err, store.ErrFailedPrecondition) {
+			return nil, status.Error(codes.FailedPrecondition, err.Error())
+		}
+		return nil, fmt.Errorf("while deleting actor template from DB: %w", err)
+	}
+
+	return deleted, nil
+}
+
+func validateDeleteActorTemplateRequest(req *ateapipb.DeleteActorTemplateRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.ActorTemplate, fldPath.Child("actor_template"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
+	}
+
+	return errs
+}

--- a/cmd/ateapi/internal/controlapi/actor_template_functional_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_template_functional_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestActorTemplateCRUD(t *testing.T) {
+	ns := namespaceForTest("ns-template-crud")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+	ctx := context.Background()
+
+	created, err := tc.client.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata:        &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "tmpl-a"},
+			Containers:      []*ateapipb.Container{{Name: "main", Image: "example.com/app:v1"}},
+			SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://my-bucket/snapshots"},
+			SandboxConfig: &ateapipb.SandboxConfig{
+				SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+				ConfigName:   "gvisor-default",
+			},
+			Resources: &ateapipb.Resources{Limits: []*ateapipb.Limits{{Name: "memory", Quantity: "1Gi"}}},
+			// Server-owned status on the request is ignored.
+			Status: &ateapipb.ActorTemplateStatus{
+				Phase:          ateapipb.ActorTemplatePhase_ACTOR_TEMPLATE_PHASE_READY,
+				GoldenSnapshot: &ateapipb.ObjectRef{Atespace: "ate-golden", Name: "sneaky"},
+				SandboxAssets:  &ateapipb.SandboxAssets{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	want := &ateapipb.ActorTemplate{
+		Metadata:        &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "tmpl-a", Version: 1},
+		Containers:      []*ateapipb.Container{{Name: "main", Image: "example.com/app:v1"}},
+		SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://my-bucket/snapshots"},
+		SandboxConfig: &ateapipb.SandboxConfig{
+			SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+			ConfigName:   "gvisor-default",
+		},
+		Resources: &ateapipb.Resources{Limits: []*ateapipb.Limits{{Name: "memory", Quantity: "1Gi"}}},
+		Status:    &ateapipb.ActorTemplateStatus{Phase: ateapipb.ActorTemplatePhase_ACTOR_TEMPLATE_PHASE_INITIAL},
+	}
+	if diff := cmp.Diff(want, created, protocmp.Transform(), ignoreUID, ignoreTimestamps); diff != "" {
+		t.Errorf("CreateActorTemplate response mismatch (-want +got):\n%s", diff)
+	}
+
+	_, err = tc.client.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata:        &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "tmpl-a"},
+			Containers:      []*ateapipb.Container{{Name: "main", Image: "example.com/app:v1"}},
+			SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://my-bucket/snapshots"},
+			SandboxConfig:   &ateapipb.SandboxConfig{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR, ConfigName: "gvisor-default"},
+		},
+	})
+	assertGrpcError(t, err, codes.AlreadyExists, "ActorTemplate "+testAtespace+"/tmpl-a already exists")
+
+	got, err := tc.client.GetActorTemplate(ctx, &ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl-a"}})
+	if err != nil {
+		t.Fatalf("GetActorTemplate failed: %v", err)
+	}
+	if diff := cmp.Diff(created, got, protocmp.Transform()); diff != "" {
+		t.Errorf("GetActorTemplate response mismatch (-created +got):\n%s", diff)
+	}
+
+	list, err := tc.client.ListActorTemplates(ctx, &ateapipb.ListActorTemplatesRequest{})
+	if err != nil {
+		t.Fatalf("ListActorTemplates failed: %v", err)
+	}
+	if len(list.GetActorTemplates()) != 1 || list.GetActorTemplates()[0].GetMetadata().GetName() != "tmpl-a" {
+		t.Errorf("ListActorTemplates = %v, want [tmpl-a]", list.GetActorTemplates())
+	}
+
+	// The atespace filter scopes the listing: a match returns the template, a
+	// different atespace returns nothing.
+	list, err = tc.client.ListActorTemplates(ctx, &ateapipb.ListActorTemplatesRequest{Atespace: testAtespace})
+	if err != nil {
+		t.Fatalf("ListActorTemplates(atespace) failed: %v", err)
+	}
+	if len(list.GetActorTemplates()) != 1 {
+		t.Errorf("ListActorTemplates(atespace=%s) = %v, want [tmpl-a]", testAtespace, list.GetActorTemplates())
+	}
+	list, err = tc.client.ListActorTemplates(ctx, &ateapipb.ListActorTemplatesRequest{Atespace: "other-atespace"})
+	if err != nil {
+		t.Fatalf("ListActorTemplates(other atespace) failed: %v", err)
+	}
+	if len(list.GetActorTemplates()) != 0 {
+		t.Errorf("ListActorTemplates(atespace=other-atespace) = %v, want []", list.GetActorTemplates())
+	}
+
+	deleted, err := tc.client.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl-a"}})
+	if err != nil {
+		t.Fatalf("DeleteActorTemplate failed: %v", err)
+	}
+	if diff := cmp.Diff(created, deleted, protocmp.Transform()); diff != "" {
+		t.Errorf("DeleteActorTemplate response mismatch (-created +deleted):\n%s", diff)
+	}
+	_, err = tc.client.GetActorTemplate(ctx, &ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl-a"}})
+	assertGrpcError(t, err, codes.NotFound, "ActorTemplate "+testAtespace+"/tmpl-a not found")
+	_, err = tc.client.DeleteActorTemplate(ctx, &ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl-a"}})
+	assertGrpcError(t, err, codes.NotFound, "ActorTemplate "+testAtespace+"/tmpl-a not found")
+}

--- a/cmd/ateapi/internal/controlapi/actor_template_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_template_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// validActorTemplate returns the smallest template that passes create
+// validation; mutations tweak it per test case.
+func validActorTemplate(mutations ...func(*ateapipb.ActorTemplate)) *ateapipb.ActorTemplate {
+	template := &ateapipb.ActorTemplate{
+		Metadata:        &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tmpl-a"},
+		Containers:      []*ateapipb.Container{{Name: "main", Image: "example.com/app:v1"}},
+		SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://my-bucket/snapshots"},
+		SandboxConfig:   &ateapipb.SandboxConfig{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR, ConfigName: "gvisor-default"},
+	}
+	for _, m := range mutations {
+		m(template)
+	}
+	return template
+}
+
+func TestValidateCreateActorTemplateRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.CreateActorTemplateRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate()},
+		nil,
+	}, {
+		"missing actor_template",
+		&ateapipb.CreateActorTemplateRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor_template"), "")},
+	}, {
+		"missing metadata.atespace",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.Metadata.Atespace = ""
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "metadata", "atespace"), "")},
+	}, {
+		"invalid metadata.atespace",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.Metadata.Atespace = "NS_1"
+		})},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "metadata", "atespace"), "NS_1", "")},
+	}, {
+		"missing metadata.name",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.Metadata.Name = ""
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "metadata", "name"), "")},
+	}, {
+		"invalid metadata.name",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.Metadata.Name = "Tmpl_A"
+		})},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "metadata", "name"), "Tmpl_A", "")},
+	}, {
+		"valid data-scoped snapshots",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.SnapshotsConfig.OnPause = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+			tmpl.SnapshotsConfig.OnCommit = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+		})},
+		nil,
+	}, {
+		"invalid worker_selector label key",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.WorkerSelector = &ateapipb.Selector{MatchLabels: map[string]string{"bad key": "v"}}
+		})},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "worker_selector", "match_labels").Key("bad key"), "bad key", "")},
+	}, {
+		"no containers",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.Containers = nil
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "containers"), "")},
+	}, {
+		"container missing name",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.Containers[0].Name = ""
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "containers").Index(0).Child("name"), "")},
+	}, {
+		"container invalid name",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.Containers[0].Name = "Main_1"
+		})},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "containers").Index(0).Child("name"), "Main_1", "")},
+	}, {
+		"container missing image",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.Containers[0].Image = ""
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "containers").Index(0).Child("image"), "")},
+	}, {
+		"missing snapshots_config",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.SnapshotsConfig = nil
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "snapshots_config"), "")},
+	}, {
+		"missing snapshots_config.storage_location",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.SnapshotsConfig.StorageLocation = ""
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "snapshots_config", "storage_location"), "")},
+	}, {
+		"on_commit broader than on_pause",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.SnapshotsConfig.OnPause = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+			tmpl.SnapshotsConfig.OnCommit = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL
+		})},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "snapshots_config", "on_commit"), "SNAPSHOT_CONTENT_SCOPE_FULL", "")},
+	}, {
+		// UNSPECIFIED defaults to FULL, so leaving on_commit unset over a DATA
+		// on_pause is also a subset violation.
+		"on_commit unset with data on_pause",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.SnapshotsConfig.OnPause = ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
+		})},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template", "snapshots_config", "on_commit"), "SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED", "")},
+	}, {
+		"missing sandbox_config",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.SandboxConfig = nil
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "sandbox_config"), "")},
+	}, {
+		"unspecified sandbox_config.sandbox_class",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.SandboxConfig.SandboxClass = ateapipb.SandboxClass_SANDBOX_CLASS_UNSPECIFIED
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "sandbox_config", "sandbox_class"), "")},
+	}, {
+		"missing sandbox_config.config_name",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.SandboxConfig.ConfigName = ""
+		})},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "sandbox_config", "config_name"), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateCreateActorTemplateRequest(tt.req), tt.want)
+		})
+	}
+}
+
+// TestCreateActorTemplate covers the atespace precondition: creation fails
+// while the atespace is missing, and succeeds once the atespace exists.
+func TestCreateActorTemplate(t *testing.T) {
+	persistence := newTestPersistence(t)
+	s := &Service{persistence: persistence}
+	ctx := context.Background()
+	req := func(atespace, name string) *ateapipb.CreateActorTemplateRequest {
+		return &ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+			tmpl.Metadata = &ateapipb.ResourceMetadata{Atespace: atespace, Name: name}
+		})}
+	}
+
+	if _, err := s.CreateActorTemplate(ctx, req("ns-missing", "tmpl-a")); status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("CreateActorTemplate in missing atespace = %v, want FailedPrecondition", err)
+	}
+
+	if _, err := persistence.CreateAtespace(ctx, &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: "ns1"}}); err != nil {
+		t.Fatalf("CreateAtespace failed: %v", err)
+	}
+	created, err := s.CreateActorTemplate(ctx, req("ns1", "tmpl-a"))
+	if err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+	if created.GetMetadata().GetName() != "tmpl-a" {
+		t.Errorf("created name = %q, want tmpl-a", created.GetMetadata().GetName())
+	}
+}
+
+// TestCreateActorTemplateIgnoresServerOwnedFields pins the create contract:
+// status on the request is dropped and the server initializes the phase. The
+// store persists whatever the handler hands it, so the handler is the only
+// guard.
+func TestCreateActorTemplateIgnoresServerOwnedFields(t *testing.T) {
+	persistence := newTestPersistence(t)
+	s := &Service{persistence: persistence}
+	ctx := context.Background()
+
+	if _, err := persistence.CreateAtespace(ctx, &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: "ns1"}}); err != nil {
+		t.Fatalf("CreateAtespace failed: %v", err)
+	}
+
+	in := validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+		tmpl.Metadata.Uid = "11111111-1111-1111-1111-111111111111"
+		tmpl.Metadata.Version = 42
+		tmpl.WorkerSelector = &ateapipb.Selector{MatchLabels: map[string]string{"pool": "default"}}
+		tmpl.Containers = []*ateapipb.Container{{Name: "main", Image: "example.com/app:v1"}}
+		tmpl.SnapshotsConfig = &ateapipb.SnapshotsConfig{StorageLocation: "gs://my-bucket/snapshots"}
+		tmpl.Resources = &ateapipb.Resources{Limits: []*ateapipb.Limits{{Name: "memory", Quantity: "1Gi"}}}
+		// Server-owned status a client must not be able to set.
+		tmpl.Status = &ateapipb.ActorTemplateStatus{
+			Phase:          ateapipb.ActorTemplatePhase_ACTOR_TEMPLATE_PHASE_READY,
+			Message:        "forged",
+			GoldenSnapshot: &ateapipb.ObjectRef{Atespace: "ate-golden", Name: "sneaky"},
+			SandboxAssets:  &ateapipb.SandboxAssets{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR},
+		}
+	})
+	created, err := s.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{ActorTemplate: in})
+	if err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+
+	want := validActorTemplate(func(tmpl *ateapipb.ActorTemplate) {
+		tmpl.Metadata.Version = 1
+		tmpl.WorkerSelector = in.GetWorkerSelector()
+		tmpl.Containers = in.GetContainers()
+		tmpl.SnapshotsConfig = in.GetSnapshotsConfig()
+		tmpl.Resources = in.GetResources()
+		tmpl.Status = &ateapipb.ActorTemplateStatus{Phase: ateapipb.ActorTemplatePhase_ACTOR_TEMPLATE_PHASE_INITIAL}
+	})
+	if diff := cmp.Diff(want, created, protocmp.Transform(), ignoreUID, ignoreTimestamps); diff != "" {
+		t.Errorf("CreateActorTemplate response mismatch (-want +got):\n%s", diff)
+	}
+	if got := created.GetMetadata().GetUid(); got == "" || got == in.GetMetadata().GetUid() {
+		t.Errorf("created uid = %q, want a fresh server-assigned uid", got)
+	}
+}
+
+func TestValidateGetActorTemplateRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.GetActorTemplateRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl-a"}},
+		nil,
+	}, {
+		"missing actor_template",
+		&ateapipb.GetActorTemplateRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor_template"), "")},
+	}, {
+		"missing atespace",
+		&ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "atespace"), "")},
+	}, {
+		"missing name",
+		&ateapipb.GetActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1"}},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "name"), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateGetActorTemplateRequest(tt.req), tt.want)
+		})
+	}
+}
+
+func TestValidateListActorTemplatesRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.ListActorTemplatesRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.ListActorTemplatesRequest{PageSize: 10},
+		nil,
+	}, {
+		"zero page size",
+		&ateapipb.ListActorTemplatesRequest{},
+		nil,
+	}, {
+		"valid atespace filter",
+		&ateapipb.ListActorTemplatesRequest{Atespace: "ns1"},
+		nil,
+	}, {
+		"invalid atespace filter",
+		&ateapipb.ListActorTemplatesRequest{Atespace: "NS_1"},
+		field.ErrorList{field.Invalid(field.NewPath("atespace"), "NS_1", "")},
+	}, {
+		"negative page size",
+		&ateapipb.ListActorTemplatesRequest{PageSize: -1},
+		field.ErrorList{field.Invalid(field.NewPath("page_size"), int32(-1), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateListActorTemplatesRequest(tt.req), tt.want)
+		})
+	}
+}
+
+func TestValidateDeleteActorTemplateRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ateapipb.DeleteActorTemplateRequest
+		want field.ErrorList
+	}{{
+		"valid",
+		&ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl-a"}},
+		nil,
+	}, {
+		"missing actor_template",
+		&ateapipb.DeleteActorTemplateRequest{},
+		field.ErrorList{field.Required(field.NewPath("actor_template"), "")},
+	}, {
+		"missing atespace",
+		&ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Name: "tmpl-a"}},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "atespace"), "")},
+	}, {
+		"missing name",
+		&ateapipb.DeleteActorTemplateRequest{ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1"}},
+		field.ErrorList{field.Required(field.NewPath("actor_template", "name"), "")},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateDeleteActorTemplateRequest(tt.req), tt.want)
+		})
+	}
+}

--- a/cmd/ateapi/internal/controlapi/service.go
+++ b/cmd/ateapi/internal/controlapi/service.go
@@ -98,6 +98,10 @@ type serviceStore interface {
 	GetAtespace(ctx context.Context, name string) (*ateapipb.Atespace, error)
 	ListAtespaces(ctx context.Context, opts store.ListOptions) (store.ListResponse[*ateapipb.Atespace], error)
 	DeleteAtespace(ctx context.Context, name string) (*ateapipb.Atespace, error)
+	CreateActorTemplate(ctx context.Context, template *ateapipb.ActorTemplate) (*ateapipb.ActorTemplate, error)
+	GetActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef) (*ateapipb.ActorTemplate, error)
+	ListActorTemplates(ctx context.Context, atespace string, opts store.ListOptions) (store.ListResponse[*ateapipb.ActorTemplate], error)
+	DeleteActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef) (*ateapipb.ActorTemplate, error)
 	ListWorkers(ctx context.Context, opts store.ListOptions) (store.ListResponse[*ateapipb.Worker], error)
 	AcquireLock(ctx context.Context, key string) (*store.Lock, error)
 }

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -155,8 +155,7 @@ type Interface interface {
 	UpdateActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef, mutate func(dbTemplate *ateapipb.ActorTemplate) error) (*ateapipb.ActorTemplate, error)
 
 	// Removes an ActorTemplate and returns the deleted resource. Returns
-	// ErrNotFound if missing, or ErrFailedPrecondition while any
-	// ActorTemplateVersion still names it as parent.
+	// ErrNotFound if missing.
 	DeleteActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef) (*ateapipb.ActorTemplate, error)
 
 	// Registers a new idle worker. Returns ErrAlreadyExists if already registered.

--- a/internal/resources/resourceref.go
+++ b/internal/resources/resourceref.go
@@ -17,6 +17,7 @@ package resources
 import (
 	"fmt"
 	"log/slog"
+	"reflect"
 	"strings"
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
@@ -44,6 +45,7 @@ func (r ResourceRef[R]) String() string {
 // than flattening them into one opaque string.
 func (r ResourceRef[R]) LogValue() slog.Value {
 	return slog.GroupValue(
+		slog.String("type", reflect.TypeFor[R]().String()),
 		slog.String("atespace", r.Atespace),
 		slog.String("name", r.Name),
 	)

--- a/internal/resources/resourceref_test.go
+++ b/internal/resources/resourceref_test.go
@@ -15,6 +15,7 @@
 package resources
 
 import (
+	"log/slog"
 	"reflect"
 	"testing"
 
@@ -35,6 +36,47 @@ func TestRefAliasesAreDistinctTypes(t *testing.T) {
 			t.Errorf("%s and %s are the same type; the phantom kind marker was lost", name, other)
 		}
 		seen[typ] = name
+	}
+}
+
+// The type attr comes from the type parameter alone, so a zero ref — where no
+// value of R was ever constructed — must log without panicking and still name
+// its resource kind.
+func TestResourceRefLogValue(t *testing.T) {
+	tests := []struct {
+		name string
+		val  slog.Value
+		want map[string]string
+	}{
+		{
+			name: "zero actor ref",
+			val:  ActorRef{}.LogValue(),
+			want: map[string]string{"type": "*ateapipb.Actor", "atespace": "", "name": ""},
+		},
+		{
+			name: "zero template ref",
+			val:  ActorTemplateRef{}.LogValue(),
+			want: map[string]string{"type": "*ateapipb.ActorTemplate", "atespace": "", "name": ""},
+		},
+		{
+			name: "populated actor ref",
+			val:  ActorRef{Atespace: "team-a", Name: "act-1"}.LogValue(),
+			want: map[string]string{"type": "*ateapipb.Actor", "atespace": "team-a", "name": "act-1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if kind := tt.val.Kind(); kind != slog.KindGroup {
+				t.Fatalf("LogValue() kind = %v, want %v", kind, slog.KindGroup)
+			}
+			got := make(map[string]string)
+			for _, attr := range tt.val.Group() {
+				got[attr.Key] = attr.Value.String()
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("LogValue() attrs = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Part of #477.

Changes
* Implement ActorTemplate CRUD in the control API
* Added a shared generic ResourceRef behind the template and actor ref types

Relevant:
* Following style guidances in https://github.com/agent-substrate/substrate/issues/891