### PR TITLE
fix(hack): let teardown delete crashed actors

### DIFF
--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -1110,7 +1110,7 @@ get_actor_state() {
 }
 
 # prepare_actor_for_delete suspends (or resumes then suspends) until DeleteActor
-# accepts the actor: ACTOR_STATE_SUSPENDED or ACTOR_STATE_CRASHED.
+# accepts the actor: ACTOR_STATE_SUSPENDED, ACTOR_STATE_CRASHED, or ACTOR_STATE_DELETING.
 prepare_actor_for_delete() {
   local actor_name="$1"
   local atespace="$2"
@@ -1124,7 +1124,7 @@ prepare_actor_for_delete() {
     fi
 
     case "${state}" in
-      ACTOR_STATE_SUSPENDED | ACTOR_STATE_CRASHED)
+      ACTOR_STATE_SUSPENDED | ACTOR_STATE_CRASHED | ACTOR_STATE_DELETING)
         return 0
         ;;
       ACTOR_STATE_PAUSED)

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -38,6 +38,11 @@ fi
 # ATE_DEMOS is an array that registers the prefix name of the demo functions.
 ATE_DEMOS=()
 
+# Called by a ${demo}_cmdline handler for an argument it does not own.
+ate_demo_flag_unhandled() {
+  ATE_DEMO_FLAG_HANDLED=false
+}
+
 # Include demos.
 source "${ROOT}"/hack/install-demo-counter.sh
 source "${ROOT}"/hack/install-demo-egress.sh
@@ -1105,7 +1110,7 @@ get_actor_state() {
 }
 
 # prepare_actor_for_delete suspends (or resumes then suspends) until DeleteActor
-# is allowed. Actors must be ACTOR_STATE_SUSPENDED before deletion.
+# accepts the actor: ACTOR_STATE_SUSPENDED or ACTOR_STATE_CRASHED.
 prepare_actor_for_delete() {
   local actor_name="$1"
   local atespace="$2"
@@ -1119,7 +1124,7 @@ prepare_actor_for_delete() {
     fi
 
     case "${state}" in
-      ACTOR_STATE_SUSPENDED)
+      ACTOR_STATE_SUSPENDED | ACTOR_STATE_CRASHED)
         return 0
         ;;
       ACTOR_STATE_PAUSED)
@@ -1138,7 +1143,7 @@ prepare_actor_for_delete() {
     sleep 2
   done
 
-  echo "timed out waiting for actor ${actor_name} to reach ACTOR_STATE_SUSPENDED" >&2
+  echo "timed out waiting for actor ${actor_name} to become deletable" >&2
   return 1
 }
 
@@ -1521,17 +1526,21 @@ podcert_workers_per_signer >/dev/null
 rollout_timeout >/dev/null
 
 while [[ "$#" -gt 0 ]]; do
-  # Run ${demo}_cmdline if it exists. If it returns 0, then we successfully
-  # handled this argument and can continue. Otherwise, fallthrough to check
-  # the other arguments.
+  # Handlers signal an unclaimed argument via ate_demo_flag_unhandled, not exit
+  # status: an `if`-condition call would suppress errexit in the whole call tree.
+  ATE_DEMO_FLAG_HANDLED=false
   for demo_name in "${ATE_DEMOS[@]}"; do
-    if declare -F "${demo_name}_cmdline" >/dev/null 2>&1; then
-      if "${demo_name}_cmdline" "$1"; then
-        shift
-        continue 2
-      fi
+    declare -F "${demo_name}_cmdline" >/dev/null 2>&1 || continue
+    ATE_DEMO_FLAG_HANDLED=true
+    "${demo_name}_cmdline" "$1"
+    if [[ "${ATE_DEMO_FLAG_HANDLED}" == "true" ]]; then
+      break
     fi
   done
+  if [[ "${ATE_DEMO_FLAG_HANDLED}" == "true" ]]; then
+    shift
+    continue
+  fi
 
   case $1 in
     --atenet-router=*) ATE_ATENET_ROUTER="${1#*=}" ;;

--- a/hack/install-demo-autoscaled-workerpool.sh
+++ b/hack/install-demo-autoscaled-workerpool.sh
@@ -27,10 +27,9 @@ demo-autoscaled-workerpool_cmdline() {
     --deploy-demo-autoscaled-workerpool) demo-autoscaled-workerpool_deploy ;;
     --delete-demo-autoscaled-workerpool) demo-autoscaled-workerpool_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 demo-autoscaled-workerpool_deploy() {

--- a/hack/install-demo-claude-code-multiplex.sh
+++ b/hack/install-demo-claude-code-multiplex.sh
@@ -23,10 +23,9 @@ demo-claude-code-multiplex_cmdline() {
     --deploy-demo-claude-code-multiplex) demo-claude-code-multiplex_deploy ;;
     --delete-demo-claude-code-multiplex) demo-claude-code-multiplex_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 # Build the workload image, push to ${KO_DOCKER_REPO}, and echo the resolved

--- a/hack/install-demo-counter.sh
+++ b/hack/install-demo-counter.sh
@@ -47,10 +47,9 @@ demo-counter_cmdline() {
         demos/counter/counter-microvm.yaml.tmpl ate-demo-counter-microvm counter-microvm
       ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 # demo-counter_render substitutes the demo's placeholders in a manifest:

--- a/hack/install-demo-egress.sh
+++ b/hack/install-demo-egress.sh
@@ -42,10 +42,9 @@ demo-egress_cmdline() {
     --deploy-demo-egress) demo-egress_deploy ;;
     --delete-demo-egress) demo-egress_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 demo-egress-microvm_cmdline() {
@@ -53,10 +52,9 @@ demo-egress-microvm_cmdline() {
     --deploy-demo-egress-microvm) demo-egress-microvm_deploy ;;
     --delete-demo-egress-microvm) demo-egress-microvm_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 demo-egress-mitm_cmdline() {
@@ -64,10 +62,9 @@ demo-egress-mitm_cmdline() {
     --deploy-demo-egress-mitm) demo-egress-mitm_deploy ;;
     --delete-demo-egress-mitm) demo-egress-mitm_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 demo-egress-microvm-mitm_cmdline() {
@@ -75,10 +72,9 @@ demo-egress-microvm-mitm_cmdline() {
     --deploy-demo-egress-microvm-mitm) demo-egress-microvm-mitm_deploy ;;
     --delete-demo-egress-microvm-mitm) demo-egress-microvm-mitm_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 demo-egress_deploy() {

--- a/hack/install-demo-jupyter.sh
+++ b/hack/install-demo-jupyter.sh
@@ -27,10 +27,9 @@ demo-jupyter_cmdline() {
     --deploy-demo-jupyter) demo-jupyter_deploy ;;
     --delete-demo-jupyter) demo-jupyter_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 demo-jupyter_deploy() {

--- a/hack/install-demo-multi-template.sh
+++ b/hack/install-demo-multi-template.sh
@@ -23,10 +23,9 @@ demo-multi-template_cmdline() {
     --deploy-demo-multi-template) demo-multi-template_deploy ;;
     --delete-demo-multi-template) demo-multi-template_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 # The demo's two templates live in two different atespaces to show that pool

--- a/hack/install-demo-parking.sh
+++ b/hack/install-demo-parking.sh
@@ -23,10 +23,9 @@ demo-parking_cmdline() {
     --deploy-demo-parking) demo-parking_deploy ;;
     --delete-demo-parking) demo-parking_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 demo-parking_deploy() {

--- a/hack/install-demo-sandbox.sh
+++ b/hack/install-demo-sandbox.sh
@@ -23,10 +23,9 @@ demo-sandbox_cmdline() {
     --deploy-demo-sandbox) demo-sandbox_deploy ;;
     --delete-demo-sandbox) demo-sandbox_delete ;;
     *)
-      return 1
+      ate_demo_flag_unhandled
       ;;
   esac
-  return 0
 }
 
 demo-sandbox_deploy() {


### PR DESCRIPTION
Fixes #794

A crashed actor makes `--delete-all` abort mid-teardown, leaving the ActorTemplate, atespace and `ate-system` behind; the next `--deploy-demo-counter` keeps the existing template, so the cluster goes on serving the stale golden snapshot.

`prepare_actor_for_delete` treats `STATUS_CRASHED` as unexpected and returns 1, which errexit turns into a hard abort, even though DeleteActor accepts CRASHED and is idempotent for an actor already marked DELETING (`workflow_delete.go`). Teardown now treats crashed and already-deleting actors as deletable as-is.

The demo flag dispatch had the mirror-image defect: handlers ran from an `if` condition, which suppresses errexit for their whole call tree, so this same teardown and failed deploys like the issue's immutable-spec apply exited 0. Handlers now run as plain commands and report an unclaimed flag through `ate_demo_flag_unhandled`; the Jupyter handler follows the same contract.

Repro: deploy the counter demo, resume an actor, delete its worker pod, wait for the syncer to mark it `STATUS_CRASHED`, then run `--delete-all`.

