### PR TITLE
demo counter pool sizing, fail when counter rollout fails, reduce postgres CPU on kind

### DIFF
--- a/demos/counter/counter.yaml.tmpl
+++ b/demos/counter/counter.yaml.tmpl
@@ -27,7 +27,12 @@ metadata:
   labels:
     workload: counter
 spec:
-  replicas: 5
+  # Sized to what a small node (a single kind node in CI) can actually place,
+  # with one worker to spare: the only suites that run actors on this pool are
+  # networking and metrics, one actor each, and they can run concurrently. A
+  # pool that cannot place every replica is worse than a smaller one -- the
+  # deploy blocks on a rollout that never completes.
+  replicas: 3
   ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
   template:
     # Per-worker resources: these size the worker POD and advertise its
@@ -36,9 +41,9 @@ spec:
     #
     # Capacity comes from the limits (workerCapacity reads limits only), while the
     # kube-scheduler packs nodes by the requests — so the CPU request is set well
-    # below the limit to keep a 5-replica pool placeable on a small node (a single
-    # kind node in CI) without changing what an actor is allowed to use. Memory is
-    # not compressible, so its request matches the limit.
+    # below the limit to keep the pool placeable alongside the rest of the install
+    # without changing what an actor is allowed to use. Memory is not
+    # compressible, so its request matches the limit.
     resources:
       limits:
         cpu: "1"

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -122,6 +122,18 @@ run_kubectl() {
     "$@"
 }
 
+# run_kubectl_fatal runs kubectl and aborts the install if it fails. Demo
+# handlers need this: the dispatcher below calls them from an `if` condition,
+# which suppresses errexit for everything they run, so a plain run_kubectl that
+# fails is silently ignored -- a broken wait then costs its whole timeout and
+# lets the install "succeed" anyway.
+run_kubectl_fatal() {
+  if ! run_kubectl "$@"; then
+    echo "error: kubectl $* failed" >&2
+    exit 1
+  fi
+}
+
 run_kubectl_ate() {
   go run ./cmd/kubectl-ate \
     ${KUBECTL_CONTEXT:+--context=${KUBECTL_CONTEXT}} \

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -280,6 +280,18 @@ apply_otel_config() {
   fi
 }
 
+# Apply the opt-in PostgreSQL StatefulSet. On kind it goes through an overlay
+# that right-sizes the CPU request for a 4-vCPU node; see
+# manifests/ate-install/kind/postgres/kustomization.yaml.
+apply_postgres() {
+  if [[ "${ATE_INSTALL_KIND:-false}" == "true" ]]; then
+    kubectl kustomize manifests/ate-install/kind/postgres \
+      --load-restrictor LoadRestrictionsNone | run_kubectl apply -f -
+  else
+    run_kubectl apply -f manifests/ate-install/postgres.yaml
+  fi
+}
+
 # --otlp-endpoint sends all control plane telemetry to a different collector for
 # the duration of a measurement. One patch is sufficient: each component reads
 # this ConfigMap through envFrom, and ate-controller copies the values to the
@@ -377,7 +389,7 @@ deploy_postgres() {
   run_kubectl rollout status deployment/podcertificate-controller \
     -n podcertificate-controller-system --timeout=120s
   wait_for_podcertificate_trust_bundles
-  run_kubectl apply -f manifests/ate-install/postgres.yaml
+  apply_postgres
   run_kubectl rollout status statefulset/postgres -n ate-system --timeout=120s
 }
 
@@ -583,7 +595,7 @@ deploy_ate_system() {
   # Store-specific overlay composition can remove the unused Valkey resources
   # in a separate change.
   if [[ "$(store_backend)" == "postgres" ]]; then
-    run_kubectl apply -f manifests/ate-install/postgres.yaml
+    apply_postgres
   fi
 
   local manifests=""

--- a/hack/install-demo-counter.sh
+++ b/hack/install-demo-counter.sh
@@ -62,8 +62,8 @@ demo-counter_deploy() {
   # with a tight readiness deadline -- run against an already-warm node instead
   # of racing that cold-start work.
   log_step "Waiting for counter demo to be ready..."
-  run_kubectl rollout status deployment/counter -n ate-demo-counter --timeout=300s
-  run_kubectl wait --for=condition=Ready actortemplate/counter -n ate-demo-counter --timeout=300s
+  run_kubectl_fatal rollout status deployment/counter -n ate-demo-counter --timeout=300s
+  run_kubectl_fatal wait --for=condition=Ready actortemplate/counter -n ate-demo-counter --timeout=300s
 }
 
 demo-counter_delete() {

--- a/manifests/ate-install/kind/postgres/kustomization.yaml
+++ b/manifests/ate-install/kind/postgres/kustomization.yaml
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Deliberately not listed in ../kustomization.yaml: PostgreSQL is opt-in
+# (--store-backend=postgres; the default is redis), so hack/install-ate.sh
+# builds this overlay standalone at the point where it applies PostgreSQL.
+resources:
+  - ../../postgres.yaml
+
+# The base reserves a full CPU for a single-replica database. On a kind node --
+# 4 vCPU on a GitHub runner -- that is a quarter of the node held for a test
+# database, and it is the largest single reason demo WorkerPools run out of
+# schedulable CPU. Only the request (what the scheduler subtracts) is lowered;
+# the 2-CPU limit is untouched, so postgres still bursts as far as it did.
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: postgres
+        namespace: ate-system
+      spec:
+        template:
+          spec:
+            containers:
+            - name: postgres
+              resources:
+                requests:
+                  cpu: 250m


### PR DESCRIPTION
On every PR currently, we waste 5m+ on "deploy gVisor counter demo"

This is because it never readies, and after 5m we give up without failing.

It never readies, because between right-sizing the pods and switching to 1 core postgres, we create pods with more cores than the 4core free actions runners.

So this resizes the counter pool to what we actually need + a tiny bit of headroom. We don't need a lot of memory, and we only run 2 at a time. So downsize and reduce to 3x250m.

We also size down postgres when on kind, to leave a little more breathing room.