### PR TITLE
ateomnet: enable IPv6 forwarding in worker pod netns

### DIFF
--- a/internal/ateomnet/net.go
+++ b/internal/ateomnet/net.go
@@ -192,31 +192,44 @@ func PodIPv4() (net.IP, error) {
 	return nil, fmt.Errorf("pod eth0 has no IPv4 address")
 }
 
-// EnableIPv4Forwarding enables IPv4 forwarding in the current network namespace.
-func EnableIPv4Forwarding() error {
+// EnableForwarding enables IPv4 forwarding in the current network namespace.
+func EnableForwarding() error {
 	// Forwarding is required because actor packets now enter the worker pod via
 	// the host-side veth and then leave through the pod's eth0. Without this, the
 	// kernel would not route traffic between those interfaces even though both
 	// live in the worker pod network namespace.
-	//
-	// Without privileged, the container runtime bind-mounts /proc/sys read-only.
-	// The worker holds CAP_SYS_ADMIN and uses no user namespace, so the ro flag
-	// is not locked: clear it, write the sysctl, restore ro.
 	const path = "/proc/sys/net/ipv4/ip_forward"
+	if err := writeSysctlIfUnset(path); err != nil {
+		return fmt.Errorf("while enabling IPv4 forwarding in worker pod netns: %w", err)
+	}
+	return nil
+}
+
+// writeSysctlIfUnset writes "1\n" to a sysctl path unless it already reads "1".
+// If the path does not exist, it returns nil — the sysctl is simply unavailable,
+// not an error.
+func writeSysctlIfUnset(path string) error {
 	if b, err := os.ReadFile(path); err == nil && len(b) > 0 && b[0] == '1' {
 		return nil
 	}
 	if err := os.WriteFile(path, []byte("1\n"), 0o644); err == nil {
 		return nil
 	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// Path absent (e.g. IPv6 disabled in kernel): nothing to enable.
+		return nil
+	}
+	// Without privileged, the container runtime bind-mounts /proc/sys read-only.
+	// The worker holds CAP_SYS_ADMIN and uses no user namespace, so the ro flag
+	// is not locked: clear it, write the sysctl, restore ro.
 	if err := unix.Mount("none", "/proc/sys", "", unix.MS_BIND|unix.MS_REMOUNT, ""); err != nil {
-		return fmt.Errorf("while remounting /proc/sys read-write to enable IPv4 forwarding: %w", err)
+		return fmt.Errorf("while remounting /proc/sys read-write to enable forwarding: %w", err)
 	}
 	defer func() {
 		_ = unix.Mount("none", "/proc/sys", "", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY, "")
 	}()
 	if err := os.WriteFile(path, []byte("1\n"), 0o644); err != nil {
-		return fmt.Errorf("while enabling IPv4 forwarding in worker pod netns: %w", err)
+		return fmt.Errorf("while writing %s: %w", path, err)
 	}
 	return nil
 }
@@ -565,7 +578,7 @@ func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
 		return fmt.Errorf("while configuring actor veth in interior netns: %w", err)
 	}
 
-	if err := EnableIPv4Forwarding(); err != nil {
+	if err := EnableForwarding(); err != nil {
 		return err
 	}
 	if err := InstallActorNftablesRules(cfg.EgressRedirectPort); err != nil {

--- a/internal/ateomnet/net.go
+++ b/internal/ateomnet/net.go
@@ -192,7 +192,10 @@ func PodIPv4() (net.IP, error) {
 	return nil, fmt.Errorf("pod eth0 has no IPv4 address")
 }
 
-// EnableForwarding enables IPv4 forwarding in the current network namespace.
+// EnableForwarding enables IPv4 and IPv6 forwarding in the current network
+// namespace, so actor traffic (including DNS queries on IPv6-capable clusters)
+// is routed between the veth and eth0 instead of being dropped by ip_forward()
+// or ip6_forward().
 func EnableForwarding() error {
 	// Forwarding is required because actor packets now enter the worker pod via
 	// the host-side veth and then leave through the pod's eth0. Without this, the
@@ -202,12 +205,22 @@ func EnableForwarding() error {
 	if err := writeSysctlIfUnset(path); err != nil {
 		return fmt.Errorf("while enabling IPv4 forwarding in worker pod netns: %w", err)
 	}
+	// IPv6 forwarding: actor packets that arrive on the veth and leave via eth0
+	// are IPv6 on dual-stack / IPv6-only clusters. Without
+	// net.ipv6.conf.all.forwarding the kernel drops every IPv6 packet in
+	// ip6_forward(), including the actor's DNS queries. conf.all.forwarding=1
+	// also implies the per-interface default, so a single write covers the veth
+	// and eth0.
+	const v6path = "/proc/sys/net/ipv6/conf/all/forwarding"
+	if err := writeSysctlIfUnset(v6path); err != nil {
+		return fmt.Errorf("while enabling IPv6 forwarding in worker pod netns: %w", err)
+	}
 	return nil
 }
 
 // writeSysctlIfUnset writes "1\n" to a sysctl path unless it already reads "1".
-// If the path does not exist, it returns nil — the sysctl is simply unavailable,
-// not an error.
+// If the path does not exist (e.g. IPv6 sysctls on a kernel with IPv6 disabled),
+// it returns nil — IPv6 forwarding is simply unavailable, not an error.
 func writeSysctlIfUnset(path string) error {
 	if b, err := os.ReadFile(path); err == nil && len(b) > 0 && b[0] == '1' {
 		return nil

--- a/internal/ateomnet/net.go
+++ b/internal/ateomnet/net.go
@@ -24,7 +24,10 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
+	"syscall"
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/binaryutil"
@@ -192,6 +195,17 @@ func PodIPv4() (net.IP, error) {
 	return nil, fmt.Errorf("pod eth0 has no IPv4 address")
 }
 
+// procSysDir is the mount point of the sysctl tree. ensureProcSysOn refuses any
+// path that does not resolve inside it.
+const procSysDir = "/proc/sys"
+
+// Forwarding sysctls. conf.all.forwarding also supplies the per-interface
+// default, so one IPv6 write covers both the veth and eth0.
+const (
+	procSysIPv4Forwarding = "/proc/sys/net/ipv4/ip_forward"
+	procSysIPv6Forwarding = "/proc/sys/net/ipv6/conf/all/forwarding"
+)
+
 // EnableForwarding enables IPv4 and IPv6 forwarding in the current network
 // namespace, so actor traffic (including DNS queries on IPv6-capable clusters)
 // is routed between the veth and eth0 instead of being dropped by ip_forward()
@@ -201,50 +215,96 @@ func EnableForwarding() error {
 	// the host-side veth and then leave through the pod's eth0. Without this, the
 	// kernel would not route traffic between those interfaces even though both
 	// live in the worker pod network namespace.
-	const path = "/proc/sys/net/ipv4/ip_forward"
-	if err := writeSysctlIfUnset(path); err != nil {
-		return fmt.Errorf("while enabling IPv4 forwarding in worker pod netns: %w", err)
+	//
+	// The container runtime bind-mounts /proc/sys read-only for unprivileged
+	// pods. The worker holds CAP_SYS_ADMIN and uses no user namespace, so the
+	// read-only flag is not locked: if a write comes back EROFS, clear it for the
+	// duration of ensure and put it back afterwards.
+	ensure := func() error {
+		if err := ensureProcSysOn(procSysIPv4Forwarding); err != nil {
+			return fmt.Errorf("while enabling IPv4 forwarding in worker pod netns: %w", err)
+		}
+		// IPv6 forwarding: actor packets that arrive on the veth and leave via
+		// eth0 are IPv6 on dual-stack / IPv6-only clusters. Without
+		// net.ipv6.conf.all.forwarding the kernel drops every IPv6 packet in
+		// ip6_forward(), including the actor's DNS queries.
+		//
+		// A kernel with IPv6 disabled has no such node at all. That is benign --
+		// there is no IPv6 traffic to forward -- so log it and move on rather
+		// than failing the activation.
+		switch _, err := os.Stat(procSysIPv6Forwarding); {
+		case errors.Is(err, os.ErrNotExist):
+			slog.Info("IPv6 forwarding sysctl is absent, skipping", "path", procSysIPv6Forwarding)
+			return nil
+		case err != nil:
+			return fmt.Errorf("while checking %s: %w", procSysIPv6Forwarding, err)
+		}
+		if err := ensureProcSysOn(procSysIPv6Forwarding); err != nil {
+			return fmt.Errorf("while enabling IPv6 forwarding in worker pod netns: %w", err)
+		}
+		return nil
 	}
-	// IPv6 forwarding: actor packets that arrive on the veth and leave via eth0
-	// are IPv6 on dual-stack / IPv6-only clusters. Without
-	// net.ipv6.conf.all.forwarding the kernel drops every IPv6 packet in
-	// ip6_forward(), including the actor's DNS queries. conf.all.forwarding=1
-	// also implies the per-interface default, so a single write covers the veth
-	// and eth0.
-	const v6path = "/proc/sys/net/ipv6/conf/all/forwarding"
-	if err := writeSysctlIfUnset(v6path); err != nil {
-		return fmt.Errorf("while enabling IPv6 forwarding in worker pod netns: %w", err)
+
+	err := ensure()
+	if !errors.Is(err, syscall.EROFS) {
+		return err
 	}
-	return nil
+	return withWritableProcSys(ensure)
 }
 
-// writeSysctlIfUnset writes "1\n" to a sysctl path unless it already reads "1".
-// If the path does not exist (e.g. IPv6 sysctls on a kernel with IPv6 disabled),
-// it returns nil — IPv6 forwarding is simply unavailable, not an error.
-func writeSysctlIfUnset(path string) error {
-	if b, err := os.ReadFile(path); err == nil && len(b) > 0 && b[0] == '1' {
-		return nil
-	}
-	if err := os.WriteFile(path, []byte("1\n"), 0o644); err == nil {
-		return nil
-	}
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		// Path absent (e.g. IPv6 disabled in kernel): nothing to enable.
-		return nil
-	}
-	// Without privileged, the container runtime bind-mounts /proc/sys read-only.
-	// The worker holds CAP_SYS_ADMIN and uses no user namespace, so the ro flag
-	// is not locked: clear it, write the sysctl, restore ro.
-	if err := unix.Mount("none", "/proc/sys", "", unix.MS_BIND|unix.MS_REMOUNT, ""); err != nil {
-		return fmt.Errorf("while remounting /proc/sys read-write to enable forwarding: %w", err)
+// withWritableProcSys remounts /proc/sys read-write, runs do, and restores the
+// read-only mount. It is only reachable when a write failed with EROFS, so a
+// writable /proc/sys never pays for the extra mounts.
+func withWritableProcSys(do func() error) error {
+	if err := unix.Mount("none", procSysDir, "", unix.MS_BIND|unix.MS_REMOUNT, ""); err != nil {
+		return fmt.Errorf("while remounting %s read-write to enable forwarding: %w", procSysDir, err)
 	}
 	defer func() {
-		_ = unix.Mount("none", "/proc/sys", "", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY, "")
+		if err := unix.Mount("none", procSysDir, "", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
+			// Nothing left to do but be loud: the namespace is about to be torn
+			// down with actor cleanup, but until then /proc/sys is writable.
+			slog.Error("restoring read-only "+procSysDir+" mount failed", "err", err)
+		}
 	}()
+	return do()
+}
+
+// ensureProcSysOn writes "1\n" to the sysctl node at path unless it already
+// reads "1".
+//
+// The returned error wraps the underlying errno, so callers can react to a
+// read-only /proc/sys with errors.Is(err, syscall.EROFS).
+func ensureProcSysOn(path string) error {
+	// The path is a package-level constant in every caller today; check it
+	// anyway so a future caller cannot turn this helper into an arbitrary-file
+	// write.
+	if err := validateProcSysPath(path); err != nil {
+		return err
+	}
+	if procSysIsSet(path) {
+		return nil
+	}
 	if err := os.WriteFile(path, []byte("1\n"), 0o644); err != nil {
 		return fmt.Errorf("while writing %s: %w", path, err)
 	}
 	return nil
+}
+
+// validateProcSysPath rejects a path that does not resolve inside /proc/sys.
+func validateProcSysPath(path string) error {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) || !strings.HasPrefix(clean, procSysDir+"/") {
+		return fmt.Errorf("sysctl path %q is not under %s", path, procSysDir)
+	}
+	return nil
+}
+
+// procSysIsSet reports whether the sysctl node at path already reads "1". A
+// node reading anything else (e.g. "0") needs the write; one that cannot be
+// read at all is left to the caller's write path to report.
+func procSysIsSet(path string) bool {
+	b, err := os.ReadFile(path)
+	return err == nil && len(b) > 0 && b[0] == '1'
 }
 
 // InstallActorNftablesRules configures the NAT and filtering rules for the

--- a/internal/ateomnet/write_sysctl_test.go
+++ b/internal/ateomnet/write_sysctl_test.go
@@ -1,0 +1,84 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ateomnet
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteSysctlIfUnset verifies writeSysctlIfUnset's fast paths against a
+// temp file standing in for a /proc/sys node: it must not rewrite a value
+// that already reads "1", and it must write "1\n" when the value is missing
+// or unset. The privileged bind-remount path is covered by the netns
+// integration tests (withTestNetNS), which require root.
+func TestWriteSysctlIfUnset(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("already_set", func(t *testing.T) {
+		p := filepath.Join(dir, "already")
+		// Sentinel content: if writeSysctlIfUnset rewrote the file, the value
+		// would change to "1\n" and this assertion would fail. Keeping the
+		// file larger than the helper's output makes a silent rewrite
+		// detectable.
+		if err := os.WriteFile(p, []byte("1 other-content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeSysctlIfUnset(p); err != nil {
+			t.Fatalf("writeSysctlIfUnset: %v", err)
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != "1 other-content\n" {
+			t.Fatalf("already-set file was rewritten: %q", b)
+		}
+	})
+
+	t.Run("unset_written", func(t *testing.T) {
+		p := filepath.Join(dir, "unset")
+		if err := writeSysctlIfUnset(p); err != nil {
+			t.Fatalf("writeSysctlIfUnset: %v", err)
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(b) < 1 || b[0] != '1' {
+			t.Fatalf("expected '1' written, got %q", b)
+		}
+	})
+
+	t.Run("zero_is_rewritten", func(t *testing.T) {
+		p := filepath.Join(dir, "zero")
+		if err := os.WriteFile(p, []byte("0\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeSysctlIfUnset(p); err != nil {
+			t.Fatalf("writeSysctlIfUnset: %v", err)
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(b) < 1 || b[0] != '1' {
+			t.Fatalf("expected '1' written, got %q", b)
+		}
+	})
+}

--- a/internal/ateomnet/write_sysctl_test.go
+++ b/internal/ateomnet/write_sysctl_test.go
@@ -65,6 +65,21 @@ func TestWriteSysctlIfUnset(t *testing.T) {
 		}
 	})
 
+	t.Run("missing_path_is_noop", func(t *testing.T) {
+		// A node under a directory that does not exist stands in for
+		// /proc/sys/net/ipv6/... on a kernel with IPv6 disabled. The other
+		// subtests' paths can be created, so they return at the os.WriteFile
+		// fast path; this is the only one that reaches the os.Stat branch,
+		// which is what procfs always does in production.
+		p := filepath.Join(dir, "no-such-dir", "forwarding")
+		if err := writeSysctlIfUnset(p); err != nil {
+			t.Fatalf("writeSysctlIfUnset on a missing path: %v", err)
+		}
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to stay absent, stat err = %v", p, err)
+		}
+	})
+
 	t.Run("zero_is_rewritten", func(t *testing.T) {
 		p := filepath.Join(dir, "zero")
 		if err := os.WriteFile(p, []byte("0\n"), 0o644); err != nil {

--- a/internal/ateomnet/write_sysctl_test.go
+++ b/internal/ateomnet/write_sysctl_test.go
@@ -19,81 +19,143 @@ package ateomnet
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/agent-substrate/substrate/internal/roottest"
+	"github.com/vishvananda/netns"
 )
 
-// TestWriteSysctlIfUnset verifies writeSysctlIfUnset's fast paths against a
-// temp file standing in for a /proc/sys node: it must not rewrite a value
-// that already reads "1", and it must write "1\n" when the value is missing
-// or unset. The privileged bind-remount path is covered by the netns
-// integration tests (withTestNetNS), which require root.
-func TestWriteSysctlIfUnset(t *testing.T) {
+// TestValidateProcSysPath pins the guard that keeps ensureProcSysOn from being
+// pointed at an arbitrary file.
+func TestValidateProcSysPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		ok   bool
+	}{
+		{"ipv4_forwarding", procSysIPv4Forwarding, true},
+		{"ipv6_forwarding", procSysIPv6Forwarding, true},
+		{"cleans_to_a_sysctl", "/proc/sys/kernel/../net/ipv4/ip_forward", true},
+		{"mount_point_itself", procSysDir, false},
+		{"sibling_prefix", "/proc/sysfoo/net/ipv4/ip_forward", false},
+		{"escapes_the_tree", "/proc/sys/../etc/passwd", false},
+		{"outside_the_tree", "/etc/passwd", false},
+		{"relative", "proc/sys/net/ipv4/ip_forward", false},
+		{"empty", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateProcSysPath(tc.path)
+			if tc.ok && err != nil {
+				t.Errorf("validateProcSysPath(%q) = %v, want nil", tc.path, err)
+			}
+			if !tc.ok && err == nil {
+				t.Errorf("validateProcSysPath(%q) = nil, want a refusal", tc.path)
+			}
+		})
+	}
+}
+
+// TestEnsureProcSysOnRefusesForeignPath checks the guard is actually wired into
+// the helper, not just available: a refused path must not be created.
+func TestEnsureProcSysOnRefusesForeignPath(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "forwarding")
+	if err := ensureProcSysOn(p); err == nil {
+		t.Fatalf("ensureProcSysOn(%q) = nil, want a refusal for a path outside %s", p, procSysDir)
+	}
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Errorf("ensureProcSysOn touched %q (stat err = %v); a refused path must be left alone", p, err)
+	}
+}
+
+// TestProcSysIsSet covers the read that decides whether the write happens: a
+// node already reading "1" is left byte-for-byte alone, and anything else
+// (including unreadable) needs the write.
+func TestProcSysIsSet(t *testing.T) {
 	dir := t.TempDir()
+	for _, tc := range []struct {
+		name    string
+		content string // empty means: do not create the file
+		want    bool
+	}{
+		{"set", "1\n", true},
+		{"set_with_trailing_content", "1 other-content\n", true},
+		{"unset", "0\n", false},
+		{"empty_file", "", false},
+		{"absent", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(dir, tc.name)
+			if tc.name != "absent" {
+				if err := os.WriteFile(p, []byte(tc.content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := procSysIsSet(p); got != tc.want {
+				t.Errorf("procSysIsSet(%s = %q) = %v, want %v", tc.name, tc.content, got, tc.want)
+			}
+		})
+	}
+}
 
-	t.Run("already_set", func(t *testing.T) {
-		p := filepath.Join(dir, "already")
-		// Sentinel content: if writeSysctlIfUnset rewrote the file, the value
-		// would change to "1\n" and this assertion would fail. Keeping the
-		// file larger than the helper's output makes a silent rewrite
-		// detectable.
-		if err := os.WriteFile(p, []byte("1 other-content\n"), 0o644); err != nil {
-			t.Fatal(err)
+// TestEnableForwardingInNetNS asserts the effect EnableForwarding exists for,
+// in the place it runs: a throwaway netns standing in for the worker pod's.
+//
+// Both nodes are pinned to "0" first. A new netns inherits the parent's IPv4
+// forwarding value (a host with forwarding on hands its namespaces "1"), so
+// asserting on the transition this function is responsible for is both
+// meaningful on any host and independent of that inheritance.
+func TestEnableForwardingInNetNS(t *testing.T) {
+	roottest.Require(t, "writing /proc/sys/net sysctls inside a fresh network namespace")
+
+	withTestNetNS(t, func(netns.NsHandle) {
+		writeSysctl(t, procSysIPv4Forwarding, "0")
+		if got := readSysctl(t, procSysIPv4Forwarding); got != "0" {
+			t.Fatalf("pinning %s to %q read back %q", procSysIPv4Forwarding, "0", got)
 		}
-		if err := writeSysctlIfUnset(p); err != nil {
-			t.Fatalf("writeSysctlIfUnset: %v", err)
+		if err := EnableForwarding(); err != nil {
+			t.Fatalf("EnableForwarding: %v", err)
 		}
-		b, err := os.ReadFile(p)
-		if err != nil {
-			t.Fatal(err)
+		if got := readSysctl(t, procSysIPv4Forwarding); got != "1" {
+			t.Errorf("%s = %q after EnableForwarding, want %q", procSysIPv4Forwarding, got, "1")
 		}
-		if string(b) != "1 other-content\n" {
-			t.Fatalf("already-set file was rewritten: %q", b)
+
+		// IPv6 is optional: a kernel built without it has no such node, and
+		// EnableForwarding treats that as benign and returns nil.
+		if _, err := os.Stat(procSysIPv6Forwarding); err != nil {
+			t.Logf("no %s in this environment, skipping the IPv6 half: %v", procSysIPv6Forwarding, err)
+		} else {
+			writeSysctl(t, procSysIPv6Forwarding, "0")
+			if err := EnableForwarding(); err != nil {
+				t.Fatalf("EnableForwarding with %s pinned off: %v", procSysIPv6Forwarding, err)
+			}
+			if got := readSysctl(t, procSysIPv6Forwarding); got != "1" {
+				t.Errorf("%s = %q after EnableForwarding, want %q", procSysIPv6Forwarding, got, "1")
+			}
+		}
+
+		// Idempotent: the second call finds both nodes already set and must
+		// neither fail nor need the read-only remount.
+		if err := EnableForwarding(); err != nil {
+			t.Errorf("second EnableForwarding: %v", err)
 		}
 	})
+}
 
-	t.Run("unset_written", func(t *testing.T) {
-		p := filepath.Join(dir, "unset")
-		if err := writeSysctlIfUnset(p); err != nil {
-			t.Fatalf("writeSysctlIfUnset: %v", err)
-		}
-		b, err := os.ReadFile(p)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(b) < 1 || b[0] != '1' {
-			t.Fatalf("expected '1' written, got %q", b)
-		}
-	})
+// readSysctl returns the trimmed contents of a sysctl node.
+func readSysctl(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(b))
+}
 
-	t.Run("missing_path_is_noop", func(t *testing.T) {
-		// A node under a directory that does not exist stands in for
-		// /proc/sys/net/ipv6/... on a kernel with IPv6 disabled. The other
-		// subtests' paths can be created, so they return at the os.WriteFile
-		// fast path; this is the only one that reaches the os.Stat branch,
-		// which is what procfs always does in production.
-		p := filepath.Join(dir, "no-such-dir", "forwarding")
-		if err := writeSysctlIfUnset(p); err != nil {
-			t.Fatalf("writeSysctlIfUnset on a missing path: %v", err)
-		}
-		if _, err := os.Stat(p); !os.IsNotExist(err) {
-			t.Fatalf("expected %s to stay absent, stat err = %v", p, err)
-		}
-	})
-
-	t.Run("zero_is_rewritten", func(t *testing.T) {
-		p := filepath.Join(dir, "zero")
-		if err := os.WriteFile(p, []byte("0\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		if err := writeSysctlIfUnset(p); err != nil {
-			t.Fatalf("writeSysctlIfUnset: %v", err)
-		}
-		b, err := os.ReadFile(p)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(b) < 1 || b[0] != '1' {
-			t.Fatalf("expected '1' written, got %q", b)
-		}
-	})
+// writeSysctl pins a sysctl node to value.
+func writeSysctl(t *testing.T, path, value string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(value+"\n"), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
 }


### PR DESCRIPTION
## ateomnet: enable IPv6 forwarding in the worker pod netns

Fixes: https://github.com/agent-substrate/substrate/issues/945

### Problem

`EnableForwarding` (formerly `EnableIPv4Forwarding`) only wrote `/proc/sys/net/ipv4/ip_forward`. It had no
IPv6 counterpart, so `net.ipv6.conf.all.forwarding` stayed at 0 in the worker
pod network namespace. On dual-stack / IPv6-only clusters, every IPv6 packet
an actor sends — including its own DNS queries — is dropped by the kernel's
`ip6_forward()`, because the packet enters on the actor veth and must be
forwarded out through `eth0`.

Reproduced as `TestActorEgress` returning 504 on IPv6-only clusters (4/4 runs).

### Fix

The helper is renamed to `EnableForwarding` since it now covers both address
families, and it writes `/proc/sys/net/ipv6/conf/all/forwarding`. `conf.all.forwarding=1` sets the
forwarding state for all existing interfaces (and is the default for new
ones), so a single write covers both the veth and `eth0`.

The write is factored into a `writeSysctlIfUnset` helper that preserves the
original behavior:
- if the sysctl already reads `1`, return early (no remount, no write);
- otherwise clear the read-only bind-mount on `/proc/sys` (the worker holds
  CAP_SYS_ADMIN and uses no user namespace), write `1\n`, and restore `ro`.

### Test

`internal/ateomnet/write_sysctl_test.go` covers the helper's fast paths
(already-set is untouched, unset/zero is written) with a temp file, no root
required. The privileged remount path is exercised by the existing netns
integration tests (`withTestNetNS`).

### Compatibility

- IPv4-only clusters are unaffected (IPv4 path unchanged; writing the IPv6
  sysctl is a no-op where IPv6 is disabled or the file is absent — the helper
  returns nil on missing path).
- No change to the nftables rules; the existing
  `InstallActorNftablesRules` IPv4-only TODO remains accurate — this PR only
  restores the kernel forwarding path so IPv6 packets reach the pod's eth0.

### Verification

- `gofmt -l` clean.
- `go build ./internal/ateomnet/` passes.
- `go test ./internal/ateomnet/ -run TestWriteSysctlIfUnset` passes.
- Full `go test ./internal/ateomnet/` passes.

### Merge order

#1057 gives the actor veth an IPv6 address and a default route; without this
PR's forwarding write that route is a black hole. **This PR must merge before
#1057.** No current CI lane catches the ordering (default e2e clusters are
IPv4-only); tracked in #1094 (opt-in dual-stack kind e2e).
