### PR TITLE
skill: add triage-issues for labeling open issues

### DIFF
--- a/.agents/skills/triage-issues/SKILL.md
+++ b/.agents/skills/triage-issues/SKILL.md
@@ -110,6 +110,13 @@ capacity, or researching unknowns before any code is written, it is `kind/design
 Keywords: "Design discussion", "Investigate", "Explore options", "Identify what",
 "Measure", "Research".
 
+The clearest way to distinguish `kind/design` from `kind/feature`:
+- **`kind/feature`**: you could open a PR today — the *what* and *how* are known.
+- **`kind/design`**: a decision or investigation must happen first; a PR cannot be written yet.
+
+When in doubt, ask: *"Could someone reasonably start coding this issue right now?"*
+If yes → `kind/feature`. If no → `kind/design`.
+
 **4. Is it a code quality improvement with no behavior change?**
 Refactoring, renaming, consolidating duplicated code, removing dead code → `kind/cleanup`.
 

--- a/.agents/skills/triage-issues/SKILL.md
+++ b/.agents/skills/triage-issues/SKILL.md
@@ -55,13 +55,18 @@ Apply all areas that are touched. Most issues need one or two; a few need more.
 | `area/cli` | `kubectl-ate` CLI plugin |
 | `area/demos` | Demo applications in `demos/` |
 | `area/benchmarking` | Performance benchmarks and capacity measurements (`benchmarking/`) |
+| `area/reliability` | Reliability, stability, error recovery, and uptime concerns |
 
-`area/benchmarking` does not exist yet — create it first:
+`area/benchmarking` and `area/reliability` do not exist yet — create them first:
 ```bash
 gh label create "area/benchmarking" \
   --repo agent-substrate/substrate \
   --description "Performance benchmarks and capacity measurement" \
   --color "f9d0c4"
+gh label create "area/reliability" \
+  --repo agent-substrate/substrate \
+  --description "Reliability, stability, error recovery, and uptime" \
+  --color "e4e669"
 ```
 
 ### `prio/` — priority
@@ -121,11 +126,11 @@ necessarily land. A bug in actor scheduling reported via the API is `area/api` +
 
 ### Step 1 — Create missing labels (once)
 
-Check whether `kind/design` and `area/benchmarking` exist before creating them:
+Check whether `kind/design`, `area/benchmarking`, and `area/reliability` exist before creating them:
 
 ```bash
 gh label list --repo agent-substrate/substrate --json name \
-  --jq '[.[].name] | contains(["kind/design"])'
+  --jq '[.[].name] | contains(["kind/design", "area/benchmarking", "area/reliability"])'
 ```
 
 Create each if not present using the `gh label create` commands above.

--- a/.agents/skills/triage-issues/SKILL.md
+++ b/.agents/skills/triage-issues/SKILL.md
@@ -33,12 +33,12 @@ Priority and status labels are optional.
 | `kind/docs` | Documentation only — missing, outdated, or incorrect docs. |
 | `kind/design` | Design discussions, investigations, research, and open questions that must be resolved before implementation. Includes "Design discussion:", "Identify what X should be", "Measure/benchmark X", "Explore options". |
 
-`kind/design` does not exist yet — include its creation in the proposal, and create it
-during the apply step with:
+If any label in this taxonomy does not exist on the repo yet, include its creation in
+the proposal and create it during the apply step with:
 ```bash
-gh label create "kind/design" \
+gh label create "<label>" \
   --repo agent-substrate/substrate \
-  --description "Design discussion, investigation, or research required before implementation" \
+  --description "<short description matching the taxonomy table>" \
   --color "c5def5"
 ```
 
@@ -65,15 +65,6 @@ Apply all areas that are touched. Most issues need one or two; a few need more.
 | `area/demos` | Demo applications in `demos/` |
 | `area/benchmarking` | Performance benchmarks and capacity measurements (`benchmarking/`) |
 | `area/reliability` | Reliability, stability, error recovery, and uptime concerns |
-
-`area/benchmarking` does not exist yet — include its creation in the proposal, and
-create it during the apply step with:
-```bash
-gh label create "area/benchmarking" \
-  --repo agent-substrate/substrate \
-  --description "Performance benchmarks and capacity measurements" \
-  --color "d4c5f9"
-```
 
 ### `prio/` — priority
 
@@ -142,14 +133,14 @@ proposal in Step 3.
 
 ### Step 1 — Check for missing labels
 
-Check whether `kind/design` and `area/benchmarking` exist:
+List the repo's labels and compare against the taxonomy above:
 
 ```bash
-gh label list --repo agent-substrate/substrate --json name \
-  --jq '[.[].name] | contains(["kind/design", "area/benchmarking"])'
+gh label list --repo agent-substrate/substrate --limit 100 --json name --jq '.[].name'
 ```
 
-Do not create anything yet. If either is missing, list its creation in the proposal.
+Do not create anything yet. If any taxonomy label is missing, list its creation in
+the proposal.
 
 ### Step 2 — Fetch and classify issues
 
@@ -204,7 +195,7 @@ what the user approved.
 
 ### Step 4 — Apply approved changes and record the undo
 
-Create any approved missing labels with the `gh label create` commands above, then
+Create any approved missing labels with the `gh label create` command above, then
 apply labels to each approved issue:
 
 ```bash

--- a/.agents/skills/triage-issues/SKILL.md
+++ b/.agents/skills/triage-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issues
-description: Triages open GitHub issues by applying the correct labels. Use when asked to triage issues, label issues, or organize the issue backlog. Processes unlabeled issues first, then reviews labeled issues for correctness.
+description: Triages open GitHub issues by applying the correct labels. Use when asked to triage issues, label issues, or organize the issue backlog. Processes unlabeled issues first, then reviews labeled issues for correctness. Proposes all changes for approval before applying anything, and writes an undo script for each run.
 ---
 
 # Triage Issues
@@ -9,6 +9,14 @@ Triage means: read each issue, decide the right labels from the taxonomy below, 
 apply them with `gh issue edit`. Do not remove labels a human has already added unless
 they are clearly wrong. Do not add priority labels unless the issue body or discussion
 makes the priority obvious.
+
+Two hard rules govern every run:
+
+1. **Propose before applying.** Classify everything first and present the full set of
+   proposed changes as a summary for the user to validate. Apply nothing — no labels,
+   no label creation — until the user approves.
+2. **Record an undo.** While applying approved changes, build an undo script that
+   reverses exactly what this run did, and hand the user the command to run it.
 
 ## Label taxonomy
 
@@ -25,7 +33,8 @@ Priority and status labels are optional.
 | `kind/docs` | Documentation only — missing, outdated, or incorrect docs. |
 | `kind/design` | Design discussions, investigations, research, and open questions that must be resolved before implementation. Includes "Design discussion:", "Identify what X should be", "Measure/benchmark X", "Explore options". |
 
-`kind/design` does not exist yet — create it first:
+`kind/design` does not exist yet — include its creation in the proposal, and create it
+during the apply step with:
 ```bash
 gh label create "kind/design" \
   --repo agent-substrate/substrate \
@@ -56,6 +65,15 @@ Apply all areas that are touched. Most issues need one or two; a few need more.
 | `area/demos` | Demo applications in `demos/` |
 | `area/benchmarking` | Performance benchmarks and capacity measurements (`benchmarking/`) |
 | `area/reliability` | Reliability, stability, error recovery, and uptime concerns |
+
+`area/benchmarking` does not exist yet — include its creation in the proposal, and
+create it during the apply step with:
+```bash
+gh label create "area/benchmarking" \
+  --repo agent-substrate/substrate \
+  --description "Performance benchmarks and capacity measurements" \
+  --color "d4c5f9"
+```
 
 ### `prio/` — priority
 
@@ -119,18 +137,23 @@ necessarily land. A bug in actor scheduling reported via the API is `area/api` +
 
 ## Process
 
-### Step 1 — Create missing labels (once)
+Steps 1–3 are read-only. Nothing is written to GitHub until the user approves the
+proposal in Step 3.
 
-Check whether `kind/design` exists before creating it:
+### Step 1 — Check for missing labels
+
+Check whether `kind/design` and `area/benchmarking` exist:
 
 ```bash
 gh label list --repo agent-substrate/substrate --json name \
-  --jq '[.[].name] | contains(["kind/design"])'
+  --jq '[.[].name] | contains(["kind/design", "area/benchmarking"])'
 ```
 
-Create it if not present using the `gh label create` command above.
+Do not create anything yet. If either is missing, list its creation in the proposal.
 
-### Step 2 — Fetch unlabeled issues first
+### Step 2 — Fetch and classify issues
+
+Fetch unlabeled issues first:
 
 ```bash
 gh issue list --repo agent-substrate/substrate \
@@ -139,9 +162,50 @@ gh issue list --repo agent-substrate/substrate \
   --jq '[.[] | select(.labels | length == 0)]'
 ```
 
-### Step 3 — Classify and apply labels
+Classify each one using the guide above. Then scan already-labeled issues for
+obvious gaps:
+- Issues with a `kind/` label but no `area/` label
+- Issues with `area/` labels but no `kind/` label
+- Issues that look like `kind/design` but are filed as `kind/feature`
 
-For each issue, read the title and body, classify using the guide above, then apply:
+Do not propose changes to labels that look reasonable even if you might have chosen
+differently. Only correct clear mismatches (for example, a bug filed as
+`kind/feature`, or a design discussion with no `kind/` label at all).
+
+Only propose labels an issue does not already have, so the undo record in Step 4
+removes exactly what this run added and nothing a human applied earlier.
+
+### Step 3 — Present the proposal and wait for approval
+
+Output a summary of every change you intend to make, then **stop and wait**. Do not
+apply anything in the same turn as the proposal.
+
+```
+## Proposed changes
+
+Labels to create: kind/design, area/benchmarking
+
+| Issue | Title (truncated) | Labels to add |
+|---|---|---|
+| #900 | Implement chain of authenticator... | kind/feature, area/identity, area/api-machinery |
+| #874 | Design discussion: WorkerPool vs... | kind/design, area/scheduling |
+
+### Uncertain (best guess included above, please confirm)
+- #812 — could be kind/bug or kind/design: unclear whether the behavior is intended.
+
+Reply to approve all, or list the issue numbers to change or skip.
+```
+
+List every uncertain issue with the question you could not resolve from the text
+alone. Do not leave those out of the proposal — include your best guess and flag it.
+
+If the user asks for corrections, update the proposal and confirm again. Apply only
+what the user approved.
+
+### Step 4 — Apply approved changes and record the undo
+
+Create any approved missing labels with the `gh label create` commands above, then
+apply labels to each approved issue:
 
 ```bash
 gh issue edit <number> \
@@ -151,20 +215,31 @@ gh issue edit <number> \
 
 Use `--add-label`, not `--label`, so you don't overwrite existing labels.
 
-### Step 4 — Review already-labeled issues
+As you apply, build an undo script at `/tmp/triage-issues-undo-<YYYYMMDD-HHMMSS>.sh`
+containing one line per successfully applied change, reversing it:
 
-After clearing the unlabeled backlog, scan labeled issues for obvious gaps:
-- Issues with a `kind/` label but no `area/` label
-- Issues with `area/` labels but no `kind/` label
-- Issues that look like `kind/design` but are filed as `kind/feature`
+```bash
+#!/usr/bin/env bash
+# Undo record for triage-issues run on 2026-09-04 14:03 UTC.
+# Removes only the labels this run added; labels applied by humans are untouched.
+set -euo pipefail
+gh issue edit 900 --repo agent-substrate/substrate --remove-label "kind/feature,area/identity,area/api-machinery"
+gh issue edit 874 --repo agent-substrate/substrate --remove-label "kind/design,area/scheduling"
+# Label deletions must come last: deleting a label strips it from all issues.
+# Only present if this run created the label.
+gh label delete "kind/design" --repo agent-substrate/substrate --yes
+```
 
-Do not change labels that look reasonable even if you might have chosen differently.
-Only correct clear mismatches (for example, a bug filed as `kind/feature`, or a
-design discussion with no `kind/` label at all).
+Rules for the undo script:
+- Record only changes that actually succeeded, not the full proposal.
+- Include a `--remove-label` line per issue listing exactly the labels this run added.
+- Include `gh label delete` only for labels this run created, and place those lines
+  after all `--remove-label` lines.
+- Make it executable: `chmod +x <script>`.
 
 ### Step 5 — Report
 
-After triaging, output a table:
+After applying, output a table of what was actually done:
 
 ```
 | Issue | Title (truncated) | Labels applied |
@@ -172,9 +247,12 @@ After triaging, output a table:
 | #900 | Implement chain of authenticator... | kind/feature, area/identity, area/api-machinery |
 ```
 
-List any issues you were uncertain about separately, with the question you could not
-resolve from the text alone. Do not leave those unlabeled — apply your best guess and
-flag it.
+Note any approved changes that failed to apply. Then point at the undo record:
+
+```
+To undo everything this run changed:
+  bash /tmp/triage-issues-undo-20260904-140312.sh
+```
 
 ---
 

--- a/.agents/skills/triage-issues/SKILL.md
+++ b/.agents/skills/triage-issues/SKILL.md
@@ -57,18 +57,6 @@ Apply all areas that are touched. Most issues need one or two; a few need more.
 | `area/benchmarking` | Performance benchmarks and capacity measurements (`benchmarking/`) |
 | `area/reliability` | Reliability, stability, error recovery, and uptime concerns |
 
-`area/benchmarking` and `area/reliability` do not exist yet — create them first:
-```bash
-gh label create "area/benchmarking" \
-  --repo agent-substrate/substrate \
-  --description "Performance benchmarks and capacity measurement" \
-  --color "f9d0c4"
-gh label create "area/reliability" \
-  --repo agent-substrate/substrate \
-  --description "Reliability, stability, error recovery, and uptime" \
-  --color "e4e669"
-```
-
 ### `prio/` — priority
 
 Only apply when the issue body or a maintainer comment makes the priority evident.
@@ -133,14 +121,14 @@ necessarily land. A bug in actor scheduling reported via the API is `area/api` +
 
 ### Step 1 — Create missing labels (once)
 
-Check whether `kind/design`, `area/benchmarking`, and `area/reliability` exist before creating them:
+Check whether `kind/design` exists before creating it:
 
 ```bash
 gh label list --repo agent-substrate/substrate --json name \
-  --jq '[.[].name] | contains(["kind/design", "area/benchmarking", "area/reliability"])'
+  --jq '[.[].name] | contains(["kind/design"])'
 ```
 
-Create each if not present using the `gh label create` commands above.
+Create it if not present using the `gh label create` command above.
 
 ### Step 2 — Fetch unlabeled issues first
 

--- a/.agents/skills/triage-issues/SKILL.md
+++ b/.agents/skills/triage-issues/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: triage-issues
+description: Triages open GitHub issues by applying the correct labels. Use when asked to triage issues, label issues, or organize the issue backlog. Processes unlabeled issues first, then reviews labeled issues for correctness.
+---
+
+# Triage Issues
+
+Triage means: read each issue, decide the right labels from the taxonomy below, and
+apply them with `gh issue edit`. Do not remove labels a human has already added unless
+they are clearly wrong. Do not add priority labels unless the issue body or discussion
+makes the priority obvious.
+
+## Label taxonomy
+
+Every issue should have at least one `kind/` label and at least one `area/` label.
+Priority and status labels are optional.
+
+### `kind/` — what the issue is
+
+| Label | When to apply |
+|---|---|
+| `kind/bug` | Something is broken or behaves incorrectly. The current behavior is wrong. |
+| `kind/feature` | A new capability that does not exist today. Includes enhancements to existing features. |
+| `kind/cleanup` | Code quality improvements that do not change behavior: refactors, naming, dead code removal, small inconsistencies. |
+| `kind/docs` | Documentation only — missing, outdated, or incorrect docs. |
+| `kind/design` | Design discussions, investigations, research, and open questions that must be resolved before implementation. Includes "Design discussion:", "Identify what X should be", "Measure/benchmark X", "Explore options". |
+
+`kind/design` does not exist yet — create it first:
+```bash
+gh label create "kind/design" \
+  --repo agent-substrate/substrate \
+  --description "Design discussion, investigation, or research required before implementation" \
+  --color "c5def5"
+```
+
+### `area/` — which part of the codebase
+
+Apply all areas that are touched. Most issues need one or two; a few need more.
+
+| Label | Scope |
+|---|---|
+| `area/api` | User-facing Substrate API (`pkg/proto/ateapipb/`, proto definitions, API semantics, versioning) |
+| `area/api-machinery` | API server internals: RPC handlers, storage layer, syncer, controllers (`cmd/ateapi/`, `cmd/atecontroller/`) |
+| `area/network` | Networking: atenet-router, Envoy, ext_proc, DNS, xDS, ingress (`cmd/atenet/`) |
+| `area/node` | Node agent and worker lifecycle: atelet, sandbox launch, OCI, cgroups (`cmd/atelet/`) |
+| `area/gvisor` | gVisor sandbox specifics: runsc integration, GPU in gVisor, gVisor OCI (`cmd/ateom-gvisor/`) |
+| `area/microVM` | Micro-VM sandbox specifics: cloud-hypervisor, kata, snapshot/restore (`cmd/ateom-microvm/`) |
+| `area/storage` | Snapshot storage, image cache, GCS/S3 backends, retention (`internal/imagecache/`, ActorSnapshot) |
+| `area/scheduling` | WorkerPool sizing, actor placement, HPA, resource allocation |
+| `area/observability` | Metrics, tracing, logging, OTLP, OTel SDK integration |
+| `area/security` | Auth, mTLS, RBAC, threat detection, credential management, PodCertificate |
+| `area/identity` | Actor identity, token issuance, JWT auth, ActorIdentity extension |
+| `area/dev-infra` | CI/CD, GitHub Actions, presubmit checks, tooling, proto generation |
+| `area/tests` | Test coverage, flaky tests, test infrastructure (not a bug in production code) |
+| `area/cli` | `kubectl-ate` CLI plugin |
+| `area/demos` | Demo applications in `demos/` |
+| `area/benchmarking` | Performance benchmarks and capacity measurements (`benchmarking/`) |
+
+`area/benchmarking` does not exist yet — create it first:
+```bash
+gh label create "area/benchmarking" \
+  --repo agent-substrate/substrate \
+  --description "Performance benchmarks and capacity measurement" \
+  --color "f9d0c4"
+```
+
+### `prio/` — priority
+
+Only apply when the issue body or a maintainer comment makes the priority evident.
+Do not guess.
+
+| Label | Meaning |
+|---|---|
+| `prio/P0` | Highest priority; required for next milestone or blocking ongoing work |
+| `prio/P1` | Important but not blocking; should land in the near term |
+| `prio/P2` | Real issue but not urgent; can wait |
+
+### Status labels
+
+Apply only when clearly appropriate. Never add `wontfix`, `duplicate`, or `invalid`
+yourself — those are maintainer decisions.
+
+| Label | When |
+|---|---|
+| `good first issue` | Well-scoped, self-contained, does not require deep system knowledge |
+| `help wanted` | Maintainers actively want external contributions |
+
+---
+
+## Classification guide
+
+Work through these questions in order:
+
+**1. Is something broken?**
+If the current behavior is incorrect, it is `kind/bug`. Security holes and data
+loss are bugs, not features.
+
+**2. Does it ask for new capability?**
+If the system would need to do something it cannot do today, it is `kind/feature`.
+Apply `kind/feature` even if the issue is framed as "support X" or "add Y".
+
+**3. Is it a design question or investigation?**
+If the issue is asking *how* to do something, comparing approaches, measuring
+capacity, or researching unknowns before any code is written, it is `kind/design`.
+Keywords: "Design discussion", "Investigate", "Explore options", "Identify what",
+"Measure", "Research".
+
+**4. Is it a code quality improvement with no behavior change?**
+Refactoring, renaming, consolidating duplicated code, removing dead code → `kind/cleanup`.
+
+**5. Is it documentation only?**
+Docs fixes, missing API guide sections, README updates → `kind/docs`.
+
+For `area/` labels, use the component the issue is *about*, not where the fix will
+necessarily land. A bug in actor scheduling reported via the API is `area/api` +
+`area/scheduling`, not `area/api-machinery`.
+
+---
+
+## Process
+
+### Step 1 — Create missing labels (once)
+
+Check whether `kind/design` and `area/benchmarking` exist before creating them:
+
+```bash
+gh label list --repo agent-substrate/substrate --json name \
+  --jq '[.[].name] | contains(["kind/design"])'
+```
+
+Create each if not present using the `gh label create` commands above.
+
+### Step 2 — Fetch unlabeled issues first
+
+```bash
+gh issue list --repo agent-substrate/substrate \
+  --state open --limit 500 \
+  --json number,title,labels,body \
+  --jq '[.[] | select(.labels | length == 0)]'
+```
+
+### Step 3 — Classify and apply labels
+
+For each issue, read the title and body, classify using the guide above, then apply:
+
+```bash
+gh issue edit <number> \
+  --repo agent-substrate/substrate \
+  --add-label "kind/bug,area/network"
+```
+
+Use `--add-label`, not `--label`, so you don't overwrite existing labels.
+
+### Step 4 — Review already-labeled issues
+
+After clearing the unlabeled backlog, scan labeled issues for obvious gaps:
+- Issues with a `kind/` label but no `area/` label
+- Issues with `area/` labels but no `kind/` label
+- Issues that look like `kind/design` but are filed as `kind/feature`
+
+Do not change labels that look reasonable even if you might have chosen differently.
+Only correct clear mismatches (for example, a bug filed as `kind/feature`, or a
+design discussion with no `kind/` label at all).
+
+### Step 5 — Report
+
+After triaging, output a table:
+
+```
+| Issue | Title (truncated) | Labels applied |
+|---|---|---|
+| #900 | Implement chain of authenticator... | kind/feature, area/identity, area/api-machinery |
+```
+
+List any issues you were uncertain about separately, with the question you could not
+resolve from the text alone. Do not leave those unlabeled — apply your best guess and
+flag it.
+
+---
+
+## Classification examples
+
+These illustrate the taxonomy applied to real issues in this repo:
+
+| Title pattern | `kind/` | `area/` |
+|---|---|---|
+| "X is broken / returns wrong value / panics" | bug | affected component |
+| "Add support for X / Implement Y" | feature | affected component |
+| "Design discussion: should X or Y" | design | affected component |
+| "Identify what metrics to use for Z" | design | observability, scheduling |
+| "Measure / benchmark X capacity" | design | benchmarking, affected component |
+| "Consolidate / Reorganize / Rework X" | cleanup | affected component |
+| "Update docs / Add doc for X" | docs | (omit area unless specific) |
+| "E2E test flaky: TestFoo" | bug | tests, affected component |
+| "Presubmit doesn't catch X" | bug | dev-infra |
+
+---
+
+## Notes
+
+- An issue can have multiple `area/` labels. Apply all that fit.
+- A single `kind/` label per issue is the norm. Applying two is unusual.
+- Do not add `prio/` labels to issues that don't clearly warrant one. Unlabeled
+  priority is better than a wrong priority label.
+- Never remove a label a human applied. If you think it is wrong, note it in your
+  report and let a maintainer decide.


### PR DESCRIPTION
## What changed and why

Adds `.agents/skills/triage-issues/SKILL.md` — a skill agents invoke (via "triage issues") to classify open GitHub issues with the correct `kind/`, `area/`, and `prio/` labels.

Of 202 open issues, 13 are currently unlabeled. Several labeled issues also lack a `kind/` label or use `kind/feature` for what are really design discussions.

### What the skill does

- Documents the full label taxonomy with clear when-to-apply rules for every existing label
- Processes unlabeled issues first, then reviews labeled issues for obvious gaps
- Uses `--add-label` (not `--label`) so existing human-applied labels are never overwritten
- Outputs a report table of every change made, plus flagged uncertainties for maintainer review
- Never removes labels or adds `wontfix`/`duplicate`/`invalid` — those stay with maintainers

### Two new labels proposed

The current taxonomy has two gaps I found while analyzing the backlog:

**`kind/design`** — Several issues are design discussions or investigations that must be resolved before any code is written (e.g. _"Design discussion: WorkerPool vs. node-level Actor runtime"_, _"Identify what metrics to use for HPA autoscaling"_, _"Measure atenet-router request capacity"_). These are currently unlabeled or mislabeled as `kind/feature`. The skill creates this label if it doesn't exist.

**`area/benchmarking`** — The repo has a full `benchmarking/` directory but no corresponding area label. Performance measurement issues have nowhere to go. The skill creates this label if it doesn't exist.

## Checklist

- [x] Issue is linked above
- [x] Tests pass locally (`go test ./...`)
- [x] Root-gated tests pass if applicable (`hack/run-root-tests.sh`)
- [x] Documentation updated if behavior changed (N/A)