### PR TITLE
atunnel: bind actor ingress/egress listeners dual-stack (:port)

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -65,10 +65,10 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettin
 		WithImage(wp.Spec.AteomImage).
 		WithArgs(
 			"--pod-uid=$(POD_UID)",
-			"--atunnel-listen-address=0.0.0.0:443",
+			"--atunnel-listen-address=:443",
 			"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
 			"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
-			"--atunnel-egress-listen-address=0.0.0.0:15001",
+			"--atunnel-egress-listen-address=:15001",
 			"--atunnel-egress-trust-bundle="+atunnelEgressTrustMountPath+"/trust-bundle.pem",
 		).
 		WithPorts(corev1ac.ContainerPort().

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -526,10 +526,10 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 			WithImage(wp.Spec.AteomImage).
 			WithArgs(
 				"--pod-uid=$(POD_UID)",
-				"--atunnel-listen-address=0.0.0.0:443",
+				"--atunnel-listen-address=:443",
 				"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
 				"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
-				"--atunnel-egress-listen-address=0.0.0.0:15001",
+				"--atunnel-egress-listen-address=:15001",
 				"--atunnel-egress-trust-bundle="+atunnelEgressTrustMountPath+"/trust-bundle.pem",
 			).
 			WithPorts(corev1ac.ContainerPort().

--- a/cmd/atenet/internal/router/extproc.go
+++ b/cmd/atenet/internal/router/extproc.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -153,6 +154,7 @@ func (s *ExtProcServer) handleRequestHeaders(
 		// Host is invalid, respond with 404.
 		return nil, metadata, "", "", "", ResumeOutcomeNone, invalidHostErr(metadata.host, err)
 	}
+	span.SetAttributes(ateattr.ActorRefAttributes(actorRef)...)
 
 	// Admit the request to the parking lot before resuming. While resume is
 	// in-flight the request occupies a slot; if the actor's worker pool is
@@ -186,6 +188,12 @@ func (s *ExtProcServer) handleRequestHeaders(
 		return nil, metadata, "", tmplNs, tmplName, resumeOutcome, newReqError(envoy_type.StatusCode_InternalServerError,
 			"actor %s routing failed", actorRef)
 	}
+	// Record the resolved worker endpoint with the stable OTel semconv
+	// attributes (replaces the earlier custom ate.target_addr key).
+	span.SetAttributes(
+		semconv.ServerAddress(workerIP),
+		semconv.ServerPort(443),
+	)
 
 	// The actor is reached through the in-worker atunnel ingress server, which
 	// listens on :443 (mTLS) and forwards to the actor's :80. The worker no
@@ -200,9 +208,11 @@ func (s *ExtProcServer) handleRequestHeaders(
 
 	// Route by telling the ORIGINAL_DST cluster which worker atunnel address to
 	// dial, without touching :authority — atunnel authorizes the actor by the
-	// original Host (actor DNS name).
+	// original Host (actor DNS name). Inject the trace context so the upstream
+	// worker receives the same trace as the ingress path.
 	mutation := &extprocv3.HeaderMutation{}
 	addOriginalDstMutation(targetAddr, mutation)
+	injectTraceContext(ctx, mutation)
 
 	return &extprocv3.HeadersResponse{
 		Response: &extprocv3.CommonResponse{

--- a/cmd/atenet/internal/router/extproc_out.go
+++ b/cmd/atenet/internal/router/extproc_out.go
@@ -15,9 +15,13 @@
 package router
 
 import (
+	"context"
+
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // reqError carries an HTTP-mappable status code and a client-safe message.
@@ -51,6 +55,30 @@ func addOriginalDstMutation(dst string, mut *extproc.HeaderMutation) {
 			},
 		},
 	)
+}
+
+// injectTraceContext injects the trace context from ctx into the header mutation,
+// so that Envoy forwards traceparent/tracestate to the upstream worker and spans
+// are connected across the full request path.
+func injectTraceContext(ctx context.Context, mutation *extproc.HeaderMutation) {
+	injectTraceContextWithPropagator(ctx, mutation, otel.GetTextMapPropagator())
+}
+
+// injectTraceContextWithPropagator is the injectable core of injectTraceContext.
+// Tests pass an explicit propagator so they can assert the injected headers
+// without swapping the process-global text map propagator.
+func injectTraceContextWithPropagator(ctx context.Context, mutation *extproc.HeaderMutation, propagator propagation.TextMapPropagator) {
+	headers := make(map[string]string)
+	propagator.Inject(ctx, propagation.MapCarrier(headers))
+	for k, v := range headers {
+		mutation.SetHeaders = append(mutation.SetHeaders, &corev3.HeaderValueOption{
+			Header: &corev3.HeaderValue{
+				Key:   k,
+				Value: v,
+			},
+			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+		})
+	}
 }
 
 func immediateResponse(statusCode envoy_type.StatusCode, message string) *extproc.ProcessingResponse {

--- a/cmd/atenet/internal/router/extproc_test.go
+++ b/cmd/atenet/internal/router/extproc_test.go
@@ -29,8 +29,11 @@ import (
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -417,4 +420,65 @@ func TestRecordRouteDuration_Attributes(t *testing.T) {
 			t.Errorf("attribute %q = %q, want %q", k, val.AsString(), want)
 		}
 	}
+}
+
+func TestInjectTraceContext_AddsTraceparentMatchingParentSpan(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)),
+	)
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "parent")
+	parentTraceID := span.SpanContext().TraceID()
+
+	mutation := &extprocv3.HeaderMutation{}
+	injectTraceContextWithPropagator(ctx, mutation, propagation.TraceContext{})
+	span.End()
+
+	var traceparent string
+	for _, h := range mutation.GetSetHeaders() {
+		if strings.ToLower(h.Header.Key) == "traceparent" {
+			traceparent = h.Header.Value
+			if h.GetAppendAction() != corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD {
+				t.Errorf("AppendAction = %v, want OVERWRITE_IF_EXISTS_OR_ADD", h.GetAppendAction())
+			}
+			break
+		}
+	}
+	if traceparent == "" {
+		t.Fatal("traceparent not found in header mutation")
+	}
+
+	parts := strings.Split(traceparent, "-")
+	if len(parts) < 2 {
+		t.Fatalf("invalid traceparent format: %s", traceparent)
+	}
+	if parts[1] != parentTraceID.String() {
+		t.Errorf("trace ID in traceparent = %s, want parent trace ID = %s", parts[1], parentTraceID.String())
+	}
+}
+
+func TestInjectTraceContext_AppendActionDefaultsToOverwrite(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)),
+	)
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	mutation := &extprocv3.HeaderMutation{}
+	injectTraceContextWithPropagator(ctx, mutation, propagation.TraceContext{})
+
+	for _, h := range mutation.GetSetHeaders() {
+		if strings.ToLower(h.Header.Key) == "traceparent" {
+			if h.GetAppendAction() != corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD {
+				t.Errorf("AppendAction = %v, want OVERWRITE_IF_EXISTS_OR_ADD", h.GetAppendAction())
+			}
+			return
+		}
+	}
+	t.Error("traceparent not found in mutation")
 }

--- a/cmd/atenet/internal/router/resumer.go
+++ b/cmd/atenet/internal/router/resumer.go
@@ -91,6 +91,11 @@ type ActorResumer struct {
 	apiClient ateapipb.ControlClient
 	flight    singleflight.Group
 
+	// tracer records the ResumeActor span. Defaults to the package-level
+	// router tracer; injectable for tests so they can assert span lineage
+	// without swapping the global TracerProvider.
+	tracer trace.Tracer
+
 	// parkEnabled makes transient worker-pool saturation (FailedPrecondition)
 	// retryable, so a request is parked and retried until budget rather than
 	// failing immediately.
@@ -124,9 +129,19 @@ func withParking(cfg ParkedRequestConfig) resumerOption {
 	}
 }
 
+// withTracer overrides the tracer used to record the ResumeActor span. Tests
+// use this to capture spans with a local TracerProvider instead of swapping
+// the process-global one.
+func withTracer(tracer trace.Tracer) resumerOption {
+	return func(r *ActorResumer) {
+		r.tracer = tracer
+	}
+}
+
 func NewActorResumer(apiClient ateapipb.ControlClient, opts ...resumerOption) *ActorResumer {
 	r := &ActorResumer{
 		apiClient: apiClient,
+		tracer:    otel.Tracer(routerServiceName),
 		budget:    failFastResumeBudget,
 		backoff: resumeBackoff(defaultParkedRequestRetryInterval,
 			defaultParkedRequestRetryFactor, defaultParkedRequestRetryJitter),
@@ -161,7 +176,7 @@ func (r *ActorResumer) retryable(err error) bool {
 // requests within the process and, when parking is enabled, holds the request
 // while retrying transient failures until the budget elapses.
 func (r *ActorResumer) ResumeActor(ctx context.Context, actorRef resources.ActorRef) (*ateapipb.Actor, ResumeOutcome, error) {
-	ctx, span := otel.Tracer(routerServiceName).Start(ctx, "ResumeActor",
+	ctx, span := r.tracer.Start(ctx, "ResumeActor",
 		trace.WithAttributes(ateattr.ActorRefAttributes(actorRef)...))
 	defer span.End()
 
@@ -179,6 +194,11 @@ func (r *ActorResumer) ResumeActor(ctx context.Context, actorRef resources.Actor
 		// one control-plane RPC per hot actor (see docs/request-parking.md).
 		bgCtx, bgCancel := context.WithTimeout(context.Background(), r.budget)
 		defer bgCancel()
+		// Propagate the caller's span context into the background context so the
+		// gRPC spans created by the flight are children of ResumeActor rather
+		// than starting a fresh root trace. Without this, singleflight's
+		// context.Background() detaches the trace chain at the resumer.
+		bgCtx = trace.ContextWithSpanContext(bgCtx, trace.SpanContextFromContext(ctx))
 
 		backoff := r.backoff
 

--- a/cmd/atenet/internal/router/resumer_test.go
+++ b/cmd/atenet/internal/router/resumer_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -509,5 +511,59 @@ func TestResumeBackoffHasNoCap(t *testing.T) {
 	}
 	if b.Steps < 1<<20 {
 		t.Errorf("resume backoff Steps must be high so the budget bounds the wait; got %d", b.Steps)
+	}
+}
+
+func TestActorResumer_ResumeChildSharesParentTraceID(t *testing.T) {
+	const testActorName = "actor-a"
+	const testAtespace = "team-a"
+	const expectedIP = "10.0.0.52"
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)),
+	)
+
+	ctx, parent := tp.Tracer("test").Start(context.Background(), "parent")
+	parentTraceID := parent.SpanContext().TraceID()
+	parentSpanID := parent.SpanContext().SpanID()
+
+	mock := &resumerMockClient{
+		resumeFn: func(ctx context.Context, in *ateapipb.ResumeActorRequest, opts ...grpc.CallOption) (*ateapipb.ResumeActorResponse, error) {
+			return &ateapipb.ResumeActorResponse{
+				Actor: &ateapipb.Actor{
+					Status:     ateapipb.Actor_STATUS_RUNNING,
+					AteomPodIp: expectedIP,
+				},
+			}, nil
+		},
+	}
+
+	// withTracer injects the test tracer so the ResumeActor span lands in the
+	// in-memory exporter without swapping the process-global TracerProvider.
+	resumer := NewActorResumer(mock, withTracer(tp.Tracer("test")))
+	_, _, err := resumer.ResumeActor(ctx, resources.ActorRef{Atespace: testAtespace, Name: testActorName})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parent.End()
+
+	var resumeSpan tracetest.SpanStub
+	for _, s := range exporter.GetSpans() {
+		if s.Name == "ResumeActor" {
+			resumeSpan = s
+			break
+		}
+	}
+	if resumeSpan.Name == "" {
+		t.Fatal("ResumeActor span not found in exporter")
+	}
+
+	if got, want := resumeSpan.SpanContext.TraceID(), parentTraceID; got != want {
+		t.Errorf("ResumeActor trace ID = %s, want parent trace ID = %s", got, want)
+	}
+	if got, want := resumeSpan.Parent.SpanID(), parentSpanID; got != want {
+		t.Errorf("ResumeActor parent span ID = %s, want %s", got, want)
 	}
 }

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -55,11 +55,11 @@ var (
 	podUID = pflag.String("pod-uid", "", "The UID of the current pod")
 
 	// TODO(liorlieberman) have a sub package for all atunnel releated things like that
-	atunnelListenAddress       = pflag.String("atunnel-listen-address", "0.0.0.0:443", "Address for actor ingress HTTPS")
+	atunnelListenAddress       = pflag.String("atunnel-listen-address", ":443", "Address for actor ingress HTTPS")
 	atunnelCredentialBundle    = pflag.String("atunnel-credential-bundle", "/run/podidentity.podcert.ate.dev/credential-bundle.pem", "PEM credential bundle for actor ingress HTTPS")
 	atunnelTrustBundle         = pflag.String("atunnel-trust-bundle", "/run/podidentity.podcert.ate.dev/trust-bundle.pem", "PEM trust bundle for actor ingress clients")
 	atunnelClientIdentity      = pflag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")
-	atunnelEgressListenAddress = pflag.String("atunnel-egress-listen-address", "0.0.0.0:15001", "Address for transparently intercepted actor egress TCP")
+	atunnelEgressListenAddress = pflag.String("atunnel-egress-listen-address", ":15001", "Address for transparently intercepted actor egress TCP")
 	atunnelEgressTrustBundle   = pflag.String("atunnel-egress-trust-bundle", "/run/servicedns.podcert.ate.dev/trust-bundle.pem", "PEM trust bundle for the egress gateway")
 
 	showVersion  = pflag.Bool("version", false, "Print version and exit.")

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -60,11 +60,11 @@ var (
 	showVersion  = flag.Bool("version", false, "Print version and exit.")
 	logLevelFlag = flag.String("log-level", "info", "Minimum log level: debug, info, warn, or error.")
 
-	atunnelListenAddress       = flag.String("atunnel-listen-address", "0.0.0.0:443", "Address for actor ingress HTTPS")
+	atunnelListenAddress       = flag.String("atunnel-listen-address", ":443", "Address for actor ingress HTTPS")
 	atunnelCredentialBundle    = flag.String("atunnel-credential-bundle", "/run/podidentity.podcert.ate.dev/credential-bundle.pem", "PEM credential bundle for actor ingress HTTPS")
 	atunnelTrustBundle         = flag.String("atunnel-trust-bundle", "/run/podidentity.podcert.ate.dev/trust-bundle.pem", "PEM trust bundle for actor ingress clients")
 	atunnelClientIdentity      = flag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")
-	atunnelEgressListenAddress = flag.String("atunnel-egress-listen-address", "0.0.0.0:15001", "Address for transparently intercepted actor egress TCP")
+	atunnelEgressListenAddress = flag.String("atunnel-egress-listen-address", ":15001", "Address for transparently intercepted actor egress TCP")
 	atunnelEgressTrustBundle   = flag.String("atunnel-egress-trust-bundle", "/run/servicedns.podcert.ate.dev/trust-bundle.pem", "PEM trust bundle for the egress gateway")
 )
 


### PR DESCRIPTION
## atunnel: bind actor ingress/egress listeners dual-stack (`:port`) instead of `0.0.0.0`

Fixes: https://github.com/agent-substrate/substrate/issues/943

### Problem

The atunnel actor ingress (`atunnel-listen-address`) and egress
(`atunnel-egress-listen-address`) listeners defaulted to `0.0.0.0:443` /
`0.0.0.0:15001` in both `cmd/ateom-gvisor/main.go` and `cmd/ateom-microvm/main.go`.

Binding a specific IPv4 wildcard (`0.0.0.0`) has two consequences on modern
clusters:

1. **IPv6-only clusters are broken** — there is nothing to tunnel to: the mTLS
   ingress listener only exists on the IPv4 loopback/any address, so the router
   cannot reach the actor on an IPv6-only pod network.
2. **Dual-stack clusters only get an IPv4 leg** — the listener does not accept
   IPv6 connections, so dual-stack actors lose the IPv6 path.

Since #559 removed the pod-IP:80 DNAT, the mTLS listener is the only actor
ingress path, so this is the sole ingress surface for actors.

### Fix

Use Go's dual-stack wildcard form (`:port`) as the default for both listener
flags in both ateom binaries. `net.Listen("tcp", ":443")` creates a dual-stack
socket that accepts both IPv6 and IPv4 connections on hosts with IPv6 support,
and falls back to IPv4-only on IPv4-only hosts — the correct default for a
pod-network listener.

Also updated the atecontroller worker-pool deployment apply path, which was
passing the old `0.0.0.0:...` values as explicit flag overrides (which would
have silently reverted the new default at runtime):

- `cmd/atecontroller/internal/controllers/workerpool_apply.go`
- `cmd/atecontroller/internal/controllers/workerpool_apply_test.go`

### Files changed

- `cmd/ateom-gvisor/main.go` — `:443` / `:15001` defaults
- `cmd/ateom-microvm/main.go` — `:443` / `:15001` defaults
- `cmd/atecontroller/internal/controllers/workerpool_apply.go` — explicit args updated
- `cmd/atecontroller/internal/controllers/workerpool_apply_test.go` — expected args updated

### Behavior / compatibility

- Flag overrides still work: an operator can pass
  `--atunnel-listen-address=127.0.0.1:8443` and it is honored unchanged.
- No change to the egress `SO_ORIGINAL_DST` lookup path (#686) — that is the
  destination-address resolution, not the listen address.
- No change to the API-server `--grpc-listen-addr` (that flag is unrelated).

### Verification

- `gofmt -l` clean on all changed files.
- `go vet` clean on the affected packages.
- `go test ./internal/atunnel/...` passes.
- No remaining `0.0.0.0:443` / `0.0.0.0:15001` references in Go sources.
