### PR TITLE
ateapi: authorize MintCert against the store, not the worker cache

### DIFF
--- a/cmd/ateapi/internal/actoridentity/actoridentity.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/actoridjwt"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
-	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/localca"
 	"github.com/agent-substrate/substrate/internal/localjwtauthority"
 	"github.com/agent-substrate/substrate/internal/principal"
@@ -55,19 +54,17 @@ type Server struct {
 
 	// store is the actor database. MintCert consults it to confirm the caller
 	// is entitled to the actor it is asking for a credential for.
-	store   store.Interface
-	workers *workercache.Cache
+	store store.Interface
 }
 
 var _ ateapipb.ActorIdentityServer = (*Server)(nil)
 
-func New(actorIdentityJWTIssuer, actorIDJWTPoolFile, actorIDCAPoolFile string, store store.Interface, workers *workercache.Cache) *Server {
+func New(actorIdentityJWTIssuer, actorIDJWTPoolFile, actorIDCAPoolFile string, store store.Interface) *Server {
 	return &Server{
 		actorIdentityJWTIssuer: actorIdentityJWTIssuer,
 		actorIDJWTPoolFile:     actorIDJWTPoolFile,
 		actorIDCAPoolFile:      actorIDCAPoolFile,
 		store:                  store,
-		workers:                workers,
 	}
 }
 
@@ -326,7 +323,7 @@ func (s *Server) authorizeActor(ctx context.Context, caller *ateletCaller, req *
 		return status.Errorf(codes.PermissionDenied, "caller is not permitted to mint credentials for this actor")
 	}
 
-	worker, err := s.workers.Worker(req.GetWorker().GetName())
+	worker, err := s.store.GetWorker(ctx, req.GetWorker().GetName())
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return nil, resources.ActorRef{}, deny("worker not found")

--- a/cmd/ateapi/internal/actoridentity/actoridentity_test.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
-	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/localca"
 	"github.com/agent-substrate/substrate/internal/principal"
 	"github.com/agent-substrate/substrate/internal/resources"
@@ -154,16 +153,7 @@ func newTestServer(t *testing.T, st store.Interface) *Server {
 		t.Fatalf("write CA pool: %v", err)
 	}
 
-	var workers *workercache.Cache
-	if st != nil {
-		workers = workercache.New(st, time.Hour)
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
-		if err := workers.Start(ctx); err != nil {
-			t.Fatalf("start worker cache: %v", err)
-		}
-	}
-	return New("issuer", "", poolFile, st, workers)
+	return New("issuer", "", poolFile, st)
 }
 
 func TestMintJWTRequiresConfiguredJWTProvider(t *testing.T) {
@@ -717,6 +707,51 @@ func TestMintCertDeniesUnassignedActorWhateverItsState(t *testing.T) {
 	}
 }
 
+// assignmentOnlyInStore serves one worker's committed assignment from
+// GetWorker alone; List and Watch still report it unassigned, the way a
+// watch-fed cache sees the store until the event lands.
+type assignmentOnlyInStore struct {
+	store.Interface
+	worker *ateapipb.Worker
+}
+
+func (s *assignmentOnlyInStore) GetWorker(ctx context.Context, name string) (*ateapipb.Worker, error) {
+	if name == s.worker.GetMetadata().GetName() {
+		return s.worker, nil
+	}
+	return s.Interface.GetWorker(ctx, name)
+}
+
+// TestMintCertUsesAnAssignmentAsSoonAsItIsWritten guards the invariant the gate
+// rests on: it reads the store, so an assignment is usable the instant resume
+// writes it. A gate behind a replica-local cache denies inside the lag window.
+func TestMintCertUsesAnAssignmentAsSoonAsItIsWritten(t *testing.T) {
+	ctx := context.Background()
+	st, cleanup := storetest.SetupTestStore(t)
+	defer cleanup()
+
+	seedActor(t, ctx, st, actorFixture{
+		state:      ateapipb.ActorState_ACTOR_STATE_RESUMING,
+		workerNode: testNode,
+		unassigned: true,
+	})
+	actorRef := resources.ActorRef{Atespace: testAtespace, Name: testActorName}
+	actor, err := st.GetActor(ctx, actorRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker, err := st.GetWorker(ctx, testWorkerName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker.Status.Assignment = &ateapipb.ActorAssignment{Actor: actorRef.ToObjectRef(), ActorUid: actor.GetMetadata().GetUid()}
+	srv := newTestServer(t, &assignmentOnlyInStore{Interface: st, worker: worker})
+
+	if _, err := srv.MintCert(ctxWithCert(ateletCertOn(t, testNode)), mintCertRequest(t, actor.GetMetadata().GetUid())); err != nil {
+		t.Errorf("MintCert() error = %v, want success from the assignment the store holds", err)
+	}
+}
+
 // TestMintCertAuthorizesBeforeSigning checks that the gate runs before any CSR
 // parsing or CA material is touched. An unauthorized caller must be rejected
 // with PermissionDenied even when the rest of the request is unusable, so that
@@ -730,13 +765,7 @@ func TestMintCertAuthorizesBeforeSigning(t *testing.T) {
 
 	// A server whose CA pool file does not exist: reaching the signing path at
 	// all would surface as Internal rather than PermissionDenied.
-	workers := workercache.New(st, time.Hour)
-	cacheCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	if err := workers.Start(cacheCtx); err != nil {
-		t.Fatal(err)
-	}
-	srv := New("issuer", "", filepath.Join(t.TempDir(), "missing.json"), st, workers)
+	srv := New("issuer", "", filepath.Join(t.TempDir(), "missing.json"), st)
 
 	actor, err := st.GetActor(ctx, resources.ActorRef{Atespace: testAtespace, Name: testActorName})
 	if err != nil {

--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -195,7 +195,7 @@ func main() {
 	ateletDialer := controlapi.NewAteletDialer(workerPodInformer.GetIndexer(), ateletPodInformer.GetIndexer(), *ateletClientCredBundle, *podIdentityCACerts)
 	sm := controlapi.NewService(persistence, workerCache, actorTemplateLister, workerPoolLister, sandboxConfigLister, csiDriverConfigLister, storageClassLister, ateletDialer, instruments, *egressGatewayAddress, volPlugins)
 
-	actorIdentitySrv := actoridentity.New(actorIdentityJWTIssuer, *actorIDJWTPoolFile, *actorIDCAPoolFile, persistence, workerCache)
+	actorIdentitySrv := actoridentity.New(actorIdentityJWTIssuer, *actorIDJWTPoolFile, *actorIDCAPoolFile, persistence)
 	debugSrv := debugapi.NewService(persistence)
 
 	lisCfg := &net.ListenConfig{}


### PR DESCRIPTION
Fixes #964

Resume can deny `MintCert` after the worker assignment is committed, so atelet fails `CallAteletRestore` and the resume is lost.

`authorizeActor` resolves the worker through the watch-fed worker cache, which lags the store by the pub/sub round trip; authorization already reads the actor from the store, so only the worker lookup could observe the stale state.

## Fix

Read the worker from the store too (`s.store.GetWorker`), the same authoritative source the actor already comes from. Credential minting must see committed assignment state; cache retries or a version barrier would only shrink the window. This adds one point read per `MintCert` and removes the `workercache` dependency from `actoridentity`. The cache keeps serving scheduling and worker-count paths, where eventual consistency is fine.

Since #1000 workers are global resources named by pod UID, so the request already carries the exact key the store needs; the earlier revision of this PR re-keyed workers by `(namespace, pod)` and hardened the syncer around that, all of which #1000 and #1014 now cover on main.

## Evidence

Before, in [run 31628573958, attempt 1](https://github.com/agent-substrate/substrate/actions/runs/31628573958/attempts/1):

```
18:50:06.844788  UpdateWorker commits the assignment
18:50:06.856480  ActorIdentity denies: worker has no actor assignment
18:50:06.858441  ResumeActor fails at CallAteletRestore

--- PASS: TestMintCertAuthorization (0.13s)
--- PASS: TestMintCertUsesAnAssignmentAsSoonAsItIsWritten (0.01s)
ok  	github.com/agent-substrate/substrate/cmd/ateapi/internal/actoridentity	1.591s
```

The new test seeds an unassigned worker, writes the assignment directly to the store, and mints immediately; it is the 11.7 ms window from the log with no cache in between.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

Supersedes #965, which was closed by an accidental force-push to its branch and cannot be reopened.
