### PR TITLE
test(atecontroller): retry the WorkerPool update on conflict

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
@@ -424,13 +424,9 @@ func TestWorkerPoolPodTemplateUpdate(t *testing.T) {
 		return err == nil && dep.Spec.Template.Spec.NodeSelector["workload"] == "substrate", nil
 	})
 
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: wp.Name, Namespace: wp.Namespace}, wp); err != nil {
-		t.Fatalf("re-fetch WorkerPool: %v", err)
-	}
-	wp.Spec.Template.NodeSelector = map[string]string{"workload": "updated"}
-	if err := k8sClient.Update(ctx, wp); err != nil {
-		t.Fatalf("update WorkerPool template: %v", err)
-	}
+	updateWorkerPoolSpec(t, ctx, wp, "update WorkerPool template", func(current *atev1alpha1.WorkerPool) {
+		current.Spec.Template.NodeSelector = map[string]string{"workload": "updated"}
+	})
 
 	eventually(t, func(ctx context.Context) (bool, error) {
 		dep, err := getDeployment(ctx, wp)


### PR DESCRIPTION
Fixes #994

`TestWorkerPoolPodTemplateUpdate` intermittently fails on main with:

```
Operation cannot be fulfilled on workerpools.ate.dev "test-template-update":
the object has been modified; please apply your changes to the latest version and try again
```

Three runs on `main` carry it, each verified to fail on this test with this signature:

- https://github.com/agent-substrate/substrate/actions/runs/31623300605
- https://github.com/agent-substrate/substrate/actions/runs/31565968779
- https://github.com/agent-substrate/substrate/actions/runs/31507505284

The test read the WorkerPool and wrote it back without handling conflicts, while `WorkerPoolReconciler` writes the same object's status (`workerpool_controller.go:142`) and bumps its `resourceVersion`. A reconcile landing between the read and the write rejects it. The file already has `updateWorkerPoolSpec`, which re-reads and retries on conflict — and the comment on its sibling describes this exact failure — so this just uses it.

## Verification

`-count=N` proves nothing here: the unfixed test passes at `-count=100 -race` locally because the window is too narrow to hit by chance. I constructed the conflict instead, inserting a write between the test's read and its write:

| | result |
|---|---|
| bare get-then-update | fails with the CI error verbatim: `Operation cannot be fulfilled on workerpools.ate.dev "race-probe-bare": the object has been modified; please apply your changes to the latest version and try again` |
| via `updateWorkerPoolSpec` | retries, succeeds, and the change lands (verified `NodeSelector` is `updated` afterwards) |

The probe tests were only for this and are not included.

Scope: this shows the race is real and that the helper handles it. It does not prove the three CI failures took this exact path — the constructed contention is a manual write, whereas on CI it is the reconciler's status update. The error signature, the cause in the code, and the pre-existing helper all line up, but that last step is inference.

I checked the other `Update` call sites in this file; they already go through the retry helpers.


