### PR TITLE
docs: fill in unfilled Contributor Covenant placeholders

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -71,12 +71,12 @@ dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
-Reports should be directed to *[PROJECT STEWARD NAME(s) AND EMAIL(s)]*, the
-Project Steward(s) for *[PROJECT NAME]*. It is the Project Steward’s duty to
+Reports should be directed to the Substrate maintainers at
+*ate-dev@googlegroups.com*. It is the maintainers’ duty to
 receive and address reported violations of the code of conduct. They will then
 work with a committee consisting of representatives from the Open Source
 Programs Office and the Google Open Source Strategy team. If for any reason you
-are uncomfortable reaching out to the Project Steward, please email
+are uncomfortable reaching out to the maintainers, please email
 opensource@google.com.
 
 We will investigate every complaint, but you may not receive a direct response.


### PR DESCRIPTION
code-of-conduct.md still had the unfilled [PROJECT STEWARD NAME(s) AND EMAIL(s)] and [PROJECT NAME] template placeholders. Points reports to the existing ate-dev@googlegroups.com maintainers list.