### PR TITLE
Extract validations for actor snapshot rpc handlers into dedicated fns

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor_snapshot.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot.go
@@ -48,10 +48,8 @@ var actorSnapshotTagScopeNames = func() []string {
 }()
 
 func (s *Service) GetActorSnapshot(ctx context.Context, req *ateapipb.GetActorSnapshotRequest) (*ateapipb.ActorSnapshot, error) {
-	// TODO: extract into validateGetActorSnapshotRequest(req) field.ErrorList,
-	// as done for other RPC methods, and return via toGRPCStatusError.
-	if errs := resources.ValidateObjectRef(req.GetSnapshot(), field.NewPath("snapshot")); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+	if errs := validateGetActorSnapshotRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	snapshot, err := s.persistence.GetActorSnapshot(ctx, req.GetSnapshot().GetAtespace(), req.GetSnapshot().GetName())
 	if errors.Is(err, store.ErrNotFound) {
@@ -63,11 +61,22 @@ func (s *Service) GetActorSnapshot(ctx context.Context, req *ateapipb.GetActorSn
 	return snapshot, nil
 }
 
+func validateGetActorSnapshotRequest(req *ateapipb.GetActorSnapshotRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if snapshot, fldPath := req.GetSnapshot(), fldPath.Child("snapshot"); snapshot == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(snapshot, fldPath)...)
+	}
+
+	return errs
+}
+
 func (s *Service) GetActorSnapshotTag(ctx context.Context, req *ateapipb.GetActorSnapshotTagRequest) (*ateapipb.ActorSnapshotTag, error) {
-	// TODO: extract into validateGetActorSnapshotTagRequest(req) field.ErrorList,
-	// as done for other RPC methods, and return via toGRPCStatusError.
-	if errs := resources.ValidateObjectRef(req.GetTag(), field.NewPath("tag")); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+	if errs := validateGetActorSnapshotTagRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	_, tag, err := s.persistence.GetActorSnapshotByTag(ctx, req.GetTag().GetAtespace(), req.GetTag().GetName())
 	if errors.Is(err, store.ErrNotFound) {
@@ -79,19 +88,22 @@ func (s *Service) GetActorSnapshotTag(ctx context.Context, req *ateapipb.GetActo
 	return tag, nil
 }
 
-func (s *Service) ListActorSnapshots(ctx context.Context, req *ateapipb.ListActorSnapshotsRequest) (*ateapipb.ListActorSnapshotsResponse, error) {
-	// TODO: extract into validateListActorSnapshotsRequest(req) field.ErrorList,
-	// as done for other RPC methods, and return via toGRPCStatusError.
+func validateGetActorSnapshotTagRequest(req *ateapipb.GetActorSnapshotTagRequest) field.ErrorList {
 	var fldPath *field.Path
 	var errs field.ErrorList
-	if req.GetAtespace() != "" {
-		errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), fldPath.Child("atespace"))...)
+
+	if tag, fldPath := req.GetTag(), fldPath.Child("tag"); tag == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(tag, fldPath)...)
 	}
-	if req.GetPageSize() < 0 {
-		errs = append(errs, field.Invalid(fldPath.Child("page_size"), req.GetPageSize(), "must be greater than or equal to 0"))
-	}
-	if len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+
+	return errs
+}
+
+func (s *Service) ListActorSnapshots(ctx context.Context, req *ateapipb.ListActorSnapshotsRequest) (*ateapipb.ListActorSnapshotsResponse, error) {
+	if errs := validateListActorSnapshotsRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	snapshots, nextToken, err := s.persistence.ListActorSnapshots(ctx, req.GetAtespace(), effectivePageSize(req.GetPageSize()), req.GetPageToken())
 	if err != nil {
@@ -100,15 +112,24 @@ func (s *Service) ListActorSnapshots(ctx context.Context, req *ateapipb.ListActo
 	return &ateapipb.ListActorSnapshotsResponse{Snapshots: snapshots, NextPageToken: nextToken}, nil
 }
 
-func (s *Service) CreateActorSnapshotTag(ctx context.Context, req *ateapipb.CreateActorSnapshotTagRequest) (*ateapipb.ActorSnapshotTag, error) {
-	// TODO: extract into validateCreateActorSnapshotTagRequest(req) field.ErrorList,
-	// folding in validateActorSnapshotTag below, as done for other RPC methods,
-	// and return via toGRPCStatusError.
-	if errs := resources.ValidateObjectRef(req.GetSnapshot(), field.NewPath("snapshot")); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+func validateListActorSnapshotsRequest(req *ateapipb.ListActorSnapshotsRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if atespace, fldPath := req.GetAtespace(), fldPath.Child("atespace"); atespace != "" {
+		errs = append(errs, resources.ValidateResourceName(atespace, fldPath)...)
 	}
-	if err := validateActorSnapshotTag(req.GetTag(), "tag"); err != nil {
-		return nil, err
+
+	if pagesize, fldPath := req.GetPageSize(), fldPath.Child("page_size"); pagesize < 0 {
+		errs = append(errs, field.Invalid(fldPath, pagesize, "must be greater than or equal to 0"))
+	}
+
+	return errs
+}
+
+func (s *Service) CreateActorSnapshotTag(ctx context.Context, req *ateapipb.CreateActorSnapshotTagRequest) (*ateapipb.ActorSnapshotTag, error) {
+	if errs := validateCreateActorSnapshotTagRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	lock, _, ref, _, err := s.lockActorSnapshot(ctx, req.GetSnapshot(), nil)
 	if err != nil {
@@ -141,6 +162,39 @@ func (s *Service) CreateActorSnapshotTag(ctx context.Context, req *ateapipb.Crea
 		return nil, fmt.Errorf("while tagging actor snapshot: %w", err)
 	}
 	return tag, nil
+}
+
+func validateCreateActorSnapshotTagRequest(req *ateapipb.CreateActorSnapshotTagRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if snapshot, fldPath := req.GetSnapshot(), fldPath.Child("snapshot"); snapshot == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(snapshot, fldPath)...)
+	}
+
+	tag := req.GetTag()
+	tagPath := fldPath.Child("tag")
+	if tag == nil {
+		return append(errs, field.Required(tagPath, ""))
+	}
+
+	metaPath := tagPath.Child("metadata")
+	if tagAtespace, p := tag.GetMetadata().GetAtespace(), metaPath.Child("atespace"); tagAtespace == "" {
+		errs = append(errs, field.Required(p, ""))
+	} else {
+		errs = append(errs, resources.ValidateResourceName(tagAtespace, p)...)
+	}
+	if tagName, p := tag.GetMetadata().GetName(), metaPath.Child("name"); tagName == "" {
+		errs = append(errs, field.Required(p, ""))
+	} else {
+		errs = append(errs, resources.ValidateResourceName(tagName, p)...)
+	}
+
+	errs = append(errs, validateActorSnapshotTagScope(tag.GetScope(), tagPath.Child("scope"))...)
+
+	return errs
 }
 
 // actorSnapshotTagMutableFields lists the ActorSnapshotTag field paths a client
@@ -193,10 +247,8 @@ func validateUpdateActorSnapshotTagRequest(req *ateapipb.UpdateActorSnapshotTagR
 }
 
 func (s *Service) DeleteActorSnapshotTag(ctx context.Context, req *ateapipb.DeleteActorSnapshotTagRequest) (*ateapipb.ActorSnapshotTag, error) {
-	// TODO: extract into validateDeleteActorSnapshotTagRequest(req) field.ErrorList,
-	// as done for other RPC methods, and return via toGRPCStatusError.
-	if errs := resources.ValidateObjectRef(req.GetTag(), field.NewPath("tag")); len(errs) > 0 {
-		return nil, status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+	if errs := validateDeleteActorSnapshotTagRequest(req); len(errs) > 0 {
+		return nil, toGRPCStatusError(errs)
 	}
 	lock, _, _, _, err := s.lockActorSnapshot(ctx, nil, req.GetTag())
 	if err != nil {
@@ -211,6 +263,19 @@ func (s *Service) DeleteActorSnapshotTag(ctx context.Context, req *ateapipb.Dele
 		return nil, fmt.Errorf("while deleting actor snapshot tag: %w", err)
 	}
 	return tag, nil
+}
+
+func validateDeleteActorSnapshotTagRequest(req *ateapipb.DeleteActorSnapshotTagRequest) field.ErrorList {
+	var fldPath *field.Path
+	var errs field.ErrorList
+
+	if tag, fldPath := req.GetTag(), fldPath.Child("tag"); tag == nil {
+		errs = append(errs, field.Required(fldPath, ""))
+	} else {
+		errs = append(errs, resources.ValidateObjectRef(tag, fldPath)...)
+	}
+
+	return errs
 }
 
 func (s *Service) getActorSnapshot(ctx context.Context, canonical, tag *ateapipb.ObjectRef) (*ateapipb.ActorSnapshot, *ateapipb.ObjectRef, *ateapipb.ActorSnapshotTag, error) {
@@ -261,21 +326,6 @@ func (s *Service) lockActorSnapshot(ctx context.Context, canonical, tag *ateapip
 		return nil, nil, nil, nil, status.Error(codes.Aborted, "ActorSnapshot reference changed, please retry")
 	}
 	return lock, snapshot, lockedCanonical, lockedTag, nil
-}
-
-func validateActorSnapshotTag(tag *ateapipb.ActorSnapshotTag, name string) error {
-	var fldPath *field.Path
-	p := fldPath.Child(name)
-	if tag == nil {
-		return status.Error(codes.InvalidArgument, field.ErrorList{field.Required(p, "")}.ToAggregate().Error())
-	}
-	if errs := resources.ValidateObjectRef(&ateapipb.ObjectRef{Atespace: tag.GetMetadata().GetAtespace(), Name: tag.GetMetadata().GetName()}, p.Child("metadata")); len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	if errs := validateActorSnapshotTagScope(tag.GetScope(), p.Child("scope")); len(errs) > 0 {
-		return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
-	}
-	return nil
 }
 
 // validateActorSnapshotTagScope checks that scope is one a client may set.

--- a/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
@@ -29,6 +29,322 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 )
 
+func TestValidateGetActorSnapshotRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *ateapipb.GetActorSnapshotRequest
+		wantError field.ErrorList
+	}{
+		{
+			name:      "valid",
+			req:       &ateapipb.GetActorSnapshotRequest{Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"}},
+			wantError: nil,
+		},
+		{
+			name:      "missing snapshot",
+			req:       &ateapipb.GetActorSnapshotRequest{},
+			wantError: field.ErrorList{field.Required(field.NewPath("snapshot"), "")},
+		},
+		{
+			name:      "missing snapshot.atespace",
+			req:       &ateapipb.GetActorSnapshotRequest{Snapshot: &ateapipb.ObjectRef{Name: "snapshot1"}},
+			wantError: field.ErrorList{field.Required(field.NewPath("snapshot", "atespace"), "")},
+		},
+		{
+			name:      "invalid snapshot.atespace",
+			req:       &ateapipb.GetActorSnapshotRequest{Snapshot: &ateapipb.ObjectRef{Atespace: "NS1", Name: "snapshot1"}},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("snapshot", "atespace"), "NS1", "")},
+		},
+		{
+			name:      "missing snapshot.name",
+			req:       &ateapipb.GetActorSnapshotRequest{Snapshot: &ateapipb.ObjectRef{Atespace: "ns1"}},
+			wantError: field.ErrorList{field.Required(field.NewPath("snapshot", "name"), "")},
+		},
+		{
+			name:      "invalid snapshot.name",
+			req:       &ateapipb.GetActorSnapshotRequest{Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "SNAPSHOT1"}},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("snapshot", "name"), "SNAPSHOT1", "")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateGetActorSnapshotRequest(tt.req), tt.wantError)
+		})
+	}
+}
+
+func TestValidateGetActorSnapshotTagRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *ateapipb.GetActorSnapshotTagRequest
+		wantError field.ErrorList
+	}{
+		{
+			name:      "valid",
+			req:       &ateapipb.GetActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tag1"}},
+			wantError: nil,
+		},
+		{
+			name:      "missing tag",
+			req:       &ateapipb.GetActorSnapshotTagRequest{},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag"), "")},
+		},
+		{
+			name:      "missing tag.atespace",
+			req:       &ateapipb.GetActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Name: "tag1"}},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag", "atespace"), "")},
+		},
+		{
+			name:      "invalid tag.atespace",
+			req:       &ateapipb.GetActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Atespace: "NS1", Name: "tag1"}},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("tag", "atespace"), "NS1", "")},
+		},
+		{
+			name:      "missing tag.name",
+			req:       &ateapipb.GetActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Atespace: "ns1"}},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag", "name"), "")},
+		},
+		{
+			name:      "invalid tag.name",
+			req:       &ateapipb.GetActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Atespace: "ns1", Name: "TAG1"}},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("tag", "name"), "TAG1", "")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateGetActorSnapshotTagRequest(tt.req), tt.wantError)
+		})
+	}
+}
+
+func TestValidateListActorSnapshotsRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *ateapipb.ListActorSnapshotsRequest
+		wantError field.ErrorList
+	}{
+		{
+			name:      "valid",
+			req:       &ateapipb.ListActorSnapshotsRequest{Atespace: "ns1", PageSize: 10},
+			wantError: nil,
+		},
+		{
+			name:      "empty atespace lists all atespaces",
+			req:       &ateapipb.ListActorSnapshotsRequest{},
+			wantError: nil,
+		},
+		{
+			name:      "invalid atespace",
+			req:       &ateapipb.ListActorSnapshotsRequest{Atespace: "NS1"},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("atespace"), "NS1", "")},
+		},
+		{
+			name:      "zero page_size defaults server-side",
+			req:       &ateapipb.ListActorSnapshotsRequest{Atespace: "ns1", PageSize: 0},
+			wantError: nil,
+		},
+		{
+			name:      "negative page_size",
+			req:       &ateapipb.ListActorSnapshotsRequest{Atespace: "ns1", PageSize: -1},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("page_size"), int32(-1), "")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateListActorSnapshotsRequest(tt.req), tt.wantError)
+		})
+	}
+}
+
+func TestValidateCreateActorSnapshotTagRequest(t *testing.T) {
+	scopes := []string{
+		ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE.String(),
+		ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED.String(),
+	}
+
+	tests := []struct {
+		name      string
+		req       *ateapipb.CreateActorSnapshotTagRequest
+		wantError field.ErrorList
+	}{
+		{
+			name: "valid",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tag1"},
+					Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED,
+				},
+			},
+			wantError: nil,
+		},
+		{
+			name: "missing snapshot",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tag1"},
+					Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED,
+				},
+			},
+			wantError: field.ErrorList{field.Required(field.NewPath("snapshot"), "")},
+		},
+		{
+			name: "invalid snapshot.name",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "SNAPSHOT1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tag1"},
+					Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED,
+				},
+			},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("snapshot", "name"), "SNAPSHOT1", "")},
+		},
+		{
+			name:      "missing tag",
+			req:       &ateapipb.CreateActorSnapshotTagRequest{Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"}},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag"), "")},
+		},
+		{
+			name: "missing tag.metadata.atespace",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Name: "tag1"},
+					Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED,
+				},
+			},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag", "metadata", "atespace"), "")},
+		},
+		{
+			name: "invalid tag.metadata.atespace",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "NS1", Name: "tag1"},
+					Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED,
+				},
+			},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("tag", "metadata", "atespace"), "NS1", "")},
+		},
+		{
+			name: "missing tag.metadata.name",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1"},
+					Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED,
+				},
+			},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag", "metadata", "name"), "")},
+		},
+		{
+			name: "invalid tag.metadata.name",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "TAG1"},
+					Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED,
+				},
+			},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("tag", "metadata", "name"), "TAG1", "")},
+		},
+		{
+			name: "server-managed tag.metadata.uid is not a precondition at creation",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tag1", Uid: "not-a-uuid"},
+					Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_PUBLISHED,
+				},
+			},
+			wantError: nil,
+		},
+		{
+			name: "unset tag.scope",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tag1"},
+				},
+			},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag", "scope"), "")},
+		},
+		{
+			name: "tag.scope outside the enum",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Atespace: "ns1", Name: "snapshot1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tag1"},
+					Scope:    ateapipb.ActorSnapshotTagScope(7),
+				},
+			},
+			wantError: field.ErrorList{field.NotSupported(field.NewPath("tag", "scope"), "7", scopes)},
+		},
+		{
+			name: "errors from snapshot and tag are aggregated",
+			req: &ateapipb.CreateActorSnapshotTagRequest{
+				Snapshot: &ateapipb.ObjectRef{Name: "snapshot1"},
+				Tag: &ateapipb.ActorSnapshotTag{
+					Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tag1"},
+				},
+			},
+			wantError: field.ErrorList{
+				field.Required(field.NewPath("snapshot", "atespace"), ""),
+				field.Required(field.NewPath("tag", "scope"), ""),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateCreateActorSnapshotTagRequest(tt.req), tt.wantError)
+		})
+	}
+}
+
+func TestValidateDeleteActorSnapshotTagRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *ateapipb.DeleteActorSnapshotTagRequest
+		wantError field.ErrorList
+	}{
+		{
+			name:      "valid",
+			req:       &ateapipb.DeleteActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tag1"}},
+			wantError: nil,
+		},
+		{
+			name:      "missing tag",
+			req:       &ateapipb.DeleteActorSnapshotTagRequest{},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag"), "")},
+		},
+		{
+			name:      "missing tag.atespace",
+			req:       &ateapipb.DeleteActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Name: "tag1"}},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag", "atespace"), "")},
+		},
+		{
+			name:      "invalid tag.atespace",
+			req:       &ateapipb.DeleteActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Atespace: "NS1", Name: "tag1"}},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("tag", "atespace"), "NS1", "")},
+		},
+		{
+			name:      "missing tag.name",
+			req:       &ateapipb.DeleteActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Atespace: "ns1"}},
+			wantError: field.ErrorList{field.Required(field.NewPath("tag", "name"), "")},
+		},
+		{
+			name:      "invalid tag.name",
+			req:       &ateapipb.DeleteActorSnapshotTagRequest{Tag: &ateapipb.ObjectRef{Atespace: "ns1", Name: "TAG1"}},
+			wantError: field.ErrorList{field.Invalid(field.NewPath("tag", "name"), "TAG1", "")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateDeleteActorSnapshotTagRequest(tt.req), tt.wantError)
+		})
+	}
+}
+
 func TestValidateUpdateActorSnapshotTagRequest(t *testing.T) {
 	mutableFields := []string{"scope"}
 	scopes := []string{


### PR DESCRIPTION
So, the resource RPC methods are consistent

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
