### PR TITLE
(chore): consolidate logging to ateattr

### DIFF
--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -377,7 +377,7 @@ type AteomService struct {
 	// The type makes a lock-free read possible; it does not make one happen.
 	// GetWorkloadStats must not take lock at all, including around the cgroup
 	// read it does with the value. TestGetWorkloadStatsDoesNotTakeLock pins that.
-	activeActor atomic.Pointer[ateomstats.ActorAttribution]
+	activeActor atomic.Pointer[resources.ActorAttribution]
 
 	// shuttingDown is set once SIGTERM has been received. While true, new
 	// workload RPCs are rejected with codes.Unavailable.
@@ -594,13 +594,12 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 		return nil, err
 	}
 
-	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
-	s.actorLogger.EmitLifecycleLog("Actor starting", actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+	attribution := ateomstats.ActorAttributionFromRequest(req)
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor starting", attribution)
 
 	// Retain the attribution before the boot rather than after it, so a sample
 	// taken against a workload that dies mid-boot is still attributable. The
 	// cleanup below drops it again if the boot fails outright.
-	attribution := ateomstats.ActorAttributionFromRequest(req)
 	s.activeActor.Store(&attribution)
 
 	// Contract with atelet:
@@ -667,9 +666,9 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	}
 
 	// Create and start each application container, each with its own log pipe so
-	// every line is tagged with the originating container (ate.dev/container_name).
+	// every line is tagged with the originating container (ate.actor.container.name).
 	for _, ac := range req.GetSpec().GetContainers() {
-		pw, err := s.actorLogger.StartJSONLogPipe(actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName(), ac.GetName())
+		pw, err := s.actorLogger.StartJSONLogPipe(attribution, ac.GetName())
 		if err != nil {
 			return nil, fmt.Errorf("while starting json log pipe for %q: %w", ac.GetName(), err)
 		}
@@ -697,7 +696,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 		return nil, err
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor started", actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor started", attribution)
 	s.activeSession = &workloadSession{rcmd: rcmd, containers: containerNames(req.GetSpec().GetContainers())}
 
 	return &ateompb.RunWorkloadResponse{}, nil
@@ -718,8 +717,8 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		return nil, err
 	}
 
-	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
-	s.actorLogger.EmitLifecycleLog("Actor checkpointing", actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+	attribution := ateomstats.ActorAttributionFromRequest(req)
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor checkpointing", attribution)
 
 	// Contract with atelet:
 	//
@@ -781,7 +780,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	// directories after uploading the snapshot.
 	if err := rcmd.cleanupContainersAfterCheckpoint(ctx, req.GetSpec().GetContainers()); err != nil {
 		slog.WarnContext(ctx, "Failed to clean up runsc containers after checkpoint",
-			"actor", actorRef,
+			"actor", attribution.Ref,
 			"actorUID", req.GetActorUid(),
 			"err", err)
 	}
@@ -807,7 +806,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		return nil, fmt.Errorf("while listing checkpoint files: %w", err)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointed", actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor checkpointed", attribution)
 	s.activeSession = nil
 
 	return &ateompb.CheckpointWorkloadResponse{SnapshotFiles: snapshotFiles}, nil
@@ -872,11 +871,10 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		return nil, err
 	}
 
-	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
-	s.actorLogger.EmitLifecycleLog("Actor restoring", actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+	attribution := ateomstats.ActorAttributionFromRequest(req)
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor restoring", attribution)
 
 	// Same as RunWorkload: retain before the boot, drop again if it fails.
-	attribution := ateomstats.ActorAttributionFromRequest(req)
 	s.activeActor.Store(&attribution)
 
 	// Contract with atelet:
@@ -956,9 +954,9 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	}
 
 	// Create and restore each application container, each with its own log pipe so
-	// every line is tagged with the originating container (ate.dev/container_name).
+	// every line is tagged with the originating container (ate.actor.container.name).
 	for _, ac := range req.GetSpec().GetContainers() {
-		pw, err := s.actorLogger.StartJSONLogPipe(actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName(), ac.GetName())
+		pw, err := s.actorLogger.StartJSONLogPipe(attribution, ac.GetName())
 		if err != nil {
 			return nil, fmt.Errorf("while starting json log pipe for %q: %w", ac.GetName(), err)
 		}
@@ -999,7 +997,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		return nil, err
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor restored", actorRef, req.GetActorUid(), req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor restored", attribution)
 	s.activeSession = &workloadSession{rcmd: rcmd, containers: containerNames(req.GetSpec().GetContainers())}
 
 	return &ateompb.RestoreWorkloadResponse{}, nil

--- a/cmd/ateom-gvisor/stats.go
+++ b/cmd/ateom-gvisor/stats.go
@@ -27,8 +27,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/agent-substrate/substrate/cmd/ateom-gvisor/internal/cgroupstats"
-	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/resources"
 )
 
 // defaultCgroupRoot is the worker pod's own cgroup scope. The worker runs in a
@@ -201,7 +201,7 @@ func noSample(reason ateompb.NoSampleReason) *ateompb.GetActiveWorkloadStatsResp
 // code for the keyed read, a normal EXECUTING answer for the discovery read.
 // Callers re-check s.activeActor against the pointer they loaded after this
 // returns; the read holds no lock.
-func (s *AteomService) sampleSandbox(active *ateomstats.ActorAttribution) (*ateompb.WorkloadStatsSample, error) {
+func (s *AteomService) sampleSandbox(active *resources.ActorAttribution) (*ateompb.WorkloadStatsSample, error) {
 	read := s.readSandboxCgroup
 	if read == nil {
 		read = cgroupstats.Read

--- a/cmd/ateom-gvisor/stats_test.go
+++ b/cmd/ateom-gvisor/stats_test.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/agent-substrate/substrate/cmd/ateom-gvisor/internal/cgroupstats"
-	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	"github.com/agent-substrate/substrate/internal/resources"
 )
@@ -42,7 +41,7 @@ import (
 // to end. What is testable here is everything GetWorkloadStats does with the
 // result, which is where the polling loop will actually live.
 
-var testActor = ateomstats.ActorAttribution{
+var testActor = resources.ActorAttribution{
 	Ref:               resources.ActorRef{Atespace: "space-a", Name: "actor-a"},
 	UID:               "uid-a",
 	TemplateNamespace: "ns-a",
@@ -121,7 +120,7 @@ func TestGetWorkloadStatsErrors(t *testing.T) {
 		files map[string]string
 		// active is stored into activeActor when non-nil; nil leaves the ateom
 		// "available".
-		active   *ateomstats.ActorAttribution
+		active   *resources.ActorAttribution
 		actorUID string
 		want     codes.Code
 	}{
@@ -289,7 +288,7 @@ func TestGetActiveWorkloadStatsTransition(t *testing.T) {
 
 	tests := []struct {
 		name string
-		to   *ateomstats.ActorAttribution
+		to   *resources.ActorAttribution
 		want ateompb.NoSampleReason
 	}{
 		// A new actor took the slot: there is a workload, its numbers are just

--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -29,9 +29,9 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/ch"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
 	"github.com/agent-substrate/substrate/internal/ateompath"
+	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/imagecache"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
-	"github.com/agent-substrate/substrate/internal/resources"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -73,12 +73,10 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		return nil, err
 	}
 
-	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
+	attribution := ateomstats.ActorAttributionFromRequest(req)
 	actorUID := req.GetActorUid()
-	templateNS := req.GetActorTemplateNamespace()
-	templateName := req.GetActorTemplateName()
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointing", actorRef, actorUID, templateNS, templateName)
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor checkpointing", attribution)
 
 	// Check what the request asks for BEFORE touching the guest: these are
 	// properties of the request, and pausing first would leave the actor
@@ -212,7 +210,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 		slog.WarnContext(ctx, "Failed to clean up actor network after checkpoint", slog.Any("err", err))
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor checkpointed", actorRef, actorUID, templateNS, templateName)
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor checkpointed", attribution)
 	slog.InfoContext(ctx, "Actor checkpointed", slog.String("id", actorUID), slog.Any("snapshot_files", snapshotFiles),
 		slog.String("scope", scope.String()), slog.Duration("pause", dPause),
 		slog.Duration("snapshot", dSnapshot),

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -44,10 +44,10 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateinterceptors"
 	"github.com/agent-substrate/substrate/internal/ateomnet"
 	"github.com/agent-substrate/substrate/internal/ateompath"
-	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/atunnel"
 	"github.com/agent-substrate/substrate/internal/otlprelay"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/internal/serverboot"
 	"github.com/agent-substrate/substrate/internal/version"
 	"github.com/vishvananda/netns"
@@ -435,7 +435,7 @@ type AteomService struct {
 	// poller through all of them. The writers keep holding lock; the point is the
 	// reader. As there, the type makes a lock-free read possible without making
 	// one happen — GetWorkloadStats must not take lock at all.
-	activeActor atomic.Pointer[ateomstats.ActorAttribution]
+	activeActor atomic.Pointer[resources.ActorAttribution]
 
 	// guestStats is what GetWorkloadStats measures with: the kata-agent client
 	// and the guest containers to sum. Nil whenever there is no guest to ask —

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -111,13 +111,13 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	durableDir := ateompath.DurableDirVolumeMountsDir(p.actorUID)
 	tStart := time.Now()
 
-	s.actorLogger.EmitLifecycleLog("Actor restoring", p.actorRef, p.actorUID, p.templateNS, p.templateName)
+	attribution := p.actorAttribution()
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor restoring", attribution)
 
 	// Same as RunWorkload: retain before the restore, drop again if it fails. A
 	// Full-scope resume reaches "executing" in a different way than a cold boot
 	// does, but the window between accepting the actor and serving it is the same
 	// window, and a poll landing in it should name the actor either way.
-	attribution := p.actorAttribution()
 	s.activeActor.Store(&attribution)
 	defer func() {
 		if retErr != nil {
@@ -158,7 +158,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		return nil, status.Errorf(codes.InvalidArgument, "unsupported snapshot scope: %v", scope)
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor restored", p.actorRef, p.actorUID, p.templateNS, p.templateName)
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor restored", attribution)
 	return &ateompb.RestoreWorkloadResponse{}, nil
 }
 
@@ -176,7 +176,6 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 // caller from their tar.
 func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, restoreDir string, tStart time.Time) (retErr error) {
 	actorUID := p.actorUID
-	templateNS, templateName := p.templateNS, p.templateName
 
 	rr := s.resolveRuntime(p.assetPaths)
 	egress, err := s.prepareActorEgress(ctx, p.actorUID, p.egressGateway)
@@ -418,9 +417,9 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 			slog.String("id", actorUID), slog.Any("err", dialErr))
 	} else {
 		ra.guestAgent = guestAC
+		attribution := p.actorAttribution()
 		for _, c := range containers {
-			streamID := c.GetName()
-			s.startActorLogForwarding(guestAC, p.actorRef, actorUID, templateNS, templateName, streamID, c.GetName())
+			s.startActorLogForwarding(guestAC, attribution, c.GetName(), c.GetName())
 		}
 	}
 

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -34,7 +34,6 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/third_party/kata/agentpb"
 	"github.com/agent-substrate/substrate/internal/ateompath"
-	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/imagecache"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	"github.com/agent-substrate/substrate/internal/readyz"
@@ -280,7 +279,8 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 		size:          sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
 	}
 
-	s.actorLogger.EmitLifecycleLog("Actor starting", p.actorRef, p.actorUID, p.templateNS, p.templateName)
+	attribution := p.actorAttribution()
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor starting", attribution)
 
 	// Retain the attribution before the boot rather than after it, so a sample
 	// taken against a workload that dies mid-boot is still attributable. A cold
@@ -288,7 +288,6 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	// readyz is one whose usage is worth reporting rather than the one case that
 	// reports nothing. The defer drops it again if the boot fails outright.
 	// Matches ateom-gvisor's RunWorkload.
-	attribution := p.actorAttribution()
 	s.activeActor.Store(&attribution)
 	defer func() {
 		if retErr != nil {
@@ -299,7 +298,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	if err := s.coldBootActorRetrying(ctx, p); err != nil {
 		return nil, err
 	}
-	s.actorLogger.EmitLifecycleLog("Actor started", p.actorRef, p.actorUID, p.templateNS, p.templateName)
+	s.actorLogger.EmitLifecycleLog(ctx, "Actor started", attribution)
 	slog.InfoContext(ctx, "Actor started (overlay rootfs)", slog.String("id", p.actorUID))
 	return &ateompb.RunWorkloadResponse{}, nil
 }
@@ -324,8 +323,8 @@ type actorBootParams struct {
 
 // actorAttribution regroups the actor fields that arrived on the Run/Restore
 // request, for retention in AteomService.activeActor.
-func (p actorBootParams) actorAttribution() ateomstats.ActorAttribution {
-	return ateomstats.ActorAttribution{
+func (p actorBootParams) actorAttribution() resources.ActorAttribution {
+	return resources.ActorAttribution{
 		Ref:               p.actorRef,
 		UID:               p.actorUID,
 		TemplateNamespace: p.templateNS,
@@ -366,7 +365,6 @@ func (s *AteomService) coldBootActorRetrying(ctx context.Context, p actorBootPar
 // owns the lifecycle logging.
 func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (retErr error) {
 	actorUID := p.actorUID
-	templateNS, templateName := p.templateNS, p.templateName
 
 	// All of the actor's containers share the one micro-VM (which is the pod
 	// sandbox): each gets its own overlay rootfs and its own kata-agent
@@ -595,8 +593,9 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	// over ac for the actor's lifetime and exit (io.EOF) when teardownActor
 	// closes ac.
 	workloadIDs := make([]string, 0, len(ctrs))
+	attribution := p.actorAttribution()
 	for _, c := range ctrs {
-		s.startActorLogForwarding(ac, p.actorRef, actorUID, templateNS, templateName, c.name, c.name)
+		s.startActorLogForwarding(ac, attribution, c.name, c.name)
 		workloadIDs = append(workloadIDs, c.name)
 	}
 
@@ -954,16 +953,16 @@ func startRootfsContainer(ctx context.Context, ac *kata.AgentClient, vsockPath s
 //
 // The streams are keyed by streamID == the kata containerID==execID (the overlay
 // workload id); lines are tagged with actorName + containerName
-// (ate.dev/container_name) so a multi-container actor demultiplexes.
+// (ate.actor.container.name) so a multi-container actor demultiplexes.
 // The reader contexts are context.Background() — the goroutines are NOT bound to the
 // RPC that started them; they terminate when ac is closed (by teardownActor), which
 // makes the in-flight ReadStdout/ReadStderr fail and the StreamReader return io.EOF,
 // ending WrapContainerLogs. This keeps the agent connection (which ttrpc allows
 // concurrent Calls on) alive for forwarding while guaranteeing no goroutine outlives
 // the connection.
-func (s *AteomService) startActorLogForwarding(ac *kata.AgentClient, actorRef resources.ActorRef, actorUID, actorTemplateNamespace, actorTemplateName, streamID, containerName string) {
-	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, false), actorRef, actorUID, actorTemplateNamespace, actorTemplateName, containerName)
-	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, true), actorRef, actorUID, actorTemplateNamespace, actorTemplateName, containerName)
+func (s *AteomService) startActorLogForwarding(ac *kata.AgentClient, a resources.ActorAttribution, streamID, containerName string) {
+	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, false), a, containerName)
+	go s.actorLogger.WrapContainerLogs(kata.NewStdioReader(context.Background(), ac, streamID, streamID, true), a, containerName)
 }
 
 // errGuestStopped reports that the micro-VM stopped before the kata-agent

--- a/cmd/ateom-microvm/stats.go
+++ b/cmd/ateom-microvm/stats.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/agentstats"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/third_party/kata/agentpb"
-	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"github.com/agent-substrate/substrate/internal/resources"
 )
 
 // statsCallTimeout bounds one container's guest-agent call. The RPC is polled
@@ -201,7 +201,7 @@ var errStaleGuestTarget = errors.New("guest agent connection belongs to a differ
 // read, a NoSampleReason for the discovery read. Callers re-check
 // s.activeActor against the pointer they loaded after this returns; the read
 // holds no lock.
-func (s *AteomService) sampleGuest(ctx context.Context, active *ateomstats.ActorAttribution) (*ateompb.WorkloadStatsSample, error) {
+func (s *AteomService) sampleGuest(ctx context.Context, active *resources.ActorAttribution) (*ateompb.WorkloadStatsSample, error) {
 	// The actor is the one here, but there is no guest to ask yet. Usually that
 	// is a poll landing in the boot or the restore: the ateom retains the
 	// attribution from the moment it accepts the actor, and the target is only

--- a/cmd/ateom-microvm/stats_test.go
+++ b/cmd/ateom-microvm/stats_test.go
@@ -41,7 +41,7 @@ func TestActorBootParamsAttribution(t *testing.T) {
 	tests := []struct {
 		name string
 		p    actorBootParams
-		want ateomstats.ActorAttribution
+		want resources.ActorAttribution
 	}{
 		{
 			name: "fully populated",
@@ -51,7 +51,7 @@ func TestActorBootParamsAttribution(t *testing.T) {
 				templateNS:   "template-ns-d",
 				templateName: "template-name-e",
 			},
-			want: ateomstats.ActorAttribution{
+			want: resources.ActorAttribution{
 				Ref:               resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
 				UID:               "uid-c",
 				TemplateNamespace: "template-ns-d",
@@ -61,7 +61,7 @@ func TestActorBootParamsAttribution(t *testing.T) {
 		{
 			name: "zero params",
 			p:    actorBootParams{},
-			want: ateomstats.ActorAttribution{},
+			want: resources.ActorAttribution{},
 		},
 	}
 
@@ -110,7 +110,7 @@ func TestActorBootParamsAttributionMatchesRequest(t *testing.T) {
 // here is everything GetWorkloadStats does with the result, which is where the
 // polling loop will actually live.
 
-var testActor = ateomstats.ActorAttribution{
+var testActor = resources.ActorAttribution{
 	Ref:               resources.ActorRef{Atespace: "space-a", Name: "actor-a"},
 	UID:               "uid-a",
 	TemplateNamespace: "ns-a",
@@ -497,7 +497,7 @@ func TestGetActiveWorkloadStatsTransition(t *testing.T) {
 
 	tests := []struct {
 		name string
-		to   *ateomstats.ActorAttribution
+		to   *resources.ActorAttribution
 		want ateompb.NoSampleReason
 	}{
 		// A new actor took the slot: there is a workload, its numbers are just

--- a/cmd/kubectl-ate/internal/cmd/logs_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/ateclient"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
@@ -326,9 +327,9 @@ func filterAndDisplayLogLine(line string, target resources.ActorRef, w io.Writer
 	for _, labelKey := range []string{"logging.googleapis.com/labels", "labels"} {
 		if labelsAny, ok := m[labelKey]; ok {
 			if labels, ok := labelsAny.(map[string]any); ok {
-				if name, ok := labels["ate.dev/actor_name"].(string); ok && name != "" {
+				if name, ok := labels[string(ateattr.ActorNameKey)].(string); ok && name != "" {
 					emitter.Name = name
-					emitter.Atespace, _ = labels["ate.dev/actor_atespace"].(string)
+					emitter.Atespace, _ = labels[string(ateattr.AtespaceKey)].(string)
 					break
 				}
 			}
@@ -345,12 +346,14 @@ func filterAndDisplayLogLine(line string, target resources.ActorRef, w io.Writer
 		return logTime, false
 	}
 
-	// remove actor labels from CLI output
+	// Remove substrate's labels from CLI output. Stripping the whole reserved
+	// prefix rather than the known keys means an actor cannot get a plausible
+	// ate.*-namespaced label of its own printed as platform attribution.
 	for _, labelKey := range []string{"logging.googleapis.com/labels", "labels"} {
 		if labelsAny, ok := m[labelKey]; ok {
 			if labels, ok := labelsAny.(map[string]any); ok {
 				for k := range labels {
-					if strings.HasPrefix(k, "ate.dev/") {
+					if strings.HasPrefix(k, ateattr.ReservedNamespace) {
 						delete(labels, k)
 					}
 				}

--- a/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
@@ -43,7 +43,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 	}{
 		{
 			name:        "matching actor, JSON log with RFC3339Nano",
-			line:        `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-1"}}`,
+			line:        `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: true,
 			wantTime:    "2026-05-16T01:03:38.602878302Z",
@@ -51,7 +51,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "matching actor, plain text log",
-			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-1"}}`,
+			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: true,
 			wantTime:    "2026-05-16T01:03:38Z",
@@ -59,7 +59,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "matching actor, JSON log with no timestamp fallback",
-			line:        `{"level":"error","msg":"Failed","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-1"}}`,
+			line:        `{"level":"error","msg":"Failed","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: true,
 			wantTime:    "",
@@ -67,7 +67,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "matching actor, fallback to standard labels key",
-			line:        `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count","labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-1"}}`,
+			line:        `{"time":"2026-05-16T01:03:38.602878302Z","level":"info","msg":"Count","labels":{"ate.atespace":"space-1","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: true,
 			wantTime:    "2026-05-16T01:03:38.602878302Z",
@@ -75,7 +75,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "non-matching actor",
-			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-2"}}`,
+			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-2"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: false,
 			wantTime:    "2026-05-16T01:03:38Z",
@@ -83,7 +83,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "same actor name in a different atespace",
-			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-2","ate.dev/actor_name":"act-1"}}`,
+			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.atespace":"space-2","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: false,
 			wantTime:    "2026-05-16T01:03:38Z",
@@ -91,7 +91,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "matching actor name without atespace label",
-			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_name":"act-1"}}`,
+			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: false,
 			wantTime:    "2026-05-16T01:03:38Z",
@@ -99,7 +99,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "empty target atespace does not match empty atespace label",
-			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"","ate.dev/actor_name":"act-1"}}`,
+			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.atespace":"","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "", Name: "act-1"},
 			wantMatched: false,
 			wantTime:    "2026-05-16T01:03:38Z",
@@ -107,7 +107,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "empty target actor name does not match empty name label",
-			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":""}}`,
+			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":""}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: ""},
 			wantMatched: false,
 			wantTime:    "2026-05-16T01:03:38Z",
@@ -123,7 +123,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "matching actor, flat JSON log",
-			line:        `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello","traceID":"abc-123","err":"timeout","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-1"}}`,
+			line:        `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello","traceID":"abc-123","err":"timeout","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: true,
 			wantTime:    "2026-05-16T01:03:38Z",
@@ -131,7 +131,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "matching actor, severity and message keys",
-			line:        `{"time":"2026-05-16T01:03:38Z","severity":"error","message":"Disk full","custom_tag":"alert","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-1"}}`,
+			line:        `{"time":"2026-05-16T01:03:38Z","severity":"error","message":"Disk full","custom_tag":"alert","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: true,
 			wantTime:    "2026-05-16T01:03:38Z",
@@ -139,7 +139,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "matching actor, 2-field structured log without time",
-			line:        `{"message":"login failed","code":401,"logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-1"}}`,
+			line:        `{"message":"login failed","code":401,"logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: true,
 			wantTime:    "",
@@ -147,11 +147,22 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		},
 		{
 			name:        "matching actor, JSON log with custom application labels",
-			line:        `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-1","app":"my-app"}}`,
+			line:        `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1","app":"my-app"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: true,
 			wantTime:    "2026-05-16T01:03:38Z",
 			wantOutput:  `{"time":"2026-05-16T01:03:38Z","level":"info","logging.googleapis.com/labels":{"app":"my-app"},"msg":"Hello"}`,
+		},
+		{
+			// ateom drops these at the producer; the CLI strips the whole reserved
+			// namespace too, so a label that reached the stream some other way is
+			// never printed as platform attribution.
+			name:        "matching actor, label in substrate's reserved namespace is stripped",
+			line:        `{"time":"2026-05-16T01:03:38Z","msg":"Hello","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1","ate.tenant":"forged","app":"my-app"}}`,
+			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
+			wantMatched: true,
+			wantTime:    "2026-05-16T01:03:38Z",
+			wantOutput:  `{"time":"2026-05-16T01:03:38Z","logging.googleapis.com/labels":{"app":"my-app"},"msg":"Hello"}`,
 		},
 	}
 
@@ -236,7 +247,7 @@ func TestLogsActorRunner_Run_OneShotSuccess(t *testing.T) {
 		},
 	}
 
-	logLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello world","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-123"}}`
+	logLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello world","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-123"}}`
 	mockStreamer := &mockPodLogsStreamer{
 		StreamLogsFunc: func(ctx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
 			if ns != namespace || name != podName {
@@ -354,7 +365,7 @@ func TestLogsActorRunner_Run_Follow_SuspendedToRunning(t *testing.T) {
 		},
 	}
 
-	logLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Follow hello","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-123"}}`
+	logLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Follow hello","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-123"}}`
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -526,7 +537,7 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 				pr, pw := io.Pipe()
 				go func() {
 					// write one line and then keep it open
-					fmt.Fprintln(pw, `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"line 1 from pod-1","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-migrate"}}`)
+					fmt.Fprintln(pw, `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"line 1 from pod-1","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-migrate"}}`)
 					close(lineRead) // guaranteed to have been read because io.Pipe is unbuffered!
 					// wait until context is cancelled
 					<-streamCtx.Done()
@@ -543,7 +554,7 @@ func TestLogsActorRunner_Run_Follow_ActorMigration(t *testing.T) {
 			// Now we can cancel the main context to exit the follow loop
 			cancel()
 
-			return io.NopCloser(strings.NewReader(`{"time":"2026-05-16T01:03:39Z","level":"info","msg":"line 1 from pod-2","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-migrate"}}` + "\n")), nil
+			return io.NopCloser(strings.NewReader(`{"time":"2026-05-16T01:03:39Z","level":"info","msg":"line 1 from pod-2","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-migrate"}}` + "\n")), nil
 		},
 	}
 
@@ -653,7 +664,7 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 			if streamCalls == 1 {
 				pr, pw := io.Pipe()
 				go func() {
-					fmt.Fprintln(pw, `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"before suspend","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-suspended-mid"}}`)
+					fmt.Fprintln(pw, `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"before suspend","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-suspended-mid"}}`)
 					close(lineRead) // guaranteed to have been read!
 					<-streamCtx.Done()
 					pw.Close()
@@ -664,7 +675,7 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 			// Second stream (after resuming): cancel context to stop test
 			cancel()
 
-			return io.NopCloser(strings.NewReader(`{"time":"2026-05-16T01:03:40Z","level":"info","msg":"after resume","logging.googleapis.com/labels":{"ate.dev/actor_atespace":"space-1","ate.dev/actor_name":"act-suspended-mid"}}` + "\n")), nil
+			return io.NopCloser(strings.NewReader(`{"time":"2026-05-16T01:03:40Z","level":"info","msg":"after resume","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-suspended-mid"}}` + "\n")), nil
 		},
 	}
 

--- a/docs/dev/best-practices/otel-collector.md
+++ b/docs/dev/best-practices/otel-collector.md
@@ -434,11 +434,26 @@ for a worked example.
 
 The collector configs here include a logs pipeline, but **Substrate does not
 currently export logs over OTLP.** `serverboot.InitLogger` writes structured
-JSON to stdout, and `atelet` wraps actor container output with the
-`ate.dev/*` metadata labels described in
+JSON to stdout, and `ateom` wraps actor container output with the `ate.*`
+metadata labels described in
 [Actor Observability](../../observability.md) — also on stdout. There is no
 `LoggerProvider` or OTLP log exporter in `internal/serverboot`, alongside
 `InitTracing` and `InitMetrics`.
+
+Those labels sit in a nested group (`labels`, or `logging.googleapis.com/labels`
+on GKE, where the key promotes the group into `LogEntry.labels`). A filelog
+receiver picking these lines up wants them as flat record attributes, which is
+one OTTL statement rather than a change to the producer:
+
+```yaml
+transform:
+  log_statements:
+    - merge_maps(attributes, attributes["labels"], "upsert") where attributes["labels"] != nil
+```
+
+The trace-context fields (`trace_id`, `span_id`, `trace_flags`) are already
+top-level and lowercase hex, so the filelog receiver's `trace_parser` maps them
+onto the log record's own trace fields with no transformation.
 
 Those logs are collected by whatever agent already reads container stdout on
 your nodes — Cloud Logging's agent on GKE, or your own. The collector is not

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,21 +6,23 @@ This guide explains how Agent Substrate achieves observability across these susp
 
 ## The Observability Model
 
-To make underlying infrastructure transitions transparent, Agent Substrate establishes a standardized metadata model to identify actors across worker pods:
-* `ate.dev/actor_name`: The name of the actor (e.g., `my-counter-1` or `test`).
-* `ate.dev/actor_atespace`: The atespace the actor lives in (e.g., `ate-demo-counter`).
-* `ate.dev/actor_uid`: Server-assigned UID of the actor, unique to the lifetime of an actor.
-* `ate.dev/actor_template_name`: The name of the actor's ActorTemplate (e.g., `counter`).
-* `ate.dev/actor_template_namespace`: The Kubernetes namespace of the actor's ActorTemplate (e.g., `ate-demo-counter`).
-* `ate.dev/container_name`: The name of the container within the actor that produced the log line (e.g., `counter`), so a multi-container actor's logs can be demultiplexed by container.
+To make underlying infrastructure transitions transparent, Agent Substrate establishes a standardized metadata model to identify actors across worker pods. These are the same `ate.*` keys the spans and metrics below use, defined once in [`internal/ateattr`](../internal/ateattr):
+* `ate.actor.name`: The name of the actor (e.g., `my-counter-1` or `test`).
+* `ate.atespace`: The atespace the actor lives in (e.g., `ate-demo-counter`).
+* `ate.actor.uid`: Server-assigned UID of the actor, unique to the lifetime of an actor.
+* `ate.template.name`: The name of the actor's ActorTemplate (e.g., `counter`).
+* `ate.template.namespace`: The Kubernetes namespace of the actor's ActorTemplate (e.g., `ate-demo-counter`).
+* `ate.actor.container.name`: The name of the container within the actor that produced the log line (e.g., `counter`), so a multi-container actor's logs can be demultiplexed by container. Absent on the synthetic lifecycle records (`Actor starting`, `Actor restored`, …): those are about the actor, so no container produced them.
 
 Currently, Agent Substrate automatically wraps container output and injects these metadata labels into **container logs**. For metrics and distributed tracing, Agent Substrate provides foundational system telemetry and on-demand request tracing, with roadmap plans to fully integrate actor-level correlation.
+
+`ate.*` is reserved for Substrate. An actor's own log lines pass through untouched except for keys in that namespace, which are dropped before the record is written, so nothing a workload emits can be read as platform-issued attribution.
 
 ---
 
 ## 1. Logging
 
-Agent Substrate captures container standard output/error, wraps them into structured JSON log entries, and injects the `ate.dev` metadata labels.
+Agent Substrate captures container standard output/error, wraps them into structured JSON log entries, and injects the `ate.*` metadata labels.
 
 ### Active Actor Inspection via CLI
 For quick, on-demand debugging of an active actor, use the Agent Substrate CLI:
@@ -77,21 +79,21 @@ Because the logging pipeline indexes the core metadata labels, you can query you
 To track the unified, continuous lifecycle of a single actor regardless of how many times it migrated across worker pods or was suspended/resumed:
 
 ```text
-labels."ate.dev/actor_name"="test"
+labels."ate.actor.name"="test"
 ```
 
 #### 2. Atespace-Centric View
 To monitor or debug all actor instances in a specific atespace (e.g., analyzing the collective behavior or error rates of all actors belonging to one tenant):
 
 ```text
-labels."ate.dev/actor_atespace"="ate-demo-counter"
+labels."ate.atespace"="ate-demo-counter"
 ```
 
 #### 3. Template-Centric View
 To monitor or debug all actor instances created from a specific ActorTemplate (e.g., analyzing the collective behavior or error rates of all counter actors). One atespace can run actors from many templates, so this is a distinct dimension from the atespace view above:
 
 ```text
-labels."ate.dev/actor_template_name"="counter"
+labels."ate.template.name"="counter"
 ```
 
 #### 4. Pod-Centric View
@@ -100,6 +102,14 @@ To inspect the physical worker pod's aggregate stream and see all co-located act
 ```text
 resource.labels.pod_name="counter-c995fdf4c-m7d96"
 ```
+
+---
+
+### Joining Logs to Traces
+
+Substrate-emitted records carry top-level `trace_id`, `span_id`, and `trace_flags` in lowercase hex, the names the [OpenTelemetry spec](https://opentelemetry.io/docs/specs/otel/compatibility/logging_trace_context/) fixes for non-OTLP log formats. That covers component logs (every `slog.*Context` call, via [`internal/contextlogging`](../internal/contextlogging)) and the synthetic actor lifecycle records, so a suspend or resume log line joins the RPC that drove it.
+
+An actor's **own** lines carry trace context only if the actor emits these fields itself, in which case they pass through unchanged. Substrate cannot supply them: one forwarder goroutine covers a container's whole output stream and cannot tell which request produced a given line. Per-line correlation for actor logs arrives with the actor telemetry relay ([#853](https://github.com/agent-substrate/substrate/issues/853)), where the actor's own SDK carries the context.
 
 ---
 

--- a/internal/actorlog/logger.go
+++ b/internal/actorlog/logger.go
@@ -66,11 +66,18 @@ type ActorLogger struct {
 	labelsKey string
 }
 
+// The two spellings of the label group. Cloud Logging promotes the second into
+// LogEntry.labels, so that is the one to use on GCE.
+const (
+	labelsKeyPlain = "labels"
+	labelsKeyGCE   = "logging.googleapis.com/labels"
+)
+
 // NewActorLogger creates a new ActorLogger wrapping the provided destination writer.
 func NewActorLogger(w io.Writer, isOnGCE bool) *ActorLogger {
-	labelsKey := "labels"
+	labelsKey := labelsKeyPlain
 	if isOnGCE {
-		labelsKey = "logging.googleapis.com/labels"
+		labelsKey = labelsKeyGCE
 	}
 	return &ActorLogger{
 		writer:    w,
@@ -152,7 +159,7 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, a resources.ActorAttributi
 						delete(m, k)
 					}
 				}
-				labels := sanitizeLabels(m[al.labelsKey])
+				labels := al.foldLabelGroups(m)
 				for k, v := range ateattr.ActorLogLabels(a, containerName) {
 					labels[k] = v
 				}
@@ -184,6 +191,31 @@ func addTraceContext(ctx context.Context, envelope map[string]any) {
 	envelope[ateattr.LogTraceIDField] = sc.TraceID().String()
 	envelope[ateattr.LogSpanIDField] = sc.SpanID().String()
 	envelope[ateattr.LogTraceFlagsField] = fmt.Sprintf("%02x", byte(sc.TraceFlags()))
+}
+
+// foldLabelGroups reduces the record to a single sanitized label group, under the
+// key this logger writes.
+//
+// Both spellings have to be handled whichever one is ours, because nothing stops
+// an actor setting either, and the one we do not write is not inert: off GCE, a
+// forged logging.googleapis.com/labels is precisely the key Cloud Logging promotes
+// into LogEntry.labels, so it would outrank the group we wrote. Keys the active
+// group already holds win, so the fold cannot change what this logger's own group
+// says.
+func (al *ActorLogger) foldLabelGroups(m map[string]any) map[string]any {
+	labels := sanitizeLabels(m[al.labelsKey])
+	for _, key := range []string{labelsKeyPlain, labelsKeyGCE} {
+		if key == al.labelsKey {
+			continue
+		}
+		for k, v := range sanitizeLabels(m[key]) {
+			if _, taken := labels[k]; !taken {
+				labels[k] = v
+			}
+		}
+		delete(m, key)
+	}
+	return labels
 }
 
 // sanitizeLabels drops reserved keys from the actor's label group and stringifies

--- a/internal/actorlog/logger.go
+++ b/internal/actorlog/logger.go
@@ -14,20 +14,31 @@
 
 // Package actorlog provides structured JSON logging for actor sandboxes shared
 // by the gVisor and micro-VM ateom runtimes. It forwards an actor container's
-// stdout/stderr to the worker pod's stdout, annotated with ate.dev/* labels, and
-// emits synthetic actor lifecycle events.
+// stdout/stderr to the worker pod's stdout, annotated with the ate.* identity
+// labels from internal/ateattr, and emits synthetic actor lifecycle events.
+//
+// Only the lifecycle events carry trace context: one forwarder goroutine covers a
+// whole container stream, so it cannot tell which request produced a given line.
+// An actor emitting its own trace_id/span_id keeps them, verbatim like the rest of
+// its fields.
 package actorlog
 
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/resources"
 )
 
@@ -67,45 +78,38 @@ func NewActorLogger(w io.Writer, isOnGCE bool) *ActorLogger {
 	}
 }
 
-// EmitLifecycleLog logs a synthetic actor lifecycle event.
-func (al *ActorLogger) EmitLifecycleLog(msg string, actorRef resources.ActorRef, actorUID, actorTemplateNamespace, actorTemplateName string) {
+// EmitLifecycleLog logs a synthetic actor lifecycle event. The record joins the
+// trace of the RPC that drove the transition whenever ctx carries one.
+func (al *ActorLogger) EmitLifecycleLog(ctx context.Context, msg string, a resources.ActorAttribution) {
 	envelope := map[string]any{
-		"time":    time.Now().Format(time.RFC3339Nano),
-		"message": msg,
-		al.labelsKey: map[string]string{
-			"ate.dev/actor_atespace":           actorRef.Atespace,
-			"ate.dev/actor_name":               actorRef.Name,
-			"ate.dev/actor_uid":                actorUID,
-			"ate.dev/actor_template_namespace": actorTemplateNamespace,
-			"ate.dev/actor_template_name":      actorTemplateName,
-		},
+		"time":       time.Now().Format(time.RFC3339Nano),
+		"message":    msg,
+		al.labelsKey: ateattr.ActorLogLabels(a, ""),
 	}
-	if envBytes, err := json.Marshal(envelope); err == nil {
-		envBytes = append(envBytes, '\n')
-		_, _ = al.writer.Write(envBytes)
-	}
+	addTraceContext(ctx, envelope)
+	al.write(envelope)
 }
 
 // StartJSONLogPipe intercepts container raw stdout/stderr streams and pipes them
 // through the logger. containerName tags every line with the originating container;
 // callers that multiplex multiple containers should give each its own pipe so the
 // tag is meaningful.
-func (al *ActorLogger) StartJSONLogPipe(actorRef resources.ActorRef, actorUID, actorTemplateNamespace, actorTemplateName, containerName string) (io.WriteCloser, error) {
+func (al *ActorLogger) StartJSONLogPipe(a resources.ActorAttribution, containerName string) (io.WriteCloser, error) {
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
 	go func() {
-		al.WrapContainerLogs(pr, actorRef, actorUID, actorTemplateNamespace, actorTemplateName, containerName)
+		al.WrapContainerLogs(pr, a, containerName)
 		pr.Close()
 	}()
 	return pw, nil
 }
 
 // WrapContainerLogs reads log lines from r, parses them, and logs them in a unified
-// structured format. containerName is added as the ate.dev/container_name label so
-// multi-container actors can be demultiplexed.
-func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorRef resources.ActorRef, actorUID, actorTemplateNamespace, actorTemplateName, containerName string) {
+// structured format. containerName is added as the ate.actor.container.name label
+// so multi-container actors can be demultiplexed.
+func (al *ActorLogger) WrapContainerLogs(r io.Reader, a resources.ActorAttribution, containerName string) {
 	rdr := bufio.NewReader(r)
 	for {
 		lineBytes, err := rdr.ReadBytes('\n')
@@ -134,45 +138,82 @@ func (al *ActorLogger) WrapContainerLogs(r io.Reader, actorRef resources.ActorRe
 			}
 
 			if unmarshalErr != nil {
-				labels := map[string]string{
-					"ate.dev/actor_atespace":           actorRef.Atespace,
-					"ate.dev/actor_name":               actorRef.Name,
-					"ate.dev/actor_uid":                actorUID,
-					"ate.dev/actor_template_namespace": actorTemplateNamespace,
-					"ate.dev/actor_template_name":      actorTemplateName,
-					"ate.dev/container_name":           containerName,
-				}
 				envelope = map[string]any{
 					"time":       time.Now().Format(time.RFC3339Nano),
 					"message":    string(lineBytes),
-					al.labelsKey: labels,
+					al.labelsKey: ateattr.ActorLogLabels(a, containerName),
 				}
 			} else {
 				if _, ok := m["time"]; !ok {
 					m["time"] = time.Now().Format(time.RFC3339Nano)
 				}
-				labels, ok := m[al.labelsKey].(map[string]any)
-				if !ok {
-					labels = make(map[string]any)
-					m[al.labelsKey] = labels
+				for k := range m {
+					if strings.HasPrefix(k, ateattr.ReservedNamespace) {
+						delete(m, k)
+					}
 				}
-				labels["ate.dev/actor_atespace"] = actorRef.Atespace
-				labels["ate.dev/actor_name"] = actorRef.Name
-				labels["ate.dev/actor_uid"] = actorUID
-				labels["ate.dev/actor_template_namespace"] = actorTemplateNamespace
-				labels["ate.dev/actor_template_name"] = actorTemplateName
-				labels["ate.dev/container_name"] = containerName
+				labels := sanitizeLabels(m[al.labelsKey])
+				for k, v := range ateattr.ActorLogLabels(a, containerName) {
+					labels[k] = v
+				}
+				m[al.labelsKey] = labels
 				envelope = m
 			}
 
-			if envBytes, err := json.Marshal(envelope); err == nil {
-				envBytes = append(envBytes, '\n')
-				_, _ = al.writer.Write(envBytes)
-			}
+			al.write(envelope)
 		}
 
 		if err != nil {
 			break
 		}
+	}
+}
+
+func (al *ActorLogger) write(envelope map[string]any) {
+	if envBytes, err := json.Marshal(envelope); err == nil {
+		envBytes = append(envBytes, '\n')
+		_, _ = al.writer.Write(envBytes)
+	}
+}
+
+func addTraceContext(ctx context.Context, envelope map[string]any) {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return
+	}
+	envelope[ateattr.LogTraceIDField] = sc.TraceID().String()
+	envelope[ateattr.LogSpanIDField] = sc.SpanID().String()
+	envelope[ateattr.LogTraceFlagsField] = fmt.Sprintf("%02x", byte(sc.TraceFlags()))
+}
+
+// sanitizeLabels drops reserved keys from the actor's label group and stringifies
+// the rest: GKE promotes the group into LogEntry.labels, where one non-string value
+// costs the whole record its labels.
+func sanitizeLabels(v any) map[string]any {
+	labels, ok := v.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(labels))
+	for k, val := range labels {
+		if strings.HasPrefix(k, ateattr.ReservedNamespace) {
+			continue
+		}
+		out[k] = labelValueString(val)
+	}
+	return out
+}
+
+func labelValueString(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case nil:
+		return ""
+	default:
+		if b, err := json.Marshal(val); err == nil {
+			return string(b)
+		}
+		return fmt.Sprint(val)
 	}
 }

--- a/internal/actorlog/logger_test.go
+++ b/internal/actorlog/logger_test.go
@@ -16,26 +16,98 @@ package actorlog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
 
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/resources"
 )
 
-func TestWrapContainerLogs(t *testing.T) {
-	input := "Test application log output\n"
-	rdr := strings.NewReader(input)
+const (
+	testAtespace     = "default"
+	testActorName    = "act-1"
+	testActorUID     = "uid-1"
+	testTemplateNS   = "tmpl-ns"
+	testTemplateName = "tmpl-1"
+	testContainer    = "ctr-1"
+)
 
-	var buf bytes.Buffer
-	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, resources.ActorRef{Atespace: "default", Name: "act-1"}, "uid-1", "tmpl-ns", "tmpl-1", "ctr-1")
+var testAttribution = resources.ActorAttribution{
+	Ref:               resources.ActorRef{Atespace: testAtespace, Name: testActorName},
+	UID:               testActorUID,
+	TemplateNamespace: testTemplateNS,
+	TemplateName:      testTemplateName,
+}
 
+// The registry owns the spellings (pinned by ateattr.TestKeySpellings), so the
+// tests read them from there rather than restating them and drifting.
+var (
+	atespaceLabel      = string(ateattr.AtespaceKey)
+	actorNameLabel     = string(ateattr.ActorNameKey)
+	actorUIDLabel      = string(ateattr.ActorUIDKey)
+	containerNameLabel = string(ateattr.ActorContainerNameKey)
+	templateNSLabel    = string(ateattr.TemplateNamespaceKey)
+	templateNameLabel  = string(ateattr.TemplateNameKey)
+)
+
+// decodeLine parses the single record written to buf, preserving number literals
+// so precision checks are meaningful.
+func decodeLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	dec.UseNumber()
 	var m map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+	if err := dec.Decode(&m); err != nil {
 		t.Fatalf("failed to parse JSON output: %v", err)
 	}
+	return m
+}
+
+func labelGroup(t *testing.T, al *ActorLogger, m map[string]any) map[string]any {
+	t.Helper()
+	labelsAny, ok := m[al.labelsKey]
+	if !ok {
+		t.Fatal("missing labels group")
+	}
+	labels, ok := labelsAny.(map[string]any)
+	if !ok {
+		t.Fatalf("labels group is not a map: %T", labelsAny)
+	}
+	return labels
+}
+
+func assertLabels(t *testing.T, labels map[string]any, want map[string]string) {
+	t.Helper()
+	for k, wv := range want {
+		if got := labels[k]; got != wv {
+			t.Errorf("label %s = %v, want %q", k, got, wv)
+		}
+	}
+}
+
+// identityLabels is the full set every container record carries.
+func identityLabels() map[string]string {
+	return map[string]string{
+		atespaceLabel:      testAtespace,
+		actorNameLabel:     testActorName,
+		actorUIDLabel:      testActorUID,
+		containerNameLabel: testContainer,
+		templateNSLabel:    testTemplateNS,
+		templateNameLabel:  testTemplateName,
+	}
+}
+
+func TestWrapContainerLogs(t *testing.T) {
+	var buf bytes.Buffer
+	al := NewActorLogger(&buf, false)
+	al.WrapContainerLogs(strings.NewReader("Test application log output\n"), testAttribution, testContainer)
+
+	m := decodeLine(t, &buf)
 
 	if m["message"] != "Test application log output" {
 		t.Errorf("got message = %v, want 'Test application log output'", m["message"])
@@ -43,54 +115,20 @@ func TestWrapContainerLogs(t *testing.T) {
 	if _, ok := m["level"]; ok {
 		t.Errorf("level should be absent for plain text logs (no guessing)")
 	}
-	if _, ok := m["actor_log"]; ok {
-		t.Errorf("actor_log should be absent for text logs")
-	}
 
-	labelsAny, ok := m[al.labelsKey]
-	if !ok {
-		t.Fatal("missing labels group")
-	}
-	labels, ok := labelsAny.(map[string]any)
-	if !ok {
-		t.Fatal("labels group is not a map")
-	}
-
-	if labels["ate.dev/actor_name"] != "act-1" {
-		t.Errorf("got actor_name = %v, want 'act-1'", labels["ate.dev/actor_name"])
-	}
-	if labels["ate.dev/actor_atespace"] != "default" {
-		t.Errorf("got actor_atespace = %v, want 'default'", labels["ate.dev/actor_atespace"])
-	}
-	if labels["ate.dev/actor_uid"] != "uid-1" {
-		t.Errorf("got actor_uid = %v, want 'uid-1'", labels["ate.dev/actor_uid"])
-	}
-	if labels["ate.dev/actor_template_namespace"] != "tmpl-ns" {
-		t.Errorf("got actor_template_namespace = %v, want 'tmpl-ns'", labels["ate.dev/actor_template_namespace"])
-	}
-	if labels["ate.dev/actor_template_name"] != "tmpl-1" {
-		t.Errorf("got actor_template_name = %v, want 'tmpl-1'", labels["ate.dev/actor_template_name"])
-	}
-	if labels["ate.dev/container_name"] != "ctr-1" {
-		t.Errorf("got container_name = %v, want 'ctr-1'", labels["ate.dev/container_name"])
-	}
+	assertLabels(t, labelGroup(t, al, m), identityLabels())
 }
 
 func TestWrapContainerLogs_JSONInput(t *testing.T) {
-	// Include large 64-bit integer and pre-existing time field
-	input := `{"level":"info","msg":"Started container","custom_attr":"value","trace_id":1234567890123456789,"time":"2026-05-16T01:03:37Z"}` + "\n"
-	rdr := strings.NewReader(input)
+	// A large 64-bit integer and a pre-existing time field: neither may be
+	// rewritten on the way through.
+	input := `{"level":"info","msg":"Started container","custom_attr":"value","count":1234567890123456789,"time":"2026-05-16T01:03:37Z"}` + "\n"
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, resources.ActorRef{Atespace: "default", Name: "act-1"}, "uid-1", "tmpl-ns", "tmpl-1", "ctr-1")
+	al.WrapContainerLogs(strings.NewReader(input), testAttribution, testContainer)
 
-	dec := json.NewDecoder(&buf)
-	dec.UseNumber()
-	var m map[string]any
-	if err := dec.Decode(&m); err != nil {
-		t.Fatalf("failed to parse JSON output: %v", err)
-	}
+	m := decodeLine(t, &buf)
 
 	if m["msg"] != "Started container" {
 		t.Errorf("got msg = %v, want 'Started container'", m["msg"])
@@ -104,33 +142,33 @@ func TestWrapContainerLogs_JSONInput(t *testing.T) {
 	if m["time"] != "2026-05-16T01:03:37Z" {
 		t.Errorf("got time = %v, want '2026-05-16T01:03:37Z' (pre-existing time should be preserved)", m["time"])
 	}
-	if m["trace_id"] != json.Number("1234567890123456789") {
-		t.Errorf("got trace_id = %v, want json.Number('1234567890123456789') (large integer should be preserved exactly)", m["trace_id"])
-	}
-	if _, ok := m["actor_log"]; ok {
-		t.Errorf("actor_log should be absent for flat JSON logs")
+	if m["count"] != json.Number("1234567890123456789") {
+		t.Errorf("got count = %v, want json.Number('1234567890123456789') (large integer should be preserved exactly)", m["count"])
 	}
 
-	labelsAny, ok := m[al.labelsKey]
-	if !ok {
-		t.Fatal("missing labels group")
-	}
-	labels, ok := labelsAny.(map[string]any)
-	if !ok {
-		t.Fatal("labels group is not a map")
-	}
+	assertLabels(t, labelGroup(t, al, m), identityLabels())
+}
 
-	if labels["ate.dev/actor_name"] != "act-1" {
-		t.Errorf("got actor_name = %v, want 'act-1'", labels["ate.dev/actor_name"])
+// TestWrapContainerLogs_ActorTraceContextPassthrough covers the only way an actor
+// log line can join a trace: the actor emitting the spec fields itself. ateom
+// cannot supply them, because one forwarder covers a whole stream.
+func TestWrapContainerLogs_ActorTraceContextPassthrough(t *testing.T) {
+	const (
+		traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+		spanID  = "00f067aa0ba902b7"
+	)
+	input := `{"msg":"handled","` + ateattr.LogTraceIDField + `":"` + traceID + `","` + ateattr.LogSpanIDField + `":"` + spanID + `"}` + "\n"
+
+	var buf bytes.Buffer
+	al := NewActorLogger(&buf, false)
+	al.WrapContainerLogs(strings.NewReader(input), testAttribution, testContainer)
+
+	m := decodeLine(t, &buf)
+	if m[ateattr.LogTraceIDField] != traceID {
+		t.Errorf("got %s = %v, want %q", ateattr.LogTraceIDField, m[ateattr.LogTraceIDField], traceID)
 	}
-	if labels["ate.dev/actor_uid"] != "uid-1" {
-		t.Errorf("got actor_uid = %v, want 'uid-1'", labels["ate.dev/actor_uid"])
-	}
-	if labels["ate.dev/actor_template_namespace"] != "tmpl-ns" {
-		t.Errorf("got actor_template_namespace = %v, want 'tmpl-ns'", labels["ate.dev/actor_template_namespace"])
-	}
-	if labels["ate.dev/actor_template_name"] != "tmpl-1" {
-		t.Errorf("got actor_template_name = %v, want 'tmpl-1'", labels["ate.dev/actor_template_name"])
+	if m[ateattr.LogSpanIDField] != spanID {
+		t.Errorf("got %s = %v, want %q", ateattr.LogSpanIDField, m[ateattr.LogSpanIDField], spanID)
 	}
 }
 
@@ -140,167 +178,231 @@ func TestSyncedWriter_Concurrency(t *testing.T) {
 
 	const numWorkers = 10
 	const writesPerWorker = 100
+	const lineLen = 10
 	var wg sync.WaitGroup
 
 	wg.Add(numWorkers)
 	for i := 0; i < numWorkers; i++ {
-		go func(workerID int) {
+		go func() {
 			defer wg.Done()
 			for j := 0; j < writesPerWorker; j++ {
-				line := []byte(strings.Repeat("a", 10) + "\n")
-				_, err := sw.Write(line)
-				if err != nil {
+				if _, err := sw.Write([]byte(strings.Repeat("a", lineLen) + "\n")); err != nil {
 					t.Errorf("write failed: %v", err)
 				}
 			}
-		}(i)
+		}()
 	}
-
 	wg.Wait()
 
-	lines := strings.Split(buf.String(), "\n")
-	if len(lines) != numWorkers*writesPerWorker+1 {
-		t.Errorf("got %d lines, want %d", len(lines)-1, numWorkers*writesPerWorker)
+	lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+	if len(lines) != numWorkers*writesPerWorker {
+		t.Errorf("got %d lines, want %d", len(lines), numWorkers*writesPerWorker)
 	}
 	for i, line := range lines {
-		if i == len(lines)-1 {
-			if line != "" {
-				t.Errorf("last line should be empty")
-			}
-			continue
-		}
-		if len(line) != 10 {
-			t.Errorf("line %d has length %d, want 10 (interleaved write detected?): %q", i, len(line), line)
+		if len(line) != lineLen {
+			t.Errorf("line %d has length %d, want %d (interleaved write detected?): %q", i, len(line), lineLen, line)
 		}
 	}
 }
 
 func TestWrapContainerLogs_MergeLabels(t *testing.T) {
 	input := `{"level":"info","msg":"App log","labels":{"app":"my-app","version":"v1"}}` + "\n"
-	rdr := strings.NewReader(input)
-
-	var buf bytes.Buffer
-	al := NewActorLogger(&buf, false) // labelsKey will be "labels"
-	al.WrapContainerLogs(rdr, resources.ActorRef{Atespace: "default", Name: "act-1"}, "uid-1", "tmpl-ns", "tmpl-1", "ctr-1")
-
-	var m map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
-		t.Fatalf("failed to parse JSON output: %v", err)
-	}
-
-	labelsAny, ok := m[al.labelsKey]
-	if !ok {
-		t.Fatal("missing labels group")
-	}
-	labels, ok := labelsAny.(map[string]any)
-	if !ok {
-		t.Fatal("labels group is not a map")
-	}
-
-	if labels["app"] != "my-app" {
-		t.Errorf("got app = %v, want 'my-app'", labels["app"])
-	}
-	if labels["version"] != "v1" {
-		t.Errorf("got version = %v, want 'v1'", labels["version"])
-	}
-	if labels["ate.dev/actor_name"] != "act-1" {
-		t.Errorf("got actor_name = %v, want 'act-1'", labels["ate.dev/actor_name"])
-	}
-	if labels["ate.dev/container_name"] != "ctr-1" {
-		t.Errorf("got container_name = %v, want 'ctr-1'", labels["ate.dev/container_name"])
-	}
-}
-
-func TestWrapContainerLogs_LabelCollision(t *testing.T) {
-	input := `{"level":"info","msg":"App log","labels":{"ate.dev/actor_name":"malicious-id","ate.dev/actor_uid":"malicious-uid","app":"my-app"}}` + "\n"
-	rdr := strings.NewReader(input)
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, resources.ActorRef{Atespace: "default", Name: "act-1"}, "uid-1", "tmpl-ns", "tmpl-1", "ctr-1")
+	al.WrapContainerLogs(strings.NewReader(input), testAttribution, testContainer)
 
-	var m map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
-		t.Fatalf("failed to parse JSON output: %v", err)
+	labels := labelGroup(t, al, decodeLine(t, &buf))
+
+	want := identityLabels()
+	want["app"] = "my-app"
+	want["version"] = "v1"
+	assertLabels(t, labels, want)
+}
+
+// TestWrapContainerLogs_ReservedNamespace pins that an actor cannot write into
+// substrate's namespace: not the identity labels it would be forging, and not any
+// other ate.* key that would read as platform-issued attribution downstream.
+func TestWrapContainerLogs_ReservedNamespace(t *testing.T) {
+	input := `{"level":"info","msg":"App log","` + actorNameLabel + `":"top-level-forgery","ate.tenant":"forged",` +
+		`"labels":{"` + actorNameLabel + `":"malicious-name","` + actorUIDLabel + `":"malicious-uid","ate.tenant":"forged","app":"my-app"}}` + "\n"
+
+	var buf bytes.Buffer
+	al := NewActorLogger(&buf, false)
+	al.WrapContainerLogs(strings.NewReader(input), testAttribution, testContainer)
+
+	m := decodeLine(t, &buf)
+	for _, k := range []string{actorNameLabel, "ate.tenant"} {
+		if v, ok := m[k]; ok {
+			t.Errorf("reserved top-level key %s survived with value %v", k, v)
+		}
 	}
 
-	labelsAny, ok := m[al.labelsKey]
-	if !ok {
-		t.Fatal("missing labels group")
+	labels := labelGroup(t, al, m)
+	if _, ok := labels["ate.tenant"]; ok {
+		t.Error("unrecognized reserved label ate.tenant survived; it reads as platform-issued")
 	}
-	labels, ok := labelsAny.(map[string]any)
-	if !ok {
-		t.Fatal("labels group is not a map")
-	}
+	want := identityLabels()
+	want["app"] = "my-app"
+	assertLabels(t, labels, want)
+}
 
-	if labels["app"] != "my-app" {
-		t.Errorf("got app = %v, want 'my-app'", labels["app"])
+// TestWrapContainerLogs_NonStringLabelValue guards the GKE label contract: one
+// non-string value under logging.googleapis.com/labels costs the whole record its
+// labels, so actor-supplied values are stringified rather than forwarded as-is.
+func TestWrapContainerLogs_NonStringLabelValue(t *testing.T) {
+	input := `{"msg":"App log","labels":{"replicas":3,"enabled":true,"nested":{"a":1},"empty":null}}` + "\n"
+
+	var buf bytes.Buffer
+	al := NewActorLogger(&buf, false)
+	al.WrapContainerLogs(strings.NewReader(input), testAttribution, testContainer)
+
+	labels := labelGroup(t, al, decodeLine(t, &buf))
+	for k, v := range labels {
+		if _, ok := v.(string); !ok {
+			t.Errorf("label %s = %v (%T), want a string", k, v, v)
+		}
 	}
-	if labels["ate.dev/actor_name"] != "act-1" {
-		t.Errorf("got actor_name = %v, want 'act-1' (Substrate metadata should take precedence)", labels["ate.dev/actor_name"])
-	}
-	if labels["ate.dev/actor_uid"] != "uid-1" {
-		t.Errorf("got actor_uid = %v, want 'uid-1' (Substrate metadata should take precedence)", labels["ate.dev/actor_uid"])
-	}
+	assertLabels(t, labels, map[string]string{
+		"replicas": "3",
+		"enabled":  "true",
+		"nested":   `{"a":1}`,
+		"empty":    "",
+	})
 }
 
 func TestWrapContainerLogs_JSONNull(t *testing.T) {
-	input := "null\n"
-	rdr := strings.NewReader(input)
-
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, resources.ActorRef{Atespace: "default", Name: "act-1"}, "uid-1", "tmpl-ns", "tmpl-1", "ctr-1")
+	al.WrapContainerLogs(strings.NewReader("null\n"), testAttribution, testContainer)
 
-	var m map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
-		t.Fatalf("failed to parse JSON output: %v", err)
-	}
-
+	m := decodeLine(t, &buf)
 	if m["message"] != "null" {
 		t.Errorf("got message = %v, want 'null'", m["message"])
 	}
-
-	labelsAny, ok := m[al.labelsKey]
-	if !ok {
-		t.Fatal("missing labels group")
-	}
-	labels, ok := labelsAny.(map[string]any)
-	if !ok {
-		t.Fatal("labels group is not a map")
-	}
-	if labels["ate.dev/actor_uid"] != "uid-1" {
-		t.Errorf("got actor_uid = %v, want 'uid-1'", labels["ate.dev/actor_uid"])
-	}
+	assertLabels(t, labelGroup(t, al, m), identityLabels())
 }
 
 func TestWrapContainerLogs_TrailingGarbage(t *testing.T) {
-	input := `{"count": 1} garbage` + "\n"
-	rdr := strings.NewReader(input)
+	const line = `{"count": 1} garbage`
 
 	var buf bytes.Buffer
 	al := NewActorLogger(&buf, false)
-	al.WrapContainerLogs(rdr, resources.ActorRef{Atespace: "default", Name: "act-1"}, "uid-1", "tmpl-ns", "tmpl-1", "ctr-1")
+	al.WrapContainerLogs(strings.NewReader(line+"\n"), testAttribution, testContainer)
 
-	var m map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
-		t.Fatalf("failed to parse JSON output: %v", err)
+	m := decodeLine(t, &buf)
+	if m["message"] != line {
+		t.Errorf("got message = %v, want %q", m["message"], line)
+	}
+	assertLabels(t, labelGroup(t, al, m), identityLabels())
+}
+
+func TestEmitLifecycleLog(t *testing.T) {
+	const (
+		traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+		spanID  = "00f067aa0ba902b7"
+		msg     = "Actor restored"
+	)
+
+	sampled := trace.SpanContextConfig{
+		TraceID:    mustTraceID(t, traceID),
+		SpanID:     mustSpanID(t, spanID),
+		TraceFlags: trace.FlagsSampled,
+	}
+	unsampled := sampled
+	unsampled.TraceFlags = 0
+
+	tests := []struct {
+		name           string
+		ctx            context.Context
+		wantTraceID    string
+		wantSpanID     string
+		wantTraceFlags string
+	}{
+		{
+			name: "no span in context",
+			ctx:  context.Background(),
+		},
+		{
+			name: "invalid span context contributes nothing",
+			ctx:  trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{})),
+		},
+		{
+			name:           "sampled span",
+			ctx:            trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(sampled)),
+			wantTraceID:    traceID,
+			wantSpanID:     spanID,
+			wantTraceFlags: "01",
+		},
+		{
+			name:           "unsampled span still correlates",
+			ctx:            trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(unsampled)),
+			wantTraceID:    traceID,
+			wantSpanID:     spanID,
+			wantTraceFlags: "00",
+		},
 	}
 
-	if m["message"] != `{"count": 1} garbage` {
-		t.Errorf("got message = %v, want '{\"count\": 1} garbage'", m["message"])
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			al := NewActorLogger(&buf, false)
+			al.EmitLifecycleLog(tt.ctx, msg, testAttribution)
 
-	labelsAny, ok := m[al.labelsKey]
-	if !ok {
-		t.Fatal("missing labels group")
-	}
-	labels, ok := labelsAny.(map[string]any)
-	if !ok {
-		t.Fatal("labels group is not a map")
-	}
+			m := decodeLine(t, &buf)
+			if m["message"] != msg {
+				t.Errorf("got message = %v, want %q", m["message"], msg)
+			}
+			if m["time"] == nil {
+				t.Error("lifecycle records must carry a timestamp")
+			}
 
-	if labels["ate.dev/actor_name"] != "act-1" {
-		t.Errorf("got actor_name = %v, want 'act-1'", labels["ate.dev/actor_name"])
+			for field, want := range map[string]string{
+				ateattr.LogTraceIDField:    tt.wantTraceID,
+				ateattr.LogSpanIDField:     tt.wantSpanID,
+				ateattr.LogTraceFlagsField: tt.wantTraceFlags,
+			} {
+				got, present := m[field]
+				if want == "" {
+					if present {
+						t.Errorf("%s = %v, want absent", field, got)
+					}
+					continue
+				}
+				if got != want {
+					t.Errorf("%s = %v, want %q", field, got, want)
+				}
+			}
+
+			labels := labelGroup(t, al, m)
+			// A lifecycle event is actor-scoped: no container produced it.
+			if v, ok := labels[containerNameLabel]; ok {
+				t.Errorf("%s = %v, want absent on a lifecycle record", containerNameLabel, v)
+			}
+			want := identityLabels()
+			delete(want, containerNameLabel)
+			assertLabels(t, labels, want)
+			if len(labels) != len(want) {
+				t.Errorf("got %d labels, want %d: %v", len(labels), len(want), labels)
+			}
+		})
 	}
+}
+
+func mustTraceID(t *testing.T, s string) trace.TraceID {
+	t.Helper()
+	id, err := trace.TraceIDFromHex(s)
+	if err != nil {
+		t.Fatalf("TraceIDFromHex(%q): %v", s, err)
+	}
+	return id
+}
+
+func mustSpanID(t *testing.T, s string) trace.SpanID {
+	t.Helper()
+	id, err := trace.SpanIDFromHex(s)
+	if err != nil {
+		t.Fatalf("SpanIDFromHex(%q): %v", s, err)
+	}
+	return id
 }

--- a/internal/actorlog/logger_test.go
+++ b/internal/actorlog/logger_test.go
@@ -247,6 +247,50 @@ func TestWrapContainerLogs_ReservedNamespace(t *testing.T) {
 	assertLabels(t, labels, want)
 }
 
+// TestWrapContainerLogs_ForeignLabelGroup covers the label group this logger does
+// not write. An actor can set either spelling, and the unwritten one is not inert:
+// off GCE a forged logging.googleapis.com/labels is the very key Cloud Logging
+// promotes into LogEntry.labels, so leaving it alone would let the actor outrank
+// substrate's own attribution, and let it match another actor's kubectl ate logs
+// stream. Both spellings fold into one sanitized group.
+func TestWrapContainerLogs_ForeignLabelGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		onGCE   bool
+		foreign string
+	}{
+		{name: "on GCE the plain group is the foreign one", onGCE: true, foreign: labelsKeyPlain},
+		{name: "off GCE the Cloud Logging group is the foreign one", onGCE: false, foreign: labelsKeyGCE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := `{"msg":"App log","` + tt.foreign + `":{"` + actorNameLabel + `":"forged-name",` +
+				`"ate.tenant":"forged","app":"my-app"}}` + "\n"
+
+			var buf bytes.Buffer
+			al := NewActorLogger(&buf, tt.onGCE)
+			al.WrapContainerLogs(strings.NewReader(input), testAttribution, testContainer)
+
+			m := decodeLine(t, &buf)
+			if _, ok := m[tt.foreign]; ok {
+				t.Errorf("foreign label group %q survived: %v", tt.foreign, m[tt.foreign])
+			}
+
+			labels := labelGroup(t, al, m)
+			if _, ok := labels["ate.tenant"]; ok {
+				t.Error("reserved label ate.tenant survived the fold")
+			}
+			want := identityLabels()
+			want["app"] = "my-app"
+			assertLabels(t, labels, want)
+			if len(labels) != len(want) {
+				t.Errorf("got %d labels, want %d: %v", len(labels), len(want), labels)
+			}
+		})
+	}
+}
+
 // TestWrapContainerLogs_NonStringLabelValue guards the GKE label contract: one
 // non-string value under logging.googleapis.com/labels costs the whole record its
 // labels, so actor-supplied values are stringified rather than forwarded as-is.

--- a/internal/ateattr/ateattr.go
+++ b/internal/ateattr/ateattr.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Dotted ate.* matches the metric-instrument naming (atenet.*, atelet.*), not the
-// ate.dev/ slash form used for k8s labels and stdout log fields.
+// ate.dev/ slash form, which is k8s labels only.
 // name vs uid mirror the k8s object model that ResourceMetadata follows:
 // ate.actor.name is the atespace-scoped addressable name, ate.actor.uid is the
 // server-assigned globally-unique key. There is deliberately no ate.actor.id
@@ -40,15 +40,41 @@ import (
 // atespace and template are their own top-level namespaces (ate.atespace,
 // ate.template.*) rather than nested under actor: both are first-class resources
 // that also appear in non-actor telemetry, so the keys must mean the same thing
-// regardless of what a span is about.
+// regardless of what a span is about. ActorContainerNameKey nests under actor for
+// the mirror-image reason: it names a container the ActorTemplate declared, which
+// exists only within an actor. It is deliberately not the registry's
+// k8s.container.name or container.name, both of which the collector already
+// assigns to the worker pod's own containers.
 const (
-	AtespaceKey          = attribute.Key("ate.atespace")
-	ActorNameKey         = attribute.Key("ate.actor.name")
-	ActorUIDKey          = attribute.Key("ate.actor.uid")
-	TemplateNameKey      = attribute.Key("ate.template.name")
-	TemplateNamespaceKey = attribute.Key("ate.template.namespace")
-	ActorVersionKey      = attribute.Key("ate.actor.version")
+	AtespaceKey           = attribute.Key("ate.atespace")
+	ActorNameKey          = attribute.Key("ate.actor.name")
+	ActorUIDKey           = attribute.Key("ate.actor.uid")
+	ActorContainerNameKey = attribute.Key("ate.actor.container.name")
+	TemplateNameKey       = attribute.Key("ate.template.name")
+	TemplateNamespaceKey  = attribute.Key("ate.template.namespace")
+	ActorVersionKey       = attribute.Key("ate.actor.version")
 )
+
+// ReservedNamespace is substrate's. A producer that merges untrusted fields into a
+// record drops everything under it, so nothing a workload sets can read as
+// platform-issued attribution downstream.
+const ReservedNamespace = "ate."
+
+// Trace-context fields for structured logs, per the OTel spec for non-OTLP log
+// formats: these exact names, top-level in the record, lowercase hex. Not ate.*
+// and not attributes - a collector maps them onto the log record's own
+// TraceId/SpanId/flags fields.
+// https://opentelemetry.io/docs/specs/otel/compatibility/logging_trace_context/
+const (
+	LogTraceIDField    = "trace_id"
+	LogSpanIDField     = "span_id"
+	LogTraceFlagsField = "trace_flags"
+)
+
+// OTLPRelayKey is a resource attribute rather than a subject one: it describes
+// how the emitting component reached the collector, not what the signal is about.
+// Only the components that have a relay to take or miss carry it.
+const OTLPRelayKey = attribute.Key("ate.otlp.relay")
 
 // Metric-label keys: the only ate.* attributes allowed on metric datapoints,
 // each with a small bounded value set. High-cardinality identity (actor
@@ -289,6 +315,24 @@ func ActorAttributes(a *ateapipb.Actor) []attribute.KeyValue {
 		TemplateNamespaceKey.String(a.GetActorTemplateNamespace()),
 		ActorVersionKey.Int64(a.GetMetadata().GetVersion()),
 	}
+}
+
+// ActorLogLabels returns the actor identity stamped on every actor log record. A
+// string map because GKE promotes the record's label group into LogEntry.labels,
+// which is string-valued. An empty containerName omits the key rather than
+// emitting it empty, so a consumer filtering on it gets container output only.
+func ActorLogLabels(a resources.ActorAttribution, containerName string) map[string]string {
+	labels := map[string]string{
+		string(AtespaceKey):          a.Ref.Atespace,
+		string(ActorNameKey):         a.Ref.Name,
+		string(ActorUIDKey):          a.UID,
+		string(TemplateNamespaceKey): a.TemplateNamespace,
+		string(TemplateNameKey):      a.TemplateName,
+	}
+	if containerName != "" {
+		labels[string(ActorContainerNameKey)] = containerName
+	}
+	return labels
 }
 
 // ActorMetricAttributes returns the metric labels for an Actor.

--- a/internal/ateattr/ateattr_test.go
+++ b/internal/ateattr/ateattr_test.go
@@ -154,6 +154,7 @@ func TestKeySpellings(t *testing.T) {
 		{AtespaceKey, "ate.atespace"},
 		{ActorNameKey, "ate.actor.name"},
 		{ActorUIDKey, "ate.actor.uid"},
+		{ActorContainerNameKey, "ate.actor.container.name"},
 		{TemplateNameKey, "ate.template.name"},
 		{TemplateNamespaceKey, "ate.template.namespace"},
 		{ActorVersionKey, "ate.actor.version"},
@@ -169,11 +170,105 @@ func TestKeySpellings(t *testing.T) {
 		{SchedulerOutcomeKey, "ate.scheduler.outcome"},
 		{ErrorTypeKey, "error.type"},
 		{FailureReasonKey, "ate.failure.reason"},
+		{OTLPRelayKey, "ate.otlp.relay"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
 			if string(tt.key) != tt.want {
 				t.Errorf("key = %q, want %q", string(tt.key), tt.want)
+			}
+		})
+	}
+}
+
+// TestLogFieldSpellings pins the trace-context field names. These are fixed by
+// the OTel spec for non-OTLP log formats, not ours to choose: a collector only
+// recognizes them at these exact spellings.
+func TestLogFieldSpellings(t *testing.T) {
+	tests := []struct {
+		got  string
+		want string
+	}{
+		{LogTraceIDField, "trace_id"},
+		{LogSpanIDField, "span_id"},
+		{LogTraceFlagsField, "trace_flags"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("field = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestActorLogLabels(t *testing.T) {
+	const containerName = "counter"
+
+	attribution := resources.ActorAttribution{
+		Ref:               resources.ActorRef{Atespace: "team-a", Name: "support-agent-42"},
+		UID:               "uid-abc",
+		TemplateNamespace: "ate-agents",
+		TemplateName:      "support-agent",
+	}
+
+	tests := []struct {
+		name          string
+		attribution   resources.ActorAttribution
+		containerName string
+		want          map[string]string
+	}{
+		{
+			name:          "container output carries the container name",
+			attribution:   attribution,
+			containerName: containerName,
+			want: map[string]string{
+				"ate.atespace":             "team-a",
+				"ate.actor.name":           "support-agent-42",
+				"ate.actor.uid":            "uid-abc",
+				"ate.actor.container.name": containerName,
+				"ate.template.namespace":   "ate-agents",
+				"ate.template.name":        "support-agent",
+			},
+		},
+		{
+			name:          "no container name omits the key rather than emitting it empty",
+			attribution:   attribution,
+			containerName: "",
+			want: map[string]string{
+				"ate.atespace":           "team-a",
+				"ate.actor.name":         "support-agent-42",
+				"ate.actor.uid":          "uid-abc",
+				"ate.template.namespace": "ate-agents",
+				"ate.template.name":      "support-agent",
+			},
+		},
+		{
+			name:          "zero attribution still produces the five identity keys",
+			attribution:   resources.ActorAttribution{},
+			containerName: "",
+			want: map[string]string{
+				"ate.atespace":           "",
+				"ate.actor.name":         "",
+				"ate.actor.uid":          "",
+				"ate.template.namespace": "",
+				"ate.template.name":      "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ActorLogLabels(tt.attribution, tt.containerName)
+			if len(got) != len(tt.want) {
+				t.Errorf("got %d labels, want %d: %v", len(got), len(tt.want), got)
+			}
+			for k, want := range tt.want {
+				if v, ok := got[k]; !ok {
+					t.Errorf("missing label %s", k)
+				} else if v != want {
+					t.Errorf("%s = %q, want %q", k, v, want)
+				}
 			}
 		})
 	}

--- a/internal/ateomstats/actorattribution.go
+++ b/internal/ateomstats/actorattribution.go
@@ -25,34 +25,8 @@ import (
 	"github.com/agent-substrate/substrate/internal/resources"
 )
 
-// ActorAttribution is what a usage sample is attributed to: the actor an ateom
-// retains from the RunWorkloadRequest / RestoreWorkloadRequest that started the
-// workload it is currently executing.
-//
-// ateom is otherwise incurious about who it is running: these fields arrive on
-// the call that starts the workload and are not needed again by the run,
-// checkpoint, or restore paths. GetWorkloadStats needs them, because a usage
-// sample is only useful once attributed to an actor and a template, and the
-// request carries nothing of its own beyond the actor UID it is asserting.
-//
-// This is the same tuple actorlog passes around as loose parameters
-// (EmitLifecycleLog, StartJSONLogPipe, WrapContainerLogs) and that ateattr
-// stamps as ate.actor.* / ate.template.*: an ActorRef plus the two things a ref
-// does not carry, the server-assigned uid and the template it was built from.
-//
-// Unrelated to the credential sense of "actor identity" elsewhere in the repo
-// (ateapi's ActorIdentity service, substratex509, ateompath.ActorIdentityDirPath)
-// — nothing here is a secret or is presented as proof of anything.
-type ActorAttribution struct {
-	Ref               resources.ActorRef
-	UID               string
-	TemplateNamespace string
-	TemplateName      string
-}
-
-// attributionSource is the attribution-bearing subset of the requests that
-// start a workload. Both RunWorkloadRequest and RestoreWorkloadRequest satisfy
-// it.
+// attributionSource is the attribution-bearing subset of the ateom requests
+// that name the actor they act on.
 type attributionSource interface {
 	GetAtespace() string
 	GetActorName() string
@@ -64,12 +38,14 @@ type attributionSource interface {
 var (
 	_ attributionSource = (*ateompb.RunWorkloadRequest)(nil)
 	_ attributionSource = (*ateompb.RestoreWorkloadRequest)(nil)
+	_ attributionSource = (*ateompb.CheckpointWorkloadRequest)(nil)
 )
 
 // ActorAttributionFromRequest extracts the attribution an ateom should retain
-// for the workload req starts.
-func ActorAttributionFromRequest(req attributionSource) ActorAttribution {
-	return ActorAttribution{
+// for the workload req starts: nothing later in the run, checkpoint, or restore
+// paths carries it, and GetWorkloadStats needs it.
+func ActorAttributionFromRequest(req attributionSource) resources.ActorAttribution {
+	return resources.ActorAttribution{
 		Ref: resources.ActorRef{
 			Atespace: req.GetAtespace(),
 			Name:     req.GetActorName(),

--- a/internal/ateomstats/actorattribution_test.go
+++ b/internal/ateomstats/actorattribution_test.go
@@ -27,7 +27,7 @@ import (
 // five values are deliberately distinct strings: the failure this test exists to
 // catch is a field being wired to the wrong source, which same-looking
 // placeholders would hide.
-var fullAttribution = ActorAttribution{
+var fullAttribution = resources.ActorAttribution{
 	Ref:               resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
 	UID:               "uid-c",
 	TemplateNamespace: "template-ns-d",
@@ -38,7 +38,7 @@ func TestActorAttributionFromRequest(t *testing.T) {
 	tests := []struct {
 		name string
 		req  attributionSource
-		want ActorAttribution
+		want resources.ActorAttribution
 	}{
 		{
 			name: "run request",
@@ -68,7 +68,7 @@ func TestActorAttributionFromRequest(t *testing.T) {
 		{
 			name: "empty run request",
 			req:  &ateompb.RunWorkloadRequest{},
-			want: ActorAttribution{},
+			want: resources.ActorAttribution{},
 		},
 		{
 			// The callers hold s.lock and are not defensive about the request
@@ -77,12 +77,12 @@ func TestActorAttributionFromRequest(t *testing.T) {
 			// to direct field access does not turn this into a panic.
 			name: "nil run request",
 			req:  (*ateompb.RunWorkloadRequest)(nil),
-			want: ActorAttribution{},
+			want: resources.ActorAttribution{},
 		},
 		{
 			name: "nil restore request",
 			req:  (*ateompb.RestoreWorkloadRequest)(nil),
-			want: ActorAttribution{},
+			want: resources.ActorAttribution{},
 		},
 	}
 

--- a/internal/contextlogging/contextlogging.go
+++ b/internal/contextlogging/contextlogging.go
@@ -16,9 +16,12 @@ package contextlogging
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
 )
 
 type ContextHandler struct {
@@ -35,11 +38,17 @@ func (h *ContextHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
 	return h.internal.Enabled(ctx, lvl)
 }
 
+// Handle records the active span on the log record under the field names the OTel
+// spec fixes for non-OTLP log formats, so a collector can lift them onto the log
+// record's own trace fields. Gated on the whole span context being valid: a trace
+// ID without a span ID names a request but not the operation within it.
 func (h *ContextHandler) Handle(ctx context.Context, rec slog.Record) error {
-	spanContext := trace.SpanContextFromContext(ctx)
-	if spanContext.HasTraceID() {
-		traceID := spanContext.TraceID()
-		rec.AddAttrs(slog.String("ate.dev/trace-id", traceID.String()))
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		rec.AddAttrs(
+			slog.String(ateattr.LogTraceIDField, sc.TraceID().String()),
+			slog.String(ateattr.LogSpanIDField, sc.SpanID().String()),
+			slog.String(ateattr.LogTraceFlagsField, fmt.Sprintf("%02x", byte(sc.TraceFlags()))),
+		)
 	}
 
 	return h.internal.Handle(ctx, rec)

--- a/internal/contextlogging/contextlogging_test.go
+++ b/internal/contextlogging/contextlogging_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contextlogging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
+)
+
+const (
+	testTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	testSpanID  = "00f067aa0ba902b7"
+)
+
+func spanContext(t *testing.T, flags trace.TraceFlags) trace.SpanContext {
+	t.Helper()
+	traceID, err := trace.TraceIDFromHex(testTraceID)
+	if err != nil {
+		t.Fatalf("TraceIDFromHex(%q): %v", testTraceID, err)
+	}
+	spanID, err := trace.SpanIDFromHex(testSpanID)
+	if err != nil {
+		t.Fatalf("SpanIDFromHex(%q): %v", testSpanID, err)
+	}
+	return trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: flags})
+}
+
+func TestHandleTraceCorrelation(t *testing.T) {
+	tests := []struct {
+		name           string
+		ctx            func(t *testing.T) context.Context
+		wantTraceID    string
+		wantSpanID     string
+		wantTraceFlags string
+	}{
+		{
+			name: "no span in context",
+			ctx:  func(*testing.T) context.Context { return context.Background() },
+		},
+		{
+			name: "invalid span context contributes nothing",
+			ctx: func(*testing.T) context.Context {
+				return trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{}))
+			},
+		},
+		{
+			name: "sampled span",
+			ctx: func(t *testing.T) context.Context {
+				return trace.ContextWithSpanContext(context.Background(), spanContext(t, trace.FlagsSampled))
+			},
+			wantTraceID:    testTraceID,
+			wantSpanID:     testSpanID,
+			wantTraceFlags: "01",
+		},
+		{
+			// An unsampled record still says which request it belongs to; the flags
+			// are what tells a reader why the trace is not in the backend.
+			name: "unsampled span still correlates",
+			ctx: func(t *testing.T) context.Context {
+				return trace.ContextWithSpanContext(context.Background(), spanContext(t, 0))
+			},
+			wantTraceID:    testTraceID,
+			wantSpanID:     testSpanID,
+			wantTraceFlags: "00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := slog.New(NewHandler(slog.NewJSONHandler(&buf, nil)))
+			logger.InfoContext(tt.ctx(t), "something happened")
+
+			var rec map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+				t.Fatalf("failed to parse log record %q: %v", buf.String(), err)
+			}
+
+			for field, want := range map[string]string{
+				ateattr.LogTraceIDField:    tt.wantTraceID,
+				ateattr.LogSpanIDField:     tt.wantSpanID,
+				ateattr.LogTraceFlagsField: tt.wantTraceFlags,
+			} {
+				got, present := rec[field]
+				if want == "" {
+					if present {
+						t.Errorf("%s = %v, want absent", field, got)
+					}
+					continue
+				}
+				if got != want {
+					t.Errorf("%s = %v, want %q", field, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleUngroupedKeepsTraceFieldsTopLevel pins the placement the spec
+// requires: a collector only lifts these onto the log record from the top level.
+func TestHandleUngroupedKeepsTraceFieldsTopLevel(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewHandler(slog.NewJSONHandler(&buf, nil)))
+	ctx := trace.ContextWithSpanContext(context.Background(), spanContext(t, trace.FlagsSampled))
+	logger.With(slog.String("component", "atelet")).InfoContext(ctx, "something happened", slog.String("id", "abc"))
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("failed to parse log record %q: %v", buf.String(), err)
+	}
+	if rec[ateattr.LogTraceIDField] != testTraceID {
+		t.Errorf("%s = %v, want %q at the top level, got record %v", ateattr.LogTraceIDField, rec[ateattr.LogTraceIDField], testTraceID, rec)
+	}
+}

--- a/internal/otlprelay/e2e_test.go
+++ b/internal/otlprelay/e2e_test.go
@@ -121,9 +121,9 @@ func TestEndToEndThroughServerboot(t *testing.T) {
 	}
 }
 
-// relayAttrKey duplicates serverboot's unexported constant. Keeping a literal
-// here is the point: if serverboot renames the attribute, the dashboards and
-// alerts keyed on it break too, and this test is where that shows up.
+// relayAttrKey duplicates ateattr.OTLPRelayKey. Keeping a literal here is the
+// point: if the registry renames the attribute, the dashboards and alerts keyed on
+// it break too, and this test is where that shows up.
 const relayAttrKey = "ate.otlp.relay"
 
 // TestEndToEndFallsBackToDirect is the other half of TestEndToEndThroughServerboot:

--- a/internal/resources/actorattribution.go
+++ b/internal/resources/actorattribution.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+// ActorAttribution is what telemetry about an actor is attributed to: an
+// ActorRef plus the two things a ref does not carry, the server-assigned uid and
+// the template the actor was built from. Shared by ateattr, actorlog, and
+// ateom's usage sampling so those producers cannot drift apart.
+//
+// Unrelated to the credential sense of "actor identity" elsewhere in the repo
+// (ateapi's ActorIdentity service, substratex509, ateompath.ActorIdentityDirPath)
+// — nothing here is a secret or is presented as proof of anything.
+type ActorAttribution struct {
+	Ref               ActorRef
+	UID               string
+	TemplateNamespace string
+	TemplateName      string
+}

--- a/internal/serverboot/serverboot.go
+++ b/internal/serverboot/serverboot.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"sync/atomic"
 
+	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/contextlogging"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -107,18 +108,6 @@ func newResource(ctx context.Context, serviceName string, extraAttrs ...attribut
 	return res, nil
 }
 
-// relayAttrKey records which OTLP export path a signal took. It only makes
-// sense for the components that have a relay to take or miss — the ateoms —
-// so relayAttrs leaves it off everything else rather than labeling, say,
-// atecontroller "direct" for a relay it was never offered.
-//
-// The name is spelled here rather than taken from internal/ateattr on purpose:
-// serverboot is the bottom of the dependency graph (it imports one other
-// agent-substrate package) and every binary's main links it, while ateattr
-// pulls in pkg/api/v1alpha1, ateapipb, internal/resources and ateletpb. Move it
-// to ateattr if that cost ever drops, or if a second non-ate.* consumer appears.
-const relayAttrKey = "ate.otlp.relay"
-
 // relayAttrs describes the export path taken by a component that could have
 // used the relay. relayCapable false means the component never had one, and
 // gets no attribute at all; true means it did, and conn says whether it got it.
@@ -136,7 +125,7 @@ func relayAttrs(relayCapable bool, conn *grpc.ClientConn) []attribute.KeyValue {
 	if conn != nil {
 		status = "relay"
 	}
-	return []attribute.KeyValue{attribute.String(relayAttrKey, status)}
+	return []attribute.KeyValue{ateattr.OTLPRelayKey.String(status)}
 }
 
 // TracingOptions configures InitTracing.

--- a/internal/serverboot/serverboot_test.go
+++ b/internal/serverboot/serverboot_test.go
@@ -31,6 +31,8 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
 )
 
 func resourceAttrs(res *resource.Resource) map[string]string {
@@ -109,15 +111,15 @@ func TestRelayAttrs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("newResource: %v", err)
 			}
-			got, ok := resourceAttrs(res)[relayAttrKey]
+			got, ok := resourceAttrs(res)[string(ateattr.OTLPRelayKey)]
 			if tc.want == "" {
 				if ok {
-					t.Errorf("%s = %q, want absent", relayAttrKey, got)
+					t.Errorf("%s = %q, want absent", string(ateattr.OTLPRelayKey), got)
 				}
 				return
 			}
 			if got != tc.want {
-				t.Errorf("%s = %q, want %q", relayAttrKey, got, tc.want)
+				t.Errorf("%s = %q, want %q", string(ateattr.OTLPRelayKey), got, tc.want)
 			}
 		})
 	}
@@ -156,16 +158,16 @@ func collectedResource(t *testing.T, relayCapable bool, conn *grpc.ClientConn) m
 // (passing the wrong flag, dropping the attrs) fails here and not in
 // TestRelayAttrs.
 func TestMeterProviderRelayAttribute(t *testing.T) {
-	if got, ok := collectedResource(t, true, lazyConn(t))[relayAttrKey]; !ok || got != "relay" {
-		t.Errorf("%s = %q (present %t), want relay", relayAttrKey, got, ok)
+	if got, ok := collectedResource(t, true, lazyConn(t))[string(ateattr.OTLPRelayKey)]; !ok || got != "relay" {
+		t.Errorf("%s = %q (present %t), want relay", string(ateattr.OTLPRelayKey), got, ok)
 	}
-	if got, ok := collectedResource(t, true, nil)[relayAttrKey]; !ok || got != "direct" {
-		t.Errorf("%s = %q (present %t), want direct", relayAttrKey, got, ok)
+	if got, ok := collectedResource(t, true, nil)[string(ateattr.OTLPRelayKey)]; !ok || got != "direct" {
+		t.Errorf("%s = %q (present %t), want direct", string(ateattr.OTLPRelayKey), got, ok)
 	}
 	// atecontroller and ateapi: no relay was ever offered, so no claim is made
 	// about which path they took.
-	if got, ok := collectedResource(t, false, nil)[relayAttrKey]; ok {
-		t.Errorf("%s = %q, want absent for a component with no relay", relayAttrKey, got)
+	if got, ok := collectedResource(t, false, nil)[string(ateattr.OTLPRelayKey)]; ok {
+		t.Errorf("%s = %q, want absent for a component with no relay", string(ateattr.OTLPRelayKey), got)
 	}
 }
 


### PR DESCRIPTION
Actor logs used `ate.dev/actor_*` while spans and metrics use `ate.*` registry in internal/ateattr. This PR makes ateattr the single source of truth for everything telemetry-related.

- Renamed the six actor log labels onto the registry: 
  - `ate.atespace`, `ate.actor.name`, `ate.actor.uid`, `ate.template.namespace`, `ate.template.name`, `ate.actor.container.name`
- Logs join traces now. Records set `trace_id`, `span_id` and `trace_flags`, so you can go from Actor restored to the resume that caused it. Our own lines only, not an actor's stdout: one goroutine forwards a whole container stream and can't know which request produced a given line. Per line correlation comes with #853.
- Actors can't fake platform labels. They already couldn't overwrite ours, but they could invent new ones like `ate.tenant` that look platform issued downstream. Anything under `ate.` from an actor is now dropped.
- Fixed the asymmetry that was actually left: actor supplied label values weren't stringified, and one non string value makes Cloud Logging discard the labels for that whole entry.
- Note: the actor_uid bullet in the issue is stale, #841 fixed it earlier. Lifecycle records still set five labels rather than six, on purpose as they're about the actor, so no container produced them.

Fixes #886

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
