### PR TITLE
ci/cd: Enable external volume e2e test by default

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -83,6 +83,13 @@ jobs:
       run: hack/create-kind-cluster.sh
     - name: Install Agent Substrate
       run: hack/install-ate-kind.sh --deploy-ate-system
+    - name: Enable NFS
+      # Load NFS kernel modules so in-cluster NFS server and CSI driver can run.
+      run: |
+        sudo modprobe nfs || true
+        sudo modprobe nfsd || true
+    - name: Install CSI NFS driver
+      run: hack/install-ate-kind.sh --setup-csi=nfs
     - name: Deploy micro-VM counter demo
       # Stages the (cached) assets into the cluster's rustfs and deploys the
       # counter-microvm demo onto the control plane installed above.

--- a/cmd/ate-setup/commands.md
+++ b/cmd/ate-setup/commands.md
@@ -37,7 +37,7 @@ a pre-scan pass, so they may appear anywhere on its command line.
 | `ate-setup` | `hack/install-ate.sh` |
 |---|---|
 | `deploy ate-system` | `--deploy-ate-system` |
-| `deploy ate-system --setup-csi` | `--deploy-ate-system --setup-csi` |
+| `deploy ate-system --setup-csi=nfs` | `--deploy-ate-system --setup-csi=nfs` |
 | `deploy atelet` | `--deploy-atelet` |
 | `deploy apiserver` | `--deploy-ate-apiserver` |
 | `deploy atenet` | `--deploy-atenet` |
@@ -76,12 +76,11 @@ Individual secrets and config that `deploy ate-system` creates automatically.
 
 | `ate-setup` | `hack/install-ate.sh` |
 |---|---|
-| `setup csi` | `--setup-csi` |
+| `setup csi [driver]` | `--setup-csi[=DRIVER]` |
 
-Kind only. `setup csi` is an error on a non-Kind cluster, where
-`hack/install-ate.sh` warns and continues. Note that `--deploy-ate-system`
-already runs the CSI setup through its own `--setup-csi` flag, so a command line
-passing both does the work once.
+`driver` is one of `nfs`, `hostpath`, `both`, or `none`; `setup csi` with `none` as the default option. The hostpath is for KIND clusters only. NFS has no such
+restriction, but it does need the `nfsd` kernel module loaded on the nodes.
+
 
 ## Benchmarks
 
@@ -109,7 +108,7 @@ See
 | `ate-setup` | `hack/install-ate.sh` | Description |
 |---|---|---|
 | `deploy demo counter` | `--deploy-demo-counter` | A counter actor exercising snapshot, resume, and atenet ingress |
-| `deploy demo counter --with-external-volume` | `--deploy-demo-counter-with-external-volume` | The same, plus an external volume and a pre-seeded file to validate (run `setup csi` first) |
+| `deploy demo counter --with-external-volume [--storage-class NAME]` | `--deploy-demo-counter-with-external-volume` (`STORAGE_CLASS=NAME`) | The same, plus an external volume and a pre-seeded file to validate. Run `setup csi` first and name the class it created, e.g. `csi-nfs-sc`; defaults to `standard` |
 | `deploy demo egress` | `--deploy-demo-egress` | Egress policy enforcement through atenet |
 | `deploy demo sandbox` | `--deploy-demo-sandbox` | An on-demand sandbox actor driven by the sandbox client |
 | `deploy demo multi-template` | `--deploy-demo-multi-template` | Two ActorTemplates sharing one WorkerPool |

--- a/cmd/ate-setup/differences.md
+++ b/cmd/ate-setup/differences.md
@@ -209,10 +209,10 @@ stdout/stderr split matches under CI log capture.
 
 ## Known differences worth flagging
 
-**`--setup-csi` on a non-Kind cluster.** The shell warns and continues;
-`ate-setup setup csi` is a hard error. CSI setup only ever worked on Kind, so
-the warning had nothing to offer a GKE caller but a slower path to the same
-outcome.
+**`--setup-csi` on a non-Kind cluster.** Both installers now accept `nfs` off
+Kind — only the hostpath plugin is patched for the single-node Kind layout, and
+both reject `hostpath` and `both` there with a hard error rather than the
+shell's old warn-and-continue.
 
 ## Testing
 

--- a/cmd/ate-setup/internal/cmd/deploy.go
+++ b/cmd/ate-setup/internal/cmd/deploy.go
@@ -95,6 +95,7 @@ func init() {
 		deployPostgresCmd,
 	)
 
-	deployAteSystemCmd.Flags().BoolVar(&deployOpts.SetupCSI, "setup-csi", false,
-		"Also install the hostpath and NFS CSI drivers (Kind only)")
+	deployAteSystemCmd.Flags().StringVar(&deployOpts.SetupCSI, "setup-csi", "none",
+		"Also install CSI driver (nfs, hostpath, both, none; default: none)")
+	deployAteSystemCmd.Flags().Lookup("setup-csi").NoOptDefVal = "none"
 }

--- a/cmd/ate-setup/internal/cmd/setup.go
+++ b/cmd/ate-setup/internal/cmd/setup.go
@@ -24,18 +24,22 @@ var setupCmd = &cobra.Command{
 }
 
 var setupCSICmd = &cobra.Command{
-	Use:   "csi",
-	Short: "Set up the hostpath and NFS CSI drivers (Kind only)",
+	Use:   "csi [driver]",
+	Short: "Set up the hostpath and/or NFS CSI drivers",
 	Long: `Install the CSI drivers that back the external volume demos.
 
-Both drivers are patched for the single-node Kind layout: the hostpath plugin is
-pinned to the worker node and bind-mounts atelet's sandbox image directory with
-bidirectional propagation, and each controller is exposed over TCP so atelet can
-reach it. Re-running this removes the previous deployment first, which clears
-stale mounts left behind by an earlier install.`,
-	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		return env.SetupCSI(cmd.Context())
+Driver options: nfs (default), hostpath, both, none. Note that hostpath is
+single-node Kind only, while NFS is not restricted to Kind.
+
+Both drivers expose their controllers over TCP so atelet and ateapi can reach them. Re-running this removes
+the previous deployment first, which clears stale mounts left behind by an earlier install.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		driver := "nfs"
+		if len(args) > 0 {
+			driver = args[0]
+		}
+		return env.SetupCSI(cmd.Context(), driver)
 	},
 }
 

--- a/cmd/ate-setup/internal/demos/counter/counter.go
+++ b/cmd/ate-setup/internal/demos/counter/counter.go
@@ -27,16 +27,17 @@ import (
 	"github.com/agent-substrate/substrate/internal/resources"
 )
 
-// namespace is the pool's k8s namespace; it doubles as the atespace holding
-// the demo's ActorTemplate.
-const namespace = "ate-demo-counter"
+const (
+	namespace = "ate-demo-counter"
+	template  = "demos/counter/counter-template.yaml.tmpl"
 
-// externalVolumeValues fills the optional external-volume placeholder lines
-// of the counter template manifest, which a plain deploy drops.
-func externalVolumeValues(e *steps.Env) map[string]string {
-	storageClass := "standard"
-	if e.Cfg.Kind {
-		storageClass = "csi-hostpath-sc"
+	defaultStorageClass = "standard"
+)
+
+func (d *demo) externalVolumeValues(e *steps.Env) map[string]string {
+	sc := defaultStorageClass
+	if d.storageClass != "" {
+		sc = d.storageClass
 	}
 	return map[string]string{
 		"VALIDATE_EXISTING_FILE_PATH_ARG": "  - --validate-existing-file-path=/external-data/test.txt",
@@ -46,7 +47,7 @@ func externalVolumeValues(e *steps.Env) map[string]string {
 			"  type: ExternalVolumeTemplate\n" +
 			"  externalVolumeTemplate:\n" +
 			"    capacity: 1Gi\n" +
-			"    storageClassName: " + storageClass,
+			"    storageClassName: " + sc,
 	}
 }
 
@@ -56,6 +57,7 @@ type demo struct {
 	demos.Substrate
 
 	withExternalVolume bool
+	storageClass       string
 }
 
 func init() {
@@ -77,6 +79,8 @@ func init() {
 func (d *demo) Flags(fs *pflag.FlagSet) {
 	fs.BoolVar(&d.withExternalVolume, "with-external-volume", false,
 		"Attach an external volume and validate a pre-seeded file on it (run \"setup csi\" first)")
+	fs.StringVar(&d.storageClass, "storage-class", defaultStorageClass,
+		"StorageClass backing the external volume, e.g. csi-nfs-sc or csi-hostpath-sc. Must be used --with-external-volume=true.")
 }
 
 // renderValues opts the template's external-volume lines in when the flag is
@@ -85,5 +89,5 @@ func (d *demo) renderValues(_ context.Context, e *steps.Env) (map[string]string,
 	if !d.withExternalVolume {
 		return nil, nil
 	}
-	return externalVolumeValues(e), nil
+	return d.externalVolumeValues(e), nil
 }

--- a/cmd/ate-setup/internal/demos/counter/counter_test.go
+++ b/cmd/ate-setup/internal/demos/counter/counter_test.go
@@ -29,23 +29,43 @@ import (
 // the ActorTemplate it is created as. The drop branch is covered by the
 // sweep test in the demos package.
 func TestExternalVolumeRenders(t *testing.T) {
-	e := demotest.Env(t)
-
-	manifest, err := demos.Render(e, "demos/counter/counter-template.yaml.tmpl", externalVolumeValues(e), nil)
-	if err != nil {
-		t.Fatalf("Render: %v", err)
-	}
-	demotest.AssertRenderedActorTemplate(t, manifest,
-		resources.ActorTemplateRef{Atespace: namespace, Name: "counter"})
-
-	for _, want := range []string{
-		"--validate-existing-file-path=/external-data/test.txt",
-		"mountPath: /external-data",
-		"externalVolumeTemplate:",
-		"storageClassName: standard",
+	for _, tc := range []struct {
+		name         string
+		storageClass string
+		wantSC       string
+	}{
+		{
+			name:         "unset",
+			storageClass: "",
+			wantSC:       "storageClassName: standard",
+		},
+		{
+			name:         "explicit",
+			storageClass: "csi-nfs-sc",
+			wantSC:       "storageClassName: csi-nfs-sc",
+		},
 	} {
-		if !strings.Contains(string(manifest), want) {
-			t.Errorf("rendered manifest is missing %q", want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			e := demotest.Env(t)
+			d := &demo{storageClass: tc.storageClass}
+
+			manifest, err := demos.Render(e, template, d.externalVolumeValues(e), nil)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			demotest.AssertRenderedActorTemplate(t, manifest, resources.ActorTemplateRef{Atespace: namespace, Name: "counter"})
+
+			for _, want := range []string{
+				"--validate-existing-file-path=/external-data/test.txt",
+				"mountPath: /external-data",
+				"type: ExternalVolumeTemplate",
+				"externalVolumeTemplate:",
+				tc.wantSC,
+			} {
+				if !strings.Contains(string(manifest), want) {
+					t.Errorf("rendered manifest is missing %q", want)
+				}
+			}
+		})
 	}
 }

--- a/cmd/ate-setup/internal/steps/csi.go
+++ b/cmd/ate-setup/internal/steps/csi.go
@@ -58,11 +58,8 @@ mountOptions:
 // SetupCSI installs the hostpath and NFS CSI drivers used by external volume
 // demos. Kind only: both drivers are patched for the single-node Kind layout
 // and reach into the node container over docker.
-func (e *Env) SetupCSI(ctx context.Context) error {
+func (e *Env) SetupCSI(ctx context.Context, driver string) error {
 	log.Step("setup_csi")
-	if err := e.RequireKind("CSI setup"); err != nil {
-		return err
-	}
 	// Both drivers register themselves with a CSIDriverConfig, so the ate CRDs
 	// have to be in place even when CSI setup runs on its own rather than as
 	// part of deploy ate-system.
@@ -87,10 +84,29 @@ func (e *Env) SetupCSI(ctx context.Context) error {
 	if err := e.WaitForPodCertificateTrustBundles(ctx); err != nil {
 		return err
 	}
-	if err := e.setupCSIHostpath(ctx); err != nil {
-		return err
+
+	switch driver {
+	case "nfs":
+		return e.setupCSINFS(ctx)
+	case "hostpath":
+		if err := e.RequireKind("csi-hostpath"); err != nil {
+			return err
+		}
+		return e.setupCSIHostpath(ctx)
+	case "both", "true":
+		if err := e.RequireKind("csi-hostpath"); err != nil {
+			return err
+		}
+		if err := e.setupCSIHostpath(ctx); err != nil {
+			return err
+		}
+		return e.setupCSINFS(ctx)
+	case "none", "false", "":
+		log.Infof("Skipping CSI driver setup.")
+		return nil
+	default:
+		return fmt.Errorf("unknown CSI driver %q (valid options: nfs, hostpath, both, none)", driver)
 	}
-	return e.setupCSINFS(ctx)
 }
 
 func (e *Env) setupCSIHostpath(ctx context.Context) error {
@@ -235,8 +251,7 @@ func (e *Env) setupCSINFS(ctx context.Context) error {
 	log.Step("setup_csi_nfs")
 
 	if err := checkNFSDSupport(); err != nil {
-		log.Warnf("%v; skipping NFS CSI driver setup", err)
-		return nil
+		return err
 	}
 
 	deployDir := e.Cfg.Path("hack", "third_party", "csi-driver-nfs", "deploy")

--- a/cmd/ate-setup/internal/steps/deploy.go
+++ b/cmd/ate-setup/internal/steps/deploy.go
@@ -45,9 +45,9 @@ var ateCRDs = []string{
 
 // DeployOptions carries the per-invocation choices for DeployAteSystem.
 type DeployOptions struct {
-	// SetupCSI additionally installs the hostpath and NFS CSI drivers. Kind
-	// only.
-	SetupCSI bool
+	// SetupCSI additionally installs the CSI driver (nfs, hostpath, both, none).
+	// Kind only. The hostpath driver is Kind only.
+	SetupCSI string
 }
 
 // DeployAteSystem installs the whole control plane: CRDs, RBAC, the
@@ -97,13 +97,8 @@ func (e *Env) DeployAteSystem(ctx context.Context, opts DeployOptions) error {
 	if err := e.WaitForPodCertificateTrustBundles(ctx); err != nil {
 		return err
 	}
-
-	if opts.SetupCSI {
-		if !e.Cfg.Kind {
-			log.Warnf("CSI setup is only supported for Kind local installations. Skipping.")
-		} else if err := e.SetupCSI(ctx); err != nil {
-			return err
-		}
+	if err := e.SetupCSI(ctx, opts.SetupCSI); err != nil {
+		return err
 	}
 
 	// Enforce per-class SandboxConfig asset requirements. This is applied

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -68,7 +68,8 @@ function usage() {
   echo "Overall infrastructure (all infrastructure components):"
   echo ""
   echo "  --deploy-ate-system                    Deploy core system (CRDs, atelet, apiserver)"
-  echo "  --setup-csi                            Setup CSI hostpath and NFS drivers (Kind only)"
+  echo "  --setup-csi[=DRIVER]                   Setup CSI driver: nfs, hostpath, both, none (default: none;"
+  echo "                                         a bare --setup-csi means nfs; hostpath is Kind only)"
   echo "  --delete-ate-system                    Delete core system"
   echo "  --delete-all                           Delete core system and all registered demos"
   echo "  --atenet-router=envoy|agentgateway     Select the ingress and egress dataplane (default: envoy)"
@@ -604,10 +605,39 @@ deploy_crds() {
   run_ko apply -f manifests/ate-install/generated
 }
 
+require_kind_for_hostpath() {
+  if [[ "${ATE_INSTALL_KIND:-false}" != "true" ]]; then
+    echo "Error: the hostpath CSI driver is only supported on Kind." >&2
+    exit 1
+  fi
+}
+
 setup_csi() {
-  log_step "setup_csi"
-  "${ROOT}/hack/setup-csi-hostpath-kind.sh"
-  "${ROOT}/hack/setup-csi-nfs-kind.sh"
+  local driver="${SETUP_CSI:-none}"
+  case "${driver}" in
+    ""|none|false)
+      return
+      ;;
+  esac
+  log_step "setup_csi (${driver})"
+  case "${driver}" in
+    nfs)
+      "${ROOT}/hack/setup-csi-nfs-kind.sh"
+      ;;
+    hostpath)
+      require_kind_for_hostpath
+      "${ROOT}/hack/setup-csi-hostpath-kind.sh"
+      ;;
+    both|true)
+      require_kind_for_hostpath
+      "${ROOT}/hack/setup-csi-hostpath-kind.sh"
+      "${ROOT}/hack/setup-csi-nfs-kind.sh"
+      ;;
+    *)
+      echo "Error: unknown CSI driver \"${driver}\" (valid options: nfs, hostpath, both, none)." >&2
+      exit 1
+      ;;
+  esac
 }
 
 deploy_ate_system() {
@@ -658,13 +688,10 @@ deploy_ate_system() {
   # exist. The ghostunnel sidecar uses projected podCertificate and clusterTrustBundle
   # volumes which cannot be fulfilled until podcertcontroller is actively signing,
   # otherwise rollout of csi-hostpath-socat times out.
-  if [[ "${SETUP_CSI:-false}" == "true" ]]; then
-    if [[ "${ATE_INSTALL_KIND:-false}" == "true" ]]; then
-      setup_csi
-    else
-      echo "Warning: CSI setup is only supported for Kind local installations. Skipping."
-    fi
-  fi
+  #
+  # setup_csi is a no-op unless --setup-csi asked for a driver, and it is the
+  # one that decides which drivers need Kind, so there is no Kind gate here.
+  setup_csi
 
   local manifests=""
   manifests="$(render_ate_system_manifests)"
@@ -1144,7 +1171,10 @@ done
 # flag they configure (e.g. --benchmark-worker-count before/after
 # --deploy-benchmarks). The dispatch loop below also accepts these flags but
 # treats them as no-ops since the value is already captured here.
-SETUP_CSI="${SETUP_CSI:-false}"
+# Valid values for SETUP_CSI: nfs, hostpath, both, none. Defaults to none: a
+# CSI driver is an opt-in extra, and NFS needs kernel modules a plain
+# workstation will not have loaded.
+SETUP_CSI="${SETUP_CSI:-none}"
 BENCHMARK_WORKER_COUNT=1
 BENCHMARK_SANDBOX_CLASS=gvisor
 # Empty keeps the default in benchmarking/workloads/deploy.sh (256Mi).
@@ -1221,8 +1251,13 @@ for ((i = 0; i < ${#prescan_args[@]}; i++)); do
       ATE_OTLP_ENDPOINT="${prescan_args[$((i + 1))]}"
       ;;
     --otlp-endpoint=*) ATE_OTLP_ENDPOINT="${prescan_args[i]#*=}" ;;
+    --setup-csi=*) SETUP_CSI="${prescan_args[i]#*=}" ;;
     --setup-csi)
-      SETUP_CSI=true
+      if (( i + 1 < ${#prescan_args[@]} )) && [[ "${prescan_args[$((i + 1))]}" != --* ]]; then
+        SETUP_CSI="${prescan_args[$((i + 1))]}"
+      else
+        SETUP_CSI="nfs"
+      fi
       ;;
   esac
 done
@@ -1285,13 +1320,20 @@ while [[ "$#" -gt 0 ]]; do
       ;;
 
     --deploy-ate-system) deploy_ate_system ;;
+    --setup-csi=*)
+      SETUP_CSI="${1#*=}"
+      ensure_crds
+      setup_csi
+      ;;
     --setup-csi)
-      if [[ "${ATE_INSTALL_KIND:-false}" == "true" ]]; then
-        ensure_crds
-        setup_csi
+      if [[ "$#" -gt 1 && "$2" != --* ]]; then
+        shift
+        SETUP_CSI="$1"
       else
-        echo "Warning: CSI setup is only supported for Kind local installations. Skipping."
+        SETUP_CSI="nfs"
       fi
+      ensure_crds
+      setup_csi
       ;;
     --delete-ate-system) delete_ate_system ;;
     --delete-all) delete_all ;;

--- a/hack/install-demo-counter.sh
+++ b/hack/install-demo-counter.sh
@@ -63,11 +63,15 @@ demo-counter_render() {
   local ext_vol_mount_cmd=("-e" "/\${EXTERNAL_VOLUME_MOUNTS}/d")
   local ext_vol_spec_cmd=("-e" "/\${EXTERNAL_VOLUMES}/d")
   if [[ "${with_external_volume}" == "true" ]]; then
-    # csi-hostpath-sc only exists when hack/setup-csi-hostpath-kind.sh has run (via SETUP_CSI=true).
-    # Otherwise fall back to the default "standard" StorageClass.
-    local storage_class="standard"
-    if [[ "${SETUP_CSI:-false}" == "true" ]]; then
-      storage_class="csi-hostpath-sc"
+    # STORAGE_CLASS names the class outright; without it, fall back to whatever
+    # --setup-csi just installed, and to "standard" when it installed nothing.
+    local storage_class="${STORAGE_CLASS:-}"
+    if [[ -z "${storage_class}" ]]; then
+      case "${SETUP_CSI:-none}" in
+        hostpath) storage_class="csi-hostpath-sc" ;;
+        nfs|both|true) storage_class="csi-nfs-sc" ;;
+        *) storage_class="standard" ;;
+      esac
     fi
 
     validate_cmd=("-e" "s|\${VALIDATE_EXISTING_FILE_PATH_ARG}|  - --validate-existing-file-path=/external-data/test.txt|g")

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -45,6 +45,7 @@ Common E2E Flags (passed after -args):
   --no-color       Disable colored output
   --kube-config    Path to kubeconfig file
   --kube-context   Kubernetes context to use
+  --storage-class  StorageClass to use for external volume tests (default: csi-nfs-sc)
 
 Common Go Test Flags (passed before -args):
   -run <regexp>    Run only tests matching regexp

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -1092,13 +1092,9 @@ func createActorTemplate(ctx context.Context, t *testing.T, clients *e2e.Clients
 }
 
 func createActorTemplateWithExternalVolume(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *e2e.Namespace, onCommit, onPause ateapipb.SnapshotContentScope, fromData ateapipb.ResumeSource) (*ateapipb.ActorTemplate, error) {
-	var scName string
-	switch {
-	// TODO: add support for other storage classes in e2e environment (e.g. csi-nfs-sc)
-	case hasStorageClass(ctx, clients, "csi-hostpath-sc"):
-		scName = "csi-hostpath-sc"
-	default:
-		t.Skip("Skipping TestExternalVolumeLifecycle: neither csi-hostpath-sc nor csi-nfs-sc StorageClass found")
+	scName := e2e.StorageClass
+	if !hasStorageClass(ctx, clients, scName) {
+		t.Fatalf("StorageClass %q not found in cluster; provide a valid --storage-class or install the CSI driver via --setup-csi", scName)
 	}
 
 	modify := func(at *ateapipb.ActorTemplate) {

--- a/internal/e2e/testmain.go
+++ b/internal/e2e/testmain.go
@@ -26,9 +26,10 @@ import (
 )
 
 var (
-	RunE2E      bool
-	KubeConfig  string
-	KubeContext string
+	RunE2E       bool
+	KubeConfig   string
+	KubeContext  string
+	StorageClass string
 )
 
 var (
@@ -58,6 +59,7 @@ func bindFlags() {
 	pflag.BoolVar(&NoColor, "no-color", false, "disable colors in output")
 	pflag.StringVar(&KubeConfig, "kube-config", "", "Location of the kubeconfig")
 	pflag.StringVar(&KubeContext, "kube-context", "", "Kubernetes context to use")
+	pflag.StringVar(&StorageClass, "storage-class", "csi-nfs-sc", "StorageClass to use for external volume tests")
 }
 
 // RunTestMain should be used to run your e2e test suite.


### PR DESCRIPTION
https://github.com/agent-substrate/substrate/issues/232

Install CSI NFS driver by default when installing ate, and default to the NFS storage class for external volumes test. 

- [X ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
