### PR TITLE
Align ActorSnapshot/ActorSnapshotTag store methods to other CRUD methods.

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/fieldmask"
 	"github.com/agent-substrate/substrate/internal/resources"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
@@ -47,42 +48,6 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 			ateattr.TemplateNamespaceKey.String(in.GetActorTemplateNamespace()),
 		)
 	}()
-	var sourceSnapshot *ateapipb.ActorSnapshot
-	var sourceSnapshotInfo *ateapipb.ActorSnapshotSource
-	if src := in.GetSourceSnapshot(); src != nil {
-		tagRef := src.GetTag()
-		tag, err := s.persistence.GetActorSnapshotTag(ctx, tagRef.GetAtespace(), tagRef.GetName())
-		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "ActorSnapshot not found")
-		}
-		if err != nil {
-			return nil, fmt.Errorf("while getting actor snapshot tag: %w", err)
-		}
-		snapshotRef := tag.GetSnapshot()
-		snapshot, err := s.persistence.GetActorSnapshot(ctx, snapshotRef.GetAtespace(), snapshotRef.GetName())
-		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "ActorSnapshot not found")
-		}
-		if err != nil {
-			return nil, fmt.Errorf("while getting actor snapshot: %w", err)
-		}
-		sourceSnapshot = snapshot
-		sourceSnapshotInfo = &ateapipb.ActorSnapshotSource{
-			Tag:         tagRef,
-			Snapshot:    snapshotRef,
-			SnapshotUid: snapshot.GetMetadata().GetUid(),
-		}
-		target := in.GetMetadata()
-		switch tag.GetScope() {
-		case ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE:
-			if tag.GetMetadata().GetAtespace() != target.GetAtespace() {
-				return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot tag is not published outside its Atespace")
-			}
-		case ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED:
-		default:
-			return nil, status.Error(codes.FailedPrecondition, "source ActorSnapshot tag has an invalid scope")
-		}
-	}
 	templateNamespace := in.GetActorTemplateNamespace()
 	templateName := in.GetActorTemplateName()
 
@@ -95,16 +60,12 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 		}
 		return nil, fmt.Errorf("while getting ActorTemplate: %w", err)
 	}
-	// TODO: Permit compatible DATA snapshots when runtimes can extract portable data.
-	if sourceSnapshot != nil && sourceSnapshot.GetActorTemplateUid() != string(template.GetUID()) {
-		return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot requires the source ActorTemplate")
-	}
-	if sourceSnapshot != nil {
-		for _, volume := range template.Spec.Volumes {
-			if volume.ExternalVolumeTemplate != nil {
-				// TODO: Permit cloning after CSI volume snapshots are supported.
-				return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot cloning does not support external volumes")
-			}
+
+	var sourceSnapshotInfo *ateapipb.ActorSnapshotSource
+	if src := in.GetSourceSnapshot(); src != nil {
+		sourceSnapshotInfo, err = s.resolveSnapshotSource(ctx, in.GetMetadata().GetAtespace(), src, template)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -149,6 +110,55 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 
 	setSpanActorAttributes(ctx, stored)
 	return stored, nil
+}
+
+// resolveSnapshotSource resolves a CreateActor request's source snapshot tag
+// and checks that its scope and ActorSnapshot are compatible with creating
+// an Actor in actorAtespace from template.
+func (s *Service) resolveSnapshotSource(ctx context.Context, actorAtespace string, src *ateapipb.ActorSnapshotSource, template *atev1alpha1.ActorTemplate) (*ateapipb.ActorSnapshotSource, error) {
+	tagRef := src.GetTag()
+	tag, err := s.persistence.GetActorSnapshotTag(ctx, tagRef.GetAtespace(), tagRef.GetName())
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, status.Error(codes.NotFound, "ActorSnapshot not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("while getting actor snapshot tag: %w", err)
+	}
+	snapshotRef := tag.GetSnapshot()
+	snapshot, err := s.persistence.GetActorSnapshot(ctx, snapshotRef.GetAtespace(), snapshotRef.GetName())
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, status.Error(codes.NotFound, "ActorSnapshot not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("while getting actor snapshot: %w", err)
+	}
+	switch tag.GetScope() {
+	case ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE:
+		if tag.GetMetadata().GetAtespace() != actorAtespace {
+			return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot tag is not published outside its Atespace")
+		}
+	case ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED:
+	default:
+		return nil, status.Error(codes.FailedPrecondition, "source ActorSnapshot tag has an invalid scope")
+	}
+	// TODO: Permit compatible DATA snapshots when runtimes can extract portable data.
+	if snapshot.GetActorTemplateUid() != string(template.GetUID()) {
+		return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot requires the source ActorTemplate")
+	}
+	for _, volume := range template.Spec.Volumes {
+		if volume.ExternalVolumeTemplate != nil {
+			// TODO: Permit cloning after CSI volume snapshots are supported.
+			return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot cloning does not support external volumes")
+		}
+	}
+	return &ateapipb.ActorSnapshotSource{
+		Tag: tagRef,
+		Snapshot: &ateapipb.ObjectRef{
+			Atespace: snapshot.GetMetadata().GetAtespace(),
+			Name:     snapshot.GetMetadata().GetName(),
+		},
+		SnapshotUid: snapshot.GetMetadata().GetUid(),
+	}, nil
 }
 
 func validateCreateActorRequest(req *ateapipb.CreateActorRequest) field.ErrorList {

--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -221,13 +221,13 @@ func (s *Service) ListActors(ctx context.Context, req *ateapipb.ListActorsReques
 		return nil, toGRPCStatusError(errs)
 	}
 
-	actors, nextToken, err := s.persistence.ListActors(ctx, req.GetAtespace(), effectivePageSize(req.GetPageSize()), req.GetPageToken())
+	page, err := s.persistence.ListActors(ctx, req.GetAtespace(), store.ListOptions{PageSize: effectivePageSize(req.GetPageSize()), PageToken: req.GetPageToken()})
 	if err != nil {
 		return nil, fmt.Errorf("while listing actors in db: %w", err)
 	}
 	return &ateapipb.ListActorsResponse{
-		Actors:        actors,
-		NextPageToken: nextToken,
+		Actors:        page.Items,
+		NextPageToken: page.NextPageToken,
 	}, nil
 }
 

--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -50,16 +50,26 @@ func (s *Service) CreateActor(ctx context.Context, req *ateapipb.CreateActorRequ
 	var sourceSnapshot *ateapipb.ActorSnapshot
 	var sourceSnapshotInfo *ateapipb.ActorSnapshotSource
 	if src := in.GetSourceSnapshot(); src != nil {
-		lock, snapshot, canonical, tag, err := s.lockActorSnapshot(ctx, nil, src.GetTag())
-		if err != nil {
-			return nil, err
+		tagRef := src.GetTag()
+		tag, err := s.persistence.GetActorSnapshotTag(ctx, tagRef.GetAtespace(), tagRef.GetName())
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "ActorSnapshot not found")
 		}
-		defer lock.Close()
-		ctx = lock.Context()
+		if err != nil {
+			return nil, fmt.Errorf("while getting actor snapshot tag: %w", err)
+		}
+		snapshotRef := tag.GetSnapshot()
+		snapshot, err := s.persistence.GetActorSnapshot(ctx, snapshotRef.GetAtespace(), snapshotRef.GetName())
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "ActorSnapshot not found")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("while getting actor snapshot: %w", err)
+		}
 		sourceSnapshot = snapshot
 		sourceSnapshotInfo = &ateapipb.ActorSnapshotSource{
-			Tag:         src.GetTag(),
-			Snapshot:    canonical,
+			Tag:         tagRef,
+			Snapshot:    snapshotRef,
 			SnapshotUid: snapshot.GetMetadata().GetUid(),
 		}
 		target := in.GetMetadata()

--- a/cmd/ateapi/internal/controlapi/actor_snapshot.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot.go
@@ -48,10 +48,8 @@ var actorSnapshotTagScopeNames = func() []string {
 }()
 
 func (s *Service) GetActorSnapshot(ctx context.Context, req *ateapipb.GetActorSnapshotRequest) (*ateapipb.ActorSnapshot, error) {
-	// TODO: extract into validateGetActorSnapshotRequest(req) field.ErrorList,
-	// as done for other RPC methods, and return via toGRPCStatusError.
-	if errs := resources.ValidateObjectRef(req.GetSnapshot(), field.NewPath("snapshot")); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+	if errs := validateGetActorSnapshotRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	snapshot, err := s.persistence.GetActorSnapshot(ctx, req.GetSnapshot().GetAtespace(), req.GetSnapshot().GetName())
 	if errors.Is(err, store.ErrNotFound) {
@@ -63,11 +61,22 @@ func (s *Service) GetActorSnapshot(ctx context.Context, req *ateapipb.GetActorSn
 	return snapshot, nil
 }
 
+func validateGetActorSnapshotRequest(req *ateapipb.GetActorSnapshotRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.Snapshot, fldPath.Child("snapshot"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
+	}
+
+	return errs
+}
+
 func (s *Service) GetActorSnapshotTag(ctx context.Context, req *ateapipb.GetActorSnapshotTagRequest) (*ateapipb.ActorSnapshotTag, error) {
-	// TODO: extract into validateGetActorSnapshotTagRequest(req) field.ErrorList,
-	// as done for other RPC methods, and return via toGRPCStatusError.
-	if errs := resources.ValidateObjectRef(req.GetTag(), field.NewPath("tag")); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+	if errs := validateGetActorSnapshotTagRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	tag, err := s.persistence.GetActorSnapshotTag(ctx, req.GetTag().GetAtespace(), req.GetTag().GetName())
 	if errors.Is(err, store.ErrNotFound) {
@@ -79,19 +88,22 @@ func (s *Service) GetActorSnapshotTag(ctx context.Context, req *ateapipb.GetActo
 	return tag, nil
 }
 
-func (s *Service) ListActorSnapshots(ctx context.Context, req *ateapipb.ListActorSnapshotsRequest) (*ateapipb.ListActorSnapshotsResponse, error) {
-	// TODO: extract into validateListActorSnapshotsRequest(req) field.ErrorList,
-	// as done for other RPC methods, and return via toGRPCStatusError.
+func validateGetActorSnapshotTagRequest(req *ateapipb.GetActorSnapshotTagRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
-	if req.GetAtespace() != "" {
-		errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), fldPath.Child("atespace"))...)
+
+	if val, fldPath := req.Tag, fldPath.Child("tag"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
-	if req.GetPageSize() < 0 {
-		errs = append(errs, field.Invalid(fldPath.Child("page_size"), req.GetPageSize(), "must be greater than or equal to 0"))
-	}
-	if len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+
+	return errs
+}
+
+func (s *Service) ListActorSnapshots(ctx context.Context, req *ateapipb.ListActorSnapshotsRequest) (*ateapipb.ListActorSnapshotsResponse, error) {
+	if errs := validateListActorSnapshotsRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	page, err := s.persistence.ListActorSnapshots(ctx, req.GetAtespace(), store.ListOptions{PageSize: effectivePageSize(req.GetPageSize()), PageToken: req.GetPageToken()})
 	if err != nil {
@@ -100,40 +112,37 @@ func (s *Service) ListActorSnapshots(ctx context.Context, req *ateapipb.ListActo
 	return &ateapipb.ListActorSnapshotsResponse{Snapshots: page.Items, NextPageToken: page.NextPageToken}, nil
 }
 
+func validateListActorSnapshotsRequest(req *ateapipb.ListActorSnapshotsRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	// An empty atespace is allowed here and means "all atespaces".
+	if val, fldPath := req.Atespace, fldPath.Child("atespace"); val != "" {
+		errs = append(errs, resources.ValidateResourceName(val, fldPath)...)
+	}
+
+	if val, fldPath := req.PageSize, fldPath.Child("page_size"); val < 0 {
+		errs = append(errs, field.Invalid(fldPath, val, "must be greater than or equal to 0"))
+	}
+
+	return errs
+}
+
 func (s *Service) CreateActorSnapshotTag(ctx context.Context, req *ateapipb.CreateActorSnapshotTagRequest) (*ateapipb.ActorSnapshotTag, error) {
-	// TODO: extract into validateCreateActorSnapshotTagRequest(req) field.ErrorList,
-	// folding in validateActorSnapshotTag below, as done for other RPC methods,
-	// and return via toGRPCStatusError.
-	if errs := resources.ValidateObjectRef(req.GetSnapshot(), field.NewPath("snapshot")); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+	if errs := validateCreateActorSnapshotTagRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
-	if err := validateActorSnapshotTag(req.GetTag(), "tag"); err != nil {
-		return nil, err
-	}
-	lock, _, ref, _, err := s.lockActorSnapshot(ctx, req.GetSnapshot(), nil)
-	if err != nil {
-		return nil, err
-	}
-	defer lock.Close()
+	ref := req.GetSnapshot()
 	if req.GetTag().GetMetadata().GetAtespace() != ref.GetAtespace() {
 		return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot tags must belong to the snapshot's Atespace")
 	}
-	atespaceLock, err := s.persistence.AcquireLock(lock.Context(), "lock:atespace:"+req.GetTag().GetMetadata().GetAtespace())
-	if errors.Is(err, store.ErrLockConflict) {
-		return nil, status.Error(codes.Aborted, "another operation is using this Atespace")
+	tag, err := s.persistence.CreateActorSnapshotTag(ctx, ref.GetAtespace(), ref.GetName(), req.GetTag())
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, status.Error(codes.NotFound, "ActorSnapshot not found")
 	}
-	if err != nil {
-		return nil, fmt.Errorf("while locking tag Atespace: %w", err)
-	}
-	defer atespaceLock.Close()
-	exists, err := s.persistence.AtespaceExists(atespaceLock.Context(), req.GetTag().GetMetadata().GetAtespace())
-	if err != nil {
-		return nil, fmt.Errorf("while checking tag Atespace: %w", err)
-	}
-	if !exists {
+	if errors.Is(err, store.ErrFailedPrecondition) {
 		return nil, status.Errorf(codes.FailedPrecondition, "Atespace %s not found", req.GetTag().GetMetadata().GetAtespace())
 	}
-	tag, err := s.persistence.CreateActorSnapshotTag(atespaceLock.Context(), ref.GetAtespace(), ref.GetName(), req.GetTag())
 	if errors.Is(err, store.ErrAlreadyExists) {
 		return nil, status.Errorf(codes.AlreadyExists, "ActorSnapshot tag %s/%s already exists", req.GetTag().GetMetadata().GetAtespace(), req.GetTag().GetMetadata().GetName())
 	}
@@ -141,6 +150,30 @@ func (s *Service) CreateActorSnapshotTag(ctx context.Context, req *ateapipb.Crea
 		return nil, fmt.Errorf("while tagging actor snapshot: %w", err)
 	}
 	return tag, nil
+}
+
+func validateCreateActorSnapshotTagRequest(req *ateapipb.CreateActorSnapshotTagRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if val, fldPath := req.Snapshot, fldPath.Child("snapshot"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
+	}
+
+	tag := req.Tag
+	tagPath := fldPath.Child("tag")
+	if tag == nil {
+		errs = append(errs, field.Required(tagPath, ""))
+		return errs
+	}
+
+	errs = append(errs, resources.ValidateObjectRef(&ateapipb.ObjectRef{Atespace: tag.GetMetadata().GetAtespace(), Name: tag.GetMetadata().GetName()}, tagPath.Child("metadata"))...)
+
+	errs = append(errs, validateActorSnapshotTagScope(tag.GetScope(), tagPath.Child("scope"))...)
+
+	return errs
 }
 
 // actorSnapshotTagMutableFields lists the ActorSnapshotTag field paths a client
@@ -193,17 +226,10 @@ func validateUpdateActorSnapshotTagRequest(req *ateapipb.UpdateActorSnapshotTagR
 }
 
 func (s *Service) DeleteActorSnapshotTag(ctx context.Context, req *ateapipb.DeleteActorSnapshotTagRequest) (*ateapipb.ActorSnapshotTag, error) {
-	// TODO: extract into validateDeleteActorSnapshotTagRequest(req) field.ErrorList,
-	// as done for other RPC methods, and return via toGRPCStatusError.
-	if errs := resources.ValidateObjectRef(req.GetTag(), field.NewPath("tag")); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+	if errs := validateDeleteActorSnapshotTagRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
-	lock, _, _, _, err := s.lockActorSnapshot(ctx, nil, req.GetTag())
-	if err != nil {
-		return nil, err
-	}
-	defer lock.Close()
-	tag, err := s.persistence.DeleteActorSnapshotTag(lock.Context(), req.GetTag().GetAtespace(), req.GetTag().GetName())
+	tag, err := s.persistence.DeleteActorSnapshotTag(ctx, req.GetTag().GetAtespace(), req.GetTag().GetName())
 	if errors.Is(err, store.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "ActorSnapshot tag %s/%s not found", req.GetTag().GetAtespace(), req.GetTag().GetName())
 	}
@@ -213,73 +239,17 @@ func (s *Service) DeleteActorSnapshotTag(ctx context.Context, req *ateapipb.Dele
 	return tag, nil
 }
 
-func (s *Service) getActorSnapshot(ctx context.Context, canonical, tag *ateapipb.ObjectRef) (*ateapipb.ActorSnapshot, *ateapipb.ObjectRef, *ateapipb.ActorSnapshotTag, error) {
-	if canonical != nil && tag != nil {
-		return nil, nil, nil, fmt.Errorf("getActorSnapshot: exactly one of canonical or tag must be set, got both")
-	}
-	if canonical != nil {
-		snapshot, err := s.persistence.GetActorSnapshot(ctx, canonical.GetAtespace(), canonical.GetName())
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		return snapshot, canonical, nil, nil
-	}
-	resolvedTag, err := s.persistence.GetActorSnapshotTag(ctx, tag.GetAtespace(), tag.GetName())
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	resolvedCanonical := &ateapipb.ObjectRef{Atespace: resolvedTag.GetSnapshot().GetAtespace(), Name: resolvedTag.GetSnapshot().GetName()}
-	snapshot, err := s.persistence.GetActorSnapshot(ctx, resolvedCanonical.GetAtespace(), resolvedCanonical.GetName())
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	return snapshot, resolvedCanonical, resolvedTag, nil
-}
-
-// lockActorSnapshot resolves and locks a snapshot by its canonical identity
-// or by tag. Exactly one of canonical or tag must be set.
-func (s *Service) lockActorSnapshot(ctx context.Context, canonical, tag *ateapipb.ObjectRef) (*store.Lock, *ateapipb.ActorSnapshot, *ateapipb.ObjectRef, *ateapipb.ActorSnapshotTag, error) {
-	_, resolvedCanonical, _, err := s.getActorSnapshot(ctx, canonical, tag)
-	if errors.Is(err, store.ErrNotFound) {
-		return nil, nil, nil, nil, status.Error(codes.NotFound, "ActorSnapshot not found")
-	}
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("while getting actor snapshot: %w", err)
-	}
-	lock, err := s.persistence.AcquireLock(ctx, "lock:actor-snapshot:"+resolvedCanonical.GetAtespace()+":"+resolvedCanonical.GetName())
-	if errors.Is(err, store.ErrLockConflict) {
-		return nil, nil, nil, nil, status.Error(codes.Aborted, "another operation is using this ActorSnapshot")
-	}
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("while locking actor snapshot: %w", err)
-	}
-	snapshot, lockedCanonical, lockedTag, err := s.getActorSnapshot(lock.Context(), canonical, tag)
-	if err != nil || resolvedCanonical.GetAtespace() != lockedCanonical.GetAtespace() || resolvedCanonical.GetName() != lockedCanonical.GetName() {
-		lock.Close()
-		if errors.Is(err, store.ErrNotFound) {
-			return nil, nil, nil, nil, status.Error(codes.NotFound, "ActorSnapshot not found")
-		}
-		if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("while getting actor snapshot: %w", err)
-		}
-		return nil, nil, nil, nil, status.Error(codes.Aborted, "ActorSnapshot reference changed, please retry")
-	}
-	return lock, snapshot, lockedCanonical, lockedTag, nil
-}
-
-func validateActorSnapshotTag(tag *ateapipb.ActorSnapshotTag, name string) error {
+func validateDeleteActorSnapshotTagRequest(req *ateapipb.DeleteActorSnapshotTagRequest) field.ErrorList {
 	var fldPath *field.Path
-	p := fldPath.Child(name)
-	if tag == nil {
-		return status.Error(codes.InvalidArgument, field.ErrorList{field.Required(p, "")}.ToAggregate().Error())
+	var errs field.ErrorList
+
+	if val, fldPath := req.Tag, fldPath.Child("tag"); val == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
 	}
-	if errs := resources.ValidateObjectRef(&ateapipb.ObjectRef{Atespace: tag.GetMetadata().GetAtespace(), Name: tag.GetMetadata().GetName()}, p.Child("metadata")); len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	if errs := validateActorSnapshotTagScope(tag.GetScope(), p.Child("scope")); len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
+
+	return errs
 }
 
 // validateActorSnapshotTagScope checks that scope is one a client may set.

--- a/cmd/ateapi/internal/controlapi/actor_snapshot.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot.go
@@ -132,19 +132,19 @@ func (s *Service) CreateActorSnapshotTag(ctx context.Context, req *ateapipb.Crea
 	if errs := validateCreateActorSnapshotTagRequest(req); len(errs) > 0 {
 		return nil, toGRPCStatusError(errs)
 	}
-	ref := req.GetSnapshot()
-	if req.GetTag().GetMetadata().GetAtespace() != ref.GetAtespace() {
+	ref := req.GetActorSnapshotTag().GetSnapshot()
+	if req.GetActorSnapshotTag().GetMetadata().GetAtespace() != ref.GetAtespace() {
 		return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot tags must belong to the snapshot's Atespace")
 	}
-	tag, err := s.persistence.CreateActorSnapshotTag(ctx, ref.GetAtespace(), ref.GetName(), req.GetTag())
+	tag, err := s.persistence.CreateActorSnapshotTag(ctx, ref.GetAtespace(), ref.GetName(), req.GetActorSnapshotTag())
 	if errors.Is(err, store.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "ActorSnapshot not found")
 	}
 	if errors.Is(err, store.ErrFailedPrecondition) {
-		return nil, status.Errorf(codes.FailedPrecondition, "Atespace %s not found", req.GetTag().GetMetadata().GetAtespace())
+		return nil, status.Errorf(codes.FailedPrecondition, "Atespace %s not found", req.GetActorSnapshotTag().GetMetadata().GetAtespace())
 	}
 	if errors.Is(err, store.ErrAlreadyExists) {
-		return nil, status.Errorf(codes.AlreadyExists, "ActorSnapshot tag %s/%s already exists", req.GetTag().GetMetadata().GetAtespace(), req.GetTag().GetMetadata().GetName())
+		return nil, status.Errorf(codes.AlreadyExists, "ActorSnapshot tag %s/%s already exists", req.GetActorSnapshotTag().GetMetadata().GetAtespace(), req.GetActorSnapshotTag().GetMetadata().GetName())
 	}
 	if err != nil {
 		return nil, fmt.Errorf("while tagging actor snapshot: %w", err)
@@ -156,20 +156,20 @@ func validateCreateActorSnapshotTagRequest(req *ateapipb.CreateActorSnapshotTagR
 	var fldPath *field.Path
 	var errs field.ErrorList
 
-	if val, fldPath := req.Snapshot, fldPath.Child("snapshot"); val == nil {
-		errs = append(errs, field.Required(fldPath, ""))
-	} else {
-		errs = append(errs, resources.ValidateObjectRef(val, fldPath)...)
-	}
-
-	tag := req.Tag
-	tagPath := fldPath.Child("tag")
+	tag := req.ActorSnapshotTag
+	tagPath := fldPath.Child("actor_snapshot_tag")
 	if tag == nil {
 		errs = append(errs, field.Required(tagPath, ""))
 		return errs
 	}
 
 	errs = append(errs, resources.ValidateObjectRef(&ateapipb.ObjectRef{Atespace: tag.GetMetadata().GetAtespace(), Name: tag.GetMetadata().GetName()}, tagPath.Child("metadata"))...)
+
+	if val, p := tag.Snapshot, tagPath.Child("snapshot"); val == nil {
+		errs = append(errs, field.Required(p, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(val, p)...)
+	}
 
 	errs = append(errs, validateActorSnapshotTagScope(tag.GetScope(), tagPath.Child("scope"))...)
 

--- a/cmd/ateapi/internal/controlapi/actor_snapshot.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot.go
@@ -93,11 +93,11 @@ func (s *Service) ListActorSnapshots(ctx context.Context, req *ateapipb.ListActo
 	if len(errs) > 0 {
 		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
 	}
-	snapshots, nextToken, err := s.persistence.ListActorSnapshots(ctx, req.GetAtespace(), effectivePageSize(req.GetPageSize()), req.GetPageToken())
+	page, err := s.persistence.ListActorSnapshots(ctx, req.GetAtespace(), store.ListOptions{PageSize: effectivePageSize(req.GetPageSize()), PageToken: req.GetPageToken()})
 	if err != nil {
 		return nil, fmt.Errorf("while listing actor snapshots: %w", err)
 	}
-	return &ateapipb.ListActorSnapshotsResponse{Snapshots: snapshots, NextPageToken: nextToken}, nil
+	return &ateapipb.ListActorSnapshotsResponse{Snapshots: page.Items, NextPageToken: page.NextPageToken}, nil
 }
 
 func (s *Service) CreateActorSnapshotTag(ctx context.Context, req *ateapipb.CreateActorSnapshotTagRequest) (*ateapipb.ActorSnapshotTag, error) {

--- a/cmd/ateapi/internal/controlapi/actor_snapshot.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot.go
@@ -69,7 +69,7 @@ func (s *Service) GetActorSnapshotTag(ctx context.Context, req *ateapipb.GetActo
 	if errs := resources.ValidateObjectRef(req.GetTag(), field.NewPath("tag")); len(errs) > 0 {
 		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
 	}
-	_, tag, err := s.persistence.GetActorSnapshotByTag(ctx, req.GetTag().GetAtespace(), req.GetTag().GetName())
+	tag, err := s.persistence.GetActorSnapshotTag(ctx, req.GetTag().GetAtespace(), req.GetTag().GetName())
 	if errors.Is(err, store.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "ActorSnapshot tag not found")
 	}
@@ -133,7 +133,7 @@ func (s *Service) CreateActorSnapshotTag(ctx context.Context, req *ateapipb.Crea
 	if !exists {
 		return nil, status.Errorf(codes.FailedPrecondition, "Atespace %s not found", req.GetTag().GetMetadata().GetAtespace())
 	}
-	tag, err := s.persistence.TagActorSnapshot(atespaceLock.Context(), ref.GetAtespace(), ref.GetName(), req.GetTag())
+	tag, err := s.persistence.CreateActorSnapshotTag(atespaceLock.Context(), ref.GetAtespace(), ref.GetName(), req.GetTag())
 	if errors.Is(err, store.ErrAlreadyExists) {
 		return nil, status.Errorf(codes.AlreadyExists, "ActorSnapshot tag %s/%s already exists", req.GetTag().GetMetadata().GetAtespace(), req.GetTag().GetMetadata().GetName())
 	}
@@ -224,11 +224,15 @@ func (s *Service) getActorSnapshot(ctx context.Context, canonical, tag *ateapipb
 		}
 		return snapshot, canonical, nil, nil
 	}
-	snapshot, resolvedTag, err := s.persistence.GetActorSnapshotByTag(ctx, tag.GetAtespace(), tag.GetName())
+	resolvedTag, err := s.persistence.GetActorSnapshotTag(ctx, tag.GetAtespace(), tag.GetName())
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	resolvedCanonical := &ateapipb.ObjectRef{Atespace: snapshot.GetMetadata().GetAtespace(), Name: snapshot.GetMetadata().GetName()}
+	resolvedCanonical := &ateapipb.ObjectRef{Atespace: resolvedTag.GetSnapshot().GetAtespace(), Name: resolvedTag.GetSnapshot().GetName()}
+	snapshot, err := s.persistence.GetActorSnapshot(ctx, resolvedCanonical.GetAtespace(), resolvedCanonical.GetName())
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	return snapshot, resolvedCanonical, resolvedTag, nil
 }
 

--- a/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
@@ -320,9 +320,9 @@ func TestUpdateActorSnapshotTag_UnsetScopeDoesNotUnpublish(t *testing.T) {
 		t.Errorf("UpdateActorSnapshotTag error = %v (code %v), want code InvalidArgument", err, code)
 	}
 
-	_, current, err := svc.persistence.GetActorSnapshotByTag(ctx, testAtespace, "tag1")
+	current, err := svc.persistence.GetActorSnapshotTag(ctx, testAtespace, "tag1")
 	if err != nil {
-		t.Fatalf("GetActorSnapshotByTag: %v", err)
+		t.Fatalf("GetActorSnapshotTag: %v", err)
 	}
 	if got, want := current.GetScope(), ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED; got != want {
 		t.Errorf("stored scope = %v, want %v: the rejected update must not have unpublished the tag", got, want)
@@ -368,9 +368,9 @@ func serviceWithActorSnapshotTag(t *testing.T, tag *ateapipb.ActorSnapshotTag) (
 		t.Fatalf("Failed to CreateActorSnapshot: %v", err)
 	}
 	tag.Snapshot = &ateapipb.ObjectRef{Atespace: snapshot.GetMetadata().GetAtespace(), Name: snapshot.GetMetadata().GetName()}
-	created, err := persistence.TagActorSnapshot(context.Background(), atespace, snapshot.GetMetadata().GetName(), tag)
+	created, err := persistence.CreateActorSnapshotTag(context.Background(), atespace, snapshot.GetMetadata().GetName(), tag)
 	if err != nil {
-		t.Fatalf("Failed to TagActorSnapshot: %v", err)
+		t.Fatalf("Failed to CreateActorSnapshotTag: %v", err)
 	}
 	return &Service{persistence: persistence}, created
 }
@@ -394,12 +394,12 @@ func TestUpdateActorSnapshotTag_DeleteRecreateRace(t *testing.T) {
 	const tagName = "before-upgrade"
 	// Tag A: what the client reads, and what its uid precondition names.
 	// Freshly created, so it sits at version 1.
-	originalTag, err := persistence.TagActorSnapshot(ctx, testAtespace, "snapshot-1", &ateapipb.ActorSnapshotTag{
+	originalTag, err := persistence.CreateActorSnapshotTag(ctx, testAtespace, "snapshot-1", &ateapipb.ActorSnapshotTag{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: tagName},
 		Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 	})
 	if err != nil {
-		t.Fatalf("Failed to TagActorSnapshot(snapshot-1): %v", err)
+		t.Fatalf("Failed to CreateActorSnapshotTag(snapshot-1): %v", err)
 	}
 
 	// A concurrent client deletes A and re-tags the same atespace/name as a
@@ -411,12 +411,12 @@ func TestUpdateActorSnapshotTag_DeleteRecreateRace(t *testing.T) {
 			if _, err := persistence.DeleteActorSnapshotTag(ctx, testAtespace, tagName); err != nil {
 				t.Fatalf("Racing writer: DeleteActorSnapshotTag: %v", err)
 			}
-			recreatedTag, err = persistence.TagActorSnapshot(ctx, testAtespace, "snapshot-2", &ateapipb.ActorSnapshotTag{
+			recreatedTag, err = persistence.CreateActorSnapshotTag(ctx, testAtespace, "snapshot-2", &ateapipb.ActorSnapshotTag{
 				Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: tagName},
 				Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 			})
 			if err != nil {
-				t.Fatalf("Racing writer: re-tag TagActorSnapshot: %v", err)
+				t.Fatalf("Racing writer: re-tag CreateActorSnapshotTag: %v", err)
 			}
 		},
 	}
@@ -442,9 +442,9 @@ func TestUpdateActorSnapshotTag_DeleteRecreateRace(t *testing.T) {
 			err, code, originalTag.GetMetadata().GetUid())
 	}
 
-	_, storedTag, err := persistence.GetActorSnapshotByTag(ctx, testAtespace, tagName)
+	storedTag, err := persistence.GetActorSnapshotTag(ctx, testAtespace, tagName)
 	if err != nil {
-		t.Fatalf("GetActorSnapshotByTag: %v", err)
+		t.Fatalf("GetActorSnapshotTag: %v", err)
 	}
 	// The stored record must still be tag B as its creator left it. Any of A's
 	// state showing up here is the clobber.
@@ -469,12 +469,12 @@ func TestUpdateActorSnapshotTag_ConcurrentUnguardedUpdate(t *testing.T) {
 	}
 
 	const tagName = "before-upgrade"
-	originalTag, err := persistence.TagActorSnapshot(ctx, testAtespace, "snapshot-1", &ateapipb.ActorSnapshotTag{
+	originalTag, err := persistence.CreateActorSnapshotTag(ctx, testAtespace, "snapshot-1", &ateapipb.ActorSnapshotTag{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: tagName},
 		Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 	})
 	if err != nil {
-		t.Fatalf("Failed to TagActorSnapshot(snapshot-1): %v", err)
+		t.Fatalf("Failed to CreateActorSnapshotTag(snapshot-1): %v", err)
 	}
 
 	// A concurrent client moves the tag past the version the caller could have
@@ -503,9 +503,9 @@ func TestUpdateActorSnapshotTag_ConcurrentUnguardedUpdate(t *testing.T) {
 		t.Fatalf("UpdateActorSnapshotTag error = %v, want success: no precondition was set, so the conflict is the server's to resolve", err)
 	}
 
-	_, storedTag, err := persistence.GetActorSnapshotByTag(ctx, testAtespace, tagName)
+	storedTag, err := persistence.GetActorSnapshotTag(ctx, testAtespace, tagName)
 	if err != nil {
-		t.Fatalf("Failed to GetActorSnapshotByTag(%s/%s): %v", testAtespace, tagName, err)
+		t.Fatalf("Failed to GetActorSnapshotTag(%s/%s): %v", testAtespace, tagName, err)
 	}
 	if got, want := storedTag.GetScope(), ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED; got != want {
 		t.Errorf("Stored scope = %v, want %v", got, want)

--- a/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
@@ -342,9 +342,9 @@ func TestCreateActorSnapshotTag_RejectsUnsetScope(t *testing.T) {
 	})
 
 	_, err := svc.CreateActorSnapshotTag(ctx, &ateapipb.CreateActorSnapshotTagRequest{
-		Snapshot: stored.GetSnapshot(),
-		Tag: &ateapipb.ActorSnapshotTag{
+		ActorSnapshotTag: &ateapipb.ActorSnapshotTag{
 			Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "tag2"},
+			Snapshot: stored.GetSnapshot(),
 		},
 	})
 	if code := status.Code(err); code != codes.InvalidArgument {

--- a/cmd/ateapi/internal/controlapi/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_test.go
@@ -193,11 +193,11 @@ func TestCreateActor_RejectsDifferentTemplateForDataSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateActorSnapshot: %v", err)
 	}
-	if _, err := tc.persistence.TagActorSnapshot(context.Background(), testAtespace, snapshot.GetMetadata().GetName(), &ateapipb.ActorSnapshotTag{
+	if _, err := tc.persistence.CreateActorSnapshotTag(context.Background(), testAtespace, snapshot.GetMetadata().GetName(), &ateapipb.ActorSnapshotTag{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "data-snapshot"},
 		Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 	}); err != nil {
-		t.Fatalf("TagActorSnapshot: %v", err)
+		t.Fatalf("CreateActorSnapshotTag: %v", err)
 	}
 
 	_, err = tc.service.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
@@ -250,11 +250,11 @@ func TestCreateActor_RejectsSnapshotWithExternalVolumes(t *testing.T) {
 		t.Fatalf("CreateActorSnapshot: %v", err)
 	}
 	tagRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "external-volume-snapshot"}
-	if _, err := tc.persistence.TagActorSnapshot(context.Background(), testAtespace, snapshot.GetMetadata().GetName(), &ateapipb.ActorSnapshotTag{
+	if _, err := tc.persistence.CreateActorSnapshotTag(context.Background(), testAtespace, snapshot.GetMetadata().GetName(), &ateapipb.ActorSnapshotTag{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: tagRef.GetAtespace(), Name: tagRef.GetName()},
 		Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 	}); err != nil {
-		t.Fatalf("TagActorSnapshot: %v", err)
+		t.Fatalf("CreateActorSnapshotTag: %v", err)
 	}
 
 	_, err = tc.service.CreateActor(context.Background(), &ateapipb.CreateActorRequest{

--- a/cmd/ateapi/internal/controlapi/atespace.go
+++ b/cmd/ateapi/internal/controlapi/atespace.go
@@ -108,13 +108,13 @@ func (s *Service) ListAtespaces(ctx context.Context, req *ateapipb.ListAtespaces
 		return nil, toGRPCStatusError(errs)
 	}
 
-	atespaces, nextToken, err := s.persistence.ListAtespaces(ctx, effectivePageSize(req.GetPageSize()), req.GetPageToken())
+	page, err := s.persistence.ListAtespaces(ctx, store.ListOptions{PageSize: effectivePageSize(req.GetPageSize()), PageToken: req.GetPageToken()})
 	if err != nil {
 		return nil, fmt.Errorf("while listing atespaces in db: %w", err)
 	}
 	return &ateapipb.ListAtespacesResponse{
-		Atespaces:     atespaces,
-		NextPageToken: nextToken,
+		Atespaces:     page.Items,
+		NextPageToken: page.NextPageToken,
 	}, nil
 }
 

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -498,7 +498,7 @@ func tagActorSnapshot(t *testing.T, tc *testContext, snapshotRef *ateapipb.Objec
 		},
 	})
 	if err != nil {
-		t.Fatalf("TagActorSnapshot(%s) failed: %v", tagName, err)
+		t.Fatalf("CreateActorSnapshotTag(%s) failed: %v", tagName, err)
 	}
 	return tag
 }
@@ -2127,7 +2127,7 @@ func TestSuspendActor(t *testing.T) {
 		},
 	})
 	if err != nil || !proto.Equal(tagged.GetSnapshot(), ref) {
-		t.Fatalf("TagActorSnapshot = (%v, %v), want tag for snapshot", tagged, err)
+		t.Fatalf("CreateActorSnapshotTag = (%v, %v), want tag for snapshot", tagged, err)
 	}
 	if _, err := tc.client.CreateActorSnapshotTag(context.Background(), &ateapipb.CreateActorSnapshotTagRequest{
 		Snapshot: snapshotRef,
@@ -2136,7 +2136,7 @@ func TestSuspendActor(t *testing.T) {
 			Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 		},
 	}); status.Code(err) != codes.FailedPrecondition {
-		t.Fatalf("cross-atespace TagActorSnapshot status = %v, want FailedPrecondition", status.Code(err))
+		t.Fatalf("cross-atespace CreateActorSnapshotTag status = %v, want FailedPrecondition", status.Code(err))
 	}
 	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{

--- a/cmd/ateapi/internal/controlapi/functional_test.go
+++ b/cmd/ateapi/internal/controlapi/functional_test.go
@@ -491,9 +491,9 @@ func createActorSnapshot(t *testing.T, tc *testContext, name string) *ateapipb.O
 func tagActorSnapshot(t *testing.T, tc *testContext, snapshotRef *ateapipb.ObjectRef, tagName string) *ateapipb.ActorSnapshotTag {
 	t.Helper()
 	tag, err := tc.client.CreateActorSnapshotTag(context.Background(), &ateapipb.CreateActorSnapshotTagRequest{
-		Snapshot: snapshotRef,
-		Tag: &ateapipb.ActorSnapshotTag{
+		ActorSnapshotTag: &ateapipb.ActorSnapshotTag{
 			Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: tagName},
+			Snapshot: snapshotRef,
 			Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 		},
 	})
@@ -2120,9 +2120,9 @@ func TestSuspendActor(t *testing.T) {
 	}
 	tagRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "before-upgrade"}
 	tagged, err := tc.client.CreateActorSnapshotTag(context.Background(), &ateapipb.CreateActorSnapshotTagRequest{
-		Snapshot: snapshotRef,
-		Tag: &ateapipb.ActorSnapshotTag{
+		ActorSnapshotTag: &ateapipb.ActorSnapshotTag{
 			Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "before-upgrade"},
+			Snapshot: snapshotRef,
 			Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 		},
 	})
@@ -2130,9 +2130,9 @@ func TestSuspendActor(t *testing.T) {
 		t.Fatalf("CreateActorSnapshotTag = (%v, %v), want tag for snapshot", tagged, err)
 	}
 	if _, err := tc.client.CreateActorSnapshotTag(context.Background(), &ateapipb.CreateActorSnapshotTagRequest{
-		Snapshot: snapshotRef,
-		Tag: &ateapipb.ActorSnapshotTag{
+		ActorSnapshotTag: &ateapipb.ActorSnapshotTag{
 			Metadata: &ateapipb.ResourceMetadata{Atespace: "other", Name: "cross-atespace"},
+			Snapshot: snapshotRef,
 			Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 		},
 	}); status.Code(err) != codes.FailedPrecondition {

--- a/cmd/ateapi/internal/controlapi/syncer.go
+++ b/cmd/ateapi/internal/controlapi/syncer.go
@@ -313,18 +313,18 @@ func (s *WorkerPoolSyncer) reconcileDeadWorker(ctx context.Context, namespace, p
 func (s *WorkerPoolSyncer) enqueueStoredWorkers(ctx context.Context) {
 	var pageToken string
 	for {
-		workers, nextToken, err := s.persistence.ListWorkers(ctx, 1000, pageToken)
+		page, err := s.persistence.ListWorkers(ctx, store.ListOptions{PageSize: 1000, PageToken: pageToken})
 		if err != nil {
 			slog.ErrorContext(ctx, "Syncer: failed to list workers for orphan reconcile", slog.Any("err", err))
 			return
 		}
-		for _, w := range workers {
+		for _, w := range page.Items {
 			s.queue.Add(workerKey{namespace: w.GetWorkerNamespace(), pool: w.GetWorkerPool(), name: w.GetWorkerPod()})
 		}
-		if nextToken == "" {
+		if !page.HasNextPage() {
 			return
 		}
-		pageToken = nextToken
+		pageToken = page.NextPageToken
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/syncer_test.go
+++ b/cmd/ateapi/internal/controlapi/syncer_test.go
@@ -105,12 +105,12 @@ func TestSyncer_Lifecycle(t *testing.T) {
 	}()
 
 	// 1. Verify no workers in Redis initially
-	workers, _, err := persistence.ListWorkers(context.Background(), 1000, "")
+	workers, err := persistence.ListWorkers(context.Background(), store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("failed to list workers: %v", err)
 	}
-	if len(workers) != 0 {
-		t.Fatalf("expected 0 workers, got %d", len(workers))
+	if len(workers.Items) != 0 {
+		t.Fatalf("expected 0 workers, got %d", len(workers.Items))
 	}
 
 	// 2. Add pod with no IP
@@ -1209,10 +1209,11 @@ func TestSyncer_PodRecreatedWithNewUID(t *testing.T) {
 	}
 
 	// Verify via ListWorkers that no stale worker record with oldUID remains in the store.
-	workers, _, err := persistence.ListWorkers(context.Background(), 100, "")
+	workersResp, err := persistence.ListWorkers(context.Background(), store.ListOptions{PageSize: 100})
 	if err != nil {
 		t.Fatalf("failed to list workers: %v", err)
 	}
+	workers := workersResp.Items
 	if len(workers) != 1 {
 		t.Fatalf("expected exactly 1 worker in store, got %d", len(workers))
 	}
@@ -1271,12 +1272,12 @@ func TestSyncer_DeleteNeverEligiblePod(t *testing.T) {
 	// The store must stay empty throughout: the pod never had an IP so no row
 	// was created, and the delete path is an idempotent no-op.
 	err := wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
-		workers, _, err := persistence.ListWorkers(ctx, 1000, "")
+		workers, err := persistence.ListWorkers(ctx, store.ListOptions{PageSize: 1000})
 		if err != nil {
 			return false, err
 		}
-		if len(workers) != 0 {
-			return false, fmt.Errorf("expected 0 workers, got %d", len(workers))
+		if len(workers.Items) != 0 {
+			return false, fmt.Errorf("expected 0 workers, got %d", len(workers.Items))
 		}
 		return false, nil // keep polling until timeout
 	})

--- a/cmd/ateapi/internal/controlapi/worker.go
+++ b/cmd/ateapi/internal/controlapi/worker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -27,13 +28,13 @@ func (s *Service) ListWorkers(ctx context.Context, req *ateapipb.ListWorkersRequ
 		return nil, toGRPCStatusError(errs)
 	}
 
-	workers, nextToken, err := s.persistence.ListWorkers(ctx, effectivePageSize(req.GetPageSize()), req.GetPageToken())
+	page, err := s.persistence.ListWorkers(ctx, store.ListOptions{PageSize: effectivePageSize(req.GetPageSize()), PageToken: req.GetPageToken()})
 	if err != nil {
 		return nil, fmt.Errorf("while listing workers in db: %w", err)
 	}
 	return &ateapipb.ListWorkersResponse{
-		Workers:       workers,
-		NextPageToken: nextToken,
+		Workers:       page.Items,
+		NextPageToken: page.NextPageToken,
 	}, nil
 }
 

--- a/cmd/ateapi/internal/store/atepg/atepg.go
+++ b/cmd/ateapi/internal/store/atepg/atepg.go
@@ -182,10 +182,11 @@ func (p *Persistence) AtespaceExists(ctx context.Context, name string) (bool, er
 	return exists, nil
 }
 
-func (p *Persistence) ListAtespaces(ctx context.Context, pageSize int32, pageTokenStr string) ([]*ateapipb.Atespace, string, error) {
+func (p *Persistence) ListAtespaces(ctx context.Context, opts store.ListOptions) (store.ListResponse[*ateapipb.Atespace], error) {
+	pageSize, pageTokenStr := opts.PageSize, opts.PageToken
 	token, err := decodePageToken(pageTokenStr, kindAtespace, "", 1)
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.Atespace]{}, err
 	}
 	var last *string
 	if len(token.Last) > 0 {
@@ -198,7 +199,7 @@ func (p *Persistence) ListAtespaces(ctx context.Context, pageSize int32, pageTok
 		ORDER BY name
 		LIMIT $2`, last, int64(pageSize)+1)
 	if err != nil {
-		return nil, "", fmt.Errorf("listing atespaces: %w", err)
+		return store.ListResponse[*ateapipb.Atespace]{}, fmt.Errorf("listing atespaces: %w", err)
 	}
 	defer rows.Close()
 
@@ -208,17 +209,17 @@ func (p *Persistence) ListAtespaces(ctx context.Context, pageSize int32, pageTok
 		var name string
 		var protoBytes []byte
 		if err := rows.Scan(&name, &protoBytes); err != nil {
-			return nil, "", fmt.Errorf("scanning atespace row: %w", err)
+			return store.ListResponse[*ateapipb.Atespace]{}, fmt.Errorf("scanning atespace row: %w", err)
 		}
 		a := &ateapipb.Atespace{}
 		if err := proto.Unmarshal(protoBytes, a); err != nil {
-			return nil, "", fmt.Errorf("unmarshaling atespace: %w", err)
+			return store.ListResponse[*ateapipb.Atespace]{}, fmt.Errorf("unmarshaling atespace: %w", err)
 		}
 		result = append(result, a)
 		names = append(names, name)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, "", fmt.Errorf("listing atespaces: %w", err)
+		return store.ListResponse[*ateapipb.Atespace]{}, fmt.Errorf("listing atespaces: %w", err)
 	}
 
 	var nextToken string
@@ -226,7 +227,7 @@ func (p *Persistence) ListAtespaces(ctx context.Context, pageSize int32, pageTok
 		result = result[:pageSize]
 		nextToken = encodePageToken(kindAtespace, "", []string{names[pageSize-1]})
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.Atespace]{Items: result, NextPageToken: nextToken}, nil
 }
 
 func (p *Persistence) DeleteAtespace(ctx context.Context, name string) (*ateapipb.Atespace, error) {
@@ -358,14 +359,15 @@ func (p *Persistence) UpdateActorTemplate(ctx context.Context, templateRef resou
 	return dbTemplate, nil
 }
 
-func (p *Persistence) ListActorTemplates(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorTemplate, string, error) {
+func (p *Persistence) ListActorTemplates(ctx context.Context, atespace string, opts store.ListOptions) (store.ListResponse[*ateapipb.ActorTemplate], error) {
+	pageSize, pageTokenStr := opts.PageSize, opts.PageToken
 	keyParts := 2
 	if atespace != "" {
 		keyParts = 1
 	}
 	token, err := decodePageToken(pageTokenStr, kindActorTemplate, atespace, keyParts)
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.ActorTemplate]{}, err
 	}
 
 	var rows pgx.Rows
@@ -389,7 +391,7 @@ func (p *Persistence) ListActorTemplates(ctx context.Context, atespace string, p
 			ORDER BY atespace, name LIMIT $3`, lastAtespace, lastName, int64(pageSize)+1)
 	}
 	if err != nil {
-		return nil, "", fmt.Errorf("listing actor templates: %w", err)
+		return store.ListResponse[*ateapipb.ActorTemplate]{}, fmt.Errorf("listing actor templates: %w", err)
 	}
 	defer rows.Close()
 
@@ -400,17 +402,17 @@ func (p *Persistence) ListActorTemplates(ctx context.Context, atespace string, p
 		var k key
 		var protoBytes []byte
 		if err := rows.Scan(&k.atespace, &k.name, &protoBytes); err != nil {
-			return nil, "", fmt.Errorf("scanning actor template row: %w", err)
+			return store.ListResponse[*ateapipb.ActorTemplate]{}, fmt.Errorf("scanning actor template row: %w", err)
 		}
 		template := &ateapipb.ActorTemplate{}
 		if err := proto.Unmarshal(protoBytes, template); err != nil {
-			return nil, "", fmt.Errorf("unmarshaling actor template: %w", err)
+			return store.ListResponse[*ateapipb.ActorTemplate]{}, fmt.Errorf("unmarshaling actor template: %w", err)
 		}
 		keys = append(keys, k)
 		result = append(result, template)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, "", fmt.Errorf("listing actor templates: %w", err)
+		return store.ListResponse[*ateapipb.ActorTemplate]{}, fmt.Errorf("listing actor templates: %w", err)
 	}
 	var nextToken string
 	if len(result) > int(pageSize) {
@@ -422,7 +424,7 @@ func (p *Persistence) ListActorTemplates(ctx context.Context, atespace string, p
 		}
 		nextToken = encodePageToken(kindActorTemplate, atespace, lastParts)
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.ActorTemplate]{Items: result, NextPageToken: nextToken}, nil
 }
 
 func (p *Persistence) DeleteActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef) (*ateapipb.ActorTemplate, error) {
@@ -507,7 +509,8 @@ func actorTemplateVersionListScope(atespace string, parent resources.ActorTempla
 	return atespace + "\x00" + parent.Atespace + "\x00" + parent.Name
 }
 
-func (p *Persistence) ListActorTemplateVersions(ctx context.Context, atespace string, parent resources.ActorTemplateRef, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorTemplateVersion, string, error) {
+func (p *Persistence) ListActorTemplateVersions(ctx context.Context, atespace string, parent resources.ActorTemplateRef, opts store.ListOptions) (store.ListResponse[*ateapipb.ActorTemplateVersion], error) {
+	pageSize, pageTokenStr := opts.PageSize, opts.PageToken
 	scope := actorTemplateVersionListScope(atespace, parent)
 	keyParts := 2
 	if atespace != "" {
@@ -515,7 +518,7 @@ func (p *Persistence) ListActorTemplateVersions(ctx context.Context, atespace st
 	}
 	token, err := decodePageToken(pageTokenStr, kindActorTemplateVersion, scope, keyParts)
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.ActorTemplateVersion]{}, err
 	}
 	filterParent := parent != (resources.ActorTemplateRef{})
 
@@ -543,7 +546,7 @@ func (p *Persistence) ListActorTemplateVersions(ctx context.Context, atespace st
 			ORDER BY atespace, name LIMIT $6`, filterParent, parent.Atespace, parent.Name, lastAtespace, lastName, int64(pageSize)+1)
 	}
 	if err != nil {
-		return nil, "", fmt.Errorf("listing actor template versions: %w", err)
+		return store.ListResponse[*ateapipb.ActorTemplateVersion]{}, fmt.Errorf("listing actor template versions: %w", err)
 	}
 	defer rows.Close()
 
@@ -554,17 +557,17 @@ func (p *Persistence) ListActorTemplateVersions(ctx context.Context, atespace st
 		var k key
 		var protoBytes []byte
 		if err := rows.Scan(&k.atespace, &k.name, &protoBytes); err != nil {
-			return nil, "", fmt.Errorf("scanning actor template version row: %w", err)
+			return store.ListResponse[*ateapipb.ActorTemplateVersion]{}, fmt.Errorf("scanning actor template version row: %w", err)
 		}
 		version := &ateapipb.ActorTemplateVersion{}
 		if err := proto.Unmarshal(protoBytes, version); err != nil {
-			return nil, "", fmt.Errorf("unmarshaling actor template version: %w", err)
+			return store.ListResponse[*ateapipb.ActorTemplateVersion]{}, fmt.Errorf("unmarshaling actor template version: %w", err)
 		}
 		keys = append(keys, k)
 		result = append(result, version)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, "", fmt.Errorf("listing actor template versions: %w", err)
+		return store.ListResponse[*ateapipb.ActorTemplateVersion]{}, fmt.Errorf("listing actor template versions: %w", err)
 	}
 	var nextToken string
 	if len(result) > int(pageSize) {
@@ -576,7 +579,7 @@ func (p *Persistence) ListActorTemplateVersions(ctx context.Context, atespace st
 		}
 		nextToken = encodePageToken(kindActorTemplateVersion, scope, lastParts)
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.ActorTemplateVersion]{Items: result, NextPageToken: nextToken}, nil
 }
 
 func (p *Persistence) DeleteActorTemplateVersion(ctx context.Context, versionRef resources.ActorTemplateVersionRef) (*ateapipb.ActorTemplateVersion, error) {
@@ -801,11 +804,19 @@ func (p *Persistence) DeleteActor(ctx context.Context, actorRef resources.ActorR
 	return out, nil
 }
 
-func (p *Persistence) ListActors(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.Actor, string, error) {
+func (p *Persistence) ListActors(ctx context.Context, atespace string, opts store.ListOptions) (store.ListResponse[*ateapipb.Actor], error) {
+	var items []*ateapipb.Actor
+	var nextToken string
+	var err error
 	if atespace != "" {
-		return p.listActorsScoped(ctx, atespace, pageSize, pageTokenStr)
+		items, nextToken, err = p.listActorsScoped(ctx, atespace, opts.PageSize, opts.PageToken)
+	} else {
+		items, nextToken, err = p.listActorsGlobal(ctx, opts.PageSize, opts.PageToken)
 	}
-	return p.listActorsGlobal(ctx, pageSize, pageTokenStr)
+	if err != nil {
+		return store.ListResponse[*ateapipb.Actor]{}, err
+	}
+	return store.ListResponse[*ateapipb.Actor]{Items: items, NextPageToken: nextToken}, nil
 }
 
 func (p *Persistence) listActorsScoped(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.Actor, string, error) {
@@ -966,11 +977,19 @@ func (p *Persistence) GetActorSnapshotTag(ctx context.Context, atespace, name st
 	return tag, nil
 }
 
-func (p *Persistence) ListActorSnapshots(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorSnapshot, string, error) {
+func (p *Persistence) ListActorSnapshots(ctx context.Context, atespace string, opts store.ListOptions) (store.ListResponse[*ateapipb.ActorSnapshot], error) {
+	var items []*ateapipb.ActorSnapshot
+	var nextToken string
+	var err error
 	if atespace != "" {
-		return p.listActorSnapshotsScoped(ctx, atespace, pageSize, pageTokenStr)
+		items, nextToken, err = p.listActorSnapshotsScoped(ctx, atespace, opts.PageSize, opts.PageToken)
+	} else {
+		items, nextToken, err = p.listActorSnapshotsGlobal(ctx, opts.PageSize, opts.PageToken)
 	}
-	return p.listActorSnapshotsGlobal(ctx, pageSize, pageTokenStr)
+	if err != nil {
+		return store.ListResponse[*ateapipb.ActorSnapshot]{}, err
+	}
+	return store.ListResponse[*ateapipb.ActorSnapshot]{Items: items, NextPageToken: nextToken}, nil
 }
 
 func (p *Persistence) listActorSnapshotsScoped(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorSnapshot, string, error) {
@@ -1393,10 +1412,11 @@ func (p *Persistence) DeleteWorker(ctx context.Context, namespace, poolName, pod
 	})
 }
 
-func (p *Persistence) ListWorkers(ctx context.Context, pageSize int32, pageTokenStr string) ([]*ateapipb.Worker, string, error) {
+func (p *Persistence) ListWorkers(ctx context.Context, opts store.ListOptions) (store.ListResponse[*ateapipb.Worker], error) {
+	pageSize, pageTokenStr := opts.PageSize, opts.PageToken
 	token, err := decodePageToken(pageTokenStr, kindWorker, "", 3)
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.Worker]{}, err
 	}
 	var lastNS, lastPool, lastPod *string
 	if len(token.Last) == 3 {
@@ -1409,7 +1429,7 @@ func (p *Persistence) ListWorkers(ctx context.Context, pageSize int32, pageToken
 		ORDER BY worker_namespace, worker_pool, worker_pod
 		LIMIT $4`, lastNS, lastPool, lastPod, int64(pageSize)+1)
 	if err != nil {
-		return nil, "", fmt.Errorf("listing workers: %w", err)
+		return store.ListResponse[*ateapipb.Worker]{}, fmt.Errorf("listing workers: %w", err)
 	}
 	defer rows.Close()
 
@@ -1420,17 +1440,17 @@ func (p *Persistence) ListWorkers(ctx context.Context, pageSize int32, pageToken
 		var k key
 		var protoBytes []byte
 		if err := rows.Scan(&k.namespace, &k.pool, &k.pod, &protoBytes); err != nil {
-			return nil, "", fmt.Errorf("scanning worker row: %w", err)
+			return store.ListResponse[*ateapipb.Worker]{}, fmt.Errorf("scanning worker row: %w", err)
 		}
 		w := &ateapipb.Worker{}
 		if err := proto.Unmarshal(protoBytes, w); err != nil {
-			return nil, "", fmt.Errorf("unmarshaling worker: %w", err)
+			return store.ListResponse[*ateapipb.Worker]{}, fmt.Errorf("unmarshaling worker: %w", err)
 		}
 		result = append(result, w)
 		keys = append(keys, k)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, "", fmt.Errorf("listing workers: %w", err)
+		return store.ListResponse[*ateapipb.Worker]{}, fmt.Errorf("listing workers: %w", err)
 	}
 
 	var nextToken string
@@ -1439,7 +1459,7 @@ func (p *Persistence) ListWorkers(ctx context.Context, pageSize int32, pageToken
 		last := keys[pageSize-1]
 		nextToken = encodePageToken(kindWorker, "", []string{last.namespace, last.pool, last.pod})
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.Worker]{Items: result, NextPageToken: nextToken}, nil
 }
 
 // WatchWorkers acquires a dedicated connection (hijacked out of the pool, so

--- a/cmd/ateapi/internal/store/atepg/atepg.go
+++ b/cmd/ateapi/internal/store/atepg/atepg.go
@@ -949,8 +949,21 @@ func (p *Persistence) GetActorSnapshot(ctx context.Context, atespace, name strin
 	return getActorSnapshotRow(ctx, p.pool, atespace, name)
 }
 
-func (p *Persistence) GetActorSnapshotByTag(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshot, *ateapipb.ActorSnapshotTag, error) {
-	return p.getActorSnapshotByTag(ctx, p.pool, atespace, name)
+func (p *Persistence) GetActorSnapshotTag(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshotTag, error) {
+	var protoBytes []byte
+	if err := p.pool.QueryRow(ctx, `
+		SELECT proto FROM actor_snapshot_tags
+		WHERE atespace = $1 AND name = $2`, atespace, name).Scan(&protoBytes); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, store.ErrNotFound
+		}
+		return nil, fmt.Errorf("getting actor snapshot tag %s/%s: %w", atespace, name, err)
+	}
+	tag := &ateapipb.ActorSnapshotTag{}
+	if err := proto.Unmarshal(protoBytes, tag); err != nil {
+		return nil, fmt.Errorf("unmarshaling actor snapshot tag: %w", err)
+	}
+	return tag, nil
 }
 
 func (p *Persistence) ListActorSnapshots(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorSnapshot, string, error) {
@@ -1052,7 +1065,7 @@ func (p *Persistence) listActorSnapshotsGlobal(ctx context.Context, pageSize int
 	return result, nextToken, nil
 }
 
-func (p *Persistence) TagActorSnapshot(ctx context.Context, snapshotAtespace, snapshotName string, tag *ateapipb.ActorSnapshotTag) (*ateapipb.ActorSnapshotTag, error) {
+func (p *Persistence) CreateActorSnapshotTag(ctx context.Context, snapshotAtespace, snapshotName string, tag *ateapipb.ActorSnapshotTag) (*ateapipb.ActorSnapshotTag, error) {
 	tagAtespace := tag.GetMetadata().GetAtespace()
 	tagName := tag.GetMetadata().GetName()
 	dbTag := proto.Clone(tag).(*ateapipb.ActorSnapshotTag)
@@ -1180,31 +1193,6 @@ func (p *Persistence) UpdateActorSnapshotTag(ctx context.Context, atespace, name
 		return nil, fmt.Errorf("committing actor snapshot tag update: %w", err)
 	}
 	return dbTag, nil
-}
-
-func (p *Persistence) getActorSnapshotByTag(ctx context.Context, q querier, atespace, name string) (*ateapipb.ActorSnapshot, *ateapipb.ActorSnapshotTag, error) {
-	var snapshotBytes, tagBytes []byte
-	err := q.QueryRow(ctx, `
-		SELECT s.proto, t.proto
-		FROM actor_snapshot_tags AS t
-		JOIN actor_snapshots AS s
-		  ON s.atespace = t.snapshot_atespace AND s.name = t.snapshot_name
-		WHERE t.atespace = $1 AND t.name = $2`, atespace, name).Scan(&snapshotBytes, &tagBytes)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil, store.ErrNotFound
-		}
-		return nil, nil, fmt.Errorf("resolving actor snapshot tag %s/%s: %w", atespace, name, err)
-	}
-	snapshot := &ateapipb.ActorSnapshot{}
-	if err := proto.Unmarshal(snapshotBytes, snapshot); err != nil {
-		return nil, nil, fmt.Errorf("unmarshaling actor snapshot: %w", err)
-	}
-	tag := &ateapipb.ActorSnapshotTag{}
-	if err := proto.Unmarshal(tagBytes, tag); err != nil {
-		return nil, nil, fmt.Errorf("unmarshaling actor snapshot tag: %w", err)
-	}
-	return snapshot, tag, nil
 }
 
 func (p *Persistence) DeleteActorSnapshotTag(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshotTag, error) {

--- a/cmd/ateapi/internal/store/atepg/atepg_test.go
+++ b/cmd/ateapi/internal/store/atepg/atepg_test.go
@@ -188,15 +188,15 @@ func TestListActorTemplateVersions_PageTokenRejectsDifferentFilter(t *testing.T)
 		}
 	}
 	parent := resources.ActorTemplateRef{Atespace: "team-a", Name: "tmpl-a"}
-	_, token, err := s.ListActorTemplateVersions(ctx, "team-a", parent, 1, "")
+	page, err := s.ListActorTemplateVersions(ctx, "team-a", parent, store.ListOptions{PageSize: 1})
 	if err != nil {
 		t.Fatalf("ListActorTemplateVersions failed: %v", err)
 	}
-	if token == "" {
+	if page.NextPageToken == "" {
 		t.Fatal("expected a second page")
 	}
 	otherParent := resources.ActorTemplateRef{Atespace: "team-a", Name: "tmpl-b"}
-	if _, _, err := s.ListActorTemplateVersions(ctx, "team-a", otherParent, 1, token); err == nil {
+	if _, err := s.ListActorTemplateVersions(ctx, "team-a", otherParent, store.ListOptions{PageSize: 1, PageToken: page.NextPageToken}); err == nil {
 		t.Error("page token was accepted with a different parent filter")
 	}
 }
@@ -288,7 +288,7 @@ func TestListActors_InvalidPageToken(t *testing.T) {
 	s := setupPostgresStore(t).(*Persistence)
 	ctx := context.Background()
 
-	if _, _, err := s.ListActors(ctx, "", 10, "not-valid-base64!!"); err == nil {
+	if _, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 10, PageToken: "not-valid-base64!!"}); err == nil {
 		t.Errorf("ListActors with malformed page token = nil error, want an error")
 	}
 }
@@ -316,30 +316,30 @@ func TestListActors_CrossScopePageToken(t *testing.T) {
 		}
 	}
 
-	_, nextToken, err := s.ListActors(ctx, "team-a", 1, "")
+	page, err := s.ListActors(ctx, "team-a", store.ListOptions{PageSize: 1})
 	if err != nil {
 		t.Fatalf("ListActors(team-a) failed: %v", err)
 	}
-	if nextToken == "" {
+	if page.NextPageToken == "" {
 		t.Fatalf("expected a next page token")
 	}
 
 	// A token minted for team-a must be rejected when replayed against team-b
 	// or against the unscoped (global) listing.
-	if _, _, err := s.ListActors(ctx, "team-b", 1, nextToken); err == nil {
+	if _, err := s.ListActors(ctx, "team-b", store.ListOptions{PageSize: 1, PageToken: page.NextPageToken}); err == nil {
 		t.Errorf("ListActors(team-b) with team-a's token = nil error, want an error")
 	}
-	if _, _, err := s.ListActors(ctx, "", 1, nextToken); err == nil {
+	if _, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 1, PageToken: page.NextPageToken}); err == nil {
 		t.Errorf("ListActors(all) with team-a's token = nil error, want an error")
 	}
 
 	// A worker-list token must be rejected by ListAtespaces (different kind).
-	_, workerToken, err := s.ListWorkers(ctx, 1, "")
+	workerPage, err := s.ListWorkers(ctx, store.ListOptions{PageSize: 1})
 	if err != nil {
 		t.Fatalf("ListWorkers failed: %v", err)
 	}
-	if workerToken != "" {
-		if _, _, err := s.ListAtespaces(ctx, 1, workerToken); err == nil {
+	if workerPage.NextPageToken != "" {
+		if _, err := s.ListAtespaces(ctx, store.ListOptions{PageSize: 1, PageToken: workerPage.NextPageToken}); err == nil {
 			t.Errorf("ListAtespaces with a worker page token = nil error, want an error")
 		}
 	}

--- a/cmd/ateapi/internal/store/atepg/atepg_test.go
+++ b/cmd/ateapi/internal/store/atepg/atepg_test.go
@@ -155,10 +155,10 @@ func TestDeleteActorTemplateVersion_TaggedGoldenSnapshotRollsBack(t *testing.T) 
 	}); err != nil {
 		t.Fatalf("CreateActorSnapshot failed: %v", err)
 	}
-	if _, err := s.TagActorSnapshot(ctx, "ate-golden", "golden-1", &ateapipb.ActorSnapshotTag{
+	if _, err := s.CreateActorSnapshotTag(ctx, "ate-golden", "golden-1", &ateapipb.ActorSnapshotTag{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "keep-golden"},
 	}); err != nil {
-		t.Fatalf("TagActorSnapshot failed: %v", err)
+		t.Fatalf("CreateActorSnapshotTag failed: %v", err)
 	}
 	version := newTestActorTemplateVersion("team-a", "tmpl-a-v1", "tmpl-a")
 	version.GoldenSnapshot = &ateapipb.ObjectRef{Atespace: "ate-golden", Name: "golden-1"}

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -782,20 +782,19 @@ func (s *Persistence) GetActorSnapshot(ctx context.Context, atespace, name strin
 	return snapshot, nil
 }
 
-func (s *Persistence) GetActorSnapshotByTag(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshot, *ateapipb.ActorSnapshotTag, error) {
+func (s *Persistence) GetActorSnapshotTag(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshotTag, error) {
 	b, err := s.rdb.Get(ctx, actorSnapshotTagDBKey(atespace, name)).Bytes()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
-			return nil, nil, store.ErrNotFound
+			return nil, store.ErrNotFound
 		}
-		return nil, nil, fmt.Errorf("while resolving actor snapshot tag %s/%s: %w", atespace, name, err)
+		return nil, fmt.Errorf("while getting actor snapshot tag %s/%s: %w", atespace, name, err)
 	}
 	tag := &ateapipb.ActorSnapshotTag{}
 	if err := protojson.Unmarshal(b, tag); err != nil {
-		return nil, nil, fmt.Errorf("while unmarshaling actor snapshot tag %s/%s: %w", atespace, name, err)
+		return nil, fmt.Errorf("while unmarshaling actor snapshot tag %s/%s: %w", atespace, name, err)
 	}
-	snapshot, err := s.GetActorSnapshot(ctx, tag.GetSnapshot().GetAtespace(), tag.GetSnapshot().GetName())
-	return snapshot, tag, err
+	return tag, nil
 }
 
 func (s *Persistence) ListActorSnapshots(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorSnapshot, string, error) {
@@ -834,7 +833,7 @@ func (s *Persistence) ListActorSnapshots(ctx context.Context, atespace string, p
 	return result, nextToken, nil
 }
 
-func (s *Persistence) TagActorSnapshot(ctx context.Context, atespace, name string, tag *ateapipb.ActorSnapshotTag) (*ateapipb.ActorSnapshotTag, error) {
+func (s *Persistence) CreateActorSnapshotTag(ctx context.Context, atespace, name string, tag *ateapipb.ActorSnapshotTag) (*ateapipb.ActorSnapshotTag, error) {
 	if _, err := s.GetActorSnapshot(ctx, atespace, name); err != nil {
 		return nil, err
 	}
@@ -960,7 +959,7 @@ func (s *Persistence) UpdateActorSnapshotTag(ctx context.Context, atespace, name
 }
 
 func (s *Persistence) DeleteActorSnapshotTag(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshotTag, error) {
-	_, tag, err := s.GetActorSnapshotByTag(ctx, atespace, name)
+	tag, err := s.GetActorSnapshotTag(ctx, atespace, name)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ateapi/internal/store/ateredis/ateredis.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis.go
@@ -183,9 +183,9 @@ func (s *Persistence) AtespaceExists(ctx context.Context, name string) (bool, er
 	return n > 0, nil
 }
 
-func (s *Persistence) ListAtespaces(ctx context.Context, pageSize int32, pageTokenStr string) ([]*ateapipb.Atespace, string, error) {
+func (s *Persistence) ListAtespaces(ctx context.Context, opts store.ListOptions) (store.ListResponse[*ateapipb.Atespace], error) {
 	var result []*ateapipb.Atespace
-	nextToken, err := s.listPage(ctx, "atespace:*", pageSize, pageTokenStr, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
+	nextToken, err := s.listPage(ctx, "atespace:*", opts.PageSize, opts.PageToken, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
 		atespaces, err := fetchProtos(ctx, master, keys, func() *ateapipb.Atespace { return &ateapipb.Atespace{} })
 		if err != nil {
 			return 0, err
@@ -194,9 +194,9 @@ func (s *Persistence) ListAtespaces(ctx context.Context, pageSize int32, pageTok
 		return len(atespaces), nil
 	})
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.Atespace]{}, err
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.Atespace]{Items: result, NextPageToken: nextToken}, nil
 }
 
 // DeleteAtespace deletes an empty atespace. Returns store.ErrNotFound if the
@@ -221,11 +221,11 @@ func (s *Persistence) DeleteAtespace(ctx context.Context, name string) (*ateapip
 	}
 
 	// Reject a non-empty atespace.
-	actors, _, err := s.ListActors(ctx, name, 1, "")
+	actors, err := s.ListActors(ctx, name, store.ListOptions{PageSize: 1})
 	if err != nil {
 		return nil, fmt.Errorf("while checking atespace emptiness: %w", err)
 	}
-	if len(actors) > 0 {
+	if len(actors.Items) > 0 {
 		return nil, store.ErrFailedPrecondition
 	}
 	hasTags, err := s.hasMatching(ctx, actorSnapshotTagScanPattern(name))
@@ -432,9 +432,9 @@ func (s *Persistence) UpdateActorTemplate(ctx context.Context, templateRef resou
 	return nil, store.ErrVersionConflict
 }
 
-func (s *Persistence) ListActorTemplates(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorTemplate, string, error) {
+func (s *Persistence) ListActorTemplates(ctx context.Context, atespace string, opts store.ListOptions) (store.ListResponse[*ateapipb.ActorTemplate], error) {
 	var result []*ateapipb.ActorTemplate
-	nextToken, err := s.listPage(ctx, actorTemplateScanPattern(atespace), pageSize, pageTokenStr, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
+	nextToken, err := s.listPage(ctx, actorTemplateScanPattern(atespace), opts.PageSize, opts.PageToken, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
 		templates, err := fetchProtos(ctx, master, keys, func() *ateapipb.ActorTemplate { return &ateapipb.ActorTemplate{} })
 		if err != nil {
 			return 0, err
@@ -443,9 +443,9 @@ func (s *Persistence) ListActorTemplates(ctx context.Context, atespace string, p
 		return len(templates), nil
 	})
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.ActorTemplate]{}, err
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.ActorTemplate]{Items: result, NextPageToken: nextToken}, nil
 }
 
 // DeleteActorTemplate deletes an ActorTemplate with no remaining versions.
@@ -473,11 +473,11 @@ func (s *Persistence) DeleteActorTemplate(ctx context.Context, templateRef resou
 	// Reject while any version still names this template as parent. The
 	// parent lives in the stored value, not the key, so probe via the
 	// filtered list (pageSize 1 stops at the first match).
-	versions, _, err := s.ListActorTemplateVersions(ctx, globalAtespace, templateRef, 1, "")
+	versions, err := s.ListActorTemplateVersions(ctx, globalAtespace, templateRef, store.ListOptions{PageSize: 1})
 	if err != nil {
 		return nil, fmt.Errorf("while checking for remaining versions: %w", err)
 	}
-	if len(versions) > 0 {
+	if len(versions.Items) > 0 {
 		return nil, store.ErrFailedPrecondition
 	}
 	if err := s.rdb.Del(ctx, dbKey).Err(); err != nil {
@@ -530,9 +530,9 @@ func (s *Persistence) GetActorTemplateVersion(ctx context.Context, versionRef re
 // actorTemplateRef is non-zero. atespace scopes the versions scanned, not the
 // parent: stored parent refs are fully qualified, so the filter matches the
 // parent's atespace and name.
-func (s *Persistence) ListActorTemplateVersions(ctx context.Context, atespace string, actorTemplateRef resources.ActorTemplateRef, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorTemplateVersion, string, error) {
+func (s *Persistence) ListActorTemplateVersions(ctx context.Context, atespace string, actorTemplateRef resources.ActorTemplateRef, opts store.ListOptions) (store.ListResponse[*ateapipb.ActorTemplateVersion], error) {
 	var result []*ateapipb.ActorTemplateVersion
-	nextToken, err := s.listPage(ctx, actorTemplateVersionScanPattern(atespace), pageSize, pageTokenStr, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
+	nextToken, err := s.listPage(ctx, actorTemplateVersionScanPattern(atespace), opts.PageSize, opts.PageToken, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
 		versions, err := fetchProtos(ctx, master, keys, func() *ateapipb.ActorTemplateVersion { return &ateapipb.ActorTemplateVersion{} })
 		if err != nil {
 			return 0, err
@@ -548,9 +548,9 @@ func (s *Persistence) ListActorTemplateVersions(ctx context.Context, atespace st
 		return matched, nil
 	})
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.ActorTemplateVersion]{}, err
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.ActorTemplateVersion]{Items: result, NextPageToken: nextToken}, nil
 }
 
 // DeleteActorTemplateVersion deletes an ActorTemplateVersion together with
@@ -797,9 +797,9 @@ func (s *Persistence) GetActorSnapshotTag(ctx context.Context, atespace, name st
 	return tag, nil
 }
 
-func (s *Persistence) ListActorSnapshots(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.ActorSnapshot, string, error) {
+func (s *Persistence) ListActorSnapshots(ctx context.Context, atespace string, opts store.ListOptions) (store.ListResponse[*ateapipb.ActorSnapshot], error) {
 	var result []*ateapipb.ActorSnapshot
-	nextToken, err := s.listPage(ctx, actorSnapshotScanPattern(atespace), pageSize, pageTokenStr, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
+	nextToken, err := s.listPage(ctx, actorSnapshotScanPattern(atespace), opts.PageSize, opts.PageToken, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
 		cmds, err := master.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 			for _, key := range keys {
 				pipe.Get(ctx, key)
@@ -828,9 +828,9 @@ func (s *Persistence) ListActorSnapshots(ctx context.Context, atespace string, p
 		return collected, nil
 	})
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.ActorSnapshot]{}, err
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.ActorSnapshot]{Items: result, NextPageToken: nextToken}, nil
 }
 
 func (s *Persistence) CreateActorSnapshotTag(ctx context.Context, atespace, name string, tag *ateapipb.ActorSnapshotTag) (*ateapipb.ActorSnapshotTag, error) {
@@ -1229,9 +1229,9 @@ func (s *Persistence) UpdateActor(ctx context.Context, actorRef resources.ActorR
 	return nil, store.ErrVersionConflict
 }
 
-func (s *Persistence) ListWorkers(ctx context.Context, pageSize int32, pageTokenStr string) ([]*ateapipb.Worker, string, error) {
+func (s *Persistence) ListWorkers(ctx context.Context, opts store.ListOptions) (store.ListResponse[*ateapipb.Worker], error) {
 	var result []*ateapipb.Worker
-	nextToken, err := s.listPage(ctx, "worker:*", pageSize, pageTokenStr, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
+	nextToken, err := s.listPage(ctx, "worker:*", opts.PageSize, opts.PageToken, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
 		workers, err := fetchProtos(ctx, master, keys, func() *ateapipb.Worker { return &ateapipb.Worker{} })
 		if err != nil {
 			return 0, err
@@ -1240,9 +1240,9 @@ func (s *Persistence) ListWorkers(ctx context.Context, pageSize int32, pageToken
 		return len(workers), nil
 	})
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.Worker]{}, err
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.Worker]{Items: result, NextPageToken: nextToken}, nil
 }
 
 type pageToken struct {
@@ -1276,9 +1276,9 @@ func hashShardAddr(addr string) string {
 // ListActors lists actors, scoped to the given atespace. An empty atespace lists
 // across all atespaces (SCAN actor:*); a non-empty atespace restricts the scan to
 // that atespace (SCAN actor:<atespace>:*).
-func (s *Persistence) ListActors(ctx context.Context, atespace string, pageSize int32, pageTokenStr string) ([]*ateapipb.Actor, string, error) {
+func (s *Persistence) ListActors(ctx context.Context, atespace string, opts store.ListOptions) (store.ListResponse[*ateapipb.Actor], error) {
 	var result []*ateapipb.Actor
-	nextToken, err := s.listPage(ctx, actorScanPattern(atespace), pageSize, pageTokenStr, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
+	nextToken, err := s.listPage(ctx, actorScanPattern(atespace), opts.PageSize, opts.PageToken, func(ctx context.Context, master *redis.Client, keys []string) (int, error) {
 		actors, err := fetchProtos(ctx, master, keys, func() *ateapipb.Actor { return &ateapipb.Actor{} })
 		if err != nil {
 			return 0, err
@@ -1287,9 +1287,9 @@ func (s *Persistence) ListActors(ctx context.Context, atespace string, pageSize 
 		return len(actors), nil
 	})
 	if err != nil {
-		return nil, "", err
+		return store.ListResponse[*ateapipb.Actor]{}, err
 	}
-	return result, nextToken, nil
+	return store.ListResponse[*ateapipb.Actor]{Items: result, NextPageToken: nextToken}, nil
 }
 
 // listPage SCANs pattern across the redis masters from the page token, feeding key batches to collect and returns the next-page token.

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -742,10 +742,11 @@ func TestListWorkers(t *testing.T) {
 		t.Fatalf("failed to create worker2: %v", err)
 	}
 
-	workers, _, err := s.ListWorkers(ctx, 1000, "")
+	workersResp, err := s.ListWorkers(ctx, store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListWorkers failed: %v", err)
 	}
+	workers := workersResp.Items
 
 	if len(workers) != 2 {
 		t.Errorf("expected 2 workers, got %d", len(workers))
@@ -792,10 +793,11 @@ func TestListActors(t *testing.T) {
 		t.Fatalf("failed to create actor2: %v", err)
 	}
 
-	actors, _, err := s.ListActors(ctx, "", 1000, "")
+	actorsResp, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActors failed: %v", err)
 	}
+	actors := actorsResp.Items
 
 	if len(actors) != 2 {
 		t.Errorf("expected 2 actors, got %d", len(actors))
@@ -886,9 +888,9 @@ func TestActorSnapshotLifecycle(t *testing.T) {
 	if byTag, err = s.GetActorSnapshot(ctx, resolvedTag.GetSnapshot().GetAtespace(), resolvedTag.GetSnapshot().GetName()); err != nil || byTag.GetMetadata().GetUid() != created.GetMetadata().GetUid() {
 		t.Fatalf("snapshot after publication = (%v, %v), want same address", byTag, err)
 	}
-	listed, _, err := s.ListActorSnapshots(ctx, testAtespace, 10, "")
-	if err != nil || len(listed) != 1 {
-		t.Fatalf("ListActorSnapshots = (%v, %v), want one", listed, err)
+	listed, err := s.ListActorSnapshots(ctx, testAtespace, store.ListOptions{PageSize: 10})
+	if err != nil || len(listed.Items) != 1 {
+		t.Fatalf("ListActorSnapshots = (%v, %v), want one", listed.Items, err)
 	}
 
 	deleted, err := s.DeleteActorSnapshotTag(ctx, testAtespace, "before-upgrade")
@@ -1262,13 +1264,13 @@ func TestCreateWorker_AlreadyExists(t *testing.T) {
 func TestListWorkers_Empty(t *testing.T) {
 	_, s, ctx := setupTest(t)
 
-	workers, _, err := s.ListWorkers(ctx, 1000, "")
+	workers, err := s.ListWorkers(ctx, store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListWorkers failed: %v", err)
 	}
 
-	if len(workers) != 0 {
-		t.Errorf("expected 0 workers, got %d", len(workers))
+	if len(workers.Items) != 0 {
+		t.Errorf("expected 0 workers, got %d", len(workers.Items))
 	}
 }
 
@@ -1290,13 +1292,13 @@ func TestListWorkers_Pagination(t *testing.T) {
 	pageToken := ""
 
 	for {
-		workers, nextToken, err := s.ListWorkers(ctx, 2, pageToken)
+		page, err := s.ListWorkers(ctx, store.ListOptions{PageSize: 2, PageToken: pageToken})
 		if err != nil {
 			t.Fatalf("ListWorkers failed: %v", err)
 		}
 
-		allWorkers = append(allWorkers, workers...)
-		pageToken = nextToken
+		allWorkers = append(allWorkers, page.Items...)
+		pageToken = page.NextPageToken
 		if pageToken == "" {
 			break
 		}
@@ -1328,13 +1330,13 @@ func TestListAtespaces_Pagination(t *testing.T) {
 	pageToken := ""
 
 	for {
-		atespaces, nextToken, err := s.ListAtespaces(ctx, 2, pageToken)
+		page, err := s.ListAtespaces(ctx, store.ListOptions{PageSize: 2, PageToken: pageToken})
 		if err != nil {
 			t.Fatalf("ListAtespaces failed: %v", err)
 		}
 
-		allAtespaces = append(allAtespaces, atespaces...)
-		pageToken = nextToken
+		allAtespaces = append(allAtespaces, page.Items...)
+		pageToken = page.NextPageToken
 		if pageToken == "" {
 			break
 		}
@@ -1356,13 +1358,13 @@ func TestListAtespaces_Pagination(t *testing.T) {
 func TestListActors_Empty(t *testing.T) {
 	_, s, ctx := setupTest(t)
 
-	actors, _, err := s.ListActors(ctx, "", 1000, "")
+	actors, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActors failed: %v", err)
 	}
 
-	if len(actors) != 0 {
-		t.Errorf("expected 0 actors, got %d", len(actors))
+	if len(actors.Items) != 0 {
+		t.Errorf("expected 0 actors, got %d", len(actors.Items))
 	}
 }
 
@@ -1385,13 +1387,13 @@ func TestListActors_Pagination(t *testing.T) {
 	pageToken := ""
 
 	for {
-		actors, nextToken, err := s.ListActors(ctx, "", 2, pageToken)
+		page, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 2, PageToken: pageToken})
 		if err != nil {
 			t.Fatalf("ListActors failed: %v", err)
 		}
 
-		allActors = append(allActors, actors...)
-		pageToken = nextToken
+		allActors = append(allActors, page.Items...)
+		pageToken = page.NextPageToken
 		if pageToken == "" {
 			break
 		}
@@ -1787,28 +1789,28 @@ func TestListActors_ScopedByAtespace(t *testing.T) {
 	}
 
 	// List is scoped to one atespace.
-	teamA, _, err := s.ListActors(ctx, "team-a", 1000, "")
+	teamA, err := s.ListActors(ctx, "team-a", store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActors(team-a) failed: %v", err)
 	}
-	if got := actorNameSet(teamA); !got["a1"] || !got["a2"] || got["b1"] || len(got) != 2 {
+	if got := actorNameSet(teamA.Items); !got["a1"] || !got["a2"] || got["b1"] || len(got) != 2 {
 		t.Errorf("ListActors(team-a) = %v, want exactly {a1, a2}", got)
 	}
 
-	teamB, _, err := s.ListActors(ctx, "team-b", 1000, "")
+	teamB, err := s.ListActors(ctx, "team-b", store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActors(team-b) failed: %v", err)
 	}
-	if got := actorNameSet(teamB); !got["b1"] || got["a1"] || len(got) != 1 {
+	if got := actorNameSet(teamB.Items); !got["b1"] || got["a1"] || len(got) != 1 {
 		t.Errorf("ListActors(team-b) = %v, want exactly {b1}", got)
 	}
 
 	// An empty atespace lists across all atespaces (the admin/dev `-A` view).
-	all, _, err := s.ListActors(ctx, "", 1000, "")
+	all, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActors(all) failed: %v", err)
 	}
-	if got := actorNameSet(all); !got["a1"] || !got["a2"] || !got["b1"] || len(got) != 3 {
+	if got := actorNameSet(all.Items); !got["a1"] || !got["a2"] || !got["b1"] || len(got) != 3 {
 		t.Errorf("ListActors(all) = %v, want exactly {a1, a2, b1}", got)
 	}
 
@@ -1910,10 +1912,11 @@ func TestListAtespaces(t *testing.T) {
 			t.Fatalf("CreateAtespace(%s) failed: %v", n, err)
 		}
 	}
-	got, _, err := s.ListAtespaces(ctx, 1000, "")
+	gotResp, err := s.ListAtespaces(ctx, store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListAtespaces failed: %v", err)
 	}
+	got := gotResp.Items
 	if len(got) != len(names) {
 		t.Fatalf("ListAtespaces returned %d atespaces, want %d", len(got), len(names))
 	}
@@ -1931,12 +1934,12 @@ func TestListAtespaces(t *testing.T) {
 func TestListAtespaces_Empty(t *testing.T) {
 	_, s, ctx := setupTest(t)
 
-	got, _, err := s.ListAtespaces(ctx, 1000, "")
+	got, err := s.ListAtespaces(ctx, store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListAtespaces failed: %v", err)
 	}
-	if len(got) != 0 {
-		t.Errorf("ListAtespaces on empty store = %v, want empty", got)
+	if len(got.Items) != 0 {
+		t.Errorf("ListAtespaces on empty store = %v, want empty", got.Items)
 	}
 }
 
@@ -2229,15 +2232,15 @@ func TestListActors_MultiMaster_Pagination(t *testing.T) {
 	var allActors []*ateapipb.Actor
 	pageToken := ""
 	for {
-		actors, nextToken, err := s.ListActors(ctx, testAtespace, 2, pageToken)
+		page, err := s.ListActors(ctx, testAtespace, store.ListOptions{PageSize: 2, PageToken: pageToken})
 		if err != nil {
 			t.Fatalf("ListActors failed: %v", err)
 		}
-		allActors = append(allActors, actors...)
-		if nextToken == "" {
+		allActors = append(allActors, page.Items...)
+		if page.NextPageToken == "" {
 			break
 		}
-		pageToken = nextToken
+		pageToken = page.NextPageToken
 	}
 
 	if len(allActors) != 9 {
@@ -2314,20 +2317,20 @@ func TestListWorkers_MultiMaster_Pagination(t *testing.T) {
 			seen := make(map[string]bool)
 			pageToken := ""
 			for {
-				workers, next, err := s.ListWorkers(ctx, pageSize, pageToken)
+				page, err := s.ListWorkers(ctx, store.ListOptions{PageSize: pageSize, PageToken: pageToken})
 				if err != nil {
 					t.Fatalf("ListWorkers: %v", err)
 				}
-				for _, w := range workers {
+				for _, w := range page.Items {
 					if seen[w.GetWorkerPod()] {
 						t.Errorf("duplicate worker in paginated results: %s", w.GetWorkerPod())
 					}
 					seen[w.GetWorkerPod()] = true
 				}
-				if next == "" {
+				if page.NextPageToken == "" {
 					break
 				}
-				pageToken = next
+				pageToken = page.NextPageToken
 			}
 			if len(seen) != numShards*3 {
 				t.Fatalf("expected %d workers across %d shards, got %d", numShards*3, numShards, len(seen))
@@ -2360,20 +2363,20 @@ func TestListAtespaces_MultiMaster_Pagination(t *testing.T) {
 			seen := make(map[string]bool)
 			pageToken := ""
 			for {
-				atespaces, next, err := s.ListAtespaces(ctx, pageSize, pageToken)
+				page, err := s.ListAtespaces(ctx, store.ListOptions{PageSize: pageSize, PageToken: pageToken})
 				if err != nil {
 					t.Fatalf("ListAtespaces: %v", err)
 				}
-				for _, a := range atespaces {
+				for _, a := range page.Items {
 					if seen[a.GetMetadata().GetName()] {
 						t.Errorf("duplicate atespace in paginated results: %s", a.GetMetadata().GetName())
 					}
 					seen[a.GetMetadata().GetName()] = true
 				}
-				if next == "" {
+				if page.NextPageToken == "" {
 					break
 				}
-				pageToken = next
+				pageToken = page.NextPageToken
 			}
 			if len(seen) != numShards*3 {
 				t.Fatalf("expected %d atespaces across %d shards, got %d", numShards*3, numShards, len(seen))
@@ -2523,10 +2526,11 @@ func TestActorTemplateLifecycle(t *testing.T) {
 		t.Errorf("CreateActorTemplate return does not match stored state (-created +got):\n%s", diff)
 	}
 
-	list, _, err := s.ListActorTemplates(ctx, "team-a", 1000, "")
+	listResp, err := s.ListActorTemplates(ctx, "team-a", store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActorTemplates failed: %v", err)
 	}
+	list := listResp.Items
 	if len(list) != 1 || list[0].GetMetadata().GetName() != "tmpl-a" {
 		t.Errorf("ListActorTemplates = %v, want [tmpl-a]", list)
 	}
@@ -3017,12 +3021,12 @@ func TestListActorTemplates_Pagination(t *testing.T) {
 	var all []*ateapipb.ActorTemplate
 	pageToken := ""
 	for {
-		templates, nextToken, err := s.ListActorTemplates(ctx, "team-a", 2, pageToken)
+		page, err := s.ListActorTemplates(ctx, "team-a", store.ListOptions{PageSize: 2, PageToken: pageToken})
 		if err != nil {
 			t.Fatalf("ListActorTemplates failed: %v", err)
 		}
-		all = append(all, templates...)
-		pageToken = nextToken
+		all = append(all, page.Items...)
+		pageToken = page.NextPageToken
 		if pageToken == "" {
 			break
 		}
@@ -3055,12 +3059,12 @@ func TestListActorTemplateVersions_ParentFilter(t *testing.T) {
 		}
 	}
 
-	unfiltered, _, err := s.ListActorTemplateVersions(ctx, "team-a", resources.ActorTemplateRef{}, 1000, "")
+	unfiltered, err := s.ListActorTemplateVersions(ctx, "team-a", resources.ActorTemplateRef{}, store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActorTemplateVersions(all) failed: %v", err)
 	}
-	if len(unfiltered) != 5 {
-		t.Fatalf("unfiltered list returned %d versions, want 5", len(unfiltered))
+	if len(unfiltered.Items) != 5 {
+		t.Fatalf("unfiltered list returned %d versions, want 5", len(unfiltered.Items))
 	}
 
 	// Filtered list, paged with a small page size to exercise the
@@ -3068,12 +3072,12 @@ func TestListActorTemplateVersions_ParentFilter(t *testing.T) {
 	var filtered []*ateapipb.ActorTemplateVersion
 	pageToken := ""
 	for {
-		versions, nextToken, err := s.ListActorTemplateVersions(ctx, "team-a", resources.ActorTemplateRef{Atespace: "team-a", Name: "tmpl-a"}, 2, pageToken)
+		page, err := s.ListActorTemplateVersions(ctx, "team-a", resources.ActorTemplateRef{Atespace: "team-a", Name: "tmpl-a"}, store.ListOptions{PageSize: 2, PageToken: pageToken})
 		if err != nil {
 			t.Fatalf("ListActorTemplateVersions(tmpl-a) failed: %v", err)
 		}
-		filtered = append(filtered, versions...)
-		pageToken = nextToken
+		filtered = append(filtered, page.Items...)
+		pageToken = page.NextPageToken
 		if pageToken == "" {
 			break
 		}
@@ -3099,12 +3103,12 @@ func TestListActorTemplateVersions_ParentFilter(t *testing.T) {
 	if _, err := s.CreateActorTemplateVersion(ctx, newTestActorTemplateVersion("team-b", "tmpl-a-v0", "tmpl-a")); err != nil {
 		t.Fatalf("failed to create team-b version: %v", err)
 	}
-	crossAtespace, _, err := s.ListActorTemplateVersions(ctx, "", resources.ActorTemplateRef{Atespace: "team-a", Name: "tmpl-a"}, 1000, "")
+	crossAtespace, err := s.ListActorTemplateVersions(ctx, "", resources.ActorTemplateRef{Atespace: "team-a", Name: "tmpl-a"}, store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActorTemplateVersions(all atespaces, team-a/tmpl-a) failed: %v", err)
 	}
-	if len(crossAtespace) != 3 {
-		t.Errorf("cross-atespace filtered list returned %d versions, want 3: team-b/tmpl-a versions must not match", len(crossAtespace))
+	if len(crossAtespace.Items) != 3 {
+		t.Errorf("cross-atespace filtered list returned %d versions, want 3: team-b/tmpl-a versions must not match", len(crossAtespace.Items))
 	}
 }
 
@@ -3160,10 +3164,11 @@ func TestListActorTemplates_AtespaceFilter(t *testing.T) {
 		}
 	}
 
-	scoped, _, err := s.ListActorTemplates(ctx, "team-a", 1000, "")
+	scopedResp, err := s.ListActorTemplates(ctx, "team-a", store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActorTemplates(team-a) failed: %v", err)
 	}
+	scoped := scopedResp.Items
 	if len(scoped) != 2 {
 		t.Errorf("ListActorTemplates(team-a) returned %d templates, want 2", len(scoped))
 	}
@@ -3173,12 +3178,12 @@ func TestListActorTemplates_AtespaceFilter(t *testing.T) {
 		}
 	}
 
-	all, _, err := s.ListActorTemplates(ctx, "", 1000, "")
+	allResp, err := s.ListActorTemplates(ctx, "", store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActorTemplates(all) failed: %v", err)
 	}
-	if len(all) != 3 {
-		t.Errorf("ListActorTemplates(all) returned %d templates, want 3", len(all))
+	if len(allResp.Items) != 3 {
+		t.Errorf("ListActorTemplates(all) returned %d templates, want 3", len(allResp.Items))
 	}
 }
 
@@ -3198,10 +3203,11 @@ func TestActorTemplateVersions_AtespaceIsolation(t *testing.T) {
 	}
 
 	// Versions of the same-named parent list per atespace.
-	scoped, _, err := s.ListActorTemplateVersions(ctx, "team-a", resources.ActorTemplateRef{Atespace: "team-a", Name: "tmpl"}, 1000, "")
+	scopedResp, err := s.ListActorTemplateVersions(ctx, "team-a", resources.ActorTemplateRef{Atespace: "team-a", Name: "tmpl"}, store.ListOptions{PageSize: 1000})
 	if err != nil {
 		t.Fatalf("ListActorTemplateVersions(team-a, tmpl) failed: %v", err)
 	}
+	scoped := scopedResp.Items
 	if len(scoped) != 1 || scoped[0].GetMetadata().GetAtespace() != "team-a" {
 		t.Errorf("ListActorTemplateVersions(team-a, tmpl) = %v, want team-a's tmpl-v1 only", scoped)
 	}

--- a/cmd/ateapi/internal/store/ateredis/ateredis_test.go
+++ b/cmd/ateapi/internal/store/ateredis/ateredis_test.go
@@ -843,13 +843,17 @@ func TestActorSnapshotLifecycle(t *testing.T) {
 		Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "before-upgrade"},
 		Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 	}
-	tagged, err := s.TagActorSnapshot(ctx, testAtespace, "snapshot-1", tag)
+	tagged, err := s.CreateActorSnapshotTag(ctx, testAtespace, "snapshot-1", tag)
 	if err != nil || tagged.GetSnapshot().GetName() != "snapshot-1" {
-		t.Fatalf("TagActorSnapshot = (%v, %v), want stable tag", tagged, err)
+		t.Fatalf("CreateActorSnapshotTag = (%v, %v), want stable tag", tagged, err)
 	}
-	byTag, resolvedTag, err := s.GetActorSnapshotByTag(ctx, testAtespace, "before-upgrade")
-	if err != nil || !proto.Equal(created, byTag) || !proto.Equal(tagged, resolvedTag) {
-		t.Fatalf("GetActorSnapshotByTag = (%v, %v, %v), want tagged snapshot", byTag, resolvedTag, err)
+	resolvedTag, err := s.GetActorSnapshotTag(ctx, testAtespace, "before-upgrade")
+	if err != nil || !proto.Equal(tagged, resolvedTag) {
+		t.Fatalf("GetActorSnapshotTag = (%v, %v), want tagged tag", resolvedTag, err)
+	}
+	byTag, err := s.GetActorSnapshot(ctx, resolvedTag.GetSnapshot().GetAtespace(), resolvedTag.GetSnapshot().GetName())
+	if err != nil || !proto.Equal(created, byTag) {
+		t.Fatalf("GetActorSnapshot(resolved tag target) = (%v, %v), want tagged snapshot", byTag, err)
 	}
 	if _, err := s.CreateActorSnapshot(ctx, &ateapipb.ActorSnapshot{
 		Metadata:    &ateapipb.ResourceMetadata{Atespace: "other", Name: "snapshot-2"},
@@ -858,15 +862,15 @@ func TestActorSnapshotLifecycle(t *testing.T) {
 		t.Fatalf("CreateActorSnapshot second snapshot: %v", err)
 	}
 	otherTag := &ateapipb.ActorSnapshotTag{Metadata: &ateapipb.ResourceMetadata{Atespace: "other", Name: "before-upgrade"}, Scope: ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE}
-	if _, err := s.TagActorSnapshot(ctx, "other", "snapshot-2", otherTag); err != nil {
+	if _, err := s.CreateActorSnapshotTag(ctx, "other", "snapshot-2", otherTag); err != nil {
 		t.Fatalf("same tag name in another Atespace: %v", err)
 	}
-	if _, err := s.TagActorSnapshot(ctx, "other", "snapshot-2", tag); !errors.Is(err, store.ErrAlreadyExists) {
+	if _, err := s.CreateActorSnapshotTag(ctx, "other", "snapshot-2", tag); !errors.Is(err, store.ErrAlreadyExists) {
 		t.Fatalf("duplicate Atespace tag error = %v, want ErrAlreadyExists", err)
 	}
 	differentScope := proto.Clone(tag).(*ateapipb.ActorSnapshotTag)
 	differentScope.Scope = ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED
-	if _, err := s.TagActorSnapshot(ctx, testAtespace, "snapshot-1", differentScope); !errors.Is(err, store.ErrAlreadyExists) {
+	if _, err := s.CreateActorSnapshotTag(ctx, testAtespace, "snapshot-1", differentScope); !errors.Is(err, store.ErrAlreadyExists) {
 		t.Fatalf("re-tag with different scope error = %v, want ErrAlreadyExists", err)
 	}
 	tagged, err = s.UpdateActorSnapshotTag(ctx, testAtespace, "before-upgrade", func(toUpdate *ateapipb.ActorSnapshotTag) error {
@@ -876,8 +880,11 @@ func TestActorSnapshotLifecycle(t *testing.T) {
 	if err != nil || tagged.GetScope() != ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED {
 		t.Fatalf("UpdateActorSnapshotTag = (%v, %v), want published", tagged, err)
 	}
-	if byTag, resolvedTag, err = s.GetActorSnapshotByTag(ctx, testAtespace, "before-upgrade"); err != nil || byTag.GetMetadata().GetUid() != created.GetMetadata().GetUid() || resolvedTag.GetScope() != ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED {
-		t.Fatalf("tag after publication = (%v, %v, %v), want same address and snapshot", byTag, resolvedTag, err)
+	if resolvedTag, err = s.GetActorSnapshotTag(ctx, testAtespace, "before-upgrade"); err != nil || resolvedTag.GetScope() != ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED {
+		t.Fatalf("tag after publication = (%v, %v), want published scope", resolvedTag, err)
+	}
+	if byTag, err = s.GetActorSnapshot(ctx, resolvedTag.GetSnapshot().GetAtespace(), resolvedTag.GetSnapshot().GetName()); err != nil || byTag.GetMetadata().GetUid() != created.GetMetadata().GetUid() {
+		t.Fatalf("snapshot after publication = (%v, %v), want same address", byTag, err)
 	}
 	listed, _, err := s.ListActorSnapshots(ctx, testAtespace, 10, "")
 	if err != nil || len(listed) != 1 {
@@ -888,7 +895,7 @@ func TestActorSnapshotLifecycle(t *testing.T) {
 	if err != nil || deleted.GetMetadata().GetName() != "before-upgrade" {
 		t.Fatalf("DeleteActorSnapshotTag = (%v, %v)", deleted, err)
 	}
-	if _, _, err := s.GetActorSnapshotByTag(ctx, testAtespace, "before-upgrade"); !errors.Is(err, store.ErrNotFound) {
+	if _, err := s.GetActorSnapshotTag(ctx, testAtespace, "before-upgrade"); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("deleted tag lookup = %v, want ErrNotFound", err)
 	}
 	if got, err := s.GetActorSnapshot(ctx, testAtespace, "snapshot-1"); err != nil || got.GetMetadata().GetUid() != created.GetMetadata().GetUid() {
@@ -906,12 +913,12 @@ func seedTaggedSnapshot(t *testing.T, s *Persistence, ctx context.Context, snaps
 	}); err != nil {
 		t.Fatalf("CreateActorSnapshot(%s) failed: %v", snapshotName, err)
 	}
-	tagged, err := s.TagActorSnapshot(ctx, testAtespace, snapshotName, &ateapipb.ActorSnapshotTag{
+	tagged, err := s.CreateActorSnapshotTag(ctx, testAtespace, snapshotName, &ateapipb.ActorSnapshotTag{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: tagName},
 		Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 	})
 	if err != nil {
-		t.Fatalf("TagActorSnapshot(%s) failed: %v", tagName, err)
+		t.Fatalf("CreateActorSnapshotTag(%s) failed: %v", tagName, err)
 	}
 	return tagged
 }
@@ -937,9 +944,9 @@ func TestUpdateActorSnapshotTag_MutateErrorAreNotRetried(t *testing.T) {
 		t.Errorf("mutate ran %d times, want exactly 1 (a rejected precondition must not be retried)", callsToMutateFn)
 	}
 
-	_, got, err := s.GetActorSnapshotByTag(ctx, testAtespace, "tag-1")
+	got, err := s.GetActorSnapshotTag(ctx, testAtespace, "tag-1")
 	if err != nil {
-		t.Fatalf("GetActorSnapshotByTag failed: %v", err)
+		t.Fatalf("GetActorSnapshotTag failed: %v", err)
 	}
 	if diff := cmp.Diff(tagged, got, protocmp.Transform()); diff != "" {
 		t.Errorf("aborted mutation was persisted (-tagged +got):\n%s", diff)
@@ -1027,9 +1034,9 @@ func TestUpdateActorSnapshotTag_RejectsImmutableFieldChange(t *testing.T) {
 				t.Errorf("UpdateActorSnapshotTag changing %s = %v, want an error containing %q", tt.name, err, want)
 			}
 
-			_, got, err := s.GetActorSnapshotByTag(ctx, testAtespace, "tag-1")
+			got, err := s.GetActorSnapshotTag(ctx, testAtespace, "tag-1")
 			if err != nil {
-				t.Fatalf("GetActorSnapshotByTag failed: %v", err)
+				t.Fatalf("GetActorSnapshotTag failed: %v", err)
 			}
 			if diff := cmp.Diff(tagged, got, protocmp.Transform()); diff != "" {
 				t.Errorf("rejected mutation was persisted anyway (-tagged +got):\n%s", diff)
@@ -1054,9 +1061,9 @@ func TestUpdateActorSnapshotTag_RetriesOnConcurrentWrite(t *testing.T) {
 		if attempts > 0 {
 			return
 		}
-		_, concurrent, err := s.GetActorSnapshotByTag(ctx, testAtespace, "tag-1")
+		concurrent, err := s.GetActorSnapshotTag(ctx, testAtespace, "tag-1")
 		if err != nil {
-			t.Errorf("GetActorSnapshotByTag for concurrent write failed: %v", err)
+			t.Errorf("GetActorSnapshotTag for concurrent write failed: %v", err)
 			return
 		}
 		// Repointing the tag is not something a mutation may do, but a writer
@@ -1113,12 +1120,12 @@ func TestUpdateActorSnapshotTag_RejectsStaleUID(t *testing.T) {
 	if _, err := s.DeleteActorSnapshotTag(ctx, testAtespace, "tag-1"); err != nil {
 		t.Fatalf("DeleteActorSnapshotTag failed: %v", err)
 	}
-	recreated, err := s.TagActorSnapshot(ctx, testAtespace, "snapshot-1", &ateapipb.ActorSnapshotTag{
+	recreated, err := s.CreateActorSnapshotTag(ctx, testAtespace, "snapshot-1", &ateapipb.ActorSnapshotTag{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "tag-1"},
 		Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 	})
 	if err != nil {
-		t.Fatalf("re-tag TagActorSnapshot failed: %v", err)
+		t.Fatalf("re-tag CreateActorSnapshotTag failed: %v", err)
 	}
 	if recreated.GetMetadata().GetUid() == original.GetMetadata().GetUid() {
 		t.Fatalf("recreated tag reused uid %s, want a fresh one", recreated.GetMetadata().GetUid())
@@ -1148,9 +1155,9 @@ func TestUpdateActorSnapshotTag_RejectsStaleUID(t *testing.T) {
 		t.Errorf("UpdateActorSnapshotTag error = %v, want no store.ErrVersionConflict match: no version was pinned", err)
 	}
 
-	_, stored, err := s.GetActorSnapshotByTag(ctx, testAtespace, "tag-1")
+	stored, err := s.GetActorSnapshotTag(ctx, testAtespace, "tag-1")
 	if err != nil {
-		t.Fatalf("GetActorSnapshotByTag failed: %v", err)
+		t.Fatalf("GetActorSnapshotTag failed: %v", err)
 	}
 	if diff := cmp.Diff(recreated, stored, protocmp.Transform()); diff != "" {
 		t.Errorf("the rejected update still wrote (-recreated +stored):\n%s", diff)
@@ -1964,17 +1971,17 @@ func TestDeleteAtespace_WithTags_Rejected(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("CreateActorSnapshot: %v", err)
 	}
-	if _, err := s.TagActorSnapshot(ctx, "team-a", "snapshot-1", &ateapipb.ActorSnapshotTag{
+	if _, err := s.CreateActorSnapshotTag(ctx, "team-a", "snapshot-1", &ateapipb.ActorSnapshotTag{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "keep-me"},
 		Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED,
 	}); err != nil {
-		t.Fatalf("TagActorSnapshot: %v", err)
+		t.Fatalf("CreateActorSnapshotTag: %v", err)
 	}
 	if _, err := s.DeleteAtespace(ctx, "team-a"); !errors.Is(err, store.ErrFailedPrecondition) {
 		t.Fatalf("DeleteAtespace = %v, want ErrFailedPrecondition", err)
 	}
-	if _, _, err := s.GetActorSnapshotByTag(ctx, "team-a", "keep-me"); err != nil {
-		t.Fatalf("GetActorSnapshotByTag after rejected deletion: %v", err)
+	if _, err := s.GetActorSnapshotTag(ctx, "team-a", "keep-me"); err != nil {
+		t.Fatalf("GetActorSnapshotTag after rejected deletion: %v", err)
 	}
 	if _, err := s.GetAtespace(ctx, "team-a"); err != nil {
 		t.Fatalf("GetAtespace after rejected deletion: %v", err)

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -59,8 +59,8 @@ type Interface interface {
 	GetActor(ctx context.Context, actorRef resources.ActorRef) (*ateapipb.Actor, error)
 
 	// Lists actors in the given atespace (scoped scan), or across ALL atespaces if atespace is
-	// empty. Returns a page of actors and a next page token.
-	ListActors(ctx context.Context, atespace string, pageSize int32, pageToken string) ([]*ateapipb.Actor, string, error)
+	// empty.
+	ListActors(ctx context.Context, atespace string, opts ListOptions) (ListResponse[*ateapipb.Actor], error)
 
 	// UpdateActor performs a transactional read-modify-write and returns the stored
 	// actor with advanced metadata (version, update_time).
@@ -88,7 +88,7 @@ type Interface interface {
 	GetActorSnapshot(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshot, error)
 
 	// Lists ActorSnapshots in one atespace, or all atespaces when empty.
-	ListActorSnapshots(ctx context.Context, atespace string, pageSize int32, pageToken string) ([]*ateapipb.ActorSnapshot, string, error)
+	ListActorSnapshots(ctx context.Context, atespace string, opts ListOptions) (ListResponse[*ateapipb.ActorSnapshot], error)
 
 	// Adds an immutable Atespace-owned tag to an ActorSnapshot.
 	CreateActorSnapshotTag(ctx context.Context, atespace, name string, tag *ateapipb.ActorSnapshotTag) (*ateapipb.ActorSnapshotTag, error)
@@ -127,8 +127,8 @@ type Interface interface {
 	// AtespaceExists reports whether the atespace object exists.
 	AtespaceExists(ctx context.Context, name string) (bool, error)
 
-	// Lists atespaces. Returns a page of atespaces and a next page token.
-	ListAtespaces(ctx context.Context, pageSize int32, pageToken string) ([]*ateapipb.Atespace, string, error)
+	// Lists atespaces.
+	ListAtespaces(ctx context.Context, opts ListOptions) (ListResponse[*ateapipb.Atespace], error)
 
 	// Removes an empty atespace and returns the deleted resource. Returns
 	// ErrNotFound if missing, or ErrFailedPrecondition if the atespace is not empty
@@ -147,8 +147,8 @@ type Interface interface {
 	ActorTemplateExists(ctx context.Context, templateRef resources.ActorTemplateRef) (bool, error)
 
 	// Lists ActorTemplates in an atespace, or across all atespaces when
-	// atespace is empty. Returns a page of templates and a next page token.
-	ListActorTemplates(ctx context.Context, atespace string, pageSize int32, pageToken string) ([]*ateapipb.ActorTemplate, string, error)
+	// atespace is empty.
+	ListActorTemplates(ctx context.Context, atespace string, opts ListOptions) (ListResponse[*ateapipb.ActorTemplate], error)
 
 	// UpdateActorTemplate performs a transactional read-modify-write and returns
 	// the updated template with advanced metadata (version, update_time).
@@ -172,7 +172,7 @@ type Interface interface {
 	// Lists ActorTemplateVersions in an atespace (all atespaces when atespace
 	// is empty), filtered to one parent template when actorTemplateRef is
 	// non-zero. The parent lives in the same atespace as its versions.
-	ListActorTemplateVersions(ctx context.Context, atespace string, actorTemplateRef resources.ActorTemplateRef, pageSize int32, pageToken string) ([]*ateapipb.ActorTemplateVersion, string, error)
+	ListActorTemplateVersions(ctx context.Context, atespace string, actorTemplateRef resources.ActorTemplateRef, opts ListOptions) (ListResponse[*ateapipb.ActorTemplateVersion], error)
 
 	// Removes an ActorTemplateVersion and returns the deleted resource, also
 	// deleting the golden snapshot recorded in golden_snapshot, if any.
@@ -186,8 +186,8 @@ type Interface interface {
 	// Fetches worker state by namespace, pool, and pod name. Returns ErrNotFound if missing.
 	GetWorker(ctx context.Context, namespace, pool, pod string) (*ateapipb.Worker, error)
 
-	// Lists workers. Returns a page of workers and a next page token.
-	ListWorkers(ctx context.Context, pageSize int32, pageToken string) ([]*ateapipb.Worker, string, error)
+	// Lists workers.
+	ListWorkers(ctx context.Context, opts ListOptions) (ListResponse[*ateapipb.Worker], error)
 
 	// Updates worker state with optimistic concurrency check. Returns ErrNotFound if missing, or ErrVersionConflict on version mismatch.
 	UpdateWorker(ctx context.Context, worker *ateapipb.Worker, expectedVersion int64) error
@@ -318,3 +318,25 @@ func (l *Lock) Context() context.Context { return l.ctx }
 // Close stops lease renewal and releases the lock. Safe to call multiple
 // times.
 func (l *Lock) Close() { l.once.Do(l.closeFn) }
+
+// ListOptions carries the pagination parameters common to every List method.
+type ListOptions struct {
+	// PageSize caps how many items a single call returns.
+	PageSize int32
+	// PageToken resumes a listing after the page it was issued for. Empty
+	// starts from the first page.
+	PageToken string
+}
+
+// ListResponse is the return value of a List method: the page of items it
+// addressed, plus the token to fetch the next page. NextPageToken is empty
+// once the listing has reached its last page.
+type ListResponse[T any] struct {
+	Items         []T
+	NextPageToken string
+}
+
+// HasNextPage reports whether another page follows this one.
+func (r ListResponse[T]) HasNextPage() bool {
+	return r.NextPageToken != ""
+}

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -50,13 +50,17 @@ var (
 
 // Interface defines the contract for the persistence layer storing actor state.
 type Interface interface {
-	// Fetches an actor by reference. Returns ErrNotFound if missing.
-	GetActor(ctx context.Context, actorRef resources.ActorRef) (*ateapipb.Actor, error)
-
 	// Stores a new actor in suspended state and returns the stored resource with
 	// server-assigned metadata (uid, version, timestamps). The input is not
 	// mutated. Returns ErrAlreadyExists if key is taken.
 	CreateActor(ctx context.Context, actor *ateapipb.Actor) (*ateapipb.Actor, error)
+
+	// Fetches an actor by reference. Returns ErrNotFound if missing.
+	GetActor(ctx context.Context, actorRef resources.ActorRef) (*ateapipb.Actor, error)
+
+	// Lists actors in the given atespace (scoped scan), or across ALL atespaces if atespace is
+	// empty. Returns a page of actors and a next page token.
+	ListActors(ctx context.Context, atespace string, pageSize int32, pageToken string) ([]*ateapipb.Actor, string, error)
 
 	// UpdateActor performs a transactional read-modify-write and returns the stored
 	// actor with advanced metadata (version, update_time).
@@ -76,10 +80,6 @@ type Interface interface {
 	// missing, or ErrFailedPrecondition if not already deleting.
 	DeleteActor(ctx context.Context, actorRef resources.ActorRef) (*ateapipb.Actor, error)
 
-	// Lists actors in the given atespace (scoped scan), or across ALL atespaces if atespace is
-	// empty. Returns a page of actors and a next page token.
-	ListActors(ctx context.Context, atespace string, pageSize int32, pageToken string) ([]*ateapipb.Actor, string, error)
-
 	// Creates an immutable ActorSnapshot. The caller sets snapshot_uri; the
 	// store keeps no location of its own.
 	CreateActorSnapshot(ctx context.Context, snapshot *ateapipb.ActorSnapshot) (*ateapipb.ActorSnapshot, error)
@@ -87,20 +87,16 @@ type Interface interface {
 	// Fetches an ActorSnapshot.
 	GetActorSnapshot(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshot, error)
 
-	// Resolves an Atespace-owned tag to an ActorSnapshot in constant time.
-	//
-	// TODO: rename to GetActorSnapshotTag to match the Create/Get/Update/Delete
-	// naming used by every other resource in this interface.
-	GetActorSnapshotByTag(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshot, *ateapipb.ActorSnapshotTag, error)
-
 	// Lists ActorSnapshots in one atespace, or all atespaces when empty.
 	ListActorSnapshots(ctx context.Context, atespace string, pageSize int32, pageToken string) ([]*ateapipb.ActorSnapshot, string, error)
 
 	// Adds an immutable Atespace-owned tag to an ActorSnapshot.
-	//
-	// TODO: rename to CreateActorSnapshotTag to match the Create/Get/Update/Delete
-	// naming used by every other resource in this interface.
-	TagActorSnapshot(ctx context.Context, atespace, name string, tag *ateapipb.ActorSnapshotTag) (*ateapipb.ActorSnapshotTag, error)
+	CreateActorSnapshotTag(ctx context.Context, atespace, name string, tag *ateapipb.ActorSnapshotTag) (*ateapipb.ActorSnapshotTag, error)
+
+	// Fetches an Atespace-owned tag. Returns ErrNotFound if missing. The tag's
+	// snapshot field names the ActorSnapshot it resolves to; fetch it with
+	// GetActorSnapshot if needed.
+	GetActorSnapshotTag(ctx context.Context, atespace, name string) (*ateapipb.ActorSnapshotTag, error)
 
 	// UpdateActorSnapshotTag performs a transactional read-modify-write on the tag
 	// addressed by atespace and name, and returns the stored ActorSnapshotTag with
@@ -128,11 +124,11 @@ type Interface interface {
 	// Fetches an atespace by name. Returns ErrNotFound if missing.
 	GetAtespace(ctx context.Context, name string) (*ateapipb.Atespace, error)
 
-	// Lists atespaces. Returns a page of atespaces and a next page token.
-	ListAtespaces(ctx context.Context, pageSize int32, pageToken string) ([]*ateapipb.Atespace, string, error)
-
 	// AtespaceExists reports whether the atespace object exists.
 	AtespaceExists(ctx context.Context, name string) (bool, error)
+
+	// Lists atespaces. Returns a page of atespaces and a next page token.
+	ListAtespaces(ctx context.Context, pageSize int32, pageToken string) ([]*ateapipb.Atespace, string, error)
 
 	// Removes an empty atespace and returns the deleted resource. Returns
 	// ErrNotFound if missing, or ErrFailedPrecondition if the atespace is not empty
@@ -150,13 +146,13 @@ type Interface interface {
 	// ActorTemplateExists reports whether the ActorTemplate exists.
 	ActorTemplateExists(ctx context.Context, templateRef resources.ActorTemplateRef) (bool, error)
 
-	// UpdateActorTemplate performs a transactional read-modify-write and returns
-	// the updated template with advanced metadata (version, update_time).
-	UpdateActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef, mutate func(dbTemplate *ateapipb.ActorTemplate) error) (*ateapipb.ActorTemplate, error)
-
 	// Lists ActorTemplates in an atespace, or across all atespaces when
 	// atespace is empty. Returns a page of templates and a next page token.
 	ListActorTemplates(ctx context.Context, atespace string, pageSize int32, pageToken string) ([]*ateapipb.ActorTemplate, string, error)
+
+	// UpdateActorTemplate performs a transactional read-modify-write and returns
+	// the updated template with advanced metadata (version, update_time).
+	UpdateActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef, mutate func(dbTemplate *ateapipb.ActorTemplate) error) (*ateapipb.ActorTemplate, error)
 
 	// Removes an ActorTemplate and returns the deleted resource. Returns
 	// ErrNotFound if missing, or ErrFailedPrecondition while any
@@ -184,20 +180,20 @@ type Interface interface {
 	// version is its parent's default_version_on_create.
 	DeleteActorTemplateVersion(ctx context.Context, versionRef resources.ActorTemplateVersionRef) (*ateapipb.ActorTemplateVersion, error)
 
+	// Registers a new idle worker. Returns ErrAlreadyExists if already registered.
+	CreateWorker(ctx context.Context, worker *ateapipb.Worker) error
+
 	// Fetches worker state by namespace, pool, and pod name. Returns ErrNotFound if missing.
 	GetWorker(ctx context.Context, namespace, pool, pod string) (*ateapipb.Worker, error)
 
-	// Registers a new idle worker. Returns ErrAlreadyExists if already registered.
-	CreateWorker(ctx context.Context, worker *ateapipb.Worker) error
+	// Lists workers. Returns a page of workers and a next page token.
+	ListWorkers(ctx context.Context, pageSize int32, pageToken string) ([]*ateapipb.Worker, string, error)
 
 	// Updates worker state with optimistic concurrency check. Returns ErrNotFound if missing, or ErrVersionConflict on version mismatch.
 	UpdateWorker(ctx context.Context, worker *ateapipb.Worker, expectedVersion int64) error
 
 	// Removes a worker. Idempotent: does nothing if worker is not found.
 	DeleteWorker(ctx context.Context, namespace, pool, pod string) error
-
-	// Lists workers. Returns a page of workers and a next page token.
-	ListWorkers(ctx context.Context, pageSize int32, pageToken string) ([]*ateapipb.Worker, string, error)
 
 	// WatchWorkers returns an active subscription to track worker state changes.
 	// The watch's Events channel is closed when the caller calls Close, the

--- a/cmd/ateapi/internal/store/storecontract/contract.go
+++ b/cmd/ateapi/internal/store/storecontract/contract.go
@@ -612,10 +612,11 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 			t.Fatalf("failed to create worker2: %v", err)
 		}
 
-		workers, _, err := s.ListWorkers(ctx, 1000, "")
+		workersResp, err := s.ListWorkers(ctx, store.ListOptions{PageSize: 1000})
 		if err != nil {
 			t.Fatalf("ListWorkers failed: %v", err)
 		}
+		workers := workersResp.Items
 		if len(workers) != 2 {
 			t.Errorf("expected 2 workers, got %d", len(workers))
 		}
@@ -638,12 +639,12 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		s := setup(t)
 		ctx := context.Background()
 
-		workers, _, err := s.ListWorkers(ctx, 1000, "")
+		workersResp, err := s.ListWorkers(ctx, store.ListOptions{PageSize: 1000})
 		if err != nil {
 			t.Fatalf("ListWorkers failed: %v", err)
 		}
-		if len(workers) != 0 {
-			t.Errorf("expected 0 workers, got %d", len(workers))
+		if len(workersResp.Items) != 0 {
+			t.Errorf("expected 0 workers, got %d", len(workersResp.Items))
 		}
 	})
 
@@ -661,12 +662,12 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		var allWorkers []*ateapipb.Worker
 		pageToken := ""
 		for {
-			workers, nextToken, err := s.ListWorkers(ctx, 2, pageToken)
+			page, err := s.ListWorkers(ctx, store.ListOptions{PageSize: 2, PageToken: pageToken})
 			if err != nil {
 				t.Fatalf("ListWorkers failed: %v", err)
 			}
-			allWorkers = append(allWorkers, workers...)
-			pageToken = nextToken
+			allWorkers = append(allWorkers, page.Items...)
+			pageToken = page.NextPageToken
 			if pageToken == "" {
 				break
 			}
@@ -697,12 +698,12 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		var allAtespaces []*ateapipb.Atespace
 		pageToken := ""
 		for {
-			atespaces, nextToken, err := s.ListAtespaces(ctx, 2, pageToken)
+			page, err := s.ListAtespaces(ctx, store.ListOptions{PageSize: 2, PageToken: pageToken})
 			if err != nil {
 				t.Fatalf("ListAtespaces failed: %v", err)
 			}
-			allAtespaces = append(allAtespaces, atespaces...)
-			pageToken = nextToken
+			allAtespaces = append(allAtespaces, page.Items...)
+			pageToken = page.NextPageToken
 			if pageToken == "" {
 				break
 			}
@@ -724,12 +725,12 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		s := setup(t)
 		ctx := context.Background()
 
-		actors, _, err := s.ListActors(ctx, "", 1000, "")
+		actorsResp, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 1000})
 		if err != nil {
 			t.Fatalf("ListActors failed: %v", err)
 		}
-		if len(actors) != 0 {
-			t.Errorf("expected 0 actors, got %d", len(actors))
+		if len(actorsResp.Items) != 0 {
+			t.Errorf("expected 0 actors, got %d", len(actorsResp.Items))
 		}
 	})
 
@@ -759,10 +760,11 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 			t.Fatalf("failed to create actor2: %v", err)
 		}
 
-		actors, _, err := s.ListActors(ctx, "", 1000, "")
+		actorsResp, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 1000})
 		if err != nil {
 			t.Fatalf("ListActors failed: %v", err)
 		}
+		actors := actorsResp.Items
 		if len(actors) != 2 {
 			t.Errorf("expected 2 actors, got %d", len(actors))
 		}
@@ -791,12 +793,12 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		var allActors []*ateapipb.Actor
 		pageToken := ""
 		for {
-			actors, nextToken, err := s.ListActors(ctx, "", 2, pageToken)
+			page, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 2, PageToken: pageToken})
 			if err != nil {
 				t.Fatalf("ListActors failed: %v", err)
 			}
-			allActors = append(allActors, actors...)
-			pageToken = nextToken
+			allActors = append(allActors, page.Items...)
+			pageToken = page.NextPageToken
 			if pageToken == "" {
 				break
 			}
@@ -834,27 +836,27 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 			}
 		}
 
-		teamA, _, err := s.ListActors(ctx, "team-a", 1000, "")
+		teamAResp, err := s.ListActors(ctx, "team-a", store.ListOptions{PageSize: 1000})
 		if err != nil {
 			t.Fatalf("ListActors(team-a) failed: %v", err)
 		}
-		if got := actorNameSet(teamA); !got["a1"] || !got["a2"] || got["b1"] || len(got) != 2 {
+		if got := actorNameSet(teamAResp.Items); !got["a1"] || !got["a2"] || got["b1"] || len(got) != 2 {
 			t.Errorf("ListActors(team-a) = %v, want exactly {a1, a2}", got)
 		}
 
-		teamB, _, err := s.ListActors(ctx, "team-b", 1000, "")
+		teamBResp, err := s.ListActors(ctx, "team-b", store.ListOptions{PageSize: 1000})
 		if err != nil {
 			t.Fatalf("ListActors(team-b) failed: %v", err)
 		}
-		if got := actorNameSet(teamB); !got["b1"] || got["a1"] || len(got) != 1 {
+		if got := actorNameSet(teamBResp.Items); !got["b1"] || got["a1"] || len(got) != 1 {
 			t.Errorf("ListActors(team-b) = %v, want exactly {b1}", got)
 		}
 
-		all, _, err := s.ListActors(ctx, "", 1000, "")
+		allResp, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 1000})
 		if err != nil {
 			t.Fatalf("ListActors(all) failed: %v", err)
 		}
-		if got := actorNameSet(all); !got["a1"] || !got["a2"] || !got["b1"] || len(got) != 3 {
+		if got := actorNameSet(allResp.Items); !got["a1"] || !got["a2"] || !got["b1"] || len(got) != 3 {
 			t.Errorf("ListActors(all) = %v, want exactly {a1, a2, b1}", got)
 		}
 
@@ -974,11 +976,11 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		if _, err := s.GetAtespace(ctx, "team-a"); !errors.Is(err, store.ErrNotFound) {
 			t.Errorf("atespace survived DebugClearAll: %v", err)
 		}
-		if actors, _, err := s.ListActors(ctx, "", 1000, ""); err != nil || len(actors) != 0 {
-			t.Errorf("actors survived DebugClearAll: actors=%v err=%v", actors, err)
+		if actors, err := s.ListActors(ctx, "", store.ListOptions{PageSize: 1000}); err != nil || len(actors.Items) != 0 {
+			t.Errorf("actors survived DebugClearAll: actors=%v err=%v", actors.Items, err)
 		}
-		if workers, _, err := s.ListWorkers(ctx, 1000, ""); err != nil || len(workers) != 0 {
-			t.Errorf("workers survived DebugClearAll: workers=%v err=%v", workers, err)
+		if workers, err := s.ListWorkers(ctx, store.ListOptions{PageSize: 1000}); err != nil || len(workers.Items) != 0 {
+			t.Errorf("workers survived DebugClearAll: workers=%v err=%v", workers.Items, err)
 		}
 		reacquired, err := s.AcquireLock(ctx, "lock-1")
 		if err != nil {
@@ -1062,10 +1064,11 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 				t.Fatalf("CreateAtespace(%s) failed: %v", n, err)
 			}
 		}
-		got, _, err := s.ListAtespaces(ctx, 1000, "")
+		gotResp, err := s.ListAtespaces(ctx, store.ListOptions{PageSize: 1000})
 		if err != nil {
 			t.Fatalf("ListAtespaces failed: %v", err)
 		}
+		got := gotResp.Items
 		if len(got) != len(names) {
 			t.Fatalf("ListAtespaces returned %d atespaces, want %d", len(got), len(names))
 		}
@@ -1084,12 +1087,12 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		s := setup(t)
 		ctx := context.Background()
 
-		got, _, err := s.ListAtespaces(ctx, 1000, "")
+		got, err := s.ListAtespaces(ctx, store.ListOptions{PageSize: 1000})
 		if err != nil {
 			t.Fatalf("ListAtespaces failed: %v", err)
 		}
-		if len(got) != 0 {
-			t.Errorf("ListAtespaces on empty store = %v, want empty", got)
+		if len(got.Items) != 0 {
+			t.Errorf("ListAtespaces on empty store = %v, want empty", got.Items)
 		}
 	})
 
@@ -1286,17 +1289,17 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		parent := resources.ActorTemplateRef{Atespace: "team-a", Name: "tmpl-a"}
 		var got []string
 		for token := ""; ; {
-			versions, next, err := s.ListActorTemplateVersions(ctx, "", parent, 1, token)
+			page, err := s.ListActorTemplateVersions(ctx, "", parent, store.ListOptions{PageSize: 1, PageToken: token})
 			if err != nil {
 				t.Fatalf("ListActorTemplateVersions failed: %v", err)
 			}
-			for _, version := range versions {
+			for _, version := range page.Items {
 				got = append(got, version.GetMetadata().GetAtespace()+"/"+version.GetMetadata().GetName())
 			}
-			if next == "" {
+			if page.NextPageToken == "" {
 				break
 			}
-			token = next
+			token = page.NextPageToken
 		}
 		if diff := cmp.Diff([]string{"team-a/a-1", "team-a/a-2"}, got); diff != "" {
 			t.Errorf("filtered pagination mismatch (-want +got):\n%s", diff)
@@ -1476,15 +1479,15 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 
 		var scoped []*ateapipb.ActorSnapshot
 		for token := ""; ; {
-			page, next, err := s.ListActorSnapshots(ctx, "team-a", 2, token)
+			page, err := s.ListActorSnapshots(ctx, "team-a", store.ListOptions{PageSize: 2, PageToken: token})
 			if err != nil {
 				t.Fatalf("scoped ListActorSnapshots failed: %v", err)
 			}
-			scoped = append(scoped, page...)
-			if next == "" {
+			scoped = append(scoped, page.Items...)
+			if page.NextPageToken == "" {
 				break
 			}
-			token = next
+			token = page.NextPageToken
 		}
 		if len(scoped) != 3 {
 			t.Errorf("scoped ListActorSnapshots returned %d snapshots, want 3", len(scoped))
@@ -1492,15 +1495,15 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 
 		var global []*ateapipb.ActorSnapshot
 		for token := ""; ; {
-			page, next, err := s.ListActorSnapshots(ctx, "", 2, token)
+			page, err := s.ListActorSnapshots(ctx, "", store.ListOptions{PageSize: 2, PageToken: token})
 			if err != nil {
 				t.Fatalf("global ListActorSnapshots failed: %v", err)
 			}
-			global = append(global, page...)
-			if next == "" {
+			global = append(global, page.Items...)
+			if page.NextPageToken == "" {
 				break
 			}
-			token = next
+			token = page.NextPageToken
 		}
 		if len(global) != 6 {
 			t.Errorf("global ListActorSnapshots returned %d snapshots, want 6", len(global))

--- a/cmd/ateapi/internal/store/storecontract/contract.go
+++ b/cmd/ateapi/internal/store/storecontract/contract.go
@@ -1392,35 +1392,39 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 			Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "production"},
 			Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 		}
-		tag, err := s.TagActorSnapshot(ctx, "team-a", "snapshot-1", tagInput)
+		tag, err := s.CreateActorSnapshotTag(ctx, "team-a", "snapshot-1", tagInput)
 		if err != nil {
-			t.Fatalf("TagActorSnapshot failed: %v", err)
+			t.Fatalf("CreateActorSnapshotTag failed: %v", err)
 		}
 		if tag.GetSnapshot().GetAtespace() != "team-a" || tag.GetSnapshot().GetName() != "snapshot-1" {
 			t.Errorf("tag snapshot = %v, want team-a/snapshot-1", tag.GetSnapshot())
 		}
 		if tagInput.GetSnapshot() != nil || tagInput.GetMetadata().GetVersion() != 0 {
-			t.Errorf("TagActorSnapshot mutated its input: %v", tagInput)
+			t.Errorf("CreateActorSnapshotTag mutated its input: %v", tagInput)
 		}
-		idempotent, err := s.TagActorSnapshot(ctx, "team-a", "snapshot-1", tagInput)
+		idempotent, err := s.CreateActorSnapshotTag(ctx, "team-a", "snapshot-1", tagInput)
 		if err != nil || !proto.Equal(idempotent, tag) {
-			t.Errorf("idempotent TagActorSnapshot = (%v, %v), want existing tag", idempotent, err)
+			t.Errorf("idempotent CreateActorSnapshotTag = (%v, %v), want existing tag", idempotent, err)
 		}
 		conflicting := proto.Clone(tagInput).(*ateapipb.ActorSnapshotTag)
 		conflicting.Scope = ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED
-		if _, err := s.TagActorSnapshot(ctx, "team-a", "snapshot-1", conflicting); !errors.Is(err, store.ErrAlreadyExists) {
-			t.Errorf("conflicting TagActorSnapshot = %v, want ErrAlreadyExists", err)
+		if _, err := s.CreateActorSnapshotTag(ctx, "team-a", "snapshot-1", conflicting); !errors.Is(err, store.ErrAlreadyExists) {
+			t.Errorf("conflicting CreateActorSnapshotTag = %v, want ErrAlreadyExists", err)
 		}
-		if _, err := s.TagActorSnapshot(ctx, "team-a", "missing", &ateapipb.ActorSnapshotTag{Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "missing"}}); !errors.Is(err, store.ErrNotFound) {
+		if _, err := s.CreateActorSnapshotTag(ctx, "team-a", "missing", &ateapipb.ActorSnapshotTag{Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "missing"}}); !errors.Is(err, store.ErrNotFound) {
 			t.Errorf("tagging missing snapshot = %v, want ErrNotFound", err)
 		}
 
-		resolved, resolvedTag, err := s.GetActorSnapshotByTag(ctx, "team-a", "production")
+		resolvedTag, err := s.GetActorSnapshotTag(ctx, "team-a", "production")
 		if err != nil {
-			t.Fatalf("GetActorSnapshotByTag failed: %v", err)
+			t.Fatalf("GetActorSnapshotTag failed: %v", err)
 		}
-		if !proto.Equal(resolved, created) || !proto.Equal(resolvedTag, tag) {
-			t.Errorf("resolved tag = (%v, %v), want created snapshot and tag", resolved, resolvedTag)
+		if !proto.Equal(resolvedTag, tag) {
+			t.Errorf("resolved tag = %v, want created tag", resolvedTag)
+		}
+		resolved, err := s.GetActorSnapshot(ctx, resolvedTag.GetSnapshot().GetAtespace(), resolvedTag.GetSnapshot().GetName())
+		if err != nil || !proto.Equal(resolved, created) {
+			t.Errorf("GetActorSnapshot(resolved tag target) = (%v, %v), want created snapshot", resolved, err)
 		}
 
 		updated, err := s.UpdateActorSnapshotTag(ctx, "team-a", "production", store.WithPrecondition(tag, func(toUpdate *ateapipb.ActorSnapshotTag) error {
@@ -1447,8 +1451,8 @@ func RunContractTests(t *testing.T, setup func(t *testing.T) store.Interface) {
 		if err != nil || !proto.Equal(deleted, updated) {
 			t.Errorf("DeleteActorSnapshotTag = (%v, %v), want updated tag", deleted, err)
 		}
-		if _, _, err := s.GetActorSnapshotByTag(ctx, "team-a", "production"); !errors.Is(err, store.ErrNotFound) {
-			t.Errorf("deleted GetActorSnapshotByTag = %v, want ErrNotFound", err)
+		if _, err := s.GetActorSnapshotTag(ctx, "team-a", "production"); !errors.Is(err, store.ErrNotFound) {
+			t.Errorf("deleted GetActorSnapshotTag = %v, want ErrNotFound", err)
 		}
 		if _, err := s.DeleteAtespace(ctx, "team-a"); err != nil {
 			t.Errorf("DeleteAtespace after tag deletion = %v, want nil", err)

--- a/cmd/ateapi/internal/workercache/workercache.go
+++ b/cmd/ateapi/internal/workercache/workercache.go
@@ -119,15 +119,15 @@ func (c *Cache) relist(ctx context.Context) error {
 	var workers []*ateapipb.Worker
 	pageToken := ""
 	for {
-		page, nextToken, err := c.store.ListWorkers(ctx, relistPageSize, pageToken)
+		page, err := c.store.ListWorkers(ctx, store.ListOptions{PageSize: relistPageSize, PageToken: pageToken})
 		if err != nil {
 			return fmt.Errorf("ListWorkers: %w", err)
 		}
-		workers = append(workers, page...)
-		if nextToken == "" {
+		workers = append(workers, page.Items...)
+		if !page.HasNextPage() {
 			break
 		}
-		pageToken = nextToken
+		pageToken = page.NextPageToken
 	}
 	newMap := make(map[string]*ateapipb.Worker, len(workers))
 	for _, w := range workers {

--- a/cmd/ateapi/internal/workercache/workercache_test.go
+++ b/cmd/ateapi/internal/workercache/workercache_test.go
@@ -407,15 +407,15 @@ func (f *fakeStore) WatchWorkers(_ context.Context) (*store.WorkerWatch, error) 
 	}), nil
 }
 
-func (f *fakeStore) ListWorkers(_ context.Context, _ int32, _ string) ([]*ateapipb.Worker, string, error) {
+func (f *fakeStore) ListWorkers(_ context.Context, _ store.ListOptions) (store.ListResponse[*ateapipb.Worker], error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.listErr != nil {
-		return nil, "", f.listErr
+		return store.ListResponse[*ateapipb.Worker]{}, f.listErr
 	}
 	out := make([]*ateapipb.Worker, len(f.workers))
 	copy(out, f.workers)
-	return out, "", nil
+	return store.ListResponse[*ateapipb.Worker]{Items: out}, nil
 }
 
 func (f *fakeStore) send(event store.WorkerEvent) {

--- a/cmd/kubectl-ate/internal/cmd/actor_snapshots.go
+++ b/cmd/kubectl-ate/internal/cmd/actor_snapshots.go
@@ -117,9 +117,9 @@ var createActorSnapshotTagCmd = &cobra.Command{
 		defer client.Close()
 
 		resp, err := client.CreateActorSnapshotTag(ctx, &ateapipb.CreateActorSnapshotTagRequest{
-			Snapshot: &ateapipb.ObjectRef{Atespace: createTagAtespaceFlag, Name: createTagSnapshotFlag},
-			Tag: &ateapipb.ActorSnapshotTag{
+			ActorSnapshotTag: &ateapipb.ActorSnapshotTag{
 				Metadata: &ateapipb.ResourceMetadata{Atespace: createTagAtespaceFlag, Name: args[0]},
+				Snapshot: &ateapipb.ObjectRef{Atespace: createTagAtespaceFlag, Name: createTagSnapshotFlag},
 				Scope:    scope,
 			},
 		})

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -157,9 +157,9 @@ func TestActorSnapshotLifecycle(t *testing.T) {
 		_, _ = clients.SubstrateAPI.DeleteActorSnapshotTag(context.Background(), &ateapipb.DeleteActorSnapshotTagRequest{Tag: tagRef})
 	})
 	if _, err := clients.SubstrateAPI.CreateActorSnapshotTag(ctx, &ateapipb.CreateActorSnapshotTagRequest{
-		Snapshot: snapshotRef,
-		Tag: &ateapipb.ActorSnapshotTag{
+		ActorSnapshotTag: &ateapipb.ActorSnapshotTag{
 			Metadata: &ateapipb.ResourceMetadata{Atespace: tagRef.GetAtespace(), Name: tagRef.GetName()},
+			Snapshot: snapshotRef,
 			Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
 		},
 	}); err != nil {

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -4133,11 +4133,11 @@ func (x *ListActorSnapshotsResponse) GetNextPageToken() string {
 }
 
 type CreateActorSnapshotTagRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Snapshot      *ObjectRef             `protobuf:"bytes,1,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
-	Tag           *ActorSnapshotTag      `protobuf:"bytes,2,opt,name=tag,proto3" json:"tag,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The tag to create.
+	ActorSnapshotTag *ActorSnapshotTag `protobuf:"bytes,1,opt,name=actor_snapshot_tag,json=actorSnapshotTag,proto3" json:"actor_snapshot_tag,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *CreateActorSnapshotTagRequest) Reset() {
@@ -4170,16 +4170,9 @@ func (*CreateActorSnapshotTagRequest) Descriptor() ([]byte, []int) {
 	return file_ateapi_proto_rawDescGZIP(), []int{59}
 }
 
-func (x *CreateActorSnapshotTagRequest) GetSnapshot() *ObjectRef {
+func (x *CreateActorSnapshotTagRequest) GetActorSnapshotTag() *ActorSnapshotTag {
 	if x != nil {
-		return x.Snapshot
-	}
-	return nil
-}
-
-func (x *CreateActorSnapshotTagRequest) GetTag() *ActorSnapshotTag {
-	if x != nil {
-		return x.Tag
+		return x.ActorSnapshotTag
 	}
 	return nil
 }
@@ -5374,10 +5367,9 @@ const file_ateapi_proto_rawDesc = "" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\"y\n" +
 	"\x1aListActorSnapshotsResponse\x123\n" +
 	"\tsnapshots\x18\x01 \x03(\v2\x15.ateapi.ActorSnapshotR\tsnapshots\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"z\n" +
-	"\x1dCreateActorSnapshotTagRequest\x12-\n" +
-	"\bsnapshot\x18\x01 \x01(\v2\x11.ateapi.ObjectRefR\bsnapshot\x12*\n" +
-	"\x03tag\x18\x02 \x01(\v2\x18.ateapi.ActorSnapshotTagR\x03tag\"\x88\x01\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"g\n" +
+	"\x1dCreateActorSnapshotTagRequest\x12F\n" +
+	"\x12actor_snapshot_tag\x18\x01 \x01(\v2\x18.ateapi.ActorSnapshotTagR\x10actorSnapshotTag\"\x88\x01\n" +
 	"\x1dUpdateActorSnapshotTagRequest\x12*\n" +
 	"\x03tag\x18\x01 \x01(\v2\x18.ateapi.ActorSnapshotTagR\x03tag\x12;\n" +
 	"\vupdate_mask\x18\x02 \x01(\v2\x1a.google.protobuf.FieldMaskR\n" +
@@ -5699,88 +5691,87 @@ var file_ateapi_proto_depIdxs = []int32{
 	18,  // 80: ateapi.GetActorSnapshotRequest.snapshot:type_name -> ateapi.ObjectRef
 	18,  // 81: ateapi.GetActorSnapshotTagRequest.tag:type_name -> ateapi.ObjectRef
 	15,  // 82: ateapi.ListActorSnapshotsResponse.snapshots:type_name -> ateapi.ActorSnapshot
-	18,  // 83: ateapi.CreateActorSnapshotTagRequest.snapshot:type_name -> ateapi.ObjectRef
-	16,  // 84: ateapi.CreateActorSnapshotTagRequest.tag:type_name -> ateapi.ActorSnapshotTag
-	16,  // 85: ateapi.UpdateActorSnapshotTagRequest.tag:type_name -> ateapi.ActorSnapshotTag
-	90,  // 86: ateapi.UpdateActorSnapshotTagRequest.update_mask:type_name -> google.protobuf.FieldMask
-	18,  // 87: ateapi.DeleteActorSnapshotTagRequest.tag:type_name -> ateapi.ObjectRef
-	75,  // 88: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
-	13,  // 89: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
-	76,  // 90: ateapi.Worker.assignment:type_name -> ateapi.Assignment
-	88,  // 91: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
-	8,   // 92: ateapi.Worker.state:type_name -> ateapi.Worker.State
-	77,  // 93: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	18,  // 94: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
-	4,   // 95: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
-	36,  // 96: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
-	37,  // 97: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
-	54,  // 98: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	55,  // 99: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	56,  // 100: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	57,  // 101: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	59,  // 102: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	61,  // 103: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	63,  // 104: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	64,  // 105: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
-	65,  // 106: ateapi.Control.GetActorSnapshotTag:input_type -> ateapi.GetActorSnapshotTagRequest
-	66,  // 107: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
-	68,  // 108: ateapi.Control.CreateActorSnapshotTag:input_type -> ateapi.CreateActorSnapshotTagRequest
-	69,  // 109: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
-	70,  // 110: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
-	71,  // 111: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	73,  // 112: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	38,  // 113: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	39,  // 114: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	40,  // 115: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	42,  // 116: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	43,  // 117: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
-	44,  // 118: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
-	45,  // 119: ateapi.Control.UpdateActorTemplate:input_type -> ateapi.UpdateActorTemplateRequest
-	46,  // 120: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
-	48,  // 121: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
-	49,  // 122: ateapi.Control.CreateActorTemplateVersion:input_type -> ateapi.CreateActorTemplateVersionRequest
-	50,  // 123: ateapi.Control.GetActorTemplateVersion:input_type -> ateapi.GetActorTemplateVersionRequest
-	51,  // 124: ateapi.Control.ListActorTemplateVersions:input_type -> ateapi.ListActorTemplateVersionsRequest
-	53,  // 125: ateapi.Control.DeleteActorTemplateVersion:input_type -> ateapi.DeleteActorTemplateVersionRequest
-	78,  // 126: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
-	80,  // 127: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	82,  // 128: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	13,  // 129: ateapi.Control.GetActor:output_type -> ateapi.Actor
-	13,  // 130: ateapi.Control.CreateActor:output_type -> ateapi.Actor
-	13,  // 131: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
-	58,  // 132: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	60,  // 133: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	62,  // 134: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	13,  // 135: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
-	15,  // 136: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
-	16,  // 137: ateapi.Control.GetActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	67,  // 138: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
-	16,  // 139: ateapi.Control.CreateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	16,  // 140: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	16,  // 141: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	72,  // 142: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	74,  // 143: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	17,  // 144: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
-	17,  // 145: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
-	41,  // 146: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	17,  // 147: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
-	21,  // 148: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
-	21,  // 149: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
-	21,  // 150: ateapi.Control.UpdateActorTemplate:output_type -> ateapi.ActorTemplate
-	47,  // 151: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
-	21,  // 152: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
-	22,  // 153: ateapi.Control.CreateActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
-	22,  // 154: ateapi.Control.GetActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
-	52,  // 155: ateapi.Control.ListActorTemplateVersions:output_type -> ateapi.ListActorTemplateVersionsResponse
-	22,  // 156: ateapi.Control.DeleteActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
-	79,  // 157: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
-	81,  // 158: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	83,  // 159: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	129, // [129:160] is the sub-list for method output_type
-	98,  // [98:129] is the sub-list for method input_type
-	98,  // [98:98] is the sub-list for extension type_name
-	98,  // [98:98] is the sub-list for extension extendee
-	0,   // [0:98] is the sub-list for field type_name
+	16,  // 83: ateapi.CreateActorSnapshotTagRequest.actor_snapshot_tag:type_name -> ateapi.ActorSnapshotTag
+	16,  // 84: ateapi.UpdateActorSnapshotTagRequest.tag:type_name -> ateapi.ActorSnapshotTag
+	90,  // 85: ateapi.UpdateActorSnapshotTagRequest.update_mask:type_name -> google.protobuf.FieldMask
+	18,  // 86: ateapi.DeleteActorSnapshotTagRequest.tag:type_name -> ateapi.ObjectRef
+	75,  // 87: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
+	13,  // 88: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
+	76,  // 89: ateapi.Worker.assignment:type_name -> ateapi.Assignment
+	88,  // 90: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
+	8,   // 91: ateapi.Worker.state:type_name -> ateapi.Worker.State
+	77,  // 92: ateapi.Assignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
+	18,  // 93: ateapi.Assignment.actor:type_name -> ateapi.ObjectRef
+	4,   // 94: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
+	36,  // 95: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
+	37,  // 96: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
+	54,  // 97: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	55,  // 98: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	56,  // 99: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	57,  // 100: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	59,  // 101: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	61,  // 102: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	63,  // 103: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	64,  // 104: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
+	65,  // 105: ateapi.Control.GetActorSnapshotTag:input_type -> ateapi.GetActorSnapshotTagRequest
+	66,  // 106: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
+	68,  // 107: ateapi.Control.CreateActorSnapshotTag:input_type -> ateapi.CreateActorSnapshotTagRequest
+	69,  // 108: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
+	70,  // 109: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
+	71,  // 110: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	73,  // 111: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	38,  // 112: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	39,  // 113: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	40,  // 114: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	42,  // 115: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	43,  // 116: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
+	44,  // 117: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
+	45,  // 118: ateapi.Control.UpdateActorTemplate:input_type -> ateapi.UpdateActorTemplateRequest
+	46,  // 119: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
+	48,  // 120: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
+	49,  // 121: ateapi.Control.CreateActorTemplateVersion:input_type -> ateapi.CreateActorTemplateVersionRequest
+	50,  // 122: ateapi.Control.GetActorTemplateVersion:input_type -> ateapi.GetActorTemplateVersionRequest
+	51,  // 123: ateapi.Control.ListActorTemplateVersions:input_type -> ateapi.ListActorTemplateVersionsRequest
+	53,  // 124: ateapi.Control.DeleteActorTemplateVersion:input_type -> ateapi.DeleteActorTemplateVersionRequest
+	78,  // 125: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
+	80,  // 126: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	82,  // 127: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	13,  // 128: ateapi.Control.GetActor:output_type -> ateapi.Actor
+	13,  // 129: ateapi.Control.CreateActor:output_type -> ateapi.Actor
+	13,  // 130: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
+	58,  // 131: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	60,  // 132: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	62,  // 133: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	13,  // 134: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
+	15,  // 135: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
+	16,  // 136: ateapi.Control.GetActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	67,  // 137: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
+	16,  // 138: ateapi.Control.CreateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	16,  // 139: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	16,  // 140: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	72,  // 141: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	74,  // 142: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	17,  // 143: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
+	17,  // 144: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
+	41,  // 145: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	17,  // 146: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
+	21,  // 147: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
+	21,  // 148: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
+	21,  // 149: ateapi.Control.UpdateActorTemplate:output_type -> ateapi.ActorTemplate
+	47,  // 150: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
+	21,  // 151: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
+	22,  // 152: ateapi.Control.CreateActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	22,  // 153: ateapi.Control.GetActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	52,  // 154: ateapi.Control.ListActorTemplateVersions:output_type -> ateapi.ListActorTemplateVersionsResponse
+	22,  // 155: ateapi.Control.DeleteActorTemplateVersion:output_type -> ateapi.ActorTemplateVersion
+	79,  // 156: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
+	81,  // 157: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	83,  // 158: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	128, // [128:159] is the sub-list for method output_type
+	97,  // [97:128] is the sub-list for method input_type
+	97,  // [97:97] is the sub-list for extension type_name
+	97,  // [97:97] is the sub-list for extension extendee
+	0,   // [0:97] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -802,8 +802,8 @@ message ListActorSnapshotsResponse {
 }
 
 message CreateActorSnapshotTagRequest {
-  ObjectRef snapshot = 1;
-  ActorSnapshotTag tag = 2;
+  // The tag to create.
+  ActorSnapshotTag actor_snapshot_tag = 1;
 }
 
 // Request to update mutable fields on an existing ActorSnapshotTag.


### PR DESCRIPTION
* Align ActorSnapshot/ActorSnapshotTag store methods to other CRUD methods.
* Add common struct types for List<Type> methods to carry parameters and returned pages.
* Sort methods in store interface to group methods for each resource.
* Remove pessimistic locking from ActorSnapshot/ActorSnapshotTag RPC handlers.
* Align CreateActorSnapshotTag method to API guideline. It should take just the resource, no extra top level field.