### PR TITLE
e2e: cover HTTPS actor egress

### DIFF
--- a/internal/e2e/suites/networking/networking_test.go
+++ b/internal/e2e/suites/networking/networking_test.go
@@ -16,15 +16,19 @@ package networking
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/agent-substrate/substrate/internal/e2e"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const networkingAtespace = "networking-e2e"
@@ -95,23 +99,146 @@ func TestActorEgress(t *testing.T) {
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
 
-	// The egress demo fetches the URL it is given and echoes the upstream
-	// status and body back.
-	payload := []byte(`{"url":"http://example.com/"}`)
 	actorRef := resources.ActorRef{Atespace: networkingAtespace, Name: actorName}
+	status, body := fetchThroughEgressActor(t, ctx, router, actorRef, "http://example.com/")
+	if status != http.StatusOK {
+		t.Fatalf("Actor egress fetch returned HTTP %d, want 200; body: %s", status, body)
+	}
+	t.Logf("Actor egress fetch succeeded; body: %s", body)
+}
+
+// TestActorEgressHTTPS covers the same path as TestActorEgress with a TLS
+// origin, where the gateway cannot see inside the request. atenet-egress
+// authorizes the CONNECT against the Actor's actor-identity certificate and
+// then relays raw TCP: it never decrypts, so the TLS session runs end to end
+// between the Actor and the origin.
+func TestActorEgressHTTPS(t *testing.T) {
+	ctx := context.Background()
+	actorName, _ := createAndResumeActor(t, ctx, "egress-https", egressTemplate)
+	router := mustRouterClient(t, ctx)
+	defer router.Close()
+
+	// Bound the access-log scan below to lines this test could have produced.
+	// The slack absorbs clock skew between here and the gateway's node.
+	since := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+
+	actorRef := resources.ActorRef{Atespace: networkingAtespace, Name: actorName}
+	status, body := fetchThroughEgressActor(t, ctx, router, actorRef, "https://example.com/")
+	if status != http.StatusOK {
+		t.Fatalf("Actor HTTPS egress fetch returned HTTP %d, want 200; body: %s", status, body)
+	}
+	t.Logf("Actor HTTPS egress fetch succeeded; body: %s", body)
+
+	assertEgressGatewayConnect(t, ctx, since, actorName, "443")
+}
+
+// fetchThroughEgressActor asks the egress demo Actor to fetch url and returns
+// the status and body it echoes back.
+func fetchThroughEgressActor(t *testing.T, ctx context.Context, router *e2e.RouterClient, actorRef resources.ActorRef, url string) (int, []byte) {
+	t.Helper()
+	payload, err := json.Marshal(map[string]string{"url": url})
+	if err != nil {
+		t.Fatalf("marshaling the fetch request for %s: %v", url, err)
+	}
 	response, err := router.PostJSON(ctx, actorRef, "/", payload)
 	if err != nil {
-		t.Fatalf("POST to egress Actor through ingress: %v", err)
+		t.Fatalf("POST %s to egress Actor through ingress: %v", url, err)
 	}
 	defer response.Body.Close()
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Fatalf("reading egress response body (HTTP %d): %v", response.StatusCode, err)
 	}
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("Actor egress fetch returned HTTP %d, want 200; body: %s", response.StatusCode, body)
+	return response.StatusCode, body
+}
+
+// assertEgressGatewayConnect waits for the atenet-egress access log to show a
+// CONNECT to port opened by actorName.
+func assertEgressGatewayConnect(t *testing.T, ctx context.Context, since metav1.Time, actorName, port string) {
+	t.Helper()
+	want := fmt.Sprintf("a CONNECT to port %s by actor %s", port, actorName)
+	waitForAccessLog(t, ctx, since, want, func(lines []string) (bool, error) {
+		for _, line := range lines {
+			authority, ok := accessLogField(line, "authority")
+			if !ok || !strings.HasSuffix(authority, ":"+port) {
+				continue
+			}
+			if !strings.Contains(line, "/actor/"+actorName) {
+				continue
+			}
+			t.Logf("egress gateway tunneled the request: %s", line)
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// waitForAccessLog polls the atenet-egress access log, across every gateway
+// replica, until predicate accepts the lines written since.
+func waitForAccessLog(t *testing.T, ctx context.Context, since metav1.Time, want string, predicate func(lines []string) (bool, error)) {
+	t.Helper()
+	const (
+		gatewayNamespace = "ate-system"
+		gatewaySelector  = "app=atenet-egress"
+		gatewayContainer = "envoy"
+		// The access log's line prefix, from the HttpConnectionManager
+		// text_format_source in manifests/ate-install/atenet-egress.yaml.
+		accessLogPrefix = "[egress] "
+	)
+
+	clients := e2e.GetClients()
+	pods, err := clients.K8s.CoreV1().Pods(gatewayNamespace).List(ctx, metav1.ListOptions{LabelSelector: gatewaySelector})
+	if err != nil {
+		t.Fatalf("listing %s pods in %s: %v", gatewaySelector, gatewayNamespace, err)
 	}
-	t.Logf("Actor egress fetch succeeded; body: %s", body)
+	if len(pods.Items) == 0 {
+		t.Fatalf("no %s pods in %s; the egress gateway is not deployed", gatewaySelector, gatewayNamespace)
+	}
+
+	// Poll for the access log line (it may show up asynchronously from the actual traffic).
+	const timeout = 30 * time.Second
+	deadline := time.Now().Add(timeout)
+	for {
+		var lines []string
+		for _, pod := range pods.Items {
+			logs, err := clients.K8s.CoreV1().Pods(gatewayNamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+				Container: gatewayContainer,
+				SinceTime: &since,
+			}).DoRaw(ctx)
+			if err != nil {
+				t.Fatalf("reading logs of %s/%s: %v", gatewayNamespace, pod.Name, err)
+			}
+			for line := range strings.SplitSeq(string(logs), "\n") {
+				if strings.Contains(line, accessLogPrefix) {
+					lines = append(lines, line)
+				}
+			}
+		}
+
+		matched, err := predicate(lines)
+		if err != nil {
+			t.Fatalf("looking for %s in the atenet-egress access log: %v", want, err)
+		}
+		if matched {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no atenet-egress access-log line for %s after %v; lines seen:\n%s",
+				want, timeout, strings.Join(lines, "\n"))
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+// accessLogField returns the value of the key=value field named key in an Envoy
+// access log line whose fields are separated by spaces.
+func accessLogField(line, key string) (string, bool) {
+	_, rest, ok := strings.Cut(line, key+"=")
+	if !ok {
+		return "", false
+	}
+	value, _, _ := strings.Cut(rest, " ")
+	return value, true
 }
 
 func createAndResumeActor(t *testing.T, ctx context.Context, prefix string, template actorTemplate) (string, *ateapipb.Actor) {


### PR DESCRIPTION
TestActorEgress only drives plain HTTP, which leaves the TLS case untested even though it is the one where the gateway cannot see inside the request. Add TestActorEgressHTTPS, which fetches an https:// origin through the egress demo Actor and then reads the atenet-egress access log for a CONNECT to port 443 carrying that Actor's SPIFFE SAN.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
