### PR TITLE
Add update/verify for Locust Python proto stubs

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -81,9 +81,10 @@ Once installed:
 
 ### Rebuilding gRPC Python clients
 
-Make sure you have a virtual environment created (`python3 -m venv venv`)
-and activated (`source venv/bin/activate`).
+Run `./hack/update/locust-protos.sh` to regenerate the checked-in Python stubs
+under `benchmarking/locust/common/`. The generator uses a pinned venv in
+`benchmarking/locust/codegen/` so the output does not depend on whatever
+packages happen to be installed locally.
 
-Install project requirements: `pip install -r requirements.txt`
-
-Then run `generate_protos.sh` to generate the Python proto clients.
+`hack/verify-all.sh` (and therefore `make verify`) fails if those stubs have
+drifted from the `.proto` sources.

--- a/hack/update/locust-protos.sh
+++ b/hack/update/locust-protos.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+# Regenerates Locust's checked-in Python gRPC stubs from ateapi.proto and
+# glutton.proto via benchmarking/locust/generate_protos.sh.
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "${ROOT}"
+
+./benchmarking/locust/generate_protos.sh

--- a/hack/verify/locust-protos.sh
+++ b/hack/verify/locust-protos.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+# Fails if Locust's checked-in Python gRPC stubs have drifted from the .proto
+# sources. hack/verify-all.sh picks this up automatically.
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "${ROOT}"
+
+./hack/third_party/kubernetes/verify-generated.sh locust-protos "$@"


### PR DESCRIPTION
Fixes #738

Adds update and verify scripts for the Locust Python proto stubs so hack/verify-all.sh catches drift from the .proto sources. Updates the benchmarking documentation with the regeneration command.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR