### PR TITLE
atunnel: bind actor ingress/egress listeners dual-stack (:port)

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -77,10 +77,10 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettin
 		WithImage(wp.Spec.AteomImage).
 		WithArgs(
 			"--pod-uid=$(POD_UID)",
-			"--atunnel-listen-address=0.0.0.0:443",
+			"--atunnel-listen-address=:443",
 			"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
 			"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
-			"--atunnel-egress-listen-address=0.0.0.0:15001",
+			"--atunnel-egress-listen-address=:15001",
 			"--atunnel-egress-trust-bundle="+atunnelEgressTrustMountPath+"/trust-bundle.pem",
 		).
 		WithPorts(corev1ac.ContainerPort().

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -734,10 +734,10 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 			WithImage(wp.Spec.AteomImage).
 			WithArgs(
 				"--pod-uid=$(POD_UID)",
-				"--atunnel-listen-address=0.0.0.0:443",
+				"--atunnel-listen-address=:443",
 				"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
 				"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
-				"--atunnel-egress-listen-address=0.0.0.0:15001",
+				"--atunnel-egress-listen-address=:15001",
 				"--atunnel-egress-trust-bundle="+atunnelEgressTrustMountPath+"/trust-bundle.pem",
 			).
 			WithPorts(corev1ac.ContainerPort().

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -65,11 +65,11 @@ var (
 	podUID = pflag.String("pod-uid", "", "The UID of the current pod")
 
 	// TODO(liorlieberman) have a sub package for all atunnel releated things like that
-	atunnelListenAddress       = pflag.String("atunnel-listen-address", "0.0.0.0:443", "Address for actor ingress HTTPS")
+	atunnelListenAddress       = pflag.String("atunnel-listen-address", ":443", "Address for actor ingress HTTPS")
 	workerCredentialBundle     = pflag.String("atunnel-credential-bundle", "/run/podidentity.podcert.ate.dev/credential-bundle.pem", "Worker Pod credential bundle used by atunnel for inbound serving and outbound mTLS")
 	podIdentityTrustBundle     = pflag.String("atunnel-trust-bundle", "/run/podidentity.podcert.ate.dev/trust-bundle.pem", "Pod identity trust bundle used for router clients and the node-local atelet")
 	atunnelClientIdentity      = pflag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")
-	atunnelEgressListenAddress = pflag.String("atunnel-egress-listen-address", "0.0.0.0:15001", "Address for transparently intercepted actor egress TCP")
+	atunnelEgressListenAddress = pflag.String("atunnel-egress-listen-address", ":15001", "Address for transparently intercepted actor egress TCP")
 	egressGatewayTrustBundle   = pflag.String("atunnel-egress-trust-bundle", "/run/servicedns.podcert.ate.dev/trust-bundle.pem", "Service DNS trust bundle for the remote egress gateway")
 
 	showVersion  = pflag.Bool("version", false, "Print version and exit.")

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -67,11 +67,11 @@ var (
 	otlpRelaySocket = flag.String("otlp-relay-socket", ateompath.AteletOTLPSocketPath(),
 		"Unix socket of atelet's OTLP relay to export telemetry through, keeping it off the pod network. Empty, or absent at startup, exports directly to OTEL_EXPORTER_OTLP_ENDPOINT instead.")
 
-	atunnelListenAddress       = flag.String("atunnel-listen-address", "0.0.0.0:443", "Address for actor ingress HTTPS")
+	atunnelListenAddress       = flag.String("atunnel-listen-address", ":443", "Address for actor ingress HTTPS")
 	workerCredentialBundle     = flag.String("atunnel-credential-bundle", "/run/podidentity.podcert.ate.dev/credential-bundle.pem", "Worker Pod credential bundle used by atunnel for inbound serving and outbound mTLS")
 	podIdentityTrustBundle     = flag.String("atunnel-trust-bundle", "/run/podidentity.podcert.ate.dev/trust-bundle.pem", "Pod identity trust bundle used for router clients and the node-local atelet")
 	atunnelClientIdentity      = flag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")
-	atunnelEgressListenAddress = flag.String("atunnel-egress-listen-address", "0.0.0.0:15001", "Address for transparently intercepted actor egress TCP")
+	atunnelEgressListenAddress = flag.String("atunnel-egress-listen-address", ":15001", "Address for transparently intercepted actor egress TCP")
 	egressGatewayTrustBundle   = flag.String("atunnel-egress-trust-bundle", "/run/servicedns.podcert.ate.dev/trust-bundle.pem", "Service DNS trust bundle for the remote egress gateway")
 )
 


### PR DESCRIPTION
## atunnel: bind actor ingress/egress listeners dual-stack (`:port`) instead of `0.0.0.0`

Fixes: https://github.com/agent-substrate/substrate/issues/943

### Problem

The atunnel actor ingress (`atunnel-listen-address`) and egress
(`atunnel-egress-listen-address`) listeners defaulted to `0.0.0.0:443` /
`0.0.0.0:15001` in both `cmd/ateom-gvisor/main.go` and `cmd/ateom-microvm/main.go`.

Binding a specific IPv4 wildcard (`0.0.0.0`) has two consequences on modern
clusters:

1. **IPv6-only clusters are broken** — there is nothing to tunnel to: the mTLS
   ingress listener only exists on the IPv4 loopback/any address, so the router
   cannot reach the actor on an IPv6-only pod network.
2. **Dual-stack clusters only get an IPv4 leg** — the listener does not accept
   IPv6 connections, so dual-stack actors lose the IPv6 path.

Since #559 removed the pod-IP:80 DNAT, the mTLS listener is the only actor
ingress path, so this is the sole ingress surface for actors.

### Fix

Use Go's dual-stack wildcard form (`:port`) as the default for both listener
flags in both ateom binaries. `net.Listen("tcp", ":443")` creates a dual-stack
socket that accepts both IPv6 and IPv4 connections on hosts with IPv6 support,
and falls back to IPv4-only on IPv4-only hosts — the correct default for a
pod-network listener.

Also updated the atecontroller worker-pool deployment apply path, which was
passing the old `0.0.0.0:...` values as explicit flag overrides (which would
have silently reverted the new default at runtime):

- `cmd/atecontroller/internal/controllers/workerpool_apply.go`
- `cmd/atecontroller/internal/controllers/workerpool_apply_test.go`

### Files changed

- `cmd/ateom-gvisor/main.go` — `:443` / `:15001` defaults
- `cmd/ateom-microvm/main.go` — `:443` / `:15001` defaults
- `cmd/atecontroller/internal/controllers/workerpool_apply.go` — explicit args updated
- `cmd/atecontroller/internal/controllers/workerpool_apply_test.go` — expected args updated

### Behavior / compatibility

- Flag overrides still work: an operator can pass
  `--atunnel-listen-address=127.0.0.1:8443` and it is honored unchanged.
- No change to the egress `SO_ORIGINAL_DST` lookup path (#686) — that is the
  destination-address resolution, not the listen address.
- No change to the API-server `--grpc-listen-addr` (that flag is unrelated).

### Verification

- `gofmt -l` clean on all changed files.
- `go vet` clean on the affected packages.
- `go test ./internal/atunnel/...` passes.
- No remaining `0.0.0.0:443` / `0.0.0.0:15001` references in Go sources.
