### PR TITLE
ateom: prepare sandboxes during image pull and DATA restore

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -484,11 +484,6 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (resp *
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	assetPaths, err := s.ensureSandboxAssets(ctx, sandboxRec)
-	if err != nil {
-		return nil, err
-	}
-
 	if err := resetActorDirs(actorUID); err != nil {
 		return nil, fmt.Errorf("while resetting actor dirs: %w", err)
 	}
@@ -512,20 +507,48 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (resp *
 	if err := s.systemInfoVolumes.Register(actorUID, actorRef, systemInfoVolumesFor(actorUID, req.GetSpec())); err != nil {
 		return nil, err
 	}
-	if err := s.prepareOCIBundles(ctx, actorUID, actorRef,
-		req.GetSpec(), sandboxRec.PauseImage, req.GetTargetAteomUid(),
-	); err != nil {
-		return nil, ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonInvalidContainerConfig)
-	}
-
 	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
 	if err != nil {
 		return nil, err
 	}
-
+	if err := s.prepareOCIPrerequisites(ctx, actorUID, actorRef, req.GetSpec()); err != nil {
+		return nil, err
+	}
 	spec, err := buildAteomWorkloadSpec(req.GetSpec())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid workload spec: %v", err)
+	}
+
+	var assetPaths map[string]string
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		dependencies, dependenciesCtx := errgroup.WithContext(gctx)
+		dependencies.Go(func() (err error) {
+			assetPaths, err = s.ensureSandboxAssets(dependenciesCtx, sandboxRec)
+			return err
+		})
+		dependencies.Go(func() error {
+			return s.preparePauseOCIBundle(dependenciesCtx, actorUID, req.GetSpec(), sandboxRec.PauseImage, req.GetTargetAteomUid())
+		})
+		if err := dependencies.Wait(); err != nil {
+			return err
+		}
+		return prepareSandbox(gctx, client, &ateompb.PrepareSandboxRequest{
+			ActorUid:          actorUID,
+			RunscPath:         runscPathFor(assetPaths),
+			RuntimeAssetPaths: assetPaths,
+			Spec:              spec,
+			RedirectEgress:    req.GetEgressGateway() != nil,
+			CpuMilli:          req.GetCpuMilli(),
+			MemoryBytes:       req.GetMemoryBytes(),
+		})
+	})
+	g.Go(func() error {
+		return s.prepareApplicationOCIBundles(gctx, actorUID, req.GetSpec(), req.GetTargetAteomUid())
+	})
+	if err := g.Wait(); err != nil {
+		discardPreparedSandbox(ctx, client, actorUID)
+		return nil, ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonInvalidContainerConfig)
 	}
 
 	// Tell ateom to start the workload. gVisor uses RunscPath; the micro-VM
@@ -543,6 +566,7 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (resp *
 		CpuMilli:              req.GetCpuMilli(),
 		MemoryBytes:           req.GetMemoryBytes(),
 	}); err != nil {
+		discardPreparedSandbox(ctx, client, actorUID)
 		return nil, fmt.Errorf("while calling ateom.RunWorkload: %w", err)
 	}
 
@@ -1577,6 +1601,20 @@ func (s *AteomHerder) prepareOCIBundles(
 	pauseImage string,
 	targetAteomUid string,
 ) error {
+	if err := s.prepareOCIPrerequisites(ctx, actorUID, actorRef, spec); err != nil {
+		return err
+	}
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return s.preparePauseOCIBundle(gctx, actorUID, spec, pauseImage, targetAteomUid)
+	})
+	g.Go(func() error {
+		return s.prepareApplicationOCIBundles(gctx, actorUID, spec, targetAteomUid)
+	})
+	return g.Wait()
+}
+
+func (s *AteomHerder) prepareOCIPrerequisites(ctx context.Context, actorUID string, actorRef resources.ActorRef, spec *ateletpb.WorkloadSpec) error {
 	// Prepare host folders for volume types that need them.
 	for _, vol := range spec.GetVolumes() {
 		switch vol.GetSource().(type) {
@@ -1587,32 +1625,32 @@ func (s *AteomHerder) prepareOCIBundles(
 			}
 		}
 	}
+	return nil
+}
 
-	g, gCtx := errgroup.WithContext(ctx)
+func (s *AteomHerder) preparePauseOCIBundle(ctx context.Context, actorUID string, spec *ateletpb.WorkloadSpec, pauseImage, targetAteomUID string) error {
+	if err := prepareOCIDirectory(
+		ctx,
+		s.imageCache,
+		actorUID,
+		ocispec.PauseContainer,
+		pauseImage,
+		[]string{"/pause"},
+		nil,
+		nil,
+		ateompath.AteomNetNSPath(targetAteomUID),
+		nil, // pause is sandbox infra; it mounts no volumes.
+		nil,
+		nil, // pause only reaps; it needs no capabilities.
+		nil, // pause carries no user-declared limits.
+	); err != nil {
+		return wrapFileSystemErr("while creating pause OCI bundle", err)
+	}
+	return nil
+}
 
-	// Pause container.
-	g.Go(func() error {
-		if err := prepareOCIDirectory(
-			gCtx,
-			s.imageCache,
-			actorUID,
-			ocispec.PauseContainer,
-			pauseImage,
-			[]string{"/pause"},
-			nil,
-			nil,
-			ateompath.AteomNetNSPath(targetAteomUid),
-			nil, // pause is sandbox infra; it mounts no volumes.
-			nil,
-			nil, // pause only reaps; it needs no capabilities.
-			nil, // pause carries no user-declared limits.
-		); err != nil {
-			return wrapFileSystemErr("while creating pause OCI bundle", err)
-		}
-		return nil
-	})
-
-	// Application containers.
+func (s *AteomHerder) prepareApplicationOCIBundles(ctx context.Context, actorUID string, spec *ateletpb.WorkloadSpec, targetAteomUID string) error {
+	g, gctx := errgroup.WithContext(ctx)
 	for _, ctr := range spec.GetContainers() {
 		ctr := ctr
 		var envs []string
@@ -1621,7 +1659,7 @@ func (s *AteomHerder) prepareOCIBundles(
 		}
 		g.Go(func() error {
 			if err := prepareOCIDirectory(
-				gCtx,
+				gctx,
 				s.imageCache,
 				actorUID,
 				ctr.GetName(),
@@ -1629,7 +1667,7 @@ func (s *AteomHerder) prepareOCIBundles(
 				ctr.GetCommand(),
 				ctr.GetArgs(),
 				envs,
-				ateompath.AteomNetNSPath(targetAteomUid),
+				ateompath.AteomNetNSPath(targetAteomUID),
 				spec.GetVolumes(),
 				ctr.GetVolumeMounts(),
 				resolveCapabilities(ctr.GetSecurityContext().GetCapabilities()),
@@ -1640,8 +1678,26 @@ func (s *AteomHerder) prepareOCIBundles(
 			return nil
 		})
 	}
-
 	return g.Wait()
+}
+
+// prepareSandbox is a no-op for runtimes and older ateom versions that do not
+// implement the split startup RPC; their RunWorkload path remains unchanged.
+func prepareSandbox(ctx context.Context, client ateompb.AteomClient, req *ateompb.PrepareSandboxRequest) error {
+	_, err := client.PrepareSandbox(ctx, req)
+	if status.Code(err) == codes.Unimplemented {
+		return nil
+	}
+	return err
+}
+
+func discardPreparedSandbox(ctx context.Context, client ateompb.AteomClient, actorUID string) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	_, err := client.DiscardPreparedSandbox(cleanupCtx, &ateompb.DiscardPreparedSandboxRequest{ActorUid: actorUID})
+	if err != nil && status.Code(err) != codes.Unimplemented {
+		slog.WarnContext(cleanupCtx, "Failed to discard prepared sandbox", slog.Any("err", err))
+	}
 }
 
 // dialAteom opens (or reuses) the gRPC connection to the target ateom

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -541,6 +541,7 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (resp *
 			RedirectEgress:    req.GetEgressGateway() != nil,
 			CpuMilli:          req.GetCpuMilli(),
 			MemoryBytes:       req.GetMemoryBytes(),
+			FromCheckpoint:    false,
 		})
 	})
 	g.Go(func() error {
@@ -759,6 +760,13 @@ func toAteomSnapshotScope(scope ateletpb.SnapshotScope) ateompb.SnapshotScope {
 	default:
 		return ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL
 	}
+}
+
+// shouldPrepareSandboxForRestore is true only for DATA snapshots. They contain
+// no sandbox memory, so the runtime cold-boots a new sandbox. FULL and
+// DATA_ON_GOLDEN restore the captured sandbox and must not create another one.
+func shouldPrepareSandboxForRestore(scope ateletpb.SnapshotScope) bool {
+	return scope == ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
 }
 
 func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string, rec *sandboxAssetsRecord) error {
@@ -994,7 +1002,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	// the way out, so a failed restore still accounts for the phases it completed.
 	// Phases left at zero never ran.
 	tStart := time.Now()
-	var dMount, dManifest, dAssets, dDownload, dBundles, dAteom time.Duration
+	var dMount, dManifest, dAssets, dDownload, dBundles, dAteom, dPrepare time.Duration
 	op := snapshotOp{
 		templateNamespace: req.GetActorTemplateAtespace(),
 		templateName:      req.GetActorTemplateName(),
@@ -1136,7 +1144,19 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	if goldenRec != nil {
 		runtimeRec = goldenRec
 	}
+	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
+	if err != nil {
+		return nil, err
+	}
+	spec, err := buildAteomWorkloadSpec(req.GetSpec())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid workload spec: %v", err)
+	}
+	dataRestore := shouldPrepareSandboxForRestore(req.GetScope())
 
+	if err = s.systemInfoVolumes.Register(actorUID, actorRef, systemInfoVolumesFor(actorUID, req.GetSpec())); err != nil {
+		return nil, err
+	}
 	// Undo the Register if the restore fails.
 	defer func() {
 		if err != nil {
@@ -1144,11 +1164,10 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		}
 	}()
 
-	// Download the memory snapshot and prepare the sandbox assets + OCI bundle
-	// CONCURRENTLY. They are independent — only the final ateom.RestoreWorkload
-	// needs both — so overlapping the GCS download (~0.5s warm) with the asset
-	// fetch + image unpack hides whichever leg is shorter, and on a cold node
-	// (uncached assets + image, ~2.5s unpack) that overlap is large.
+	// Download the checkpoint and prepare the sandbox assets + OCI bundles
+	// concurrently. For a DATA restore, also start the new sandbox as soon as its
+	// runtime assets and pause bundle are ready. The final RestoreWorkload waits
+	// for both the download and preparation legs.
 	// TODO(dberkov): the old pause checkpoint files are not deleted after they are
 	// copied to checkpointDir for the LOCAL case.
 	var assetPaths map[string]string
@@ -1205,16 +1224,95 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	})
 	g.Go(func() (err error) {
 		defer func() { prepErr = err }()
+		if dataRestore {
+			tPrerequisites := time.Now()
+			if err := s.prepareOCIPrerequisites(gctx, actorUID, actorRef, req.GetSpec()); err != nil {
+				dBundles = time.Since(tPrerequisites)
+				prepFailedPhase = ateattr.SnapshotPhaseOCIUnpack
+				return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonTerminalFileSystemError)
+			}
+			dPrerequisites := time.Since(tPrerequisites)
+
+			var assetErr, pauseErr, appErr, prepareErr error
+			var dPause, dApps time.Duration
+			work, workCtx := errgroup.WithContext(gctx)
+			work.Go(func() (err error) {
+				t := time.Now()
+				defer func() {
+					dApps = time.Since(t)
+					appErr = err
+				}()
+				err = s.prepareApplicationOCIBundles(workCtx, actorUID, req.GetSpec(), req.GetTargetAteomUid())
+				return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonTerminalFileSystemError, ateerrors.ReasonInvalidContainerConfig)
+			})
+			work.Go(func() error {
+				dependencies, dependenciesCtx := errgroup.WithContext(workCtx)
+				dependencies.Go(func() (err error) {
+					t := time.Now()
+					defer func() {
+						dAssets = time.Since(t)
+						assetErr = err
+					}()
+					assetPaths, err = s.ensureSandboxAssets(dependenciesCtx, runtimeRec)
+					if err != nil {
+						return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonFailedGetExternalObject, ateerrors.ReasonInvalidObjectURL, ateerrors.ReasonTerminalFileSystemError, ateerrors.ReasonInvalidSandboxAsset)
+					}
+					return nil
+				})
+				dependencies.Go(func() (err error) {
+					t := time.Now()
+					defer func() {
+						dPause = time.Since(t)
+						pauseErr = err
+					}()
+					err = s.preparePauseOCIBundle(dependenciesCtx, actorUID, req.GetSpec(), runtimeRec.PauseImage, req.GetTargetAteomUid())
+					return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonTerminalFileSystemError, ateerrors.ReasonInvalidContainerConfig)
+				})
+				if err := dependencies.Wait(); err != nil {
+					return err
+				}
+				t := time.Now()
+				prepareErr = prepareSandbox(workCtx, client, &ateompb.PrepareSandboxRequest{
+					ActorUid:          actorUID,
+					RunscPath:         runscPathFor(assetPaths),
+					RuntimeAssetPaths: assetPaths,
+					Spec:              spec,
+					RedirectEgress:    req.GetEgressGateway() != nil,
+					CpuMilli:          req.GetCpuMilli(),
+					MemoryBytes:       req.GetMemoryBytes(),
+					FromCheckpoint:    true,
+				})
+				dPrepare = time.Since(t)
+				return prepareErr
+			})
+
+			err = work.Wait()
+			dBundles = dPrerequisites + max(dPause, dApps)
+
+			switch {
+			case assetErr != nil && !errors.Is(assetErr, context.Canceled):
+				prepFailedPhase = ateattr.SnapshotPhaseSandboxAssets
+			case (pauseErr != nil && !errors.Is(pauseErr, context.Canceled)) ||
+				(appErr != nil && !errors.Is(appErr, context.Canceled)):
+				prepFailedPhase = ateattr.SnapshotPhaseOCIUnpack
+			case prepareErr != nil && !errors.Is(prepareErr, context.Canceled):
+				prepFailedPhase = ateattr.SnapshotPhaseAteomRestore
+			case assetErr != nil:
+				prepFailedPhase = ateattr.SnapshotPhaseSandboxAssets
+			case pauseErr != nil || appErr != nil:
+				prepFailedPhase = ateattr.SnapshotPhaseOCIUnpack
+			case prepareErr != nil:
+				prepFailedPhase = ateattr.SnapshotPhaseAteomRestore
+			}
+			return err
+		}
+
 		tAssets := time.Now()
 		assetPaths, err = s.ensureSandboxAssets(gctx, runtimeRec)
 		dAssets = time.Since(tAssets)
 		if err != nil {
 			prepFailedPhase = ateattr.SnapshotPhaseSandboxAssets
 			return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonFailedGetExternalObject, ateerrors.ReasonInvalidObjectURL, ateerrors.ReasonTerminalFileSystemError, ateerrors.ReasonInvalidSandboxAsset)
-		}
-		if err = s.systemInfoVolumes.Register(actorUID, actorRef, systemInfoVolumesFor(actorUID, req.GetSpec())); err != nil {
-			prepFailedPhase = ateattr.SnapshotPhaseOCIUnpack
-			return err
 		}
 		t := time.Now()
 		err = s.prepareOCIBundles(gctx, actorUID, actorRef, req.GetSpec(), runtimeRec.PauseImage, req.GetTargetAteomUid())
@@ -1226,30 +1324,22 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		return nil
 	})
 	if err := g.Wait(); err != nil {
+		if dataRestore {
+			dAteom = dPrepare
+			discardPreparedSandbox(ctx, client, actorUID)
+		}
 		op.failedPhase = groupFailedPhase(err, downloadErr, prepErr, prepFailedPhase)
 		if isCollateral(err, downloadErr) {
 			dDownload = 0
 		}
 		if isCollateral(err, prepErr) {
 			dAssets, dBundles = assetsAfterCollateral(prepFailedPhase, dAssets), 0
+			dAteom = 0
 		}
 		return nil, err
 	}
 
-	client, err := s.dialAteom(ctx, req.GetTargetAteomUid())
-	if err != nil {
-		return nil, err
-	}
-
-	// Tell ateom to do runsc create + runsc restore for pause container and
-	// all application containers.
-	spec, err := buildAteomWorkloadSpec(req.GetSpec())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid workload spec: %v", err)
-	}
-
-	// The ateom_restore phase is opaque from here; ateom logs its own breakdown of
-	// this call as "Actor restore phases".
+	// Tell ateom to complete the restore and start all application containers.
 	tAteom := time.Now()
 	_, err = client.RestoreWorkload(ctx, &ateompb.RestoreWorkloadRequest{
 		Atespace:              actorRef.Atespace,
@@ -1269,8 +1359,11 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		// ateom restores from the shared dir and never fetches this URI.
 		GoldenSnapshotUri: req.GetGoldenSnapshotUri(),
 	})
-	dAteom = time.Since(tAteom)
+	dAteom = dPrepare + time.Since(tAteom)
 	if err != nil {
+		if dataRestore {
+			discardPreparedSandbox(ctx, client, actorUID)
+		}
 		// TODO: classify the errors returned by Ateom and crash the actor if needed.
 		op.failedPhase = ateattr.SnapshotPhaseAteomRestore
 		return nil, fmt.Errorf("while calling ateom.RestoreWorkload: %w", err)

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -68,6 +68,20 @@ const (
 	goldenSnapshotURI = "gs://" + goldenSnapshotPath
 )
 
+type unimplementedPrepareClient struct {
+	ateompb.AteomClient
+}
+
+func (unimplementedPrepareClient) PrepareSandbox(context.Context, *ateompb.PrepareSandboxRequest, ...grpc.CallOption) (*ateompb.PrepareSandboxResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "runtime uses RunWorkload")
+}
+
+func TestPrepareSandboxFallsBackWhenUnimplemented(t *testing.T) {
+	if err := prepareSandbox(context.Background(), unimplementedPrepareClient{}, &ateompb.PrepareSandboxRequest{}); err != nil {
+		t.Fatalf("prepareSandbox returned an error for a runtime without the split RPC: %v", err)
+	}
+}
+
 // TestPortFlagDefault verifies the default value of the --port flag.
 func TestPortFlagDefault(t *testing.T) {
 	f := pflag.Lookup("port")

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -494,6 +494,22 @@ func TestToAteomSnapshotScope(t *testing.T) {
 	}
 }
 
+func TestShouldPrepareSandboxForRestore(t *testing.T) {
+	tests := []struct {
+		scope ateletpb.SnapshotScope
+		want  bool
+	}{
+		{ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA, true},
+		{ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL, false},
+		{ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN, false},
+	}
+	for _, tt := range tests {
+		if got := shouldPrepareSandboxForRestore(tt.scope); got != tt.want {
+			t.Errorf("shouldPrepareSandboxForRestore(%v) = %v, want %v", tt.scope, got, tt.want)
+		}
+	}
+}
+
 // TestFetchAssetRejectsBadHash confirms fetchAsset validates the asset hash
 // before the cache-hit os.Stat/early-return, not merely "at some point". To
 // prove the ordering, it plants a real file at the exact path an invalid hash

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -349,13 +349,18 @@ type preparedSandbox struct {
 	cpuMilli       int64
 	memoryBytes    int64
 	durableVolumes []string
+	fromCheckpoint bool
+	rootCreated    bool
+	// cleanupStarted prevents a partially discarded sandbox from being reused.
+	cleanupStarted bool
 	// rootDeleted makes DiscardPreparedSandbox retryable when later cleanup fails.
 	rootDeleted bool
 }
 
-func (p *preparedSandbox) matches(actorUID, runscPath string, redirectEgress bool, cpuMilli, memoryBytes int64, durableVolumes []string) bool {
+func (p *preparedSandbox) matches(actorUID, runscPath string, redirectEgress bool, cpuMilli, memoryBytes int64, durableVolumes []string, fromCheckpoint bool) bool {
 	return p.actorUID == actorUID && p.runscPath == runscPath && p.redirectEgress == redirectEgress &&
-		p.cpuMilli == cpuMilli && p.memoryBytes == memoryBytes && slices.Equal(p.durableVolumes, durableVolumes)
+		p.cpuMilli == cpuMilli && p.memoryBytes == memoryBytes &&
+		slices.Equal(p.durableVolumes, durableVolumes) && p.fromCheckpoint == fromCheckpoint
 }
 
 type cancelableMutex struct {
@@ -653,8 +658,10 @@ func containerNames(containers []*ateompb.Container) []string {
 	return names
 }
 
-// PrepareSandbox starts gVisor's root container while atelet continues pulling
-// and unpacking the application images.
+// PrepareSandbox performs the sandbox work that does not depend on application
+// images or checkpoint contents. A cold Run can start the root container here;
+// a DATA restore configures networking and the rootfs but defers runsc create
+// until RestoreWorkload has the filesystem checkpoint.
 func (s *AteomService) PrepareSandbox(ctx context.Context, req *ateompb.PrepareSandboxRequest) (resp *ateompb.PrepareSandboxResponse, retErr error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -665,10 +672,10 @@ func (s *AteomService) PrepareSandbox(ctx context.Context, req *ateompb.PrepareS
 		return nil, status.Error(codes.InvalidArgument, "actor_uid and runsc_path are required")
 	}
 	if s.prepared != nil {
-		if s.prepared.rootDeleted {
+		if s.prepared.cleanupStarted {
 			return nil, status.Error(codes.FailedPrecondition, "prepared sandbox cleanup is incomplete")
 		}
-		if s.prepared.matches(req.GetActorUid(), req.GetRunscPath(), req.GetRedirectEgress(), req.GetCpuMilli(), req.GetMemoryBytes(), durableVolumeNames(req.GetSpec())) {
+		if s.prepared.matches(req.GetActorUid(), req.GetRunscPath(), req.GetRedirectEgress(), req.GetCpuMilli(), req.GetMemoryBytes(), durableVolumeNames(req.GetSpec()), req.GetFromCheckpoint()) {
 			return &ateompb.PrepareSandboxResponse{}, nil
 		}
 		return nil, status.Error(codes.FailedPrecondition, "ateom already has a different prepared sandbox")
@@ -723,12 +730,14 @@ func (s *AteomService) PrepareSandbox(ctx context.Context, req *ateompb.PrepareS
 	if err := imagecache.SetupBundleRootfs(ateompath.OCIBundlePath(req.GetActorUid(), ocispec.PauseContainer)); err != nil {
 		return nil, fmt.Errorf("while composing pause rootfs: %w", err)
 	}
-	if err := rcmd.cmdCreate(ctx, os.Stdout, ocispec.PauseContainer, nil); err != nil {
-		return nil, fmt.Errorf("while creating pause container: %w", err)
-	}
-	rootCreated = true
-	if err := rcmd.cmdStart(ctx, os.Stdout, ocispec.PauseContainer); err != nil {
-		return nil, fmt.Errorf("while starting pause container: %w", err)
+	if !req.GetFromCheckpoint() {
+		if err := rcmd.cmdCreate(ctx, os.Stdout, ocispec.PauseContainer, nil); err != nil {
+			return nil, fmt.Errorf("while creating pause container: %w", err)
+		}
+		rootCreated = true
+		if err := rcmd.cmdStart(ctx, os.Stdout, ocispec.PauseContainer); err != nil {
+			return nil, fmt.Errorf("while starting pause container: %w", err)
+		}
 	}
 
 	s.prepared = &preparedSandbox{
@@ -738,12 +747,14 @@ func (s *AteomService) PrepareSandbox(ctx context.Context, req *ateompb.PrepareS
 		cpuMilli:       req.GetCpuMilli(),
 		memoryBytes:    req.GetMemoryBytes(),
 		durableVolumes: durableVolumeNames(req.GetSpec()),
+		fromCheckpoint: req.GetFromCheckpoint(),
+		rootCreated:    rootCreated,
 	}
 	return &ateompb.PrepareSandboxResponse{}, nil
 }
 
-// DiscardPreparedSandbox releases a root sandbox when another concurrent
-// preparation step failed before RunWorkload could use it.
+// DiscardPreparedSandbox releases sandbox resources when another concurrent
+// preparation step failed before RunWorkload or RestoreWorkload could use them.
 func (s *AteomService) DiscardPreparedSandbox(ctx context.Context, req *ateompb.DiscardPreparedSandboxRequest) (*ateompb.DiscardPreparedSandboxResponse, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -755,10 +766,11 @@ func (s *AteomService) DiscardPreparedSandbox(ctx context.Context, req *ateompb.
 	}
 
 	p := s.prepared
+	p.cleanupStarted = true
 	s.activeActor.Store(nil)
 	rcmd := &runsc{path: p.runscPath, actorUID: p.actorUID}
 	var cleanupErr error
-	if !p.rootDeleted {
+	if p.rootCreated && !p.rootDeleted {
 		if err := rcmd.cmdDelete(ctx, ocispec.PauseContainer); err != nil {
 			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while deleting prepared pause container: %w", err))
 		} else {
@@ -790,10 +802,10 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	defer s.clearActiveRPC()
 
 	prepared := s.prepared != nil
-	if prepared && s.prepared.rootDeleted {
+	if prepared && s.prepared.cleanupStarted {
 		return nil, status.Error(codes.FailedPrecondition, "prepared sandbox cleanup is incomplete")
 	}
-	if prepared && !s.prepared.matches(req.GetActorUid(), req.GetRunscPath(), req.GetEgressGateway() != nil, req.GetCpuMilli(), req.GetMemoryBytes(), durableVolumeNames(req.GetSpec())) {
+	if prepared && !s.prepared.matches(req.GetActorUid(), req.GetRunscPath(), req.GetEgressGateway() != nil, req.GetCpuMilli(), req.GetMemoryBytes(), durableVolumeNames(req.GetSpec()), false) {
 		return nil, status.Error(codes.FailedPrecondition, "prepared sandbox does not match RunWorkload request")
 	}
 	if !prepared {
@@ -1077,8 +1089,13 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	if err := s.rejectIfDraining(); err != nil {
 		return nil, err
 	}
-	if s.prepared != nil {
-		return nil, status.Error(codes.FailedPrecondition, "cannot restore over a prepared sandbox")
+	prepared := s.prepared != nil
+	if prepared && s.prepared.cleanupStarted {
+		return nil, status.Error(codes.FailedPrecondition, "prepared sandbox cleanup is incomplete")
+	}
+	if prepared && (req.GetScope() != ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA ||
+		!s.prepared.matches(req.GetActorUid(), req.GetRunscPath(), req.GetEgressGateway() != nil, req.GetCpuMilli(), req.GetMemoryBytes(), durableVolumeNames(req.GetSpec()), true)) {
+		return nil, status.Error(codes.FailedPrecondition, "prepared sandbox does not match RestoreWorkload request")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -1086,8 +1103,10 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	s.setActiveRPC(rpcRestoreWorkload, cancel)
 	defer s.clearActiveRPC()
 
-	if err := s.deactivateActorNetworking(ctx); err != nil {
-		return nil, err
+	if !prepared {
+		if err := s.deactivateActorNetworking(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	attribution := ateomstats.ActorAttributionFromRequest(req)
@@ -1106,14 +1125,16 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	if err != nil {
 		return nil, err
 	}
-	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
-		InteriorNetNS:      s.interiorNetNS,
-		DumpNetInfo:        true,
-		EgressRedirectPort: s.egressRedirectPort(req.GetEgressGateway() != nil),
-	}); err != nil {
-		// Same as the Run path: the defer below is not registered yet.
-		s.activeActor.Store(nil)
-		return nil, fmt.Errorf("while setting up actor network: %w", err)
+	if !prepared {
+		if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+			InteriorNetNS:      s.interiorNetNS,
+			DumpNetInfo:        true,
+			EgressRedirectPort: s.egressRedirectPort(req.GetEgressGateway() != nil),
+		}); err != nil {
+			// Same as the Run path: the defer below is not registered yet.
+			s.activeActor.Store(nil)
+			return nil, fmt.Errorf("while setting up actor network: %w", err)
+		}
 	}
 	rcmd := &runsc{
 		path:           req.GetRunscPath(),
@@ -1141,6 +1162,9 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 			}
 		}
 	}()
+	if prepared {
+		s.prepared = nil
+	}
 	checkpointDir := ateompath.RestoreStateDir(req.GetActorUid())
 
 	if hasDurableVolumes(req.GetSpec().GetContainers()) {
@@ -1148,11 +1172,12 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 			return nil, fmt.Errorf("while restoring durable-dir volumes: %w", err)
 		}
 	}
-	// Compose the pause rootfs before create (see RunWorkload). runsc restore
-	// only needs the rootfs to hold the correct content; whether it came from
-	// an untar or an overlay of cached layers is transparent to it.
-	if err := imagecache.SetupBundleRootfs(ateompath.OCIBundlePath(req.GetActorUid(), ocispec.PauseContainer)); err != nil {
-		return nil, fmt.Errorf("while composing pause rootfs: %w", err)
+	if !prepared {
+		// PrepareSandbox already composed this rootfs on the parallel path. The
+		// serial fallback still needs it before runsc create/restore.
+		if err := imagecache.SetupBundleRootfs(ateompath.OCIBundlePath(req.GetActorUid(), ocispec.PauseContainer)); err != nil {
+			return nil, fmt.Errorf("while composing pause rootfs: %w", err)
+		}
 	}
 
 	switch req.GetScope() {

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -321,6 +321,7 @@ func runAtunnel(ctx context.Context, upstream *url.URL) (*atunnel.Server, *atunn
 }
 
 const (
+	rpcPrepareSandbox     = "PrepareSandbox"
 	rpcRunWorkload        = "RunWorkload"
 	rpcRestoreWorkload    = "RestoreWorkload"
 	rpcCheckpointWorkload = "CheckpointWorkload"
@@ -337,6 +338,24 @@ type activeRPCInfo struct {
 type workloadSession struct {
 	rcmd       *runsc
 	containers []string
+}
+
+// preparedSandbox is the root container started by PrepareSandbox and waiting
+// for the matching RunWorkload call. It is guarded by AteomService.lock.
+type preparedSandbox struct {
+	actorUID       string
+	runscPath      string
+	redirectEgress bool
+	cpuMilli       int64
+	memoryBytes    int64
+	durableVolumes []string
+	// rootDeleted makes DiscardPreparedSandbox retryable when later cleanup fails.
+	rootDeleted bool
+}
+
+func (p *preparedSandbox) matches(actorUID, runscPath string, redirectEgress bool, cpuMilli, memoryBytes int64, durableVolumes []string) bool {
+	return p.actorUID == actorUID && p.runscPath == runscPath && p.redirectEgress == redirectEgress &&
+		p.cpuMilli == cpuMilli && p.memoryBytes == memoryBytes && slices.Equal(p.durableVolumes, durableVolumes)
 }
 
 type cancelableMutex struct {
@@ -422,6 +441,10 @@ type AteomService struct {
 	// RunWorkload/RestoreWorkload, cleared by CheckpointWorkload. Guarded by lock.
 	activeSession *workloadSession
 
+	// prepared is non-nil between PrepareSandbox and the matching RunWorkload,
+	// or until DiscardPreparedSandbox tears the sandbox down.
+	prepared *preparedSandbox
+
 	activeRPCMu sync.Mutex
 	activeRPC   *activeRPCInfo
 
@@ -476,10 +499,10 @@ func (s *AteomService) clearActiveRPC() {
 	s.activeRPC = nil
 }
 
-func (s *AteomService) cancelActiveRestoreOrRunRPC() {
+func (s *AteomService) cancelActiveStartupRPC() {
 	s.activeRPCMu.Lock()
 	defer s.activeRPCMu.Unlock()
-	if s.activeRPC != nil && (s.activeRPC.name == rpcRestoreWorkload || s.activeRPC.name == rpcRunWorkload) {
+	if s.activeRPC != nil && (s.activeRPC.name == rpcPrepareSandbox || s.activeRPC.name == rpcRestoreWorkload || s.activeRPC.name == rpcRunWorkload) {
 		slog.Info("Cancelling in-progress workload startup RPC due to graceful shutdown", slog.String("rpc", s.activeRPC.name))
 		s.activeRPC.cancel()
 	}
@@ -489,10 +512,10 @@ func (s *AteomService) cancelActiveRestoreOrRunRPC() {
 // containers to exit.
 func (s *AteomService) gracefulShutdown(ctx context.Context) {
 	s.shuttingDown.Store(true)
-	// If there is an active run or restore RPC, try to cancel it. This is considered
+	// If there is an active startup RPC, try to cancel it. This is considered
 	// less disruptive than waiting for it to complete and then immediately sending
 	// a SIGTERM.
-	s.cancelActiveRestoreOrRunRPC()
+	s.cancelActiveStartupRPC()
 
 	// One deadline covers the whole drain. Waiting for the lock and waiting out
 	// SIGTERM below both run against it, so the two phases split a single grace
@@ -630,6 +653,130 @@ func containerNames(containers []*ateompb.Container) []string {
 	return names
 }
 
+// PrepareSandbox starts gVisor's root container while atelet continues pulling
+// and unpacking the application images.
+func (s *AteomService) PrepareSandbox(ctx context.Context, req *ateompb.PrepareSandboxRequest) (resp *ateompb.PrepareSandboxResponse, retErr error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if err := s.rejectIfDraining(); err != nil {
+		return nil, err
+	}
+	if req.GetActorUid() == "" || req.GetRunscPath() == "" {
+		return nil, status.Error(codes.InvalidArgument, "actor_uid and runsc_path are required")
+	}
+	if s.prepared != nil {
+		if s.prepared.rootDeleted {
+			return nil, status.Error(codes.FailedPrecondition, "prepared sandbox cleanup is incomplete")
+		}
+		if s.prepared.matches(req.GetActorUid(), req.GetRunscPath(), req.GetRedirectEgress(), req.GetCpuMilli(), req.GetMemoryBytes(), durableVolumeNames(req.GetSpec())) {
+			return &ateompb.PrepareSandboxResponse{}, nil
+		}
+		return nil, status.Error(codes.FailedPrecondition, "ateom already has a different prepared sandbox")
+	}
+	if s.activeSession != nil {
+		return nil, status.Error(codes.FailedPrecondition, "ateom already has a running workload")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	s.setActiveRPC(rpcPrepareSandbox, cancel)
+	defer s.clearActiveRPC()
+
+	if err := s.deactivateActorNetworking(ctx); err != nil {
+		return nil, err
+	}
+	rcmd := &runsc{
+		path:           req.GetRunscPath(),
+		actorUID:       req.GetActorUid(),
+		size:           sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
+		durableVolumes: durableVolumeNames(req.GetSpec()),
+	}
+	rootCreated := false
+	networkConfigured := false
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cleanupCancel()
+		if rootCreated {
+			deleteContainers(cleanupCtx, rcmd, []string{ocispec.PauseContainer}, "PrepareSandbox")
+		}
+		if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(req.GetActorUid())); err != nil {
+			slog.WarnContext(cleanupCtx, "Failed to unmount rootfs after PrepareSandbox failure", "actorUID", req.GetActorUid(), "err", err)
+		}
+		if networkConfigured {
+			if err := ateomnet.CleanupActorNetwork(cleanupCtx, s.interiorNetNS); err != nil {
+				slog.WarnContext(cleanupCtx, "Failed to clean up actor network after PrepareSandbox failure", slog.Any("err", err))
+			}
+		}
+	}()
+
+	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+		InteriorNetNS:      s.interiorNetNS,
+		DumpNetInfo:        true,
+		EgressRedirectPort: s.egressRedirectPort(req.GetRedirectEgress()),
+	}); err != nil {
+		return nil, fmt.Errorf("while setting up actor network: %w", err)
+	}
+	networkConfigured = true
+	if err := imagecache.SetupBundleRootfs(ateompath.OCIBundlePath(req.GetActorUid(), ocispec.PauseContainer)); err != nil {
+		return nil, fmt.Errorf("while composing pause rootfs: %w", err)
+	}
+	if err := rcmd.cmdCreate(ctx, os.Stdout, ocispec.PauseContainer, nil); err != nil {
+		return nil, fmt.Errorf("while creating pause container: %w", err)
+	}
+	rootCreated = true
+	if err := rcmd.cmdStart(ctx, os.Stdout, ocispec.PauseContainer); err != nil {
+		return nil, fmt.Errorf("while starting pause container: %w", err)
+	}
+
+	s.prepared = &preparedSandbox{
+		actorUID:       req.GetActorUid(),
+		runscPath:      req.GetRunscPath(),
+		redirectEgress: req.GetRedirectEgress(),
+		cpuMilli:       req.GetCpuMilli(),
+		memoryBytes:    req.GetMemoryBytes(),
+		durableVolumes: durableVolumeNames(req.GetSpec()),
+	}
+	return &ateompb.PrepareSandboxResponse{}, nil
+}
+
+// DiscardPreparedSandbox releases a root sandbox when another concurrent
+// preparation step failed before RunWorkload could use it.
+func (s *AteomService) DiscardPreparedSandbox(ctx context.Context, req *ateompb.DiscardPreparedSandboxRequest) (*ateompb.DiscardPreparedSandboxResponse, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.prepared == nil {
+		return &ateompb.DiscardPreparedSandboxResponse{}, nil
+	}
+	if req.GetActorUid() != s.prepared.actorUID {
+		return nil, status.Errorf(codes.FailedPrecondition, "prepared sandbox belongs to actor %q", s.prepared.actorUID)
+	}
+
+	p := s.prepared
+	s.activeActor.Store(nil)
+	rcmd := &runsc{path: p.runscPath, actorUID: p.actorUID}
+	var cleanupErr error
+	if !p.rootDeleted {
+		if err := rcmd.cmdDelete(ctx, ocispec.PauseContainer); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while deleting prepared pause container: %w", err))
+		} else {
+			p.rootDeleted = true
+		}
+	}
+	if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(p.actorUID)); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while unmounting prepared sandbox rootfs: %w", err))
+	}
+	if err := ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("while cleaning up prepared sandbox network: %w", err))
+	}
+	if cleanupErr == nil {
+		s.prepared = nil
+	}
+	return &ateompb.DiscardPreparedSandboxResponse{}, cleanupErr
+}
+
 func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkloadRequest) (resp *ateompb.RunWorkloadResponse, retErr error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -642,8 +789,17 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	s.setActiveRPC(rpcRunWorkload, cancel)
 	defer s.clearActiveRPC()
 
-	if err := s.deactivateActorNetworking(ctx); err != nil {
-		return nil, err
+	prepared := s.prepared != nil
+	if prepared && s.prepared.rootDeleted {
+		return nil, status.Error(codes.FailedPrecondition, "prepared sandbox cleanup is incomplete")
+	}
+	if prepared && !s.prepared.matches(req.GetActorUid(), req.GetRunscPath(), req.GetEgressGateway() != nil, req.GetCpuMilli(), req.GetMemoryBytes(), durableVolumeNames(req.GetSpec())) {
+		return nil, status.Error(codes.FailedPrecondition, "prepared sandbox does not match RunWorkload request")
+	}
+	if !prepared {
+		if err := s.deactivateActorNetworking(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	attribution := ateomstats.ActorAttributionFromRequest(req)
@@ -663,15 +819,15 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	if err != nil {
 		return nil, err
 	}
-	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
-		InteriorNetNS:      s.interiorNetNS,
-		DumpNetInfo:        true,
-		EgressRedirectPort: s.egressRedirectPort(req.GetEgressGateway() != nil),
-	}); err != nil {
-		// Cleared here as well as in the deferred cleanup below, because that
-		// defer is not registered until after this check.
-		s.activeActor.Store(nil)
-		return nil, fmt.Errorf("while setting up actor network: %w", err)
+	if !prepared {
+		if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+			InteriorNetNS:      s.interiorNetNS,
+			DumpNetInfo:        true,
+			EgressRedirectPort: s.egressRedirectPort(req.GetEgressGateway() != nil),
+		}); err != nil {
+			s.activeActor.Store(nil)
+			return nil, fmt.Errorf("while setting up actor network: %w", err)
+		}
 	}
 	rcmd := &runsc{
 		path:           req.GetRunscPath(),
@@ -680,21 +836,21 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 		durableVolumes: durableVolumeNames(req.GetSpec()),
 	}
 	var containersToDelete []string
+	if prepared {
+		containersToDelete = append(containersToDelete, ocispec.PauseContainer)
+		s.prepared = nil
+	}
 	defer func() {
 		if retErr != nil {
 			s.activeActor.Store(nil)
-			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-			defer cancel()
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cleanupCancel()
 			if err := s.deactivateActorNetworking(cleanupCtx); err != nil {
 				slog.WarnContext(cleanupCtx, "Failed to deactivate actor networking after Run failure", slog.Any("err", err))
 			}
 			deleteContainers(cleanupCtx, rcmd, containersToDelete, "Run")
-			// Detach any bundle rootfs overlays a partially-completed setup
-			// mounted, mirroring the post-checkpoint cleanup — otherwise they
-			// linger in this namespace until atelet wipes the bundle dirs.
-			// Run before the network cleanup.
 			if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(req.GetActorUid())); err != nil {
-				slog.WarnContext(ctx, "Failed to unmount bundle rootfs overlays after Run failure",
+				slog.WarnContext(cleanupCtx, "Failed to unmount bundle rootfs overlays after Run failure",
 					"actorUID", req.GetActorUid(), "err", err)
 			}
 			if err := ateomnet.CleanupActorNetwork(cleanupCtx, s.interiorNetNS); err != nil {
@@ -702,20 +858,22 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 			}
 		}
 	}()
-	// Create and start pause container. The bundle rootfs is composed here —
-	// an overlay of the node's cached image layers plus the bundle's private
-	// upper — because mounting is ateom's job (atelet runs with no
-	// capabilities); runsc's gofer resolves the mount in this pod's mount
-	// namespace.
-	if err := imagecache.SetupBundleRootfs(ateompath.OCIBundlePath(req.GetActorUid(), ocispec.PauseContainer)); err != nil {
-		return nil, fmt.Errorf("while composing pause rootfs: %w", err)
-	}
-	containersToDelete = append(containersToDelete, ocispec.PauseContainer)
-	if err := rcmd.cmdCreate(ctx, os.Stdout, ocispec.PauseContainer, nil); err != nil {
-		return nil, fmt.Errorf("while creating pause container: %w", err)
-	}
-	if err := rcmd.cmdStart(ctx, os.Stdout, ocispec.PauseContainer); err != nil {
-		return nil, fmt.Errorf("while starting pause container: %w", err)
+	if !prepared {
+		// Create and start pause container. The bundle rootfs is composed here;
+		// an overlay of the node's cached image layers plus the bundle's private
+		// upper because mounting is ateom's job (atelet runs with no
+		// capabilities); runsc's gofer resolves the mount in this pod's mount
+		// namespace.
+		if err := imagecache.SetupBundleRootfs(ateompath.OCIBundlePath(req.GetActorUid(), ocispec.PauseContainer)); err != nil {
+			return nil, fmt.Errorf("while composing pause rootfs: %w", err)
+		}
+		containersToDelete = append(containersToDelete, ocispec.PauseContainer)
+		if err := rcmd.cmdCreate(ctx, os.Stdout, ocispec.PauseContainer, nil); err != nil {
+			return nil, fmt.Errorf("while creating pause container: %w", err)
+		}
+		if err := rcmd.cmdStart(ctx, os.Stdout, ocispec.PauseContainer); err != nil {
+			return nil, fmt.Errorf("while starting pause container: %w", err)
+		}
 	}
 
 	// Create and start each application container, each with its own log pipe so
@@ -757,6 +915,9 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.CheckpointWorkloadRequest) (*ateompb.CheckpointWorkloadResponse, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	if s.prepared != nil {
+		return nil, status.Error(codes.FailedPrecondition, "cannot checkpoint a prepared sandbox")
+	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -915,6 +1076,9 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	defer s.lock.Unlock()
 	if err := s.rejectIfDraining(); err != nil {
 		return nil, err
+	}
+	if s.prepared != nil {
+		return nil, status.Error(codes.FailedPrecondition, "cannot restore over a prepared sandbox")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/cmd/ateom-gvisor/prepared_test.go
+++ b/cmd/ateom-gvisor/prepared_test.go
@@ -63,6 +63,47 @@ func TestPreparedSandboxRejectsMismatchedRun(t *testing.T) {
 	}
 }
 
+func TestPreparedSandboxOriginMustMatchConsumer(t *testing.T) {
+	p := &preparedSandbox{
+		actorUID:       "actor-a",
+		runscPath:      "/runsc",
+		cpuMilli:       1000,
+		memoryBytes:    1 << 30,
+		durableVolumes: []string{"data"},
+		fromCheckpoint: true,
+	}
+	if p.matches("actor-a", "/runsc", false, 1000, 1<<30, []string{"data"}, false) {
+		t.Fatal("checkpoint preparation matched a cold RunWorkload")
+	}
+	if p.matches("actor-a", "/runsc", false, 1000, 1<<30, []string{"other"}, true) {
+		t.Fatal("checkpoint preparation matched different durable volumes")
+	}
+	if !p.matches("actor-a", "/runsc", false, 1000, 1<<30, []string{"data"}, true) {
+		t.Fatal("checkpoint preparation did not match its RestoreWorkload")
+	}
+}
+
+func TestCheckpointPreparedSandboxCannotBeReusedAfterCleanupStarts(t *testing.T) {
+	p := &preparedSandbox{
+		actorUID:       "actor-a",
+		runscPath:      "/runsc",
+		fromCheckpoint: true,
+		cleanupStarted: true,
+	}
+	s := &AteomService{lock: newCancelableMutex(), prepared: p}
+
+	if _, err := s.PrepareSandbox(t.Context(), &ateompb.PrepareSandboxRequest{
+		ActorUid: "actor-a", RunscPath: "/runsc", FromCheckpoint: true,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("PrepareSandbox() during cleanup error = %v, want FailedPrecondition", err)
+	}
+	if _, err := s.RestoreWorkload(t.Context(), &ateompb.RestoreWorkloadRequest{
+		ActorUid: "actor-a", RunscPath: "/runsc", Scope: ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("RestoreWorkload() during cleanup error = %v, want FailedPrecondition", err)
+	}
+}
+
 // TestPreparedSandboxLifecycleWithRunsc crosses the actual gVisor boundary:
 // PrepareSandbox boots the Sentry, then RunWorkload adds an application to it.
 // Set RUNSC_TEST_BINARY and run this test as root (a throwaway user/net/mount

--- a/cmd/ateom-gvisor/prepared_test.go
+++ b/cmd/ateom-gvisor/prepared_test.go
@@ -1,0 +1,229 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/agent-substrate/substrate/internal/actorlog"
+	"github.com/agent-substrate/substrate/internal/ateomnet"
+	"github.com/agent-substrate/substrate/internal/ateompath"
+	"github.com/agent-substrate/substrate/internal/atunnel"
+	"github.com/agent-substrate/substrate/internal/imagecache"
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/roottest"
+)
+
+func TestPreparedSandboxRejectsMismatchedRun(t *testing.T) {
+	s := &AteomService{
+		lock: newCancelableMutex(),
+		prepared: &preparedSandbox{
+			actorUID:    "actor-a",
+			runscPath:   "/runsc",
+			cpuMilli:    1000,
+			memoryBytes: 1 << 30,
+		},
+	}
+	req := &ateompb.PrepareSandboxRequest{ActorUid: "actor-a", RunscPath: "/runsc", CpuMilli: 1000, MemoryBytes: 1 << 30}
+	if _, err := s.PrepareSandbox(context.Background(), req); err != nil {
+		t.Fatalf("idempotent PrepareSandbox: %v", err)
+	}
+	_, err := s.RunWorkload(context.Background(), &ateompb.RunWorkloadRequest{
+		ActorUid: "actor-a", RunscPath: "/runsc", CpuMilli: 500, MemoryBytes: 1 << 30,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("mismatched RunWorkload code = %v, want %v", status.Code(err), codes.FailedPrecondition)
+	}
+}
+
+// TestPreparedSandboxLifecycleWithRunsc crosses the actual gVisor boundary:
+// PrepareSandbox boots the Sentry, then RunWorkload adds an application to it.
+// Set RUNSC_TEST_BINARY and run this test as root (a throwaway user/net/mount
+// namespace is sufficient).
+func TestPreparedSandboxLifecycleWithRunsc(t *testing.T) {
+	runscPath := os.Getenv("RUNSC_TEST_BINARY")
+	if runscPath == "" {
+		t.Skip("set RUNSC_TEST_BINARY to exercise the real gVisor lifecycle")
+	}
+	roottest.Require(t, "creating network namespaces, veth pairs, and nftables rules")
+	runscPath, err := filepath.Abs(runscPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	withPreparedSandboxNetNS(t, func(interior netns.NsHandle) {
+		oldActorsDir := ateompath.ActorsDir
+		ateompath.ActorsDir = t.TempDir()
+		defer func() { ateompath.ActorsDir = oldActorsDir }()
+
+		const actorUID = "prepared-sandbox-test"
+		for _, dir := range []string{ateompath.PIDFileDir(actorUID), ateompath.RunSCStateDir(actorUID)} {
+			if err := os.MkdirAll(dir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}
+		writeRunscTestBundle(t, actorUID, "pause", "sandbox")
+		writeRunscTestBundle(t, actorUID, "app", "container")
+
+		wrapper := filepath.Join(t.TempDir(), "runsc")
+		script := fmt.Sprintf("#!/bin/sh\n"+
+			"previous=\n"+
+			"for argument in \"$@\"; do\n"+
+			"  if [ \"$previous\" = \"-bundle\" ]; then\n"+
+			"    sed -i '/\"cgroupsPath\":/d' \"$argument/config.json\"\n"+
+			"  fi\n"+
+			"  previous=\"$argument\"\n"+
+			"done\n"+
+			"exec %q --TESTONLY-unsafe-nonroot --network=none --ignore-cgroups \"$@\"\n", runscPath)
+		if err := os.WriteFile(wrapper, []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+
+		s := NewService(interior, actorlog.NewActorLogger(io.Discard, false), &atunnel.Server{}, &atunnel.Egress{}, 0, "", "", "")
+		ctx := context.Background()
+		rcmd := &runsc{path: wrapper, actorUID: actorUID}
+		if _, err := s.PrepareSandbox(ctx, &ateompb.PrepareSandboxRequest{ActorUid: actorUID, RunscPath: wrapper}); err != nil {
+			t.Fatalf("PrepareSandbox: %v", err)
+		}
+		defer func() {
+			_ = rcmd.cmdDelete(context.Background(), "app")
+			_ = rcmd.cmdDelete(context.Background(), "pause")
+			_ = unix.Unmount(filepath.Join(ateompath.RunSCStateDir(actorUID), "null-netns"), unix.MNT_DETACH)
+			_ = imagecache.UnmountAllUnder(ateompath.OCIBundleDir(actorUID))
+			_ = ateomnet.CleanupActorNetwork(context.Background(), interior)
+		}()
+		if err := rcmd.cmdState(ctx, "pause"); err != nil {
+			t.Fatalf("prepared pause container is not running: %v", err)
+		}
+		// Fail after the pause container is deleted, then verify that retrying
+		// finishes the remaining cleanup without trying to delete it again.
+		closedNetNS, err := netns.Get()
+		if err != nil {
+			t.Fatal(err)
+		}
+		closedNetNS.Close()
+		s.interiorNetNS = closedNetNS
+		if _, err := s.DiscardPreparedSandbox(ctx, &ateompb.DiscardPreparedSandboxRequest{ActorUid: actorUID}); err == nil {
+			t.Fatal("DiscardPreparedSandbox succeeded with a closed network namespace")
+		}
+		s.interiorNetNS = interior
+		if _, err := s.DiscardPreparedSandbox(ctx, &ateompb.DiscardPreparedSandboxRequest{ActorUid: actorUID}); err != nil {
+			t.Fatalf("retrying DiscardPreparedSandbox: %v", err)
+		}
+		if err := rcmd.cmdState(ctx, "pause"); err == nil {
+			t.Fatal("pause container still exists after DiscardPreparedSandbox")
+		}
+		if _, err := s.PrepareSandbox(ctx, &ateompb.PrepareSandboxRequest{ActorUid: actorUID, RunscPath: wrapper}); err != nil {
+			t.Fatalf("PrepareSandbox after discard: %v", err)
+		}
+		if err := rcmd.cmdState(ctx, "app"); err == nil {
+			t.Fatal("application started before RunWorkload")
+		}
+
+		if _, err := s.RunWorkload(ctx, &ateompb.RunWorkloadRequest{
+			Atespace: "test", ActorName: "actor", ActorUid: actorUID, RunscPath: wrapper,
+			Spec: &ateompb.WorkloadSpec{Containers: []*ateompb.Container{{Name: "app"}}},
+		}); err != nil {
+			t.Fatalf("RunWorkload: %v", err)
+		}
+		if err := rcmd.cmdState(ctx, "app"); err != nil {
+			t.Fatalf("application did not join the prepared sandbox: %v", err)
+		}
+	})
+}
+
+func withPreparedSandboxNetNS(t *testing.T, fn func(netns.NsHandle)) {
+	t.Helper()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	original, err := netns.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer original.Close()
+	defer func() {
+		if err := netns.Set(original); err != nil {
+			t.Errorf("restoring original netns: %v", err)
+		}
+	}()
+	pod, err := netns.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pod.Close()
+	interior, err := netns.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer interior.Close()
+	if err := netns.Set(pod); err != nil {
+		t.Fatal(err)
+	}
+	fn(interior)
+}
+
+func writeRunscTestBundle(t *testing.T, actorUID, name, containerType string) {
+	t.Helper()
+	bundle := ateompath.OCIBundlePath(actorUID, name)
+	binDir := filepath.Join(bundle, "rootfs", "bin")
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	busybox, err := os.ReadFile("/bin/busybox")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "busybox"), busybox, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	annotations := map[string]string{
+		"io.kubernetes.cri.container-type": containerType,
+		"io.kubernetes.cri.container-name": name,
+	}
+	if containerType == "container" {
+		annotations["io.kubernetes.cri.sandbox-id"] = "pause"
+	}
+	spec := specs.Spec{
+		Version: specs.Version,
+		Process: &specs.Process{User: specs.User{}, Args: []string{"/bin/busybox", "sh", "-c", "while :; do /bin/busybox sleep 3600; done"}, Cwd: "/"},
+		Root:    &specs.Root{Path: "rootfs"},
+		Linux: &specs.Linux{Namespaces: []specs.LinuxNamespace{
+			{Type: specs.PIDNamespace}, {Type: specs.NetworkNamespace}, {Type: specs.IPCNamespace}, {Type: specs.UTSNamespace}, {Type: specs.MountNamespace},
+		}},
+		Annotations: annotations,
+	}
+	data, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "config.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -341,6 +341,7 @@ func ensureSharedPropagation(ctx context.Context, path string) error {
 }
 
 const (
+	rpcPrepareSandbox     = "PrepareSandbox"
 	rpcRunWorkload        = "RunWorkload"
 	rpcRestoreWorkload    = "RestoreWorkload"
 	rpcCheckpointWorkload = "CheckpointWorkload"
@@ -403,11 +404,16 @@ type AteomService struct {
 	shuttingDown atomic.Bool
 
 	// activeRPC is the workload RPC in flight, tracked so gracefulShutdown can
-	// cancel a run or restore rather than wait out its boot. Guarded by
+	// cancel a prepare, run, or restore rather than wait out its boot. Guarded by
 	// activeRPCMu, which is separate from lock because the whole point is to reach
 	// it while lock is held by the RPC being cancelled.
 	activeRPCMu sync.Mutex
 	activeRPC   *activeRPCInfo
+
+	// prepared is a micro-VM booted by PrepareSandbox while atelet prepares the
+	// application OCI bundles. RunWorkload consumes the slot; a failed parallel
+	// preparation releases it through DiscardPreparedSandbox.
+	prepared *preparedSandbox
 
 	podUID     string
 	chBinary   string
@@ -613,14 +619,14 @@ func (s *AteomService) clearActiveRPC() {
 	s.activeRPC = nil
 }
 
-// cancelActiveRestoreOrRunRPC cancels an in-flight run or restore so it releases
-// lock instead of running its boot to completion. A checkpoint is deliberately
-// left alone: it is the one workload RPC worth finishing during a drain, since
-// it is what saves the actor's state.
-func (s *AteomService) cancelActiveRestoreOrRunRPC() {
+// cancelActiveStartupRPC cancels an in-flight prepare, run, or restore so it
+// releases lock instead of running its boot to completion. A checkpoint is
+// deliberately left alone: it is the one workload RPC worth finishing during
+// a drain, since it is what saves the actor's state.
+func (s *AteomService) cancelActiveStartupRPC() {
 	s.activeRPCMu.Lock()
 	defer s.activeRPCMu.Unlock()
-	if s.activeRPC != nil && (s.activeRPC.name == rpcRestoreWorkload || s.activeRPC.name == rpcRunWorkload) {
+	if s.activeRPC != nil && (s.activeRPC.name == rpcPrepareSandbox || s.activeRPC.name == rpcRestoreWorkload || s.activeRPC.name == rpcRunWorkload) {
 		slog.Info("Cancelling in-progress workload startup RPC due to graceful shutdown", slog.String("rpc", s.activeRPC.name))
 		s.activeRPC.cancel()
 	}

--- a/cmd/ateom-microvm/prepared.go
+++ b/cmd/ateom-microvm/prepared.go
@@ -1,0 +1,293 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/ch"
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
+	"github.com/agent-substrate/substrate/internal/ateomnet"
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/sizing"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// sandboxBootParams is the subset of a workload request that fixes the shape
+// of a microVM before any application rootfs is available.
+type sandboxBootParams struct {
+	actorUID       string
+	assetPaths     map[string]string
+	redirectEgress bool
+	size           sizing.SandboxSize
+}
+
+func (p sandboxBootParams) matches(other sandboxBootParams) bool {
+	return p.actorUID == other.actorUID &&
+		maps.Equal(p.assetPaths, other.assetPaths) &&
+		p.redirectEgress == other.redirectEgress &&
+		p.size == other.size
+}
+
+func sandboxParamsFromPrepare(req *ateompb.PrepareSandboxRequest) sandboxBootParams {
+	return sandboxBootParams{
+		actorUID:       req.GetActorUid(),
+		assetPaths:     req.GetRuntimeAssetPaths(),
+		redirectEgress: req.GetRedirectEgress(),
+		size:           sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
+	}
+}
+
+func sandboxParamsFromRun(req *ateompb.RunWorkloadRequest) sandboxBootParams {
+	return sandboxBootParams{
+		actorUID:       req.GetActorUid(),
+		assetPaths:     req.GetRuntimeAssetPaths(),
+		redirectEgress: req.GetEgressGateway() != nil,
+		size:           sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
+	}
+}
+
+// preparedSandbox is a booted microVM whose kata-agent is answering, but whose
+// application rootfs has not been mounted and whose sandbox has not been
+// created in the guest. RunWorkload consumes it after atelet finishes the OCI
+// bundles; DiscardPreparedSandbox tears it down when the parallel image path
+// fails.
+type preparedSandbox struct {
+	params   sandboxBootParams
+	actor    *runningActor
+	envelope guestEnvelope
+
+	// cleanupStarted keeps an idempotent Prepare call from reporting success
+	// after a failed Discard has already torn down some of the resources.
+	cleanupStarted bool
+}
+
+// PrepareSandbox boots a microVM through a responsive kata-agent while atelet
+// prepares application OCI bundles in parallel. The kataShared filesystem is
+// deliberately left unmounted in the guest until RunWorkload late-mounts the
+// rootfs trees on the host and calls CreateSandbox.
+func (s *AteomService) PrepareSandbox(ctx context.Context, req *ateompb.PrepareSandboxRequest) (*ateompb.PrepareSandboxResponse, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if err := s.rejectIfDraining(); err != nil {
+		return nil, err
+	}
+	if req.GetActorUid() == "" {
+		return nil, status.Error(codes.InvalidArgument, "actor_uid is required")
+	}
+	containers := req.GetSpec().GetContainers()
+	if len(containers) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "actor spec has no containers")
+	}
+	if len(containers) > maxActorContainers {
+		return nil, status.Errorf(codes.Unimplemented, "ateom-microvm supports at most %d containers, got %d", maxActorContainers, len(containers))
+	}
+
+	params := sandboxParamsFromPrepare(req)
+	if s.prepared != nil {
+		if s.prepared.cleanupStarted {
+			return nil, status.Error(codes.FailedPrecondition, "prepared sandbox cleanup is incomplete")
+		}
+		if s.prepared.params.matches(params) {
+			return &ateompb.PrepareSandboxResponse{}, nil
+		}
+		return nil, status.Error(codes.FailedPrecondition, "ateom already has a different prepared sandbox")
+	}
+	if len(s.running) != 0 {
+		return nil, status.Error(codes.FailedPrecondition, "ateom already has a running workload")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	s.setActiveRPC(rpcPrepareSandbox, cancel)
+	defer s.clearActiveRPC()
+
+	if err := s.deactivateActorNetworking(ctx); err != nil {
+		return nil, err
+	}
+	prepared, err := s.bootSandbox(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	s.prepared = prepared
+	return &ateompb.PrepareSandboxResponse{}, nil
+}
+
+// DiscardPreparedSandbox releases a microVM whose application preparation
+// failed. Cleanup is retryable: a partial first attempt leaves the state in the
+// slot, but it can no longer be mistaken for a usable prepared sandbox.
+func (s *AteomService) DiscardPreparedSandbox(ctx context.Context, req *ateompb.DiscardPreparedSandboxRequest) (*ateompb.DiscardPreparedSandboxResponse, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.prepared == nil {
+		return &ateompb.DiscardPreparedSandboxResponse{}, nil
+	}
+	if req.GetActorUid() != s.prepared.params.actorUID {
+		return nil, status.Errorf(codes.FailedPrecondition, "prepared sandbox belongs to actor %q", s.prepared.params.actorUID)
+	}
+
+	s.prepared.cleanupStarted = true
+	if err := s.cleanupPreparedSandbox(ctx, s.prepared); err != nil {
+		return &ateompb.DiscardPreparedSandboxResponse{}, err
+	}
+	s.prepared = nil
+	return &ateompb.DiscardPreparedSandboxResponse{}, nil
+}
+
+// bootSandbox creates the runtime pieces that do not depend on an application
+// image: host networking, an empty unified virtio-fs share, the VMM, and the guest through
+// a responsive kata-agent. The caller owns the returned resources.
+func (s *AteomService) bootSandbox(ctx context.Context, params sandboxBootParams) (prepared *preparedSandbox, retErr error) {
+	paths := params.assetPaths
+	kernel, image := paths[assetKernel], paths[assetImage]
+	if kernel == "" || image == "" {
+		return nil, fmt.Errorf("ateom-microvm requires %q and %q asset paths", assetKernel, assetImage)
+	}
+	rr := s.resolveRuntime(paths)
+	memMiB, vcpus, kparams, err := s.guestConfig(rr)
+	if err != nil {
+		return nil, err
+	}
+	if v := params.size.VCPUs(); v > 0 {
+		vcpus = v
+	}
+	memMiB, err = resolveGuestMemMiB(params.size.MemoryBytes, s.memReserveMiB, memMiB)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+		InteriorNetNS:      s.interiorNetNS,
+		HostVethHWAddr:     hostVethHWAddr,
+		SweepInteriorLinks: true,
+		EgressRedirectPort: s.egressRedirectPort(params.redirectEgress),
+	}); err != nil {
+		return nil, fmt.Errorf("while setting up actor network: %w", err)
+	}
+
+	prepared = &preparedSandbox{
+		params: params,
+		actor:  &runningActor{baseID: params.actorUID},
+		envelope: guestEnvelope{
+			memMiB:        memMiB,
+			vcpus:         vcpus,
+			declaredBytes: params.size.MemoryBytes,
+			reserveMiB:    s.memReserveMiB,
+		},
+	}
+	cleanupTarget := prepared
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if cleanupErr := s.cleanupPreparedSandbox(cleanupCtx, cleanupTarget); cleanupErr != nil {
+			slog.WarnContext(cleanupCtx, "Failed to clean up microVM preparation", slog.Any("err", cleanupErr))
+		}
+	}()
+
+	kata.CleanupSandboxState(ctx, params.actorUID)
+	if err := os.MkdirAll(kata.VMDir(params.actorUID), 0o700); err != nil {
+		return nil, fmt.Errorf("while creating VM dir: %w", err)
+	}
+	if err := resetRootfsUpperDir(params.actorUID); err != nil {
+		return nil, err
+	}
+
+	prepared.actor.vfsdCmd, err = s.startRootfsShare(ctx, rr, params.actorUID)
+	if err != nil {
+		return nil, err
+	}
+
+	apiSocket := filepath.Join(kata.VMDir(params.actorUID), "clh-api.sock")
+	prepared.actor.apiSocket = apiSocket
+	var client *ch.Client
+	prepared.actor.chCmd, client, err = ch.LaunchVMM(ctx, ch.LaunchVMMOptions{
+		Binary:    rr.chBinary,
+		APISocket: apiSocket,
+		Stdout:    slogWriter{ctx},
+		Stderr:    slogWriter{ctx},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("while launching VMM: %w", err)
+	}
+
+	consoleLog := kata.ConsoleLogPath(params.actorUID)
+	vmCfg := buildVMConfig(params.actorUID, kernel, image, kparams, consoleLog, memMiB, vcpus,
+		agentInit(ctx, client.Info()), s.kataDebug)
+	if err := client.CreateVM(ctx, vmCfg); err != nil {
+		return nil, fmt.Errorf("while creating VM: %w", err)
+	}
+
+	tapFiles, err := s.setupRestoreTap(ctx, "tap0_kata", 1)
+	if err != nil {
+		return nil, fmt.Errorf("while building tap: %w", err)
+	}
+	defer func() {
+		for _, f := range tapFiles {
+			_ = f.Close()
+		}
+	}()
+	var fds []int
+	for _, f := range tapFiles {
+		fds = append(fds, int(f.Fd()))
+	}
+	if err := client.AddNetWithFDs(ctx, actorGuestMAC, 2*len(tapFiles), fds); err != nil {
+		return nil, fmt.Errorf("while adding net device: %w", err)
+	}
+
+	bootStart := time.Now()
+	if err := client.BootVM(ctx); err != nil {
+		return nil, fmt.Errorf("while booting VM: %w", err)
+	}
+	vsockPath := kata.VsockSocketPath(params.actorUID)
+	if !waitForFile(vsockPath, 15*time.Second) {
+		return nil, fmt.Errorf("kata-agent vsock socket %q did not appear", vsockPath)
+	}
+	vsockReady := time.Now()
+	prepared.actor.guestAgent, err = dialAgentRetry(ctx, vsockPath, 60*time.Second)
+	if err != nil {
+		logGuestBootDiagnostics(ctx, params.actorUID, consoleLog)
+		return nil, fmt.Errorf("while dialing kata-agent: %w", err)
+	}
+	agentReady := time.Now()
+	slog.InfoContext(ctx, "Micro-VM prepared", slog.String("id", params.actorUID),
+		slog.Duration("vsock_wait", vsockReady.Sub(bootStart)),
+		slog.Duration("agent_dial", agentReady.Sub(vsockReady)),
+		slog.Duration("boot_to_agent", agentReady.Sub(bootStart)))
+	return prepared, nil
+}
+
+func (s *AteomService) cleanupPreparedSandbox(ctx context.Context, prepared *preparedSandbox) error {
+	if prepared == nil {
+		return nil
+	}
+	return errors.Join(
+		s.teardownActor(ctx, prepared.params.actorUID, prepared.actor, nil),
+		s.deactivateActorNetworking(ctx),
+		ateomnet.CleanupActorNetwork(ctx, s.interiorNetNS),
+	)
+}

--- a/cmd/ateom-microvm/prepared.go
+++ b/cmd/ateom-microvm/prepared.go
@@ -42,13 +42,15 @@ type sandboxBootParams struct {
 	assetPaths     map[string]string
 	redirectEgress bool
 	size           sizing.SandboxSize
+	fromCheckpoint bool
 }
 
 func (p sandboxBootParams) matches(other sandboxBootParams) bool {
 	return p.actorUID == other.actorUID &&
 		maps.Equal(p.assetPaths, other.assetPaths) &&
 		p.redirectEgress == other.redirectEgress &&
-		p.size == other.size
+		p.size == other.size &&
+		p.fromCheckpoint == other.fromCheckpoint
 }
 
 func sandboxParamsFromPrepare(req *ateompb.PrepareSandboxRequest) sandboxBootParams {
@@ -57,6 +59,17 @@ func sandboxParamsFromPrepare(req *ateompb.PrepareSandboxRequest) sandboxBootPar
 		assetPaths:     req.GetRuntimeAssetPaths(),
 		redirectEgress: req.GetRedirectEgress(),
 		size:           sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
+		fromCheckpoint: req.GetFromCheckpoint(),
+	}
+}
+
+func sandboxParamsFromRestore(req *ateompb.RestoreWorkloadRequest) sandboxBootParams {
+	return sandboxBootParams{
+		actorUID:       req.GetActorUid(),
+		assetPaths:     req.GetRuntimeAssetPaths(),
+		redirectEgress: req.GetEgressGateway() != nil,
+		size:           sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
+		fromCheckpoint: true,
 	}
 }
 
@@ -71,9 +84,9 @@ func sandboxParamsFromRun(req *ateompb.RunWorkloadRequest) sandboxBootParams {
 
 // preparedSandbox is a booted microVM whose kata-agent is answering, but whose
 // application rootfs has not been mounted and whose sandbox has not been
-// created in the guest. RunWorkload consumes it after atelet finishes the OCI
-// bundles; DiscardPreparedSandbox tears it down when the parallel image path
-// fails.
+// created in the guest. RunWorkload or a DATA RestoreWorkload consumes it after
+// atelet finishes the OCI bundles; DiscardPreparedSandbox tears it down when a
+// concurrent preparation step fails.
 type preparedSandbox struct {
 	params   sandboxBootParams
 	actor    *runningActor
@@ -85,9 +98,9 @@ type preparedSandbox struct {
 }
 
 // PrepareSandbox boots a microVM through a responsive kata-agent while atelet
-// prepares application OCI bundles in parallel. The kataShared filesystem is
-// deliberately left unmounted in the guest until RunWorkload late-mounts the
-// rootfs trees on the host and calls CreateSandbox.
+// prepares application OCI bundles and, for a DATA restore, downloads the
+// checkpoint in parallel. The shared tree stays empty until RunWorkload or
+// RestoreWorkload stages the rootfs and volumes before CreateSandbox.
 func (s *AteomService) PrepareSandbox(ctx context.Context, req *ateompb.PrepareSandboxRequest) (*ateompb.PrepareSandboxResponse, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/cmd/ateom-microvm/prepared_integration_test.go
+++ b/cmd/ateom-microvm/prepared_integration_test.go
@@ -1,0 +1,121 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
+	"github.com/agent-substrate/substrate/internal/roottest"
+	"golang.org/x/sys/unix"
+)
+
+// This exercises the load-bearing filesystem boundary in split microVM
+// startup with a real virtiofsd: the daemon starts on an empty share, then an
+// application overlay mounted later must become visible in its mount namespace.
+func TestPreparedRootfsBecomesVisibleToVirtiofsd(t *testing.T) {
+	roottest.Require(t, "creating an isolated mount namespace and overlay mount")
+	virtiofsd := os.Getenv("VIRTIOFSD_TEST_BINARY")
+	if virtiofsd == "" {
+		t.Skip("set VIRTIOFSD_TEST_BINARY to run the real virtiofsd integration test")
+	}
+	if _, err := os.Stat(virtiofsd); err != nil {
+		t.Fatalf("VIRTIOFSD_TEST_BINARY: %v", err)
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	originalMountNS, err := os.Open("/proc/thread-self/ns/mnt")
+	if err != nil {
+		t.Fatalf("open original mount namespace: %v", err)
+	}
+	defer originalMountNS.Close()
+	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
+		t.Fatalf("unshare mount namespace: %v", err)
+	}
+	defer func() {
+		if err := unix.Setns(int(originalMountNS.Fd()), unix.CLONE_NEWNS); err != nil {
+			t.Errorf("restore original mount namespace: %v", err)
+		}
+	}()
+	if err := unix.Mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+		t.Fatalf("make test mount namespace private: %v", err)
+	}
+	if err := os.MkdirAll("/run/kata-containers", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureSharedPropagation(t.Context(), "/run/kata-containers"); err != nil {
+		t.Fatal(err)
+	}
+
+	id := fmt.Sprintf("prepared-rootfs-test-%d", os.Getpid())
+	kata.CleanupSandboxState(t.Context(), id)
+	defer kata.CleanupSandboxState(t.Context(), id)
+	defer os.RemoveAll(rootfsUpperDir(id))
+	if err := os.MkdirAll(kata.VMDir(id), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := resetRootfsUpperDir(id); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &AteomService{}
+	vfsd, err := s.startRootfsShare(t.Context(), resolvedRuntime{virtiofsd: virtiofsd}, id)
+	if err != nil {
+		t.Fatalf("startRootfsShare: %v", err)
+	}
+	defer func() {
+		if vfsd.Process != nil {
+			_ = vfsd.Process.Kill()
+			_, _ = vfsd.Process.Wait()
+		}
+	}()
+
+	lower := t.TempDir()
+	const proof = "mounted after virtiofsd started"
+	if err := os.WriteFile(filepath.Join(lower, "proof.txt"), []byte(proof), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctrs := []actorContainer{{name: "app", bundleRootfs: lower}}
+	if err := s.stageMergedRootfsMounts(t.Context(), id, ctrs, nil); err != nil {
+		t.Fatalf("stageMergedRootfsMounts: %v", err)
+	}
+	defer kata.UnmountMergedRootfs(id, "app")
+
+	// virtiofsd pivots its root to the shared directory. Reading through proc
+	// therefore observes its private mount namespace, not this test's namespace.
+	proofPath := filepath.Join(fmt.Sprintf("/proc/%d/root", vfsd.Process.Pid), "app", "rootfs", "proof.txt")
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, err := os.ReadFile(proofPath)
+		if err == nil {
+			if string(got) != proof {
+				t.Fatalf("proof content = %q, want %q", got, proof)
+			}
+			return
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("late rootfs mount never appeared inside virtiofsd: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/cmd/ateom-microvm/prepared_test.go
+++ b/cmd/ateom-microvm/prepared_test.go
@@ -46,6 +46,7 @@ func TestSandboxBootParamsMatchesVMShape(t *testing.T) {
 		{name: "assets", other: sandboxBootParams{actorUID: want.actorUID, assetPaths: map[string]string{assetKernel: "/other", assetImage: "/image"}, redirectEgress: true, size: want.size}},
 		{name: "egress", other: sandboxBootParams{actorUID: want.actorUID, assetPaths: want.assetPaths, size: want.size}},
 		{name: "limits", other: sandboxBootParams{actorUID: want.actorUID, assetPaths: want.assetPaths, redirectEgress: true, size: sizing.FromLimits(2000, 512*1024*1024)}},
+		{name: "checkpoint origin", other: sandboxBootParams{actorUID: want.actorUID, assetPaths: want.assetPaths, redirectEgress: true, size: want.size, fromCheckpoint: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -53,6 +54,23 @@ func TestSandboxBootParamsMatchesVMShape(t *testing.T) {
 				t.Fatalf("matches() = %v, want %v", got, tt.match)
 			}
 		})
+	}
+}
+
+func TestSandboxParamsFromRestoreMarksCheckpointOrigin(t *testing.T) {
+	req := &ateompb.RestoreWorkloadRequest{
+		ActorUid:          "actor-1",
+		RuntimeAssetPaths: map[string]string{assetKernel: "/kernel", assetImage: "/image"},
+		EgressGateway:     &ateompb.EgressGateway{},
+		CpuMilli:          1500,
+		MemoryBytes:       512 * 1024 * 1024,
+	}
+	got := sandboxParamsFromRestore(req)
+	if !got.fromCheckpoint {
+		t.Fatal("sandboxParamsFromRestore() did not mark checkpoint origin")
+	}
+	if got.actorUID != req.GetActorUid() || !got.redirectEgress || got.size != sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()) {
+		t.Fatalf("sandboxParamsFromRestore() = %+v, want request shape", got)
 	}
 }
 

--- a/cmd/ateom-microvm/prepared_test.go
+++ b/cmd/ateom-microvm/prepared_test.go
@@ -1,0 +1,109 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/sizing"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func testSandboxParams() sandboxBootParams {
+	return sandboxBootParams{
+		actorUID:       "actor-1",
+		assetPaths:     map[string]string{assetKernel: "/kernel", assetImage: "/image"},
+		redirectEgress: true,
+		size:           sizing.FromLimits(1500, 512*1024*1024),
+	}
+}
+
+func TestSandboxBootParamsMatchesVMShape(t *testing.T) {
+	want := testSandboxParams()
+	tests := []struct {
+		name  string
+		other sandboxBootParams
+		match bool
+	}{
+		{name: "identical", other: testSandboxParams(), match: true},
+		{name: "actor", other: sandboxBootParams{actorUID: "actor-2", assetPaths: want.assetPaths, redirectEgress: true, size: want.size}},
+		{name: "assets", other: sandboxBootParams{actorUID: want.actorUID, assetPaths: map[string]string{assetKernel: "/other", assetImage: "/image"}, redirectEgress: true, size: want.size}},
+		{name: "egress", other: sandboxBootParams{actorUID: want.actorUID, assetPaths: want.assetPaths, size: want.size}},
+		{name: "limits", other: sandboxBootParams{actorUID: want.actorUID, assetPaths: want.assetPaths, redirectEgress: true, size: sizing.FromLimits(2000, 512*1024*1024)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := want.matches(tt.other); got != tt.match {
+				t.Fatalf("matches() = %v, want %v", got, tt.match)
+			}
+		})
+	}
+}
+
+func TestRunWorkloadMismatchDoesNotConsumePreparedSandbox(t *testing.T) {
+	prepared := &preparedSandbox{params: testSandboxParams(), actor: &runningActor{}}
+	s := &AteomService{lock: newCancelableMutex(), prepared: prepared}
+
+	_, err := s.RunWorkload(t.Context(), &ateompb.RunWorkloadRequest{
+		ActorUid:          "different-actor",
+		RuntimeAssetPaths: testSandboxParams().assetPaths,
+		EgressGateway:     &ateompb.EgressGateway{},
+		CpuMilli:          1500,
+		MemoryBytes:       512 * 1024 * 1024,
+		Spec: &ateompb.WorkloadSpec{Containers: []*ateompb.Container{{
+			Name: "app",
+			DurableDirVolumeMounts: []*ateompb.DurableDirVolumeMount{{
+				VolumeName: "data",
+			}},
+		}}},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("RunWorkload() error = %v, want FailedPrecondition", err)
+	}
+	if s.prepared != prepared {
+		t.Fatal("mismatched RunWorkload consumed the prepared sandbox")
+	}
+}
+
+func TestPrepareSandboxIdempotencyStopsWhenCleanupStarts(t *testing.T) {
+	params := testSandboxParams()
+	prepared := &preparedSandbox{params: params, actor: &runningActor{}}
+	s := &AteomService{lock: newCancelableMutex(), prepared: prepared}
+	req := &ateompb.PrepareSandboxRequest{
+		ActorUid:          params.actorUID,
+		RuntimeAssetPaths: params.assetPaths,
+		RedirectEgress:    true,
+		CpuMilli:          1500,
+		MemoryBytes:       512 * 1024 * 1024,
+		Spec: &ateompb.WorkloadSpec{Containers: []*ateompb.Container{{
+			Name: "app",
+			DurableDirVolumeMounts: []*ateompb.DurableDirVolumeMount{{
+				VolumeName: "data",
+			}},
+		}}},
+	}
+
+	if _, err := s.PrepareSandbox(t.Context(), req); err != nil {
+		t.Fatalf("idempotent PrepareSandbox() returned %v", err)
+	}
+	prepared.cleanupStarted = true
+	if _, err := s.PrepareSandbox(t.Context(), req); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("PrepareSandbox() during cleanup error = %v, want FailedPrecondition", err)
+	}
+}

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -85,6 +85,18 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	if err := s.rejectIfDraining(); err != nil {
 		return nil, err
 	}
+	var prepared *preparedSandbox
+	if s.prepared != nil {
+		if s.prepared.cleanupStarted {
+			return nil, status.Error(codes.FailedPrecondition, "prepared sandbox cleanup is incomplete")
+		}
+		if req.GetScope() != ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA ||
+			!s.prepared.params.matches(sandboxParamsFromRestore(req)) {
+			return nil, status.Error(codes.FailedPrecondition, "RestoreWorkload does not match the prepared sandbox")
+		}
+		prepared = s.prepared
+		s.prepared = nil
+	}
 
 	// Same as RunWorkload: a restore is a boot, and graceful shutdown cancels it
 	// rather than queueing behind it.
@@ -93,9 +105,22 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	s.setActiveRPC(rpcRestoreWorkload, cancel)
 	defer s.clearActiveRPC()
 
-	if err := s.deactivateActorNetworking(ctx); err != nil {
-		return nil, err
+	if prepared == nil {
+		if err := s.deactivateActorNetworking(ctx); err != nil {
+			return nil, err
+		}
 	}
+	preparedPending := prepared
+	defer func() {
+		if retErr == nil || preparedPending == nil {
+			return
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cleanupCancel()
+		if err := s.cleanupPreparedSandbox(cleanupCtx, preparedPending); err != nil {
+			slog.WarnContext(cleanupCtx, "Failed to clean up prepared microVM after Restore failure", slog.Any("err", err))
+		}
+	}()
 
 	p := actorBootParams{
 		actorRef:         resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()},
@@ -149,6 +174,8 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		// A Data snapshot holds no guest state, so this is a cold boot that
 		// happens to start with the volumes already populated. readyz gating comes
 		// with the cold-boot path, so the actor is serving when we return.
+		p.prepared = prepared
+		preparedPending = nil // coldBootActor owns cleanup from this point.
 		if err := s.coldBootActorRetrying(ctx, p); err != nil {
 			return nil, err
 		}

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -351,8 +351,9 @@ type actorBootParams struct {
 	// Zero fields keep the kata defaults.
 	size sizing.SandboxSize
 	// prepared is non-nil when PrepareSandbox already booted the VM while atelet
-	// prepared the application OCI bundles. coldBootActor consumes it exactly
-	// once; a retry after a dead prepared VM performs a full fresh boot.
+	// prepared the application OCI bundles and, on restore, the checkpoint.
+	// coldBootActor consumes it exactly once; a retry after a dead prepared VM
+	// performs a full fresh boot.
 	prepared *preparedSandbox
 }
 
@@ -414,7 +415,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 		defer cancel()
 		if prepared != nil {
 			if cleanupErr := s.cleanupPreparedSandbox(cleanupCtx, prepared); cleanupErr != nil {
-				slog.WarnContext(cleanupCtx, "Failed to clean up microVM after Run failure", slog.Any("err", cleanupErr))
+				slog.WarnContext(cleanupCtx, "Failed to clean up microVM after cold boot failure", slog.Any("err", cleanupErr))
 			}
 		}
 		// buildActorContainers may have composed bundle overlays before a fresh

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -57,7 +57,7 @@ type runningActor struct {
 	// base-id file so the chain survives suspend->resume->suspend.
 	baseID string
 
-	// ateom owns this CH process (booted at Run or relaunched at Restore).
+	// ateom owns this CH process (booted at Prepare/Run or relaunched at Restore).
 	chCmd *exec.Cmd
 	// vfsdCmd is the virtiofsd serving the unified share (merged rootfs overlay,
 	// durable-dir volumes, and CSI volumes). ateom owns it; teardownActor
@@ -254,7 +254,9 @@ func writeGuestResolvConf(rootfs string) error {
 	return nil
 }
 
-// RunWorkload boots the actor as a cloud-hypervisor micro-VM and starts its containers.
+// RunWorkload starts an actor's containers in a cloud-hypervisor micro-VM. It
+// consumes a VM booted by PrepareSandbox when one is available, otherwise it
+// performs the same boot inline.
 //
 // ateom boots cloud-hypervisor directly (no kata shim) and gives each container a
 // rootfs merged ON THE HOST: overlay(image lower + host-disk upper), served over the
@@ -281,7 +283,17 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	s.setActiveRPC(rpcRunWorkload, cancel)
 	defer s.clearActiveRPC()
 
-	if err := s.deactivateActorNetworking(ctx); err != nil {
+	var prepared *preparedSandbox
+	if s.prepared != nil {
+		if s.prepared.cleanupStarted {
+			return nil, status.Error(codes.FailedPrecondition, "prepared sandbox cleanup is incomplete")
+		}
+		if !s.prepared.params.matches(sandboxParamsFromRun(req)) {
+			return nil, status.Error(codes.FailedPrecondition, "RunWorkload does not match the prepared sandbox")
+		}
+		prepared = s.prepared
+		s.prepared = nil
+	} else if err := s.deactivateActorNetworking(ctx); err != nil {
 		return nil, err
 	}
 
@@ -294,6 +306,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 		assetPaths:       req.GetRuntimeAssetPaths(),
 		egressGateway:    req.GetEgressGateway(),
 		size:             sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
+		prepared:         prepared,
 	}
 
 	attribution := p.actorAttribution()
@@ -337,6 +350,10 @@ type actorBootParams struct {
 	// memory); a container's own cgroup limit comes from its declared resources.
 	// Zero fields keep the kata defaults.
 	size sizing.SandboxSize
+	// prepared is non-nil when PrepareSandbox already booted the VM while atelet
+	// prepared the application OCI bundles. coldBootActor consumes it exactly
+	// once; a retry after a dead prepared VM performs a full fresh boot.
+	prepared *preparedSandbox
 }
 
 // actorAttribution regroups the actor fields that arrived on the Run/Restore
@@ -351,14 +368,13 @@ func (p actorBootParams) actorAttribution() resources.ActorAttribution {
 }
 
 // coldBootAttempts is how many times a cold boot is tried when the micro-VM
-// stops before the kata-agent answers. Two: one retry covers a transient guest
-// death (a contended host makes the guest's boot pathologically slow, and a
-// boot that stalls long enough is torn down guest-side), and beyond that the
-// fault is not transient and the caller should hear about it.
+// stops before any application container starts. Two: one retry covers a
+// transient guest death, and beyond that the fault is not transient and the
+// caller should hear about it.
 const coldBootAttempts = 2
 
 // coldBootActorRetrying cold-boots the actor, retrying if the micro-VM stopped
-// before the kata-agent answered.
+// before any application container started.
 //
 // Retrying is safe there and nowhere else: a guest that never reached its agent
 // ran none of the actor's containers, so the attempt has no observable effect,
@@ -370,19 +386,44 @@ const coldBootAttempts = 2
 func (s *AteomService) coldBootActorRetrying(ctx context.Context, p actorBootParams) error {
 	for attempt := 1; ; attempt++ {
 		err := s.coldBootActor(ctx, p)
+		p.prepared = nil
 		if err == nil || attempt >= coldBootAttempts || !errors.Is(err, errGuestStopped) {
 			return err
 		}
-		slog.WarnContext(ctx, "Micro-VM stopped before the kata-agent answered; retrying cold boot",
+		slog.WarnContext(ctx, "Micro-VM stopped before application containers started; retrying cold boot",
 			slog.String("id", p.actorUID), slog.Int("attempt", attempt), slog.Any("err", err))
 	}
 }
 
-// coldBootActor boots the actor's micro-VM from scratch and starts its
-// containers, registering the result in s.running. The caller holds s.lock and
+// coldBootActor completes a cold boot and starts the actor's containers,
+// reusing a VM from PrepareSandbox when supplied and otherwise booting one
+// inline. It registers the result in s.running. The caller holds s.lock and
 // owns the lifecycle logging.
 func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (retErr error) {
 	actorUID := p.actorUID
+	prepared := p.prepared
+
+	// From this point coldBootActor owns a VM supplied by PrepareSandbox or one
+	// returned by bootSandbox below. Install cleanup before any other operation:
+	// egress setup and OCI-bundle validation can fail before the normal boot path.
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if prepared != nil {
+			if cleanupErr := s.cleanupPreparedSandbox(cleanupCtx, prepared); cleanupErr != nil {
+				slog.WarnContext(cleanupCtx, "Failed to clean up microVM after Run failure", slog.Any("err", cleanupErr))
+			}
+		}
+		// buildActorContainers may have composed bundle overlays before a fresh
+		// boot was attempted. bootSandbox cleanup also reaches these mounts, but
+		// this covers failures that happen before bootSandbox owns any resources.
+		if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(actorUID)); err != nil {
+			slog.WarnContext(cleanupCtx, "Failed to unmount bundle rootfs overlays after Run failure", slog.Any("err", err))
+		}
+	}()
 
 	// All of the actor's containers share the one micro-VM (which is the pod
 	// sandbox): each gets its own overlay rootfs and its own kata-agent
@@ -403,59 +444,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	if kernel == "" || image == "" {
 		return fmt.Errorf("ateom-microvm requires %q and %q asset paths", assetKernel, assetImage)
 	}
-	rr := s.resolveRuntime(paths)
 	egress, err := s.prepareActorEgress(ctx, p.actorUID, p.egressGateway)
-	if err != nil {
-		return err
-	}
-
-	// Networking (host side): per-activation veth into the interior netns. The
-	// tap + TC mirror is built below (after the VM exists) so its FDs are fresh.
-	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
-		InteriorNetNS:      s.interiorNetNS,
-		HostVethHWAddr:     hostVethHWAddr,
-		SweepInteriorLinks: true,
-		EgressRedirectPort: s.egressRedirectPort(p.egressGateway != nil),
-	}); err != nil {
-		return fmt.Errorf("while setting up actor network: %w", err)
-	}
-	defer func() {
-		if retErr != nil {
-			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-			defer cancel()
-			if cleanupErr := s.deactivateActorNetworking(cleanupCtx); cleanupErr != nil {
-				slog.WarnContext(cleanupCtx, "Failed to deactivate actor networking after Run failure", slog.Any("err", cleanupErr))
-			}
-			if cleanupErr := ateomnet.CleanupActorNetwork(cleanupCtx, s.interiorNetNS); cleanupErr != nil {
-				slog.WarnContext(cleanupCtx, "Failed to clean up actor network after Run failure", slog.Any("err", cleanupErr))
-			}
-			// Detach any bundle rootfs overlays mounted by buildActorContainers
-			// before the failure, mirroring teardownActor's cleanup.
-			if err := imagecache.UnmountAllUnder(ateompath.OCIBundleDir(actorUID)); err != nil {
-				slog.WarnContext(ctx, "Failed to unmount bundle rootfs overlays after Run failure", slog.Any("err", err))
-			}
-		}
-	}()
-
-	// Guest sizing + agent kernel params from the kata config.
-	memMiB, vcpus, kparams, err := s.guestConfig(rr)
-	if err != nil {
-		return err
-	}
-
-	// Right-size the VM to the actor's declared limits (see internal/sizing),
-	// keeping the kata-config values above as the fallback when a limit is unset.
-	// vCPUs round up; VM RAM reserves a fixed margin for the VMM + virtiofsd, which
-	// share the pod cgroup with the guest RAM. A declared memory limit the reserve
-	// leaves too small to boot is rejected (resolveGuestMemMiB) rather than silently
-	// falling back to the larger kata default. NB: a FULL-scope snapshot restore
-	// reuses the size baked into the snapshot (restoreFullScope), so resizing an
-	// existing actor takes effect on its next cold boot.
-	sz := p.size
-	if v := sz.VCPUs(); v > 0 {
-		vcpus = v
-	}
-	memMiB, err = resolveGuestMemMiB(sz.MemoryBytes, s.memReserveMiB, memMiB)
 	if err != nil {
 		return err
 	}
@@ -467,125 +456,50 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 		return err
 	}
 
-	// Reject limits the guest can never satisfy, before the containers reach the
-	// agent. Restore does not repeat this: it resumes a snapshotted VM, and the
-	// template spec is immutable, so an actor's limits were validated when its
-	// golden was built.
-	if err := checkResourceEnvelope(ctrs, guestEnvelope{
-		memMiB:        memMiB,
-		vcpus:         vcpus,
-		declaredBytes: sz.MemoryBytes,
-		reserveMiB:    s.memReserveMiB,
-	}); err != nil {
+	tStarted := time.Now()
+	preparedEarly := prepared != nil
+	if prepared == nil {
+		prepared, err = s.bootSandbox(ctx, sandboxBootParams{
+			actorUID:       actorUID,
+			assetPaths:     paths,
+			redirectEgress: p.egressGateway != nil,
+			size:           p.size,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	tSandbox := time.Now()
+
+	// Reject limits the booted guest can never satisfy before any application
+	// container reaches the agent. The envelope is captured from the exact
+	// sizing used by bootSandbox, including for a VM prepared by an earlier RPC.
+	if err := checkResourceEnvelope(ctrs, prepared.envelope); err != nil {
 		return err
 	}
 
-	// Clean stale per-sandbox state + create the runtime dir for the sockets.
-	kata.CleanupSandboxState(ctx, actorUID)
-	if err := os.MkdirAll(kata.VMDir(actorUID), 0o700); err != nil {
-		return fmt.Errorf("while creating VM dir: %w", err)
-	}
-
-	// A cold boot starts from the bare image: give it a pristine host upper dir
-	// (atelet's actor-dir reset does not know this directory; see rootfsupper.go).
-	if err := resetRootfsUpperDir(actorUID); err != nil {
+	// virtiofsd and the guest are already running. Mount the application rootfs
+	// overlays into its shared tree only after atelet has completed the bundles;
+	// the guest first reads that tree in CreateSandbox below.
+	if err := s.stageMergedRootfsMounts(ctx, actorUID, ctrs, containers); err != nil {
 		return err
 	}
+	tRootfs := time.Now()
 
-	// Assemble each container's merged rootfs on the host (overlay of image lower +
-	// host upper, mounted into the shared dir) + durable-dir and CSI volumes (if any),
-	// and start the ONE virtiofsd that serves them all. CH connects to it at vm.create
-	// and demand-pages for the actor's lifetime, so ateom owns the process (killed in teardownActor).
-	vfsdCmd, err := s.stageMergedRootfs(ctx, rr, actorUID, ctrs, containers)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if retErr != nil && vfsdCmd.Process != nil {
-			_ = vfsdCmd.Process.Kill()
-			_, _ = vfsdCmd.Process.Wait()
-		}
-	}()
-
-	// Launch a bare VMM (CH + api-socket); ateom owns this process for teardown.
-	apiSocket := filepath.Join(kata.VMDir(actorUID), "clh-api.sock")
-	chCmd, client, err := ch.LaunchVMM(ctx, ch.LaunchVMMOptions{
-		Binary:    rr.chBinary,
-		APISocket: apiSocket,
-		Stdout:    slogWriter{ctx},
-		Stderr:    slogWriter{ctx},
-	})
-	if err != nil {
-		return fmt.Errorf("while launching VMM: %w", err)
-	}
-	defer func() {
-		if retErr != nil && chCmd.Process != nil {
-			_ = chCmd.Process.Kill()
-			_, _ = chCmd.Process.Wait()
-		}
-	}()
-
-	// Assemble the CH VmConfig (kata-compatible cmdline, RO kata image on /dev/vda +
-	// the virtio-fs device; no actor virtio-blk disks — rootfs writes land in the
-	// host-side overlay upper through the shared mount). The console log is also read
-	// on a failed agent dial below, so keep it here.
-	consoleLog := kata.ConsoleLogPath(actorUID)
-	vmCfg := buildVMConfig(actorUID, kernel, image, kparams, consoleLog, memMiB, vcpus,
-		agentInit(ctx, client.Info()), s.kataDebug)
-	if err := client.CreateVM(ctx, vmCfg); err != nil {
-		return fmt.Errorf("while creating VM: %w", err)
-	}
-
-	// Network device: build the tap + TC mirror against the actor veth and add a
-	// virtio-net to the created (pre-boot) VM with the tap FDs (SCM_RIGHTS).
-	tapFiles, err := s.setupRestoreTap(ctx, "tap0_kata", 1)
-	if err != nil {
-		return fmt.Errorf("while building tap: %w", err)
-	}
-	defer func() {
-		for _, f := range tapFiles {
-			_ = f.Close() // CH dups adopted FDs; ours always close.
-		}
-	}()
-	var fds []int
-	for _, f := range tapFiles {
-		fds = append(fds, int(f.Fd()))
-	}
-	if err := client.AddNetWithFDs(ctx, actorGuestMAC, 2*len(tapFiles), fds); err != nil {
-		return fmt.Errorf("while adding net device: %w", err)
-	}
-
-	// Boot.
-	if err := client.BootVM(ctx); err != nil {
-		return fmt.Errorf("while booting VM: %w", err)
-	}
-	slog.InfoContext(ctx, "Micro-VM booted", slog.String("id", actorUID), slog.String("api", apiSocket))
-
-	// Dial the kata-agent over hybrid-vsock. The agent only starts listening once
-	// the guest's init reaches kata-containers.target — well after CH creates the
-	// vsock socket file — so poll the CONNECT until it answers (as the kata shim
-	// does), rather than dialing once.
-	tBooted := time.Now()
+	// A VM prepared in a separate RPC can die while atelet is still pulling the
+	// image. Cloud Hypervisor removes this socket when it exits; classify that as
+	// the one safe retry case because no application container has run yet.
 	vsockPath := kata.VsockSocketPath(actorUID)
-	if !waitForFile(vsockPath, 15*time.Second) {
-		return fmt.Errorf("kata-agent vsock socket %q did not appear", vsockPath)
-	}
-	tVsock := time.Now()
-	ac, err := dialAgentRetry(ctx, vsockPath, 60*time.Second)
-	if err != nil {
-		logGuestBootDiagnostics(ctx, actorUID, consoleLog)
-		return fmt.Errorf("while dialing kata-agent: %w", err)
-	}
-	tDialed := time.Now()
-	// The agent client must stay open past this RPC: the stdout/stderr forwarding
-	// goroutines (started below) read over it for the actor's lifetime. It is stored
-	// on the runningActor and closed by teardownActor. Close it here only if Run
-	// fails after this point (no runningActor recorded).
-	defer func() {
-		if retErr != nil {
-			_ = ac.Close()
+	if _, err := os.Stat(vsockPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w (cloud-hypervisor removed %q): %v", errGuestStopped, vsockPath, err)
 		}
-	}()
+		return fmt.Errorf("while checking kata-agent vsock socket %q: %w", vsockPath, err)
+	}
+	ac := prepared.actor.guestAgent
+	if ac == nil {
+		return fmt.Errorf("prepared micro-VM has no kata-agent client")
+	}
 
 	// Post-boot kata-agent setup: sandbox, guest networking, start each container.
 	if err := s.startActorContainers(ctx, ac, actorUID, vsockPath, ctrs); err != nil {
@@ -597,21 +511,20 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	if err := readyz.WaitAll(ctx, containers, ateomnet.ActorVethIP); err != nil {
 		return fmt.Errorf("while waiting for container readyz: %w", err)
 	}
+	tReady := time.Now()
 
-	// Everything from BootVM onward, split. ateom used to log only the total, which
-	// hid where a cold boot actually goes: it is not the guest booting.
 	slog.InfoContext(ctx, "Actor boot phases", slog.String("id", actorUID),
-		slog.Duration("vsock_wait", tVsock.Sub(tBooted)),
-		slog.Duration("agent_dial", tDialed.Sub(tVsock)),
-		slog.Duration("containers", tContainers.Sub(tDialed)),
-		slog.Duration("readyz", time.Since(tContainers)),
-		slog.Duration("since_boot", time.Since(tBooted)))
+		slog.Bool("prepared_early", preparedEarly),
+		slog.Duration("sandbox", tSandbox.Sub(tStarted)),
+		slog.Duration("rootfs", tRootfs.Sub(tSandbox)),
+		slog.Duration("containers", tContainers.Sub(tRootfs)),
+		slog.Duration("readyz", tReady.Sub(tContainers)))
 
-	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, apiSocket: apiSocket, baseID: actorUID, guestAgent: ac, workloadIDs: workloadIDs(ctrs)}
 	if err := s.activateActorNetworking(p.actorRef.Atespace, p.actorRef.Name, egress); err != nil {
 		return err
 	}
-	s.running[actorUID] = ra
+	prepared.actor.workloadIDs = workloadIDs(ctrs)
+	s.running[actorUID] = prepared.actor
 
 	// Forward each container's stdout/stderr into the pod logs, keyed by the
 	// container id (== the name; see StartRootfsContainer). The goroutines read
@@ -678,45 +591,53 @@ func (s *AteomService) buildActorContainers(actorUID string, containers []*ateom
 	return ctrs, nil
 }
 
-// stageMergedRootfs assembles each container's merged rootfs on the host
-// (overlay: image lower + the actor's rootfs-upper dirs) at virtiofsd's
-// find-paths location (SharedDir(id)/<cid>/rootfs), stages durable-dir volumes,
-// CSI volumes, and system-info volumes (if any) under SharedDir(id)/durable,
-// SharedDir(id)/csi, and SharedDir(id)/system-info,
-// then starts the ONE virtiofsd that serves them all. Must run AFTER CleanupSandboxState (which
-// wipes SharedDir) and resetRootfsUpperDir/untarRootfsUpper (which own the
-// upper contents). The returned virtiofsd cmd outlives this call (CH
-// demand-pages from it); the caller owns it (tracked on runningActor, killed
-// in teardownActor).
-func (s *AteomService) stageMergedRootfs(ctx context.Context, rr resolvedRuntime, id string, ctrs []actorContainer, containers []*ateompb.Container) (*exec.Cmd, error) {
+// stageMergedRootfsMounts assembles each container's merged rootfs on the host
+// at virtiofsd's find-paths location and stages the actor's volumes beneath the
+// same unified share. It is separate from startRootfsShare so PrepareSandbox can
+// boot before the OCI bundles exist, then add all mounts before CreateSandbox.
+func (s *AteomService) stageMergedRootfsMounts(ctx context.Context, id string, ctrs []actorContainer, containers []*ateompb.Container) error {
 	upperBase := rootfsUpperDir(id)
 	for _, c := range ctrs {
 		if err := kata.StageMergedRootfs(ctx, c.bundleRootfs, upperBase, id, c.name); err != nil {
-			return nil, fmt.Errorf("while staging merged rootfs for %q: %w", c.name, err)
+			return fmt.Errorf("while staging merged rootfs for %q: %w", c.name, err)
 		}
 		for _, vm := range c.imageMounts {
 			src := ateompath.ImageVolumeMountPath(id, c.name, vm.GetVolumeName())
 			if err := kata.StageImageVolume(ctx, src, id, c.name, vm.GetVolumeName()); err != nil {
-				return nil, fmt.Errorf("while staging image volume %q for %q: %w", vm.GetVolumeName(), c.name, err)
+				return fmt.Errorf("while staging image volume %q for %q: %w", vm.GetVolumeName(), c.name, err)
 			}
 		}
 	}
 	if hasDurableVolumes(containers) {
 		if err := s.stageDurableVolumes(ctx, id); err != nil {
-			return nil, fmt.Errorf("while staging durable-dir volumes: %w", err)
+			return fmt.Errorf("while staging durable-dir volumes: %w", err)
 		}
 	}
 	if hasCsiVolumes(containers) {
 		if err := s.stageCsiVolumes(ctx, id); err != nil {
-			return nil, fmt.Errorf("while staging CSI volumes: %w", err)
+			return fmt.Errorf("while staging CSI volumes: %w", err)
 		}
 	}
 	if hasSystemInfoVolumes(containers) {
 		if err := s.stageSystemInfoVolumes(ctx, id); err != nil {
-			return nil, fmt.Errorf("while staging system-info volumes: %w", err)
+			return fmt.Errorf("while staging system-info volumes: %w", err)
 		}
 	}
-	vfsdLog, _ := os.OpenFile(virtiofsdLogPath(id), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	return nil
+}
+
+// startRootfsShare starts the one virtiofsd serving an actor's shared rootfs
+// tree. The tree may still be empty: mounts added later beneath this rshared
+// path propagate into virtiofsd's mount namespace.
+func (s *AteomService) startRootfsShare(ctx context.Context, rr resolvedRuntime, id string) (*exec.Cmd, error) {
+	if err := os.MkdirAll(kata.SharedDir(id), 0o755); err != nil {
+		return nil, fmt.Errorf("while creating virtiofsd shared directory: %w", err)
+	}
+	vfsdLog, err := os.OpenFile(virtiofsdLogPath(id), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("while opening virtiofsd log: %w", err)
+	}
+	defer vfsdLog.Close()
 	vfsdCmd, err := kata.StartVirtiofsd(ctx, kata.VirtiofsdOptions{
 		Binary:     rr.virtiofsd,
 		SocketPath: kata.VirtiofsdSocketPath(id),
@@ -727,6 +648,16 @@ func (s *AteomService) stageMergedRootfs(ctx context.Context, rr resolvedRuntime
 		return nil, fmt.Errorf("while starting virtiofsd: %w", err)
 	}
 	return vfsdCmd, nil
+}
+
+// stageMergedRootfs preserves the restore path's original ordering: assemble
+// all rootfs mounts first, then start virtiofsd. The returned process outlives
+// this call and is owned by the caller.
+func (s *AteomService) stageMergedRootfs(ctx context.Context, rr resolvedRuntime, id string, ctrs []actorContainer, containers []*ateompb.Container) (*exec.Cmd, error) {
+	if err := s.stageMergedRootfsMounts(ctx, id, ctrs, containers); err != nil {
+		return nil, err
+	}
+	return s.startRootfsShare(ctx, rr, id)
 }
 
 // guestConfig reads guest sizing + agent kernel params from the resolved kata
@@ -961,10 +892,10 @@ func (s *AteomService) startActorLogForwarding(ac *kata.AgentClient, a resources
 	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, true), a, containerName)
 }
 
-// errGuestStopped reports that the micro-VM stopped before the kata-agent
-// answered. Callers that can start over (a cold boot has no observable side
-// effects until the agent runs the containers) retry on it.
-var errGuestStopped = errors.New("micro-VM stopped before the kata-agent answered")
+// errGuestStopped reports that the micro-VM stopped before an application
+// container started. Callers can safely retry because there are no workload
+// side effects yet.
+var errGuestStopped = errors.New("micro-VM stopped before application containers started")
 
 // Bounds on the kata-agent dial poll. What they set is the window between the agent
 // starting to listen and us noticing: an attempt already in flight when the agent

--- a/cmd/ateom-microvm/shutdown.go
+++ b/cmd/ateom-microvm/shutdown.go
@@ -72,9 +72,10 @@ func (s *AteomService) gracefulShutdown(ctx context.Context) {
 	// are still waiting is turned away rather than queued behind us.
 	s.shuttingDown.Store(true)
 
-	// Cancel an in-flight run or restore. Waiting for a cold boot to finish only to
-	// SIGTERM the guest it just produced is strictly worse than aborting it.
-	s.cancelActiveRestoreOrRunRPC()
+	// Cancel an in-flight prepare, run, or restore. Waiting for a VM startup to
+	// finish only to SIGTERM the guest it just produced is strictly worse than
+	// aborting it.
+	s.cancelActiveStartupRPC()
 
 	// One deadline covers the whole drain. Waiting for the lock and waiting out
 	// SIGTERM below both run against it, so the two phases split a single grace
@@ -92,6 +93,11 @@ func (s *AteomService) gracefulShutdown(ctx context.Context) {
 		slog.ErrorContext(ctx, "Failed to acquire lock during graceful shutdown; another RPC is still running")
 		return
 	}
+	// A completed PrepareSandbox has no application process to signal, but it
+	// still owns a VMM, virtiofsds, mounts, and host networking. Remove it from
+	// the service slot under lock, then tear it down after unlocking.
+	prepared := s.prepared
+	s.prepared = nil
 	// Snapshot by value rather than ranging over s.running directly: we drop the
 	// lock immediately below, and a suspend landing mid-drain deletes from the live
 	// map and writes through the *runningActor it finds there (teardownActor closes
@@ -108,6 +114,11 @@ func (s *AteomService) gracefulShutdown(ctx context.Context) {
 	// Release lock so the service can answer new RPCs — notably a suspend arriving
 	// mid-drain — while the stop below waits out the grace period.
 	s.lock.Unlock()
+	if prepared != nil {
+		if err := s.cleanupPreparedSandbox(ctx, prepared); err != nil {
+			slog.WarnContext(ctx, "Failed to clean up prepared microVM during graceful shutdown", slog.Any("err", err))
+		}
+	}
 
 	if len(targets) == 0 {
 		slog.InfoContext(ctx, "No active actor sessions at shutdown; exiting cleanly")

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -1852,10 +1852,15 @@ type PrepareSandboxRequest struct {
 	RuntimeAssetPaths map[string]string `protobuf:"bytes,6,rep,name=runtime_asset_paths,json=runtimeAssetPaths,proto3" json:"runtime_asset_paths,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Runtime-specific preparation needs the workload shape: gVisor declares
 	// durable mount hints while microVM decides its early sandbox shape.
-	// Application image contents are consumed only by RunWorkload.
-	Spec          *WorkloadSpec `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Application rootfs and volume data are consumed only by RunWorkload or
+	// RestoreWorkload, after atelet finishes preparing them.
+	Spec *WorkloadSpec `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	// Whether RestoreWorkload, rather than RunWorkload, will consume this
+	// sandbox. Runtimes can defer initialization that depends on checkpoint
+	// contents.
+	FromCheckpoint bool `protobuf:"varint,8,opt,name=from_checkpoint,json=fromCheckpoint,proto3" json:"from_checkpoint,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *PrepareSandboxRequest) Reset() {
@@ -1935,6 +1940,13 @@ func (x *PrepareSandboxRequest) GetSpec() *WorkloadSpec {
 		return x.Spec
 	}
 	return nil
+}
+
+func (x *PrepareSandboxRequest) GetFromCheckpoint() bool {
+	if x != nil {
+		return x.FromCheckpoint
+	}
+	return false
 }
 
 type PrepareSandboxResponse struct {
@@ -2193,7 +2205,7 @@ const file_ateom_proto_rawDesc = "" +
 	"\x1eGetActiveWorkloadStatsResponse\x124\n" +
 	"\x06sample\x18\x01 \x01(\v2\x1a.ateom.WorkloadStatsSampleH\x00R\x06sample\x12A\n" +
 	"\x10no_sample_reason\x18\x02 \x01(\x0e2\x15.ateom.NoSampleReasonH\x00R\x0enoSampleReasonB\b\n" +
-	"\x06result\"\x90\x03\n" +
+	"\x06result\"\xb9\x03\n" +
 	"\x15PrepareSandboxRequest\x12\x1b\n" +
 	"\tactor_uid\x18\x01 \x01(\tR\bactorUid\x12\x1d\n" +
 	"\n" +
@@ -2202,7 +2214,8 @@ const file_ateom_proto_rawDesc = "" +
 	"\tcpu_milli\x18\x04 \x01(\x03R\bcpuMilli\x12!\n" +
 	"\fmemory_bytes\x18\x05 \x01(\x03R\vmemoryBytes\x12c\n" +
 	"\x13runtime_asset_paths\x18\x06 \x03(\v23.ateom.PrepareSandboxRequest.RuntimeAssetPathsEntryR\x11runtimeAssetPaths\x12'\n" +
-	"\x04spec\x18\a \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\x1aD\n" +
+	"\x04spec\x18\a \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\x12'\n" +
+	"\x0ffrom_checkpoint\x18\b \x01(\bR\x0efromCheckpoint\x1aD\n" +
 	"\x16RuntimeAssetPathsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x18\n" +

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -1850,8 +1850,9 @@ type PrepareSandboxRequest struct {
 	MemoryBytes int64 `protobuf:"varint,5,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"` // Memory limit in bytes.
 	// Runtime assets needed before a microVM can boot. Empty for gVisor.
 	RuntimeAssetPaths map[string]string `protobuf:"bytes,6,rep,name=runtime_asset_paths,json=runtimeAssetPaths,proto3" json:"runtime_asset_paths,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// The runtime-specific sandbox preparation may depend on workload shape,
-	// while application image contents are consumed only by RunWorkload.
+	// Runtime-specific preparation needs the workload shape: gVisor declares
+	// durable mount hints while microVM decides its early sandbox shape.
+	// Application image contents are consumed only by RunWorkload.
 	Spec          *WorkloadSpec `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -1838,6 +1838,220 @@ func (*GetActiveWorkloadStatsResponse_Sample) isGetActiveWorkloadStatsResponse_R
 
 func (*GetActiveWorkloadStatsResponse_NoSampleReason) isGetActiveWorkloadStatsResponse_Result() {}
 
+type PrepareSandboxRequest struct {
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	ActorUid  string                 `protobuf:"bytes,1,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	RunscPath string                 `protobuf:"bytes,2,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	// Whether the actor network needs transparent egress redirection.
+	RedirectEgress bool `protobuf:"varint,3,opt,name=redirect_egress,json=redirectEgress,proto3" json:"redirect_egress,omitempty"`
+	// The actor's declared size. The pause/root container is created by this RPC,
+	// so it must receive the same limits as the later RunWorkload call.
+	CpuMilli    int64 `protobuf:"varint,4,opt,name=cpu_milli,json=cpuMilli,proto3" json:"cpu_milli,omitempty"`          // CPU limit in millicores (1000 = one core).
+	MemoryBytes int64 `protobuf:"varint,5,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"` // Memory limit in bytes.
+	// Runtime assets needed before a microVM can boot. Empty for gVisor.
+	RuntimeAssetPaths map[string]string `protobuf:"bytes,6,rep,name=runtime_asset_paths,json=runtimeAssetPaths,proto3" json:"runtime_asset_paths,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// The runtime-specific sandbox preparation may depend on workload shape,
+	// while application image contents are consumed only by RunWorkload.
+	Spec          *WorkloadSpec `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareSandboxRequest) Reset() {
+	*x = PrepareSandboxRequest{}
+	mi := &file_ateom_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareSandboxRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareSandboxRequest) ProtoMessage() {}
+
+func (x *PrepareSandboxRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateom_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareSandboxRequest.ProtoReflect.Descriptor instead.
+func (*PrepareSandboxRequest) Descriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *PrepareSandboxRequest) GetActorUid() string {
+	if x != nil {
+		return x.ActorUid
+	}
+	return ""
+}
+
+func (x *PrepareSandboxRequest) GetRunscPath() string {
+	if x != nil {
+		return x.RunscPath
+	}
+	return ""
+}
+
+func (x *PrepareSandboxRequest) GetRedirectEgress() bool {
+	if x != nil {
+		return x.RedirectEgress
+	}
+	return false
+}
+
+func (x *PrepareSandboxRequest) GetCpuMilli() int64 {
+	if x != nil {
+		return x.CpuMilli
+	}
+	return 0
+}
+
+func (x *PrepareSandboxRequest) GetMemoryBytes() int64 {
+	if x != nil {
+		return x.MemoryBytes
+	}
+	return 0
+}
+
+func (x *PrepareSandboxRequest) GetRuntimeAssetPaths() map[string]string {
+	if x != nil {
+		return x.RuntimeAssetPaths
+	}
+	return nil
+}
+
+func (x *PrepareSandboxRequest) GetSpec() *WorkloadSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+type PrepareSandboxResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareSandboxResponse) Reset() {
+	*x = PrepareSandboxResponse{}
+	mi := &file_ateom_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareSandboxResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareSandboxResponse) ProtoMessage() {}
+
+func (x *PrepareSandboxResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ateom_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareSandboxResponse.ProtoReflect.Descriptor instead.
+func (*PrepareSandboxResponse) Descriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{23}
+}
+
+type DiscardPreparedSandboxRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ActorUid      string                 `protobuf:"bytes,1,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiscardPreparedSandboxRequest) Reset() {
+	*x = DiscardPreparedSandboxRequest{}
+	mi := &file_ateom_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscardPreparedSandboxRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscardPreparedSandboxRequest) ProtoMessage() {}
+
+func (x *DiscardPreparedSandboxRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ateom_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscardPreparedSandboxRequest.ProtoReflect.Descriptor instead.
+func (*DiscardPreparedSandboxRequest) Descriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *DiscardPreparedSandboxRequest) GetActorUid() string {
+	if x != nil {
+		return x.ActorUid
+	}
+	return ""
+}
+
+type DiscardPreparedSandboxResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiscardPreparedSandboxResponse) Reset() {
+	*x = DiscardPreparedSandboxResponse{}
+	mi := &file_ateom_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscardPreparedSandboxResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscardPreparedSandboxResponse) ProtoMessage() {}
+
+func (x *DiscardPreparedSandboxResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ateom_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscardPreparedSandboxResponse.ProtoReflect.Descriptor instead.
+func (*DiscardPreparedSandboxResponse) Descriptor() ([]byte, []int) {
+	return file_ateom_proto_rawDescGZIP(), []int{25}
+}
+
 var File_ateom_proto protoreflect.FileDescriptor
 
 const file_ateom_proto_rawDesc = "" +
@@ -1978,7 +2192,23 @@ const file_ateom_proto_rawDesc = "" +
 	"\x1eGetActiveWorkloadStatsResponse\x124\n" +
 	"\x06sample\x18\x01 \x01(\v2\x1a.ateom.WorkloadStatsSampleH\x00R\x06sample\x12A\n" +
 	"\x10no_sample_reason\x18\x02 \x01(\x0e2\x15.ateom.NoSampleReasonH\x00R\x0enoSampleReasonB\b\n" +
-	"\x06result*\x84\x01\n" +
+	"\x06result\"\x90\x03\n" +
+	"\x15PrepareSandboxRequest\x12\x1b\n" +
+	"\tactor_uid\x18\x01 \x01(\tR\bactorUid\x12\x1d\n" +
+	"\n" +
+	"runsc_path\x18\x02 \x01(\tR\trunscPath\x12'\n" +
+	"\x0fredirect_egress\x18\x03 \x01(\bR\x0eredirectEgress\x12\x1b\n" +
+	"\tcpu_milli\x18\x04 \x01(\x03R\bcpuMilli\x12!\n" +
+	"\fmemory_bytes\x18\x05 \x01(\x03R\vmemoryBytes\x12c\n" +
+	"\x13runtime_asset_paths\x18\x06 \x03(\v23.ateom.PrepareSandboxRequest.RuntimeAssetPathsEntryR\x11runtimeAssetPaths\x12'\n" +
+	"\x04spec\x18\a \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\x1aD\n" +
+	"\x16RuntimeAssetPathsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x18\n" +
+	"\x16PrepareSandboxResponse\"<\n" +
+	"\x1dDiscardPreparedSandboxRequest\x12\x1b\n" +
+	"\tactor_uid\x18\x01 \x01(\tR\bactorUid\" \n" +
+	"\x1eDiscardPreparedSandboxResponse*\x84\x01\n" +
 	"\rSnapshotScope\x12\x1e\n" +
 	"\x1aSNAPSHOT_SCOPE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13SNAPSHOT_SCOPE_FULL\x10\x01\x12\x17\n" +
@@ -1995,8 +2225,10 @@ const file_ateom_proto_rawDesc = "" +
 	"\x0eNoSampleReason\x12 \n" +
 	"\x1cNO_SAMPLE_REASON_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cNO_SAMPLE_REASON_NO_WORKLOAD\x10\x01\x12'\n" +
-	"#NO_SAMPLE_REASON_NOT_MEASURABLE_YET\x10\x022\x9a\x04\n" +
-	"\x05Ateom\x12F\n" +
+	"#NO_SAMPLE_REASON_NOT_MEASURABLE_YET\x10\x022\xd4\x05\n" +
+	"\x05Ateom\x12O\n" +
+	"\x0ePrepareSandbox\x12\x1c.ateom.PrepareSandboxRequest\x1a\x1d.ateom.PrepareSandboxResponse\"\x00\x12g\n" +
+	"\x16DiscardPreparedSandbox\x12$.ateom.DiscardPreparedSandboxRequest\x1a%.ateom.DiscardPreparedSandboxResponse\"\x00\x12F\n" +
 	"\vRunWorkload\x12\x19.ateom.RunWorkloadRequest\x1a\x1a.ateom.RunWorkloadResponse\"\x00\x12[\n" +
 	"\x12CheckpointWorkload\x12 .ateom.CheckpointWorkloadRequest\x1a!.ateom.CheckpointWorkloadResponse\"\x00\x12R\n" +
 	"\x0fRestoreWorkload\x12\x1d.ateom.RestoreWorkloadRequest\x1a\x1e.ateom.RestoreWorkloadResponse\"\x00\x12U\n" +
@@ -2017,7 +2249,7 @@ func file_ateom_proto_rawDescGZIP() []byte {
 }
 
 var file_ateom_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_ateom_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_ateom_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_ateom_proto_goTypes = []any{
 	(SnapshotScope)(0),                     // 0: ateom.SnapshotScope
 	(SandboxClass)(0),                      // 1: ateom.SandboxClass
@@ -2045,14 +2277,19 @@ var file_ateom_proto_goTypes = []any{
 	(*GetWorkloadStatsResponse)(nil),       // 23: ateom.GetWorkloadStatsResponse
 	(*GetActiveWorkloadStatsRequest)(nil),  // 24: ateom.GetActiveWorkloadStatsRequest
 	(*GetActiveWorkloadStatsResponse)(nil), // 25: ateom.GetActiveWorkloadStatsResponse
-	nil,                                    // 26: ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
-	nil,                                    // 27: ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
-	nil,                                    // 28: ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
+	(*PrepareSandboxRequest)(nil),          // 26: ateom.PrepareSandboxRequest
+	(*PrepareSandboxResponse)(nil),         // 27: ateom.PrepareSandboxResponse
+	(*DiscardPreparedSandboxRequest)(nil),  // 28: ateom.DiscardPreparedSandboxRequest
+	(*DiscardPreparedSandboxResponse)(nil), // 29: ateom.DiscardPreparedSandboxResponse
+	nil,                                    // 30: ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
+	nil,                                    // 31: ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
+	nil,                                    // 32: ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
+	nil,                                    // 33: ateom.PrepareSandboxRequest.RuntimeAssetPathsEntry
 }
 var file_ateom_proto_depIdxs = []int32{
 	8,  // 0: ateom.TerminateWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
 	8,  // 1: ateom.RunWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	26, // 2: ateom.RunWorkloadRequest.runtime_asset_paths:type_name -> ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
+	30, // 2: ateom.RunWorkloadRequest.runtime_asset_paths:type_name -> ateom.RunWorkloadRequest.RuntimeAssetPathsEntry
 	7,  // 3: ateom.RunWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
 	9,  // 4: ateom.WorkloadSpec.containers:type_name -> ateom.Container
 	14, // 5: ateom.Container.readyz:type_name -> ateom.Readyz
@@ -2062,10 +2299,10 @@ var file_ateom_proto_depIdxs = []int32{
 	13, // 9: ateom.Container.image_volume_mounts:type_name -> ateom.ImageVolumeMount
 	15, // 10: ateom.Readyz.http_get:type_name -> ateom.HTTPGetAction
 	8,  // 11: ateom.CheckpointWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	27, // 12: ateom.CheckpointWorkloadRequest.runtime_asset_paths:type_name -> ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
+	31, // 12: ateom.CheckpointWorkloadRequest.runtime_asset_paths:type_name -> ateom.CheckpointWorkloadRequest.RuntimeAssetPathsEntry
 	0,  // 13: ateom.CheckpointWorkloadRequest.scope:type_name -> ateom.SnapshotScope
 	8,  // 14: ateom.RestoreWorkloadRequest.spec:type_name -> ateom.WorkloadSpec
-	28, // 15: ateom.RestoreWorkloadRequest.runtime_asset_paths:type_name -> ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
+	32, // 15: ateom.RestoreWorkloadRequest.runtime_asset_paths:type_name -> ateom.RestoreWorkloadRequest.RuntimeAssetPathsEntry
 	0,  // 16: ateom.RestoreWorkloadRequest.scope:type_name -> ateom.SnapshotScope
 	7,  // 17: ateom.RestoreWorkloadRequest.egress_gateway:type_name -> ateom.EgressGateway
 	1,  // 18: ateom.WorkloadStatsSample.sandbox_class:type_name -> ateom.SandboxClass
@@ -2073,23 +2310,29 @@ var file_ateom_proto_depIdxs = []int32{
 	22, // 20: ateom.GetWorkloadStatsResponse.sample:type_name -> ateom.WorkloadStatsSample
 	22, // 21: ateom.GetActiveWorkloadStatsResponse.sample:type_name -> ateom.WorkloadStatsSample
 	3,  // 22: ateom.GetActiveWorkloadStatsResponse.no_sample_reason:type_name -> ateom.NoSampleReason
-	6,  // 23: ateom.Ateom.RunWorkload:input_type -> ateom.RunWorkloadRequest
-	17, // 24: ateom.Ateom.CheckpointWorkload:input_type -> ateom.CheckpointWorkloadRequest
-	19, // 25: ateom.Ateom.RestoreWorkload:input_type -> ateom.RestoreWorkloadRequest
-	21, // 26: ateom.Ateom.GetWorkloadStats:input_type -> ateom.GetWorkloadStatsRequest
-	24, // 27: ateom.Ateom.GetActiveWorkloadStats:input_type -> ateom.GetActiveWorkloadStatsRequest
-	4,  // 28: ateom.Ateom.TerminateWorkload:input_type -> ateom.TerminateWorkloadRequest
-	16, // 29: ateom.Ateom.RunWorkload:output_type -> ateom.RunWorkloadResponse
-	18, // 30: ateom.Ateom.CheckpointWorkload:output_type -> ateom.CheckpointWorkloadResponse
-	20, // 31: ateom.Ateom.RestoreWorkload:output_type -> ateom.RestoreWorkloadResponse
-	23, // 32: ateom.Ateom.GetWorkloadStats:output_type -> ateom.GetWorkloadStatsResponse
-	25, // 33: ateom.Ateom.GetActiveWorkloadStats:output_type -> ateom.GetActiveWorkloadStatsResponse
-	5,  // 34: ateom.Ateom.TerminateWorkload:output_type -> ateom.TerminateWorkloadResponse
-	29, // [29:35] is the sub-list for method output_type
-	23, // [23:29] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	33, // 23: ateom.PrepareSandboxRequest.runtime_asset_paths:type_name -> ateom.PrepareSandboxRequest.RuntimeAssetPathsEntry
+	8,  // 24: ateom.PrepareSandboxRequest.spec:type_name -> ateom.WorkloadSpec
+	26, // 25: ateom.Ateom.PrepareSandbox:input_type -> ateom.PrepareSandboxRequest
+	28, // 26: ateom.Ateom.DiscardPreparedSandbox:input_type -> ateom.DiscardPreparedSandboxRequest
+	6,  // 27: ateom.Ateom.RunWorkload:input_type -> ateom.RunWorkloadRequest
+	17, // 28: ateom.Ateom.CheckpointWorkload:input_type -> ateom.CheckpointWorkloadRequest
+	19, // 29: ateom.Ateom.RestoreWorkload:input_type -> ateom.RestoreWorkloadRequest
+	21, // 30: ateom.Ateom.GetWorkloadStats:input_type -> ateom.GetWorkloadStatsRequest
+	24, // 31: ateom.Ateom.GetActiveWorkloadStats:input_type -> ateom.GetActiveWorkloadStatsRequest
+	4,  // 32: ateom.Ateom.TerminateWorkload:input_type -> ateom.TerminateWorkloadRequest
+	27, // 33: ateom.Ateom.PrepareSandbox:output_type -> ateom.PrepareSandboxResponse
+	29, // 34: ateom.Ateom.DiscardPreparedSandbox:output_type -> ateom.DiscardPreparedSandboxResponse
+	16, // 35: ateom.Ateom.RunWorkload:output_type -> ateom.RunWorkloadResponse
+	18, // 36: ateom.Ateom.CheckpointWorkload:output_type -> ateom.CheckpointWorkloadResponse
+	20, // 37: ateom.Ateom.RestoreWorkload:output_type -> ateom.RestoreWorkloadResponse
+	23, // 38: ateom.Ateom.GetWorkloadStats:output_type -> ateom.GetWorkloadStatsResponse
+	25, // 39: ateom.Ateom.GetActiveWorkloadStats:output_type -> ateom.GetActiveWorkloadStatsResponse
+	5,  // 40: ateom.Ateom.TerminateWorkload:output_type -> ateom.TerminateWorkloadResponse
+	33, // [33:41] is the sub-list for method output_type
+	25, // [25:33] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_ateom_proto_init() }
@@ -2109,7 +2352,7 @@ func file_ateom_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateom_proto_rawDesc), len(file_ateom_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   25,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -21,7 +21,8 @@ option go_package = "github.com/agent-substrate/substrate/internal/proto/ateompb
 // Ateom is the interface to control a single gVisor (or, in the future microVM)
 // guest inside a worker pod.
 //
-// Each ateom server has two main states, "available" and "executing".
+// Each ateom server may be available, have a prepared root sandbox, or be
+// executing a workload.
 //
 // When the ateom is "available", the substrate control plane is free to either
 // boot a new workload (using RunWorkload), or restore an existing workload from
@@ -32,6 +33,14 @@ option go_package = "github.com/agent-substrate/substrate/internal/proto/ateompb
 // running workload (with CheckpointWorkload).  This moves the ateom back to
 // "free" state.
 service Ateom {
+  // PrepareSandbox starts the root sandbox before application images finish
+  // downloading. RunWorkload later attaches and starts the applications.
+  rpc PrepareSandbox(PrepareSandboxRequest) returns (PrepareSandboxResponse) {}
+
+  // DiscardPreparedSandbox tears down a sandbox that cannot be used because
+  // another concurrent preparation step failed.
+  rpc DiscardPreparedSandbox(DiscardPreparedSandboxRequest) returns (DiscardPreparedSandboxResponse) {}
+
   // RunWorkload tells ateom to begin running a new workload (one or more
   // containers, potentially with shared filesystems).
   rpc RunWorkload(RunWorkloadRequest) returns (RunWorkloadResponse) {}
@@ -454,4 +463,34 @@ message GetActiveWorkloadStatsResponse {
     WorkloadStatsSample sample = 1;
     NoSampleReason no_sample_reason = 2;
   }
+}
+
+message PrepareSandboxRequest {
+  string actor_uid = 1;
+  string runsc_path = 2;
+
+  // Whether the actor network needs transparent egress redirection.
+  bool redirect_egress = 3;
+
+  // The actor's declared size. The pause/root container is created by this RPC,
+  // so it must receive the same limits as the later RunWorkload call.
+  int64 cpu_milli = 4;    // CPU limit in millicores (1000 = one core).
+  int64 memory_bytes = 5; // Memory limit in bytes.
+
+  // Runtime assets needed before a microVM can boot. Empty for gVisor.
+  map<string, string> runtime_asset_paths = 6;
+
+  // The runtime-specific sandbox preparation may depend on workload shape,
+  // while application image contents are consumed only by RunWorkload.
+  WorkloadSpec spec = 7;
+}
+
+message PrepareSandboxResponse {
+}
+
+message DiscardPreparedSandboxRequest {
+  string actor_uid = 1;
+}
+
+message DiscardPreparedSandboxResponse {
 }

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -482,8 +482,14 @@ message PrepareSandboxRequest {
 
   // Runtime-specific preparation needs the workload shape: gVisor declares
   // durable mount hints while microVM decides its early sandbox shape.
-  // Application image contents are consumed only by RunWorkload.
+  // Application rootfs and volume data are consumed only by RunWorkload or
+  // RestoreWorkload, after atelet finishes preparing them.
   WorkloadSpec spec = 7;
+
+  // Whether RestoreWorkload, rather than RunWorkload, will consume this
+  // sandbox. Runtimes can defer initialization that depends on checkpoint
+  // contents.
+  bool from_checkpoint = 8;
 }
 
 message PrepareSandboxResponse {

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -18,8 +18,8 @@ package ateom;
 
 option go_package = "github.com/agent-substrate/substrate/internal/proto/ateompb";
 
-// Ateom is the interface to control a single gVisor (or, in the future microVM)
-// guest inside a worker pod.
+// Ateom is the interface to control a single gVisor or microVM guest inside a
+// worker pod.
 //
 // Each ateom server may be available, have a prepared root sandbox, or be
 // executing a workload.
@@ -480,8 +480,9 @@ message PrepareSandboxRequest {
   // Runtime assets needed before a microVM can boot. Empty for gVisor.
   map<string, string> runtime_asset_paths = 6;
 
-  // The runtime-specific sandbox preparation may depend on workload shape,
-  // while application image contents are consumed only by RunWorkload.
+  // Runtime-specific preparation needs the workload shape: gVisor declares
+  // durable mount hints while microVM decides its early sandbox shape.
+  // Application image contents are consumed only by RunWorkload.
   WorkloadSpec spec = 7;
 }
 

--- a/internal/proto/ateompb/ateom_grpc.pb.go
+++ b/internal/proto/ateompb/ateom_grpc.pb.go
@@ -47,8 +47,8 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
-// Ateom is the interface to control a single gVisor (or, in the future microVM)
-// guest inside a worker pod.
+// Ateom is the interface to control a single gVisor or microVM guest inside a
+// worker pod.
 //
 // Each ateom server may be available, have a prepared root sandbox, or be
 // executing a workload.
@@ -227,8 +227,8 @@ func (c *ateomClient) TerminateWorkload(ctx context.Context, in *TerminateWorklo
 // All implementations must embed UnimplementedAteomServer
 // for forward compatibility.
 //
-// Ateom is the interface to control a single gVisor (or, in the future microVM)
-// guest inside a worker pod.
+// Ateom is the interface to control a single gVisor or microVM guest inside a
+// worker pod.
 //
 // Each ateom server may be available, have a prepared root sandbox, or be
 // executing a workload.

--- a/internal/proto/ateompb/ateom_grpc.pb.go
+++ b/internal/proto/ateompb/ateom_grpc.pb.go
@@ -33,6 +33,8 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
+	Ateom_PrepareSandbox_FullMethodName         = "/ateom.Ateom/PrepareSandbox"
+	Ateom_DiscardPreparedSandbox_FullMethodName = "/ateom.Ateom/DiscardPreparedSandbox"
 	Ateom_RunWorkload_FullMethodName            = "/ateom.Ateom/RunWorkload"
 	Ateom_CheckpointWorkload_FullMethodName     = "/ateom.Ateom/CheckpointWorkload"
 	Ateom_RestoreWorkload_FullMethodName        = "/ateom.Ateom/RestoreWorkload"
@@ -48,7 +50,8 @@ const (
 // Ateom is the interface to control a single gVisor (or, in the future microVM)
 // guest inside a worker pod.
 //
-// Each ateom server has two main states, "available" and "executing".
+// Each ateom server may be available, have a prepared root sandbox, or be
+// executing a workload.
 //
 // When the ateom is "available", the substrate control plane is free to either
 // boot a new workload (using RunWorkload), or restore an existing workload from
@@ -59,6 +62,12 @@ const (
 // running workload (with CheckpointWorkload).  This moves the ateom back to
 // "free" state.
 type AteomClient interface {
+	// PrepareSandbox starts the root sandbox before application images finish
+	// downloading. RunWorkload later attaches and starts the applications.
+	PrepareSandbox(ctx context.Context, in *PrepareSandboxRequest, opts ...grpc.CallOption) (*PrepareSandboxResponse, error)
+	// DiscardPreparedSandbox tears down a sandbox that cannot be used because
+	// another concurrent preparation step failed.
+	DiscardPreparedSandbox(ctx context.Context, in *DiscardPreparedSandboxRequest, opts ...grpc.CallOption) (*DiscardPreparedSandboxResponse, error)
 	// RunWorkload tells ateom to begin running a new workload (one or more
 	// containers, potentially with shared filesystems).
 	RunWorkload(ctx context.Context, in *RunWorkloadRequest, opts ...grpc.CallOption) (*RunWorkloadResponse, error)
@@ -134,6 +143,26 @@ func NewAteomClient(cc grpc.ClientConnInterface) AteomClient {
 	return &ateomClient{cc}
 }
 
+func (c *ateomClient) PrepareSandbox(ctx context.Context, in *PrepareSandboxRequest, opts ...grpc.CallOption) (*PrepareSandboxResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PrepareSandboxResponse)
+	err := c.cc.Invoke(ctx, Ateom_PrepareSandbox_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *ateomClient) DiscardPreparedSandbox(ctx context.Context, in *DiscardPreparedSandboxRequest, opts ...grpc.CallOption) (*DiscardPreparedSandboxResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DiscardPreparedSandboxResponse)
+	err := c.cc.Invoke(ctx, Ateom_DiscardPreparedSandbox_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *ateomClient) RunWorkload(ctx context.Context, in *RunWorkloadRequest, opts ...grpc.CallOption) (*RunWorkloadResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(RunWorkloadResponse)
@@ -201,7 +230,8 @@ func (c *ateomClient) TerminateWorkload(ctx context.Context, in *TerminateWorklo
 // Ateom is the interface to control a single gVisor (or, in the future microVM)
 // guest inside a worker pod.
 //
-// Each ateom server has two main states, "available" and "executing".
+// Each ateom server may be available, have a prepared root sandbox, or be
+// executing a workload.
 //
 // When the ateom is "available", the substrate control plane is free to either
 // boot a new workload (using RunWorkload), or restore an existing workload from
@@ -212,6 +242,12 @@ func (c *ateomClient) TerminateWorkload(ctx context.Context, in *TerminateWorklo
 // running workload (with CheckpointWorkload).  This moves the ateom back to
 // "free" state.
 type AteomServer interface {
+	// PrepareSandbox starts the root sandbox before application images finish
+	// downloading. RunWorkload later attaches and starts the applications.
+	PrepareSandbox(context.Context, *PrepareSandboxRequest) (*PrepareSandboxResponse, error)
+	// DiscardPreparedSandbox tears down a sandbox that cannot be used because
+	// another concurrent preparation step failed.
+	DiscardPreparedSandbox(context.Context, *DiscardPreparedSandboxRequest) (*DiscardPreparedSandboxResponse, error)
 	// RunWorkload tells ateom to begin running a new workload (one or more
 	// containers, potentially with shared filesystems).
 	RunWorkload(context.Context, *RunWorkloadRequest) (*RunWorkloadResponse, error)
@@ -287,6 +323,12 @@ type AteomServer interface {
 // pointer dereference when methods are called.
 type UnimplementedAteomServer struct{}
 
+func (UnimplementedAteomServer) PrepareSandbox(context.Context, *PrepareSandboxRequest) (*PrepareSandboxResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PrepareSandbox not implemented")
+}
+func (UnimplementedAteomServer) DiscardPreparedSandbox(context.Context, *DiscardPreparedSandboxRequest) (*DiscardPreparedSandboxResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DiscardPreparedSandbox not implemented")
+}
 func (UnimplementedAteomServer) RunWorkload(context.Context, *RunWorkloadRequest) (*RunWorkloadResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RunWorkload not implemented")
 }
@@ -324,6 +366,42 @@ func RegisterAteomServer(s grpc.ServiceRegistrar, srv AteomServer) {
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&Ateom_ServiceDesc, srv)
+}
+
+func _Ateom_PrepareSandbox_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PrepareSandboxRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AteomServer).PrepareSandbox(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Ateom_PrepareSandbox_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AteomServer).PrepareSandbox(ctx, req.(*PrepareSandboxRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Ateom_DiscardPreparedSandbox_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DiscardPreparedSandboxRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AteomServer).DiscardPreparedSandbox(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Ateom_DiscardPreparedSandbox_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AteomServer).DiscardPreparedSandbox(ctx, req.(*DiscardPreparedSandboxRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _Ateom_RunWorkload_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -441,6 +519,14 @@ var Ateom_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "ateom.Ateom",
 	HandlerType: (*AteomServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "PrepareSandbox",
+			Handler:    _Ateom_PrepareSandbox_Handler,
+		},
+		{
+			MethodName: "DiscardPreparedSandbox",
+			Handler:    _Ateom_DiscardPreparedSandbox_Handler,
+		},
 		{
 			MethodName: "RunWorkload",
 			Handler:    _Ateom_RunWorkload_Handler,


### PR DESCRIPTION
Related to #968.

This implements early sandbox preparation for both cold starts and DATA-scope restores on gVisor and microVM. FULL and DATA_ON_GOLDEN restore paths remain unchanged because they resume the captured sandbox state.

## Summary

- split atelet OCI preparation into sandbox prerequisites and application-bundle preparation
- add internal PrepareSandbox and DiscardPreparedSandbox RPCs with request matching, idempotency, and retryable cleanup
- carry from_checkpoint on PrepareSandbox so runtimes can distinguish RunWorkload from RestoreWorkload consumers
- overlap DATA checkpoint download, application OCI preparation, and runtime initialization
- prepare gVisor networking + pause rootfs early; cold Run starts the root container immediately, while DATA restore defers runsc create until the filesystem checkpoint is available
- prepare microVM host networking + virtiofsd + Cloud Hypervisor + kata-agent early; RunWorkload or DATA RestoreWorkload late-mounts the completed rootfs/volume tree before guest CreateSandbox
- preserve CPU/memory limits, egress shape, runtime assets, and request origin across Prepare and its consumer
- retain the original inline RunWorkload / RestoreWorkload behavior when a runtime returns Unimplemented

## Synchronization

RunWorkload and RestoreWorkload are the barriers: atelet calls them only after both the checkpoint/image leg and sandbox preparation have completed. If either parallel leg fails, atelet discards the prepared sandbox with a detached, bounded cleanup context.

Only DATA restore uses from_checkpoint=true. FULL and DATA_ON_GOLDEN do not call PrepareSandbox, because their sandbox state comes from the memory image.

## Testing

- [x] make verify, including full-repository race tests, generation checks, lint, licenses, proto formatting, and shellcheck
- [x] real gVisor cold-start lifecycle in throwaway user/mount/network namespaces
- [x] real virtiofsd late-mount propagation test
- [x] real local KVM + Cloud Hypervisor + kata-agent PrepareSandbox -> RunWorkload through application-container startup
- [x] real local KVM + Cloud Hypervisor + kata-agent PrepareSandbox(from_checkpoint=true) -> RestoreWorkload(DATA) through application-container startup
- [x] compatibility test for runtimes returning Unimplemented
- [x] request-origin matching and partial-cleanup state tests
