### PR TITLE
[WIP] e2e: note that not every failed suite retains a namespace

### DIFF
--- a/internal/e2e/README.md
+++ b/internal/e2e/README.md
@@ -40,6 +40,16 @@ of running pods, so clean up once you are done reading:
 $ hack/cleanup-e2e.sh   # deletes every namespace labeled ate.dev/e2e
 ```
 
+Not every suite has a namespace to keep. One that runs against a pre-installed
+worker pool -- `TestActorEgress` uses the standing `ate-demo-egress` pool from
+`hack/install-ate-kind.sh --deploy-demo-egress` -- creates only an atespace,
+which lives in Valkey rather than Kubernetes, so a failure leaves nothing
+labeled `ate.dev/e2e` behind. Read the standing namespace instead:
+
+```shell
+$ kubectl logs -n ate-demo-egress -l ate.dev/worker-pool=egress
+```
+
 ## Creating a new test suite
 
 Copy `testmain_test.go` from `internal/e2e/suites/example` into your new suite. It will


### PR DESCRIPTION
The "After a failure" section of internal/e2e/README.md tells you a failed run
keeps its namespaces so you can read the worker-pod logs. That only holds for
namespaces the suite created itself. A suite that runs against a pre-installed
worker pool keeps its atespace in Valkey, not Kubernetes, so a failure leaves
nothing labeled ate.dev/e2e and the documented recovery step comes up empty.

Adds a short caveat naming TestActorEgress as the case in the tree and pointing
at the standing ate-demo-egress namespace instead. Docs only.
