### PR TITLE
benchmarking: right-size actor memory, default 256Mi

### DIFF
--- a/benchmarking/automation/orchestrator.py
+++ b/benchmarking/automation/orchestrator.py
@@ -314,17 +314,22 @@ def teardown_microvm_deps() -> None:
     run_no_check(["hack/install-microvm-deps.sh", "--delete"])
 
 
-def deploy_workloads(worker_count: int = 1, sandbox_class: str = "gvisor") -> None:
-    run(
-        [
-            "benchmarking/workloads/deploy.sh",
-            "--deploy",
-            "--worker-count",
-            str(worker_count),
-            "--sandbox-class",
-            sandbox_class,
-        ]
-    )
+def deploy_workloads(
+    worker_count: int = 1, sandbox_class: str = "gvisor", actor_memory: str = ""
+) -> None:
+    cmd = [
+        "benchmarking/workloads/deploy.sh",
+        "--deploy",
+        "--worker-count",
+        str(worker_count),
+        "--sandbox-class",
+        sandbox_class,
+    ]
+    # Empty keeps the default in workloads/deploy.sh (512Mi, the microvm
+    # minimum); RAM-consuming suites set actorMemory in tests.yaml.
+    if actor_memory:
+        cmd += ["--actor-memory", actor_memory]
+    run(cmd)
     # Block until ActorTemplates are Ready
     run(
         [
@@ -508,7 +513,11 @@ def main() -> None:
                 # deploy_workloads needs the microvm SandboxConfig.
                 if sandbox_class == "microvm":
                     install_microvm_deps()
-                deploy_workloads(test.get("workerCount", 1), sandbox_class)
+                deploy_workloads(
+                    test.get("workerCount", 1),
+                    sandbox_class,
+                    test.get("actorMemory", ""),
+                )
                 try:
                     status = run_test(
                         test,

--- a/benchmarking/automation/orchestrator.py
+++ b/benchmarking/automation/orchestrator.py
@@ -325,7 +325,7 @@ def deploy_workloads(
         "--sandbox-class",
         sandbox_class,
     ]
-    # Empty keeps the default in workloads/deploy.sh (512Mi, the microvm
+    # Empty keeps the default in workloads/deploy.sh (256Mi, the microvm
     # minimum); RAM-consuming suites set actorMemory in tests.yaml.
     if actor_memory:
         cmd += ["--actor-memory", actor_memory]

--- a/benchmarking/automation/tests.yaml
+++ b/benchmarking/automation/tests.yaml
@@ -27,7 +27,7 @@
 # Optional `sandboxClass` (default "gvisor") picks the sandbox runtime for
 # the benchmark WorkerPool. Allowed values: "gvisor" | "microvm".
 #
-# Optional `actorMemory` (default "512Mi", the smallest size microvm admits)
+# Optional `actorMemory` (default "256Mi", the smallest size microvm admits)
 # sets the memory limit on the benchmark ActorTemplates. Raise it for suites
 # that exercise glutton's WriteRAM path.
 #

--- a/benchmarking/automation/tests.yaml
+++ b/benchmarking/automation/tests.yaml
@@ -27,6 +27,10 @@
 # Optional `sandboxClass` (default "gvisor") picks the sandbox runtime for
 # the benchmark WorkerPool. Allowed values: "gvisor" | "microvm".
 #
+# Optional `actorMemory` (default "512Mi", the smallest size microvm admits)
+# sets the memory limit on the benchmark ActorTemplates. Raise it for suites
+# that exercise glutton's WriteRAM path.
+#
 # Required `targetCluster` names a config file under
 # /etc/orchestrator/target-clusters/ (e.g. `targetCluster: dev` ->
 # /etc/orchestrator/target-clusters/dev.sh). The orchestrator copies that

--- a/benchmarking/deploy_locust.sh
+++ b/benchmarking/deploy_locust.sh
@@ -29,7 +29,7 @@ WORKER_COUNT=1
 SANDBOX_CLASS=gvisor
 SKIP_BUILD=0
 OTLP_ENDPOINT=""
-# Empty keeps the default in workloads/deploy.sh (512Mi, the microvm minimum).
+# Empty keeps the default in workloads/deploy.sh (256Mi, the microvm minimum).
 ACTOR_MEMORY=""
 
 usage() {
@@ -44,7 +44,7 @@ usage() {
   echo "  --otlp-endpoint URL     Forwarded to workloads/deploy.sh. The address to which an"
   echo "                          instrumented actor container sends telemetry."
   echo "  --actor-memory SIZE     Forwarded to workloads/deploy.sh. Memory limit for the"
-  echo "                          benchmark ActorTemplates (default: 512Mi, the microvm minimum)."
+  echo "                          benchmark ActorTemplates (default: 256Mi, the microvm minimum)."
   echo "  --skip-build            Skip locust image build/push (use the existing :latest image)"
   echo "  -h|--help               Show this help message"
   echo ""

--- a/benchmarking/deploy_locust.sh
+++ b/benchmarking/deploy_locust.sh
@@ -29,6 +29,8 @@ WORKER_COUNT=1
 SANDBOX_CLASS=gvisor
 SKIP_BUILD=0
 OTLP_ENDPOINT=""
+# Empty keeps the default in workloads/deploy.sh (512Mi, the microvm minimum).
+ACTOR_MEMORY=""
 
 usage() {
   echo "Usage: $0 [options]"
@@ -41,6 +43,8 @@ usage() {
   echo "                          microvm requires hack/install-microvm-deps.sh --install to have run."
   echo "  --otlp-endpoint URL     Forwarded to workloads/deploy.sh. The address to which an"
   echo "                          instrumented actor container sends telemetry."
+  echo "  --actor-memory SIZE     Forwarded to workloads/deploy.sh. Memory limit for the"
+  echo "                          benchmark ActorTemplates (default: 512Mi, the microvm minimum)."
   echo "  --skip-build            Skip locust image build/push (use the existing :latest image)"
   echo "  -h|--help               Show this help message"
   echo ""
@@ -65,6 +69,8 @@ while [[ "$#" -gt 0 ]]; do
     --sandbox-class=*) SANDBOX_CLASS="${1#*=}" ;;
     --otlp-endpoint) shift; OTLP_ENDPOINT="$1" ;;
     --otlp-endpoint=*) OTLP_ENDPOINT="${1#*=}" ;;
+    --actor-memory) shift; ACTOR_MEMORY="$1" ;;
+    --actor-memory=*) ACTOR_MEMORY="${1#*=}" ;;
     --skip-build) SKIP_BUILD=1 ;;
     -h|--help) usage; exit 0 ;;
     *)
@@ -92,6 +98,9 @@ if [[ "${action}" == "deploy" ]]; then
   workload_args=(--deploy --worker-count "${WORKER_COUNT}" --sandbox-class "${SANDBOX_CLASS}")
   if [[ -n "${OTLP_ENDPOINT}" ]]; then
     workload_args+=(--otlp-endpoint "${OTLP_ENDPOINT}")
+  fi
+  if [[ -n "${ACTOR_MEMORY}" ]]; then
+    workload_args+=(--actor-memory "${ACTOR_MEMORY}")
   fi
   "${BENCHMARKING_DIR}/workloads/deploy.sh" "${workload_args[@]}"
 

--- a/benchmarking/workloads/deploy.sh
+++ b/benchmarking/workloads/deploy.sh
@@ -39,10 +39,10 @@ fi
 WORKER_COUNT=1
 SANDBOX_CLASS="gvisor"
 # Actor memory limit (ActorTemplate spec.resources.limits.memory). The default
-# is the smallest size microvm admits (256Mi VMM reserve + 256Mi guest floor),
+# is the smallest size microvm admits (128Mi VMM reserve + 128Mi guest floor),
 # so benchmark actors do not inherit the 2 GiB kata default and drag its page
 # cache into every memory snapshot. Raise it for RAM-consuming suites.
-ACTOR_MEMORY="512Mi"
+ACTOR_MEMORY="256Mi"
 # The address to which an instrumented actor container sends its telemetry.
 # --otlp-endpoint sets it. Without the flag, resolve_otlp_endpoint reads the
 # address that the control plane uses.
@@ -57,7 +57,7 @@ usage() {
   echo "  --worker-count N            Number of WorkerPool replicas (default: 1)"
   echo "  --sandbox-class CLASS       Sandbox runtime for the WorkerPool: gvisor | microvm (default: gvisor)."
   echo "                              microvm requires hack/install-microvm-deps.sh --install to have run."
-  echo "  --actor-memory SIZE         Memory limit for the benchmark ActorTemplates (default: 512Mi,"
+  echo "  --actor-memory SIZE         Memory limit for the benchmark ActorTemplates (default: 256Mi,"
   echo "                              the smallest size microvm admits)"
   echo "  --otlp-endpoint URL         The address to which an instrumented actor container"
   echo "                              sends telemetry (default: the endpoint in the"

--- a/benchmarking/workloads/deploy.sh
+++ b/benchmarking/workloads/deploy.sh
@@ -38,6 +38,11 @@ fi
 
 WORKER_COUNT=1
 SANDBOX_CLASS="gvisor"
+# Actor memory limit (ActorTemplate spec.resources.limits.memory). The default
+# is the smallest size microvm admits (256Mi VMM reserve + 256Mi guest floor),
+# so benchmark actors do not inherit the 2 GiB kata default and drag its page
+# cache into every memory snapshot. Raise it for RAM-consuming suites.
+ACTOR_MEMORY="512Mi"
 # The address to which an instrumented actor container sends its telemetry.
 # --otlp-endpoint sets it. Without the flag, resolve_otlp_endpoint reads the
 # address that the control plane uses.
@@ -52,6 +57,8 @@ usage() {
   echo "  --worker-count N            Number of WorkerPool replicas (default: 1)"
   echo "  --sandbox-class CLASS       Sandbox runtime for the WorkerPool: gvisor | microvm (default: gvisor)."
   echo "                              microvm requires hack/install-microvm-deps.sh --install to have run."
+  echo "  --actor-memory SIZE         Memory limit for the benchmark ActorTemplates (default: 512Mi,"
+  echo "                              the smallest size microvm admits)"
   echo "  --otlp-endpoint URL         The address to which an instrumented actor container"
   echo "                              sends telemetry (default: the endpoint in the"
   echo "                              ate-otel-config ConfigMap)"
@@ -95,12 +102,13 @@ substitute() {
       -e "s|\${SANDBOX_CLASS}|${SANDBOX_CLASS}|g" \
       -e "s|\${SANDBOX_CONFIG_NAME}|${sandbox_config_name}|g" \
       -e "s|\${OTLP_ENDPOINT}|${OTLP_ENDPOINT}|g" \
+      -e "s|\${ACTOR_MEMORY}|${ACTOR_MEMORY}|g" \
       "${MANIFEST_TEMPLATE}"
 }
 
 deploy() {
   resolve_otlp_endpoint
-  echo "Deploying workloads (worker_count=${WORKER_COUNT}, otlp_endpoint=${OTLP_ENDPOINT})..."
+  echo "Deploying workloads (worker_count=${WORKER_COUNT}, actor_memory=${ACTOR_MEMORY}, otlp_endpoint=${OTLP_ENDPOINT})..."
   # ActorTemplate.spec has the rule `self == oldSelf` (see
   # pkg/api/v1alpha1/actortemplate_types.go). Thus the API server rejects an
   # apply that changes a template. A value that changes for each run — the OTLP
@@ -153,6 +161,13 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --otlp-endpoint=*)
       OTLP_ENDPOINT="${1#*=}"
+      ;;
+    --actor-memory)
+      shift
+      ACTOR_MEMORY="$1"
+      ;;
+    --actor-memory=*)
+      ACTOR_MEMORY="${1#*=}"
       ;;
     -h|--help)
       usage

--- a/benchmarking/workloads/manifests/workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/workloads.yaml.tmpl
@@ -46,6 +46,13 @@ spec:
   - name: sleep
     image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
     command: ["/bin/sleep", "1000000"]
+  # Without a limit a microvm actor gets the kata default 2 GiB guest, and
+  # anything the guest kernel caches rides along in the memory snapshot —
+  # bigger guest, bigger snapshot, slower suspend/resume. microvm requires at
+  # least 512Mi (256Mi VMM reserve + 256Mi guest floor).
+  resources:
+    limits:
+      memory: ${ACTOR_MEMORY}
   workerSelector:
     matchLabels:
       workload: benchmark-ateom
@@ -92,6 +99,12 @@ spec:
       httpGet:
         path: /readyz
         port: 80
+  # See the note on the sleep template: unset means the 2 GiB microvm default,
+  # which the benchmarks should not silently inherit. Raise ${ACTOR_MEMORY}
+  # for suites that exercise glutton's WriteRAM path.
+  resources:
+    limits:
+      memory: ${ACTOR_MEMORY}
   workerSelector:
     matchLabels:
       workload: benchmark-ateom

--- a/benchmarking/workloads/manifests/workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/workloads.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
   # Without a limit a microvm actor gets the kata default 2 GiB guest, and
   # anything the guest kernel caches rides along in the memory snapshot —
   # bigger guest, bigger snapshot, slower suspend/resume. microvm requires at
-  # least 512Mi (256Mi VMM reserve + 256Mi guest floor).
+  # least 256Mi (128Mi VMM reserve + 128Mi guest floor).
   resources:
     limits:
       memory: ${ACTOR_MEMORY}

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -105,6 +105,8 @@ function usage() {
   echo "  --benchmark-worker-count N             Number of WorkerPool replicas (default: 1)"
   echo "  --benchmark-sandbox-class CLASS        Sandbox runtime for the benchmark WorkerPool: gvisor | microvm (default: gvisor)."
   echo "                                         microvm requires hack/install-microvm-deps.sh --install to have run."
+  echo "  --benchmark-actor-memory SIZE          Memory limit for the benchmark ActorTemplates (default: 512Mi,"
+  echo "                                         the smallest size microvm admits)"
   echo ""
   for demo_name in "${ATE_DEMOS[@]}"; do
     echo "Demo: ${demo_name}"
@@ -874,6 +876,9 @@ deploy_benchmarks() {
   if [[ -n "${ATE_OTLP_ENDPOINT:-}" ]]; then
     benchmark_args+=(--otlp-endpoint "${ATE_OTLP_ENDPOINT}")
   fi
+  if [[ -n "${BENCHMARK_ACTOR_MEMORY}" ]]; then
+    benchmark_args+=(--actor-memory "${BENCHMARK_ACTOR_MEMORY}")
+  fi
   "${ROOT}/benchmarking/deploy_locust.sh" "${benchmark_args[@]}"
 }
 
@@ -918,6 +923,8 @@ done
 SETUP_CSI=false
 BENCHMARK_WORKER_COUNT=1
 BENCHMARK_SANDBOX_CLASS=gvisor
+# Empty keeps the default in benchmarking/workloads/deploy.sh (512Mi).
+BENCHMARK_ACTOR_MEMORY=""
 prescan_args=("$@")
 for ((i = 0; i < ${#prescan_args[@]}; i++)); do
   case "${prescan_args[i]}" in
@@ -961,6 +968,16 @@ for ((i = 0; i < ${#prescan_args[@]}; i++)); do
       ;;
     --benchmark-sandbox-class=*)
       BENCHMARK_SANDBOX_CLASS="${prescan_args[i]#*=}"
+      ;;
+    --benchmark-actor-memory)
+      if (( i + 1 >= ${#prescan_args[@]} )); then
+        echo "Error: --benchmark-actor-memory requires a size (e.g. 512Mi)" >&2
+        exit 1
+      fi
+      BENCHMARK_ACTOR_MEMORY="${prescan_args[$((i + 1))]}"
+      ;;
+    --benchmark-actor-memory=*)
+      BENCHMARK_ACTOR_MEMORY="${prescan_args[i]#*=}"
       ;;
     --otlp-endpoint)
       if (( i + 1 >= ${#prescan_args[@]} )); then
@@ -1056,6 +1073,8 @@ while [[ "$#" -gt 0 ]]; do
     --benchmark-worker-count=*) ;;
     --benchmark-sandbox-class) shift ;;
     --benchmark-sandbox-class=*) ;;
+    --benchmark-actor-memory) shift ;;
+    --benchmark-actor-memory=*) ;;
     --otlp-endpoint) shift ;;
     --otlp-endpoint=*) ;;
 

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -105,7 +105,7 @@ function usage() {
   echo "  --benchmark-worker-count N             Number of WorkerPool replicas (default: 1)"
   echo "  --benchmark-sandbox-class CLASS        Sandbox runtime for the benchmark WorkerPool: gvisor | microvm (default: gvisor)."
   echo "                                         microvm requires hack/install-microvm-deps.sh --install to have run."
-  echo "  --benchmark-actor-memory SIZE          Memory limit for the benchmark ActorTemplates (default: 512Mi,"
+  echo "  --benchmark-actor-memory SIZE          Memory limit for the benchmark ActorTemplates (default: 256Mi,"
   echo "                                         the smallest size microvm admits)"
   echo ""
   for demo_name in "${ATE_DEMOS[@]}"; do
@@ -923,7 +923,7 @@ done
 SETUP_CSI=false
 BENCHMARK_WORKER_COUNT=1
 BENCHMARK_SANDBOX_CLASS=gvisor
-# Empty keeps the default in benchmarking/workloads/deploy.sh (512Mi).
+# Empty keeps the default in benchmarking/workloads/deploy.sh (256Mi).
 BENCHMARK_ACTOR_MEMORY=""
 prescan_args=("$@")
 for ((i = 0; i < ${#prescan_args[@]}; i++)); do
@@ -971,7 +971,7 @@ for ((i = 0; i < ${#prescan_args[@]}; i++)); do
       ;;
     --benchmark-actor-memory)
       if (( i + 1 >= ${#prescan_args[@]} )); then
-        echo "Error: --benchmark-actor-memory requires a size (e.g. 512Mi)" >&2
+        echo "Error: --benchmark-actor-memory requires a size (e.g. 256Mi)" >&2
         exit 1
       fi
       BENCHMARK_ACTOR_MEMORY="${prescan_args[$((i + 1))]}"


### PR DESCRIPTION
#### benchmarking: right-size actor memory, default 256Mi

Benchmark `ActorTemplates` declared no resources, so microvm actors fell through to the 2 GiB kata default guest — and everything the guest kernel caches rides along in the memory snapshot, inflating snapshot size and suspend/resume latency, which the benchmarks then measure.

Set `spec.resources.limits.memory` on the `glutton` and `sleep` templates, parameterized as `ACTOR_MEMORY` with a `256Mi` default (the smallest size microvm admits: 128Mi VMM reserve + 128Mi guest floor), and thread it through the deploy chain:
- `--actor-memory` on `workloads/deploy.sh` and `deploy_locust.sh`
- `--benchmark-actor-memory` on `install-ate.sh`
- Optional per-test `actorMemory` field in the automation's `tests.yaml` for future `WriteRAM` stress suites.