### PR TITLE
atelet: close ateom conns evicted from the dialer cache

### DIFF
--- a/cmd/atelet/ateomdialer_test.go
+++ b/cmd/atelet/ateomdialer_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/connectivity"
+)
+
+// TestAteomDialerClosesEvictedConns pins the eviction behavior: a connection
+// pushed out of the cache must be closed, not forgotten. A forgotten conn
+// keeps its goroutines and buffers for the life of the process, which turns
+// worker pod churn past the cache size into an unbounded leak.
+func TestAteomDialerClosesEvictedConns(t *testing.T) {
+	d := newAteomDialer(1)
+
+	first, err := d.DialAteomPod(context.Background(), "pod-a")
+	if err != nil {
+		t.Fatalf("DialAteomPod(pod-a) error = %v", err)
+	}
+	if _, err := d.DialAteomPod(context.Background(), "pod-b"); err != nil {
+		t.Fatalf("DialAteomPod(pod-b) error = %v", err)
+	}
+
+	if got := first.GetState(); got != connectivity.Shutdown {
+		t.Errorf("evicted conn state = %v, want %v (closed on eviction)", got, connectivity.Shutdown)
+	}
+}
+
+// TestAteomDialerReusesCachedConn pins the cache hit path: dialing the same
+// pod twice returns the same live connection.
+func TestAteomDialerReusesCachedConn(t *testing.T) {
+	d := newAteomDialer(2)
+
+	first, err := d.DialAteomPod(context.Background(), "pod-a")
+	if err != nil {
+		t.Fatalf("DialAteomPod(pod-a) error = %v", err)
+	}
+	second, err := d.DialAteomPod(context.Background(), "pod-a")
+	if err != nil {
+		t.Fatalf("DialAteomPod(pod-a) again error = %v", err)
+	}
+	if first != second {
+		t.Errorf("second dial returned a different conn; want the cached one")
+	}
+	if got := first.GetState(); got == connectivity.Shutdown {
+		t.Errorf("cached conn is shut down; want it live")
+	}
+}

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -1796,6 +1796,12 @@ type AteomDialer struct {
 // (the channel idle timeout parks only one of them). Closing on eviction can
 // fail an RPC still in flight on a conn that aged to the LRU tail, but that
 // failure is visible and retryable, unlike the leak.
+//
+// TODO: Consider pool semantics instead of a cache: a conn evicted for
+// capacity would drain — close only once its last in-flight RPC finishes
+// (e.g. refcounted checkout/release) — rather than being closed out from
+// under a caller. Worth revisiting if the retryable eviction failures show
+// up in practice.
 func newAteomDialer(size int) *AteomDialer {
 	return &AteomDialer{
 		conns: lru.NewWithEvictionFunc(size, func(_ lru.Key, value interface{}) {

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -184,9 +184,7 @@ func main() {
 		}()
 	}
 
-	ateomDialer := &AteomDialer{
-		conns: lru.New(256),
-	}
+	ateomDialer := newAteomDialer(256)
 
 	var gcpRegistryAuthn authn.Authenticator
 	if *gcpAuthForImagePulls {
@@ -1790,6 +1788,20 @@ func toAteomReadyz(in *ateletpb.Readyz) *ateompb.Readyz {
 
 type AteomDialer struct {
 	conns *lru.Cache
+}
+
+// newAteomDialer builds a dialer whose cache closes the connections it
+// evicts. A conn pushed out of the LRU without Close is not reclaimed: grpc
+// keeps most of its goroutines and buffers alive for the life of the process
+// (the channel idle timeout parks only one of them). Closing on eviction can
+// fail an RPC still in flight on a conn that aged to the LRU tail, but that
+// failure is visible and retryable, unlike the leak.
+func newAteomDialer(size int) *AteomDialer {
+	return &AteomDialer{
+		conns: lru.NewWithEvictionFunc(size, func(_ lru.Key, value interface{}) {
+			value.(*grpc.ClientConn).Close()
+		}),
+	}
 }
 
 func (d *AteomDialer) DialAteomPod(ctx context.Context, podUID string) (*grpc.ClientConn, error) {


### PR DESCRIPTION
AteomDialer caches one grpc.ClientConn per worker pod UID in a 256-entry LRU, but the cache had no eviction function: a conn pushed out to make room was forgotten, never closed. grpc does not reclaim an un-Closed conn -- measured against a dead socket, each one holds 4 goroutines, and the channel idle timeout later parks only one of them, so ~3 goroutines and their buffers leak per eviction for the life of the process.

Today evictions need >256 distinct worker pods dialed since atelet started, so the leak is a slow drip reset by restarts. Close evicted conns via the cache's eviction hook. The trade is that an RPC still in flight on a conn that aged to the LRU tail now fails visibly instead of completing on a leaked conn; that needs the same >256-pod churn, and the failure is retryable.

Fixes #1009.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
