### PR TITLE
Return the full status from the server unary interceptor

### DIFF
--- a/internal/ateinterceptors/ateinterceptors.go
+++ b/internal/ateinterceptors/ateinterceptors.go
@@ -64,8 +64,7 @@ func ServerUnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServer
 		}
 
 		if errors.As(err, &statusErr) {
-			st := statusErr.GRPCStatus()
-			return nil, status.Error(st.Code(), st.Message())
+			return nil, statusErr.GRPCStatus().Err()
 		}
 
 		// No status error found in chain.

--- a/internal/ateinterceptors/ateinterceptors_test.go
+++ b/internal/ateinterceptors/ateinterceptors_test.go
@@ -174,6 +174,41 @@ func TestInternalServerUnaryInterceptorPreservesDetails(t *testing.T) {
 	}
 }
 
+// TestServerUnaryInterceptorPreservesDetails verifies the public interceptor
+// returns the handler's status intact: ErrorInfo details (reason and metadata)
+// must survive the public wire, even when the status is wrapped.
+func TestServerUnaryInterceptorPreservesDetails(t *testing.T) {
+	metadata := map[string]string{"want": "0.2.0", "have": "0.1.0"}
+	structuredErr := ateerrors.NewGRPCError(context.Background(), codes.FailedPrecondition, ateerrors.ReasonInvalidCheckpointResult, metadata, errors.New("refused"))
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, fmt.Errorf("outer error: %w", structuredErr)
+	}
+
+	_, err := ServerUnaryInterceptor(context.Background(), "request", &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, handler)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	st, _ := status.FromError(err)
+	if st.Code() != codes.FailedPrecondition {
+		t.Errorf("code = %v, want %v", st.Code(), codes.FailedPrecondition)
+	}
+
+	info := errorInfoOf(t, err)
+	if info == nil {
+		t.Fatal("status is missing the ErrorInfo detail")
+	}
+	if got, want := info.GetReason(), string(ateerrors.ReasonInvalidCheckpointResult); got != want {
+		t.Errorf("ErrorInfo.Reason = %q, want %q", got, want)
+	}
+	for k, want := range metadata {
+		if got := info.GetMetadata()[k]; got != want {
+			t.Errorf("ErrorInfo.Metadata[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
 type trailerStream struct {
 	method   string
 	trailers metadata.MD


### PR DESCRIPTION
AIP-193 - we should return the details of ErrorInfo instead of a rebuilt, following how `InternalServerUnaryInterceptor` already did.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
