### PR TITLE
microvm: mount the rootfs overlays volatile

### DIFF
--- a/cmd/ateom-microvm/internal/kata/overlay_linux.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux.go
@@ -188,6 +188,11 @@ func StageMergedRootfs(ctx context.Context, bundleRootfs, upperBase, restoreID, 
 	if err := reaper.Run(exec.Command("umount", dst)); err != nil {
 		_ = reaper.Run(exec.Command("umount", "-l", dst))
 	}
+	// The workdir is scratch: wipe it so a volatile mount is never refused by a
+	// dirty marker left behind by the previous activation.
+	if err := os.RemoveAll(work); err != nil {
+		return fmt.Errorf("clearing overlay workdir %q: %w", work, err)
+	}
 	for _, d := range []string{dst, upper, work} {
 		if err := os.MkdirAll(d, 0o755); err != nil {
 			return fmt.Errorf("creating %q: %w", d, err)
@@ -203,8 +208,13 @@ func StageMergedRootfs(ctx context.Context, bundleRootfs, upperBase, restoreID, 
 	// off, every copy-up is a full data copy and the upper is self-contained —
 	// the portability the find-paths comment above promises. (redirect_dir is
 	// path-based and travels fine, so it stays at the kernel default.)
+	// volatile: skip the sync overlayfs would otherwise do on this upper,
+	// including at umount. The upper is throwaway — it is tarred into the
+	// snapshot and then deleted — so the durability volatile gives up is
+	// durability we do not use. It refuses to mount over a workdir left dirty by
+	// a previous volatile mount, hence the wipe above.
 	opts := "lowerdir=" + bundleRootfs + ",upperdir=" + upper + ",workdir=" + work +
-		",metacopy=off,index=off"
+		",metacopy=off,index=off,volatile"
 	cmd := exec.CommandContext(ctx, "mount", "-t", "overlay", "overlay", "-o", opts, dst)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr

--- a/internal/imagecache/bundle_linux.go
+++ b/internal/imagecache/bundle_linux.go
@@ -131,6 +131,15 @@ func mountOverlay(mountpoint string, lowers []string, upper, work string) error 
 	if err := set("workdir", work); err != nil {
 		return err
 	}
+	// volatile: skip overlayfs's syncs on this upper, including the one it does
+	// at umount, which measured ~450ms per actor on GKE. The bundle upper holds
+	// only copy-ups made during one activation and atelet wipes it between them
+	// (RemoveAllWritable), so nothing here is expected to outlive a crash. Note
+	// the merged rootfs overlay stacked on top of this one must be volatile too:
+	// with only one of them volatile the sync simply moves to the other.
+	if err := unix.FsconfigSetFlag(fsfd, "volatile"); err != nil {
+		return fmt.Errorf("while setting overlay volatile: %w%s", err, fsContextLog(fsfd))
+	}
 
 	if err := unix.FsconfigCreate(fsfd); err != nil {
 		return fmt.Errorf("while creating overlay superblock: %w%s", err, fsContextLog(fsfd))


### PR DESCRIPTION
Suspend on micro-VM cost ~590ms against gVisor's ~99ms on GKE, and phase timing put ~490ms of that in teardown - specifically in one umount, after the snapshot was already on disk. It is overlayfs syncing the upper at umount.

Mount both overlays volatile to skip the syncs (it must be both or we just move the sync to the last one unmounted).

Measured on GKE, counter demo, 4 suspend/resume cycles:
```
  teardown             433-579ms -> 21-31ms
  CheckpointWorkload   549-695ms -> 105-113ms   (gVisor: 92-134ms)
  RestoreWorkload      unchanged at ~160ms
```

Noting: Writes an actor makes to its own rootfs, including through fsync, may not reach disk if the node crashes.

This substantially improves uVM checkpoint inline with gvisor.

https://www.redhat.com/en/blog/container-volatile-overlay-mounts


