### PR TITLE
ateom-microvm: smaller guests

### DIFF
--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -134,11 +134,15 @@ const vmmMemReserveMiB = 256
 // minGuestMemMiB is the floor for guest RAM (the declared limit minus the VMM
 // reserve); a declared memory limit that leaves less is rejected at cold boot with a
 // clear error instead of being silently honored (see resolveGuestMemMiB), since too
-// little RAM makes the guest hang on boot rather than fail cleanly. It is a
-// conservative estimate; calibrate against a measured kata boot minimum if a tighter
-// bound is needed, and keep the admission floor on ActorTemplate.spec.resources in
-// sync (it is this value + vmmMemReserveMiB).
-const minGuestMemMiB = 256
+// little RAM makes the guest hang on boot rather than fail cleanly. Keep the admission
+// floor on ActorTemplate.spec.resources in sync (it is this value + vmmMemReserveMiB).
+//
+// Measured against the counter demo on a guest booting the agent as PID 1: 32MiB never
+// reaches Ready, 64MiB boots but idles with 1.1MB free (it only survives because page
+// cache is reclaimable), and 128MiB idles with 43MiB free. So 128 is the smallest size
+// with real headroom, not the smallest that boots — a workload heavier than a static Go
+// binary needs more, and this floor cannot know how much.
+const minGuestMemMiB = 128
 
 // maxActorContainers is a sanity cap on containers per actor (all share the one
 // micro-VM + virtiofsd). 25 is far above any real pod.

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -129,7 +129,20 @@ const kataAgentPath = "/usr/bin/kata-agent"
 // for the cloud-hypervisor VMM + virtiofsd, which run as host processes in the same
 // pod cgroup as the guest RAM; without a margin the pod OOMs. Overridable per
 // deployment via --vmm-mem-reserve-mib (see AteomService.memReserveMiB).
-const vmmMemReserveMiB = 256
+//
+// Measured on the worker pod's cgroup with one 256MiB-guest actor: the VMM stack's own
+// cost is ~12MiB (anon 8.1 + kernel 3.7; the rest of cloud-hypervisor's RSS is the guest
+// memfd, already accounted as guest RAM), and two virtiofsds are ~3MiB each. What needs
+// the rest of the margin is transient: a pause/resume cycle took the cgroup from 94MiB
+// to 153MiB, and the 57MiB difference was page cache from writing and reading the
+// snapshot.
+//
+// That transient scales with snapshot size, so no fixed reserve is right for every guest
+// size — this one is halved rather than cut to the ~32MiB the steady state would justify.
+// The fix that would let it drop that far is keeping snapshot I/O out of the page cache
+// (posix_fadvise(DONTNEED) after the checkpoint write and the restore read); until then
+// the margin absorbs it, and a deployment running large guests can raise the flag.
+const vmmMemReserveMiB = 128
 
 // minGuestMemMiB is the floor for guest RAM (the declared limit minus the VMM
 // reserve); a declared memory limit that leaves less is rejected at cold boot with a

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -90,7 +90,7 @@ spec:
   resources:
     limits:
       cpu: "2"
-      memory: 1536Mi
+      memory: 512Mi
   workerSelector:
     matchLabels:
       workload: counter-microvm

--- a/manifests/ate-install/generated/ate.dev_actortemplates.yaml
+++ b/manifests/ate-install/generated/ate.dev_actortemplates.yaml
@@ -498,11 +498,11 @@ spec:
             - message: spec.resources.claims is not supported
               rule: '!has(self.resources) || !has(self.resources.claims)'
             - message: For sandboxClass 'microvm', spec.resources.limits.memory must
-                be at least 384Mi (256Mi VMM reserve + 128Mi guest minimum); below
+                be at least 256Mi (128Mi VMM reserve + 128Mi guest minimum); below
                 this the VM cannot boot
               rule: '!has(self.sandboxClass) || self.sandboxClass != ''microvm'' ||
                 !has(self.resources) || !has(self.resources.limits) || !(''memory''
-                in self.resources.limits) || !quantity(self.resources.limits[''memory'']).isLessThan(quantity(''384Mi''))'
+                in self.resources.limits) || !quantity(self.resources.limits[''memory'']).isLessThan(quantity(''256Mi''))'
           status:
             description: status is the observed state of ActorTemplate
             properties:

--- a/manifests/ate-install/generated/ate.dev_actortemplates.yaml
+++ b/manifests/ate-install/generated/ate.dev_actortemplates.yaml
@@ -498,11 +498,11 @@ spec:
             - message: spec.resources.claims is not supported
               rule: '!has(self.resources) || !has(self.resources.claims)'
             - message: For sandboxClass 'microvm', spec.resources.limits.memory must
-                be at least 512Mi (256Mi VMM reserve + 256Mi guest minimum); below
+                be at least 384Mi (256Mi VMM reserve + 128Mi guest minimum); below
                 this the VM cannot boot
               rule: '!has(self.sandboxClass) || self.sandboxClass != ''microvm'' ||
                 !has(self.resources) || !has(self.resources.limits) || !(''memory''
-                in self.resources.limits) || !quantity(self.resources.limits[''memory'']).isLessThan(quantity(''512Mi''))'
+                in self.resources.limits) || !quantity(self.resources.limits[''memory'']).isLessThan(quantity(''384Mi''))'
           status:
             description: status is the observed state of ActorTemplate
             properties:

--- a/pkg/api/v1alpha1/actortemplate_types.go
+++ b/pkg/api/v1alpha1/actortemplate_types.go
@@ -316,14 +316,14 @@ type SnapshotsConfig struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.resources) || !has(self.resources.requests)",message="spec.resources.requests is not supported; actors are sized by spec.resources.limits only"
 // +kubebuilder:validation:XValidation:rule="!has(self.resources) || !has(self.resources.claims)",message="spec.resources.claims is not supported"
 // A micro-VM's guest RAM is the declared memory limit minus a fixed VMM reserve
-// (256Mi, held back for cloud-hypervisor + virtiofsd); below a 128Mi guest minimum
+// (128Mi, held back for cloud-hypervisor + virtiofsd); below a 128Mi guest minimum
 // there is no useful headroom. Reject at admission any micro-VM memory limit under
-// 384Mi (256Mi reserve + 128Mi guest minimum) so it fails at create time rather than at
+// 256Mi (128Mi reserve + 128Mi guest minimum) so it fails at create time rather than at
 // cold boot — a coarse pre-filter; the reserve-aware check in ateom (see
-// cmd/ateom-microvm/run.go: resolveGuestMemMiB) stays authoritative. The 384Mi floor
+// cmd/ateom-microvm/run.go: resolveGuestMemMiB) stays authoritative. The 256Mi floor
 // assumes the default reserve; deployments that raise --vmm-mem-reserve-mib rely on
 // the runtime check. gVisor has no reserve, so this only applies to micro-VM.
-// +kubebuilder:validation:XValidation:rule="!has(self.sandboxClass) || self.sandboxClass != 'microvm' || !has(self.resources) || !has(self.resources.limits) || !('memory' in self.resources.limits) || !quantity(self.resources.limits['memory']).isLessThan(quantity('384Mi'))",message="For sandboxClass 'microvm', spec.resources.limits.memory must be at least 384Mi (256Mi VMM reserve + 128Mi guest minimum); below this the VM cannot boot"
+// +kubebuilder:validation:XValidation:rule="!has(self.sandboxClass) || self.sandboxClass != 'microvm' || !has(self.resources) || !has(self.resources.limits) || !('memory' in self.resources.limits) || !quantity(self.resources.limits['memory']).isLessThan(quantity('256Mi'))",message="For sandboxClass 'microvm', spec.resources.limits.memory must be at least 256Mi (128Mi VMM reserve + 128Mi guest minimum); below this the VM cannot boot"
 type ActorTemplateSpec struct {
 	// Containers is the workload definition.
 	//

--- a/pkg/api/v1alpha1/actortemplate_types.go
+++ b/pkg/api/v1alpha1/actortemplate_types.go
@@ -316,14 +316,14 @@ type SnapshotsConfig struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.resources) || !has(self.resources.requests)",message="spec.resources.requests is not supported; actors are sized by spec.resources.limits only"
 // +kubebuilder:validation:XValidation:rule="!has(self.resources) || !has(self.resources.claims)",message="spec.resources.claims is not supported"
 // A micro-VM's guest RAM is the declared memory limit minus a fixed VMM reserve
-// (256Mi, held back for cloud-hypervisor + virtiofsd); below a 256Mi guest minimum
-// the VM cannot boot. Reject at admission any micro-VM memory limit under 512Mi
-// (256Mi reserve + 256Mi guest minimum) so it fails at create time rather than at
+// (256Mi, held back for cloud-hypervisor + virtiofsd); below a 128Mi guest minimum
+// there is no useful headroom. Reject at admission any micro-VM memory limit under
+// 384Mi (256Mi reserve + 128Mi guest minimum) so it fails at create time rather than at
 // cold boot — a coarse pre-filter; the reserve-aware check in ateom (see
-// cmd/ateom-microvm/run.go: resolveGuestMemMiB) stays authoritative. The 512Mi floor
+// cmd/ateom-microvm/run.go: resolveGuestMemMiB) stays authoritative. The 384Mi floor
 // assumes the default reserve; deployments that raise --vmm-mem-reserve-mib rely on
 // the runtime check. gVisor has no reserve, so this only applies to micro-VM.
-// +kubebuilder:validation:XValidation:rule="!has(self.sandboxClass) || self.sandboxClass != 'microvm' || !has(self.resources) || !has(self.resources.limits) || !('memory' in self.resources.limits) || !quantity(self.resources.limits['memory']).isLessThan(quantity('512Mi'))",message="For sandboxClass 'microvm', spec.resources.limits.memory must be at least 512Mi (256Mi VMM reserve + 256Mi guest minimum); below this the VM cannot boot"
+// +kubebuilder:validation:XValidation:rule="!has(self.sandboxClass) || self.sandboxClass != 'microvm' || !has(self.resources) || !has(self.resources.limits) || !('memory' in self.resources.limits) || !quantity(self.resources.limits['memory']).isLessThan(quantity('384Mi'))",message="For sandboxClass 'microvm', spec.resources.limits.memory must be at least 384Mi (256Mi VMM reserve + 128Mi guest minimum); below this the VM cannot boot"
 type ActorTemplateSpec struct {
 	// Containers is the workload definition.
 	//

--- a/pkg/api/v1alpha1/actortemplate_validation_test.go
+++ b/pkg/api/v1alpha1/actortemplate_validation_test.go
@@ -414,11 +414,11 @@ func TestActorTemplateValidation(t *testing.T) {
 		},
 		wantErr: false,
 	}, {
-		name: "microvm memory limit at the 512Mi floor is valid",
+		name: "microvm memory limit at the 384Mi floor is valid",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.SandboxClass = SandboxClassMicroVM
 			at.Spec.Resources = &corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("384Mi")},
 			}
 		},
 		wantErr: false,
@@ -440,17 +440,17 @@ func TestActorTemplateValidation(t *testing.T) {
 			}
 		},
 		wantErr: true,
-		errMsg:  "must be at least 512Mi",
+		errMsg:  "must be at least 384Mi",
 	}, {
 		name: "microvm memory limit just below the floor is rejected",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.SandboxClass = SandboxClassMicroVM
 			at.Spec.Resources = &corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("511Mi")},
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("383Mi")},
 			}
 		},
 		wantErr: true,
-		errMsg:  "must be at least 512Mi",
+		errMsg:  "must be at least 384Mi",
 	}, {
 		name: "microvm with no resources is valid (floor only applies to a set limit)",
 		mutate: func(at *ActorTemplate) {

--- a/pkg/api/v1alpha1/actortemplate_validation_test.go
+++ b/pkg/api/v1alpha1/actortemplate_validation_test.go
@@ -414,11 +414,11 @@ func TestActorTemplateValidation(t *testing.T) {
 		},
 		wantErr: false,
 	}, {
-		name: "microvm memory limit at the 384Mi floor is valid",
+		name: "microvm memory limit at the 256Mi floor is valid",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.SandboxClass = SandboxClassMicroVM
 			at.Spec.Resources = &corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("384Mi")},
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
 			}
 		},
 		wantErr: false,
@@ -436,21 +436,21 @@ func TestActorTemplateValidation(t *testing.T) {
 		mutate: func(at *ActorTemplate) {
 			at.Spec.SandboxClass = SandboxClassMicroVM
 			at.Spec.Resources = &corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},
 			}
 		},
 		wantErr: true,
-		errMsg:  "must be at least 384Mi",
+		errMsg:  "must be at least 256Mi",
 	}, {
 		name: "microvm memory limit just below the floor is rejected",
 		mutate: func(at *ActorTemplate) {
 			at.Spec.SandboxClass = SandboxClassMicroVM
 			at.Spec.Resources = &corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("383Mi")},
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("255Mi")},
 			}
 		},
 		wantErr: true,
-		errMsg:  "must be at least 384Mi",
+		errMsg:  "must be at least 256Mi",
 	}, {
 		name: "microvm with no resources is valid (floor only applies to a set limit)",
 		mutate: func(at *ActorTemplate) {


### PR DESCRIPTION
Shrink unnecessary memory floor, right-size the counter demo.

I measured actual needed memory and relaxed the floor.

This will really help with performance (snapshot size, density, memory snapshot + restore timing).

Next up after https://github.com/agent-substrate/substrate/pull/972
