### PR TITLE
ateom-microvm: fix graceful termination, cleanup dead code

### DIFF
--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -144,10 +144,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	//     the write-through share makes the tar coherent.
 	//   - Rootfs upper tar (Full only): host-backed like the durable volumes —
 	//     the memory snapshot does not carry rootfs writes. Under Data the
-	//     workload cold-starts on restore, discarding rootfs state. Gated on
-	//     the host dir a disk-upper boot creates (actorHasDiskUpper) so a
-	//     legacy actor restored from a tmpfs-upper snapshot checkpoints
-	//     correctly (its upper is inside the memory image).
+	//     workload cold-starts on restore, discarding rootfs state.
 	var dSnapshot, dDurable, dUpper time.Duration
 	g, gctx := errgroup.WithContext(ctx)
 	if scope == ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL {
@@ -167,7 +164,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 			return nil
 		})
 	}
-	if scope == ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL && actorHasDiskUpper(actorUID) {
+	if scope == ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL {
 		g.Go(func() error {
 			t := time.Now()
 			if err := tarRootfsUpper(gctx, rootfsUpperDir(actorUID), checkpointDir); err != nil {
@@ -280,7 +277,6 @@ func (s *AteomService) snapshotVMState(ctx context.Context, client *ch.Client, r
 
 	// The RO lower never ships (reconstructed from the OCI image at restore).
 	// The disk-backed upper ships as its own tar from CheckpointWorkload; a
-	// legacy tmpfs upper is already inside the memory snapshot above.
 	return dSnapshot, nil
 }
 
@@ -354,8 +350,7 @@ func (s *AteomService) teardownActor(ctx context.Context, id string, ra *running
 
 	// Remove the rootfs upper dir: ateom owns it — atelet's actor-dir reset
 	// doesn't know it — and its absence is what marks a worker as holding no
-	// disk-backed upper (actorHasDiskUpper). Runs after the checkpoint tar,
-	// which is already on disk. A no-op for legacy tmpfs-upper actors.
+	// disk-backed upper. Runs after the checkpoint tar, which is already on disk.
 	if err := os.RemoveAll(rootfsUpperDir(id)); err != nil {
 		slog.WarnContext(ctx, "Failed to remove rootfs upper dir", slog.String("actorUID", id), slog.Any("err", err))
 	}

--- a/cmd/ateom-microvm/durable.go
+++ b/cmd/ateom-microvm/durable.go
@@ -128,7 +128,6 @@ func (s *AteomService) stageDurableShare(ctx context.Context, rr resolvedRuntime
 		Binary:     rr.virtiofsd,
 		SocketPath: kata.DurableVirtiofsdSocketPath(actorUID),
 		SharedDir:  shared,
-		Cache:      "auto",
 		Log:        log,
 	})
 	if err != nil {

--- a/cmd/ateom-microvm/internal/kata/overlay_linux.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux.go
@@ -24,10 +24,7 @@ package kata
 // itself. Rootfs writes therefore cost host disk, not guest RAM, and persist across
 // suspend/resume via the snapshot's rootfs-upper tar.
 //
-// (Snapshots from the retired guest-tmpfs-upper mode still restore: their upper rides
-// inside the restored guest memory, and the lower is re-presented with the legacy
-// read-only bind, see ReconstructSharedDirFromImage.) This file holds the
-// rootfs-staging helpers.
+// This file holds the rootfs-staging helpers.
 
 import (
 	"context"
@@ -100,28 +97,15 @@ type VirtiofsdOptions struct {
 	Binary     string // virtiofsd executable; defaults to "virtiofsd"
 	SocketPath string // vhost-user socket CH connects to (VirtiofsdSocketPath)
 	SharedDir  string // directory to serve (SharedDir(id))
-	// Cache is virtiofsd's --cache mode. Empty defaults to "always", which is
-	// only correct for a strictly read-only share (see virtiofsdArgs).
-	Cache string
-	Log   io.Writer
+	Log        io.Writer
 }
 
 // virtiofsdArgs builds the virtiofsd command line for o.
 func virtiofsdArgs(o VirtiofsdOptions) []string {
-	cache := o.Cache
-	if cache == "" {
-		// "always" is only correct for a strictly read-only share with immutable
-		// host contents — today that is solely the LEGACY restore path's bare-image
-		// share (see ReconstructSharedDirFromImage). WRITABLE shares (the merged
-		// rootfs, the durable-dir volumes) must pass Cache: "auto": the guest
-		// writes through them and the host contents change underneath the guest
-		// on restore, so cache=always would serve stale data.
-		cache = "always"
-	}
 	return []string{
 		"--socket-path=" + o.SocketPath,
 		"--shared-dir=" + o.SharedDir,
-		"--cache=" + cache,
+		"--cache=auto",
 		"--thread-pool-size=1",
 		"--announce-submounts",
 		"--migration-mode", "find-paths",
@@ -245,48 +229,6 @@ func UnmountMergedRootfs(restoreID, cid string) {
 	if err := reaper.Run(exec.Command("umount", dst)); err != nil {
 		_ = reaper.Run(exec.Command("umount", "-l", dst))
 	}
-}
-
-// ReconstructSharedDirFromImage bind-mounts a container's OCI image rootfs at
-// <cid>/rootfs under SharedDir(restoreID) so virtiofsd serves it as the read-only
-// lower. LEGACY restores only: guests from retired guest-tmpfs-upper snapshots hold
-// this plain image tree open (their overlay upper lives inside the restored guest
-// memory), so the share must present the bare image, not a merged overlay. The bind
-// copies nothing on the host. cid is stable across the actor's lineage.
-func ReconstructSharedDirFromImage(ctx context.Context, bundleRootfs, restoreID, cid string) error {
-	if cid == "" {
-		return fmt.Errorf("ReconstructSharedDirFromImage: empty container id")
-	}
-	dst := filepath.Join(SharedDir(restoreID), cid, "rootfs")
-	// Drop any stale bind first (lazy if busy), then ensure a clean mountpoint. Not
-	// RemoveAll: that would chase a live bind into bundleRootfs.
-	if err := reaper.Run(exec.Command("umount", dst)); err != nil {
-		_ = reaper.Run(exec.Command("umount", "-l", dst))
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		return fmt.Errorf("creating shared dir %q: %w", dst, err)
-	}
-	cmd := exec.CommandContext(ctx, "mount", "--bind", bundleRootfs, dst)
-	var stderr strings.Builder
-	cmd.Stderr = &stderr
-	if err := reaper.Run(cmd); err != nil {
-		return fmt.Errorf("bind-mounting image rootfs %q -> %q: %w (%s)", bundleRootfs, dst, err, strings.TrimSpace(stderr.String()))
-	}
-	// Ensure the standard OCI mountpoints exist even for minimal images: the container
-	// mounts /proc,/sys,/dev over them, and find-paths re-opens the lower by path on
-	// restore, so the layout must match on every node. (Bind still writable; ignore EEXIST.)
-	for _, d := range []string{"proc", "sys", "dev"} {
-		_ = os.MkdirAll(filepath.Join(dst, d), 0o755)
-	}
-	// Remount read-only: the lower is immutable, so all writes go to the overlay upper
-	// and it stays byte-identical across reconstructions (required by find-paths migration).
-	ro := exec.CommandContext(ctx, "mount", "-o", "remount,bind,ro", dst)
-	var roErr strings.Builder
-	ro.Stderr = &roErr
-	if err := reaper.Run(ro); err != nil {
-		return fmt.Errorf("remounting overlay lower read-only %q: %w (%s)", dst, err, strings.TrimSpace(roErr.String()))
-	}
-	return nil
 }
 
 // CreateSandboxForActor creates the guest sandbox with the kataShared virtio-fs mount

--- a/cmd/ateom-microvm/internal/kata/overlay_linux_test.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux_test.go
@@ -48,49 +48,16 @@ func TestUpperWorkDirsAreSiblings(t *testing.T) {
 }
 
 func TestVirtiofsdArgs(t *testing.T) {
-	tests := []struct {
-		name      string
-		opts      VirtiofsdOptions
-		wantCache string
-	}{
-		{
-			name:      "legacy bare-image share defaults to cache=always",
-			opts:      VirtiofsdOptions{SocketPath: "/run/vm/virtiofsd.sock", SharedDir: "/run/shared"},
-			wantCache: "--cache=always",
-		},
-		{
-			name: "writable merged-rootfs share overrides the cache mode",
-			opts: VirtiofsdOptions{
-				SocketPath: "/run/vm/virtiofsd.sock",
-				SharedDir:  "/run/kata-containers/shared/sandboxes/uid/shared",
-				Cache:      "auto",
-			},
-			wantCache: "--cache=auto",
-		},
+	args := virtiofsdArgs(VirtiofsdOptions{
+		SocketPath: "/run/vm/virtiofsd.sock",
+		SharedDir:  "/run/kata-containers/shared/sandboxes/uid/shared",
+	})
+	if !slices.Contains(args, "--cache=auto") {
+		t.Errorf("args %v do not contain --cache=auto", args)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			args := virtiofsdArgs(tc.opts)
-			if !slices.Contains(args, tc.wantCache) {
-				t.Errorf("args %v do not contain %q", args, tc.wantCache)
-			}
-			// The host kernel owns the overlay; the guest needs no xattr
-			// passthrough, so the flag must never be emitted.
-			if slices.Contains(args, "--xattr") {
-				t.Errorf("args %v contain --xattr; the guest has no overlay to feed it to", args)
-			}
-			for _, want := range []string{
-				"--socket-path=" + tc.opts.SocketPath,
-				"--shared-dir=" + tc.opts.SharedDir,
-				// find-paths re-opens the guest's open files by path on
-				// restore; both shares depend on it.
-				"--migration-mode",
-				"find-paths",
-			} {
-				if !slices.Contains(args, want) {
-					t.Errorf("args %v do not contain %q", args, want)
-				}
-			}
-		})
+	// The host kernel owns the overlay; the guest needs no xattr passthrough, so
+	// the flag must never be emitted.
+	if slices.Contains(args, "--xattr") {
+		t.Errorf("args %v contain --xattr; the guest has no overlay to feed it to", args)
 	}
 }

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -422,7 +422,11 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 		chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd,
 		apiSocket: apiSocket, baseID: srcID, restoreSourceDir: restoreDir,
 		snapshotIsSelfContained: memMode == ch.MemRestoreEager,
-		workloadIDs:             overlayWorkloadIDs(ctrs),
+		// Same id split as the log forwarding and stats below: containers run under
+		// their bare name, except in a guest restored from a legacy snapshot, which
+		// still holds the retired <name>_ovl workloads. Signalling an id the agent
+		// does not know fails the whole graceful shutdown with InvalidContainerId.
+		workloadIDs: restoredWorkloadIDs(ctrs, hasUpper),
 	}
 
 	// Re-attach stdout/stderr forwarding for each container: the restored guest's

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -212,19 +212,16 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	// An error return between here and the join MUST drain the goroutine (the
 	// deferred receive below): returning with the untar still writing would let
 	// a retried restore's own untar race it inside the same directory.
-	hasUpper := snapshotHasRootfsUpper(restoreDir)
 	untarDone := make(chan error, 1)
 	untarJoined := false
-	if hasUpper {
-		go func() {
-			untarDone <- untarRootfsUpper(rootfsUpperDir(actorUID), restoreDir)
-		}()
-		defer func() {
-			if !untarJoined {
-				<-untarDone
-			}
-		}()
-	}
+	go func() {
+		untarDone <- untarRootfsUpper(rootfsUpperDir(actorUID), restoreDir)
+	}()
+	defer func() {
+		if !untarJoined {
+			<-untarDone
+		}
+	}()
 
 	// Reconstruct each container's rootfs at the frozen find-paths location
 	// SharedDir(id)/<cid>/rootfs from the LOCAL OCI bundle (atelet re-unpacked
@@ -252,42 +249,17 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	if err != nil {
 		return err
 	}
-	var vfsdCmd *exec.Cmd
-	if hasUpper {
-		// The overlay mounts need the upper on disk: join the background untar
-		// (still overlapped with the bundle preparation above), then assemble
-		// the merged trees and serve them.
-		untarErr := <-untarDone
-		untarJoined = true
-		if untarErr != nil {
-			return untarErr
-		}
-		if vfsdCmd, err = s.stageMergedRootfs(ctx, rr, actorUID, ctrs); err != nil {
-			return err
-		}
-	} else {
-		// LEGACY snapshot: leave the upper directory ABSENT — a stale dir
-		// orphaned by a crash before teardown would otherwise make
-		// actorHasDiskUpper mislabel this lineage's next checkpoint — and
-		// present the bare image over the immutable (cache=always) bind,
-		// exactly what the restored guest's in-memory overlay expects.
-		if err := os.RemoveAll(rootfsUpperDir(actorUID)); err != nil {
-			return fmt.Errorf("while clearing stale rootfs upper dir: %w", err)
-		}
-		for _, c := range ctrs {
-			if err := kata.ReconstructSharedDirFromImage(ctx, c.bundleRootfs, actorUID, c.name); err != nil {
-				return fmt.Errorf("while staging legacy lower for %q: %w", c.name, err)
-			}
-		}
-		vfsdLog, _ := os.OpenFile(virtiofsdLogPath(actorUID), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-		if vfsdCmd, err = kata.StartVirtiofsd(ctx, kata.VirtiofsdOptions{
-			Binary:     rr.virtiofsd,
-			SocketPath: kata.VirtiofsdSocketPath(actorUID),
-			SharedDir:  kata.SharedDir(actorUID),
-			Log:        vfsdLog,
-		}); err != nil {
-			return fmt.Errorf("while starting virtiofsd: %w", err)
-		}
+	// The overlay mounts need the upper on disk: join the background untar (still
+	// overlapped with the bundle preparation above), then assemble the merged trees
+	// and serve them.
+	untarErr := <-untarDone
+	untarJoined = true
+	if untarErr != nil {
+		return untarErr
+	}
+	vfsdCmd, err := s.stageMergedRootfs(ctx, rr, actorUID, ctrs)
+	if err != nil {
+		return err
 	}
 	defer func() {
 		if retErr != nil && vfsdCmd.Process != nil {
@@ -422,11 +394,9 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 		chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd,
 		apiSocket: apiSocket, baseID: srcID, restoreSourceDir: restoreDir,
 		snapshotIsSelfContained: memMode == ch.MemRestoreEager,
-		// Same id split as the log forwarding and stats below: containers run under
-		// their bare name, except in a guest restored from a legacy snapshot, which
-		// still holds the retired <name>_ovl workloads. Signalling an id the agent
-		// does not know fails the whole graceful shutdown with InvalidContainerId.
-		workloadIDs: restoredWorkloadIDs(ctrs, hasUpper),
+		// Signaling an id the agent does not know fails the whole graceful
+		// shutdown with InvalidContainerId, so these must be what the guest runs.
+		workloadIDs: workloadIDs(ctrs),
 	}
 
 	// Re-attach stdout/stderr forwarding for each container: the restored guest's
@@ -441,12 +411,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	} else {
 		ra.guestAgent = guestAC
 		for _, c := range containers {
-			// Containers run under their bare name; guests restored from LEGACY
-			// snapshots still hold the retired <name>_ovl workload containers.
 			streamID := c.GetName()
-			if !hasUpper {
-				streamID = overlayWorkloadID(c.GetName())
-			}
 			s.startActorLogForwarding(guestAC, p.actorRef, actorUID, templateNS, templateName, streamID, c.GetName())
 		}
 	}
@@ -463,17 +428,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	// its own — whatever kept the agent from answering a 15s retry loop would
 	// keep it from answering that one too.
 	if ra.guestAgent != nil {
-		// Same id split as the log forwarding above: bare names, except for
-		// guests restored from legacy snapshots, which hold <name>_ovl containers.
-		workloadIDs := make([]string, 0, len(containers))
-		for _, c := range containers {
-			id := c.GetName()
-			if !hasUpper {
-				id = overlayWorkloadID(c.GetName())
-			}
-			workloadIDs = append(workloadIDs, id)
-		}
-		s.guestStats.Store(&guestStatsTarget{actorUID: actorUID, agent: ra.guestAgent, workloadIDs: workloadIDs})
+		s.guestStats.Store(&guestStatsTarget{actorUID: actorUID, agent: ra.guestAgent, workloadIDs: ra.workloadIDs})
 	}
 
 	slog.InfoContext(ctx, "Actor restored (overlay rootfs)",

--- a/cmd/ateom-microvm/rootfsupper.go
+++ b/cmd/ateom-microvm/rootfsupper.go
@@ -39,12 +39,9 @@ package main
 // Snapshots: the upper does not ride in guest memory, so a FULL snapshot
 // ships it as a tar (rootfsUpperTarFile), taken while the guest is paused
 // (the share is write-through, so a paused guest's completed writes are
-// already in the upper). Restore is self-describing — the tar's presence is
-// what says the snapshot carries a host-merged rootfs — which is also what
-// keeps legacy tmpfs-upper snapshots restorable: no tar means the share
-// presents the bare image and the guest's own in-memory upper takes over. A
-// DATA snapshot deliberately excludes rootfs state: the workload cold-starts
-// on restore.
+// already in the upper). Every FULL snapshot carries one; restoring anything
+// older fails at the untar. A DATA snapshot deliberately excludes rootfs state:
+// the workload cold-starts on restore.
 
 import (
 	"context"
@@ -84,26 +81,6 @@ func resetRootfsUpperDir(actorUID string) error {
 		return fmt.Errorf("while creating rootfs upper dir %q: %w", dir, err)
 	}
 	return nil
-}
-
-// actorHasDiskUpper reports whether the running actor's rootfs is host-merged,
-// by the host directory only a merged-rootfs boot/restore creates (and
-// teardownActor removes; a legacy restore explicitly removes any crash-orphaned
-// leftover, so "directory absent" means the same thing on every entry path).
-// A LEGACY actor — restored from a snapshot taken by the retired tmpfs-upper
-// implementation — has no directory: its upper lives inside guest memory, and
-// its checkpoints must keep capturing it there.
-func actorHasDiskUpper(actorUID string) bool {
-	_, err := os.Stat(rootfsUpperDir(actorUID))
-	return err == nil
-}
-
-// snapshotHasRootfsUpper reports whether a snapshot carries host-merged rootfs
-// uppers — i.e. whether restore must re-materialize them and mount the merged
-// trees (vs a legacy snapshot, whose share presents the bare image).
-func snapshotHasRootfsUpper(snapshotDir string) bool {
-	_, err := os.Stat(filepath.Join(snapshotDir, rootfsUpperTarFile))
-	return err == nil
 }
 
 // tarRootfsUpper archives the actor's rootfs uppers (dir) into the checkpoint

--- a/cmd/ateom-microvm/rootfsupper_test.go
+++ b/cmd/ateom-microvm/rootfsupper_test.go
@@ -53,10 +53,6 @@ func TestRootfsUpperRoundTrip(t *testing.T) {
 	if err := tarRootfsUpper(t.Context(), src, checkpointDir); err != nil {
 		t.Fatalf("tarRootfsUpper: %v", err)
 	}
-	if !snapshotHasRootfsUpper(checkpointDir) {
-		t.Fatalf("snapshotHasRootfsUpper(%q) = false after tarRootfsUpper", checkpointDir)
-	}
-
 	// Restore: onto a directory holding a stale previous activation's contents,
 	// which must not leak into the restored overlay state.
 	dst := upperDirWith(t, map[string]string{"app_ovl/fs/stale.txt": "stale"})
@@ -75,13 +71,5 @@ func TestRootfsUpperRoundTrip(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dst, "app_ovl/fs/stale.txt")); !os.IsNotExist(err) {
 		t.Errorf("stale pre-restore content survived untarRootfsUpper (stat err = %v), want it wiped", err)
-	}
-}
-
-// A snapshot without the tar is a legacy tmpfs-upper snapshot: restore must
-// not stage the ateUpper share (the guest has no fs device for it).
-func TestSnapshotHasRootfsUpperAbsent(t *testing.T) {
-	if snapshotHasRootfsUpper(t.TempDir()) {
-		t.Error("snapshotHasRootfsUpper() = true for a snapshot without the tar")
 	}
 }

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -95,9 +95,8 @@ type runningActor struct {
 	// this activation.
 	guestAgent *kata.AgentClient
 
-	// workloadIDs are the kata overlay-workload container ids (overlayWorkloadID of
-	// each container name) running in the guest. The SIGTERM handler signals and
-	// waits on these to gracefully stop the actor before the VM is torn down.
+	// workloadIDs are the guest container ids of this actor's workloads, for the
+	// SIGTERM the graceful shutdown propagates into the guest (see shutdown.go).
 	workloadIDs []string
 }
 
@@ -145,42 +144,17 @@ const minGuestMemMiB = 256
 // micro-VM + virtiofsd). 25 is far above any real pod.
 const maxActorContainers = 25
 
-// overlayWorkloadID is the kata containerID the RETIRED guest-overlay
-// arrangement gave a container's workload (the bare name went to a "carrier"
-// container; the workload overlaying it was <name>_ovl). Containers now run
-// under their bare name, but guests restored from legacy snapshots still hold
-// the _ovl containers, so log forwarding for those lineages keys on this.
-func overlayWorkloadID(name string) string { return name + "_ovl" }
-
 // workloadIDs returns the guest container ids for the actor's containers, in
 // order. Recorded on runningActor so the SIGTERM handler knows which guest
 // workloads to signal and wait on, and it must name what the guest actually
 // runs: a container the agent does not know is rejected with InvalidContainerId,
 // and graceful shutdown then gives up without ever reaching the workload.
 //
-// A cold boot always runs containers under their bare name. Only a guest
-// restored from a legacy snapshot still holds <name>_ovl workloads, which is the
-// restore path's business (see RestoreWorkload).
+// Containers run under their bare name.
 func workloadIDs(ctrs []actorContainer) []string {
 	ids := make([]string, 0, len(ctrs))
 	for _, c := range ctrs {
 		ids = append(ids, c.name)
-	}
-	return ids
-}
-
-// restoredWorkloadIDs is workloadIDs for a restored guest: hasUpper says the
-// snapshot carries a rootfs upper, i.e. it was taken by the host-overlay design
-// whose containers run under their bare name. A legacy snapshot predates that and
-// its guest still holds <name>_ovl workloads.
-func restoredWorkloadIDs(ctrs []actorContainer, hasUpper bool) []string {
-	ids := make([]string, 0, len(ctrs))
-	for _, c := range ctrs {
-		if hasUpper {
-			ids = append(ids, c.name)
-			continue
-		}
-		ids = append(ids, overlayWorkloadID(c.name))
 	}
 	return ids
 }
@@ -686,11 +660,7 @@ func (s *AteomService) stageMergedRootfs(ctx context.Context, rr resolvedRuntime
 		Binary:     rr.virtiofsd,
 		SocketPath: kata.VirtiofsdSocketPath(id),
 		SharedDir:  kata.SharedDir(id),
-		// Writable share whose host contents also change on restore (the upper
-		// is re-materialized from the snapshot tar) — same reasoning as the
-		// durable-dir share.
-		Cache: "auto",
-		Log:   vfsdLog,
+		Log:        vfsdLog,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("while starting virtiofsd: %w", err)

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -152,12 +152,34 @@ const maxActorContainers = 25
 // the _ovl containers, so log forwarding for those lineages keys on this.
 func overlayWorkloadID(name string) string { return name + "_ovl" }
 
-// overlayWorkloadIDs returns the overlay-workload container ids for the actor's
-// containers, in order. Recorded on runningActor so the SIGTERM handler knows
-// which guest workloads to signal and wait on.
-func overlayWorkloadIDs(ctrs []actorContainer) []string {
+// workloadIDs returns the guest container ids for the actor's containers, in
+// order. Recorded on runningActor so the SIGTERM handler knows which guest
+// workloads to signal and wait on, and it must name what the guest actually
+// runs: a container the agent does not know is rejected with InvalidContainerId,
+// and graceful shutdown then gives up without ever reaching the workload.
+//
+// A cold boot always runs containers under their bare name. Only a guest
+// restored from a legacy snapshot still holds <name>_ovl workloads, which is the
+// restore path's business (see RestoreWorkload).
+func workloadIDs(ctrs []actorContainer) []string {
 	ids := make([]string, 0, len(ctrs))
 	for _, c := range ctrs {
+		ids = append(ids, c.name)
+	}
+	return ids
+}
+
+// restoredWorkloadIDs is workloadIDs for a restored guest: hasUpper says the
+// snapshot carries a rootfs upper, i.e. it was taken by the host-overlay design
+// whose containers run under their bare name. A legacy snapshot predates that and
+// its guest still holds <name>_ovl workloads.
+func restoredWorkloadIDs(ctrs []actorContainer, hasUpper bool) []string {
+	ids := make([]string, 0, len(ctrs))
+	for _, c := range ctrs {
+		if hasUpper {
+			ids = append(ids, c.name)
+			continue
+		}
 		ids = append(ids, overlayWorkloadID(c.name))
 	}
 	return ids
@@ -576,7 +598,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 		return fmt.Errorf("while waiting for container readyz: %w", err)
 	}
 
-	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, apiSocket: apiSocket, baseID: actorUID, guestAgent: ac, workloadIDs: overlayWorkloadIDs(ctrs)}
+	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, apiSocket: apiSocket, baseID: actorUID, guestAgent: ac, workloadIDs: workloadIDs(ctrs)}
 	if err := s.activateActorNetworking(p.actorRef.Atespace, p.actorRef.Name, egress); err != nil {
 		return err
 	}

--- a/cmd/ateom-microvm/run_test.go
+++ b/cmd/ateom-microvm/run_test.go
@@ -203,22 +203,13 @@ func TestInitParams(t *testing.T) {
 // The SIGTERM path signals these ids over ttrpc, and the agent rejects an id it
 // does not know with InvalidContainerId — which aborts the whole graceful
 // shutdown, so a stale id here silently costs the guest its clean exit.
+// The SIGTERM path signals these ids over ttrpc, and the agent rejects an id it
+// does not know with InvalidContainerId — which aborts the whole graceful
+// shutdown, so a stale id here silently costs the guest its clean exit.
 func TestWorkloadIDs(t *testing.T) {
 	ctrs := []actorContainer{{name: "counter"}, {name: "sidecar"}}
-
-	// A cold-booted guest runs containers under their bare name.
 	got := workloadIDs(ctrs)
 	if want := []string{"counter", "sidecar"}; !slices.Equal(got, want) {
 		t.Errorf("workloadIDs() = %v, want %v", got, want)
-	}
-
-	// A restore from a snapshot carrying a rootfs upper is the same design.
-	if got := restoredWorkloadIDs(ctrs, true); !slices.Equal(got, []string{"counter", "sidecar"}) {
-		t.Errorf("restoredWorkloadIDs(hasUpper=true) = %v, want bare names", got)
-	}
-
-	// A legacy snapshot predates it: that guest still holds <name>_ovl workloads.
-	if got := restoredWorkloadIDs(ctrs, false); !slices.Equal(got, []string{"counter_ovl", "sidecar_ovl"}) {
-		t.Errorf("restoredWorkloadIDs(hasUpper=false) = %v, want _ovl ids", got)
 	}
 }

--- a/cmd/ateom-microvm/run_test.go
+++ b/cmd/ateom-microvm/run_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"net"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -196,5 +197,28 @@ func TestInitParams(t *testing.T) {
 	}
 	if strings.Contains(systemd, "init=") {
 		t.Errorf("initParams(false) = %q, must not override init", systemd)
+	}
+}
+
+// The SIGTERM path signals these ids over ttrpc, and the agent rejects an id it
+// does not know with InvalidContainerId — which aborts the whole graceful
+// shutdown, so a stale id here silently costs the guest its clean exit.
+func TestWorkloadIDs(t *testing.T) {
+	ctrs := []actorContainer{{name: "counter"}, {name: "sidecar"}}
+
+	// A cold-booted guest runs containers under their bare name.
+	got := workloadIDs(ctrs)
+	if want := []string{"counter", "sidecar"}; !slices.Equal(got, want) {
+		t.Errorf("workloadIDs() = %v, want %v", got, want)
+	}
+
+	// A restore from a snapshot carrying a rootfs upper is the same design.
+	if got := restoredWorkloadIDs(ctrs, true); !slices.Equal(got, []string{"counter", "sidecar"}) {
+		t.Errorf("restoredWorkloadIDs(hasUpper=true) = %v, want bare names", got)
+	}
+
+	// A legacy snapshot predates it: that guest still holds <name>_ovl workloads.
+	if got := restoredWorkloadIDs(ctrs, false); !slices.Equal(got, []string{"counter_ovl", "sidecar_ovl"}) {
+		t.Errorf("restoredWorkloadIDs(hasUpper=false) = %v, want _ovl ids", got)
 	}
 }

--- a/cmd/ateom-microvm/stats.go
+++ b/cmd/ateom-microvm/stats.go
@@ -65,7 +65,7 @@ type guestStatsTarget struct {
 
 	// workloadIDs are the guest containers to sum, one per actor container.
 	// Each actor container exists in the guest as TWO kata containers (see
-	// overlayWorkloadID): a "carrier", whose only job is to make the agent
+	// the retired guest-overlay design): a "carrier", whose only job is to make the agent
 	// bind the read-only image rootfs at a fixed guest path, and the overlay
 	// WORKLOAD, which lays a writable upper over it and runs the container's
 	// actual process. Only workload ids belong here: a carrier is created but


### PR DESCRIPTION
Fixes #1016

1. Fix graceful termination, which was broken by the drop of the "carrier container" hack when we switched to overlay for the rootfs writes
2. Drop dead code attempting to enable compatibility before that change. It's a lot of complexity and we're not there yet

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
