### PR TITLE
microvm: serve durable-dir volumes through the one kataShared virtiofsd

### DIFF
--- a/cmd/ateom-microvm/csi.go
+++ b/cmd/ateom-microvm/csi.go
@@ -20,12 +20,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
-	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/reaper"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -64,19 +60,8 @@ func (s *AteomService) stageCsiVolumes(ctx context.Context, actorUID string) err
 	if _, err := os.Stat(src); err != nil {
 		return fmt.Errorf("while checking CSI volumes dir %q: %w", src, err)
 	}
-	dst := filepath.Join(kata.SharedDir(actorUID), "csi")
-	// Drop any stale mount first (lazy if busy), then ensure clean mountpoint.
-	if err := reaper.Run(exec.Command("umount", dst)); err != nil {
-		_ = reaper.Run(exec.Command("umount", "-l", dst))
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		return fmt.Errorf("creating %q: %w", dst, err)
-	}
-	cmd := exec.CommandContext(ctx, "mount", "--bind", src, dst)
-	var stderr strings.Builder
-	cmd.Stderr = &stderr
-	if err := reaper.Run(cmd); err != nil {
-		return fmt.Errorf("bind-mounting CSI volumes at %q: %w (%s)", dst, err, strings.TrimSpace(stderr.String()))
+	if err := kata.BindIntoShare(ctx, src, actorUID, "csi"); err != nil {
+		return fmt.Errorf("while binding CSI volumes into the shared tree: %w", err)
 	}
 	return nil
 }

--- a/cmd/ateom-microvm/durable.go
+++ b/cmd/ateom-microvm/durable.go
@@ -41,12 +41,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
-	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/reaper"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/tarutil"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
@@ -115,19 +112,8 @@ func (s *AteomService) stageDurableVolumes(ctx context.Context, actorUID string)
 	if _, err := os.Stat(src); err != nil {
 		return fmt.Errorf("while checking durable-dir volumes dir %q: %w", src, err)
 	}
-	dst := filepath.Join(kata.SharedDir(actorUID), "durable")
-	// Drop any stale mount first (lazy if busy), then ensure clean mountpoint.
-	if err := reaper.Run(exec.Command("umount", dst)); err != nil {
-		_ = reaper.Run(exec.Command("umount", "-l", dst))
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		return fmt.Errorf("creating %q: %w", dst, err)
-	}
-	cmd := exec.CommandContext(ctx, "mount", "--bind", src, dst)
-	var stderr strings.Builder
-	cmd.Stderr = &stderr
-	if err := reaper.Run(cmd); err != nil {
-		return fmt.Errorf("bind-mounting durable-dir volumes at %q: %w (%s)", dst, err, strings.TrimSpace(stderr.String()))
+	if err := kata.BindIntoShare(ctx, src, actorUID, "durable"); err != nil {
+		return fmt.Errorf("while binding durable-dir volumes into the shared tree: %w", err)
 	}
 	return nil
 }

--- a/cmd/ateom-microvm/internal/kata/cleanup_linux.go
+++ b/cmd/ateom-microvm/internal/kata/cleanup_linux.go
@@ -37,13 +37,31 @@ import (
 // .../virtiofsd.sock: bind: address already in use", "Could not bind mount
 // .../shared/sandboxes/<id>/mounts", "directory not empty". Calling this
 // before each run gives a clean slate.
+//
+// Removal is gated on the unmounting: the shared tree holds bind mounts whose
+// SOURCES belong to someone else (the durable-dir and CSI volume dirs are
+// atelet's — see BindIntoShare), and a RemoveAll that walks into a live bind
+// deletes the actor's data through it. So a dir is removed only once every
+// mount beneath it is known detached; otherwise it is left in place for the
+// next sweep (the stagers tolerate a leftover dir — they unmount stale binds
+// and reuse mountpoints).
 func CleanupSandboxState(ctx context.Context, id string) {
 	dirs := []string{
 		filepath.Join("/run/kata-containers/shared/sandboxes", id),
 		filepath.Join(vcVMDir, id),
 	}
-	if b, err := os.ReadFile("/proc/self/mountinfo"); err == nil {
-		var mounts []string
+	removable := make(map[string]bool, len(dirs))
+	if b, err := os.ReadFile("/proc/self/mountinfo"); err != nil {
+		// Without the mount table there is no telling what is still mounted
+		// under the dirs, so none of them is provably safe to remove.
+		slog.WarnContext(ctx, "Cannot read mountinfo; leaving sandbox dirs in place",
+			slog.Any("err", err))
+	} else {
+		for _, d := range dirs {
+			removable[d] = true
+		}
+		type mount struct{ mp, dir string }
+		var mounts []mount
 		for _, line := range strings.Split(string(b), "\n") {
 			fields := strings.Fields(line)
 			if len(fields) < 5 {
@@ -52,21 +70,27 @@ func CleanupSandboxState(ctx context.Context, id string) {
 			mp := fields[4] // mount point
 			for _, d := range dirs {
 				if mp == d || strings.HasPrefix(mp, d+"/") {
-					mounts = append(mounts, mp)
+					mounts = append(mounts, mount{mp: mp, dir: d})
 					break
 				}
 			}
 		}
 		// Deepest paths first so child mounts unmount before their parents.
-		sort.Slice(mounts, func(i, j int) bool { return len(mounts[i]) > len(mounts[j]) })
-		for _, mp := range mounts {
-			if err := unix.Unmount(mp, unix.MNT_DETACH); err != nil {
+		sort.Slice(mounts, func(i, j int) bool { return len(mounts[i].mp) > len(mounts[j].mp) })
+		for _, m := range mounts {
+			if err := unix.Unmount(m.mp, unix.MNT_DETACH); err != nil {
 				slog.WarnContext(ctx, "Failed to unmount leftover sandbox mount",
-					slog.String("mount", mp), slog.Any("err", err))
+					slog.String("mount", m.mp), slog.Any("err", err))
+				removable[m.dir] = false
 			}
 		}
 	}
 	for _, d := range dirs {
+		if !removable[d] {
+			slog.WarnContext(ctx, "Leaving sandbox dir in place: mounts under it were not all detached",
+				slog.String("dir", d))
+			continue
+		}
 		if err := os.RemoveAll(d); err != nil {
 			slog.WarnContext(ctx, "Failed to remove leftover sandbox dir",
 				slog.String("dir", d), slog.Any("err", err))

--- a/cmd/ateom-microvm/internal/kata/overlay_linux.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux.go
@@ -195,19 +195,12 @@ func StageImageVolume(ctx context.Context, src, id, cid, volumeName string) erro
 	if cid == "" || volumeName == "" {
 		return fmt.Errorf("StageImageVolume: empty container id or volume name")
 	}
+	if err := BindIntoShare(ctx, src, id, filepath.Join(cid, "volumes", volumeName)); err != nil {
+		return fmt.Errorf("while binding image volume %q into the shared tree: %w", volumeName, err)
+	}
+	// Read-only is this volume type's contract (the image is someone else's,
+	// mounted for its contents); the other subtree consumers stay writable.
 	dst := SharedVolumeDir(id, cid, volumeName)
-	if err := reaper.Run(exec.Command("umount", dst)); err != nil {
-		_ = reaper.Run(exec.Command("umount", "-l", dst))
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		return fmt.Errorf("creating shared volume dir %q: %w", dst, err)
-	}
-	cmd := exec.CommandContext(ctx, "mount", "--rbind", src, dst)
-	var stderr strings.Builder
-	cmd.Stderr = &stderr
-	if err := reaper.Run(cmd); err != nil {
-		return fmt.Errorf("bind-mounting image volume %q -> %q: %w (%s)", src, dst, err, strings.TrimSpace(stderr.String()))
-	}
 	ro := exec.CommandContext(ctx, "mount", "-o", "remount,bind,ro", dst)
 	var roErr strings.Builder
 	ro.Stderr = &roErr
@@ -288,6 +281,50 @@ func UnmountMergedRootfs(restoreID, cid string) {
 	if err := reaper.Run(exec.Command("umount", dst)); err != nil {
 		_ = reaper.Run(exec.Command("umount", "-l", dst))
 	}
+}
+
+// BindIntoShare bind-mounts a host directory at SharedDir(id)/<name>, so the
+// ONE virtiofsd serves it to the guest as a subtree of the kataShared mount
+// (--announce-submounts presents it to the guest as its own filesystem).
+//
+// This is THE pattern for exposing another host directory to the guest — the
+// durable-dir and CSI volumes ride it today: a separate share would otherwise
+// pay for its own virtiofsd (a process, a vhost socket, an fs device in every
+// snapshot config and a restore-time revival of all three) per actor, forever.
+// A bind costs one mount, and teardown already covers it: CleanupSandboxState
+// lazily detaches every mount under the sandbox dir first, and will not remove
+// a dir whose mounts it could not all detach, so the source directory (which
+// may belong to atelet, as the volume dirs do) is never deleted through a live
+// bind. Callers must stage binds before StartVirtiofsd, both to keep
+// the served tree complete from the first request and because find-paths
+// migration re-opens a restored guest's open files by path at reconnect.
+//
+// rel is the mount's path relative to the share root: a top-level name sits
+// beside the per-container <cid>/... entries, so it must not collide with a
+// container id (the durable/csi subtrees); a path inside a container's own
+// subtree (the image volumes' <cid>/volumes/<name>) cannot collide at all.
+func BindIntoShare(ctx context.Context, src, id, rel string) error {
+	if rel == "" {
+		return fmt.Errorf("BindIntoShare: empty share-relative path")
+	}
+	dst := filepath.Join(SharedDir(id), rel)
+	// Drop any stale bind first (lazy if busy), then ensure a clean mountpoint.
+	if err := reaper.Run(exec.Command("umount", dst)); err != nil {
+		_ = reaper.Run(exec.Command("umount", "-l", dst))
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return fmt.Errorf("creating share subdir %q: %w", dst, err)
+	}
+	// --rbind, not --bind: a source that is itself a mount (a composed image
+	// volume) comes along either way, but only rbind carries mounts nested
+	// beneath it; for the plain-directory sources it is the same operation.
+	cmd := exec.CommandContext(ctx, "mount", "--rbind", src, dst)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := reaper.Run(cmd); err != nil {
+		return fmt.Errorf("bind-mounting %q into the shared tree at %q: %w (%s)", src, dst, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
 }
 
 // ReconstructSharedDirFromImage bind-mounts a container's OCI image rootfs at

--- a/cmd/ateom-microvm/internal/kata/overlay_linux_test.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux_test.go
@@ -47,6 +47,27 @@ func TestUpperWorkDirsAreSiblings(t *testing.T) {
 	}
 }
 
+// The volume subtrees ride the ONE kataShared device (BindIntoShare): the host
+// side is bind-mounted under the directory virtiofsd serves, and the guest
+// re-opens the same relative path under its kataShared mount — find-paths
+// re-opens open volume files by path on restore, so host and guest must agree.
+func TestVolumeSubtreePaths(t *testing.T) {
+	for name, guest := range map[string]string{
+		"durable": GuestDurableVolumeDir("data"),
+		"csi":     GuestCSIVolumeDir("data"),
+	} {
+		host := filepath.Join(SharedDir("uid"), name, "data")
+		hostRel, err := filepath.Rel(SharedDir("uid"), host)
+		if err != nil {
+			t.Fatalf("Rel(host): %v", err)
+		}
+		guestRel := strings.TrimPrefix(guest, guestSharedDir)
+		if hostRel != guestRel {
+			t.Errorf("%s: host-relative path %q != guest-relative path %q; find-paths would re-open the wrong file", name, hostRel, guestRel)
+		}
+	}
+}
+
 func TestVirtiofsdArgs(t *testing.T) {
 	args := virtiofsdArgs(VirtiofsdOptions{
 		SocketPath: "/run/vm/virtiofsd.sock",


### PR DESCRIPTION
## What Changed and Why

Durable-dir volumes were previously served to the guest by a second per-actor `virtiofsd`. That arrangement predates the writable `kataShared` share: when the rootfs share was a read-only lower, a writable durable share had to be its own device. Since #846, the `kataShared` tree is writable and served with `--announce-submounts`, making the second daemon redundant—it cost an extra process and `vhost` socket per actor, an extra `fs` device in every snapshot config, and a restore-time revival of all three.

This PR folds the durable-dir volumes into the single existing share:

* **Subtree Bind Mounting (`_durable`):**  
  `kata.BindIntoShare` bind-mounts the `atelet`-owned volumes directory into the served tree as its `_durable` subtree. The leading underscore keeps it out of the container-ID namespace (container names are RFC 1123 labels and cannot begin with an underscore). The guest sees it as a submount of the `kataShared` mount, and containers bind their volumes from `<shared>/_durable/<volume>` exactly as they previously did from the second share.
* **Streamlined VM Configuration:**  
  Cold boot no longer spawns the durable `virtiofsd`, and the VM configuration carries exactly one `virtio-fs` device.
* **Unchanged Ownership Semantics:**  
  `atelet` still owns the directory (creates it before boot, wipes it on actor reset). The bind is `ateom`-owned mount state, detached by `CleanupSandboxState` before any removal, ensuring `atelet`'s data is never touched through it.
* **Unchanged Snapshot Content:**  
  Checkpoints tar the host directory directly under every scope, exactly as before.

> [!NOTE]  
> The bind uses the same mechanism the per-container merged rootfs mounts already use through this `virtiofsd` (submounts inside the served tree, re-opened by `find-paths` on restore), introducing no new guest-side behavior. `BindIntoShare`'s doc comment establishes this pattern for future per-actor shares: **mount a reserved subtree rather than adding a device** (relevant to in-flight work such as #803; #923 already follows this subtree approach).

---

## Compatibility with Existing Snapshots

Restore is self-describing in both directions:

* **Two-Share Era Snapshots:**  
  A snapshot whose `config.json` carries an `ateDurable` fs device originates from the two-share era. The resumed guest still expects that device, so restore revives the second `virtiofsd` exactly as before (`stageLegacyDurableShare`). Such a lineage remains two-share across its own re-checkpoints since `cloud-hypervisor` re-emits the device.
* **Single-Share Snapshots:**  
  A snapshot without the device gets the volumes re-bound into the shared tree before `virtiofsd` starts, allowing `find-paths` to re-open the guest's open durable files at their `_durable/...` paths, which the restored tar reproduces exactly.

Detection logic lives in `rewriteSnapshotSocketPaths`, which already inspects the configuration's `fs` devices. The configuration acts as the authority because the device is what `cloud-hypervisor` re-opens, regardless of the actor's spec.

---

## How This Was Tested

* **Unit Tests:**  
  * Added assertions verifying that `rewriteSnapshotSocketPaths` classifies single-device and two-device snapshot configs correctly (routing restore to the bind vs. the legacy share).
  * Added a new `kata-package` test pinning `_durable` subtree invariants: the underscore namespace reservation, the guest path residing inside the single `kataShared` mount, and host/guest agreement on the relative path re-opened by `find-paths`.
  * Verified that existing durable-volume unit tests (tar/untar round-trip, container mount construction, spec isolation) continue to pass unchanged.
* **End-to-End Verification:**  
  * Ran the counter demo on a GKE cluster with nested virtualization: verified cold boot, suspend, and resume of a durable-volume actor on this branch (volume contents survived across worker pods).
  * Verified restore of a legacy snapshot taken on `main` before this change to exercise the legacy two-share fallback path.