### PR TITLE
ateapi: return ResourceExhausted when no worker is free

### DIFF
--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -62,6 +62,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 )
 
@@ -113,33 +114,10 @@ func TestMain(m *testing.M) {
 		log.Fatalf("create fast storage class: %v", err)
 	}
 
-	// Create shared Atelet Pod
-	ateletPod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "atelet-shared",
-			Namespace: "ate-system",
-			Labels: map[string]string{
-				"app": "atelet",
-			},
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "node1",
-			Containers: []corev1.Container{
-				{Name: "main", Image: "nginx"},
-			},
-		},
-	}
-	createdAtelet, err := k8sClient.CoreV1().Pods("ate-system").Create(context.Background(), ateletPod, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		log.Fatalf("create atelet pod: %v", err)
-	}
-	if err == nil {
-		createdAtelet.Status.PodIPs = []corev1.PodIP{{IP: "127.0.0.1"}}
-		createdAtelet.Status.Phase = corev1.PodRunning
-		_, err = k8sClient.CoreV1().Pods("ate-system").UpdateStatus(context.Background(), createdAtelet, metav1.UpdateOptions{})
-		if err != nil {
-			log.Fatalf("update atelet pod status: %v", err)
-		}
+	// Create shared Atelet Pod. Tests that place workers on another node add
+	// their own atelet there via setupAteletOnNode.
+	if err := createAteletPod(k8sClient, "atelet-shared", "node1"); err != nil {
+		log.Fatalf("%v", err)
 	}
 
 	// Start Fake Atelet Server on port 8085
@@ -281,6 +259,10 @@ type testContext struct {
 	actorTemplateLister listersv1alpha1.ActorTemplateLister
 	workerPoolLister    listersv1alpha1.WorkerPoolLister
 	sandboxConfigLister listersv1alpha1.SandboxConfigLister
+	// ateletIndexer is the index DialForAteletOnNode looks up atelets in.
+	// setupAteletOnNode waits on it so a test never dials a node whose atelet the
+	// informer has not seen yet.
+	ateletIndexer cache.Indexer
 }
 
 // setupTest sets up a fully isolated test environment.
@@ -440,6 +422,7 @@ func setupTest(t *testing.T, ns string) *testContext {
 		actorTemplateLister: actorTemplateLister,
 		workerPoolLister:    workerPoolLister,
 		sandboxConfigLister: sandboxConfigLister,
+		ateletIndexer:       ateletInformer.GetIndexer(),
 	}
 }
 
@@ -768,6 +751,71 @@ func createWorkerPod(t *testing.T, tc *testContext, ns string, name string, node
 	})
 	if err != nil {
 		t.Fatalf("failed to wait for worker to appear in worker cache: %v", err)
+	}
+}
+
+// createAteletPod creates an atelet pod on nodeName and marks it Running with
+// an IP, which DialForAteletOnNode requires. The pod carries the namespace and
+// app=atelet label AteletInformer selects on, and is indexed by its node.
+func createAteletPod(kc kubernetes.Interface, name, nodeName string) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ateletNamespace,
+			Labels:    map[string]string{"app": "atelet"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   nodeName,
+			Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+		},
+	}
+	created, err := kc.CoreV1().Pods(ateletNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("creating atelet pod %s on %s: %w", name, nodeName, err)
+	}
+	created.Status.PodIPs = []corev1.PodIP{{IP: "127.0.0.1"}}
+	created.Status.Phase = corev1.PodRunning
+	if _, err := kc.CoreV1().Pods(ateletNamespace).UpdateStatus(context.Background(), created, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating atelet pod %s status: %w", name, err)
+	}
+	return nil
+}
+
+// setupAteletOnNode makes nodeName dialable for the duration of the test: it
+// creates an atelet pod there, waits for the dialer's index to see it, and
+// removes it on cleanup. The package fixture only creates one atelet, on
+// node1, and the dialer resolves atelets per node, so a worker on any other
+// node is unreachable without this.
+func setupAteletOnNode(t *testing.T, tc *testContext, name, nodeName string) {
+	t.Helper()
+	if err := createAteletPod(tc.k8sClient, name, nodeName); err != nil {
+		t.Fatalf("%v", err)
+	}
+	t.Cleanup(func() {
+		_ = tc.k8sClient.CoreV1().Pods(ateletNamespace).Delete(context.Background(), name, metav1.DeleteOptions{
+			GracePeriodSeconds: ptr.To[int64](0),
+		})
+	})
+
+	// Wait for the dialer's index to see the newly created atlet
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		atelets, err := tc.ateletIndexer.ByIndex(byNode, nodeName)
+		if err != nil {
+			return false, nil
+		}
+		for _, obj := range atelets {
+			p := obj.(*corev1.Pod)
+			if p.Name == name && len(p.Status.PodIPs) > 0 {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to wait for atelet pod on %s to be indexed: %v", nodeName, err)
 	}
 }
 
@@ -1884,7 +1932,7 @@ func TestResumeActor_NoWorkers(t *testing.T) {
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
 	})
-	assertGrpcError(t, err, codes.FailedPrecondition, "no free workers available")
+	assertGrpcError(t, err, codes.ResourceExhausted, "no free workers available")
 }
 
 // TestResumeActor_MultiPoolSelector exercises the AND-of-two-selectors path
@@ -3663,5 +3711,99 @@ func TestSuspendActor_FromPaused_RetryAfterUploadFailure(t *testing.T) {
 	}
 	if got := tc.fakeAtelet.UploadRequest.GetDestinationSnapshotUri(); got != firstDestination {
 		t.Errorf("retry destination = %q, want the original %q (idempotent upload target)", got, firstDestination)
+	}
+}
+
+// TestResumeActor_RelocatesAfterSuspendFromPaused covers the capacity-recovery
+// flow: a PAUSED actor is pinned to the node holding its local snapshot, so it
+// cannot resume while that node is full. Suspending it uploads the snapshot and
+// drops the node pinning, after which it is scheduled onto a worker on a different
+// node.
+func TestResumeActor_RelocatesAfterSuspendFromPaused(t *testing.T) {
+	ns := namespaceForTest("ns-resume-relocate")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	const pinned, relocated = "actor-pinned", "actor-squatter"
+	for _, name := range []string{pinned, relocated} {
+		if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+			ActorTemplateNamespace: ns,
+			ActorTemplateName:      "tmpl1",
+		}}); err != nil {
+			t.Fatalf("CreateActor(%s) failed: %v", name, err)
+		}
+	}
+
+	// The actor under test runs on node1's only worker, then pauses — which
+	// frees that worker but pins the actor to node1 via LocalSnapshotInfo.
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: pinned},
+	}); err != nil {
+		t.Fatalf("ResumeActor(%s) failed: %v", pinned, err)
+	}
+	if _, err := tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: pinned},
+	}); err != nil {
+		t.Fatalf("PauseActor(%s) failed: %v", pinned, err)
+	}
+	paused, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: pinned},
+	})
+	if err != nil {
+		t.Fatalf("GetActor(%s) failed: %v", pinned, err)
+	}
+	if got := paused.GetLocalSnapshotInfo().GetNodeVmsWithLocalSnapshots(); len(got) != 1 || got[0] != "node1" {
+		t.Fatalf("paused actor pinned to %v, want [node1]", got)
+	}
+
+	// Another actor takes node1's only worker, so the pinned actor's node is full
+	// while free capacity exists elsewhere.
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: relocated},
+	}); err != nil {
+		t.Fatalf("ResumeActor(%s) failed: %v", relocated, err)
+	}
+	createWorkerPod(t, tc, ns, "worker-2", "node2", "pool1")
+	setupAteletOnNode(t, tc, "atelet-node2", "node2")
+
+	// Capacity exhaustion is ResourceExhausted.
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: pinned},
+	})
+	assertGrpcError(t, err, codes.ResourceExhausted, "no free workers available")
+
+	suspended, err := tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: pinned},
+	})
+	if err != nil {
+		t.Fatalf("SuspendActor(%s) failed: %v", pinned, err)
+	}
+	if got := suspended.GetActor().GetStatus(); got != ateapipb.Actor_STATUS_SUSPENDED {
+		t.Fatalf("status after suspend = %v, want SUSPENDED", got)
+	}
+	if got := suspended.GetActor().GetLocalSnapshotInfo(); got != nil {
+		t.Fatalf("LocalSnapshotInfo = %v, want cleared so the actor can be scheduled anywhere", got)
+	}
+
+	// Resume should succeed now and the actor scheduled on node2.
+	resumed, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: pinned},
+	})
+	if err != nil {
+		t.Fatalf("ResumeActor(%s) after suspend failed: %v", pinned, err)
+	}
+	if got := resumed.GetActor().GetWorkerAssignment().GetWorkerPod(); got != "worker-2" {
+		t.Errorf("resumed onto worker %q, want worker-2 (the worker on node2)", got)
+	}
+	worker, err := tc.persistence.GetWorker(context.Background(), ns, "pool1", "worker-2")
+	if err != nil {
+		t.Fatalf("GetWorker(worker-2) failed: %v", err)
+	}
+	if got := worker.GetNodeName(); got != "node2" {
+		t.Errorf("worker-2 node = %q, want node2", got)
 	}
 }

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -482,7 +482,7 @@ func (w *ActorWorkflow) assignWorkerAttempt(ctx context.Context, actorRef resour
 		if err != nil {
 			if errors.Is(err, scheduling.ErrNoCapacity) {
 				outcome = ateattr.SchedulerOutcomeNoFreeWorker
-				return nil, nil, status.Errorf(codes.FailedPrecondition, "no free workers available")
+				return nil, nil, status.Errorf(codes.ResourceExhausted, "no free workers available")
 			}
 			return nil, nil, err
 		}

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -98,8 +98,8 @@ func TestAssignWorkerAttempt_SkipsWorkerAssignedInOtherAtespace(t *testing.T) {
 		Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor},
 	}
 	_, _, err := w.assignWorkerAttempt(ctx, resources.ActorRef{Atespace: "team-a", Name: "shared"}, actor, tmpl)
-	if status.Code(err) != codes.FailedPrecondition {
-		t.Fatalf("assignWorkerAttempt() error = %v, want FailedPrecondition (no free workers)", err)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("assignWorkerAttempt() error = %v, want ResourceExhausted (no free workers)", err)
 	}
 
 	stored, err := persistence.GetWorker(ctx, "worker-ns", "pool", "pod-1")

--- a/cmd/atenet/internal/router/extproc/metrics.go
+++ b/cmd/atenet/internal/router/extproc/metrics.go
@@ -83,16 +83,16 @@ func classifyOutcome(err error) string {
 		return "timeout"
 	}
 	switch status.Code(err) {
-	case codes.FailedPrecondition:
+	case codes.ResourceExhausted:
 		return "no_capacity"
+	case codes.FailedPrecondition:
+		return "failed_precondition"
 	case codes.Aborted:
 		return "lock_conflict"
 	case codes.NotFound:
 		return "not_found"
 	case codes.Unavailable:
 		return "unavailable"
-	case codes.ResourceExhausted:
-		return "rate_limited"
 	}
 	var re *ReqError
 	if errors.As(err, &re) {

--- a/cmd/atenet/internal/router/extproc/metrics_test.go
+++ b/cmd/atenet/internal/router/extproc/metrics_test.go
@@ -52,9 +52,9 @@ func TestClassifyOutcome(t *testing.T) {
 			expected: "timeout",
 		},
 		{
-			name:     "FailedPrecondition gRPC code maps to no_capacity",
-			err:      status.Error(codes.FailedPrecondition, "capacity full"),
-			expected: "no_capacity",
+			name:     "FailedPrecondition gRPC code maps to failed_precondition",
+			err:      status.Error(codes.FailedPrecondition, "actor is not in a resumable state"),
+			expected: "failed_precondition",
 		},
 		{
 			name:     "Aborted gRPC code maps to lock_conflict",
@@ -72,9 +72,9 @@ func TestClassifyOutcome(t *testing.T) {
 			expected: "unavailable",
 		},
 		{
-			name:     "ResourceExhausted gRPC code maps to rate_limited",
-			err:      status.Error(codes.ResourceExhausted, "rate limit exceeded"),
-			expected: "rate_limited",
+			name:     "ResourceExhausted gRPC code maps to no_capacity",
+			err:      status.Error(codes.ResourceExhausted, "no free workers available"),
+			expected: "no_capacity",
 		},
 		{
 			name:     "StatusCode_NotFound ReqError maps to not_found",

--- a/cmd/atenet/internal/router/ingress/errors.go
+++ b/cmd/atenet/internal/router/ingress/errors.go
@@ -95,9 +95,8 @@ func mapResumeError(actorRef resources.ActorRef, err error) error {
 		re.Msg = fmt.Sprintf("actor %s not found", actorRef)
 	case codes.FailedPrecondition:
 		// Preserve the gRPC description for FailedPrecondition and Aborted:
-		// they carry actionable client-facing context (e.g. "no free workers
-		// available", "another operation is in progress for this actor") and
-		// are not security-sensitive.
+		// they carry actionable client-facing context (e.g. "another operation is
+		// in progress for this actor") and are not security-sensitive.
 		re.StatusCode = int(envoy_type.StatusCode_ServiceUnavailable)
 		re.Msg = fmt.Sprintf("actor %s unavailable: %s", actorRef, statusDescription(err))
 	case codes.Aborted:
@@ -118,8 +117,13 @@ func mapResumeError(actorRef resources.ActorRef, err error) error {
 		re.StatusCode = int(envoy_type.StatusCode_Unauthorized)
 		re.Msg = fmt.Sprintf("actor %s authentication required", actorRef)
 	case codes.ResourceExhausted:
-		re.StatusCode = int(envoy_type.StatusCode_TooManyRequests)
-		re.Msg = fmt.Sprintf("actor %s rate limited", actorRef)
+		// Preserve the gRPC description for ResourceExhausted. It carries actionable
+		// client-facing context (e.g. "no free workers available") and are not
+		// security-sensitive.
+		// Pool saturation (ResourceExhausted) is 503 rather than 429: the fleet is
+		// full, the caller did not send too many requests.
+		re.StatusCode = int(envoy_type.StatusCode_ServiceUnavailable)
+		re.Msg = fmt.Sprintf("actor %s unavailable: %s", actorRef, statusDescription(err))
 	default:
 		re.StatusCode = int(envoy_type.StatusCode_InternalServerError)
 		re.Msg = fmt.Sprintf("error resuming actor %s", actorRef)

--- a/cmd/atenet/internal/router/ingress/errors_test.go
+++ b/cmd/atenet/internal/router/ingress/errors_test.go
@@ -142,10 +142,12 @@ func TestMapResumeError(t *testing.T) {
 			wantBody: `actor team-a/ctr6 authentication required`,
 		},
 		{
-			name:     "ResourceExhausted maps to 429",
-			err:      status.Error(codes.ResourceExhausted, "quota"),
-			wantCode: envoy_type.StatusCode_TooManyRequests,
-			wantBody: `actor team-a/ctr6 rate limited`,
+			// Pool saturation is 503, not 429: the fleet is full, the caller
+			// did not send too many requests.
+			name:     "ResourceExhausted maps to 503 preserving the description",
+			err:      status.Error(codes.ResourceExhausted, "no free workers available"),
+			wantCode: envoy_type.StatusCode_ServiceUnavailable,
+			wantBody: `actor team-a/ctr6 unavailable: no free workers available`,
 		},
 		{
 			name:     "unknown gRPC code maps to 500 without leaking desc",

--- a/cmd/atenet/internal/router/ingress/parking.go
+++ b/cmd/atenet/internal/router/ingress/parking.go
@@ -70,7 +70,7 @@ const (
 //
 // When a request targets a suspended actor, the router resumes it via the
 // control plane before routing. If the worker pool is momentarily saturated the
-// control plane returns FailedPrecondition ("no free workers available"). With
+// control plane returns ResourceExhausted ("no free workers available"). With
 // parking enabled the router holds ("parks") such a request and keeps retrying
 // the resume until the actor becomes routable or Budget elapses, instead of
 // failing the request immediately. Max bounds how many requests may be parked

--- a/cmd/atenet/internal/router/ingress/resumer.go
+++ b/cmd/atenet/internal/router/ingress/resumer.go
@@ -111,7 +111,7 @@ type ActorResumer struct {
 type resumerOption func(*ActorResumer)
 
 // withParking configures parking behavior from cfg. When parking is enabled,
-// FailedPrecondition ("no free workers available") becomes retryable and the
+// ResourceExhausted ("no free workers available") becomes retryable and the
 // resume is retried, at cfg's retry cadence, for up to cfg's budget. When
 // disabled, the resumer applies fail-fast-on-capacity behavior.
 func withParking(cfg ParkedRequestConfig) resumerOption {
@@ -140,18 +140,20 @@ func NewActorResumer(apiClient ateapipb.ControlClient, opts ...resumerOption) *A
 
 // retryable reports whether err warrants another resume attempt while the
 // request remains parked. A concurrent-resume conflict (Aborted) is always
-// retried. Transient pool saturation (FailedPrecondition, "no free workers
+// retried. Transient pool saturation (ResourceExhausted, "no free workers
 // available") and transient control-plane unavailability (Unavailable, e.g. an
 // ateapi rolling restart) are retried only when parking is enabled, turning a
 // momentary condition into a bounded wait instead of an immediate failure — a
 // parked request should ride out a blip, not fail on it with budget remaining.
+// FailedPrecondition stays retryable too: it no longer carries saturation, but
+// it does cover states a concurrent operation can move the actor out of.
 // All other codes (NotFound, DeadlineExceeded, PermissionDenied, ...) are
 // returned to the caller so the HTTP boundary can map them with full fidelity.
 func (r *ActorResumer) retryable(err error) bool {
 	switch status.Code(err) {
 	case codes.Aborted:
 		return true
-	case codes.FailedPrecondition, codes.Unavailable:
+	case codes.ResourceExhausted, codes.FailedPrecondition, codes.Unavailable:
 		return r.parkEnabled
 	default:
 		return false

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -131,7 +131,7 @@ For `ate.workerpool.desired_workers` and `ate.workerpool.ready_workers`:
 * **Autoscaling Control Loop & Anti-Windup**: `desired - ready > 0` sustained beyond a few minutes indicates undelivered capacity due to node pool exhaustion, quota limits, or stuck worker pods, serving as anti-windup input for demand-reactive capacity scaling.
 
 For `atenet.router.route.duration`:
-* `ate.router.outcome` categorizes the route attempt result: `ok`, `cancelled`, `timeout`, `no_capacity`, `lock_conflict`, `not_found`, `unavailable`, `rate_limited`, or `resume_error`.
+* `ate.router.outcome` categorizes the route attempt result: `ok`, `cancelled`, `timeout`, `no_capacity`, `failed_precondition`, `lock_conflict`, `not_found`, `unavailable`, `rate_limited`, or `resume_error`.
 * `ate.router.resume` indicates the singleflight execution state of actor resumption: `none` (actor already running), `triggered` (initiated cold activation), or `joined` (parked on in-flight activation).
 
 For `ate.scheduler.eligible_workers`:

--- a/docs/request-parking.md
+++ b/docs/request-parking.md
@@ -20,7 +20,7 @@ Envoy --(ext_proc RequestHeaders)--> router.handleRequestHeaders
 `ateapi`'s `AssignWorkerStep` claims a free worker from the actor's `WorkerPool`.
 In an oversubscribed system — the core premise of Substrate, where many actors
 multiplex onto few workers — a burst of traffic can momentarily exhaust the
-pool. `AssignWorkerStep` then returns `FailedPrecondition: "no free workers
+pool. `AssignWorkerStep` then returns `ResourceExhausted: "no free workers
 available"`.
 
 Previously the router mapped that straight to an HTTP `503` and failed the
@@ -30,12 +30,12 @@ user-visible error.
 
 ## Behavior
 
-With parking enabled (the default), the router treats `FailedPrecondition` and
-`Unavailable` from `ResumeActor` as **retryable** conditions (alongside the
-existing `Aborted` concurrent-resume conflict) — a parked request rides out
-transient pool saturation and control-plane blips (e.g. an ateapi rolling
-restart) alike. The request is *parked*: the resumer keeps retrying with
-exponential backoff until either
+With parking enabled (the default), the router treats `ResourceExhausted`,
+`FailedPrecondition` and `Unavailable` from `ResumeActor` as **retryable**
+conditions (alongside the existing `Aborted` concurrent-resume conflict) — a
+parked request rides out transient pool saturation and control-plane blips
+(e.g. an ateapi rolling restart) alike. The request is *parked*: the resumer
+keeps retrying with exponential backoff until either
 
 - the resume succeeds (the actor is `RUNNING` and has a worker IP) — the request
   is then routed normally; or


### PR DESCRIPTION
ResumeActor returned `FailedPrecondition` both when the fleet had no free worker and when the actor was not in a resumable state. Only the former is fixable by suspending the actor to drop its node pinning, and a client driving that recovery could not tell the two apart.

`assignWorkerAttempt()` now returns `ResourceExhausted` for `scheduling.ErrNoCapacity`. `FailedPrecondition` was the de-facto capacity signal, so three router consumers move with it:

- `retryable()`: `ResourceExhausted` is parked, so saturation behaves as before. `FailedPrecondition` stays retryable on purpose. It no longer carries saturation, but it does cover states a concurrent operation can move the actor out of.
- `mapResumeError()`: `ResourceExhausted` now preserves the gRPC description, keeping saturation at 503 as today. Its former 429 "rate limited" branch was written speculatively as nothing in substrate produced the code until now, and the fleet being full is not the caller sending too many requests.
- `classifyOutcome()`: `no_capacity` moves to `ResourceExhausted`, and `FailedPrecondition` gets its own label so the capacity bucket stops collecting non-capacity errors.

`TestResumeActor_RelocatesAfterSuspendFromPaused` covers the recovery flow this signal exists for: a PAUSED actor pinned to a full node cannot resume, and after a suspend clears the pinning it schedules onto a worker on another node.

Fixes #660

- `make test` clean (except the pre-existing macOS-only `internal/atunnel` failures, untouched by this PR)
- `make fmt` clean
- `go vet ./cmd/...` clean