### PR TITLE
atenet: never cancel an in-flight resume at the park budget

### DIFF
--- a/cmd/atenet/internal/router/ingress/resumer.go
+++ b/cmd/atenet/internal/router/ingress/resumer.go
@@ -182,15 +182,24 @@ func (r *ActorResumer) ResumeActor(ctx context.Context, actorRef resources.Actor
 		// one control-plane RPC per hot actor (see docs/request-parking.md).
 		bgCtx, bgCancel := context.WithTimeout(context.Background(), r.budget)
 		defer bgCancel()
+		// The budget bounds the RETRY LOOP only — it never cancels an
+		// in-flight ResumeActor. ateapi durably claims the worker and marks
+		// the actor RESUMING before the expensive snapshot restore begins,
+		// rolls back neither on cancellation, and nothing reclaims a RESUMING
+		// actor whose worker pod is alive — a budget cancel therefore throws
+		// the restore away and strands the worker (#675). An attempt still
+		// running when the budget elapses is waited for and its real result
+		// classified below; ateapi's own server-side RPC deadline bounds it.
+		attemptCtx := context.WithoutCancel(bgCtx)
 
 		backoff := r.backoff
 
 		var resumeResp *ateapipb.ResumeActorResponse
 		var lastRetryErr error
 
-		err := wait.ExponentialBackoffWithContext(bgCtx, backoff, func(ctx context.Context) (bool, error) {
+		err := wait.ExponentialBackoffWithContext(bgCtx, backoff, func(context.Context) (bool, error) {
 			var err error
-			resumeResp, err = r.apiClient.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+			resumeResp, err = r.apiClient.ResumeActor(attemptCtx, &ateapipb.ResumeActorRequest{
 				Actor: actorRef.ToObjectRef(),
 			})
 			if err == nil {
@@ -205,18 +214,20 @@ func (r *ActorResumer) ResumeActor(ctx context.Context, actorRef resources.Actor
 		})
 
 		if err != nil {
-			// If the budget elapsed while we were still retrying a transient error,
-			// surface that underlying error rather than the generic wait/deadline
-			// error so the HTTP boundary maps it faithfully (e.g. 503 "no free
-			// workers available") instead of a misleading timeout. The wrapper marks
-			// the exhaustion explicitly for the parking wait-duration metric.
+			// If the budget elapsed while we were still blocked on a retryable
+			// condition, surface that underlying error rather than the generic
+			// wait/deadline error so the HTTP boundary maps it faithfully
+			// (e.g. 503 "no free workers available") instead of a misleading
+			// timeout. The wrapper marks the exhaustion explicitly for the
+			// parking wait-duration metric.
 			//
-			// Gate on bgCtx itself, not on errors.Is(err, context.DeadlineExceeded):
-			// when the deadline lands during an in-flight ResumeActor RPC, gRPC
-			// surfaces a *status* error with code DeadlineExceeded that does not
-			// match the context sentinel, which would misreport budget exhaustion
-			// as a 504. bgCtx is this loop's only deadline source, so checking it
-			// covers both landing spots (mid-RPC and between retries).
+			// wait.Interrupted covers the budget landing between retries; the
+			// bgCtx check covers an attempt that came back with a retryable
+			// error only after the budget had already elapsed (the loop then
+			// exits with the context error). The RPC itself is never canceled,
+			// so the loop cannot end before its first attempt has completed —
+			// lastRetryErr is always the attempt's real answer here, and a
+			// definitive error (NotFound, ...) still passes through untouched.
 			if lastRetryErr != nil && (bgCtx.Err() != nil || wait.Interrupted(err)) {
 				return &resumeCallResult{leaderID: reqID, err: &budgetExhaustedError{lastErr: lastRetryErr}}, nil
 			}

--- a/cmd/atenet/internal/router/ingress/resumer_test.go
+++ b/cmd/atenet/internal/router/ingress/resumer_test.go
@@ -362,40 +362,94 @@ func TestActorResumer_Parking(t *testing.T) {
 		})
 	})
 
-	t.Run("BudgetExpiryDuringInFlightRPC", func(t *testing.T) {
+	t.Run("InFlightAttemptRunsToCompletion", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
+			// The core of #675: an attempt still running when the budget
+			// elapses is NEVER canceled — ateapi has already claimed a worker
+			// for it, and canceling would discard the restore and strand that
+			// worker. The attempt runs to completion and its success is served,
+			// while no new attempt starts after the budget.
+			const budget = 300 * time.Millisecond
+			var mu sync.Mutex
+			var calls int
+			var attemptStarts []time.Duration
+			var ctxErrAtReturn error
+			base := time.Now()
+			mock := &resumerMockClient{
+				resumeFn: func(ctx context.Context, in *ateapipb.ResumeActorRequest, opts ...grpc.CallOption) (*ateapipb.ResumeActorResponse, error) {
+					mu.Lock()
+					calls++
+					n := calls
+					attemptStarts = append(attemptStarts, time.Since(base))
+					mu.Unlock()
+					if n == 1 {
+						return nil, status.Error(codes.ResourceExhausted, "no free workers available")
+					}
+					// The restore overshoots the budget, as it routinely does
+					// under CI node contention.
+					time.Sleep(budget)
+					mu.Lock()
+					ctxErrAtReturn = ctx.Err()
+					mu.Unlock()
+					return &ateapipb.ResumeActorResponse{
+						Actor:   &ateapipb.Actor{Metadata: &ateapipb.ResourceMetadata{Name: testActorName}, Status: &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING, WorkerAssignment: &ateapipb.WorkerAssignment{WorkerPodIp: expectedIP}}},
+						Resumed: true,
+					}, nil
+				},
+			}
+
+			resumer := NewActorResumer(mock, withParking(ParkedRequestConfig{Max: 1, Budget: budget}))
+			actor, _, err := resumer.ResumeActor(context.Background(), testActorRef)
+			if err != nil {
+				t.Fatalf("expected the overshooting resume to be served, got %v", err)
+			}
+			if actor.GetStatus().GetWorkerAssignment().GetWorkerPodIp() != expectedIP {
+				t.Errorf("expected IP %q, got %q", expectedIP, actor.GetStatus().GetWorkerAssignment().GetWorkerPodIp())
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if ctxErrAtReturn != nil {
+				t.Errorf("the in-flight attempt's context was canceled (%v); the budget must never cancel an attempt", ctxErrAtReturn)
+			}
+			for i, s := range attemptStarts {
+				if s >= budget {
+					t.Errorf("attempt %d started at %v, after the %v budget: retries must stop at the budget", i+1, s, budget)
+				}
+			}
+		})
+	})
+
+	t.Run("LateRetryableErrorIsBudgetExhaustion", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// An attempt that outlives the budget and then fails with a
+			// retryable error must classify as budget exhaustion — the
+			// meaningful capacity 503, not a generic timeout 504.
+			const budget = 300 * time.Millisecond
 			var mu sync.Mutex
 			var calls int
 			mock := &resumerMockClient{
 				resumeFn: func(ctx context.Context, in *ateapipb.ResumeActorRequest, opts ...grpc.CallOption) (*ateapipb.ResumeActorResponse, error) {
 					mu.Lock()
 					calls++
-					n := calls
 					mu.Unlock()
-					if n == 1 {
-						// First attempt: transient saturation, remembered as the
-						// last retryable error.
-						return nil, status.Error(codes.FailedPrecondition, "no free workers available")
-					}
-					// Later attempt: block until the park budget cancels the RPC,
-					// then return what a real gRPC client returns — a *status*
-					// error with code DeadlineExceeded that does NOT satisfy
-					// errors.Is(err, context.DeadlineExceeded).
-					<-ctx.Done()
-					return nil, status.FromContextError(ctx.Err()).Err()
+					time.Sleep(budget + 100*time.Millisecond)
+					return nil, status.Error(codes.ResourceExhausted, "no free workers available")
 				},
 			}
 
-			resumer := NewActorResumer(mock, withParking(ParkedRequestConfig{Max: 1, Budget: 300 * time.Millisecond}))
+			resumer := NewActorResumer(mock, withParking(ParkedRequestConfig{Max: 1, Budget: budget}))
 			_, _, err := resumer.ResumeActor(context.Background(), testActorRef)
-			// The deadline landed mid-RPC; the client must still see the capacity
-			// error (503 "no free workers available"), not a generic timeout (504).
-			if got := status.Code(err); got != codes.FailedPrecondition {
-				t.Errorf("expected FailedPrecondition when the budget lands mid-RPC, got %v (err=%v)", got, err)
+			if got := status.Code(err); got != codes.ResourceExhausted {
+				t.Errorf("expected ResourceExhausted after a late retryable failure, got %v (err=%v)", got, err)
 			}
-			var budget *budgetExhaustedError
-			if !errors.As(err, &budget) {
+			var budgetErr *budgetExhaustedError
+			if !errors.As(err, &budgetErr) {
 				t.Errorf("expected the error to be marked as budget exhaustion, got %T (%v)", err, err)
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if calls != 1 {
+				t.Errorf("expected exactly 1 attempt (no retry after the budget), got %d", calls)
 			}
 		})
 	})

--- a/docs/request-parking.md
+++ b/docs/request-parking.md
@@ -43,6 +43,27 @@ keeps retrying with exponential backoff until either
   underlying capacity error is returned, surfacing as `503 "actor <id>
   unavailable: no free workers available"`.
 
+**The budget bounds retries, not a committed resume.** When the budget elapses
+the router stops starting new resume attempts, but an attempt already in
+flight is **never canceled**: by then the control plane has committed work to
+it, and canceling would discard an in-progress restore. Instead the router
+waits for that attempt's real result: a restore that overshoots the budget
+(routine under node contention) is **served late** rather than failed, and a
+late retryable error still surfaces as the capacity `503`. The attempt is
+bounded by the control plane's own server-side RPC deadline, and Envoy's
+ext_proc message timeout (`budget + 5s`) remains the ceiling on how long a
+client is held either way.
+
+**Worst-case occupancy.** A parked request's lot slot is held until its caller
+stops waiting; with the Envoy dataplane that is bounded by the ext_proc
+message timeout (`budget + 5s`). The resume attempt itself can outlive every
+caller: it carries no client-side deadline and runs until ateapi's
+server-side maximum RPC deadline, holding that actor's singleflight entry.
+New requests for the same actor during that window do not start another
+control-plane call — they join the in-flight attempt, and if it has not
+resolved by their own stream deadline they are ended by the dataplane's
+timeout rather than a router verdict.
+
 To bound resource use and provide backpressure, the router admits requests to a
 **parking lot** of fixed capacity (`--parked-request-max`, default `1024`). Each
 in-flight resume occupies one slot. When the lot is full, further requests are

--- a/internal/e2e/suites/parking/parking_test.go
+++ b/internal/e2e/suites/parking/parking_test.go
@@ -115,10 +115,28 @@ func TestRequestParking(t *testing.T) {
 		if !strings.Contains(res.body, "hello from") {
 			t.Errorf("parked request body = %q, want the counter greeting", res.body)
 		}
-		if elapsed >= routerParkBudget+2*time.Second {
-			t.Errorf("parked request served after %v, want inside the %v budget window", elapsed, routerParkBudget)
+		// The budget bounds retries, not a committed resume: a restore that
+		// overshoots the budget under CI contention is served rather than
+		// canceled, so the window allows for the overshoot while staying
+		// under Envoy's ext_proc timeout (budget + 5s).
+		if elapsed >= routerParkBudget+4*time.Second {
+			t.Errorf("parked request served after %v, want inside the %v budget window (+overshoot)", elapsed, routerParkBudget)
 		}
 		t.Logf("parked request served after %v", elapsed)
+
+		// The flake's root cause stranded actors in RESUMING with the worker
+		// claimed (#675): pin that B really converges and a follow-up request
+		// is served warm — a stranded actor would 503 it.
+		waitForActorState(ctx, t, clients, actorB, ateapipb.ActorState_ACTOR_STATE_RUNNING)
+		followUp, err := router.Get(ctx, resources.ActorRef{Atespace: parkingAtespace, Name: actorB}, "/")
+		if err != nil {
+			t.Fatalf("follow-up request failed transport-level: %v", err)
+		}
+		followUpBody, _ := io.ReadAll(followUp.Body)
+		followUp.Body.Close()
+		if followUp.StatusCode != http.StatusOK {
+			t.Errorf("follow-up request: status = %d (body %q), want 200 from the resumed actor", followUp.StatusCode, string(followUpBody))
+		}
 
 		// The slot must be released once served.
 		waitForParkedCount(ctx, t, statusz, func(active int) bool { return active == 0 })


### PR DESCRIPTION
The park budget doubled as the ResumeActor RPC deadline, so a resume that outlived it was cancelled mid-restore. ateapi claims the worker and persists RESUMING before the restore begins, rolls back neither on cancellation, and nothing reclaims a RESUMING actor on a live worker - a budget cancel therefore discarded the restore and stranded the worker, which is the TestRequestParking/ParkThenServed flake (#675).

The budget now bounds the retry loop only: an attempt still in flight when it elapses runs to completion on a non-cancellable context (bounded by ateapi's own server-side RPC deadline, with Envoy's ext_proc timeout unchanged as the client-side ceiling), and its real result is classified - an overshooting restore is served late instead of failed, and a late retryable error still surfaces as the capacity
503.

The e2e window widens to admit a served-late overshoot, and the test now pins the invariants the flake exposed: actor B reaches RUNNING and a follow-up request is served warm.

Fixes #675

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
