### PR TITLE
ateom-microvm: time the boot and restore phases, and stop polling the agent slowly

### DIFF
--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -200,6 +200,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	if err := os.MkdirAll(kata.VMDir(actorUID), 0o700); err != nil {
 		return fmt.Errorf("while creating VM dir: %w", err)
 	}
+	tPrep := time.Now()
 
 	// Merged-rootfs snapshots carry the upper as rootfs-upper.tar (the tar's
 	// presence is what says which model the guest expects). Start
@@ -249,6 +250,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	if err != nil {
 		return err
 	}
+	tBundles := time.Now()
 	// The overlay mounts need the upper on disk: join the background untar (still
 	// overlapped with the bundle preparation above), then assemble the merged trees
 	// and serve them.
@@ -257,6 +259,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	if untarErr != nil {
 		return untarErr
 	}
+	tUpper := time.Now()
 	vfsdCmd, err := s.stageMergedRootfs(ctx, rr, actorUID, ctrs)
 	if err != nil {
 		return err
@@ -267,6 +270,8 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 			_, _ = vfsdCmd.Process.Wait()
 		}
 	}()
+
+	tLowers := time.Now()
 
 	// Restart the durable-dir share's virtiofsd over the contents the caller
 	// restored. The guest reattaches to it by the socket path rewritten into the
@@ -284,6 +289,8 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 			}
 		}()
 	}
+
+	tDurable := time.Now()
 
 	// Networking: rebuild the per-activation veth + tap; the snapshot's virtio-net
 	// is fd-backed, so CH needs fresh tap FDs (net_fds) on restore.
@@ -339,6 +346,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	// Relaunch CH and restore with the tap FDs attached (SCM_RIGHTS). CH reopens
 	// /dev/vda (image) + each /dev/vd{b+i} (actor rootfs) from the snapshot config paths.
 	apiSocket := filepath.Join(kata.VMDir(actorUID), "clh-api-restore.sock")
+	tTap := time.Now()
 	chCmd, client, err := ch.LaunchVMM(ctx, ch.LaunchVMMOptions{
 		Binary: rr.chBinary, APISocket: apiSocket, Stdout: slogWriter{ctx}, Stderr: slogWriter{ctx},
 	})
@@ -360,20 +368,40 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	//   - Eager: every populated extent is read here and now. Nothing pages from the
 	//     source afterwards and nothing merges against it, so it is dropped below and
 	//     the next snapshot stands on its own.
+	tLaunch := time.Now()
 	memMode := restoreMemMode(ctx, client.Info())
 	slog.InfoContext(ctx, "restoring guest memory",
 		slog.String("mode", memMode), slog.String("vmm_version", client.Info().Version))
 	if err := client.RestoreWithNetFDs(ctx, restoreDir, restoredNets, memMode); err != nil {
 		return fmt.Errorf("while restoring VM with net FDs: %w", err)
 	}
+	tVMRestore := time.Now()
 	if err := client.Resume(ctx); err != nil {
 		return fmt.Errorf("while resuming restored guest: %w", err)
 	}
+	tResume := time.Now()
 
 	// Block until every readyz-enabled container reports 200.
 	if err := readyz.WaitAll(ctx, containers, ateomnet.ActorVethIP); err != nil {
 		return fmt.Errorf("while waiting for container readyz: %w", err)
 	}
+
+	// Where a resume goes. Like the boot phases, this used to be a single total,
+	// which hid that a first (cold) restore and a later (warm) one differ by more
+	// than 5x on the same actor. upper/lowers is the host reassembling the rootfs;
+	// vm_restore is cloud-hypervisor reading guest RAM back.
+	slog.InfoContext(ctx, "Actor restore phases", slog.String("id", actorUID),
+		slog.Duration("prep", tPrep.Sub(tStart)),
+		slog.Duration("bundles", tBundles.Sub(tPrep)),
+		slog.Duration("upper_join", tUpper.Sub(tBundles)),
+		slog.Duration("lowers", tLowers.Sub(tUpper)),
+		slog.Duration("durable", tDurable.Sub(tLowers)),
+		slog.Duration("tap", tTap.Sub(tDurable)),
+		slog.Duration("vmm_launch", tLaunch.Sub(tTap)),
+		slog.Duration("vm_restore", tVMRestore.Sub(tLaunch)),
+		slog.Duration("resume", tResume.Sub(tVMRestore)),
+		slog.Duration("readyz", time.Since(tResume)),
+		slog.Duration("total", time.Since(tStart)))
 
 	// An eager restore has read the whole snapshot into guest memory, and nothing
 	// merges against it afterwards, so the staged copy is dead weight from here on —

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -543,15 +543,18 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	// the guest's init reaches kata-containers.target — well after CH creates the
 	// vsock socket file — so poll the CONNECT until it answers (as the kata shim
 	// does), rather than dialing once.
+	tBooted := time.Now()
 	vsockPath := kata.VsockSocketPath(actorUID)
 	if !waitForFile(vsockPath, 15*time.Second) {
 		return fmt.Errorf("kata-agent vsock socket %q did not appear", vsockPath)
 	}
+	tVsock := time.Now()
 	ac, err := dialAgentRetry(ctx, vsockPath, 60*time.Second)
 	if err != nil {
 		logGuestBootDiagnostics(ctx, actorUID, serialLog)
 		return fmt.Errorf("while dialing kata-agent: %w", err)
 	}
+	tDialed := time.Now()
 	// The agent client must stay open past this RPC: the stdout/stderr forwarding
 	// goroutines (started below) read over it for the actor's lifetime. It is stored
 	// on the runningActor and closed by teardownActor. Close it here only if Run
@@ -566,11 +569,21 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	if err := s.startActorContainers(ctx, ac, actorUID, vsockPath, ctrs, durable); err != nil {
 		return err
 	}
+	tContainers := time.Now()
 
 	// Block until every readyz-enabled container reports 200.
 	if err := readyz.WaitAll(ctx, containers, ateomnet.ActorVethIP); err != nil {
 		return fmt.Errorf("while waiting for container readyz: %w", err)
 	}
+
+	// Everything from BootVM onward, split. ateom used to log only the total, which
+	// hid where a cold boot actually goes: it is not the guest booting.
+	slog.InfoContext(ctx, "Actor boot phases", slog.String("id", actorUID),
+		slog.Duration("vsock_wait", tVsock.Sub(tBooted)),
+		slog.Duration("agent_dial", tDialed.Sub(tVsock)),
+		slog.Duration("containers", tContainers.Sub(tDialed)),
+		slog.Duration("readyz", time.Since(tContainers)),
+		slog.Duration("since_boot", time.Since(tBooted)))
 
 	ra := &runningActor{chCmd: chCmd, vfsdCmd: vfsdCmd, durableVfsdCmd: durableVfsdCmd, apiSocket: apiSocket, baseID: actorUID, guestAgent: ac, workloadIDs: workloadIDs(ctrs)}
 	if err := s.activateActorNetworking(p.actorRef.Atespace, p.actorRef.Name, egress); err != nil {
@@ -855,12 +868,14 @@ func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentC
 	// Establish the agent sandbox + the kataShared virtio-fs mount (every
 	// container's merged rootfs). All containers share it, so use the first
 	// container's hostname.
+	tStart := time.Now()
 	sbCtx, sbCancel := context.WithTimeout(ctx, 20*time.Second)
 	err := ac.CreateSandboxForActor(sbCtx, id, ctrs[0].spec.Hostname, durable)
 	sbCancel()
 	if err != nil {
 		return fmt.Errorf("while creating agent sandbox: %w", err)
 	}
+	tSandbox := time.Now()
 
 	// Configure guest networking (the shim's job): eth0 IP/MAC/MTU, routes, ARP.
 	mtu := uint64(s.actorVethMTU(ctx))
@@ -873,11 +888,18 @@ func (s *AteomService) startActorContainers(ctx context.Context, ac *kata.AgentC
 		return fmt.Errorf("while configuring guest network: %w", err)
 	}
 
+	tNetwork := time.Now()
+
 	for _, c := range ctrs {
 		if err := startRootfsContainer(ctx, ac, vsockPath, c); err != nil {
 			return err
 		}
 	}
+	slog.InfoContext(ctx, "Agent setup phases", slog.String("id", id),
+		slog.Duration("sandbox", tSandbox.Sub(tStart)),
+		slog.Duration("network", tNetwork.Sub(tSandbox)),
+		slog.Duration("containers", time.Since(tNetwork)),
+		slog.Int("container_count", len(ctrs)))
 	return nil
 }
 
@@ -927,12 +949,26 @@ func (s *AteomService) startActorLogForwarding(ac *kata.AgentClient, actorRef re
 // effects until the agent runs the containers) retry on it.
 var errGuestStopped = errors.New("micro-VM stopped before the kata-agent answered")
 
+// Bounds on the kata-agent dial poll. What they set is the window between the agent
+// starting to listen and us noticing: an attempt already in flight when the agent
+// comes up cannot succeed (cloud-hypervisor has answered that CONNECT), so the wait
+// is the attempt plus the interval.
+//
+// They were 5s and 500ms, i.e. one attempt a second. What dominates this phase is
+// the guest not listening yet — measured at 1.37s on GKE — so the poll should cost
+// a fraction of that, not add half a second of its own.
+const (
+	agentDialAttemptTimeout = 300 * time.Millisecond
+	agentDialInterval       = 20 * time.Millisecond
+)
+
 // dialAgentRetry polls DialAgent until the kata-agent answers the hybrid-vsock
-// CONNECT (the socket file exists at boot, but the agent only listens once the
-// guest reaches kata-containers.target) or the overall timeout elapses. Each
-// attempt is capped at 5s (usually it fails fast with connection-refused while
-// the agent isn't listening yet; the cap only bounds a rare hung dial), then
-// waits 500ms before retrying — so steady-state polling is ~every 500ms, not 5s.
+// CONNECT (the socket file exists as soon as cloud-hypervisor boots, but the agent
+// only listens once the guest's init reaches it) or the overall timeout elapses.
+//
+// Poll fast. A failed attempt is cheap — cloud-hypervisor answers the CONNECT of a
+// port nothing is listening on straight away — while a slow poll adds its whole
+// interval to every cold boot, for nothing.
 //
 // A dial that fails with ENOENT ends the poll immediately as errGuestStopped:
 // callers wait for the socket to appear before dialing, and cloud-hypervisor
@@ -941,16 +977,25 @@ var errGuestStopped = errors.New("micro-VM stopped before the kata-agent answere
 // of the timeout to report a bare "no such file or directory".
 func dialAgentRetry(ctx context.Context, vsockPath string, timeout time.Duration) (*kata.AgentClient, error) {
 	deadline := time.Now().Add(timeout)
+	start := time.Now()
 	var lastErr error
-	for {
-		dctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	for attempt := 1; ; attempt++ {
+		dctx, cancel := context.WithTimeout(ctx, agentDialAttemptTimeout)
 		ac, err := kata.DialAgent(dctx, vsockPath)
 		cancel()
 		if err == nil {
+			slog.InfoContext(ctx, "kata-agent answered", slog.Int("attempts", attempt),
+				slog.Duration("elapsed", time.Since(start)))
 			return ac, nil
 		}
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("%w (cloud-hypervisor removed %q): %w", errGuestStopped, vsockPath, err)
+		}
+		if lastErr == nil {
+			// The first failure is the interesting one: it says why the agent is not
+			// answering yet. Later attempts repeat it until it succeeds.
+			slog.DebugContext(ctx, "kata-agent not answering yet", slog.Any("err", err),
+				slog.Duration("attempt_took", time.Since(start)))
 		}
 		lastErr = err
 		if time.Now().After(deadline) {
@@ -959,7 +1004,7 @@ func dialAgentRetry(ctx context.Context, vsockPath string, timeout time.Duration
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(agentDialInterval):
 		}
 	}
 }

--- a/cmd/ateom-microvm/run_test.go
+++ b/cmd/ateom-microvm/run_test.go
@@ -203,9 +203,6 @@ func TestInitParams(t *testing.T) {
 // The SIGTERM path signals these ids over ttrpc, and the agent rejects an id it
 // does not know with InvalidContainerId — which aborts the whole graceful
 // shutdown, so a stale id here silently costs the guest its clean exit.
-// The SIGTERM path signals these ids over ttrpc, and the agent rejects an id it
-// does not know with InvalidContainerId — which aborts the whole graceful
-// shutdown, so a stale id here silently costs the guest its clean exit.
 func TestWorkloadIDs(t *testing.T) {
 	ctrs := []actorContainer{{name: "counter"}, {name: "sidecar"}}
 	got := workloadIDs(ctrs)


### PR DESCRIPTION
- measure and expose timing data in logs
- fix and unnecessarily slow polling for agent ready

---

 - [x] Tests pass
 - [x] Appropriate changes to documentation are included in the PR
