### PR TITLE
CI e2e: run all suites for microvm

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -85,10 +85,13 @@ jobs:
       run: hack/run-microvm-demo-kind.sh --ateapi-client-auth=cert
     - name: Deploy gVisor counter demo
       run: hack/install-ate-kind.sh --deploy-demo-counter
-    - name: Deploy egress demo
-      # TestActorEgress in the networking suite builds its Actor from the
-      # ate-demo-egress/egress ActorTemplate, so the fixture has to exist before.
-      run: hack/install-ate-kind.sh --deploy-demo-egress
+    - name: Deploy egress demos
+      # TestActorEgress in the networking suite builds its Actor from the egress
+      # ActorTemplate for the class under test, so both fixtures have to exist
+      # before their respective lane runs.
+      run: |
+        hack/install-ate-kind.sh --deploy-demo-egress
+        hack/install-ate-kind.sh --deploy-demo-egress-microvm
     - name: Wait for micro-VM golden snapshot
       run: |
         kubectl --context kind-kind wait --for=condition=Ready \
@@ -96,13 +99,14 @@ jobs:
     - name: Run E2E tests (gVisor)
       run: hack/run-e2e-kind.sh -v -args --no-color
     - name: Run E2E tests (micro-VM)
-      # Same demo lifecycle suite (create -> suspend -> resume -> in-RAM continuity),
-      # pointed at the micro-VM counter via env (see createActorTemplate in demo_test.go).
+      # The same suites again, with every fixture repointed at its micro-VM
+      # variant by the single E2E_SANDBOX_CLASS knob (see internal/e2e/sandbox.go).
+      # Sequential with the gVisor lane above, not concurrent: a suite releases
+      # its namespace — and with it its worker pods — as each test passes, so the
+      # two runs do not contend for the one kind node.
       env:
-        E2E_TEMPLATE_NAMESPACE: ate-demo-counter-microvm
-        E2E_TEMPLATE_NAME: counter-microvm
-        E2E_TEMPLATE_READY_TIMEOUT: 600s
-      run: hack/run-e2e-kind.sh ./internal/e2e/suites/demo -v -args --no-color
+        E2E_SANDBOX_CLASS: microvm
+      run: hack/run-e2e-kind.sh -v -args --no-color
     - name: Dump diagnostics on failure
       if: failure()
       run: |

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -85,6 +85,14 @@ spec:
       httpGet:
         path: /readyz
         port: 80
+      # Well above readyz.DefaultOverallTimeout (30s), which the gVisor counter
+      # is happy with. A micro-VM actor answers in a few seconds on an idle
+      # node, but CI runs every suite against this one pool on a single kind
+      # node and a guest boot stretches badly under that contention — 30s was
+      # marginal enough to fail several suites intermittently. Raising it here
+      # rather than the default is what internal/readyz asks for: "a workload
+      # that needs longer says so on its ActorTemplate".
+      timeoutSeconds: 120
     # The counter writes its file counter here. With the durableDir volume below
     # it lands on a host-backed virtio-fs share instead of the guest-RAM rootfs
     # upper, so it survives a Data-scope snapshot (which keeps no guest memory).

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -73,6 +73,14 @@ spec:
   containers:
   - name: counter
     image: ko://github.com/agent-substrate/substrate/demos/counter
+    command:
+    - /ko-app/counter
+    # Exercises atenet-router's arbitrary-port ingress support: a second
+    # listener a test can address by CONNECTing to <actor-dns>:9090, distinct
+    # from the primary port 80 every other assertion in this demo uses. Kept in
+    # step with counter.yaml.tmpl — the networking suite runs against whichever
+    # of the two the sandbox class under test selects.
+    - --extra-port=9090
     readyz:
       httpGet:
         path: /readyz

--- a/demos/egress/egress-microvm.yaml.tmpl
+++ b/demos/egress/egress-microvm.yaml.tmpl
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Micro-VM (kata + cloud-hypervisor) variant of the egress demo, so the
+# networking suite's egress tests run against both sandbox classes. The actor's
+# outbound TCP is redirected into atunnel by nftables in the ateom
+# (prepareActorEgress), which the micro-VM ateom implements the same way the
+# gVisor one does — this fixture is what proves it end to end.
+#
+# Kept in step with egress.yaml.tmpl; the deltas are the runtime fields and the
+# sandbox size. The cluster-wide `microvm` SandboxConfig referenced below by
+# name is installed by hack/install-microvm-deps.sh.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ate-demo-egress-microvm
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: WorkerPool
+metadata:
+  name: egress-microvm
+  namespace: ate-demo-egress-microvm
+  labels:
+    workload: egress-microvm
+spec:
+  replicas: 2
+  sandboxClass: microvm
+  sandboxConfigName: microvm
+  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
+  # No template.resources, unlike counter-microvm: an unlimited ateom container
+  # reports no capacity, which the scheduler reads as unconstrained, and the pod
+  # requests nothing so it stays placeable next to the counter-microvm pool's
+  # reservation on CI's single kind node. What actually bounds the memory here
+  # is the ActorTemplate's resources below, which size the guest.
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: ActorTemplate
+metadata:
+  name: egress-microvm
+  namespace: ate-demo-egress-microvm
+spec:
+  # Must match the WorkerPool's sandboxClass: a snapshot is not portable across
+  # sandbox classes, so only pools of the same class are eligible to run this
+  # template's actors.
+  sandboxClass: microvm
+  containers:
+  - name: egress
+    image: ko://github.com/agent-substrate/substrate/demos/egress
+    command: ["/ko-app/egress"]
+    readyz:
+      httpGet:
+        path: /readyz
+        port: 80
+  # Sandbox size: without these the guest boots at the kata config's default
+  # (2GiB). ateom applies them to the VM (see internal/sizing).
+  resources:
+    limits:
+      cpu: "1"
+      memory: 512Mi
+  workerSelector:
+    matchLabels:
+      workload: egress-microvm
+  snapshotsConfig:
+    onPause: Full
+    onCommit: Full
+    location: gs://${BUCKET_NAME}/ate-demo-egress-microvm/

--- a/demos/egress/egress-microvm.yaml.tmpl
+++ b/demos/egress/egress-microvm.yaml.tmpl
@@ -67,6 +67,9 @@ spec:
       httpGet:
         path: /readyz
         port: 80
+      # See counter-microvm.yaml.tmpl: a micro-VM guest needs more than
+      # readyz's 30s default once CI's single kind node is under load.
+      timeoutSeconds: 120
   # Sandbox size: without these the guest boots at the kata config's default
   # (2GiB). ateom applies them to the VM (see internal/sizing).
   resources:

--- a/hack/install-demo-egress.sh
+++ b/hack/install-demo-egress.sh
@@ -17,11 +17,27 @@
 # This is sourced as part of install-ate.sh. Do not run directly.
 
 ATE_DEMOS+=(demo-egress) # register demo-egress
+# The micro-VM variant is its own demo rather than a flag on demo-egress: that
+# gets it into --help and into delete_all's teardown sweep for free, and the two
+# can be installed side by side (the networking suite runs against whichever the
+# sandbox class under test selects).
+ATE_DEMOS+=(demo-egress-microvm) # register demo-egress-microvm
 
 demo-egress_cmdline() {
   case "${1}" in
     --deploy-demo-egress) demo-egress_deploy ;;
     --delete-demo-egress) demo-egress_delete ;;
+    *)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+demo-egress-microvm_cmdline() {
+  case "${1}" in
+    --deploy-demo-egress-microvm) demo-egress-microvm_deploy ;;
+    --delete-demo-egress-microvm) demo-egress-microvm_delete ;;
     *)
       return 1
       ;;
@@ -47,5 +63,30 @@ demo-egress_delete() {
   log_step "demo-egress_delete"
   delete_demo_actors ate-demo-egress egress
   sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/egress/egress.yaml.tmpl \
+    | run_kubectl delete --ignore-not-found -f -
+}
+
+demo-egress-microvm_usage() {
+  echo "  Needs hack/install-microvm-deps.sh --install to have run (cluster-wide microvm SandboxConfig)."
+}
+
+demo-egress-microvm_deploy() {
+  log_step "demo-egress-microvm_deploy"
+  ensure_crds
+  sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/egress/egress-microvm.yaml.tmpl \
+    | run_ko apply -f -
+
+  log_step "Waiting for micro-VM egress demo to be ready..."
+  run_kubectl rollout status deployment/egress-microvm -n ate-demo-egress-microvm --timeout=300s
+  # A micro-VM golden is a cloud-hypervisor cold boot plus a checkpoint, on
+  # nested KVM in CI, so it needs a longer budget than the gVisor one above.
+  run_kubectl wait --for=condition=Ready actortemplate/egress-microvm \
+    -n ate-demo-egress-microvm --timeout=600s
+}
+
+demo-egress-microvm_delete() {
+  log_step "demo-egress-microvm_delete"
+  delete_demo_actors ate-demo-egress-microvm egress-microvm
+  sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/egress/egress-microvm.yaml.tmpl \
     | run_kubectl delete --ignore-not-found -f -
 }

--- a/internal/e2e/README.md
+++ b/internal/e2e/README.md
@@ -22,6 +22,36 @@ The e2e tests assume you have a cluster set up with Agent Substrate installed,
 for example via `hack/install-ate.sh --deploy-ate-system` or
 `hack/install-ate-kind.sh --deploy-ate-system`.
 
+## Sandbox classes
+
+The suites are runtime-agnostic: the same tests run against gVisor and against
+the micro-VM (kata + cloud-hypervisor) sandbox class. `E2E_SANDBOX_CLASS`
+selects which, by repointing every fixture at its variant --- see
+`e2e.CounterFixture`, `e2e.EgressFixture` and `e2e.RenderFixtureManifest` in
+[sandbox.go](sandbox.go). Unset means gVisor.
+
+```shell
+# gVisor (the default), against the demos install-ate-kind.sh deploys
+$ hack/run-e2e-kind.sh -v -args --no-color
+
+# micro-VM, against the counter-microvm and egress-microvm demos
+$ E2E_SANDBOX_CLASS=microvm hack/run-e2e-kind.sh -v -args --no-color
+```
+
+The micro-VM lane needs its fixtures installed first, which also needs a node
+with `/dev/kvm` (`hack/create-kind-cluster.sh` detects one and labels the node):
+
+```shell
+$ hack/run-microvm-demo-kind.sh                        # counter-microvm + assets
+$ hack/install-ate-kind.sh --deploy-demo-egress-microvm # egress-microvm
+```
+
+A handful of knobs override the class defaults, mostly for a cluster that
+installs the fixtures elsewhere: `E2E_TEMPLATE_NAMESPACE` / `E2E_TEMPLATE_NAME`
+point the counter fixture somewhere else, and `E2E_TEMPLATE_READY_TIMEOUT`
+replaces the golden-snapshot budget (90s on gVisor, 10m on micro-VM, where the
+golden is a cloud-hypervisor cold boot plus a checkpoint).
+
 ## After a failure
 
 A suite deletes the namespaces it created only when it passed. A failed run

--- a/internal/e2e/fixtures/probe/probe-sized.yaml.tmpl
+++ b/internal/e2e/fixtures/probe/probe-sized.yaml.tmpl
@@ -17,6 +17,11 @@
 # sandbox is shaped to those limits. Reuses the probe image (it serves the
 # /resources endpoint). Kept in its own namespace so it never collides with
 # the plain probe fixture.
+#
+# Rendered by e2e.RenderFixtureManifest, which fills the ${...} placeholders for
+# the sandbox class under test. Unlike probe.yaml.tmpl this declares its own
+# resources (they are the thing under test), so it carries no
+# ${TEMPLATE_RESOURCES} placeholder.
 
 apiVersion: v1
 kind: Namespace
@@ -34,7 +39,8 @@ metadata:
     workload: probe-sized
 spec:
   replicas: 3
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  ateomImage: ${ATEOM_IMAGE}
+${WORKERPOOL_RUNTIME}
 
 ---
 
@@ -44,6 +50,7 @@ metadata:
   name: probe-sized
   namespace: ate-e2e-sizing
 spec:
+${TEMPLATE_SANDBOX_CLASS}
   containers:
   - name: probe
     image: ko://github.com/agent-substrate/substrate/internal/e2e/fixtures/probe
@@ -57,7 +64,8 @@ spec:
         port: 80
   # The feature under test: these limits size the sandbox (and, when the worker
   # advertises capacity, gate scheduling). CPU=2 makes NumCPU() inside the
-  # gVisor sandbox a distinct, assertable value.
+  # sandbox a distinct, assertable value — the vCPU count of the micro-VM guest,
+  # or what runsc --cpu-num-from-quota provisions the gVisor sentry with.
   resources:
     limits:
       cpu: "2"
@@ -66,4 +74,4 @@ spec:
     matchLabels:
       workload: probe-sized
   snapshotsConfig:
-    location: gs://${BUCKET_NAME}/ate-e2e-sizing/
+    location: gs://${BUCKET_NAME}/ate-e2e-sizing${SNAPSHOT_SUFFIX}/

--- a/internal/e2e/fixtures/probe/probe-sized.yaml.tmpl
+++ b/internal/e2e/fixtures/probe/probe-sized.yaml.tmpl
@@ -26,7 +26,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: ate-e2e-sizing
+  name: ate-e2e-sizing${FIXTURE_SUFFIX}
 
 ---
 
@@ -34,7 +34,7 @@ apiVersion: ate.dev/v1alpha1
 kind: WorkerPool
 metadata:
   name: probe-sized
-  namespace: ate-e2e-sizing
+  namespace: ate-e2e-sizing${FIXTURE_SUFFIX}
   labels:
     workload: probe-sized
 spec:
@@ -48,7 +48,7 @@ apiVersion: ate.dev/v1alpha1
 kind: ActorTemplate
 metadata:
   name: probe-sized
-  namespace: ate-e2e-sizing
+  namespace: ate-e2e-sizing${FIXTURE_SUFFIX}
 spec:
 ${TEMPLATE_SANDBOX_CLASS}
   containers:
@@ -74,4 +74,4 @@ ${TEMPLATE_SANDBOX_CLASS}
     matchLabels:
       workload: probe-sized
   snapshotsConfig:
-    location: gs://${BUCKET_NAME}/ate-e2e-sizing${SNAPSHOT_SUFFIX}/
+    location: gs://${BUCKET_NAME}/ate-e2e-sizing${FIXTURE_SUFFIX}/

--- a/internal/e2e/fixtures/probe/probe.yaml.tmpl
+++ b/internal/e2e/fixtures/probe/probe.yaml.tmpl
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: ate-e2e-probe
+  name: ate-e2e-probe${FIXTURE_SUFFIX}
 
 ---
 
@@ -28,7 +28,7 @@ apiVersion: ate.dev/v1alpha1
 kind: WorkerPool
 metadata:
   name: probe
-  namespace: ate-e2e-probe
+  namespace: ate-e2e-probe${FIXTURE_SUFFIX}
   labels:
     workload: probe
 spec:
@@ -42,7 +42,7 @@ apiVersion: ate.dev/v1alpha1
 kind: ActorTemplate
 metadata:
   name: probe
-  namespace: ate-e2e-probe
+  namespace: ate-e2e-probe${FIXTURE_SUFFIX}
 spec:
 ${TEMPLATE_SANDBOX_CLASS}
   containers:
@@ -63,4 +63,4 @@ ${TEMPLATE_RESOURCES}
     matchLabels:
       workload: probe
   snapshotsConfig:
-    location: gs://${BUCKET_NAME}/ate-e2e-probe${SNAPSHOT_SUFFIX}/
+    location: gs://${BUCKET_NAME}/ate-e2e-probe${FIXTURE_SUFFIX}/

--- a/internal/e2e/fixtures/probe/probe.yaml.tmpl
+++ b/internal/e2e/fixtures/probe/probe.yaml.tmpl
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Rendered by e2e.RenderFixtureManifest, which fills the ${...} placeholders for
+# the sandbox class under test: one manifest serves both runtimes so the gVisor
+# and micro-VM variants cannot drift apart. A placeholder that has no value for
+# the selected class takes its whole line with it.
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -28,7 +33,8 @@ metadata:
     workload: probe
 spec:
   replicas: 3
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  ateomImage: ${ATEOM_IMAGE}
+${WORKERPOOL_RUNTIME}
 
 ---
 
@@ -38,6 +44,7 @@ metadata:
   name: probe
   namespace: ate-e2e-probe
 spec:
+${TEMPLATE_SANDBOX_CLASS}
   containers:
   - name: probe
     image: ko://github.com/agent-substrate/substrate/internal/e2e/fixtures/probe
@@ -51,8 +58,9 @@ spec:
         path: /healthz
         port: 80
       timeoutSeconds: 60
+${TEMPLATE_RESOURCES}
   workerSelector:
     matchLabels:
       workload: probe
   snapshotsConfig:
-    location: gs://${BUCKET_NAME}/ate-e2e-probe/
+    location: gs://${BUCKET_NAME}/ate-e2e-probe${SNAPSHOT_SUFFIX}/

--- a/internal/e2e/sandbox.go
+++ b/internal/e2e/sandbox.go
@@ -92,6 +92,19 @@ func EgressFixture() Fixture {
 	}
 }
 
+// FixtureName suffixes a fixture's name for the sandbox class under test, so
+// the gVisor and micro-VM lanes never share one. That matters most for the
+// namespaces a suite creates and deletes itself: the two lanes run one after
+// the other, and a namespace still Terminating from the previous one would
+// fail the next one's apply. ${FIXTURE_SUFFIX} does the same job inside the
+// fixture manifests.
+func FixtureName(base string) string {
+	if IsMicroVM() {
+		return base + "-" + SandboxClassMicroVM
+	}
+	return base
+}
+
 // TemplateReadyTimeout is how long to wait for an ActorTemplate's golden
 // snapshot. A micro-VM golden (a cloud-hypervisor cold boot plus checkpoint, on
 // nested KVM in CI) takes several times what a gVisor one does, so the default
@@ -166,10 +179,9 @@ func fixtureSubstitutions(bucket string) (inline, blocks map[string]string) {
 	inline = map[string]string{
 		"${BUCKET_NAME}": bucket,
 		"${ATEOM_IMAGE}": "ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor",
-		// Same fixture name, different runtime: keeping the goldens under
-		// separate prefixes stops a stray object from one class turning up while
-		// debugging the other.
-		"${SNAPSHOT_SUFFIX}": "",
+		// The manifest-side half of FixtureName: it suffixes the fixture's
+		// namespace, and with it the snapshot prefix underneath.
+		"${FIXTURE_SUFFIX}": "",
 	}
 	blocks = map[string]string{
 		"${WORKERPOOL_RUNTIME}":     "",
@@ -181,7 +193,7 @@ func fixtureSubstitutions(bucket string) (inline, blocks map[string]string) {
 	}
 
 	inline["${ATEOM_IMAGE}"] = "ko://github.com/agent-substrate/substrate/cmd/ateom-microvm"
-	inline["${SNAPSHOT_SUFFIX}"] = "-microvm"
+	inline["${FIXTURE_SUFFIX}"] = "-" + SandboxClassMicroVM
 	// The cluster-wide SandboxConfig hack/install-microvm-deps.sh installs. A
 	// micro-VM WorkerPool has to name it: it is deliberately not the class
 	// default, so a missing or stale one fails loudly.

--- a/internal/e2e/sandbox.go
+++ b/internal/e2e/sandbox.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// SandboxClassMicroVM is the kata + cloud-hypervisor runtime, spelled as the
+// WorkerPool/ActorTemplate spec.sandboxClass field spells it.
+const SandboxClassMicroVM = "microvm"
+
+// sandboxClassEnv selects which runtime's fixtures the suites build actors
+// from. Unset means gVisor: the default every runtime-agnostic suite ran
+// against before the micro-VM lane existed.
+const sandboxClassEnv = "E2E_SANDBOX_CLASS"
+
+// SandboxClass returns the sandbox class under test, "" for gVisor. CI sets
+// E2E_SANDBOX_CLASS=microvm for the micro-VM lane and leaves it unset for the
+// gVisor one, so a single knob repoints every suite's fixtures.
+func SandboxClass() string { return os.Getenv(sandboxClassEnv) }
+
+// IsMicroVM reports whether the suites are pointed at the micro-VM fixtures.
+// Assertions that only hold for one runtime gate on this.
+func IsMicroVM() bool { return SandboxClass() == SandboxClassMicroVM }
+
+// Fixture identifies an installed WorkerPool + ActorTemplate pair (both carry
+// the same name) that suites either create Actors from directly or copy the
+// resolved runtime — sandbox class, ateom image, container images — out of.
+type Fixture struct {
+	Namespace string
+	Name      string
+	// DeployWith is the install flag or script that creates the fixture, so a
+	// missing one reports how to fix it rather than just failing.
+	DeployWith string
+}
+
+// CounterFixture returns the counter demo for the sandbox class under test.
+// E2E_TEMPLATE_NAMESPACE / E2E_TEMPLATE_NAME override it, for a cluster that
+// installs the fixture somewhere else.
+func CounterFixture() Fixture {
+	f := Fixture{
+		Namespace:  "ate-demo-counter",
+		Name:       "counter",
+		DeployWith: "hack/install-ate-kind.sh --deploy-demo-counter",
+	}
+	if IsMicroVM() {
+		f = Fixture{
+			Namespace:  "ate-demo-counter-microvm",
+			Name:       "counter-microvm",
+			DeployWith: "hack/run-microvm-demo-kind.sh",
+		}
+	}
+	if v := os.Getenv("E2E_TEMPLATE_NAMESPACE"); v != "" {
+		f.Namespace = v
+	}
+	if v := os.Getenv("E2E_TEMPLATE_NAME"); v != "" {
+		f.Name = v
+	}
+	return f
+}
+
+// EgressFixture returns the egress demo for the sandbox class under test.
+func EgressFixture() Fixture {
+	if IsMicroVM() {
+		return Fixture{
+			Namespace:  "ate-demo-egress-microvm",
+			Name:       "egress-microvm",
+			DeployWith: "hack/install-ate-kind.sh --deploy-demo-egress-microvm",
+		}
+	}
+	return Fixture{
+		Namespace:  "ate-demo-egress",
+		Name:       "egress",
+		DeployWith: "hack/install-ate-kind.sh --deploy-demo-egress",
+	}
+}
+
+// TemplateReadyTimeout is how long to wait for an ActorTemplate's golden
+// snapshot. A micro-VM golden (a cloud-hypervisor cold boot plus checkpoint, on
+// nested KVM in CI) takes several times what a gVisor one does, so the default
+// follows the class under test. E2E_TEMPLATE_READY_TIMEOUT overrides it.
+func TemplateReadyTimeout(t *testing.T) time.Duration {
+	t.Helper()
+	d := 90 * time.Second
+	if IsMicroVM() {
+		d = 10 * time.Minute
+	}
+	if v := os.Getenv("E2E_TEMPLATE_READY_TIMEOUT"); v != "" {
+		parsed, err := time.ParseDuration(v)
+		if err != nil {
+			t.Fatalf("invalid E2E_TEMPLATE_READY_TIMEOUT %q: %v", v, err)
+		}
+		d = parsed
+	}
+	return d
+}
+
+// RenderFixtureManifest renders the manifest template at relPath (repo-relative,
+// under internal/e2e/fixtures) for the sandbox class under test, writes it into
+// the test's temp dir and returns that path. Both an apply and a later delete
+// can then consume the same file, with no shell involved.
+//
+// One template serves both sandbox classes so the two variants of a fixture
+// cannot drift apart. Templates carry two kinds of ${...} placeholder:
+//
+//   - inline, substituted wherever they appear (an empty value just disappears);
+//   - block, which must be the entire content of their line. They expand to a
+//     YAML fragment that brings its own indentation, and an empty value takes
+//     the whole line with it — the same trick hack/install-demo-counter.sh
+//     plays with `sed /.../d`. Requiring the placeholder to be the whole line
+//     is what lets a comment mention one without being deleted.
+func RenderFixtureManifest(t *testing.T, relPath, bucket string) string {
+	t.Helper()
+	root, err := FindRepoRoot()
+	if err != nil {
+		t.Fatalf("FindRepoRoot: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, relPath))
+	if err != nil {
+		t.Fatalf("reading fixture manifest %s: %v", relPath, err)
+	}
+
+	inline, blocks := fixtureSubstitutions(bucket)
+	var out []string
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		if value, isBlock := blocks[strings.TrimSpace(line)]; isBlock {
+			if value != "" {
+				out = append(out, value)
+			}
+			continue
+		}
+		for placeholder, value := range inline {
+			line = strings.ReplaceAll(line, placeholder, value)
+		}
+		out = append(out, line)
+	}
+
+	rendered := strings.TrimSuffix(filepath.Join(t.TempDir(), filepath.Base(relPath)), ".tmpl")
+	if err := os.WriteFile(rendered, []byte(strings.Join(out, "\n")), 0o644); err != nil {
+		t.Fatalf("writing rendered fixture manifest %s: %v", rendered, err)
+	}
+	return rendered
+}
+
+// fixtureSubstitutions is the placeholder set the internal/e2e/fixtures
+// manifest templates carry, split into the inline and whole-line-block kinds
+// RenderFixtureManifest treats differently.
+func fixtureSubstitutions(bucket string) (inline, blocks map[string]string) {
+	inline = map[string]string{
+		"${BUCKET_NAME}": bucket,
+		"${ATEOM_IMAGE}": "ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor",
+		// Same fixture name, different runtime: keeping the goldens under
+		// separate prefixes stops a stray object from one class turning up while
+		// debugging the other.
+		"${SNAPSHOT_SUFFIX}": "",
+	}
+	blocks = map[string]string{
+		"${WORKERPOOL_RUNTIME}":     "",
+		"${TEMPLATE_SANDBOX_CLASS}": "",
+		"${TEMPLATE_RESOURCES}":     "",
+	}
+	if !IsMicroVM() {
+		return inline, blocks
+	}
+
+	inline["${ATEOM_IMAGE}"] = "ko://github.com/agent-substrate/substrate/cmd/ateom-microvm"
+	inline["${SNAPSHOT_SUFFIX}"] = "-microvm"
+	// The cluster-wide SandboxConfig hack/install-microvm-deps.sh installs. A
+	// micro-VM WorkerPool has to name it: it is deliberately not the class
+	// default, so a missing or stale one fails loudly.
+	blocks["${WORKERPOOL_RUNTIME}"] = "  sandboxClass: microvm\n  sandboxConfigName: microvm"
+	// Must match the WorkerPool's: a snapshot is not portable across sandbox
+	// classes, so only same-class pools are eligible to run these actors.
+	blocks["${TEMPLATE_SANDBOX_CLASS}"] = "  sandboxClass: microvm"
+	// Only for fixtures that declare no limits of their own. Without them the
+	// guest boots at the kata config's default (2GiB), and several of those do
+	// not fit beside the demo pools on CI's single kind node. These size the VM
+	// itself — see internal/sizing.
+	blocks["${TEMPLATE_RESOURCES}"] = "  resources:\n    limits:\n      cpu: \"1\"\n      memory: 512Mi"
+	return inline, blocks
+}

--- a/internal/e2e/sandbox_test.go
+++ b/internal/e2e/sandbox_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -28,44 +29,49 @@ var fixtureManifests = []string{
 	"internal/e2e/fixtures/probe/probe-sized.yaml.tmpl",
 }
 
-// renderedFixture is the subset of a rendered fixture document the assertions
-// below care about. Every field is optional: one document is a Namespace.
-type renderedFixture struct {
-	Kind string `json:"kind"`
-	Spec struct {
-		AteomImage        string `json:"ateomImage"`
-		SandboxClass      string `json:"sandboxClass"`
-		SandboxConfigName string `json:"sandboxConfigName"`
-		Resources         *struct {
-			Limits map[string]string `json:"limits"`
-		} `json:"resources"`
-		SnapshotsConfig struct {
-			Location string `json:"location"`
-		} `json:"snapshotsConfig"`
-	} `json:"spec"`
-}
-
-// decodeFixture renders a manifest and returns its documents by kind. It fails
-// the test on any document that is not valid YAML, which is the thing most
-// likely to break: the runtime blocks are injected as pre-indented text.
-func decodeFixture(t *testing.T, relPath string) map[string]renderedFixture {
+// renderFixture renders a manifest and decodes the two resources the
+// assertions below care about (the third document is a Namespace).
+//
+// Strict decoding against the real API types is the point: the runtime blocks
+// are injected as pre-indented text, so a placeholder that lands at the wrong
+// depth yields YAML that still parses but hangs the field off the wrong parent
+// — which strict mode reports as an unknown field instead of silently applying
+// a WorkerPool that never gets a micro-VM worker.
+func renderFixture(t *testing.T, relPath string) (*v1alpha1.WorkerPool, *v1alpha1.ActorTemplate) {
 	t.Helper()
 	raw, err := os.ReadFile(RenderFixtureManifest(t, relPath, "test-bucket"))
 	if err != nil {
 		t.Fatalf("reading the rendered %s: %v", relPath, err)
 	}
-	byKind := map[string]renderedFixture{}
+
+	pool, template := &v1alpha1.WorkerPool{}, &v1alpha1.ActorTemplate{}
 	for doc := range strings.SplitSeq(string(raw), "\n---\n") {
 		if strings.TrimSpace(doc) == "" {
 			continue
 		}
-		var out renderedFixture
-		if err := yaml.Unmarshal([]byte(doc), &out); err != nil {
+		var meta struct {
+			Kind string `json:"kind"`
+		}
+		if err := yaml.Unmarshal([]byte(doc), &meta); err != nil {
 			t.Fatalf("rendered %s is not valid YAML: %v\n%s", relPath, err, doc)
 		}
-		byKind[out.Kind] = out
+		var into any
+		switch meta.Kind {
+		case "WorkerPool":
+			into = pool
+		case "ActorTemplate":
+			into = template
+		default:
+			continue
+		}
+		if err := yaml.UnmarshalStrict([]byte(doc), into); err != nil {
+			t.Fatalf("rendered %s %s does not match the API type: %v\n%s", relPath, meta.Kind, err, doc)
+		}
 	}
-	return byKind
+	if pool.Name == "" || template.Name == "" {
+		t.Fatalf("rendered %s is missing a WorkerPool or an ActorTemplate", relPath)
+	}
+	return pool, template
 }
 
 // TestRenderFixtureManifest_GVisor pins the default rendering: every micro-VM
@@ -75,9 +81,8 @@ func TestRenderFixtureManifest_GVisor(t *testing.T) {
 	t.Setenv(sandboxClassEnv, "")
 	for _, relPath := range fixtureManifests {
 		t.Run(relPath, func(t *testing.T) {
-			docs := decodeFixture(t, relPath)
+			pool, template := renderFixture(t, relPath)
 
-			pool := docs["WorkerPool"]
 			if !strings.HasSuffix(pool.Spec.AteomImage, "/cmd/ateom-gvisor") {
 				t.Errorf("WorkerPool ateomImage = %q, want the gVisor ateom", pool.Spec.AteomImage)
 			}
@@ -86,7 +91,6 @@ func TestRenderFixtureManifest_GVisor(t *testing.T) {
 					pool.Spec.SandboxClass, pool.Spec.SandboxConfigName)
 			}
 
-			template := docs["ActorTemplate"]
 			if template.Spec.SandboxClass != "" {
 				t.Errorf("ActorTemplate sandboxClass = %q, want unset for gVisor", template.Spec.SandboxClass)
 			}
@@ -111,9 +115,8 @@ func TestRenderFixtureManifest_MicroVM(t *testing.T) {
 	t.Setenv(sandboxClassEnv, SandboxClassMicroVM)
 	for _, relPath := range fixtureManifests {
 		t.Run(relPath, func(t *testing.T) {
-			docs := decodeFixture(t, relPath)
+			pool, template := renderFixture(t, relPath)
 
-			pool := docs["WorkerPool"]
 			if !strings.HasSuffix(pool.Spec.AteomImage, "/cmd/ateom-microvm") {
 				t.Errorf("WorkerPool ateomImage = %q, want the micro-VM ateom", pool.Spec.AteomImage)
 			}
@@ -122,14 +125,13 @@ func TestRenderFixtureManifest_MicroVM(t *testing.T) {
 					pool.Spec.SandboxClass, pool.Spec.SandboxConfigName)
 			}
 
-			template := docs["ActorTemplate"]
 			if template.Spec.SandboxClass != SandboxClassMicroVM {
 				t.Errorf("ActorTemplate sandboxClass = %q, want %q — it must match the pool's or no worker is eligible",
 					template.Spec.SandboxClass, SandboxClassMicroVM)
 			}
 			// Undeclared limits boot the guest at the kata config default
 			// (2GiB), which does not fit beside the demo pools on one kind node.
-			if template.Spec.Resources == nil || template.Spec.Resources.Limits["memory"] == "" {
+			if template.Spec.Resources.Limits.Memory().IsZero() {
 				t.Errorf("ActorTemplate declares no memory limit, so the guest would boot at the kata default: %+v", template.Spec.Resources)
 			}
 			if want := "-microvm/"; !strings.HasSuffix(template.Spec.SnapshotsConfig.Location, want) {

--- a/internal/e2e/sandbox_test.go
+++ b/internal/e2e/sandbox_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// fixtureManifests are every template RenderFixtureManifest is asked to render.
+var fixtureManifests = []string{
+	"internal/e2e/fixtures/probe/probe.yaml.tmpl",
+	"internal/e2e/fixtures/probe/probe-sized.yaml.tmpl",
+}
+
+// renderedFixture is the subset of a rendered fixture document the assertions
+// below care about. Every field is optional: one document is a Namespace.
+type renderedFixture struct {
+	Kind string `json:"kind"`
+	Spec struct {
+		AteomImage        string `json:"ateomImage"`
+		SandboxClass      string `json:"sandboxClass"`
+		SandboxConfigName string `json:"sandboxConfigName"`
+		Resources         *struct {
+			Limits map[string]string `json:"limits"`
+		} `json:"resources"`
+		SnapshotsConfig struct {
+			Location string `json:"location"`
+		} `json:"snapshotsConfig"`
+	} `json:"spec"`
+}
+
+// decodeFixture renders a manifest and returns its documents by kind. It fails
+// the test on any document that is not valid YAML, which is the thing most
+// likely to break: the runtime blocks are injected as pre-indented text.
+func decodeFixture(t *testing.T, relPath string) map[string]renderedFixture {
+	t.Helper()
+	raw, err := os.ReadFile(RenderFixtureManifest(t, relPath, "test-bucket"))
+	if err != nil {
+		t.Fatalf("reading the rendered %s: %v", relPath, err)
+	}
+	byKind := map[string]renderedFixture{}
+	for doc := range strings.SplitSeq(string(raw), "\n---\n") {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var out renderedFixture
+		if err := yaml.Unmarshal([]byte(doc), &out); err != nil {
+			t.Fatalf("rendered %s is not valid YAML: %v\n%s", relPath, err, doc)
+		}
+		byKind[out.Kind] = out
+	}
+	return byKind
+}
+
+// TestRenderFixtureManifest_GVisor pins the default rendering: every micro-VM
+// block is gone and no placeholder survives, so the gVisor lane keeps applying
+// exactly what it applied before the templates were parameterized.
+func TestRenderFixtureManifest_GVisor(t *testing.T) {
+	t.Setenv(sandboxClassEnv, "")
+	for _, relPath := range fixtureManifests {
+		t.Run(relPath, func(t *testing.T) {
+			docs := decodeFixture(t, relPath)
+
+			pool := docs["WorkerPool"]
+			if !strings.HasSuffix(pool.Spec.AteomImage, "/cmd/ateom-gvisor") {
+				t.Errorf("WorkerPool ateomImage = %q, want the gVisor ateom", pool.Spec.AteomImage)
+			}
+			if pool.Spec.SandboxClass != "" || pool.Spec.SandboxConfigName != "" {
+				t.Errorf("WorkerPool carries micro-VM runtime fields: class=%q config=%q",
+					pool.Spec.SandboxClass, pool.Spec.SandboxConfigName)
+			}
+
+			template := docs["ActorTemplate"]
+			if template.Spec.SandboxClass != "" {
+				t.Errorf("ActorTemplate sandboxClass = %q, want unset for gVisor", template.Spec.SandboxClass)
+			}
+			// An inline placeholder with an empty value must substitute, not
+			// delete its line: the location is what the golden snapshot needs.
+			if want := "gs://test-bucket/"; !strings.HasPrefix(template.Spec.SnapshotsConfig.Location, want) {
+				t.Errorf("ActorTemplate snapshot location = %q, want it to start with %q",
+					template.Spec.SnapshotsConfig.Location, want)
+			}
+			if strings.HasSuffix(template.Spec.SnapshotsConfig.Location, "-microvm/") {
+				t.Errorf("ActorTemplate snapshot location = %q, want no micro-VM suffix",
+					template.Spec.SnapshotsConfig.Location)
+			}
+		})
+	}
+}
+
+// TestRenderFixtureManifest_MicroVM pins the micro-VM rendering: the pool names
+// the cluster-wide SandboxConfig, the template matches its class, and the
+// snapshots land under their own prefix.
+func TestRenderFixtureManifest_MicroVM(t *testing.T) {
+	t.Setenv(sandboxClassEnv, SandboxClassMicroVM)
+	for _, relPath := range fixtureManifests {
+		t.Run(relPath, func(t *testing.T) {
+			docs := decodeFixture(t, relPath)
+
+			pool := docs["WorkerPool"]
+			if !strings.HasSuffix(pool.Spec.AteomImage, "/cmd/ateom-microvm") {
+				t.Errorf("WorkerPool ateomImage = %q, want the micro-VM ateom", pool.Spec.AteomImage)
+			}
+			if pool.Spec.SandboxClass != SandboxClassMicroVM || pool.Spec.SandboxConfigName != "microvm" {
+				t.Errorf("WorkerPool runtime = class %q / config %q, want microvm / microvm",
+					pool.Spec.SandboxClass, pool.Spec.SandboxConfigName)
+			}
+
+			template := docs["ActorTemplate"]
+			if template.Spec.SandboxClass != SandboxClassMicroVM {
+				t.Errorf("ActorTemplate sandboxClass = %q, want %q — it must match the pool's or no worker is eligible",
+					template.Spec.SandboxClass, SandboxClassMicroVM)
+			}
+			// Undeclared limits boot the guest at the kata config default
+			// (2GiB), which does not fit beside the demo pools on one kind node.
+			if template.Spec.Resources == nil || template.Spec.Resources.Limits["memory"] == "" {
+				t.Errorf("ActorTemplate declares no memory limit, so the guest would boot at the kata default: %+v", template.Spec.Resources)
+			}
+			if want := "-microvm/"; !strings.HasSuffix(template.Spec.SnapshotsConfig.Location, want) {
+				t.Errorf("ActorTemplate snapshot location = %q, want it to end with %q",
+					template.Spec.SnapshotsConfig.Location, want)
+			}
+		})
+	}
+}
+
+// TestCounterFixture covers the knob every suite reads: the class picks the
+// fixture, and the explicit environment overrides still win.
+func TestCounterFixture(t *testing.T) {
+	t.Run("gvisor", func(t *testing.T) {
+		t.Setenv(sandboxClassEnv, "")
+		if got := CounterFixture(); got.Namespace != "ate-demo-counter" || got.Name != "counter" {
+			t.Errorf("CounterFixture() = %+v, want the gVisor counter demo", got)
+		}
+	})
+	t.Run("microvm", func(t *testing.T) {
+		t.Setenv(sandboxClassEnv, SandboxClassMicroVM)
+		if got := CounterFixture(); got.Namespace != "ate-demo-counter-microvm" || got.Name != "counter-microvm" {
+			t.Errorf("CounterFixture() = %+v, want the micro-VM counter demo", got)
+		}
+		if got := EgressFixture(); got.Namespace != "ate-demo-egress-microvm" || got.Name != "egress-microvm" {
+			t.Errorf("EgressFixture() = %+v, want the micro-VM egress demo", got)
+		}
+	})
+	t.Run("explicit override wins", func(t *testing.T) {
+		t.Setenv(sandboxClassEnv, SandboxClassMicroVM)
+		t.Setenv("E2E_TEMPLATE_NAMESPACE", "elsewhere")
+		t.Setenv("E2E_TEMPLATE_NAME", "other")
+		if got := CounterFixture(); got.Namespace != "elsewhere" || got.Name != "other" {
+			t.Errorf("CounterFixture() = %+v, want the environment override", got)
+		}
+	})
+}

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -324,7 +323,7 @@ func TestDurableDirLifecycle(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if test.tc.microVMOnly && !isMicroVMEnvironment() {
+			if test.tc.microVMOnly && !e2e.IsMicroVM() {
 				t.Skipf("Skipping %s: micro-VM-only case (Golden resume source, or durable-data extraction from a Full capture)", test.name)
 			}
 			t.Parallel()
@@ -389,7 +388,7 @@ func TestMultipleDurableDirLifecycle(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if test.tc.microVMOnly && !isMicroVMEnvironment() {
+			if test.tc.microVMOnly && !e2e.IsMicroVM() {
 				t.Skipf("Skipping %s: the Golden resume source is micro-VM only", test.name)
 			}
 			t.Parallel()
@@ -873,17 +872,11 @@ func createActorTemplateInternal(ctx context.Context, t *testing.T, clients *e2e
 		t.Fatalf("CheckEnv failed: %v", err)
 	}
 
-	// The source WorkerPool+ActorTemplate to copy the resolved runtime (sandbox class,
-	// ateom image, container images) from. Defaults to the gVisor counter demo; CI
-	// overrides these to point this same lifecycle test at the micro-VM counter.
-	srcNS := "ate-demo-counter"
-	if v := os.Getenv("E2E_TEMPLATE_NAMESPACE"); v != "" {
-		srcNS = v
-	}
-	srcName := "counter"
-	if v := os.Getenv("E2E_TEMPLATE_NAME"); v != "" {
-		srcName = v
-	}
+	// The source WorkerPool+ActorTemplate to copy the resolved runtime (sandbox
+	// class, ateom image, container images, sandbox size) from: the counter demo
+	// for the sandbox class under test, so this one lifecycle test covers both.
+	src := e2e.CounterFixture()
+	srcNS, srcName := src.Namespace, src.Name
 
 	// Query existing WorkerPool and ActorTemplate to get the resolved container images
 	existingWp, err := clients.SubstrateK8s.ApiV1alpha1().WorkerPools(srcNS).Get(ctx, srcName, metav1.GetOptions{})
@@ -932,6 +925,10 @@ func createActorTemplateInternal(ctx context.Context, t *testing.T, clients *e2e
 			// "microvm"; the gVisor source leaves it "" — copying keeps both correct.
 			SandboxClass: existingAt.Spec.SandboxClass,
 			Containers:   existingAt.Spec.Containers,
+			// The source's limits size the sandbox. Copying them matters most on
+			// micro-VM, where an ActorTemplate that declares none boots the guest
+			// at the kata config default (2GiB) instead of the demo's 512Mi.
+			Resources: existingAt.Spec.Resources,
 			SnapshotsConfig: v1alpha1.SnapshotsConfig{
 				Location: "gs://" + env["BUCKET_NAME"] + "/ate-demo-" + name,
 				OnPause:  onPause,
@@ -949,18 +946,11 @@ func createActorTemplateInternal(ctx context.Context, t *testing.T, clients *e2e
 		t.Fatalf("failed to create ActorTemplate: %v", err)
 	}
 
-	// Wait for ActorTemplate to be Ready (golden snapshot created) before creating an actor.
-	// The micro-VM golden (CH boot + checkpoint on nested KVM) is slower than gVisor, so
-	// CI raises this via E2E_TEMPLATE_READY_TIMEOUT.
+	// Wait for ActorTemplate to be Ready (golden snapshot created) before creating
+	// an actor. TemplateReadyTimeout budgets for the micro-VM golden (a CH cold
+	// boot plus checkpoint on nested KVM) being slower than the gVisor one.
 	t.Logf("Waiting for ActorTemplate %s to be Ready...", at.Name)
-	tmplTimeout := 90 * time.Second
-	if v := os.Getenv("E2E_TEMPLATE_READY_TIMEOUT"); v != "" {
-		d, perr := time.ParseDuration(v)
-		if perr != nil {
-			t.Fatalf("invalid E2E_TEMPLATE_READY_TIMEOUT %q: %v", v, perr)
-		}
-		tmplTimeout = d
-	}
+	tmplTimeout := e2e.TemplateReadyTimeout(t)
 	tmplCtx, tmplCancel := context.WithTimeout(ctx, tmplTimeout)
 	defer tmplCancel()
 	var lastPhase v1alpha1.PhaseType
@@ -1219,13 +1209,6 @@ func callActorPathOnce(t *testing.T, actorRef resources.ActorRef, method, path s
 	}
 
 	return string(body), nil
-}
-
-// isMicroVMEnvironment reports whether the suite is running against the
-// micro-VM demo template, which does not support every volume type yet (see
-// TestExternalVolumeLifecycle).
-func isMicroVMEnvironment() bool {
-	return os.Getenv("E2E_TEMPLATE_NAMESPACE") == "ate-demo-counter-microvm"
 }
 
 func TestWorkerPodDeletion(t *testing.T) {

--- a/internal/e2e/suites/identity/identity_test.go
+++ b/internal/e2e/suites/identity/identity_test.go
@@ -30,10 +30,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	probeNamespace = "ate-e2e-probe"
-	probeTemplate  = "probe"
-)
+const probeTemplate = "probe"
+
+// probeNamespace is where deployProbe applies the fixture, and the atespace its
+// actors live in. Suffixed per sandbox class (see e2e.FixtureName) so the two
+// lanes' fixtures never collide: they run one after the other, and this
+// namespace is deleted by the test that created it.
+var probeNamespace = e2e.FixtureName("ate-e2e-probe")
 
 type whoamiResponse struct {
 	File     string `json:"file"`

--- a/internal/e2e/suites/identity/identity_test.go
+++ b/internal/e2e/suites/identity/identity_test.go
@@ -19,9 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -98,17 +96,9 @@ func deployProbe(t *testing.T, bucket string) {
 		t.Fatalf("FindRepoRoot: %v", err)
 	}
 
-	// Render the manifest template to a file so both apply and delete can
-	// consume it without any shell involved.
-	tmpl, err := os.ReadFile(filepath.Join(root, "internal/e2e/fixtures/probe/probe.yaml.tmpl"))
-	if err != nil {
-		t.Fatalf("reading probe manifest template: %v", err)
-	}
-	manifest := filepath.Join(t.TempDir(), "probe.yaml")
-	rendered := strings.ReplaceAll(string(tmpl), "${BUCKET_NAME}", bucket)
-	if err := os.WriteFile(manifest, []byte(rendered), 0o644); err != nil {
-		t.Fatalf("writing rendered probe manifest: %v", err)
-	}
+	// One manifest, rendered for the sandbox class under test, so both apply and
+	// delete consume the same file without any shell involved.
+	manifest := e2e.RenderFixtureManifest(t, "internal/e2e/fixtures/probe/probe.yaml.tmpl", bucket)
 
 	// Build/push the probe image and apply the manifest through the repo's
 	// pinned ko (hack/run-tool.sh ko); CI does not install ko on PATH, and every
@@ -140,7 +130,7 @@ func deployProbe(t *testing.T, bucket string) {
 
 func waitForGolden(t *testing.T, ctx context.Context, clients *e2e.Clients) string {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Minute)
+	deadline := time.Now().Add(e2e.TemplateReadyTimeout(t))
 	for time.Now().Before(deadline) {
 		at, err := clients.SubstrateK8s.ApiV1alpha1().ActorTemplates(probeNamespace).Get(ctx, probeTemplate, metav1.GetOptions{})
 		if err == nil {

--- a/internal/e2e/suites/identity/identity_test.go
+++ b/internal/e2e/suites/identity/identity_test.go
@@ -53,6 +53,18 @@ type whoamiResponse struct {
 // restoring TWO actors from one golden snapshot and asserting each observes its
 // OWN id — and explicitly that it is not the golden id.
 func TestActorIdentity_AfterRestore_IsOwnID_NotGolden(t *testing.T) {
+	// The micro-VM runtime does not expose the identity file yet. ateom-microvm
+	// replaces atelet's mount set with the one the kata agent accepts, and drops
+	// atelet's read-only /run/ate/actor-id bind with it: the guest sees only the
+	// virtio-fs shares, so a host-path bind has nothing to bind to. Exposing it
+	// needs a per-actor volume plumbed into the guest — see the KNOWN GAP comment
+	// in cmd/ateom-microvm/spec.go. Running this against micro-VM reports the
+	// probe reading an empty ID, which is that gap and not a regression, so skip
+	// until the gap closes rather than encode it as expected behavior.
+	if e2e.IsMicroVM() {
+		t.Skip("micro-VM does not mount /run/ate/actor-id yet (KNOWN GAP in cmd/ateom-microvm/spec.go)")
+	}
+
 	env, err := e2e.CheckEnv("BUCKET_NAME", "KO_DOCKER_REPO")
 	if err != nil {
 		t.Fatalf("CheckEnv failed: %v", err)

--- a/internal/e2e/suites/metrics/metrics_test.go
+++ b/internal/e2e/suites/metrics/metrics_test.go
@@ -16,14 +16,13 @@
 // the platform metrics in e2e.PlatformMetricPrefixes reach the kind stack's OTel
 // Collector. It closes the "silent regression" gap: a renamed or dropped
 // instrument fails here rather than surfacing as an empty dashboard. The prefix
-// set grows as each metric slice lands. Requires the demo counter template to be
-// installed (override with E2E_TEMPLATE_NAMESPACE / _NAME).
+// set grows as each metric slice lands. Requires the demo counter template for
+// the sandbox class under test to be installed (see e2e.CounterFixture).
 package metrics
 
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -38,21 +37,10 @@ import (
 
 const metricsAtespace = "ate-metrics-e2e"
 
-func templateRef() (namespace, name string) {
-	namespace, name = "ate-demo-counter", "counter"
-	if v := os.Getenv("E2E_TEMPLATE_NAMESPACE"); v != "" {
-		namespace = v
-	}
-	if v := os.Getenv("E2E_TEMPLATE_NAME"); v != "" {
-		name = v
-	}
-	return namespace, name
-}
-
 func TestPlatformMetricsEmitted(t *testing.T) {
 	ctx := context.Background()
 	clients := e2e.GetClients()
-	tmplNS, tmplName := templateRef()
+	tmpl := e2e.CounterFixture()
 	actorID := fmt.Sprintf("metrics-probe-%d", time.Now().UnixNano())
 
 	// CreateActor requires the atespace to exist first; ignore AlreadyExists.
@@ -62,8 +50,8 @@ func TestPlatformMetricsEmitted(t *testing.T) {
 
 	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
 		Metadata:               &ateapipb.ResourceMetadata{Atespace: metricsAtespace, Name: actorID},
-		ActorTemplateNamespace: tmplNS,
-		ActorTemplateName:      tmplName,
+		ActorTemplateNamespace: tmpl.Namespace,
+		ActorTemplateName:      tmpl.Name,
 	}}); err != nil {
 		t.Fatalf("CreateActor: %v", err)
 	}

--- a/internal/e2e/suites/networking/arbitraryport_test.go
+++ b/internal/e2e/suites/networking/arbitraryport_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/e2e"
 	"github.com/agent-substrate/substrate/internal/resources"
 )
 
@@ -48,7 +49,7 @@ const counterExtraPort = 9090
 // resolution and atunnel's dial to the actor's pod actually happen.
 func TestActorArbitraryPortAccess(t *testing.T) {
 	ctx := context.Background()
-	actorName, _ := createAndResumeActor(t, ctx, "arbitraryport", counterTemplate)
+	actorName, _ := createAndResumeActor(t, ctx, "arbitraryport", e2e.CounterFixture())
 	actorRef := resources.ActorRef{Atespace: networkingAtespace, Name: actorName}
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
@@ -77,11 +78,12 @@ func TestActorArbitraryPortAccess(t *testing.T) {
 		}
 
 		// Cross-check against the default port's own response, both self-reported
-		// by the same counter binary via getCurrentIP() -- gVisor virtualizes the
-		// sandbox's network stack, so this address is not the pod's Kubernetes IP,
-		// but it is consistent between the two ports on one actor. Asserting they
-		// match proves the tunnel reached the same actor's extra port rather than
-		// some other, unrelated open port.
+		// by the same counter binary via getCurrentIP() -- either sandbox has its
+		// own network stack (the gVisor sentry's, or the micro-VM guest's), so
+		// this address is not the pod's Kubernetes IP, but it is consistent
+		// between the two ports on one actor. Asserting they match proves the
+		// tunnel reached the same actor's extra port rather than some other,
+		// unrelated open port.
 		defaultResp, err := router.Get(ctx, actorRef, "/")
 		if err != nil {
 			t.Fatalf("GET the actor's default port through ingress: %v", err)

--- a/internal/e2e/suites/networking/networking_test.go
+++ b/internal/e2e/suites/networking/networking_test.go
@@ -33,24 +33,9 @@ import (
 
 const networkingAtespace = "networking-e2e"
 
-// actorTemplate identifies a demo ActorTemplate to build test Actors from,
-// along with the hack/install-ate.sh flag that deploys it.
-type actorTemplate struct {
-	namespace string
-	name      string
-	// deployFlag names the install flag that creates the template, so a
-	// missing fixture reports how to fix it rather than just failing.
-	deployFlag string
-}
-
-var (
-	counterTemplate = actorTemplate{namespace: "ate-demo-counter", name: "counter", deployFlag: "--deploy-demo-counter"}
-	egressTemplate  = actorTemplate{namespace: "ate-demo-egress", name: "egress", deployFlag: "--deploy-demo-egress"}
-)
-
 func TestActorDirectAccess(t *testing.T) {
 	ctx := context.Background()
-	actorName, actor := createAndResumeActor(t, ctx, "direct", counterTemplate)
+	actorName, actor := createAndResumeActor(t, ctx, "direct", e2e.CounterFixture())
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
 
@@ -74,7 +59,7 @@ func TestActorDirectAccess(t *testing.T) {
 // asserts the gateway is deployed and that it did not reject the Actor.
 func TestActorEgress(t *testing.T) {
 	ctx := context.Background()
-	actorName, _ := createAndResumeActor(t, ctx, "egress", egressTemplate)
+	actorName, _ := createAndResumeActor(t, ctx, "egress", e2e.EgressFixture())
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
 
@@ -93,7 +78,7 @@ func TestActorEgress(t *testing.T) {
 // between the Actor and the origin.
 func TestActorEgressHTTPS(t *testing.T) {
 	ctx := context.Background()
-	actorName, _ := createAndResumeActor(t, ctx, "egress-https", egressTemplate)
+	actorName, _ := createAndResumeActor(t, ctx, "egress-https", e2e.EgressFixture())
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
 
@@ -231,7 +216,7 @@ func accessLogField(line, key string) (string, bool) {
 	return value, true
 }
 
-func createAndResumeActor(t *testing.T, ctx context.Context, prefix string, template actorTemplate) (string, *ateapipb.Actor) {
+func createAndResumeActor(t *testing.T, ctx context.Context, prefix string, template e2e.Fixture) (string, *ateapipb.Actor) {
 	t.Helper()
 	clients := e2e.GetClients()
 	actorName := fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
@@ -243,10 +228,10 @@ func createAndResumeActor(t *testing.T, ctx context.Context, prefix string, temp
 	})
 	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
 		Metadata:               &ateapipb.ResourceMetadata{Atespace: networkingAtespace, Name: actorName},
-		ActorTemplateNamespace: template.namespace,
-		ActorTemplateName:      template.name,
+		ActorTemplateNamespace: template.Namespace,
+		ActorTemplateName:      template.Name,
 	}}); err != nil {
-		t.Fatalf("CreateActor from %s/%s: %v (deploy the fixture with %s)", template.namespace, template.name, err, template.deployFlag)
+		t.Fatalf("CreateActor from %s/%s: %v (deploy the fixture with %s)", template.Namespace, template.Name, err, template.DeployWith)
 	}
 	t.Cleanup(func() {
 		_, _ = clients.SubstrateAPI.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{Actor: actorRef})

--- a/internal/e2e/suites/networkpolicy/networkpolicy_test.go
+++ b/internal/e2e/suites/networkpolicy/networkpolicy_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -280,14 +279,8 @@ func TestNetworkPolicyDataPlaneEnforcement(t *testing.T) {
 
 func setupDemoCounterTemplate(ctx context.Context, t *testing.T, clients *e2e.Clients, ns string) (*v1alpha1.WorkerPool, *v1alpha1.ActorTemplate) {
 	t.Helper()
-	srcNS := "ate-demo-counter"
-	if v := os.Getenv("E2E_TEMPLATE_NAMESPACE"); v != "" {
-		srcNS = v
-	}
-	srcName := "counter"
-	if v := os.Getenv("E2E_TEMPLATE_NAME"); v != "" {
-		srcName = v
-	}
+	src := e2e.CounterFixture()
+	srcNS, srcName := src.Namespace, src.Name
 
 	existingWp, err := clients.SubstrateK8s.ApiV1alpha1().WorkerPools(srcNS).Get(ctx, srcName, metav1.GetOptions{})
 	if err != nil {
@@ -325,8 +318,12 @@ func setupDemoCounterTemplate(ctx context.Context, t *testing.T, clients *e2e.Cl
 			WorkerSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"netpol-test": ns},
 			},
-			SandboxClass:    existingAt.Spec.SandboxClass,
-			Containers:      existingAt.Spec.Containers,
+			SandboxClass: existingAt.Spec.SandboxClass,
+			Containers:   existingAt.Spec.Containers,
+			// The source's limits size the sandbox. Copying them matters most on
+			// micro-VM, where an ActorTemplate that declares none boots the guest
+			// at the kata config default (2GiB) instead of the demo's 512Mi.
+			Resources:       existingAt.Spec.Resources,
 			SnapshotsConfig: existingAt.Spec.SnapshotsConfig,
 			Volumes:         existingAt.Spec.Volumes,
 		},
@@ -336,14 +333,7 @@ func setupDemoCounterTemplate(ctx context.Context, t *testing.T, clients *e2e.Cl
 	}
 
 	t.Logf("Waiting for ActorTemplate %s/%s to be Ready...", ns, at.Name)
-	tmplTimeout := 90 * time.Second
-	if v := os.Getenv("E2E_TEMPLATE_READY_TIMEOUT"); v != "" {
-		d, perr := time.ParseDuration(v)
-		if perr != nil {
-			t.Fatalf("invalid E2E_TEMPLATE_READY_TIMEOUT %q: %v", v, perr)
-		}
-		tmplTimeout = d
-	}
+	tmplTimeout := e2e.TemplateReadyTimeout(t)
 	tmplCtx, tmplCancel := context.WithTimeout(ctx, tmplTimeout)
 	defer tmplCancel()
 	var lastPhase v1alpha1.PhaseType

--- a/internal/e2e/suites/parking/parking_test.go
+++ b/internal/e2e/suites/parking/parking_test.go
@@ -172,7 +172,8 @@ func createParkingFixture(ctx context.Context, t *testing.T, clients *e2e.Client
 		t.Fatalf("CheckEnv failed: %v", err)
 	}
 
-	srcNS, srcName := "ate-demo-counter", "counter"
+	src := e2e.CounterFixture()
+	srcNS, srcName := src.Namespace, src.Name
 	existingWp, err := clients.SubstrateK8s.ApiV1alpha1().WorkerPools(srcNS).Get(ctx, srcName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get source WorkerPool %s/%s: %v", srcNS, srcName, err)
@@ -210,6 +211,10 @@ func createParkingFixture(ctx context.Context, t *testing.T, clients *e2e.Client
 			},
 			SandboxClass: existingAt.Spec.SandboxClass,
 			Containers:   existingAt.Spec.Containers,
+			// The source's limits size the sandbox. Copying them matters most on
+			// micro-VM, where an ActorTemplate that declares none boots the guest
+			// at the kata config default (2GiB) instead of the demo's 512Mi.
+			Resources: existingAt.Spec.Resources,
 			SnapshotsConfig: v1alpha1.SnapshotsConfig{
 				Location: "gs://" + env["BUCKET_NAME"] + "/e2e-parking-" + nsObj.Name,
 			},
@@ -221,7 +226,7 @@ func createParkingFixture(ctx context.Context, t *testing.T, clients *e2e.Client
 	}
 
 	t.Logf("Waiting for ActorTemplate %s to be Ready...", at.Name)
-	tmplCtx, tmplCancel := context.WithTimeout(ctx, 90*time.Second)
+	tmplCtx, tmplCancel := context.WithTimeout(ctx, e2e.TemplateReadyTimeout(t))
 	defer tmplCancel()
 	var lastPhase v1alpha1.PhaseType
 	for {

--- a/internal/e2e/suites/sdsmint/actoridentity_test.go
+++ b/internal/e2e/suites/sdsmint/actoridentity_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/url"
-	"os"
 	"path"
 	"sync"
 	"testing"
@@ -73,20 +72,6 @@ const (
 	podIdentityCredentialPath = "/run/podidentity.podcert.ate.dev/credential-bundle.pem"
 )
 
-// templateRef is the ActorTemplate the suite's actor is created from. The
-// default is the one every other suite uses; the environment overrides exist
-// for clusters that install the fixtures elsewhere.
-func templateRef() (namespace, name string) {
-	namespace, name = "ate-demo-counter", "counter"
-	if v := os.Getenv("E2E_TEMPLATE_NAMESPACE"); v != "" {
-		namespace = v
-	}
-	if v := os.Getenv("E2E_TEMPLATE_NAME"); v != "" {
-		name = v
-	}
-	return namespace, name
-}
-
 // probeActor is the identity the probe authenticates to the gateway as.
 type probeActor struct {
 	atespace string
@@ -111,7 +96,7 @@ func createLiveActor() (*probeActor, error) {
 	defer cancel()
 
 	clients := e2e.GetClients()
-	tmplNS, tmplName := templateRef()
+	tmpl := e2e.CounterFixture()
 	name := fmt.Sprintf("sdsmint-probe-%d", time.Now().UnixNano())
 	ref := &ateapipb.ObjectRef{Atespace: probeAtespace, Name: name}
 
@@ -122,11 +107,11 @@ func createLiveActor() (*probeActor, error) {
 	})
 	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
 		Metadata:               &ateapipb.ResourceMetadata{Atespace: probeAtespace, Name: name},
-		ActorTemplateNamespace: tmplNS,
-		ActorTemplateName:      tmplName,
+		ActorTemplateNamespace: tmpl.Namespace,
+		ActorTemplateName:      tmpl.Name,
 	}}); err != nil {
-		return nil, fmt.Errorf("creating actor %s/%s from template %s/%s: %w (install the fixture with hack/install-demo-counter.sh, or point E2E_TEMPLATE_NAMESPACE/E2E_TEMPLATE_NAME at another one)",
-			probeAtespace, name, tmplNS, tmplName, err)
+		return nil, fmt.Errorf("creating actor %s/%s from template %s/%s: %w (deploy the fixture with %s)",
+			probeAtespace, name, tmpl.Namespace, tmpl.Name, err, tmpl.DeployWith)
 	}
 	e2e.RegisterSuiteCleanup(func() {
 		// DeleteActor requires the actor to be suspended first. Both are

--- a/internal/e2e/suites/sizing/sizing_test.go
+++ b/internal/e2e/suites/sizing/sizing_test.go
@@ -19,9 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -59,9 +57,10 @@ type resourcesResponse struct {
 // honors them, by resuming an actor and asking it (via the probe /resources
 // endpoint) what compute envelope it sees from the inside.
 //
-// gVisor is the default (and only) runtime in the macOS/colima kind
-// environment, so the assertions target what runsc --cpu-num-from-quota and the
-// cgroup memory limit produce inside the sentry.
+// Both runtimes reach the declared numbers by different routes, and the
+// assertions below are written to hold for either: gVisor sizes the sentry from
+// the CPU quota and the cgroup memory limit, while the micro-VM sizes the guest
+// VM itself (see internal/sizing).
 func TestActorSizing_SandboxObservesDeclaredLimits(t *testing.T) {
 	env, err := e2e.CheckEnv("BUCKET_NAME", "KO_DOCKER_REPO")
 	if err != nil {
@@ -87,15 +86,19 @@ func TestActorSizing_SandboxObservesDeclaredLimits(t *testing.T) {
 		got.NumCPU, got.MemTotalBytes, got.CPUMax, got.MemoryMax, got.MemTotalError)
 
 	// CPU: runsc provisions the sentry's vCPU count from the CPU quota
-	// (--cpu-num-from-quota), so the sandbox must see exactly the declared limit.
+	// (--cpu-num-from-quota) and the micro-VM boots the guest with
+	// SandboxSize.VCPUs(); either way the sandbox must see exactly the declared
+	// limit.
 	if got.NumCPU != wantCPU {
 		t.Errorf("sandbox NumCPU = %d, want %d (declared limits.cpu=%d) — sandbox not sized to actor limits", got.NumCPU, wantCPU, wantCPU)
 	}
 
-	// Memory: the sandbox must be bounded by the declared limit. gVisor may
-	// report slightly under the limit (reserved overhead) but must never see
-	// more; a value near the node's full RAM means the limit was not applied.
-	// Allow 10% headroom above the limit for accounting differences.
+	// Memory: the sandbox must be bounded by the declared limit. Both runtimes
+	// report under it — gVisor by its reserved overhead, the micro-VM by the
+	// 128MiB VMM reserve held back from the guest plus what the guest kernel
+	// takes — but neither may see more; a value near the node's full RAM means
+	// the limit was not applied. Allow 10% headroom above the limit for
+	// accounting differences, and half the limit below it for those overheads.
 	if got.MemTotalError != "" {
 		t.Errorf("probe could not read MemTotal: %s", got.MemTotalError)
 	} else if got.MemTotalBytes > wantMemBytes*11/10 {
@@ -112,17 +115,9 @@ func deploySizedProbe(t *testing.T, bucket string) {
 		t.Fatalf("FindRepoRoot: %v", err)
 	}
 
-	// Render the manifest template to a file so both apply and delete can
-	// consume it without any shell involved (mirrors the identity suite).
-	tmpl, err := os.ReadFile(filepath.Join(root, "internal/e2e/fixtures/probe/probe-sized.yaml.tmpl"))
-	if err != nil {
-		t.Fatalf("reading sized probe manifest template: %v", err)
-	}
-	manifest := filepath.Join(t.TempDir(), "probe-sized.yaml")
-	rendered := strings.ReplaceAll(string(tmpl), "${BUCKET_NAME}", bucket)
-	if err := os.WriteFile(manifest, []byte(rendered), 0o644); err != nil {
-		t.Fatalf("writing rendered sized probe manifest: %v", err)
-	}
+	// One manifest, rendered for the sandbox class under test (mirrors the
+	// identity suite).
+	manifest := e2e.RenderFixtureManifest(t, "internal/e2e/fixtures/probe/probe-sized.yaml.tmpl", bucket)
 
 	// Build/push the probe image and apply through the repo's pinned ko. See the
 	// identity suite's deployProbe for why KO_CONFIG_PATH and the trailing
@@ -144,7 +139,7 @@ func deploySizedProbe(t *testing.T, bucket string) {
 
 func waitForTemplateReady(t *testing.T, ctx context.Context, clients *e2e.Clients) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Minute)
+	deadline := time.Now().Add(e2e.TemplateReadyTimeout(t))
 	for time.Now().Before(deadline) {
 		at, err := clients.SubstrateK8s.ApiV1alpha1().ActorTemplates(sizingNamespace).Get(ctx, sizingTemplate, metav1.GetOptions{})
 		if err == nil {

--- a/internal/e2e/suites/sizing/sizing_test.go
+++ b/internal/e2e/suites/sizing/sizing_test.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	sizingNamespace = "ate-e2e-sizing"
-	sizingTemplate  = "probe-sized"
+	sizingTemplate = "probe-sized"
 
 	// The limits declared in probe-sized.yaml.tmpl. Keep these in sync with the
 	// manifest: the whole point of the suite is to assert the sandbox observes
@@ -40,6 +39,11 @@ const (
 	wantCPU      = 2
 	wantMemBytes = 512 * 1024 * 1024 // 512Mi
 )
+
+// sizingNamespace is where deploySizedProbe applies the fixture, and the
+// atespace its actor lives in. Suffixed per sandbox class (see
+// e2e.FixtureName) so the two lanes' fixtures never collide.
+var sizingNamespace = e2e.FixtureName("ate-e2e-sizing")
 
 // resourcesResponse mirrors the /resources endpoint of the probe fixture.
 type resourcesResponse struct {


### PR DESCRIPTION
We were only running a subset of tests. That was meant to be temporary.

Fix the tests and enable the full suite for uVM.

Consolidate on a single env `E2E_SANDBOX_CLASS` as input to select microvm vs gvisor.

NOTE: we still skip identity. That will be replaced by #268 
