### PR TITLE
benchmarking: add Nighthawk ingress capacity benchmark

### DIFF
--- a/benchmarking/automation/Dockerfile
+++ b/benchmarking/automation/Dockerfile
@@ -60,8 +60,9 @@ RUN python3 -m venv /opt/automation/venv \
  && /opt/automation/venv/bin/pip install --no-cache-dir -r /opt/automation/requirements.txt
 ENV PATH=/opt/automation/venv/bin:$PATH
 
-COPY orchestrator.py /opt/automation/orchestrator.py
-COPY manifests/runner-job.yaml.tmpl /opt/automation/manifests/runner-job.yaml.tmpl
+COPY orchestrator.py util.py /opt/automation/
+COPY testtypes/ /opt/automation/testtypes/
+COPY manifests/runner-job.yaml.tmpl manifests/nighthawk-ingress-runner-job.yaml.tmpl /opt/automation/manifests/
 
 ENV PYTHONUNBUFFERED=1
 

--- a/benchmarking/automation/README.md
+++ b/benchmarking/automation/README.md
@@ -3,7 +3,10 @@
 Scheduled, repeatable benchmark runs of a substrate branch. A CronJob on an
 **orchestration cluster** drives the full build/deploy/run/teardown cycle
 against a separate **test cluster**, once per entry in [tests.yaml](tests.yaml).
-Each run uploads results to GCS via `benchmarking/locust/runner.py`.
+Each run uploads results to GCS via `benchmarking/locust/runner.py`
+(`type: locust`) or `benchmarking/nighthawk-ingress/runner.py` (`type: nighthawk-ingress`,
+the router capacity benchmark — see
+[benchmarking/nighthawk-ingress/README.md](../nighthawk-ingress/README.md)).
 
 ## How it works
 
@@ -12,8 +15,9 @@ Each run uploads results to GCS via `benchmarking/locust/runner.py`.
 2. Orchestrator waits for DIND, copies the appropriate `ate-dev-env.sh`, runs
    `gcloud container clusters get-credentials` for the test cluster.
 3. Shallow-clones `--repo` at `--branch`, captures the commit hash.
-4. `docker build && docker push` builds the locust image tagged with the commit
-   hash and pushes it to `${KO_DOCKER_REPO}/locust-test:<commit>`.
+4. `docker build && docker push` builds the runner image for each test type
+   in use, tagged with the commit hash: `${KO_DOCKER_REPO}/locust-test:<commit>`
+   and/or `${KO_DOCKER_REPO}/nighthawk-ingress-test:<commit>`.
 5. `hack/install-ate.sh --deploy-ate-system` + `benchmarking/workloads/deploy.sh
    --deploy --sandbox-class <class>` (these build & push substrate / workload
    images via `ko` as part of their deploy steps — there's no separate
@@ -21,10 +25,17 @@ Each run uploads results to GCS via `benchmarking/locust/runner.py`.
    runs `hack/install-microvm-deps.sh --install` between the two, which
    stages kata + cloud-hypervisor + virtiofsd assets to the cluster's object
    store bucket and applies the cluster-wide `microvm` SandboxConfig.
+   For a `nighthawk-ingress` test the orchestrator additionally patches the
+   `atenet-router` Deployment right after `deploy_substrate`: `envoyCpu`
+   is the benchmark's independent variable and the shipped manifest sets
+   no cpu resources or `--concurrency`, so each test pins cpu
+   requests=limits and Envoy's thread count to its own `envoyCpu`, then
+   waits for the rollout before deploying workloads. The teardown after
+   each test redeploys substrate, so the pin never outlives its run.
 6. For each test in `tests.yaml`:
-   - Submits a Job using the just-built locust image; the Job runs
-     `runner.py -f <file> -t <duration> -u <users> --tag <commit> --name <name>
-     --dest <dest>`.
+   - Submits a Job using the just-built image for the test's type
+     (`runner-job.yaml.tmpl` for locust,
+     `nighthawk-ingress-runner-job.yaml.tmpl` for nighthawk-ingress).
    - Polls until complete/failed/timeout; tails logs; deletes the Job.
    - Tears down workloads + micro-VM deps (if any) + substrate.
    - If not the last test, redeploys them so the next run starts clean.

--- a/benchmarking/automation/manifests/nighthawk-ingress-runner-job.yaml.tmpl
+++ b/benchmarking/automation/manifests/nighthawk-ingress-runner-job.yaml.tmpl
@@ -1,0 +1,145 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Per-test Job manifest for `type: nighthawk-ingress` tests. Rendered by
+# orchestrator.py (${...} placeholders substituted before kubectl apply);
+# mirrors runner-job.yaml.tmpl's structure, labels, and credential volumes.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmarking
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: benchmark-runner
+  namespace: benchmarking
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: automated-benchmarking-permissions
+  namespace: ate-system
+subjects:
+- kind: ServiceAccount
+  name: benchmark-runner
+  namespace: benchmarking
+roleRef:
+  kind: Role
+  name: atelet-endpointslices
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: benchmarking
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: substrate-benchmark-runner
+        test-name: ${NAME}
+        tag: ${TAG}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: benchmark-runner
+      containers:
+      - name: runner
+        image: ${IMAGE}
+        imagePullPolicy: IfNotPresent
+        command:
+        - "python3"
+        - "/app/runner.py"
+        args:
+        - "--name"
+        - "${NAME}"
+        - "--tag"
+        - "${TAG}"
+        - "--dest"
+        - "${DEST}"
+        - "--envoy-cpu"
+        - "${ENVOY_CPU}"
+        - "--actors"
+        - "${ACTORS}"
+        - "--atespace"
+        - "${ATESPACE}"
+        - "--client-concurrency"
+        - "${CLIENT_CONCURRENCY}"
+        - "--connections"
+        - "${CONNECTIONS}"
+        - "--max-pending"
+        - "${MAX_PENDING}"
+        - "--initial-rps"
+        - "${INITIAL_RPS}"
+        - "--exp-factor"
+        - "${EXP_FACTOR}"
+        - "--measuring-period"
+        - "${MEASURING_PERIOD}"
+        - "--convergence-deadline"
+        - "${CONVERGENCE_DEADLINE}"
+        - "--testing-stage-duration"
+        - "${TESTING_STAGE_DURATION}"
+        - "--success-rate-threshold"
+        - "${SUCCESS_RATE}"
+        - "--send-rate-threshold"
+        - "${SEND_RATE}"
+        - "--tail-latency-slo-ms"
+        - "${TAIL_LATENCY_SLO_MS}"
+        env:
+        - name: ATE_ATEAPI_CLIENT_AUTH
+          value: "${ATE_ATEAPI_CLIENT_AUTH}"
+        volumeMounts:
+        - name: servicedns-ca
+          mountPath: /run/servicedns-ca
+          readOnly: true
+        - name: ateapi-token
+          mountPath: /run/ateapi-token
+          readOnly: true
+        - name: podidentity
+          mountPath: /run/podidentity.podcert.ate.dev
+          readOnly: true
+        # One core per event loop + one for the runner; no cpu limit so
+        # open-loop pacing is never throttled.
+        resources:
+          requests:
+            cpu: "${RUNNER_CPU}"
+            memory: "1Gi"
+      volumes:
+      - name: servicedns-ca
+        projected:
+          sources:
+          - clusterTrustBundle:
+              signerName: servicedns.podcert.ate.dev/identity
+              labelSelector:
+                matchLabels:
+                  podcert.ate.dev/canarying: live
+              path: ca.crt
+      - name: ateapi-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: api.ate-system.svc
+              expirationSeconds: 3600
+              path: token
+      - name: podidentity
+        projected:
+          sources:
+          - podCertificate:
+              signerName: podidentity.podcert.ate.dev/identity
+              keyType: ECDSAP256
+              credentialBundlePath: credential-bundle.pem

--- a/benchmarking/automation/orchestrator.py
+++ b/benchmarking/automation/orchestrator.py
@@ -14,17 +14,32 @@
 
 """Substrate benchmark orchestrator.
 
-Clones a branch of the substrate repo, builds and deploys it to the test
-cluster, then submits one Kubernetes Job per entry in tests.yaml that runs
-benchmarking/locust/runner.py. Tears down substrate + workloads between
-tests so they don't pollute each other.
+Owns the generic benchmark lifecycle; everything specific to a test type
+lives in a testtypes/ module (see that package's docstring for the hook
+contract). The flow, with the type hooks marked:
+
+  1. Clone the substrate branch once; wait for the DIND sidecar.
+  2. Validate every tests.yaml entry before any cluster work
+     [hook: validate].
+  3. Per test entry:
+     a. Source the target cluster's env; gcloud/docker/kubectl setup and
+        the runner image build [hook: build_image] are cached per
+        target cluster.
+     b. Sweep leftovers, deploy substrate, let the type shape the
+        cluster [hook: pre_test], deploy workloads (+ microvm deps when
+        the sandbox class needs them).
+     c. Render the type's Job template [hooks: job_tmpl, job_subs],
+        submit it, wait, tail logs, delete the Job.
+     d. Tear substrate + workloads down again so tests don't pollute
+        each other, then drop the env file so the next test can't
+        inherit this one's cluster.
+  4. Exit non-zero if any test didn't complete.
 """
 
 import argparse
 import json
 import os
 import re
-import shlex
 import shutil
 import subprocess
 import sys
@@ -37,12 +52,17 @@ from typing import Any
 
 import yaml
 
+from testtypes import TYPES
+from util import parse_duration_seconds, run, run_no_check
+
 
 SUBSTRATE_DIR = "/workspace/substrate"
 TARGET_CLUSTER_DIR = "/etc/orchestrator/target-clusters"
 ENV_FILE_NAME = ".ate-dev-env.sh"
-RUNNER_JOB_TMPL = "/opt/automation/manifests/runner-job.yaml.tmpl"
+MANIFESTS_DIR = "/opt/automation/manifests"
 NAMESPACE = "benchmarking"
+
+TEST_TYPES = tuple(TYPES)
 
 # Snapshot the process's initial env so apply_config can return to a known
 # baseline before sourcing the next config (avoids stale vars carrying over
@@ -70,25 +90,15 @@ def parse_args() -> argparse.Namespace:
         help="Directory containing target cluster configuration scripts (<cluster>.sh)",
     )
     p.add_argument(
-        "--runner-job-tmpl",
-        default=RUNNER_JOB_TMPL,
-        help="Path to the runner job YAML template file",
+        "--manifests-dir",
+        default=MANIFESTS_DIR,
+        help="Directory holding the per-type runner Job templates",
     )
     p.add_argument(
         "--junit-output",
         help="Path to write a JUnit XML report summarizing test results and durations",
     )
     return p.parse_args()
-
-
-def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
-    print(f"$ {' '.join(shlex.quote(c) for c in cmd)}", flush=True)
-    return subprocess.run(cmd, check=True, **kwargs)
-
-
-def run_no_check(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
-    print(f"$ {' '.join(shlex.quote(c) for c in cmd)}", flush=True)
-    return subprocess.run(cmd, check=False, **kwargs)
 
 
 def source_env(path: str) -> None:
@@ -164,24 +174,8 @@ def gcloud_setup_for_target_cluster() -> None:
     )
 
 
-def build_locust_image(commit: str) -> str:
-    """Build & push the locust image to the current config's registry. The
-    image must live in the same project as the test cluster so the runner
-    Job can pull it. Returns the fully-qualified image reference."""
-    image = f"{os.environ['KO_DOCKER_REPO']}/locust-test:{commit}"
-    run(
-        [
-            "docker",
-            "build",
-            "-t",
-            image,
-            "-f",
-            "benchmarking/locust/Dockerfile",
-            ".",
-        ]
-    )
-    run(["docker", "push", image])
-    return image
+def test_type(test: dict[str, Any]) -> str:
+    return test["type"]
 
 
 def wait_for_docker(timeout: int = 120) -> None:
@@ -217,15 +211,6 @@ def render_template(path: str, subs: dict[str, Any], extra_args: Iterable[str] =
                 str(a) for a in extra_args
             )
     return yaml.safe_dump_all(docs)
-
-
-def parse_duration_seconds(s: str) -> int:
-    m = re.fullmatch(r"(\d+)\s*([smh]?)", s.strip())
-    if not m:
-        raise ValueError(f"unrecognized duration: {s}")
-    n = int(m.group(1))
-    unit = m.group(2) or "s"
-    return n * {"s": 1, "m": 60, "h": 3600}[unit]
 
 
 def wait_for_no_active_runners(timeout: int = 300) -> None:
@@ -292,6 +277,34 @@ def wait_for_job(name: str, timeout_seconds: int) -> str:
 SANDBOX_CLASSES = ("gvisor", "microvm")
 
 
+def validate_and_normalize_tests(tests: list[dict[str, Any]]) -> None:
+    """Fail fast (ValueError) on malformed entries, before any cluster
+    work: the type-independent fields here, everything else via the
+    type's validate hook."""
+    for t in tests:
+        name = t.get("name")
+        if not t.get("targetCluster"):
+            raise ValueError(f"test {name!r} missing required 'targetCluster' field")
+        sandbox_class = t.get("sandboxClass", "gvisor")
+        if sandbox_class not in SANDBOX_CLASSES:
+            raise ValueError(
+                f"test {name!r} has invalid sandboxClass {sandbox_class!r} "
+                f"(want one of {list(SANDBOX_CLASSES)})"
+            )
+        if "type" not in t:
+            raise ValueError(
+                f"test {name!r} missing required 'type' field "
+                f"(one of {list(TEST_TYPES)})"
+            )
+        ttype = test_type(t)
+        if ttype not in TEST_TYPES:
+            raise ValueError(
+                f"test {name!r} has invalid type {ttype!r} "
+                f"(want one of {list(TEST_TYPES)})"
+            )
+        TYPES[ttype].validate(t)
+
+
 def deploy_substrate() -> None:
     run(["hack/install-ate.sh", "--deploy-ate-system"])
 
@@ -354,22 +367,22 @@ def run_test(
     image: str,
     dest: str,
     commit: str,
-    runner_job_tmpl: str = RUNNER_JOB_TMPL,
+    manifests_dir: str = MANIFESTS_DIR,
 ) -> str:
     name = test["name"]
     job_name = f"runner-{sanitize(name)}-{commit[:7]}-{uuid.uuid4().hex[:6]}"
     subs = {
         "JOB_NAME": job_name,
         "IMAGE": image,
-        "TEST_FILE": test["file"],
-        "DURATION": test["duration"],
-        "USERS": test["users"],
         "TAG": commit,
         "NAME": name,
         "DEST": dest,
         "ATE_ATEAPI_CLIENT_AUTH": os.environ.get("ATE_ATEAPI_CLIENT_AUTH", "cert"),
     }
-    manifest = render_template(runner_job_tmpl, subs, test.get("flags", []))
+    mod = TYPES[test_type(test)]
+    tmpl = mod.job_tmpl(manifests_dir)
+    subs.update(mod.job_subs(test))
+    manifest = render_template(tmpl, subs, test.get("flags", []))
     wait_for_no_active_runners()
     print(f"Submitting Job {job_name}", flush=True)
     subprocess.run(
@@ -449,24 +462,19 @@ def main() -> None:
 
     tests = yaml.safe_load(Path(args.tests).read_text())["tests"]
     print(f"Running {len(tests)} test(s)", flush=True)
-    for t in tests:
-        if not t.get("targetCluster"):
-            sys.exit(
-                f"test {t.get('name')!r} missing required 'targetCluster' field"
-            )
-        sandbox_class = t.get("sandboxClass", "gvisor")
-        if sandbox_class not in SANDBOX_CLASSES:
-            sys.exit(
-                f"test {t.get('name')!r} has invalid sandboxClass "
-                f"{sandbox_class!r} (want one of {list(SANDBOX_CLASSES)})"
-            )
+    try:
+        validate_and_normalize_tests(tests)
+    except ValueError as e:
+        sys.exit(str(e))
 
     # Per-target-cluster caches: re-running setup for the same target
     # cluster is wasted work, so we track what was last set up and only
     # redo it when the target cluster name changes (substrate images get
-    # rebuilt by install-ate.sh each test anyway via ko apply).
+    # rebuilt by install-ate.sh each test anyway via ko apply). Runner
+    # images are built lazily per test type, so a locust-only tests.yaml
+    # never builds the nighthawk image and vice versa.
     last_target = None
-    locust_image = None
+    images: dict[str, str] = {}
     results = []
 
     for i, test in enumerate(tests):
@@ -489,8 +497,11 @@ def main() -> None:
         try:
             if target_cluster != last_target:
                 gcloud_setup_for_target_cluster()
-                locust_image = build_locust_image(commit)
+                images = {}
                 last_target = target_cluster
+            ttype = test_type(test)
+            if ttype not in images:
+                images[ttype] = TYPES[ttype].build_image(commit)
 
             # Idempotent sweep before anything else: a previous CronJob
             # fire that crashed mid-test (or any other process that left
@@ -509,6 +520,7 @@ def main() -> None:
             start_time = time.time()
             try:
                 deploy_substrate()
+                TYPES[ttype].pre_test(test)
                 # install-microvm-deps needs the CRDs from deploy_substrate;
                 # deploy_workloads needs the microvm SandboxConfig.
                 if sandbox_class == "microvm":
@@ -521,10 +533,10 @@ def main() -> None:
                 try:
                     status = run_test(
                         test,
-                        locust_image,
+                        images[ttype],
                         args.dest,
                         commit,
-                        args.runner_job_tmpl,
+                        args.manifests_dir,
                     )
                     if status != "complete":
                         failure_msg = f"Test finished with status: {status}"

--- a/benchmarking/automation/test_util.py
+++ b/benchmarking/automation/test_util.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for util.py: python3 benchmarking/automation/test_util.py"""
+
+import unittest
+from unittest import mock
+
+import util
+
+
+class ParseDurationSecondsTest(unittest.TestCase):
+    def test_units(self):
+        self.assertEqual(util.parse_duration_seconds("30"), 30)
+        self.assertEqual(util.parse_duration_seconds("30s"), 30)
+        self.assertEqual(util.parse_duration_seconds("5m"), 300)
+        self.assertEqual(util.parse_duration_seconds("2h"), 7200)
+
+    def test_whitespace(self):
+        self.assertEqual(util.parse_duration_seconds(" 10 m "), 600)
+
+    def test_invalid(self):
+        for bad in ("10 parsecs", "", "m", "1d", "-5s"):
+            with self.assertRaises(ValueError):
+                util.parse_duration_seconds(bad)
+
+
+class BuildAndPushTest(unittest.TestCase):
+    @mock.patch("util.run")
+    def test_builds_amd64_and_pushes(self, run_mock):
+        image = util.build_and_push("gcr.io/p/repo/img:tag", "path/Dockerfile")
+
+        self.assertEqual(image, "gcr.io/p/repo/img:tag")
+        build_cmd, push_cmd = (c.args[0] for c in run_mock.call_args_list)
+        self.assertEqual(build_cmd[:2], ["docker", "build"])
+        self.assertIn("--platform", build_cmd)
+        self.assertEqual(build_cmd[build_cmd.index("--platform") + 1], "linux/amd64")
+        self.assertEqual(build_cmd[build_cmd.index("-t") + 1], "gcr.io/p/repo/img:tag")
+        self.assertEqual(build_cmd[build_cmd.index("-f") + 1], "path/Dockerfile")
+        self.assertEqual(push_cmd, ["docker", "push", "gcr.io/p/repo/img:tag"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarking/automation/tests.yaml
+++ b/benchmarking/automation/tests.yaml
@@ -12,34 +12,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Each test runs `runner.py -f <file> -t <duration> -u <users> --name <name>`
-# with --tag set to the build commit hash and --dest set from the orchestrator's
-# --dest flag. The orchestrator deploys + tears down substrate + workloads
-# around each test so runs don't pollute each other.
+# The orchestrator deploys + tears down substrate + workloads around each
+# test so runs don't pollute each other.
 #
+# Fields shared by every entry:
+#
+#   type           Required. Selects the runner: "locust" | "nighthawk-ingress".
+#                  Each type's own fields are described in its section.
+#   targetCluster  Required. Names a config file under
+#                  /etc/orchestrator/target-clusters/ (e.g. `targetCluster:
+#                  dev` -> /etc/orchestrator/target-clusters/dev.sh). The
+#                  orchestrator copies that file into the cloned repo as
+#                  .ate-dev-env.sh before the test runs and deletes it
+#                  after, so different tests can target different clusters
+#                  / projects from one CronJob run.
+#   sandboxClass   Optional (default "gvisor"). Sandbox runtime for the
+#                  benchmark WorkerPool: "gvisor" | "microvm".
+#   workerCount    Optional (default 1). WorkerPool replica count for the
+#                  deploy that runs before this test. The orchestrator
+#                  redeploys workloads between tests, so each test can
+#                  pick its own scale.
+#   actorMemory    Optional (default "256Mi", the smallest size microvm
+#                  admits). Memory limit on the benchmark ActorTemplates;
+#                  raise it for suites that exercise glutton's WriteRAM path.
+#
+# ---- type: locust -----------------------------------------------------------
+#
+# Runs `runner.py -f <file> -t <duration> -u <users> --name <name>` in a
+# Job, with --tag set to the build commit hash and --dest from the
+# orchestrator's --dest flag. `file`, `duration` and `users` are required.
 # Optional `flags` is a list of arbitrary strings appended to runner.py's
 # argv; runner.py forwards them to locust verbatim.
 #
-# Optional `workerCount` (default 1) sets the WorkerPool replica count for
-# the deploy that runs before this test. The orchestrator redeploys
-# workloads between tests, so each test can pick its own scale.
+# ---- type: nighthawk-ingress --------------------------------------------------------
 #
-# Optional `sandboxClass` (default "gvisor") picks the sandbox runtime for
-# the benchmark WorkerPool. Allowed values: "gvisor" | "microvm".
-#
-# Optional `actorMemory` (default "256Mi", the smallest size microvm admits)
-# sets the memory limit on the benchmark ActorTemplates. Raise it for suites
-# that exercise glutton's WriteRAM path.
-#
-# Required `targetCluster` names a config file under
-# /etc/orchestrator/target-clusters/ (e.g. `targetCluster: dev` ->
-# /etc/orchestrator/target-clusters/dev.sh). The orchestrator copies that
-# file into the cloned repo as .ate-dev-env.sh before the test runs and
-# deletes it after, so different tests can target different clusters /
-# projects from one CronJob run.
+# Runs the Nighthawk adaptive router-capacity benchmark. `duration` is the
+# job-wait budget only; the test knobs live in a `nighthawk-ingress:` block — see
+# the "Configuration knobs" table in benchmarking/nighthawk-ingress/README.md.
+# `workerCount` is required: the benchmark warms one actor per worker, so
+# it is also the actor fleet size.
 
 tests:
   - name: glutton_baseline_1_user
+    type: locust
     description: "Glutton baseline: 1 concurrent user for 1 minute"
     targetCluster: dev
     file: /app/tests/glutton.py
@@ -52,6 +67,7 @@ tests:
       - "--max-wait-time"
       - "1.0"
   - name: glutton_baseline_5_users
+    type: locust
     description: "Glutton baseline: 5 concurrent users for 1 minute"
     targetCluster: dev
     file: /app/tests/glutton.py
@@ -64,6 +80,7 @@ tests:
       - "--max-wait-time"
       - "1.0"
   - name: glutton_baseline_10_users
+    type: locust
     description: "Glutton baseline: 10 concurrent users for 1 minute (doubles the number of workers/node)"
     targetCluster: dev
     file: /app/tests/glutton.py
@@ -76,6 +93,7 @@ tests:
       - "--max-wait-time"
       - "1.0"
   - name: glutton_oversubscribe_15_users
+    type: locust
     description: "Glutton baseline: 15 concurrent users for 2 minutes (50% oversubscribed)"
     targetCluster: dev
     file: /app/tests/glutton.py
@@ -88,6 +106,7 @@ tests:
       - "--max-wait-time"
       - "1.0"
   - name: durdir_data_baseline
+    type: locust
     description: "DurDir data baseline: 1 concurrent user, 8 MiB file, explicit resume"
     targetCluster: dev
     file: /app/tests/durdir.py
@@ -106,6 +125,7 @@ tests:
       - "--max-wait-time"
       - "1.0"
   - name: durdir_full_baseline
+    type: locust
     description: "DurDir full baseline: 1 concurrent user, 8 MiB file, full memory restore comparison"
     targetCluster: dev
     file: /app/tests/durdir.py
@@ -124,6 +144,7 @@ tests:
       - "--max-wait-time"
       - "1.0"
   - name: durdir_implicit_resume
+    type: locust
     description: "DurDir implicit resume: 1 concurrent user, 8 MiB file, traffic-triggered resume"
     targetCluster: dev
     file: /app/tests/durdir.py
@@ -142,6 +163,7 @@ tests:
       - "--max-wait-time"
       - "1.0"
   - name: durdir_size_5mb
+    type: locust
     description: "DurDir file size sweep (5 MiB): 1 concurrent user, digest read mode"
     targetCluster: dev
     file: /app/tests/durdir.py
@@ -162,6 +184,7 @@ tests:
       - "--max-wait-time"
       - "1.0"
   - name: durdir_size_10mb
+    type: locust
     description: "DurDir file size sweep (10 MiB): 1 concurrent user, digest read mode"
     targetCluster: dev
     file: /app/tests/durdir.py
@@ -182,6 +205,7 @@ tests:
       - "--max-wait-time"
       - "1.0"
   - name: durdir_size_64mb
+    type: locust
     description: "DurDir file size sweep (64 MiB): 1 concurrent user, digest read mode"
     targetCluster: dev
     file: /app/tests/durdir.py
@@ -201,3 +225,39 @@ tests:
       - "1.0"
       - "--max-wait-time"
       - "1.0"
+  - name: ingress_routercap_envoy_2cpu
+    description: "Router capacity: Nighthawk adaptive max-RPS search under a 25ms tail-latency SLO, Envoy at 2 CPUs"
+    type: nighthawk-ingress
+    targetCluster: dev
+    duration: 30m
+    workerCount: 50
+    nighthawk-ingress:
+      envoyCpu: 2
+      tailLatencySloMs: 25
+  - name: ingress_routercap_envoy_4cpu
+    description: "Router capacity: Nighthawk adaptive max-RPS search under a 25ms tail-latency SLO, Envoy at 4 CPUs"
+    type: nighthawk-ingress
+    targetCluster: dev
+    duration: 30m
+    workerCount: 50
+    nighthawk-ingress:
+      envoyCpu: 4
+      tailLatencySloMs: 25
+  - name: ingress_routercap_envoy_8cpu
+    description: "Router capacity: Nighthawk adaptive max-RPS search under a 25ms tail-latency SLO, Envoy at 8 CPUs"
+    type: nighthawk-ingress
+    targetCluster: dev
+    duration: 30m
+    workerCount: 50
+    nighthawk-ingress:
+      envoyCpu: 8
+      tailLatencySloMs: 25
+  - name: ingress_routercap_envoy_16cpu
+    description: "Router capacity: Nighthawk adaptive max-RPS search under a 25ms tail-latency SLO, Envoy at 16 CPUs"
+    type: nighthawk-ingress
+    targetCluster: dev
+    duration: 30m
+    workerCount: 50
+    nighthawk-ingress:
+      envoyCpu: 16
+      tailLatencySloMs: 25

--- a/benchmarking/automation/testtypes/__init__.py
+++ b/benchmarking/automation/testtypes/__init__.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One module per tests.yaml `type`; orchestrator.py dispatches via TYPES.
+
+Each module implements the TestType hooks, called in lifecycle order:
+
+  validate(test)        preflight, before any cluster work. Raises
+                        ValueError on a malformed entry; may normalize it
+                        (nighthawk-ingress requires workerCount).
+  build_image(commit)   builds + pushes the runner image; called lazily,
+                        once per (target cluster, type).
+  pre_test(test)        after deploy_substrate, before deploy_workloads —
+                        the type's chance to shape the cluster (nighthawk-ingress
+                        pins the router; locust needs nothing).
+  job_tmpl(manifests_dir)
+                        path of the type's own Job template.
+  job_subs(test)        the type's ${...} substitutions for it. The test
+                        itself is always the same shared machinery:
+                        orchestrator renders the template, submits the
+                        Job, waits, tails logs, deletes it.
+
+No post_test hook: teardown is type-independent today. Name it here when
+a type needs one.
+
+Adding a test type = one new module here + one entry in TYPES.
+"""
+
+from typing import Any, Protocol
+
+from testtypes import locust
+from testtypes import nighthawk_ingress
+
+
+class TestType(Protocol):
+    TEST_TYPE: str
+
+    def validate(self, test: dict[str, Any]) -> None: ...
+    def build_image(self, commit: str) -> str: ...
+    def pre_test(self, test: dict[str, Any]) -> None: ...
+    def job_tmpl(self, manifests_dir: str) -> str: ...
+    def job_subs(self, test: dict[str, Any]) -> dict[str, Any]: ...
+
+
+TYPES: dict[str, TestType] = {
+    locust.TEST_TYPE: locust,
+    nighthawk_ingress.TEST_TYPE: nighthawk_ingress,
+}
+
+# The Protocol above only binds when a type checker runs, and CI runs none
+# for Python — so enforce the contract here, where every entry point
+# (orchestrator, run-dev.sh, the unit tests) fails at import instead of
+# mid-benchmark.
+for _name, _mod in TYPES.items():
+    for _hook in ("validate", "build_image", "pre_test", "job_tmpl", "job_subs"):
+        assert hasattr(_mod, _hook), f"test type {_name!r} missing hook {_hook!r}"

--- a/benchmarking/automation/testtypes/locust.py
+++ b/benchmarking/automation/testtypes/locust.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The `type: locust` hooks (see the package docstring for the lifecycle).
+
+The runner Job wraps benchmarking/locust/runner.py, which drives locust
+(and boomer for glutton tests) and uploads its own results.
+"""
+
+import os
+from typing import Any
+
+from util import build_and_push
+
+TEST_TYPE = "locust"
+
+
+def validate(test: dict[str, Any]) -> None:
+    name = test.get("name")
+    for field in ("file", "duration", "users"):
+        if field not in test:
+            raise ValueError(f"locust test {name!r} missing {field!r}")
+
+
+def build_image(commit: str) -> str:
+    """Build & push the locust runner image. It must live in the same
+    project as the test cluster so the runner Job can pull it."""
+    return build_and_push(
+        f"{os.environ['KO_DOCKER_REPO']}/locust-test:{commit}",
+        "benchmarking/locust/Dockerfile",
+    )
+
+
+def pre_test(test: dict[str, Any]) -> None:
+    """Nothing to shape on the cluster before a locust run."""
+
+
+def job_tmpl(manifests_dir: str) -> str:
+    return os.path.join(manifests_dir, "runner-job.yaml.tmpl")
+
+
+def job_subs(test: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "TEST_FILE": test["file"],
+        "DURATION": test["duration"],
+        "USERS": test["users"],
+    }

--- a/benchmarking/automation/testtypes/nighthawk_ingress.py
+++ b/benchmarking/automation/testtypes/nighthawk_ingress.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The `type: nighthawk-ingress` hooks (see the package docstring for the
+lifecycle).
+
+Measures atenet-router capacity at one Envoy CPU limit: pre_test pins the
+router to the size under test, and the runner Job drives Nighthawk's
+adaptive search against it.
+"""
+
+import json
+import os
+import re
+from typing import Any
+
+from util import build_and_push, parse_duration_seconds, run
+
+TEST_TYPE = "nighthawk-ingress"
+
+# Defaults for the tests.yaml `nighthawk-ingress:` block; envoyCpu has no default —
+# it is the benchmark's independent variable. Documented in
+# benchmarking/nighthawk-ingress/README.md, "Configuration knobs".
+DEFAULTS = {
+    # Actor namespace: one atespace per experiment, never per run —
+    # nothing deletes atespaces automatically.
+    "atespace": "ingress-benchmark",
+    # Client sizing decoupled from envoyCpu so the harness never binds.
+    "clientConcurrency": 16,
+    "connections": 1000,
+    "maxPendingRequests": 10000,
+    "initialRps": 500,
+    "exponentialFactor": 2.0,
+    "measuringPeriod": "10s",
+    "convergenceDeadline": "600s",
+    "testingStageDuration": "60s",
+    "successRateThreshold": 0.999,
+    "sendRateThreshold": 0.9,
+    # Tail-latency SLO (mean+2stdev) in ms; 0 disables.
+    "tailLatencySloMs": 0,
+}
+
+
+def config(test: dict[str, Any]) -> dict[str, Any]:
+    """The test's `nighthawk:` block merged over DEFAULTS."""
+    return {**DEFAULTS, **test.get("nighthawk-ingress", {})}
+
+
+def job_tmpl(manifests_dir: str) -> str:
+    return os.path.join(manifests_dir, "nighthawk-ingress-runner-job.yaml.tmpl")
+
+
+def validate(test: dict[str, Any]) -> None:
+    """The nighthawk-specific half of validate_and_normalize_tests:
+    raises ValueError on a malformed entry. workerCount is required — the
+    benchmark warms one actor per worker (warm-path-only measurement), so
+    it is also the actor fleet size."""
+    name = test.get("name")
+    if "duration" not in test:
+        raise ValueError(f"nighthawk-ingress test {name!r} missing 'duration'")
+    # Unknown knobs are rejected rather than silently merged: a typo (or a
+    # knob removed in a schema change) must not run with defaults.
+    allowed = set(DEFAULTS) | {"envoyCpu"}
+    unknown = set(test.get("nighthawk-ingress", {})) - allowed
+    if unknown:
+        raise ValueError(
+            f"nighthawk-ingress test {name!r} has unknown knob(s) "
+            f"{sorted(unknown)}; allowed: {sorted(allowed)}"
+        )
+    nh = config(test)
+    envoy_cpu = nh.get("envoyCpu")
+    if not isinstance(envoy_cpu, int) or envoy_cpu < 1:
+        raise ValueError(
+            f"nighthawk-ingress test {name!r} needs nighthawk-ingress.envoyCpu (int >= 1)"
+        )
+    client_concurrency = nh["clientConcurrency"]
+    if not isinstance(client_concurrency, int) or client_concurrency < 1:
+        raise ValueError(
+            f"nighthawk-ingress test {name!r} has invalid "
+            f"nighthawk-ingress.clientConcurrency {client_concurrency!r}"
+        )
+    worker_count = test.get("workerCount")
+    if not isinstance(worker_count, int) or worker_count < 1:
+        raise ValueError(
+            f"nighthawk-ingress test {name!r} needs workerCount (int >= 1): the "
+            f"benchmark warms one actor per worker, so it is also the "
+            f"actor fleet size"
+        )
+    for field in ("measuringPeriod", "convergenceDeadline", "testingStageDuration"):
+        parse_duration_seconds(str(nh[field]))
+    if not re.fullmatch(r"[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?", nh["atespace"]):
+        raise ValueError(
+            f"nighthawk-ingress test {name!r} atespace {nh['atespace']!r} "
+            f"must be a DNS label (it is routed as a Host-header subdomain)"
+        )
+
+
+def build_image(commit: str) -> str:
+    """Build & push the nighthawk capacity-benchmark runner image."""
+    return build_and_push(
+        f"{os.environ['KO_DOCKER_REPO']}/nighthawk-ingress-test:{commit}",
+        "benchmarking/nighthawk-ingress/Dockerfile",
+    )
+
+
+def pre_test(test: dict[str, Any]) -> None:
+    """Pin atenet-router to the test's envoyCpu: both containers get
+    requests=limits=envoyCpu (Guaranteed QoS), and envoy's command is
+    replaced to add --concurrency envoyCpu and drop the base manifest's
+    debug log flags. Blocks on rollout. No unpatch: every test redeploys
+    substrate."""
+    cpu = str(config(test)["envoyCpu"])
+    patch = {
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "atenet-router",
+                            "resources": {
+                                "requests": {"cpu": cpu},
+                                "limits": {"cpu": cpu},
+                            },
+                        },
+                        {
+                            "name": "envoy",
+                            "command": [
+                                "/usr/local/bin/envoy",
+                                "-c",
+                                "/etc/envoy/envoy.yaml",
+                                "--concurrency",
+                                cpu,
+                            ],
+                            "resources": {
+                                "requests": {"cpu": cpu},
+                                "limits": {"cpu": cpu},
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+    }
+    run(
+        [
+            "kubectl",
+            "-n",
+            "ate-system",
+            "patch",
+            "deployment",
+            "atenet-router",
+            "--type=strategic",
+            "-p",
+            json.dumps(patch),
+        ]
+    )
+    run(
+        [
+            "kubectl",
+            "-n",
+            "ate-system",
+            "rollout",
+            "status",
+            "deployment/atenet-router",
+            "--timeout=300s",
+        ]
+    )
+
+
+def job_subs(test: dict[str, Any]) -> dict[str, Any]:
+    """Template substitutions specific to the nighthawk runner Job."""
+    nh = config(test)
+    return {
+        "ENVOY_CPU": nh["envoyCpu"],
+        "ATESPACE": nh["atespace"],
+        # Warm-path-only measurement: one running actor per worker, so
+        # the fleet size is the worker count.
+        "ACTORS": test["workerCount"],
+        "CLIENT_CONCURRENCY": nh["clientConcurrency"],
+        "CONNECTIONS": nh["connections"],
+        "MAX_PENDING": nh["maxPendingRequests"],
+        "INITIAL_RPS": nh["initialRps"],
+        "EXP_FACTOR": nh["exponentialFactor"],
+        "MEASURING_PERIOD": nh["measuringPeriod"],
+        "CONVERGENCE_DEADLINE": nh["convergenceDeadline"],
+        "TESTING_STAGE_DURATION": nh["testingStageDuration"],
+        "SUCCESS_RATE": nh["successRateThreshold"],
+        "SEND_RATE": nh["sendRateThreshold"],
+        "TAIL_LATENCY_SLO_MS": nh["tailLatencySloMs"],
+        # One core per event loop + one for the python runner.
+        "RUNNER_CPU": nh["clientConcurrency"] + 1,
+    }

--- a/benchmarking/automation/util.py
+++ b/benchmarking/automation/util.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers shared by orchestrator.py and the per-test-type modules."""
+
+import re
+import shlex
+import subprocess
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"$ {' '.join(shlex.quote(c) for c in cmd)}", flush=True)
+    return subprocess.run(cmd, check=True, **kwargs)
+
+
+def run_no_check(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"$ {' '.join(shlex.quote(c) for c in cmd)}", flush=True)
+    return subprocess.run(cmd, check=False, **kwargs)
+
+
+def build_and_push(image: str, dockerfile: str) -> str:
+    """docker build (linux/amd64, the cluster architecture) + push, from
+    the repo root."""
+    run(
+        [
+            "docker",
+            "build",
+            "--platform",
+            "linux/amd64",
+            "-t",
+            image,
+            "-f",
+            dockerfile,
+            ".",
+        ]
+    )
+    run(["docker", "push", image])
+    return image
+
+
+def parse_duration_seconds(s: str) -> int:
+    m = re.fullmatch(r"(\d+)\s*([smh]?)", s.strip())
+    if not m:
+        raise ValueError(f"unrecognized duration: {s}")
+    n = int(m.group(1))
+    unit = m.group(2) or "s"
+    return n * {"s": 1, "m": 60, "h": 3600}[unit]

--- a/benchmarking/nighthawk-ingress/Dockerfile
+++ b/benchmarking/nighthawk-ingress/Dockerfile
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Nighthawk router-capacity benchmark runner image. Build context is the
+# repo root; always build with --platform linux/amd64
+# (envoyproxy/nighthawk-dev publishes no arm64 images):
+#   docker build --platform linux/amd64 -f benchmarking/nighthawk-ingress/Dockerfile .
+
+# The three pins move together: NIGHTHAWK_IMAGE_DIGEST is the digest of the
+# Docker Hub tag envoyproxy/nighthawk-dev:<NIGHTHAWK_COMMIT> (resolve with
+# docker buildx imagetools inspect), and ENVOY_COMMIT is nighthawk's envoy
+# pin from bazel/repositories.bzl at that commit.
+ARG NIGHTHAWK_COMMIT=21f3f100b86b11e5211e5672ade956c87baaa75c
+ARG ENVOY_COMMIT=ad01ae36a702169140334ebadb2d0fc3be56327e
+ARG NIGHTHAWK_IMAGE_DIGEST=sha256:7729902afea9d83f593b240690ba7d6e8fff04f6215ada538cfb4c1452b2553e
+
+# --- Stage 1: proto descriptor set -----------------------------------------
+# nighthawk_service speaks protobuf: spec.py builds the adaptive-load session
+# spec and output.py parses the result, and those message trees pull in types
+# from envoy, xds, protoc-gen-validate and googleapis. This stage compiles
+# that whole closure into one FileDescriptorSet, which spec.py/output.py load
+# at runtime.
+FROM python:3.12-slim AS protogen
+ARG NIGHTHAWK_COMMIT
+ARG ENVOY_COMMIT
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir grpcio-tools==1.81.1
+
+# Shallow-fetch each tree at its pin. nighthawk/envoy are pinned to bare
+# commits, which clone --branch can't fetch, hence init+fetch.
+RUN git clone --depth 1 https://github.com/cncf/xds /src/xds \
+    && git clone --depth 1 https://github.com/bufbuild/protoc-gen-validate /src/pgv \
+    && git clone --depth 1 https://github.com/googleapis/googleapis /src/googleapis
+RUN git init /src/nighthawk \
+    && git -C /src/nighthawk fetch --depth 1 https://github.com/envoyproxy/nighthawk "${NIGHTHAWK_COMMIT}" \
+    && git -C /src/nighthawk checkout FETCH_HEAD
+RUN git init /src/envoy \
+    && git -C /src/envoy fetch --depth 1 https://github.com/envoyproxy/envoy "${ENVOY_COMMIT}" \
+    && git -C /src/envoy checkout FETCH_HEAD
+
+COPY benchmarking/nighthawk-ingress/protogen/generate_descriptor.sh /gen.sh
+RUN bash /gen.sh /out/nighthawk.desc
+
+# --- Stage 2: runtime -------------------------------------------------------
+# nighthawk-dev has no stable tags; pinned by digest so the pull is
+# immutable. Ships the nighthawk_* binaries in /usr/local/bin on ubuntu.
+FROM envoyproxy/nighthawk-dev@${NIGHTHAWK_IMAGE_DIGEST}
+
+# Deps must be installed with this image's own interpreter: grpcio/protobuf
+# native extensions are python-version-specific.
+COPY benchmarking/nighthawk-ingress/requirements.txt /tmp/requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip ca-certificates \
+    && python3 -m pip install --no-cache-dir --break-system-packages \
+        --target=/app/deps -r /tmp/requirements.txt \
+    && apt-get purge -y python3-pip \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/requirements.txt
+
+WORKDIR /app
+COPY --from=protogen /out/nighthawk.desc /app/nighthawk.desc
+
+# ateapi client reused from the locust harness (atespace.py excluded: it
+# imports locust).
+COPY benchmarking/locust/common/__init__.py /app/common/__init__.py
+COPY benchmarking/locust/common/ateapi_channel.py /app/common/ateapi_channel.py
+COPY benchmarking/locust/common/ateapi_pb2.py /app/common/ateapi_pb2.py
+COPY benchmarking/locust/common/ateapi_pb2_grpc.py /app/common/ateapi_pb2_grpc.py
+
+COPY benchmarking/nighthawk-ingress/runner.py \
+     benchmarking/nighthawk-ingress/spec.py \
+     benchmarking/nighthawk-ingress/output.py \
+     benchmarking/nighthawk-ingress/actors.py \
+     /app/
+COPY benchmarking/nighthawk-ingress/tests /app/tests
+
+ENV PYTHONPATH=/app:/app/deps
+ENV PYTHONUNBUFFERED=1
+ENV NIGHTHAWK_DESC=/app/nighthawk.desc
+
+ENTRYPOINT ["python3", "/app/runner.py"]

--- a/benchmarking/nighthawk-ingress/README.md
+++ b/benchmarking/nighthawk-ingress/README.md
@@ -1,0 +1,216 @@
+# Nighthawk ingress-capacity benchmark
+
+## Objective
+
+Measure the scale and performance of substrate's networking
+infrastructure. This benchmark covers the ingress routing path
+(`atenet-router --mode=ingress`); egress will be a separate benchmark.
+
+The concrete measurement, per Envoy CPU configuration:
+
+> **What is the maximum request rate the ingress path sustains while
+> tail latency stays under the SLO?\***
+
+The benchmark finds that number automatically using
+[Nighthawk](https://github.com/envoyproxy/nighthawk) (Envoy's benchmarking
+client) in
+[adaptive mode](https://github.com/envoyproxy/nighthawk/blob/main/docs/root/adaptive_load_controller.md):
+it ramps open-loop load until a threshold breaks, binary-searches the
+boundary, and confirms with a longer run. Run
+it across `envoyCpu` configs to get a capacity-per-core curve, or
+continuously in CI to catch routing-path performance regressions.
+
+\* *The SLO bounds latency **mean+2σ**, not a true percentile: Nighthawk's
+adaptive search can only gate on its
+[built-in metrics](https://github.com/envoyproxy/nighthawk/blob/main/docs/root/adaptive_load_controller.md#available-metric-plugins)
+(success-rate, send-rate, rps, latency mean/stdev). mean+2σ ≈ p95–p97 for
+bell-shaped latency; true p50/p95/p99 are still reported per stage, they
+just don't steer the search.*
+
+## What it measures
+
+Every request exercises the **full production routing path** — created and
+warmed sandboxed actors, Host-header routing, the ext_proc routing
+decision, and the mTLS hop to the worker:
+
+```mermaid
+flowchart LR
+    subgraph job["nighthawk runner Job"]
+        alc["nighthawk_adaptive_load_client<br/>exponential ramp + binary search"]
+        svc["nighthawk_service<br/>16 event loops, Host header<br/>rotated across all actors"]
+        alc -->|gRPC| svc
+    end
+
+    subgraph pod["atenet-router pod — pinned to envoyCpu CPUs"]
+        envoy["envoy :8080<br/>--concurrency envoyCpu"]
+        extproc["atenet-router sidecar<br/>ext_proc routing decision"]
+        envoy -->|request headers| extproc
+        extproc -->|x-ate-original-dst| envoy
+    end
+
+    ateapi["ateapi<br/>worker assignment"]
+
+    subgraph worker["worker pod — xN (workerCount), one running actor each"]
+        atunnel["atunnel :443"] --> glutton["glutton actor<br/>POST /ping :80"]
+    end
+
+    svc -->|"HTTP :80, Host:<br/>actor-N.benchmark.actors..."| envoy
+    extproc -->|ResumeActor| ateapi
+    envoy -->|"mTLS :443"| atunnel
+```
+
+Client-measured latency therefore covers: network to Envoy, Envoy
+processing, the routing decision in the ext_proc sidecar (including its
+ateapi lookup), the mTLS hop, and the actor's handler.
+
+**"Capacity" means all three of the following hold at once** — each threshold
+catches a failure mode the others can't see:
+
+| Threshold (tests.yaml knob) | Guards against | Typical symptom at the limit |
+|---|---|---|
+| `tailLatencySloMs` — latency mean+2σ ≤ X ms (~p95 proxy, see [Objective](#objective)) | the router getting *slow* | queues build inside Envoy/router, tail latency climbs past the SLO |
+| `successRateThreshold` (0.999) | the router getting *fast but wrong* | 503s from parking overflow, 504 route timeouts |
+| `sendRateThreshold` (0.9) | the *client* being unable to deliver the load | paced requests skipped once latency × RPS exceeds the connection pools |
+
+## How it works
+
+One Kubernetes Job per `type: nighthawk-ingress` tests.yaml entry, driven by
+[`../automation/orchestrator.py`](../automation/orchestrator.py):
+
+1. **Pin the router.** The orchestrator patches the `atenet-router`
+   Deployment: both containers get cpu `requests=limits=envoyCpu`
+   (Guaranteed QoS), Envoy gets `--concurrency envoyCpu`, and the debug
+   log flags are dropped. Waits for rollout; every test tears substrate
+   down afterwards, so nothing leaks.
+2. **Create + warm actors.** The runner creates one glutton actor per
+   WorkerPool worker (the entry's `workerCount`) via ateapi and POSTs
+   `/ping` through the router with each actor's Host header until it
+   answers 200.
+3. **Adaptive search.** Open-loop traffic with the Host header rotated
+   across all actors; `clientConcurrency` event loops (default 16,
+   decoupled from `envoyCpu`) and large per-loop pools so the harness is
+   never the bottleneck. Exponential ramp → binary search → a 60s
+   **testing stage** at the converged rate.
+4. **Upload results** (see below). The Job exits 0 only if the session
+   converged and all artifacts uploaded.
+
+## How to run it
+
+### In CI
+
+Add a `type: nighthawk-ingress` entry to the tests file the orchestrator
+runs (`--tests`), e.g.:
+
+```yaml
+- name: ingress_routercap_envoy_2cpu
+  type: nighthawk-ingress
+  targetCluster: dev
+  duration: 30m          # job-wait budget only
+  workerCount: 50        # also the actor fleet size: one warm actor per worker
+  nighthawk-ingress:
+    envoyCpu: 2
+    tailLatencySloMs: 25
+```
+
+### On a dev cluster
+
+One-time prerequisites: a cluster from the GKE Quickstart in the repo
+README, with nodes big enough for the two large pods (the router pod
+requests 2×`envoyCpu` CPUs; the runner requests `clientConcurrency`+1).
+
+```bash
+# .ate-dev-env.sh at the repo root, then:
+hack/install-ate.sh --deploy-ate-system
+benchmarking/workloads/deploy.sh --deploy --worker-count 50 --sandbox-class gvisor
+```
+
+Then each benchmark run is one command, ~8–10 min:
+
+```bash
+./benchmarking/nighthawk-ingress/run-dev.sh --envoy-cpu 2
+```
+
+[`run-dev.sh`](run-dev.sh) runs only the benchmark layer. One invocation:
+
+1. Verifies the prerequisites above, printing the fix for anything missing.
+2. Pins the router if its current cpu differs from `--envoy-cpu`, so CPU
+   sweeps need no redeploy.
+3. Builds the runner image **from your working tree** — uncommitted changes
+   included, and such runs are tagged `-dirty`.
+4. Submits the Job, streams its logs, and prints the resulting
+   `capacity.json`.
+
+Flags: `--envoy-cpu`, `--actors`, `--tail-latency-slo-ms`, `--atespace`,
+`--dest` (see
+`--help`). It needs a running Docker daemon and gcloud/kubectl credentials.
+
+Notes:
+
+- The script does not redeploy substrate — if substrate code changed,
+  rerun `hack/install-ate.sh --deploy-ate-system` first.
+- `--atespace` isolates actor *fleets* between experiments sharing a
+  cluster; capacity runs themselves still need the router exclusively
+  (the cpu pin is global and the run saturates it).
+- The full clone + deploy/teardown-per-test cycle is the orchestrator's
+  job and runs in CI — see "In CI" above.
+
+### Reading the results
+
+Artifacts land under
+`<dest>/runs/<name>/run_date=.../run_ts=.../run_tag=<commit>/`.
+Start with `capacity.json`, drill into `stats.jsonl`:
+
+| file | contents |
+|---|---|
+| `capacity.json` | **the verdict**: `slo_max_rps` — the highest rate that passed every threshold (the number to track), `binding_threshold` — which limit defined it, plus the testing stage's metrics and p50/p95/p99 |
+| `stats.jsonl` | one record per stage: Nighthawk's builtin metrics under `metric_nighthawk.builtin_*` keys (note: `achieved_rps` counts requests *sent*, errors included), status counts, latency percentiles, and the stage's `failed_thresholds` |
+| `results.json` | full session, 1:1 with Nighthawk's output |
+| `spec.textproto`, `output.textproto` | exact Nighthawk input/output, for reproducibility |
+| `status.json`, `logs.txt` | run metadata + process logs |
+
+## Tuning
+
+### Configuration knobs (the `nighthawk-ingress:` block)
+
+The fleet size is the entry's top-level `workerCount` (required): the
+benchmark warms one actor per worker, so it is also the number of glutton
+actors receiving rotated-Host traffic. Everything else lives in the
+`nighthawk-ingress:` block:
+
+| Knob | Default | Meaning |
+|---|---|---|
+| `envoyCpu` | required | cpu `requests=limits` on both router containers, and Envoy's `--concurrency`. The benchmark's independent variable. |
+| `atespace` | `ingress-benchmark` | Actor namespace; name it per *experiment*, never per run (atespaces are never auto-deleted). |
+| `tailLatencySloMs` | 0 (disabled) | The SLO: upper bound on latency mean+2σ (~p95 proxy), in ms. |
+| `successRateThreshold` | 0.999 | Minimum 2xx fraction of sent requests. |
+| `sendRateThreshold` | 0.9 | Minimum sent fraction of the paced schedule (open-loop backstop). |
+| `clientConcurrency` | 16 | Nighthawk event loops; the runner Job requests `clientConcurrency+1` CPUs. Deliberately decoupled from `envoyCpu`. |
+| `connections` | 1000 | Client connections per event loop. |
+| `maxPendingRequests` | 10000 | Client-side queue per event loop. |
+| `initialRps` | 500 | Total starting RPS of the exponential ramp. |
+| `exponentialFactor` | 2.0 | Ramp multiplier per step; smaller = tighter bracket around the knee, more steps. |
+| `measuringPeriod` | 10s | Length of each adjusting step. |
+| `convergenceDeadline` | 600s | The session errors if the search hasn't converged by then. |
+| `testingStageDuration` | 60s | Final confirmation run at the converged rate. |
+
+### Sizing the rig: hit the router's ceiling, not the harness's
+
+Three components sit in series; the reported capacity is whichever
+saturates first. The sizing knobs exist to make that the router:
+
+```mermaid
+flowchart LR
+    client["nighthawk client"] --> router["atenet-router<br/>(under test)"] --> fleet["actor fleet"]
+```
+
+**One rule:** client and fleet must each handle ~2× the capacity you
+expect to measure — the ramp overshoots before converging, and the rig
+must survive the overshoot stages, not just the converged rate. A failed
+stage's row in `stats.jsonl` tells you who saturated:
+
+- `send_rate` below threshold — the client; raise `clientConcurrency`.
+- 502s — the actor fleet; raise `workerCount`.
+- latency climbing smoothly into the SLO — the router itself; that is
+  the measurement.
+
+

--- a/benchmarking/nighthawk-ingress/actors.py
+++ b/benchmarking/nighthawk-ingress/actors.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Actor lifecycle for the capacity benchmark.
+
+Creates N glutton actors via ateapi and warms each by POSTing /ping through
+the router until it answers 200 — the same data path the load test
+exercises. Actors stay resumed for the whole session; cleanup is
+best-effort suspend+delete.
+"""
+
+import concurrent.futures
+import time
+
+import grpc
+import requests
+
+from common import ateapi_pb2
+from common import ateapi_pb2_grpc
+from common.ateapi_channel import CA_FILE, SERVER_NAME, ateapi_channel
+
+import spec as spec_mod
+
+ATEAPI_HOST = "api.ate-system.svc.cluster.local:443"
+TOKEN_FILE = "/run/ateapi-token/token"
+
+# Default --atespace (see the knob docs in the README). Actors are named
+# nh-<idx>.
+ATESPACE = "ingress-benchmark"
+
+TEMPLATE_NAMESPACE = "benchmark-workloads"
+TEMPLATE_NAME = "glutton"
+
+
+def _token_channel(host: str) -> grpc.Channel:
+    """Bearer-token variant of common.ateapi_channel (mTLS-only): server
+    validated against the projected CA, identity from the projected SA
+    token (ATE_ATEAPI_CLIENT_AUTH=token)."""
+    with open(CA_FILE, "rb") as f:
+        ca_cert = f.read()
+    with open(TOKEN_FILE) as f:
+        token = f.read().strip()
+    creds = grpc.composite_channel_credentials(
+        grpc.ssl_channel_credentials(root_certificates=ca_cert),
+        grpc.access_token_call_credentials(token),
+    )
+    return grpc.secure_channel(
+        host, creds, options=[("grpc.ssl_target_name_override", SERVER_NAME)]
+    )
+
+
+def ateapi_stub(auth_mode: str = "cert"):
+    if auth_mode == "token":
+        channel = _token_channel(ATEAPI_HOST)
+    else:
+        channel = ateapi_channel(ATEAPI_HOST)
+    return ateapi_pb2_grpc.ControlStub(channel)
+
+
+def ensure_atespace(stub, name: str = ATESPACE) -> None:
+    """CreateAtespace, treating ALREADY_EXISTS as success (idempotent)."""
+    try:
+        stub.CreateAtespace(
+            ateapi_pb2.CreateAtespaceRequest(
+                atespace=ateapi_pb2.Atespace(
+                    metadata=ateapi_pb2.ResourceMetadata(name=name)
+                )
+            )
+        )
+    except grpc.RpcError as e:
+        if e.code() != grpc.StatusCode.ALREADY_EXISTS:
+            raise
+
+
+def create_actor(stub, name: str, atespace: str = ATESPACE) -> None:
+    try:
+        stub.CreateActor(
+            ateapi_pb2.CreateActorRequest(
+                actor=ateapi_pb2.Actor(
+                    metadata=ateapi_pb2.ResourceMetadata(
+                        atespace=atespace, name=name
+                    ),
+                    actor_template_namespace=TEMPLATE_NAMESPACE,
+                    actor_template_name=TEMPLATE_NAME,
+                )
+            )
+        )
+    except grpc.RpcError as e:
+        if e.code() != grpc.StatusCode.ALREADY_EXISTS:
+            raise
+
+
+def _warm_actor(
+    stub, router_url: str, name: str, atespace: str, deadline: float, log
+) -> None:
+    """Bring one created actor to serving, so the load ladder never
+    measures a cold start: resume the actor, then poll POST /ping through
+    the router (addressed by the actor's Host header) until it answers
+    200 or the deadline expires. Resume errors are retried: ateapi
+    returns FailedPrecondition/Unavailable until a worker frees up."""
+    ref = ateapi_pb2.ObjectRef(atespace=atespace, name=name)
+    host = spec_mod.actor_host(name, atespace)
+    session = requests.Session()
+    last_err: str = "not attempted"
+    while time.time() < deadline:
+        try:
+            stub.ResumeActor(ateapi_pb2.ResumeActorRequest(actor=ref))
+        except grpc.RpcError as e:
+            last_err = f"ResumeActor: {e.code().name}"
+        try:
+            resp = session.post(
+                f"{router_url.rstrip('/')}/ping",
+                headers={"Host": host},
+                data=b"",
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                return
+            last_err = f"POST /ping -> {resp.status_code}"
+        except requests.RequestException as e:
+            last_err = f"POST /ping: {e}"
+        time.sleep(2)
+    raise RuntimeError(f"actor {name} not warm by deadline ({last_err})")
+
+
+def create_and_warm(
+    stub,
+    router_url: str,
+    count: int,
+    created: list[str],
+    atespace: str = ATESPACE,
+    warm_deadline_s: int = 600,
+    parallelism: int = 16,
+    log=print,
+) -> list[str]:
+    """Create `count` actors and warm them all; returns their names.
+
+    Appends each name to `created` at creation time so the caller can
+    cleanup() a partial fleet when this raises.
+    """
+    ensure_atespace(stub, atespace)
+    names = [f"nh-{i:03d}" for i in range(count)]
+    for name in names:
+        create_actor(stub, name, atespace)
+        created.append(name)
+    log(f"Created {count} actors from {TEMPLATE_NAMESPACE}/{TEMPLATE_NAME}")
+
+    deadline = time.time() + warm_deadline_s
+    failures: list[str] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallelism) as ex:
+        futures = {
+            ex.submit(
+                _warm_actor, stub, router_url, name, atespace, deadline, log
+            ): name
+            for name in names
+        }
+        warmed = 0
+        for fut in concurrent.futures.as_completed(futures):
+            name = futures[fut]
+            try:
+                fut.result()
+                warmed += 1
+                if warmed % 10 == 0 or warmed == count:
+                    log(f"Warmed {warmed}/{count} actors")
+            except Exception as e:
+                failures.append(name)
+                log(f"Warm failed: {e}")
+    if failures:
+        raise RuntimeError(
+            f"{len(failures)}/{count} actors failed to warm "
+            f"within {warm_deadline_s}s: {failures[:5]}..."
+        )
+    return names
+
+
+def cleanup(stub, names: list[str], atespace: str = ATESPACE, log=print) -> None:
+    """Best-effort delete; never raises."""
+    for name in names:
+        ref = ateapi_pb2.ObjectRef(atespace=atespace, name=name)
+        try:
+            stub.DeleteActor(ateapi_pb2.DeleteActorRequest(actor=ref))
+        except Exception as e:
+            log(f"DeleteActor({name}) failed: {e}")

--- a/benchmarking/nighthawk-ingress/output.py
+++ b/benchmarking/nighthawk-ingress/output.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transforms Nighthawk's AdaptiveLoadSessionOutput textproto into the run
+artifacts runner.py uploads:
+
+  results.json   parse_output_textproto() — the session as JSON, 1:1.
+  stats.jsonl    stage_rows() -> stats_records() — one record per stage,
+                 shaped {timestamp, tag, test_name, metric, measurements}
+                 for compatibility with the locust pipeline.
+  capacity.json  capacity_summary() — one-record verdict.
+
+Measurement keys come in three tiers: metric_nighthawk.builtin_* (verbatim
+builtin metrics), plain counters / *_ms conversions, and derived verdicts
+(slo_max_rps, failed_thresholds, binding_threshold — the last two use
+short native metric names, identifying thresholds).
+"""
+
+import json
+import re
+
+# Statistic carrying client-measured end-to-end request latency.
+LATENCY_STAT_ID = "benchmark_http_client.request_to_response"
+
+# First line of a textproto field: `name {` or `name: value`.
+_FIELD_LINE = re.compile(r"^\s*[A-Za-z_][A-Za-z0-9_]*\s*[:{]")
+
+PERCENTILE_TARGETS = {"p50": 0.5, "p90": 0.9, "p95": 0.95, "p99": 0.99}
+
+COUNTERS_OF_INTEREST = (
+    "benchmark.http_2xx",
+    "benchmark.http_3xx",
+    "benchmark.http_4xx",
+    "benchmark.http_5xx",
+    "benchmark.pool_overflow",
+    "benchmark.pool_connection_failure",
+    "benchmark.stream_resets",
+    "upstream_rq_total",
+)
+
+# Builtin metric formulas (source/adaptive_load/metrics_plugin_impl.cc):
+#   attempted-rps = specified / duration
+#   achieved-rps  = sent / duration  (errors included — NOT successes)
+#   send-rate     = sent / specified
+#   success-rate  = http_2xx / sent
+BUILTIN_PREFIX = "metric_nighthawk.builtin_"
+
+
+def _builtin_key(metric_name: str) -> str:
+    """'attempted-rps' -> 'metric_nighthawk.builtin_attempted_rps'."""
+    return BUILTIN_PREFIX + metric_name.replace("-", "_")
+
+
+def parse_output_textproto(text: str, desc_path: str) -> dict:
+    # Imported here rather than at module level: this is the only function
+    # that needs protobuf. Everything below transforms plain dicts, so the
+    # unit tests (which feed canned dicts) run without the runner image's
+    # dependencies installed.
+    from google.protobuf import json_format
+    from google.protobuf import text_format
+
+    import spec as spec_mod
+
+    # Drop the client's leading "goo.gle/debugproto" marker line(s).
+    lines = text.splitlines()
+    start = 0
+    while start < len(lines) and not _FIELD_LINE.match(lines[start]):
+        start += 1
+    text = "\n".join(lines[start:])
+
+    pool = spec_mod.load_pool(desc_path)
+    msg = spec_mod.message_class(pool, spec_mod.OUTPUT_MESSAGE)()
+    text_format.Parse(text, msg, descriptor_pool=pool)
+    return json_format.MessageToDict(
+        msg, preserving_proto_field_name=True, descriptor_pool=pool
+    )
+
+
+def _duration_seconds(value) -> float:
+    """json_format renders google.protobuf.Duration as e.g. '30.000001s'."""
+    if value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    return float(str(value).rstrip("s") or 0)
+
+
+def _global_result(nighthawk_output: dict) -> dict:
+    results = nighthawk_output.get("results", [])
+    for r in results:
+        if r.get("name") == "global":
+            return r
+    return results[0] if results else {}
+
+
+def _counters(result: dict) -> dict:
+    return {
+        c.get("name", ""): int(c.get("value", 0))
+        for c in result.get("counters", [])
+    }
+
+
+def _latency_ms(result: dict) -> dict:
+    """Extract mean + percentile latencies (ms) from the e2e statistic."""
+    out: dict = {}
+    for stat in result.get("statistics", []):
+        if stat.get("id") != LATENCY_STAT_ID:
+            continue
+        out["latency_mean_ms"] = _duration_seconds(stat.get("mean")) * 1000.0
+        out["latency_min_ms"] = _duration_seconds(stat.get("min")) * 1000.0
+        out["latency_max_ms"] = _duration_seconds(stat.get("max")) * 1000.0
+        percentiles = stat.get("percentiles", [])
+        for label, target in PERCENTILE_TARGETS.items():
+            # HdrHistogram points are irregular; first point >= target.
+            for p in percentiles:
+                if float(p.get("percentile", 0)) >= target:
+                    out[f"{label}_ms"] = _duration_seconds(p.get("duration")) * 1000.0
+                    break
+        break
+    return out
+
+
+def _stage_row(stage: str, benchmark_result: dict) -> dict:
+    nh_output = benchmark_result.get("nighthawk_service_output", {})
+    options = nh_output.get("options", {})
+    result = _global_result(nh_output)
+    counters = _counters(result)
+    duration_s = _duration_seconds(result.get("execution_duration"))
+
+    per_worker_rps = int(options.get("requests_per_second", 0))
+    concurrency = int(options.get("concurrency", "1") or "1")
+
+    row = {
+        "stage": stage,
+        "start_time": benchmark_result.get("start_time", ""),
+        "end_time": benchmark_result.get("end_time", ""),
+        "duration_s": duration_s,
+        "per_worker_rps": per_worker_rps,
+        "concurrency": concurrency,
+    }
+    # threshold_score: +1 pass, -1 violated, absent for informational.
+    failed = []
+    for ev in benchmark_result.get("metric_evaluations", []):
+        name = ev.get("metric_id", "").split("/")[-1]
+        if name:
+            row[_builtin_key(name)] = ev.get("metric_value", 0.0)
+        if float(ev.get("threshold_score", 0)) < 0:
+            failed.append(name)
+    # Fallbacks per the native formulas when an evaluation is absent.
+    sent = counters.get("upstream_rq_total", 0)
+    http_2xx = counters.get("benchmark.http_2xx", 0)
+    attempted_key = _builtin_key("attempted-rps")
+    achieved_key = _builtin_key("achieved-rps")
+    row.setdefault(attempted_key, per_worker_rps * concurrency)
+    row.setdefault(achieved_key, (sent / duration_s) if duration_s else 0.0)
+    row.setdefault(
+        _builtin_key("send-rate"),
+        (row[achieved_key] / row[attempted_key]) if row[attempted_key] else 0.0,
+    )
+    row.setdefault(
+        _builtin_key("success-rate"), (http_2xx / sent) if sent else 0.0
+    )
+    for name in COUNTERS_OF_INTEREST:
+        row[name.replace("benchmark.", "")] = counters.get(name, 0)
+    row.update(_latency_ms(result))
+    row["failed_thresholds"] = sorted(failed)
+    return row
+
+
+def stage_rows(output_dict: dict) -> list[dict]:
+    rows = [
+        _stage_row(f"adjusting_{i:03d}", br)
+        for i, br in enumerate(output_dict.get("adjusting_stage_results", []))
+    ]
+    testing = output_dict.get("testing_stage_result")
+    if testing:
+        rows.append(_stage_row("testing", testing))
+    return rows
+
+
+def stats_records(rows: list[dict], tag: str, test_name: str) -> list[dict]:
+    """Locust-runner-compatible stats.jsonl records (one per stage)."""
+    records = []
+    for row in rows:
+        measurements = {
+            k: v for k, v in row.items() if k not in ("stage", "start_time")
+        }
+        records.append(
+            {
+                "timestamp": row.get("start_time", ""),
+                "tag": tag,
+                "test_name": test_name,
+                "metric": f"nighthawk_{row['stage']}",
+                "measurements": measurements,
+            }
+        )
+    return records
+
+
+def session_succeeded(output_dict: dict) -> bool:
+    """google.rpc.Status: absent/zero code means OK."""
+    return int(output_dict.get("session_status", {}).get("code", 0)) == 0
+
+
+def capacity_summary(
+    output_dict: dict,
+    *,
+    envoy_cpu: int,
+    actors: int,
+    client_concurrency: int | None = None,
+    tail_latency_slo_ms: float | None = None,
+) -> dict:
+    rows = stage_rows(output_dict)
+    testing = next((r for r in rows if r["stage"] == "testing"), None)
+    binding = sorted(
+        {name for r in rows for name in r.get("failed_thresholds", [])}
+    )
+    # The search converges to the failure boundary, so the testing stage
+    # can be marginal; the highest-attempted fully-clean stage is the
+    # conservative counterpart.
+    clean = [r for r in rows if not r.get("failed_thresholds")]
+    best_clean = max(
+        clean, key=lambda r: r[_builtin_key("attempted-rps")], default=None
+    )
+    summary = {
+        "envoy_cpu": envoy_cpu,
+        "actors": actors,
+        "client_concurrency": client_concurrency,
+        "tail_latency_slo_ms": tail_latency_slo_ms,
+        "binding_threshold": binding,
+        # achieved-rps of a clean stage is within successRateThreshold of
+        # its successful throughput, so no derived 2xx/s metric is kept.
+        "slo_max_rps": (
+            best_clean[_builtin_key("achieved-rps")] if best_clean else None
+        ),
+        "slo_max_stage": best_clean["stage"] if best_clean else None,
+        "converged": session_succeeded(output_dict) and testing is not None,
+        "adjusting_stages": sum(1 for r in rows if r["stage"] != "testing"),
+    }
+    if testing:
+        for name in ("attempted-rps", "achieved-rps", "send-rate", "success-rate"):
+            summary[_builtin_key(name)] = testing.get(_builtin_key(name))
+        for name in ("p50_ms", "p95_ms", "p99_ms"):
+            summary[name] = testing.get(name)
+    return summary
+
+
+def write_jsonl(records: list[dict], path) -> None:
+    with open(path, "w") as f:
+        for record in records:
+            f.write(json.dumps(record) + "\n")

--- a/benchmarking/nighthawk-ingress/protogen/generate_descriptor.sh
+++ b/benchmarking/nighthawk-ingress/protogen/generate_descriptor.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate nighthawk.desc to avoid putting a large number of
+# dependencies into the repository for running the benchmark.
+#
+# Source trees are cloned by the Dockerfile protogen stage:
+#   /src/nighthawk   envoyproxy/nighthawk  (pinned commit)
+#   /src/envoy       envoyproxy/envoy      (nighthawk's ENVOY_COMMIT pin)
+#   /src/xds         cncf/xds              (xds/ + udpa/ import roots)
+#   /src/pgv         bufbuild/protoc-gen-validate
+#   /src/googleapis  googleapis/googleapis
+set -euo pipefail
+
+OUT=${1:-/out/nighthawk.desc}
+mkdir -p "$(dirname "$OUT")"
+
+cd /src/nighthawk
+
+# shellcheck disable=SC2046  # word-splitting of the glob expansions is intended
+python3 -m grpc_tools.protoc \
+  --include_imports \
+  --descriptor_set_out="$OUT" \
+  -I/src/nighthawk \
+  -I/src/envoy/api \
+  -I/src/xds \
+  -I/src/pgv \
+  -I/src/googleapis \
+  api/adaptive_load/*.proto \
+  api/client/*.proto \
+  api/request_source/*.proto
+
+echo "wrote $OUT ($(wc -c <"$OUT") bytes)"

--- a/benchmarking/nighthawk-ingress/requirements.txt
+++ b/benchmarking/nighthawk-ingress/requirements.txt
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# protobuf/grpcio floors match benchmarking/locust/requirements.txt so the
+# ateapi_pb2*.py files copied from locust/common load under both images.
+protobuf>=6.33.5
+grpcio>=1.81.1
+requests
+google-cloud-storage

--- a/benchmarking/nighthawk-ingress/run-dev.sh
+++ b/benchmarking/nighthawk-ingress/run-dev.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Quick dev run of the Nighthawk ingress-capacity benchmark (~8-10 min).
+#
+# Runs ONLY the benchmark layer against an already-prepared cluster: pins
+# the router if needed, builds the runner image from the WORKING TREE
+# (uncommitted changes included), submits the benchmark Job, waits, and
+# prints capacity.json. Cluster prerequisites (substrate + workers) are set
+# up by the user — see benchmarking/nighthawk-ingress/README.md.
+#
+#   ./benchmarking/nighthawk-ingress/run-dev.sh --envoy-cpu 2
+set -euo pipefail
+
+ENVOY_CPU=2
+ACTORS=100
+TAIL_LATENCY_SLO_MS=25
+ATESPACE="ingress-benchmark"
+DEST=""
+VENV="${HOME}/.venvs/substrate-bench"
+NAMESPACE="benchmarking"
+
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+  --envoy-cpu N             router cpu pin, the independent variable (default: ${ENVOY_CPU})
+  --actors N                actor fleet size; needs that many workers Running (default: ${ACTORS})
+  --tail-latency-slo-ms N   SLO bound; 0 disables (default: ${TAIL_LATENCY_SLO_MS})
+  --atespace NAME           actor namespace (default: ${ATESPACE})
+  --dest gs://...           results root (default: gs://\$BUCKET_NAME/nighthawk-ingress-results)
+EOF
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --envoy-cpu) ENVOY_CPU="$2"; shift 2 ;;
+    --actors) ACTORS="$2"; shift 2 ;;
+    --tail-latency-slo-ms) TAIL_LATENCY_SLO_MS="$2"; shift 2 ;;
+    --atespace) ATESPACE="$2"; shift 2 ;;
+    --dest) DEST="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# --- preflight (each failure prints its fix) ---------------------------------
+[[ -f .ate-dev-env.sh ]] || {
+  echo "ERROR: .ate-dev-env.sh not found at repo root (see GKE Quickstart in the repo README)" >&2
+  exit 1
+}
+# shellcheck disable=SC1091
+source .ate-dev-env.sh
+for var in PROJECT_ID CLUSTER_NAME CLUSTER_LOCATION KO_DOCKER_REPO BUCKET_NAME; do
+  [[ -n "${!var:-}" ]] || { echo "ERROR: ${var} not set by .ate-dev-env.sh" >&2; exit 1; }
+done
+DEST="${DEST:-gs://${BUCKET_NAME}/nighthawk-ingress-results}"
+
+docker info >/dev/null 2>&1 || {
+  echo "ERROR: docker daemon not running (the runner image is built locally)" >&2
+  exit 1
+}
+
+kubectl get deployment atenet-router -n ate-system >/dev/null 2>&1 || {
+  echo "ERROR: substrate is not deployed on ${CLUSTER_NAME}. Run:" >&2
+  echo "  hack/install-ate.sh --deploy-ate-system" >&2
+  exit 1
+}
+
+RUNNING_WORKERS="$(kubectl get pods -n benchmark-workloads --no-headers 2>/dev/null | grep -c ' Running ' || true)"
+if (( RUNNING_WORKERS < ACTORS )); then
+  echo "ERROR: ${RUNNING_WORKERS} workers Running in benchmark-workloads, need ${ACTORS}. Run:" >&2
+  echo "  benchmarking/workloads/deploy.sh --deploy --worker-count ${ACTORS} --sandbox-class gvisor" >&2
+  exit 1
+fi
+
+# Every value below is used as-is, defaults included — read this before the
+# router gets pinned.
+echo ">>> run config:"
+echo "      cluster:              ${CLUSTER_NAME} (${CLUSTER_LOCATION})"
+echo "      envoy_cpu:            ${ENVOY_CPU}"
+echo "      actors:               ${ACTORS}"
+echo "      workers running:      ${RUNNING_WORKERS}"
+echo "      tail_latency_slo_ms:  ${TAIL_LATENCY_SLO_MS}"
+echo "      atespace:             ${ATESPACE}"
+echo "      dest:                 ${DEST}"
+
+# venv: importing orchestrator.py (defaults/rendering/patch) needs PyYAML.
+if ! "${VENV}/bin/python" -c 'import yaml' 2>/dev/null; then
+  python3 -m venv "${VENV}"
+  "${VENV}/bin/pip" install --quiet pyyaml ||
+    "${VENV}/bin/pip" install --quiet --index-url https://pypi.org/simple/ pyyaml
+fi
+PY="${VENV}/bin/python"
+
+# --- pin the router if its current cpu differs --------------------------------
+CURRENT_CPU="$(kubectl get deployment atenet-router -n ate-system \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="envoy")].resources.limits.cpu}')"
+if [[ "${CURRENT_CPU}" != "${ENVOY_CPU}" ]]; then
+  echo ">>> pinning router: envoy cpu '${CURRENT_CPU:-unset}' -> ${ENVOY_CPU}"
+  "${PY}" -c "
+import sys
+sys.path.insert(0, 'benchmarking/automation')
+from testtypes import nighthawk_ingress
+nighthawk_ingress.pre_test({'nighthawk-ingress': {'envoyCpu': ${ENVOY_CPU}}})"
+fi
+
+# --- runner image from the working tree ---------------------------------------
+SHA7="$(git rev-parse --short=7 HEAD)"
+DIRTY=""
+[[ -n "$(git status --porcelain)" ]] && DIRTY="-dirty"
+TAG="quick-${SHA7}${DIRTY}-$(date +%H%M%S)"
+IMAGE="${KO_DOCKER_REPO}/nighthawk-ingress-test:${TAG}"
+echo ">>> building ${IMAGE} from the working tree"
+# --platform is required: the clusters are amd64 and the default target on
+# an arm64 host produces an image the nodes cannot pull.
+docker build --platform linux/amd64 \
+  -f benchmarking/nighthawk-ingress/Dockerfile -t "${IMAGE}" .
+docker push "${IMAGE}"
+
+# --- render + submit the Job ---------------------------------------------------
+NAME="ingress_routercap_envoy_${ENVOY_CPU}cpu"
+JOB="runner-ingress-routercap-${ENVOY_CPU}cpu-quick-$(date +%H%M%S)"
+export IMAGE JOB NAME DEST TAG ENVOY_CPU ACTORS TAIL_LATENCY_SLO_MS ATESPACE
+"${PY}" - <<'EOF' | kubectl apply -f -
+import os
+import sys
+
+sys.path.insert(0, "benchmarking/automation")
+import orchestrator
+from testtypes import nighthawk_ingress
+
+test = {
+    "name": os.environ["NAME"],
+    "type": "nighthawk-ingress",
+    "targetCluster": "dev",
+    "duration": "30m",
+    "workerCount": int(os.environ["ACTORS"]),
+    "nighthawk-ingress": {
+        "envoyCpu": int(os.environ["ENVOY_CPU"]),
+        "atespace": os.environ["ATESPACE"],
+        "tailLatencySloMs": float(os.environ["TAIL_LATENCY_SLO_MS"]),
+    },
+}
+orchestrator.validate_and_normalize_tests([test])
+subs = {
+    "JOB_NAME": os.environ["JOB"],
+    "IMAGE": os.environ["IMAGE"],
+    "TAG": os.environ["TAG"],
+    "NAME": test["name"],
+    "DEST": os.environ["DEST"],
+    "ATE_ATEAPI_CLIENT_AUTH": os.environ.get("ATE_ATEAPI_CLIENT_AUTH", "cert"),
+    **nighthawk_ingress.job_subs(test),
+}
+tmpl = nighthawk_ingress.job_tmpl("benchmarking/automation/manifests")
+print(orchestrator.render_template(tmpl, subs))
+EOF
+
+# --- wait, streaming the runner's own log lines --------------------------------
+# [service]/[adaptive] lines are Nighthawk's raw textproto/metric dumps —
+# they are in the uploaded logs.txt; too noisy for the terminal.
+echo ">>> waiting for job/${JOB} (progress lines only; full logs land in logs.txt)"
+( until kubectl logs -f "job/${JOB}" -n "${NAMESPACE}" 2>/dev/null \
+    | grep --line-buffered -vE '^\[(service|adaptive)\] '; do sleep 5; done ) &
+LOGS_PID=$!
+STATUS="timeout"
+for _ in $(seq 1 150); do  # 150 x 10s = 25 min
+  S="$(kubectl get job "${JOB}" -n "${NAMESPACE}" -o jsonpath='{.status.succeeded}' 2>/dev/null)"
+  F="$(kubectl get job "${JOB}" -n "${NAMESPACE}" -o jsonpath='{.status.failed}' 2>/dev/null)"
+  [[ "${S}" == "1" ]] && { STATUS="complete"; break; }
+  [[ "${F}" == "1" ]] && { STATUS="failed"; break; }
+  sleep 10
+done
+kill "${LOGS_PID}" 2>/dev/null || true
+
+# --- verdict --------------------------------------------------------------------
+if [[ "${STATUS}" == "complete" ]]; then
+  CAPACITY="$(gcloud storage ls "${DEST}/runs/${NAME}/**/run_tag=${TAG}/capacity.json" 2>/dev/null | tail -1)"
+  if [[ -n "${CAPACITY}" ]]; then
+    echo ">>> ${CAPACITY}"
+    gcloud storage cat "${CAPACITY}"
+  fi
+  kubectl delete job "${JOB}" -n "${NAMESPACE}" >/dev/null
+  echo ">>> ${NAME}: complete (tag ${TAG})"
+else
+  echo ">>> ${NAME}: ${STATUS} — job/${JOB} kept for debugging:" >&2
+  echo "      kubectl logs job/${JOB} -n ${NAMESPACE}" >&2
+  echo "    (warm-up 503s with TLS errors = expired router pod cert; fix:" >&2
+  echo "      kubectl -n ate-system rollout restart deployment/atenet-router)" >&2
+  exit 1
+fi

--- a/benchmarking/nighthawk-ingress/runner.py
+++ b/benchmarking/nighthawk-ingress/runner.py
@@ -1,0 +1,389 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nighthawk adaptive router-capacity benchmark runner.
+
+One Kubernetes Job per tests.yaml entry (submitted by
+benchmarking/automation/orchestrator.py):
+  1. Create + warm N glutton actors through the router.
+  2. Build the AdaptiveLoadSessionSpec (spec.py).
+  3. Run nighthawk_service + nighthawk_adaptive_load_client.
+  4. Convert the output (output.py) and upload to <dest>/runs/<name>/...
+     (same Hive-partitioned layout as the locust runner).
+
+Exit 0 iff the session converged (client exit 0 AND a testing-stage result
+parsed) and all artifacts uploaded.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, TextIO
+
+import actors
+import output as output_mod
+import spec as spec_mod
+
+NIGHTHAWK_SERVICE = "nighthawk_service"
+ADAPTIVE_CLIENT = "nighthawk_adaptive_load_client"
+SERVICE_ADDRESS = "127.0.0.1:8443"
+
+DEFAULT_ROUTER_URL = "http://atenet-router.ate-system.svc.cluster.local:80"
+DESC_PATH = os.environ.get("NIGHTHAWK_DESC", "/app/nighthawk.desc")
+
+
+def parse_duration_seconds(s: str) -> int:
+    """Same grammar as the orchestrator: <int>[smh], default seconds."""
+    m = re.fullmatch(r"(\d+)\s*([smh]?)", s.strip())
+    if not m:
+        raise ValueError(f"unrecognized duration: {s}")
+    return int(m.group(1)) * {"s": 1, "m": 60, "h": 3600}[m.group(2) or "s"]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--name", required=True, help="Test name (GCS path component)")
+    p.add_argument("--tag", required=True, help="Tag for this run (commit sha)")
+    p.add_argument(
+        "--dest",
+        required=True,
+        help="Root destination (gs://bucket/path or local path)",
+    )
+    p.add_argument("--envoy-cpu", required=True, type=int, dest="envoy_cpu")
+    p.add_argument("--actors", type=int, default=100)
+    # Event loops and per-loop pools are sized so the client never binds
+    # before the router; decoupled from --envoy-cpu.
+    p.add_argument(
+        "--client-concurrency", type=int, default=16, dest="client_concurrency"
+    )
+    p.add_argument("--connections", type=int, default=1000)
+    p.add_argument("--max-pending", type=int, default=10000, dest="max_pending")
+    p.add_argument("--initial-rps", type=int, default=500, dest="initial_rps")
+    p.add_argument("--exp-factor", type=float, default=2.0, dest="exp_factor")
+    p.add_argument("--measuring-period", default="10s", dest="measuring_period")
+    p.add_argument(
+        "--convergence-deadline", default="600s", dest="convergence_deadline"
+    )
+    p.add_argument(
+        "--testing-stage-duration", default="60s", dest="testing_stage_duration"
+    )
+    p.add_argument(
+        "--success-rate-threshold",
+        type=float,
+        default=0.999,
+        dest="success_rate",
+    )
+    # Open-loop backstop; without it the search diverges (see spec.py).
+    p.add_argument(
+        "--send-rate-threshold", type=float, default=0.9, dest="send_rate"
+    )
+    # SLO bound on latency-ns-mean-plus-2stdev, in ms; <= 0 disables.
+    p.add_argument(
+        "--tail-latency-slo-ms",
+        type=float,
+        default=0,
+        dest="tail_latency_slo_ms",
+    )
+    p.add_argument("--router-url", default=DEFAULT_ROUTER_URL, dest="router_url")
+    p.add_argument("--warm-deadline", default="600s", dest="warm_deadline")
+    p.add_argument("--atespace", default=actors.ATESPACE)
+    args, extra = p.parse_known_args()
+    args.extra = extra
+    return args
+
+
+def tee(logs: TextIO, msg: str) -> None:
+    print(msg, flush=True)
+    logs.write(msg + "\n")
+    logs.flush()
+
+
+def pump_stream(prefix: str, stream: IO[str], logs: TextIO) -> None:
+    for line in stream:
+        tagged = f"[{prefix}] {line.rstrip()}"
+        sys.stdout.write(tagged + "\n")
+        sys.stdout.flush()
+        logs.write(tagged + "\n")
+        logs.flush()
+
+
+def start_service(logs: TextIO) -> subprocess.Popen:
+    proc = subprocess.Popen(
+        [NIGHTHAWK_SERVICE, "--listen", SERVICE_ADDRESS],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+        text=True,
+    )
+    threading.Thread(
+        target=pump_stream, args=("service", proc.stdout, logs), daemon=True
+    ).start()
+    host, port = SERVICE_ADDRESS.split(":")
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"{NIGHTHAWK_SERVICE} exited early with {proc.returncode}"
+            )
+        try:
+            with socket.create_connection((host, int(port)), timeout=1):
+                tee(logs, f"{NIGHTHAWK_SERVICE} ready on {SERVICE_ADDRESS}")
+                return proc
+        except OSError:
+            time.sleep(0.5)
+    proc.terminate()
+    raise RuntimeError(f"{NIGHTHAWK_SERVICE} not listening within 30s")
+
+
+def run_adaptive_client(
+    spec_path: Path, output_path: Path, logs: TextIO
+) -> int:
+    cmd = [
+        ADAPTIVE_CLIENT,
+        "--spec-file",
+        str(spec_path),
+        "--output-file",
+        str(output_path),
+        "--nighthawk-service-address",
+        SERVICE_ADDRESS,
+    ]
+    tee(logs, f"Running: {' '.join(cmd)}")
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+        text=True,
+    )
+    pump_stream("adaptive", proc.stdout, logs)
+    return proc.wait()
+
+
+def upload_to_gcs(local_path: Path, gcs_uri: str) -> None:
+    # Imported here so non-GCS use doesn't require google-cloud-storage.
+    from google.cloud import storage
+
+    bucket_name, _, blob_path = gcs_uri[len("gs://"):].partition("/")
+    storage.Client().bucket(bucket_name).blob(blob_path).upload_from_filename(
+        str(local_path)
+    )
+
+
+def upload(src: Path, dest: str) -> None:
+    if dest.startswith("gs://"):
+        upload_to_gcs(src, dest)
+    else:
+        dest_path = Path(dest)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(src, dest_path)
+
+
+def log_run_config(args: argparse.Namespace, prefix: str, logs: TextIO) -> None:
+    lines = [
+        "==== Run config ====",
+        f"  name:                   {args.name}",
+        f"  tag:                    {args.tag}",
+        f"  envoy_cpu (router limits + envoy --concurrency): {args.envoy_cpu}",
+        f"  client_concurrency (nighthawk event loops): {args.client_concurrency}",
+        f"  actors:                 {args.actors}",
+        f"  connections/loop:       {args.connections}",
+        f"  max_pending/loop:       {args.max_pending}",
+        f"  initial_total_rps:      {args.initial_rps}",
+        f"  exponential_factor:     {args.exp_factor}",
+        f"  measuring_period:       {args.measuring_period}",
+        f"  convergence_deadline:   {args.convergence_deadline}",
+        f"  testing_stage_duration: {args.testing_stage_duration}",
+        f"  success_rate_threshold: {args.success_rate}",
+        f"  send_rate_threshold:    {args.send_rate}",
+        f"  tail_latency_slo_ms:    {args.tail_latency_slo_ms or '(disabled)'}",
+        f"  atespace:               {args.atespace}",
+        f"  router_url:             {args.router_url}",
+        f"  dest_prefix:            {prefix}",
+        f"  extra flags (ignored):  {' '.join(args.extra) or '(none)'}",
+        "====================",
+    ]
+    for line in lines:
+        tee(logs, line)
+
+
+def main() -> None:
+    args = parse_args()
+    now = datetime.now(timezone.utc)
+    work_dir = Path(f"/tmp/{now.strftime('%Y%m%dT%H%M%SZ')}-nighthawk-runner")
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    prefix = (
+        f"{args.dest.rstrip('/')}/runs/{args.name}"
+        f"/run_date={now.strftime('%Y-%m-%d')}/run_ts={int(now.timestamp())}"
+        f"/run_tag={args.tag}"
+    )
+
+    logs_path = work_dir / "logs.txt"
+    spec_path = work_dir / "spec.textproto"
+    output_path = work_dir / "output.textproto"
+    results_path = work_dir / "results.json"
+    stats_path = work_dir / "stats.jsonl"
+    capacity_path = work_dir / "capacity.json"
+    status_path = work_dir / "status.json"
+
+    adaptive_exit: int | None = None
+    testing_stage_parsed = False
+    actor_names: list[str] = []
+    service_proc = None
+
+    with open(logs_path, "w") as logs:
+        log_run_config(args, prefix, logs)
+        auth_mode = os.environ.get("ATE_ATEAPI_CLIENT_AUTH", "cert")
+        stub = actors.ateapi_stub(auth_mode)
+        try:
+            # Filled incrementally so the finally-block cleanup covers a
+            # fleet that failed partway through warming.
+            actors.create_and_warm(
+                stub,
+                args.router_url,
+                args.actors,
+                created=actor_names,
+                atespace=args.atespace,
+                warm_deadline_s=parse_duration_seconds(args.warm_deadline),
+                log=lambda m: tee(logs, m),
+            )
+
+            hosts = [
+                spec_mod.actor_host(n, args.atespace) for n in actor_names
+            ]
+            spec_dict = spec_mod.build_spec_dict(
+                uri=f"{args.router_url.rstrip('/')}/ping",
+                hosts=hosts,
+                client_concurrency=args.client_concurrency,
+                connections=args.connections,
+                max_pending_requests=args.max_pending,
+                initial_total_rps=args.initial_rps,
+                exponential_factor=args.exp_factor,
+                measuring_period_s=parse_duration_seconds(args.measuring_period),
+                convergence_deadline_s=parse_duration_seconds(
+                    args.convergence_deadline
+                ),
+                testing_stage_duration_s=parse_duration_seconds(
+                    args.testing_stage_duration
+                ),
+                success_rate_threshold=args.success_rate,
+                send_rate_threshold=args.send_rate,
+                tail_latency_slo_ms=(
+                    args.tail_latency_slo_ms
+                    if args.tail_latency_slo_ms > 0
+                    else None
+                ),
+            )
+            spec_path.write_text(
+                spec_mod.spec_dict_to_textproto(spec_dict, DESC_PATH)
+            )
+            tee(logs, f"Wrote spec to {spec_path}")
+
+            service_proc = start_service(logs)
+            adaptive_exit = run_adaptive_client(spec_path, output_path, logs)
+            tee(logs, f"{ADAPTIVE_CLIENT} exited with code {adaptive_exit}")
+
+            if output_path.exists():
+                output_dict = output_mod.parse_output_textproto(
+                    output_path.read_text(), DESC_PATH
+                )
+                results_path.write_text(json.dumps(output_dict, indent=2))
+                rows = output_mod.stage_rows(output_dict)
+                output_mod.write_jsonl(
+                    output_mod.stats_records(rows, args.tag, args.name),
+                    stats_path,
+                )
+                summary = output_mod.capacity_summary(
+                    output_dict,
+                    envoy_cpu=args.envoy_cpu,
+                    actors=args.actors,
+                    client_concurrency=args.client_concurrency,
+                    tail_latency_slo_ms=(
+                        args.tail_latency_slo_ms
+                        if args.tail_latency_slo_ms > 0
+                        else None
+                    ),
+                )
+                capacity_path.write_text(json.dumps(summary, indent=2))
+                testing_stage_parsed = any(
+                    r["stage"] == "testing" for r in rows
+                )
+                tee(logs, f"Capacity summary: {json.dumps(summary)}")
+            else:
+                tee(logs, f"No output file at {output_path}")
+        except Exception as e:
+            tee(logs, f"Run failed: {e}")
+        finally:
+            if service_proc is not None:
+                service_proc.terminate()
+                try:
+                    service_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    service_proc.kill()
+            if actor_names:
+                tee(logs, f"Cleaning up {len(actor_names)} actors")
+                actors.cleanup(
+                    stub,
+                    actor_names,
+                    atespace=args.atespace,
+                    log=lambda m: tee(logs, m),
+                )
+
+    converged = adaptive_exit == 0 and testing_stage_parsed
+    status_path.write_text(
+        json.dumps(
+            {
+                "adaptive_client_exit_code": adaptive_exit,
+                "converged": converged,
+                "actors_created": len(actor_names),
+            }
+        )
+    )
+
+    upload_ok = True
+    files = [
+        (status_path, "status.json"),
+        (logs_path, "logs.txt"),
+        (spec_path, "spec.textproto"),
+        (output_path, "output.textproto"),
+        (results_path, "results.json"),
+        (stats_path, "stats.jsonl"),
+        (capacity_path, "capacity.json"),
+    ]
+    for src, basename in files:
+        if not src.exists():
+            print(f"Skipping {src}: not produced", flush=True)
+            continue
+        dest = f"{prefix}/{basename}"
+        try:
+            upload(src, dest)
+            print(f"Uploaded {src} -> {dest}", flush=True)
+        except Exception as e:
+            print(f"Upload of {src} failed: {e}", flush=True)
+            upload_ok = False
+
+    sys.exit(0 if (converged and upload_ok) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/nighthawk-ingress/spec.py
+++ b/benchmarking/nighthawk-ingress/spec.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AdaptiveLoadSessionSpec builder.
+
+Specs are plain dicts, validated and rendered to textproto through the
+FileDescriptorSet built by protogen/generate_descriptor.sh — field names
+are checked against the real Nighthawk protos at spec-build time.
+"""
+
+SPEC_MESSAGE = "nighthawk.adaptive_load.AdaptiveLoadSessionSpec"
+OUTPUT_MESSAGE = "nighthawk.adaptive_load.AdaptiveLoadSessionOutput"
+
+# Registered plugin names: adaptive-load plugins use underscores upstream,
+# request-source plugins use hyphens.
+STEP_CONTROLLER_PLUGIN = "nighthawk.exponential_search"
+STEP_CONTROLLER_TYPE_URL = (
+    "type.googleapis.com/nighthawk.adaptive_load.ExponentialSearchStepControllerConfig"
+)
+BINARY_SCORING_PLUGIN = "nighthawk.binary_scoring"
+BINARY_SCORING_TYPE_URL = (
+    "type.googleapis.com/nighthawk.adaptive_load.BinaryScoringFunctionConfig"
+)
+BUILTIN_METRICS_PLUGIN = "nighthawk.builtin"
+REQUEST_SOURCE_PLUGIN = "nighthawk.in-line-options-list-request-source-plugin"
+REQUEST_SOURCE_TYPE_URL = (
+    "type.googleapis.com/nighthawk.request_source.InLineOptionsListRequestSourceConfig"
+)
+
+# The default failure predicates (all 0) abort an execution on the first
+# 4xx/5xx; measuring periods must instead run to completion so overload
+# scores as degraded success-rate. All five defaults overridden.
+PERMISSIVE_FAILURE_PREDICATES = {
+    "benchmark.http_4xx": "1000000000",
+    "benchmark.http_5xx": "1000000000",
+    "benchmark.pool_connection_failure": "1000000000",
+    "benchmark.stream_resets": "1000000000",
+    "requestsource.upstream_rq_5xx": "1000000000",
+}
+
+INFORMATIONAL_METRICS = (
+    "attempted-rps",
+    "achieved-rps",
+    "send-rate",
+    "latency-ns-mean",
+    "latency-ns-mean-plus-2stdev",
+)
+
+
+def actor_host(actor: str, atespace: str) -> str:
+    """Host header the router routes on (internal/resources/actor.go)."""
+    return f"{actor}.{atespace}.actors.resources.substrate.ate.dev"
+
+
+def _metric_spec(name: str) -> dict:
+    return {"metric_name": name, "metrics_plugin_name": BUILTIN_METRICS_PLUGIN}
+
+
+def _binary_threshold(
+    metric_name: str,
+    lower_threshold: float | None = None,
+    upper_threshold: float | None = None,
+) -> dict:
+    config: dict = {"@type": BINARY_SCORING_TYPE_URL}
+    if lower_threshold is not None:
+        config["lower_threshold"] = lower_threshold
+    if upper_threshold is not None:
+        config["upper_threshold"] = upper_threshold
+    return {
+        "metric_spec": _metric_spec(metric_name),
+        "threshold_spec": {
+            "scoring_function": {
+                "name": BINARY_SCORING_PLUGIN,
+                "typed_config": config,
+            },
+        },
+    }
+
+
+def build_spec_dict(
+    *,
+    uri: str,
+    hosts: list[str],
+    client_concurrency: int,
+    connections: int,
+    max_pending_requests: int,
+    initial_total_rps: int,
+    exponential_factor: float,
+    measuring_period_s: int,
+    convergence_deadline_s: int,
+    testing_stage_duration_s: int,
+    success_rate_threshold: float,
+    send_rate_threshold: float | None = 0.9,
+    tail_latency_slo_ms: float | None = None,
+    benchmark_cooldown_s: int = 5,
+) -> dict:
+    """Assemble the AdaptiveLoadSessionSpec as a JSON-shaped dict.
+
+    The controller varies the *per-worker* requests_per_second, so
+    initial_value = initial_total_rps / client_concurrency. The template
+    must not set duration (the controller rejects it); open_loop is forced
+    true by the controller.
+    """
+    request_variants = [
+        {
+            "request_method": "POST",
+            "request_headers": [
+                {
+                    "header": {"key": "host", "value": host},
+                    "append_action": "OVERWRITE_IF_EXISTS_OR_ADD",
+                }
+            ],
+        }
+        for host in hosts
+    ]
+    # Threshold roles: tail latency (mean+2stdev, ~p95 proxy — no true
+    # percentiles in the builtin adaptive metrics) is the SLO bound;
+    # success-rate catches fast-error saturation (503/504) that latency and
+    # send-rate miss; send-rate is the open-loop backstop — skipped
+    # requests are neither failures nor latency samples, so without it the
+    # search ramps unboundedly.
+    thresholds = [
+        _binary_threshold("success-rate", lower_threshold=success_rate_threshold)
+    ]
+    if send_rate_threshold is not None:
+        thresholds.append(
+            _binary_threshold("send-rate", lower_threshold=send_rate_threshold)
+        )
+    if tail_latency_slo_ms is not None:
+        thresholds.append(
+            _binary_threshold(
+                "latency-ns-mean-plus-2stdev",
+                upper_threshold=tail_latency_slo_ms * 1_000_000.0,
+            )
+        )
+    return {
+        "nighthawk_traffic_template": {
+            "uri": uri,
+            "concurrency": str(client_concurrency),
+            "connections": connections,
+            "max_pending_requests": max_pending_requests,
+            "open_loop": True,
+            "failure_predicates": dict(PERMISSIVE_FAILURE_PREDICATES),
+            # request_options shares a oneof with this field: method and
+            # headers must come from the per-variant RequestOptions.
+            "request_source_plugin_config": {
+                "name": REQUEST_SOURCE_PLUGIN,
+                "typed_config": {
+                    "@type": REQUEST_SOURCE_TYPE_URL,
+                    "options_list": {"options": request_variants},
+                    # 0 = cycle through options_list indefinitely.
+                    "num_requests": 0,
+                },
+            },
+        },
+        "metric_thresholds": thresholds,
+        "informational_metric_specs": [
+            _metric_spec(m) for m in INFORMATIONAL_METRICS
+        ],
+        "step_controller_config": {
+            "name": STEP_CONTROLLER_PLUGIN,
+            "typed_config": {
+                "@type": STEP_CONTROLLER_TYPE_URL,
+                "initial_value": max(1.0, initial_total_rps / client_concurrency),
+                "exponential_factor": exponential_factor,
+            },
+        },
+        "measuring_period": f"{measuring_period_s}s",
+        "convergence_deadline": f"{convergence_deadline_s}s",
+        "testing_stage_duration": f"{testing_stage_duration_s}s",
+        "benchmark_cooldown_duration": f"{benchmark_cooldown_s}s",
+    }
+
+
+# protobuf imports are deferred: the dict builder above must work without
+# protobuf installed.
+
+
+def load_pool(desc_path: str):
+    from google.protobuf import descriptor_pb2
+    from google.protobuf import descriptor_pool
+
+    pool = descriptor_pool.DescriptorPool()
+    fds = descriptor_pb2.FileDescriptorSet()
+    with open(desc_path, "rb") as f:
+        fds.ParseFromString(f.read())
+    for file_proto in fds.file:
+        pool.Add(file_proto)
+    return pool
+
+
+def message_class(pool, full_name: str):
+    from google.protobuf import message_factory
+
+    return message_factory.GetMessageClass(pool.FindMessageTypeByName(full_name))
+
+
+def spec_dict_to_textproto(spec_dict: dict, desc_path: str) -> str:
+    """Validate the dict against the real protos and render textproto.
+
+    No descriptor_pool for MessageToString: expanded-form Any is not
+    parseable by nighthawk_adaptive_load_client for plugin types it does
+    not link (the request-source config); raw type_url/value form is.
+    """
+    from google.protobuf import json_format
+    from google.protobuf import text_format
+
+    pool = load_pool(desc_path)
+    msg = message_class(pool, SPEC_MESSAGE)()
+    json_format.ParseDict(spec_dict, msg, descriptor_pool=pool)
+    return text_format.MessageToString(msg)

--- a/benchmarking/nighthawk-ingress/tests/test_output.py
+++ b/benchmarking/nighthawk-ingress/tests/test_output.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for AdaptiveLoadSessionOutput -> rows/records/summary.
+
+Uses a canned dict in the exact shape json_format.MessageToDict(
+preserving_proto_field_name=True) produces from a real session output
+(uint64 counters as strings, Durations as '30s' strings)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import output as output_mod
+
+
+def benchmark_result(
+    rps: int, http_2xx: int, http_5xx: int = 0, failed_metric: str | None = None
+) -> dict:
+    total = http_2xx + http_5xx
+    return {
+        "nighthawk_service_output": {
+            "options": {"requests_per_second": rps, "concurrency": "4"},
+            "results": [
+                {
+                    "name": "global",
+                    "execution_duration": "10s",
+                    "counters": [
+                        {"name": "benchmark.http_2xx", "value": str(http_2xx)},
+                        {"name": "benchmark.http_5xx", "value": str(http_5xx)},
+                        {"name": "upstream_rq_total", "value": str(total)},
+                    ],
+                    "statistics": [
+                        {
+                            "id": output_mod.LATENCY_STAT_ID,
+                            "count": str(total),
+                            "mean": "0.004s",
+                            "min": "0.001s",
+                            "max": "0.100s",
+                            "percentiles": [
+                                {"percentile": 0.5, "duration": "0.003s"},
+                                {"percentile": 0.95, "duration": "0.008s"},
+                                {"percentile": 0.990625, "duration": "0.020s"},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+        "start_time": "2026-08-14T00:00:00Z",
+        "end_time": "2026-08-14T00:00:10Z",
+        "metric_evaluations": [
+            {
+                "metric_id": "nighthawk.builtin/success-rate",
+                "metric_value": http_2xx / total if total else 0.0,
+                "threshold_score": 1.0,
+            },
+            # informational metrics: no threshold_score field at all
+            {
+                "metric_id": "nighthawk.builtin/attempted-rps",
+                "metric_value": float(rps * 4),
+            },
+            {
+                "metric_id": "nighthawk.builtin/achieved-rps",
+                "metric_value": total / 10.0,
+            },
+            {
+                "metric_id": "nighthawk.builtin/send-rate",
+                "metric_value": (total / 10.0) / (rps * 4) if rps else 0.0,
+            },
+        ] + ([
+            {
+                "metric_id": f"nighthawk.builtin/{failed_metric}",
+                "metric_value": 999.0,
+                "threshold_score": -1.0,
+            }
+        ] if failed_metric else []),
+    }
+
+
+SESSION = {
+    "session_status": {},
+    "adjusting_stage_results": [
+        benchmark_result(rps=125, http_2xx=5000),
+        benchmark_result(rps=250, http_2xx=9990, http_5xx=10),
+    ],
+    "testing_stage_result": benchmark_result(rps=200, http_2xx=8000),
+}
+
+
+def test_stage_rows():
+    rows = output_mod.stage_rows(SESSION)
+    assert [r["stage"] for r in rows] == [
+        "adjusting_000",
+        "adjusting_001",
+        "testing",
+    ]
+    first = rows[0]
+    assert first["metric_nighthawk.builtin_attempted_rps"] == 500.0
+    assert first["metric_nighthawk.builtin_achieved_rps"] == 500.0
+    assert first["metric_nighthawk.builtin_success_rate"] == 1.0
+    assert first["metric_nighthawk.builtin_send_rate"] == 1.0
+    assert first["p50_ms"] == 3.0
+    assert first["p95_ms"] == 8.0
+    # 0.990625 is the first HdrHistogram point at/above 0.99.
+    assert first["p99_ms"] == 20.0
+    assert first["latency_mean_ms"] == 4.0
+
+    degraded = rows[1]
+    assert degraded["metric_nighthawk.builtin_attempted_rps"] == 1000.0
+    assert degraded["metric_nighthawk.builtin_achieved_rps"] == 1000.0  # sent counts errors too
+    assert degraded["http_5xx"] == 10
+    assert 0.998 < degraded["metric_nighthawk.builtin_success_rate"] < 1.0
+
+
+def test_stats_records_shape():
+    rows = output_mod.stage_rows(SESSION)
+    records = output_mod.stats_records(rows, tag="abc123", test_name="cap2")
+    assert len(records) == 3
+    rec = records[-1]
+    assert rec["metric"] == "nighthawk_testing"
+    assert rec["tag"] == "abc123"
+    assert rec["test_name"] == "cap2"
+    assert rec["timestamp"] == "2026-08-14T00:00:00Z"
+    assert rec["measurements"]["metric_nighthawk.builtin_attempted_rps"] == 800.0
+    assert "stage" not in rec["measurements"]
+
+
+def test_capacity_summary_converged():
+    summary = output_mod.capacity_summary(
+        SESSION, envoy_cpu=4, actors=100,
+        client_concurrency=16, tail_latency_slo_ms=25,
+    )
+    assert summary["converged"] is True
+    assert summary["envoy_cpu"] == 4
+    assert summary["client_concurrency"] == 16
+    assert summary["tail_latency_slo_ms"] == 25
+    assert summary["adjusting_stages"] == 2
+    assert "max_total_rps" not in summary
+    assert summary["metric_nighthawk.builtin_attempted_rps"] == 800.0
+    assert summary["metric_nighthawk.builtin_achieved_rps"] == 800.0
+    assert summary["p99_ms"] == 20.0
+    # slo_max = achieved-rps of the highest-attempted clean stage
+    # (adjusting_001: 10000 sent / 10s).
+    assert summary["binding_threshold"] == []
+    assert summary["slo_max_stage"] == "adjusting_001"
+    assert summary["slo_max_rps"] == 1000.0
+
+
+def test_failed_thresholds_and_binding():
+    session = {
+        "session_status": {},
+        "adjusting_stage_results": [
+            benchmark_result(rps=125, http_2xx=5000),
+            benchmark_result(
+                rps=500, http_2xx=9000,
+                failed_metric="latency-ns-mean-plus-2stdev",
+            ),
+            benchmark_result(rps=250, http_2xx=9000, failed_metric="send-rate"),
+        ],
+        "testing_stage_result": benchmark_result(rps=200, http_2xx=8000),
+    }
+    rows = output_mod.stage_rows(session)
+    assert rows[0]["failed_thresholds"] == []
+    assert rows[1]["failed_thresholds"] == ["latency-ns-mean-plus-2stdev"]
+    # Threshold fields use short native names, not measurement keys.
+    assert rows[2]["failed_thresholds"] == ["send-rate"]
+    summary = output_mod.capacity_summary(session, envoy_cpu=2, actors=100)
+    assert summary["binding_threshold"] == [
+        "latency-ns-mean-plus-2stdev", "send-rate",
+    ]
+    # Failing stages are skipped; testing (800 attempted) is clean.
+    assert summary["slo_max_stage"] == "testing"
+    assert summary["slo_max_rps"] == 800.0
+
+
+def test_capacity_summary_no_testing_stage():
+    session = {
+        "session_status": {"code": 4, "message": "convergence deadline"},
+        "adjusting_stage_results": [benchmark_result(rps=125, http_2xx=100)],
+    }
+    summary = output_mod.capacity_summary(session, envoy_cpu=2, actors=10)
+    assert summary["converged"] is False
+    assert "max_total_rps" not in summary
+
+
+if __name__ == "__main__":
+    for fn_name, fn in sorted(dict(globals()).items()):
+        if fn_name.startswith("test_") and callable(fn):
+            fn()
+            print(f"PASS {fn_name}")

--- a/benchmarking/nighthawk-ingress/tests/test_spec.py
+++ b/benchmarking/nighthawk-ingress/tests/test_spec.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the AdaptiveLoadSessionSpec dict builder.
+
+The dict-shape tests run anywhere (stdlib only, `python3 tests/test_spec.py`
+or pytest). The textproto round-trip test needs the FileDescriptorSet built
+by the Docker protogen stage and self-skips when NIGHTHAWK_DESC is absent
+(i.e. outside the runner image):
+  docker run --rm --entrypoint python3 <image> -m pytest /app/tests
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import spec as spec_mod
+
+
+def build(**overrides):
+    kwargs = dict(
+        uri="http://atenet-router.ate-system.svc.cluster.local:80/ping",
+        hosts=[
+            spec_mod.actor_host(f"sb-{i}", "benchmark") for i in range(3)
+        ],
+        client_concurrency=4,
+        connections=1000,
+        max_pending_requests=10000,
+        initial_total_rps=500,
+        exponential_factor=2.0,
+        measuring_period_s=10,
+        convergence_deadline_s=600,
+        testing_stage_duration_s=60,
+        success_rate_threshold=0.999,
+    )
+    kwargs.update(overrides)
+    return spec_mod.build_spec_dict(**kwargs)
+
+
+def test_traffic_template_shape():
+    spec = build()
+    template = spec["nighthawk_traffic_template"]
+    # The adaptive controller rejects templates that set duration.
+    assert "duration" not in template
+    assert template["open_loop"] is True
+    assert template["concurrency"] == "4"
+    # All five default failure predicates must be overridden (spec.py).
+    assert set(template["failure_predicates"]) == {
+        "benchmark.http_4xx",
+        "benchmark.http_5xx",
+        "benchmark.pool_connection_failure",
+        "benchmark.stream_resets",
+        "requestsource.upstream_rq_5xx",
+    }
+
+
+def test_host_rotation_covers_all_actors():
+    hosts = [spec_mod.actor_host(f"sb-{i}", "benchmark") for i in range(5)]
+    spec = build(hosts=hosts)
+    plugin = spec["nighthawk_traffic_template"]["request_source_plugin_config"]
+    assert plugin["name"] == spec_mod.REQUEST_SOURCE_PLUGIN
+    options = plugin["typed_config"]["options_list"]["options"]
+    got = [o["request_headers"][0]["header"]["value"] for o in options]
+    assert got == hosts
+    assert all(o["request_method"] == "POST" for o in options)
+    # 0 = loop the list indefinitely.
+    assert plugin["typed_config"]["num_requests"] == 0
+
+
+def test_initial_rps_is_per_worker():
+    spec = build(initial_total_rps=1000, client_concurrency=4)
+    controller = spec["step_controller_config"]
+    assert controller["name"] == spec_mod.STEP_CONTROLLER_PLUGIN
+    assert controller["typed_config"]["initial_value"] == 250.0
+
+
+def test_thresholds_and_durations():
+    # send-rate must be a default threshold: with no SLO set, nothing else
+    # bounds the open-loop search.
+    spec = build()
+    names = [
+        t["metric_spec"]["metric_name"] for t in spec["metric_thresholds"]
+    ]
+    assert names == ["success-rate", "send-rate"]
+    scoring = spec["metric_thresholds"][0]["threshold_spec"]["scoring_function"]
+    assert scoring["name"] == spec_mod.BINARY_SCORING_PLUGIN
+    assert scoring["typed_config"]["lower_threshold"] == 0.999
+    assert spec["measuring_period"] == "10s"
+    assert spec["convergence_deadline"] == "600s"
+    assert spec["testing_stage_duration"] == "60s"
+
+
+def test_tail_latency_slo_threshold():
+    spec = build(tail_latency_slo_ms=25)
+    thresholds = spec["metric_thresholds"]
+    names = [t["metric_spec"]["metric_name"] for t in thresholds]
+    assert names == ["success-rate", "send-rate", "latency-ns-mean-plus-2stdev"]
+    latency = thresholds[-1]["threshold_spec"]["scoring_function"]["typed_config"]
+    # SLO is an UPPER bound, in nanoseconds (25 ms).
+    assert latency["upper_threshold"] == 25_000_000.0
+    assert "lower_threshold" not in latency
+    # Disabled (None) => no latency threshold at all.
+    assert len(build(tail_latency_slo_ms=None)["metric_thresholds"]) == 2
+
+
+def test_actor_host_format():
+    assert (
+        spec_mod.actor_host("sb-1", "benchmark")
+        == "sb-1.benchmark.actors.resources.substrate.ate.dev"
+    )
+
+
+def test_spec_round_trips_through_real_protos():
+    """Round-trip through the real Nighthawk protos; self-skips outside the
+    runner image (no FileDescriptorSet)."""
+    desc = os.environ.get("NIGHTHAWK_DESC", "/app/nighthawk.desc")
+    if not os.path.exists(desc):
+        print("SKIP: FileDescriptorSet only present inside the runner image")
+        return
+    from google.protobuf import text_format
+
+    text = spec_mod.spec_dict_to_textproto(build(tail_latency_slo_ms=25), desc)
+    pool = spec_mod.load_pool(desc)
+    msg = spec_mod.message_class(pool, spec_mod.SPEC_MESSAGE)()
+    text_format.Parse(text, msg, descriptor_pool=pool)
+    assert msg.nighthawk_traffic_template.concurrency.value == "4"
+    assert msg.measuring_period.seconds == 10
+    # success-rate + send-rate defaults, plus the tail-latency SLO.
+    assert len(msg.metric_thresholds) == 3
+
+
+if __name__ == "__main__":
+    for fn_name, fn in sorted(dict(globals()).items()):
+        if fn_name.startswith("test_") and callable(fn):
+            fn()
+            print(f"PASS {fn_name}")


### PR DESCRIPTION
Measures the max RPS atenet-router's **ingress** side sustains at a given Envoy CPU limit, under a tail-latency SLO, using Nighthawk's adaptive load controller in open-loop mode against the real routing path (Host-header routing via ext_proc to warmed glutton actors). Egress is a separate, future benchmark. See `benchmarking/nighthawk-ingress/README.md` for design, knobs, and usage.

- `benchmarking/nighthawk-ingress/`: runner Job that creates and warms the actor fleet, drives `nighthawk_service` + `nighthawk_adaptive_load_client` with Host rotation across actors, and uploads JSON/JSONL results to GCS.
- Search converges on three thresholds — tail latency (measured mean+2σ must stay under `tailLatencySloMs`), success-rate, and send-rate — and records which one bounded the run. The client is oversized (fixed event loops, large pools) so the harness is never the ceiling.
- Test types are pluggable per review feedback: `orchestrator.py` owns the generic lifecycle and dispatches to `testtypes/` modules (validate / build_image / pre_test / job_tmpl / job_subs hooks); `type: nighthawk-ingress` pins the router (cpu requests=limits, envoy `--concurrency`) in its pre_test hook.
- `run-dev.sh`: one-command dev runs (~8 min) against a prepared cluster.

Validated end to end on a dev GKE cluster: ~9.4k RPS at 2 Envoy CPUs under a 25ms tail-latency SLO. A companion test-infra change registers `ingress_routercap_envoy_{2,4,8,16}cpu` in the continuous suite; it lands after this merges.