### PR TITLE
Add ttl cache to jwt verification

### DIFF
--- a/cmd/ateapi/internal/actoridentity/actoridentity.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity.go
@@ -51,6 +51,7 @@ type Server struct {
 
 	clientJWTIssuer   string
 	clientJWTAudience string
+	clientJWTKeys     *k8sjwt.KeyCache
 
 	// TODO: Cache the signing keys in memory, so we don't read from a file every time.
 	actorIDJWTPoolFile string
@@ -67,10 +68,11 @@ type Server struct {
 
 var _ ateapipb.ActorIdentityServer = (*Server)(nil)
 
-func New(clientJWTIssuer, clientJWTAudience, actorIDJWTPoolFile, actorIDCAPoolFile, workerCACerts string, httpClient *http.Client, store store.Interface, workers *workercache.Cache) *Server {
+func New(clientJWTIssuer, clientJWTAudience, actorIDJWTPoolFile, actorIDCAPoolFile, workerCACerts string, httpClient *http.Client, clientJWTKeys *k8sjwt.KeyCache, store store.Interface, workers *workercache.Cache) *Server {
 	return &Server{
 		clientJWTIssuer:    clientJWTIssuer,
 		clientJWTAudience:  clientJWTAudience,
+		clientJWTKeys:      clientJWTKeys,
 		actorIDJWTPoolFile: actorIDJWTPoolFile,
 		actorIDCAPoolFile:  actorIDCAPoolFile,
 		workerCACerts:      workerCACerts,
@@ -107,7 +109,7 @@ func (s *Server) MintJWT(ctx context.Context, req *ateapipb.MintJWTRequest) (*at
 
 	clientJWT := strings.TrimPrefix(authorization[0], "Bearer ")
 
-	clientClaims, err := k8sjwt.Verify(ctx, s.httpClient, clientJWT, s.clientJWTIssuer, s.clientJWTAudience, time.Now())
+	clientClaims, err := k8sjwt.Verify(ctx, s.httpClient, s.clientJWTKeys, clientJWT, s.clientJWTIssuer, s.clientJWTAudience, time.Now())
 	if err != nil {
 		slog.ErrorContext(ctx, "Error while verifying client JWT", slog.Any("err", err))
 		return nil, status.Errorf(codes.Unauthenticated, "Unauthenticated")

--- a/cmd/ateapi/internal/actoridentity/actoridentity_test.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity_test.go
@@ -157,7 +157,7 @@ func newTestServer(t *testing.T, st store.Interface) *Server {
 			t.Fatalf("start worker cache: %v", err)
 		}
 	}
-	return New("issuer", "audience", "", poolFile, "", nil, st, workers)
+	return New("issuer", "audience", "", poolFile, "", nil, nil, st, workers)
 }
 
 // newCSR returns a DER-encoded, correctly self-signed CSR.
@@ -697,7 +697,7 @@ func TestMintCertAuthorizesBeforeSigning(t *testing.T) {
 	if err := workers.Start(cacheCtx); err != nil {
 		t.Fatal(err)
 	}
-	srv := New("issuer", "audience", "", filepath.Join(t.TempDir(), "missing.json"), "", nil, st, workers)
+	srv := New("issuer", "audience", "", filepath.Join(t.TempDir(), "missing.json"), "", nil, nil, st, workers)
 
 	actor, err := st.GetActor(ctx, resources.ActorRef{Atespace: testAtespace, Name: testActorName})
 	if err != nil {

--- a/cmd/ateapi/internal/k8sjwt/k8sjwt.go
+++ b/cmd/ateapi/internal/k8sjwt/k8sjwt.go
@@ -32,6 +32,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	utilcache "k8s.io/apimachinery/pkg/util/cache"
 )
 
 // KeyAndID wraps a crypto.PublicKey along with the key ID that will identify it during
@@ -42,6 +44,42 @@ import (
 type KeyAndID struct {
 	KeyID     string
 	PublicKey crypto.PublicKey
+}
+
+// KeyCache caches the keys Verify fetches from issuers so that repeated
+// verifications skip OIDC discovery and JWKS fetches. Entries expire after
+// ttl; in addition, a verification whose key ID is missing from the cached
+// set triggers a single refresh so key rotations are picked up promptly.
+// A nil *KeyCache disables caching.
+type KeyCache struct {
+	ttl   time.Duration
+	cache *utilcache.Expiring
+}
+
+// NewKeyCache returns a cache whose entries expire after ttl. A non-positive
+// ttl makes every lookup miss, effectively disabling the cache.
+func NewKeyCache(ttl time.Duration) *KeyCache {
+	return &KeyCache{
+		ttl:   ttl,
+		cache: utilcache.NewExpiring(),
+	}
+}
+
+// lookup returns the cached keys for issuer if they are still fresh.
+func (c *KeyCache) lookup(issuer string) ([]*KeyAndID, bool) {
+	val, ok := c.cache.Get(issuer)
+	if !ok {
+		return nil, false
+	}
+	keys, ok := val.([]*KeyAndID)
+	if !ok {
+		return nil, false
+	}
+	return keys, true
+}
+
+func (c *KeyCache) store(issuer string, keys []*KeyAndID) {
+	c.cache.Set(issuer, keys, c.ttl)
 }
 
 type parseHeader struct {
@@ -124,8 +162,10 @@ var (
 // cluster.
 //
 // httpClient is used for OIDC discovery and JWKS fetches; nil uses a default
-// client with a whole-request timeout.
-func Verify(ctx context.Context, httpClient *http.Client, jwt string, expectedIssuer, expectedAudience string, now time.Time) (*KubernetesClaims, error) {
+// client with a whole-request timeout. cache, when non-nil, serves the
+// issuer's keys from a TTL'd cache instead of fetching them on every call;
+// see KeyCache.
+func Verify(ctx context.Context, httpClient *http.Client, cache *KeyCache, jwt string, expectedIssuer, expectedAudience string, now time.Time) (*KubernetesClaims, error) {
 	segments := strings.Split(jwt, ".")
 	if len(segments) != 3 {
 		return nil, fmt.Errorf("malformed JWT")
@@ -174,8 +214,7 @@ func Verify(ctx context.Context, httpClient *http.Client, jwt string, expectedIs
 		return nil, fmt.Errorf("unexpected issuer %q", rawClaims.Issuer)
 	}
 
-	// TODO: Cache keys, and only fetch new keys if the JWT's key ID is not in the cache.
-	keys, err := discoverKeysForIssuer(ctx, httpClient, rawClaims.Issuer)
+	keys, fromCache, err := keysForIssuer(ctx, cache, httpClient, rawClaims.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("while discovering keys from issuer: %w", err)
 	}
@@ -187,6 +226,20 @@ func Verify(ctx context.Context, httpClient *http.Client, jwt string, expectedIs
 	selectedKeyIndex := slices.IndexFunc(keys, func(k *KeyAndID) bool {
 		return k.KeyID == header.KeyID
 	})
+	if selectedKeyIndex == -1 && fromCache {
+		// The issuer may have rotated its keys since the cache was populated;
+		// refresh once before declaring the key unknown.
+		refreshed, refreshErr := discoverKeysForIssuer(ctx, httpClient, rawClaims.Issuer)
+		if refreshErr != nil {
+			slog.WarnContext(ctx, "Failed to refresh keys for unknown key ID; using cached keys", slog.Any("err", refreshErr))
+		} else {
+			cache.store(rawClaims.Issuer, refreshed)
+			keys = refreshed
+			selectedKeyIndex = slices.IndexFunc(keys, func(k *KeyAndID) bool {
+				return k.KeyID == header.KeyID
+			})
+		}
+	}
 	if selectedKeyIndex == -1 {
 		return nil, fmt.Errorf("unknown key ID %q", header.KeyID)
 	}
@@ -379,6 +432,25 @@ type jwkT struct {
 	RSAE string `json:"e"`
 }
 
+// keysForIssuer returns the issuer's verification keys. When cache holds a
+// fresh entry for the issuer it is returned with fromCache true; otherwise
+// the keys are discovered over OIDC and stored in the cache (if non-nil).
+func keysForIssuer(ctx context.Context, cache *KeyCache, httpClient *http.Client, issuer string) (keys []*KeyAndID, fromCache bool, err error) {
+	if cache != nil {
+		if keys, ok := cache.lookup(issuer); ok {
+			return keys, true, nil
+		}
+	}
+	keys, err = discoverKeysForIssuer(ctx, httpClient, issuer)
+	if err != nil {
+		return nil, false, err
+	}
+	if cache != nil {
+		cache.store(issuer, keys)
+	}
+	return keys, false, nil
+}
+
 func discoverKeysForIssuer(ctx context.Context, httpClient *http.Client, issuer string) ([]*KeyAndID, error) {
 	var discoveryDocURL string
 	if strings.HasSuffix(issuer, "/") {
@@ -409,7 +481,8 @@ func discoverKeysForIssuer(ctx context.Context, httpClient *http.Client, issuer 
 			// Skip an unusable key instead of failing the whole issuer; it's safe because
 			// keys are selected by kid and the signature is still verified, so a skipped
 			// key can't be abused. Debug, not Warn: unsupported key types are a normal
-			// config and discovery runs on every Verify (no cache yet), so Warn would spam.
+			// config and discovery repeats whenever the cache misses or refreshes, so
+			// Warn would spam.
 			slog.DebugContext(ctx, "Skipping unusable JWK from issuer",
 				slog.String("kid", jwk.KeyID), slog.String("kty", jwk.KeyType), slog.Any("err", err))
 			skipped++

--- a/cmd/ateapi/internal/k8sjwt/k8sjwt_test.go
+++ b/cmd/ateapi/internal/k8sjwt/k8sjwt_test.go
@@ -30,8 +30,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	utilcache "k8s.io/apimachinery/pkg/util/cache"
+	"k8s.io/utils/clock"
 )
 
 const testAudience = "ate-api"
@@ -40,9 +44,12 @@ func b64url(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
 
 // testIssuer serves the OIDC discovery document and a JWKS built from the keys
 // registered on it, standing in for a Kubernetes API server's OIDC endpoints.
+// The hit counters let tests observe how often Verify fetches from it.
 type testIssuer struct {
-	server *httptest.Server
-	jwks   jwkSetT
+	server        *httptest.Server
+	jwks          jwkSetT
+	discoveryHits atomic.Int64
+	jwksHits      atomic.Int64
 }
 
 func newTestIssuer(t *testing.T) *testIssuer {
@@ -50,9 +57,11 @@ func newTestIssuer(t *testing.T) *testIssuer {
 	ti := &testIssuer{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		ti.discoveryHits.Add(1)
 		writeJSON(t, w, oidcConfigT{JWKSURI: ti.server.URL + "/jwks"})
 	})
 	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		ti.jwksHits.Add(1)
 		writeJSON(t, w, ti.jwks)
 	})
 	ti.server = httptest.NewServer(mux)
@@ -233,7 +242,7 @@ func TestVerifyECDSA(t *testing.T) {
 			ti.addEC(t, "ec-1", tc.crv, &key.PublicKey)
 			tok := mintJWT(t, tc.alg, "ec-1", key, validClaims(ti.issuer()))
 
-			if _, err := Verify(context.Background(), ti.server.Client(), tok, ti.issuer(), testAudience, time.Now()); err != nil {
+			if _, err := Verify(context.Background(), ti.server.Client(), nil, tok, ti.issuer(), testAudience, time.Now()); err != nil {
 				t.Fatalf("Verify(%s) = %v, want nil", tc.alg, err)
 			}
 		})
@@ -253,7 +262,7 @@ func TestVerifyRejectsECKeyForRSAlg(t *testing.T) {
 	// RS256 header pointing at the EC key; the RSA signing key is irrelevant because
 	// the key-type check fails before signature verification.
 	tok := mintJWT(t, "RS256", "ec-1", testRSAKey(t), validClaims(ti.issuer()))
-	if _, err := Verify(context.Background(), ti.server.Client(), tok, ti.issuer(), testAudience, time.Now()); err == nil {
+	if _, err := Verify(context.Background(), ti.server.Client(), nil, tok, ti.issuer(), testAudience, time.Now()); err == nil {
 		t.Fatal("Verify accepted an RS256 token whose kid names an EC key")
 	}
 }
@@ -272,7 +281,7 @@ func TestVerifyMixedJWKS(t *testing.T) {
 	ti.addEC(t, "ec-1", "P-256", &ecKey.PublicKey)
 
 	tok := mintJWT(t, "RS256", "rsa-1", rsaKey, validClaims(ti.issuer()))
-	if _, err := Verify(context.Background(), ti.server.Client(), tok, ti.issuer(), testAudience, time.Now()); err != nil {
+	if _, err := Verify(context.Background(), ti.server.Client(), nil, tok, ti.issuer(), testAudience, time.Now()); err != nil {
 		t.Fatalf("Verify with a mixed RSA+EC JWKS = %v, want nil", err)
 	}
 }
@@ -291,12 +300,12 @@ func TestVerifyUnusableJWKSKeySkipped(t *testing.T) {
 	})
 
 	good := mintJWT(t, "RS256", "rsa-1", rsaKey, validClaims(ti.issuer()))
-	if _, err := Verify(context.Background(), ti.server.Client(), good, ti.issuer(), testAudience, time.Now()); err != nil {
+	if _, err := Verify(context.Background(), ti.server.Client(), nil, good, ti.issuer(), testAudience, time.Now()); err != nil {
 		t.Fatalf("Verify with an unusable key in the JWKS = %v, want nil (bad key should be skipped)", err)
 	}
 
 	referencesSkipped := mintJWT(t, "RS256", "ec-bad", rsaKey, validClaims(ti.issuer()))
-	if _, err := Verify(context.Background(), ti.server.Client(), referencesSkipped, ti.issuer(), testAudience, time.Now()); err == nil {
+	if _, err := Verify(context.Background(), ti.server.Client(), nil, referencesSkipped, ti.issuer(), testAudience, time.Now()); err == nil {
 		t.Fatal("Verify accepted a token whose kid names a key that was skipped")
 	}
 }
@@ -360,5 +369,164 @@ func TestEllipticCurveForJWK(t *testing.T) {
 	}
 	if _, err := ellipticCurveForJWK("P-192"); err == nil {
 		t.Error("ellipticCurveForJWK(P-192) = nil, want error")
+	}
+}
+
+// fakeClock embeds clock.RealClock so it satisfies clock.Clock (which requires
+// After, NewTimer, Sleep, Tick in addition to Now/Since), while overriding
+// Now/Since to a controllable value. utilcache.Expiring only ever calls
+// Now(), so the promoted real methods are never invoked by the cache.
+type fakeClock struct {
+	clock.RealClock
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock(now time.Time) *fakeClock {
+	return &fakeClock{now: now}
+}
+
+func (f *fakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+func (f *fakeClock) Since(ts time.Time) time.Duration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now.Sub(ts)
+}
+
+func (f *fakeClock) step(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(d)
+}
+
+// newKeyCacheWithClock is the test-only constructor that injects a clock so
+// cache expiry can be driven deterministically.
+func newKeyCacheWithClock(ttl time.Duration, clk clock.Clock) *KeyCache {
+	return &KeyCache{ttl: ttl, cache: utilcache.NewExpiringWithClock(clk)}
+}
+
+func TestVerifyKeyCacheHit(t *testing.T) {
+	ti := newTestIssuer(t)
+	key := testRSAKey(t)
+	ti.addRSA("rsa-1", &key.PublicKey)
+	tok := mintJWT(t, "RS256", "rsa-1", key, validClaims(ti.issuer()))
+	cache := NewKeyCache(time.Hour)
+	now := time.Now()
+
+	for i := 0; i < 3; i++ {
+		if _, err := Verify(context.Background(), ti.server.Client(), cache, tok, ti.issuer(), testAudience, now); err != nil {
+			t.Fatalf("Verify #%d = %v, want nil", i, err)
+		}
+	}
+	if got := ti.discoveryHits.Load(); got != 1 {
+		t.Errorf("discovery hits = %d, want 1", got)
+	}
+	if got := ti.jwksHits.Load(); got != 1 {
+		t.Errorf("jwks hits = %d, want 1", got)
+	}
+}
+
+func TestVerifyKeyCacheExpiry(t *testing.T) {
+	ti := newTestIssuer(t)
+	key := testRSAKey(t)
+	ti.addRSA("rsa-1", &key.PublicKey)
+	tok := mintJWT(t, "RS256", "rsa-1", key, validClaims(ti.issuer()))
+	fc := newFakeClock(time.Now())
+	cache := newKeyCacheWithClock(time.Minute, fc)
+	now := time.Now()
+
+	if _, err := Verify(context.Background(), ti.server.Client(), cache, tok, ti.issuer(), testAudience, now); err != nil {
+		t.Fatalf("Verify = %v, want nil", err)
+	}
+	// Advance the cache's clock past its 1-minute TTL so the entry expires;
+	// the JWT itself is valid for an hour, so stepping a couple minutes is fine.
+	fc.step(2 * time.Minute)
+	if _, err := Verify(context.Background(), ti.server.Client(), cache, tok, ti.issuer(), testAudience, now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("Verify after cache expiry = %v, want nil", err)
+	}
+	if got := ti.discoveryHits.Load(); got != 2 {
+		t.Errorf("discovery hits = %d, want 2", got)
+	}
+	if got := ti.jwksHits.Load(); got != 2 {
+		t.Errorf("jwks hits = %d, want 2", got)
+	}
+}
+
+func TestVerifyKeyCacheRefreshesOnUnknownKeyID(t *testing.T) {
+	ti := newTestIssuer(t)
+	key := testRSAKey(t)
+	ti.addRSA("k1", &key.PublicKey)
+	cache := NewKeyCache(time.Hour)
+	now := time.Now()
+
+	tok1 := mintJWT(t, "RS256", "k1", key, validClaims(ti.issuer()))
+	if _, err := Verify(context.Background(), ti.server.Client(), cache, tok1, ti.issuer(), testAudience, now); err != nil {
+		t.Fatalf("Verify(k1) = %v, want nil", err)
+	}
+
+	// Simulate a rotation: the issuer publishes a new key after the cache
+	// was populated. The unknown kid must trigger a refresh, not a rejection.
+	ti.addRSA("k2", &key.PublicKey)
+	tok2 := mintJWT(t, "RS256", "k2", key, validClaims(ti.issuer()))
+	if _, err := Verify(context.Background(), ti.server.Client(), cache, tok2, ti.issuer(), testAudience, now); err != nil {
+		t.Fatalf("Verify after key rotation = %v, want nil", err)
+	}
+	if got := ti.jwksHits.Load(); got != 2 {
+		t.Errorf("jwks hits = %d, want 2 (one refresh on unknown kid)", got)
+	}
+
+	// The refreshed set is cached again: no further fetches.
+	if _, err := Verify(context.Background(), ti.server.Client(), cache, tok2, ti.issuer(), testAudience, now); err != nil {
+		t.Fatalf("Verify(tok2) after refresh = %v, want nil", err)
+	}
+	if got := ti.discoveryHits.Load(); got != 2 {
+		t.Errorf("discovery hits = %d, want 2", got)
+	}
+	if got := ti.jwksHits.Load(); got != 2 {
+		t.Errorf("jwks hits = %d, want 2", got)
+	}
+}
+
+func TestVerifyNilCacheFetchesEveryTime(t *testing.T) {
+	ti := newTestIssuer(t)
+	key := testRSAKey(t)
+	ti.addRSA("rsa-1", &key.PublicKey)
+	tok := mintJWT(t, "RS256", "rsa-1", key, validClaims(ti.issuer()))
+
+	for i := 0; i < 2; i++ {
+		if _, err := Verify(context.Background(), ti.server.Client(), nil, tok, ti.issuer(), testAudience, time.Now()); err != nil {
+			t.Fatalf("Verify #%d = %v, want nil", i, err)
+		}
+	}
+	if got := ti.discoveryHits.Load(); got != 2 {
+		t.Errorf("discovery hits = %d, want 2", got)
+	}
+	if got := ti.jwksHits.Load(); got != 2 {
+		t.Errorf("jwks hits = %d, want 2", got)
+	}
+}
+
+func TestVerifyKeyCacheNonPositiveTTLDisables(t *testing.T) {
+	ti := newTestIssuer(t)
+	key := testRSAKey(t)
+	ti.addRSA("rsa-1", &key.PublicKey)
+	tok := mintJWT(t, "RS256", "rsa-1", key, validClaims(ti.issuer()))
+	cache := NewKeyCache(0) // non-positive TTL: every lookup misses
+
+	for i := 0; i < 2; i++ {
+		if _, err := Verify(context.Background(), ti.server.Client(), cache, tok, ti.issuer(), testAudience, time.Now()); err != nil {
+			t.Fatalf("Verify #%d = %v, want nil", i, err)
+		}
+	}
+	if got := ti.discoveryHits.Load(); got != 2 {
+		t.Errorf("discovery hits = %d, want 2", got)
+	}
+	if got := ti.jwksHits.Load(); got != 2 {
+		t.Errorf("jwks hits = %d, want 2", got)
 	}
 }

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -87,6 +87,8 @@ var (
 	showVersion     = pflag.Bool("version", false, "Print version and exit.")
 	logLevelFlag    = pflag.String("log-level", "info", "Minimum log level: debug, info, warn, or error.")
 	clientJWTCAFile = pflag.String("client-jwt-ca-cert", ateapiauth.DefaultServiceAccountCAFile, "CA cert file used to verify TLS when fetching the OIDC discovery document and JWKS for JWT authentication. Defaults to the in-cluster service account CA.")
+
+	clientJWTKeyCacheTTL = pflag.Duration("client-jwt-key-cache-ttl", 10*time.Minute, "How long the issuer's JWKS keys remain cached for client JWT verification before being re-fetched. Tokens carrying an unknown key ID trigger an immediate refresh. Non-positive values disable the cache.")
 )
 
 func main() {
@@ -190,8 +192,9 @@ func main() {
 	sm := controlapi.NewService(redisPersistence, workerCache, actorTemplateLister, workerPoolLister, sandboxConfigLister, csiDriverConfigLister, storageClassLister, ateletDialer, instruments, *egressGatewayAddress, volPlugins)
 
 	jwtIssuerDiscoveryClient := buildK8sServiceAccountIssuerDiscoveryClient(ctx, *clientJWTCAFile, *clientJWTIssuer)
+	jwtKeyCache := k8sjwt.NewKeyCache(*clientJWTKeyCacheTTL)
 
-	actorIdentitySrv := actoridentity.New(*clientJWTIssuer, *clientJWTAudience, *actorIDJWTPoolFile, *actorIDCAPoolFile, *podIdentityCACerts, jwtIssuerDiscoveryClient, redisPersistence, workerCache)
+	actorIdentitySrv := actoridentity.New(*clientJWTIssuer, *clientJWTAudience, *actorIDJWTPoolFile, *actorIDCAPoolFile, *podIdentityCACerts, jwtIssuerDiscoveryClient, jwtKeyCache, redisPersistence, workerCache)
 	debugSrv := debugapi.NewService(redisPersistence)
 
 	lisCfg := &net.ListenConfig{}
@@ -202,7 +205,7 @@ func main() {
 
 	authCfg := ateapiauth.ServerConfig{
 		VerifyBearerToken: func(ctx context.Context, bearer string) (string, error) {
-			claims, err := k8sjwt.Verify(ctx, jwtIssuerDiscoveryClient, bearer, *clientJWTIssuer, *clientJWTAudience, time.Now())
+			claims, err := k8sjwt.Verify(ctx, jwtIssuerDiscoveryClient, jwtKeyCache, bearer, *clientJWTIssuer, *clientJWTAudience, time.Now())
 			if err != nil {
 				return "", err
 			}
@@ -317,6 +320,7 @@ func logFlagValues(ctx context.Context) {
 		slog.String("atelet-client-cred-bundle", *ateletClientCredBundle),
 		slog.Duration("drain-delay", *drainDelay),
 		slog.Duration("drain-timeout", *drainTimeout),
+		slog.Duration("client-jwt-key-cache-ttl", *clientJWTKeyCacheTTL),
 	)
 }
 


### PR DESCRIPTION
This PR implements the TODO that was in Verify:
    ``` // TODO: Cache keys, and only fetch new keys if the JWT's key ID is not in the cache.```


Summary
   - Problem: Every client JWT verification in ateapi issued two HTTP requests to the Kubernetes API server — one for OIDC discovery and one for JWKS — even though the signing keys rarely change. This added
   unnecessary latency and network traffic on every gRPC request.
   - Solution: Added a TTL-based key cache backed by k8s.io/apimachinery/pkg/util/cache.Expiring (already vendored). Repeated verifications within the TTL window skip both fetches entirely.
   - Key rotation: When a JWT carries a kid not found in the cached key set, the cache is refreshed once before rejecting — so key rotations are picked up promptly without waiting for TTL expiry.
   - Configuration: New --client-jwt-key-cache-ttl flag (default 10 min; non-positive value disables caching).

   Changes

   - k8sjwt.go: New KeyCache wrapping utilcache.Expiring; Verify() gains a cache *KeyCache parameter (nil disables caching); new keysForIssuer() handles cache lookup/store and returns a fromCache flag; unknown-kid
   refresh path re-fetches and updates the cache.
   - actoridentity.go: Server holds clientJWTKeys; New() accepts the cache; MintJWT passes it to Verify.
   - main.go: New --client-jwt-key-cache-ttl flag; cache instance created at startup and wired into both actoridentity.New() and the gRPC bearer-token auth interceptor; flag value logged in logFlagValues.
   - k8sjwt_test.go: 5 new tests — cache hit, TTL expiry (via injected fake clock), key-rotation refresh, nil cache fetches every time, non-positive TTL disables caching. testIssuer gains atomic.Int64 hit counters
   for discovery and JWKS endpoints.

   Design notes

   - utilcache.Expiring was chosen over a hand-rolled map+mutex to reduce custom code and gain automatic expired-entry GC (the alternative would leak stale entries). Both k8s.io/apimachinery/pkg/util/cache and
   k8s.io/utils/clock are already vendored — no new dependencies.
   - The now time.Time parameter in Verify is retained for JWT time-binding checks (exp/nbf/iat) but no longer drives cache freshness — Expiring manages its own clock. Tests inject a fakeClock (embedding
   clock.RealClock) to drive expiry deterministically.