### PR TITLE
 microvm: exclude overlay workdirs from rootfs snapshots

### DIFF
--- a/cmd/ateom-microvm/internal/tarutil/tarutil.go
+++ b/cmd/ateom-microvm/internal/tarutil/tarutil.go
@@ -54,10 +54,21 @@ import (
 // srcDir itself is not an entry.
 //
 // Regular files, directories, symlinks, FIFOs, and device nodes are archived
-// with their mode, ownership, modification time, and user.* xattrs. A file
-// with multiple links inside srcDir is archived once and referenced as a
-// hardlink thereafter. Sockets are skipped (see writeTree).
+// with their mode, ownership, modification time, and user.* / trusted.overlay.*
+// xattrs. A file with multiple links inside srcDir is archived once and
+// referenced as a hardlink thereafter. Sockets are skipped (see writeTree).
 func Create(ctx context.Context, tarPath, srcDir string) error {
+	return CreateFiltered(ctx, tarPath, srcDir, nil)
+}
+
+// SkipFunc reports whether an archive entry should be omitted, given its
+// slash-separated path relative to the archive root. Returning true for a
+// directory omits its entire subtree.
+type SkipFunc func(rel string) bool
+
+// CreateFiltered is Create with entries omitted where skip returns true. A nil
+// skip archives everything.
+func CreateFiltered(ctx context.Context, tarPath, srcDir string, skip SkipFunc) error {
 	f, err := os.Create(tarPath)
 	if err != nil {
 		return fmt.Errorf("creating tar %q: %w", tarPath, err)
@@ -65,7 +76,7 @@ func Create(ctx context.Context, tarPath, srcDir string) error {
 	defer f.Close()
 
 	tw := tar.NewWriter(f)
-	if err := writeTree(ctx, tw, srcDir); err != nil {
+	if err := writeTree(ctx, tw, srcDir, skip); err != nil {
 		return err
 	}
 	if err := tw.Close(); err != nil {
@@ -80,9 +91,10 @@ func Create(ctx context.Context, tarPath, srcDir string) error {
 }
 
 // writeTree walks srcDir in lexical order (filepath.WalkDir) and writes one
-// entry per path. The deterministic order keeps archives of identical trees
+// entry per path, omitting entries (and, for directories, subtrees) that skip
+// selects. The deterministic order keeps archives of identical trees
 // byte-comparable, which makes snapshot diffs meaningful.
-func writeTree(ctx context.Context, tw *tar.Writer, srcDir string) error {
+func writeTree(ctx context.Context, tw *tar.Writer, srcDir string, skip SkipFunc) error {
 	// Maps an already-archived multi-link inode to the name it was archived
 	// under, so later links become tar hardlink entries instead of copies.
 	linked := map[inodeKey]string{}
@@ -96,6 +108,12 @@ func writeTree(ctx context.Context, tw *tar.Writer, srcDir string) error {
 			return err
 		}
 		if rel == "." {
+			return nil
+		}
+		if skip != nil && skip(filepath.ToSlash(rel)) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/cmd/ateom-microvm/internal/tarutil/tarutil_test.go
+++ b/cmd/ateom-microvm/internal/tarutil/tarutil_test.go
@@ -239,10 +239,43 @@ func TestRoundTripFifo(t *testing.T) {
 // snapshots: a socket in the archived tree — which agents leave behind routinely
 // — must not fail the archive, because that would make the actor impossible to
 // suspend.
-// CreateFiltered must drop exactly the entries the skip function selects — for
-// a directory, the whole subtree — and leave everything else identical to an
-// unfiltered archive. The rootfs snapshot leans on this to exclude overlay
-// workdirs.
+func TestCreateSkipsSockets(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "keep.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+	l, err := net.Listen("unix", filepath.Join(src, "agent.sock"))
+	if err != nil {
+		t.Fatalf("creating socket: %v", err)
+	}
+	defer l.Close()
+
+	tarPath := filepath.Join(t.TempDir(), "sock.tar")
+	if err := Create(t.Context(), tarPath, src); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	dst := t.TempDir()
+	if err := Extract(tarPath, dst); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	// The rest of the tree survives; the socket itself is dropped.
+	got, err := os.ReadFile(filepath.Join(dst, "keep.txt"))
+	if err != nil {
+		t.Fatalf("reading archived file: %v", err)
+	}
+	if string(got) != "data" {
+		t.Errorf("keep.txt = %q, want %q", got, "data")
+	}
+	if _, err := os.Lstat(filepath.Join(dst, "agent.sock")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("socket was archived (lstat err = %v), want it skipped", err)
+	}
+}
+
+// TestCreateFilteredSkipsSubtree verifies CreateFiltered drops exactly the
+// entries the skip function selects — for a directory, the whole subtree — and
+// leaves everything else identical to an unfiltered archive. The rootfs
+// snapshot leans on this to exclude overlay workdirs.
 func TestCreateFilteredSkipsSubtree(t *testing.T) {
 	src := t.TempDir()
 	for rel, content := range map[string]string{
@@ -280,39 +313,6 @@ func TestCreateFilteredSkipsSubtree(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dst, "app/work")); !os.IsNotExist(err) {
 		t.Errorf("skipped subtree app/work survived (stat err = %v), want absent", err)
-	}
-}
-
-func TestCreateSkipsSockets(t *testing.T) {
-	src := t.TempDir()
-	if err := os.WriteFile(filepath.Join(src, "keep.txt"), []byte("data"), 0o644); err != nil {
-		t.Fatalf("writing file: %v", err)
-	}
-	l, err := net.Listen("unix", filepath.Join(src, "agent.sock"))
-	if err != nil {
-		t.Fatalf("creating socket: %v", err)
-	}
-	defer l.Close()
-
-	tarPath := filepath.Join(t.TempDir(), "sock.tar")
-	if err := Create(t.Context(), tarPath, src); err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	dst := t.TempDir()
-	if err := Extract(tarPath, dst); err != nil {
-		t.Fatalf("Extract: %v", err)
-	}
-
-	// The rest of the tree survives; the socket itself is dropped.
-	got, err := os.ReadFile(filepath.Join(dst, "keep.txt"))
-	if err != nil {
-		t.Fatalf("reading archived file: %v", err)
-	}
-	if string(got) != "data" {
-		t.Errorf("keep.txt = %q, want %q", got, "data")
-	}
-	if _, err := os.Lstat(filepath.Join(dst, "agent.sock")); !errors.Is(err, os.ErrNotExist) {
-		t.Errorf("socket was archived (lstat err = %v), want it skipped", err)
 	}
 }
 

--- a/cmd/ateom-microvm/internal/tarutil/tarutil_test.go
+++ b/cmd/ateom-microvm/internal/tarutil/tarutil_test.go
@@ -239,6 +239,50 @@ func TestRoundTripFifo(t *testing.T) {
 // snapshots: a socket in the archived tree — which agents leave behind routinely
 // — must not fail the archive, because that would make the actor impossible to
 // suspend.
+// CreateFiltered must drop exactly the entries the skip function selects — for
+// a directory, the whole subtree — and leave everything else identical to an
+// unfiltered archive. The rootfs snapshot leans on this to exclude overlay
+// workdirs.
+func TestCreateFilteredSkipsSubtree(t *testing.T) {
+	src := t.TempDir()
+	for rel, content := range map[string]string{
+		"app/fs/data.txt":  "keep",
+		"app/work/tmp.bin": "drop",
+		"app/work/#1/f":    "drop nested",
+		"beta/work-not/f":  "keep (not an exact match)",
+	} {
+		p := filepath.Join(src, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir for %q: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %q: %v", rel, err)
+		}
+	}
+
+	tarPath := filepath.Join(t.TempDir(), "filtered.tar")
+	skip := func(rel string) bool {
+		parts := strings.Split(rel, "/")
+		return len(parts) == 2 && parts[1] == "work"
+	}
+	if err := CreateFiltered(t.Context(), tarPath, src, skip); err != nil {
+		t.Fatalf("CreateFiltered: %v", err)
+	}
+	dst := t.TempDir()
+	if err := Extract(tarPath, dst); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	for _, rel := range []string{"app/fs/data.txt", "beta/work-not/f"} {
+		if _, err := os.Stat(filepath.Join(dst, rel)); err != nil {
+			t.Errorf("kept entry %q missing after filtered round trip: %v", rel, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dst, "app/work")); !os.IsNotExist(err) {
+		t.Errorf("skipped subtree app/work survived (stat err = %v), want absent", err)
+	}
+}
+
 func TestCreateSkipsSockets(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "keep.txt"), []byte("data"), 0o644); err != nil {

--- a/cmd/ateom-microvm/rootfsupper.go
+++ b/cmd/ateom-microvm/rootfsupper.go
@@ -51,16 +51,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/tarutil"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 )
 
 // rootfsUpperTarFile is the snapshot file holding the tar of the actor's
-// rootfs uppers. Its entries are <containerID>/fs/... and <containerID>/work/...
-// relative to rootfsUpperDir — the same layout kata.UpperWorkDirs mounts — so
-// extraction restores exactly the tree the merged overlays (and the guest's
-// find-paths) expect.
+// rootfs uppers. Its entries are <containerID>/fs/... relative to
+// rootfsUpperDir — the upperdir half of the layout kata.UpperWorkDirs mounts —
+// so extraction restores exactly the tree the merged overlays (and the guest's
+// find-paths) expect. The workdir half is deliberately absent (see
+// tarRootfsUpper); StageMergedRootfs recreates it at mount.
 const rootfsUpperTarFile = "rootfs-upper.tar"
 
 // rootfsUpperDir is the host directory backing the actor's rootfs overlay
@@ -110,8 +112,19 @@ func snapshotHasRootfsUpper(snapshotDir string) bool {
 // directory. The caller must have paused the guest first: virtiofsd is
 // write-through, so a completed guest write has reached the host overlay's
 // upper by then, but a running guest could still add more after the walk.
+//
+// Each container's overlay WORKDIR (<cid>/work) is excluded: with index=off
+// pinned on the mount (see kata.StageMergedRootfs) a restored workdir is
+// inert — overlayfs wipes and rebuilds it at mount, and StageMergedRootfs
+// recreates the directory regardless — so archiving it is dead weight on the
+// suspend path. Not always trivial weight, either: a copy-up in flight when
+// the guest paused can leave file-sized temp data there.
 func tarRootfsUpper(ctx context.Context, dir, checkpointDir string) error {
-	if err := tarutil.Create(ctx, filepath.Join(checkpointDir, rootfsUpperTarFile), dir); err != nil {
+	skipWorkdir := func(rel string) bool {
+		parts := strings.Split(rel, "/")
+		return len(parts) == 2 && parts[1] == "work"
+	}
+	if err := tarutil.CreateFiltered(ctx, filepath.Join(checkpointDir, rootfsUpperTarFile), dir, skipWorkdir); err != nil {
 		return fmt.Errorf("while archiving rootfs uppers from %q: %w", dir, err)
 	}
 	return nil

--- a/cmd/ateom-microvm/rootfsupper_test.go
+++ b/cmd/ateom-microvm/rootfsupper_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -41,11 +42,14 @@ func upperDirWith(t *testing.T, files map[string]string) string {
 }
 
 func TestRootfsUpperRoundTrip(t *testing.T) {
-	// Checkpoint: every container's upper/work, archived while the guest is
-	// paused. The layout under the dir is exactly what find-paths re-opens.
+	// Checkpoint: every container's upper, archived while the guest is paused.
+	// The fs/ layout under the dir is exactly what find-paths re-opens; the
+	// workdirs are deliberately left out of the archive (inert with index=off,
+	// recreated at mount).
 	files := map[string]string{
 		"app_ovl/fs/home/agent/notes.txt": "rootfs write",
 		"app_ovl/work/index":              "",
+		"app_ovl/work/#1/tmp.bin":         "in-flight copy-up temp",
 		"sidecar_ovl/fs/var/log/s.log":    "sidecar write",
 	}
 	src := upperDirWith(t, files)
@@ -64,6 +68,9 @@ func TestRootfsUpperRoundTrip(t *testing.T) {
 		t.Fatalf("untarRootfsUpper: %v", err)
 	}
 	for rel, want := range files {
+		if strings.Contains(rel, "/work/") {
+			continue // asserted absent below
+		}
 		got, err := os.ReadFile(filepath.Join(dst, rel))
 		if err != nil {
 			t.Errorf("reading restored %q: %v", rel, err)
@@ -72,6 +79,11 @@ func TestRootfsUpperRoundTrip(t *testing.T) {
 		if string(got) != want {
 			t.Errorf("restored %q = %q, want %q", rel, got, want)
 		}
+	}
+	// The workdirs must NOT survive the round trip: they are excluded from the
+	// archive (dead weight; overlayfs rebuilds them at mount).
+	if _, err := os.Stat(filepath.Join(dst, "app_ovl/work")); !os.IsNotExist(err) {
+		t.Errorf("workdir survived the snapshot round trip (stat err = %v), want it excluded", err)
 	}
 	if _, err := os.Stat(filepath.Join(dst, "app_ovl/fs/stale.txt")); !os.IsNotExist(err) {
 		t.Errorf("stale pre-restore content survived untarRootfsUpper (stat err = %v), want it wiped", err)


### PR DESCRIPTION
#### microvm: Exclude Overlay Workdirs from Rootfs Snapshots

With `index=off` pinned on the merged rootfs mount, a restored workdir is inert: overlayfs wipes and rebuilds it at mount time, and staging recreates the directory regardless. 

Archiving `<cid>/work` was therefore dead weight on the suspend path—and not always trivial weight, since a copy-up in flight at pause can leave file-sized temporary data there.

---

#### Key Changes:

* **`tarutil.CreateFiltered`**: Added a skip predicate over `Create` (skipping a directory prunes its entire subtree).
* **Workdir Pruning**: Drops exactly the second-level `work` entries during snapshot archive creation.
* **Backward Compatibility**: Extraction logic remains unchanged; existing snapshots containing `workdir` entries will still restore without issue.

---

> **Follow-up to #846 review note:** With `index=off` pinned, a restored workdir is inert and overlayfs rebuilds it at mount, making its archival unnecessary overhead on the suspend path.
