### PR TITLE
microvm: log the guest over virtio-console, not the emulated UART

### DIFF
--- a/cmd/ateom-microvm/internal/kata/restore.go
+++ b/cmd/ateom-microvm/internal/kata/restore.go
@@ -30,6 +30,14 @@ func VMDir(id string) string { return filepath.Join(vcVMDir, id) }
 // references; CH recreates the listener here on restore.
 func VsockSocketPath(id string) string { return filepath.Join(VMDir(id), "clh.sock") }
 
+// ConsoleLogPath is where the guest's virtio-console (hvc0) is captured: the kernel
+// log from virtio-console probe onwards, plus everything the kata-agent prints.
+func ConsoleLogPath(id string) string { return filepath.Join(VMDir(id), "console.log") }
+
+// SerialLogPath is where the emulated UART is captured. Only wired up in debug mode,
+// where it carries the early-boot messages hvc0 is too late to see.
+func SerialLogPath(id string) string { return filepath.Join(VMDir(id), "serial.log") }
+
 // DurableVirtiofsdSocketPath is the vhost-user-fs socket for the actor's writable
 // durable-dir share, served by a second virtiofsd alongside the rootfs share's.
 func DurableVirtiofsdSocketPath(id string) string {

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -463,13 +463,21 @@ func rewriteSnapshotSocketPaths(snapshotDir, id string) error {
 	if vsock, ok := cfg["vsock"].(map[string]any); ok {
 		vsock["socket"] = kata.VsockSocketPath(id)
 	}
-	// ateom captures the guest serial console to a file under the source actor's
-	// VMDir (Serial{Mode:"File"}). On restore that path is stale
-	// (points at the golden/source pod's VMDir), so CH's CreateConsoleDevice fails
-	// (No such file or directory). Repoint it at this actor's VMDir.
-	if serial, ok := cfg["serial"].(map[string]any); ok {
-		if mode, _ := serial["mode"].(string); mode == "File" {
-			serial["file"] = filepath.Join(kata.VMDir(id), "serial.log")
+	// ateom captures the guest console to a file under the source actor's VMDir
+	// (virtio-console normally, plus the UART in debug mode). On restore those paths
+	// are stale (they point at the golden/source pod's VMDir), so CH's
+	// CreateConsoleDevice fails (No such file or directory). Repoint them at this
+	// actor's VMDir.
+	for key, path := range map[string]string{
+		"console": kata.ConsoleLogPath(id),
+		"serial":  kata.SerialLogPath(id),
+	} {
+		dev, ok := cfg[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		if mode, _ := dev["mode"].(string); mode == "File" {
+			dev["file"] = path
 		}
 	}
 	// The virtio-fs share is served by its per-VMDir virtiofsd socket; the

--- a/cmd/ateom-microvm/restore_test.go
+++ b/cmd/ateom-microvm/restore_test.go
@@ -26,14 +26,17 @@ import (
 )
 
 // writeSnapshotConfig writes a config.json holding the given fs devices (plus the
-// vsock and serial entries every snapshot has) into a fresh snapshot dir.
+// vsock and console entries every snapshot has) into a fresh snapshot dir. The
+// serial device is the debug-mode one, present here so the rewrite is exercised
+// against a snapshot that has both.
 func writeSnapshotConfig(t *testing.T, fsDevices []map[string]any) string {
 	t.Helper()
 	dir := t.TempDir()
 	cfg := map[string]any{
-		"vsock":  map[string]any{"cid": 3, "socket": "/run/vc/vm/golden/clh.sock"},
-		"serial": map[string]any{"mode": "File", "file": "/run/vc/vm/golden/serial.log"},
-		"fs":     fsDevices,
+		"vsock":   map[string]any{"cid": 3, "socket": "/run/vc/vm/golden/clh.sock"},
+		"console": map[string]any{"mode": "File", "file": "/run/vc/vm/golden/console.log"},
+		"serial":  map[string]any{"mode": "File", "file": "/run/vc/vm/golden/serial.log"},
+		"fs":      fsDevices,
 	}
 	b, err := json.Marshal(cfg)
 	if err != nil {
@@ -121,7 +124,7 @@ func TestRewriteSnapshotSocketPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("vsock and serial are repointed", func(t *testing.T) {
+	t.Run("vsock and console devices are repointed", func(t *testing.T) {
 		dir := writeSnapshotConfig(t, []map[string]any{
 			{"tag": kata.FsTag, "socket": "/run/vc/vm/golden/virtiofsd.sock"},
 		})
@@ -133,8 +136,9 @@ func TestRewriteSnapshotSocketPaths(t *testing.T) {
 			t.Fatalf("reading config.json: %v", err)
 		}
 		var cfg struct {
-			Vsock  struct{ Socket string } `json:"vsock"`
-			Serial struct{ File string }   `json:"serial"`
+			Vsock   struct{ Socket string } `json:"vsock"`
+			Console struct{ File string }   `json:"console"`
+			Serial  struct{ File string }   `json:"serial"`
 		}
 		if err := json.Unmarshal(b, &cfg); err != nil {
 			t.Fatalf("parsing rewritten config: %v", err)
@@ -142,7 +146,10 @@ func TestRewriteSnapshotSocketPaths(t *testing.T) {
 		if want := kata.VsockSocketPath(id); cfg.Vsock.Socket != want {
 			t.Errorf("vsock socket = %q, want %q", cfg.Vsock.Socket, want)
 		}
-		if want := filepath.Join(kata.VMDir(id), "serial.log"); cfg.Serial.File != want {
+		if want := kata.ConsoleLogPath(id); cfg.Console.File != want {
+			t.Errorf("console file = %q, want %q", cfg.Console.File, want)
+		}
+		if want := kata.SerialLogPath(id); cfg.Serial.File != want {
 			t.Errorf("serial file = %q, want %q", cfg.Serial.File, want)
 		}
 	})

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -504,11 +504,11 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 
 	// Assemble the CH VmConfig (kata-compatible cmdline, RO kata image on /dev/vda +
 	// the virtio-fs device; no actor virtio-blk disks — rootfs writes land in the
-	// host-side overlay upper through the shared mount). serialLog is also read on a
-	// failed agent dial below, so keep it here.
-	serialLog := filepath.Join(kata.VMDir(actorUID), "serial.log")
-	vmCfg := buildVMConfig(actorUID, kernel, image, kparams, serialLog, memMiB, vcpus,
-		agentInit(ctx, client.Info()))
+	// host-side overlay upper through the shared mount). The console log is also read
+	// on a failed agent dial below, so keep it here.
+	consoleLog := kata.ConsoleLogPath(actorUID)
+	vmCfg := buildVMConfig(actorUID, kernel, image, kparams, consoleLog, memMiB, vcpus,
+		agentInit(ctx, client.Info()), s.kataDebug)
 	if err := client.CreateVM(ctx, vmCfg); err != nil {
 		return fmt.Errorf("while creating VM: %w", err)
 	}
@@ -550,7 +550,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	tVsock := time.Now()
 	ac, err := dialAgentRetry(ctx, vsockPath, 60*time.Second)
 	if err != nil {
-		logGuestBootDiagnostics(ctx, actorUID, serialLog)
+		logGuestBootDiagnostics(ctx, actorUID, consoleLog)
 		return fmt.Errorf("while dialing kata-agent: %w", err)
 	}
 	tDialed := time.Now()
@@ -823,16 +823,26 @@ func initParams(agentInit bool) string {
 // stays frozen at the instant it was snapshotted.
 //
 // The disk-backed rootfs upper share (see rootfsupper.go) is always present.
-func buildVMConfig(id, kernel, image, kparams, serialLog string, memMiB, vcpus int, agentInit bool) ch.VmConfig {
-	console := "ttyS0"
-	if runtime.GOARCH == "arm64" {
-		console = "ttyAMA0"
-	}
+//
+// The guest console is a virtio-console (hvc0), not the emulated UART. Every byte
+// written to an 8250/pl011 traps to the VMM, and a kata guest prints ~340 lines
+// before the agent listens, so the UART — not the kernel's work — dominated cold
+// boot: measured host-launch to the agent's ttrpc accept, 1.24s -> 0.39s on a GKE
+// amd64 node and 21.6s -> 1.9s on a nested-virt arm64 kind node. What that costs is
+// the earliest messages: hvc0 only exists once virtio-console probes, so the memory
+// map, CPU features and ACPI lines never reach the log. kataDebug adds the UART back
+// with earlycon (and pays the ~800ms) for diagnosing a guest that dies before then.
+func buildVMConfig(id, kernel, image, kparams, consoleLog string, memMiB, vcpus int, agentInit, debug bool) ch.VmConfig {
 	cmdline := "root=/dev/vda1 rootflags=data=ordered,errors=remount-ro ro rootfstype=ext4 " +
-		"panic=1 no_timer_check noreplace-smp console=" + console + ",115200n8 " +
+		"panic=1 no_timer_check noreplace-smp console=hvc0 " +
 		initParams(agentInit)
 	if kparams != "" {
 		cmdline += " " + kparams
+	}
+	serial := &ch.ConsoleConfig{Mode: "Off"}
+	if debug {
+		cmdline += " " + earlyconParam()
+		serial = &ch.ConsoleConfig{Mode: "File", File: kata.SerialLogPath(id)}
 	}
 	return ch.VmConfig{
 		Cpus:    ch.CpusConfig{BootVcpus: int32(vcpus), MaxVcpus: int32(vcpus)},
@@ -844,9 +854,19 @@ func buildVMConfig(id, kernel, image, kparams, serialLog string, memMiB, vcpus i
 		Fs:       buildFsConfigs(id),
 		Platform: &ch.PlatformConfig{NumPciSegments: 2},
 		Rng:      &ch.RngConfig{Src: "/dev/urandom"},
-		Serial:   &ch.ConsoleConfig{Mode: "File", File: serialLog},
+		Console:  &ch.ConsoleConfig{Mode: "File", File: consoleLog},
+		Serial:   serial,
 		Vsock:    &ch.VsockConfig{Cid: 3, Socket: kata.VsockSocketPath(id)},
 	}
+}
+
+// earlyconParam points the kernel's early console at the UART cloud-hypervisor
+// emulates before virtio-console exists: an ISA port on x86, MMIO on arm64.
+func earlyconParam() string {
+	if runtime.GOARCH == "arm64" {
+		return "earlycon=pl011,mmio,0x09000000"
+	}
+	return "earlycon=uart,io,0x3f8,115200"
 }
 
 // buildFsConfigs returns the VM's virtio-fs device: the unified share hosting
@@ -1015,9 +1035,10 @@ func dialAgentRetry(ctx context.Context, vsockPath string, timeout time.Duration
 // reached the kata-agent: the console tail, where a guest-side panic or an early
 // power-off shows up, and each virtiofsd's log — cloud-hypervisor stops the VM
 // when a vhost-user backend dies, and that leaves the console silent.
-func logGuestBootDiagnostics(ctx context.Context, actorUID, serialLog string) {
+func logGuestBootDiagnostics(ctx context.Context, actorUID, consoleLog string) {
 	for _, l := range []struct{ name, path string }{
-		{"serial", serialLog},
+		{"console", consoleLog},
+		{"serial", kata.SerialLogPath(actorUID)},
 		{"virtiofsd", virtiofsdLogPath(actorUID)},
 	} {
 		b, err := os.ReadFile(l.path)

--- a/cmd/ateom-microvm/run_test.go
+++ b/cmd/ateom-microvm/run_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
 	"github.com/agent-substrate/substrate/internal/sizing"
 )
 
@@ -197,6 +198,37 @@ func TestInitParams(t *testing.T) {
 	}
 	if strings.Contains(systemd, "init=") {
 		t.Errorf("initParams(false) = %q, must not override init", systemd)
+	}
+}
+
+// The guest must log over virtio-console, not the emulated UART: the UART traps to
+// the VMM per byte, which costs ~800ms of cold boot on the kata guest's boot log.
+// Debug mode adds the UART back (with earlycon) to capture the early messages hvc0
+// is too late to see.
+func TestBuildVMConfigConsole(t *testing.T) {
+	const id = "actor-1"
+	consoleLog := kata.ConsoleLogPath(id)
+
+	cfg := buildVMConfig(id, "/vmlinux", "/rootfs.img", "", consoleLog, 256, 1, true, false)
+	if cfg.Console == nil || cfg.Console.Mode != "File" || cfg.Console.File != consoleLog {
+		t.Errorf("Console = %+v, want File %q", cfg.Console, consoleLog)
+	}
+	if cfg.Serial == nil || cfg.Serial.Mode != "Off" {
+		t.Errorf("Serial = %+v, want mode Off", cfg.Serial)
+	}
+	if !strings.Contains(cfg.Payload.Cmdline, "console=hvc0") {
+		t.Errorf("cmdline = %q, want console=hvc0", cfg.Payload.Cmdline)
+	}
+	if strings.Contains(cfg.Payload.Cmdline, "earlycon") {
+		t.Errorf("cmdline = %q, must not pay for earlycon outside debug mode", cfg.Payload.Cmdline)
+	}
+
+	dbg := buildVMConfig(id, "/vmlinux", "/rootfs.img", "", consoleLog, 256, 1, true, true)
+	if dbg.Serial == nil || dbg.Serial.Mode != "File" || dbg.Serial.File != kata.SerialLogPath(id) {
+		t.Errorf("debug Serial = %+v, want File %q", dbg.Serial, kata.SerialLogPath(id))
+	}
+	if !strings.Contains(dbg.Payload.Cmdline, "earlycon=") {
+		t.Errorf("debug cmdline = %q, want an earlycon", dbg.Payload.Cmdline)
 	}
 }
 


### PR DESCRIPTION
Every byte written to an emulated 8250/pl011 traps to the VMM, and a kata guest prints ~340 lines of kernel log before the agent listens. That made the console, not the kernel's work, the largest single cost of a cold boot.

Measured host-launch to the agent's first ttrpc accept, booting the same image by hand with nothing else attached:

```
  GKE amd64 node   1213-1274 ms -> 391-399 ms
  kind arm64 node  21.3-22.0 s  -> 1.89-1.93 s 
```

What this costs is the earliest messages: hvc0 only exists once virtio-console probes, so the memory map, CPU features and ACPI lines no longer reach the log. 

`--kata-debug` mode turns the UART back on with earlycon and pays the ~800 ms for debugging purposes.
