### PR TITLE
[WIP] ateomnet: give the actor an IPv6 address when the pod has one

### DIFF
--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -643,7 +643,7 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	if err != nil {
 		return nil, err
 	}
-	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+	if _, err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
 		InteriorNetNS:      s.interiorNetNS,
 		DumpNetInfo:        true,
 		EgressRedirectPort: s.egressRedirectPort(req.GetEgressGateway() != nil),
@@ -922,7 +922,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	if err != nil {
 		return nil, err
 	}
-	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+	if _, err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
 		InteriorNetNS:      s.interiorNetNS,
 		DumpNetInfo:        true,
 		EgressRedirectPort: s.egressRedirectPort(req.GetEgressGateway() != nil),

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -266,7 +266,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 
 	// Networking: rebuild the per-activation veth + tap; the snapshot's virtio-net
 	// is fd-backed, so CH needs fresh tap FDs (net_fds) on restore.
-	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+	if _, err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
 		InteriorNetNS:      s.interiorNetNS,
 		HostVethHWAddr:     hostVethHWAddr,
 		SweepInteriorLinks: true,

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -1061,6 +1061,10 @@ func tailString(s string, n int) string {
 // agent: configure eth0 (IP/MAC/MTU), install the connected + default routes, and
 // pin the gateway's ARP entry to its fixed MAC (so a restored guest's frozen
 // neighbor entry stays valid).
+//
+// TODO(#246): the guest is configured IPv4-only, so a micro-VM actor sees no
+// IPv6 even on a dual-stack pod where the host veth has one. gVisor reads the
+// interior netns and picks the address up; this path has to be told.
 func (s *AteomService) configureGuestNetwork(ctx context.Context, ac *kata.AgentClient, mtu uint64) error {
 	if err := ac.UpdateInterface(ctx, &agentpb.Interface{
 		Device: ateomnet.ActorVethName,

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -411,7 +411,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 
 	// Networking (host side): per-activation veth into the interior netns. The
 	// tap + TC mirror is built below (after the VM exists) so its FDs are fresh.
-	if err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
+	if _, err := ateomnet.SetupActorNetwork(ctx, ateomnet.NetworkConfig{
 		InteriorNetNS:      s.interiorNetNS,
 		HostVethHWAddr:     hostVethHWAddr,
 		SweepInteriorLinks: true,

--- a/internal/ateomnet/net.go
+++ b/internal/ateomnet/net.go
@@ -229,8 +229,8 @@ func InstallActorNftablesRules(egressPort uint16) error {
 	// rules in an ateom-owned table makes cleanup simple and avoids mutating
 	// Kubernetes or CNI-managed chains directly.
 	//
-	// TODO: Add IPv6 veth addressing, forwarding, and nftables rules once actor
-	// networking supports dual-stack pods. The current actor network is IPv4-only.
+	// TODO(#246): Add the IPv6 veth addressing and forwarding. The actor
+	// network itself is still IPv4-only.
 	//
 	// The rules do three things:
 	//
@@ -247,8 +247,10 @@ func InstallActorNftablesRules(egressPort uint16) error {
 	}
 
 	c := &nftables.Conn{}
+	// The inet family lets one table carry both address families once the
+	// actor veth is dual-stack.
 	table := &nftables.Table{
-		Family: nftables.TableFamilyIPv4,
+		Family: nftables.TableFamilyINet,
 		Name:   ActorNftTableName,
 	}
 	c.AddTable(table)
@@ -274,7 +276,7 @@ func InstallActorNftablesRules(egressPort uint16) error {
 	c.AddRule(&nftables.Rule{
 		Table: table,
 		Chain: postrouting,
-		Exprs: append(IPSourceEqual(ActorVethIP), &expr.Masq{}),
+		Exprs: append(ipv4SourceEqual(ActorVethIP), &expr.Masq{}),
 	})
 
 	acceptPolicy := nftables.ChainPolicyAccept
@@ -295,7 +297,7 @@ func InstallActorNftablesRules(egressPort uint16) error {
 	})
 
 	if err := c.Flush(); err != nil {
-		return fmt.Errorf("while installing actor nftables rules: %w", err)
+		return fmt.Errorf("while installing actor nftables rules (inet nat needs Linux 5.2 or later): %w", err)
 	}
 	return nil
 }
@@ -305,10 +307,23 @@ func RemoveActorNftablesRules() error {
 	// Delete the whole ateom nftables table if it exists. The table is
 	// per-worker and currently per-active-actor because this worker path runs at
 	// most one actor at a time. Missing tables are treated as already clean.
+	//
+	// A table name is unique per family, so both families are swept: an ateom
+	// from before the inet move can have left an ip table in this netns.
+	// TODO(ypgao): Drop the ip sweep once no live pod can predate this change.
+	return errors.Join(
+		removeActorNftablesTable("inet", nftables.TableFamilyINet),
+		removeActorNftablesTable("ip", nftables.TableFamilyIPv4),
+	)
+}
+
+// removeActorNftablesTable deletes the actor table in one family. A missing
+// table is treated as already clean.
+func removeActorNftablesTable(name string, family nftables.TableFamily) error {
 	c := &nftables.Conn{}
-	tables, err := c.ListTablesOfFamily(nftables.TableFamilyIPv4)
+	tables, err := c.ListTablesOfFamily(family)
 	if err != nil {
-		return fmt.Errorf("while listing nftables tables: %w", err)
+		return fmt.Errorf("while listing %s nftables tables: %w", name, err)
 	}
 	for _, table := range tables {
 		if table.Name != ActorNftTableName {
@@ -316,19 +331,27 @@ func RemoveActorNftablesRules() error {
 		}
 		c.DelTable(table)
 		if err := c.Flush(); err != nil {
-			return fmt.Errorf("while deleting actor nftables table: %w", err)
+			return fmt.Errorf("while deleting the %s actor nftables table: %w", name, err)
 		}
 		return nil
 	}
 	return nil
 }
 
-func IPSourceEqual(ip string) []expr.Any {
-	return IPPayloadEqual(12, ip)
+func ipv4SourceEqual(ip string) []expr.Any {
+	return ipv4PayloadEqual(12, ip)
 }
 
-func IPPayloadEqual(offset uint32, ip string) []expr.Any {
+// ipv4PayloadEqual matches a 4-byte IPv4 network-header field, guarded by an
+// nfproto comparison so it is safe in the inet table.
+func ipv4PayloadEqual(offset uint32, ip string) []expr.Any {
 	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     []byte{unix.NFPROTO_IPV4},
+		},
 		&expr.Payload{
 			DestRegister: 1,
 			Base:         expr.PayloadBaseNetworkHeader,
@@ -361,7 +384,7 @@ func ActorEgressRedirectRule(table *nftables.Table, chain *nftables.Chain, port 
 	if port == 0 {
 		return nil
 	}
-	exprs := append(IPSourceEqual(ActorVethIP), TCPProtocol()...)
+	exprs := append(ipv4SourceEqual(ActorVethIP), TCPProtocol()...)
 	exprs = append(exprs,
 		&expr.Immediate{
 			Register: 1,

--- a/internal/ateomnet/net.go
+++ b/internal/ateomnet/net.go
@@ -59,8 +59,10 @@ const (
 	ActorVethIPv6Gateway = "fd00:169:254::1"
 	ActorVethIPv6IP      = "fd00:169:254::2"
 
-	// ActorVethSubnet is the point-to-point /30 the actor veth lives on.
-	ActorVethSubnet = "169.254.17.0/30"
+	// ActorVethSubnet is the point-to-point /30 the actor veth lives on, and
+	// ActorVethIPv6Subnet is its /126 counterpart.
+	ActorVethSubnet     = "169.254.17.0/30"
+	ActorVethIPv6Subnet = "fd00:169:254::/126"
 )
 
 var (
@@ -630,6 +632,19 @@ func DumpNetInfo(ctx context.Context, prefix string) error {
 	return nil
 }
 
+// ActorNetwork is what SetupActorNetwork configured, for a caller that cannot
+// read it back out of the interior netns. gVisor can: runsc adopts that
+// namespace's links, addresses and routes as the guest's own. A micro-VM cannot
+// -- its interior veth is cross-connected to a tap at L2, so the L3 state there
+// is inert and the guest has to be told over the kata-agent channel.
+//
+// The zero value is the IPv4-only configuration, which is also what an error
+// return leaves behind.
+type ActorNetwork struct {
+	// IPv6 reports whether the actor veth was given its IPv6 address.
+	IPv6 bool
+}
+
 type NetworkConfig struct {
 	// InteriorNetNS is the target network namespace for the actor's veth pair peer.
 	// Used by: Both gVisor and MicroVM.
@@ -655,7 +670,7 @@ type NetworkConfig struct {
 
 // SetupActorNetwork builds a fresh point-to-point network between the worker
 // pod netns and the interior netns.
-func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
+func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (_ ActorNetwork, retErr error) {
 	// Build a fresh point-to-point network between the worker pod netns and the
 	// gVisor interior netns. The worker side keeps the pod's real eth0 and creates
 	// ateom0 as the gateway; the pair's peer is born inside the actor netns as
@@ -670,7 +685,7 @@ func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
 	// Clean up stale state from a failed prior activation before creating the
 	// next actor-side network. The worker currently runs one actor at a time.
 	if err := CleanupActorNetwork(ctx, cfg.InteriorNetNS); err != nil {
-		return fmt.Errorf("failed to clean up stale actor network before setup: %w", err)
+		return ActorNetwork{}, fmt.Errorf("failed to clean up stale actor network before setup: %w", err)
 	}
 	defer func() {
 		if retErr != nil {
@@ -696,7 +711,7 @@ func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
 			}
 			return nil
 		}); err != nil {
-			return err
+			return ActorNetwork{}, err
 		}
 	}
 
@@ -720,15 +735,15 @@ func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
 	}
 
 	if err := netlink.LinkAdd(veth); err != nil {
-		return fmt.Errorf("while creating actor veth pair: %w", err)
+		return ActorNetwork{}, fmt.Errorf("while creating actor veth pair: %w", err)
 	}
 
 	hostLink, err := netlink.LinkByName(HostVethName)
 	if err != nil {
-		return fmt.Errorf("while getting host veth: %w", err)
+		return ActorNetwork{}, fmt.Errorf("while getting host veth: %w", err)
 	}
 	if err := netlink.AddrReplace(hostLink, HostVethAddr); err != nil {
-		return fmt.Errorf("while assigning host veth address: %w", err)
+		return ActorNetwork{}, fmt.Errorf("while assigning host veth address: %w", err)
 	}
 	// Decided once, here in the worker pod netns, and carried into the interior
 	// netns below. Probing separately on each side would let them disagree: the
@@ -746,39 +761,39 @@ func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
 	actorIPv6 := podIPv6 && vethIPv6
 	if actorIPv6 {
 		if err := netlink.AddrReplace(hostLink, HostVethIPv6Addr); err != nil {
-			return fmt.Errorf("while assigning host veth ipv6 address: %w", err)
+			return ActorNetwork{}, fmt.Errorf("while assigning host veth ipv6 address: %w", err)
 		}
 	} else {
 		slog.DebugContext(ctx, "actor networking is IPv4-only",
 			"link", HostVethName, "podHasGlobalIPv6", podIPv6, "vethIPv6Enabled", vethIPv6)
 	}
 	if err := netlink.LinkSetUp(hostLink); err != nil {
-		return fmt.Errorf("while bringing up host veth: %w", err)
+		return ActorNetwork{}, fmt.Errorf("while bringing up host veth: %w", err)
 	}
 
 	if err := NetNSDo(ctx, cfg.InteriorNetNS, func(ctx context.Context) error {
 		return ConfigureActorVeth(ctx, actorIPv6)
 	}); err != nil {
-		return fmt.Errorf("while configuring actor veth in interior netns: %w", err)
+		return ActorNetwork{}, fmt.Errorf("while configuring actor veth in interior netns: %w", err)
 	}
 
 	if err := EnableIPv4Forwarding(); err != nil {
-		return err
+		return ActorNetwork{}, err
 	}
 	if err := InstallActorNftablesRules(cfg.EgressRedirectPort); err != nil {
-		return err
+		return ActorNetwork{}, err
 	}
 
 	if cfg.DumpNetInfo {
 		if err := DumpNetInfo(ctx, "Pod NetNS "); err != nil {
-			return fmt.Errorf("while dumping pod netns links: %w", err)
+			return ActorNetwork{}, fmt.Errorf("while dumping pod netns links: %w", err)
 		}
 		if err := NetNSDo(ctx, cfg.InteriorNetNS, func(ctx context.Context) error {
 			return DumpNetInfo(ctx, "Interior NetNS ")
 		}); err != nil {
-			return fmt.Errorf("while dumping interior netns links: %w", err)
+			return ActorNetwork{}, fmt.Errorf("while dumping interior netns links: %w", err)
 		}
 	}
 
-	return nil
+	return ActorNetwork{IPv6: actorIPv6}, nil
 }

--- a/internal/ateomnet/net.go
+++ b/internal/ateomnet/net.go
@@ -43,6 +43,22 @@ const (
 	ActorVethIP       = "169.254.17.2"
 	ActorNftTableName = "ateom_actor"
 
+	// podPrimaryIfaceName is the worker pod's own interface, the one the CNI
+	// gave it. It is not ActorVethName despite the identical value: that one
+	// names the actor's end of the veth, which lives in the interior netns.
+	podPrimaryIfaceName = "eth0"
+
+	// The IPv6 counterparts of the point-to-point pair above, chosen to echo the
+	// v4 addresses digit for digit. A fixed ULA rather than an RFC 4193 random
+	// prefix so the pair stays as readable in a packet dump as 169.254.17.x, and
+	// not fe80::/10 because a link-local source would need a scope id everywhere
+	// it is used. It must not overlap the cluster's pod CIDR; kind's dual-stack
+	// default is fd00:10:244::/56.
+	HostVethIPv6CIDR     = "fd00:169:254::1/126"
+	ActorVethIPv6CIDR    = "fd00:169:254::2/126"
+	ActorVethIPv6Gateway = "fd00:169:254::1"
+	ActorVethIPv6IP      = "fd00:169:254::2"
+
 	// ActorVethSubnet is the point-to-point /30 the actor veth lives on.
 	ActorVethSubnet = "169.254.17.0/30"
 )
@@ -51,6 +67,10 @@ var (
 	HostVethAddr  = MustParseAddr(HostVethCIDR)
 	ActorVethAddr = MustParseAddr(ActorVethCIDR)
 	ActorVethGwIP = MustParseIP(ActorVethGateway)
+
+	HostVethIPv6Addr  = mustParseNoDADAddr(HostVethIPv6CIDR)
+	ActorVethIPv6Addr = mustParseNoDADAddr(ActorVethIPv6CIDR)
+	ActorVethIPv6GwIP = MustParseIPv6(ActorVethIPv6Gateway)
 )
 
 // MustParseAddr parses a CIDR string into a netlink.Addr, panicking on error.
@@ -62,6 +82,18 @@ func MustParseAddr(cidr string) *netlink.Addr {
 	return a
 }
 
+// mustParseNoDADAddr parses a CIDR into an address flagged IFA_F_NODAD.
+//
+// Per-address flag rather than the interface-wide accept_dad sysctl because the
+// ateom container is unprivileged, so containerd mounts /proc/sys read-only.
+// DAD is pointless on a point-to-point veth nobody else can reach, and it would
+// otherwise hold the address tentative for ~1s on every resume.
+func mustParseNoDADAddr(cidr string) *netlink.Addr {
+	a := MustParseAddr(cidr)
+	a.Flags = unix.IFA_F_NODAD
+	return a
+}
+
 // MustParseIP parses an IPv4 string into a net.IP, panicking on error.
 func MustParseIP(s string) net.IP {
 	ip := net.ParseIP(s).To4()
@@ -69,6 +101,57 @@ func MustParseIP(s string) net.IP {
 		panic(fmt.Sprintf("parsing constant IPv4 %q", s))
 	}
 	return ip
+}
+
+// MustParseIPv6 parses an IPv6 string into a net.IP, panicking on error. An
+// IPv4 string is an error: net.IP holds it as a 16-byte v4-mapped address, so
+// it would pass a length check and then compare against no IPv6 header.
+func MustParseIPv6(s string) net.IP {
+	ip := net.ParseIP(s)
+	if ip == nil || ip.To4() != nil {
+		panic(fmt.Sprintf("parsing constant IPv6 %q", s))
+	}
+	return ip.To16()
+}
+
+// linkIPv6Enabled reports whether IPv6 addresses can be assigned to the named
+// link in the current netns. It answers a kernel capability question, not a
+// cluster one: IPv4-only GKE leaves disable_ipv6=1 and netlink then rejects
+// every IPv6 address with EPERM, but IPv4-only kind leaves it at 0 because the
+// node kernel has IPv6 compiled in. A kernel built without IPv6 has no sysctl
+// at all. Pair it with linkHasGlobalIPv6 to decide whether the actor gets IPv6;
+// on its own it says yes on clusters that have no IPv6 anywhere.
+func linkIPv6Enabled(name string) bool {
+	b, err := os.ReadFile("/proc/sys/net/ipv6/conf/" + name + "/disable_ipv6")
+	if err != nil {
+		return false
+	}
+	return len(b) > 0 && b[0] == '0'
+}
+
+// linkHasGlobalIPv6 reports whether link carries a global IPv6 address. Called
+// on the worker pod's own interface, that is what decides the families the
+// actor can egress on.
+//
+// It answers whether the pod has an address to egress from, not whether that
+// address routes anywhere: IsGlobalUnicast is true for a ULA, and dual-stack
+// kind hands pods a ULA with no path off the host. Reachability is the
+// cluster's problem, not something this can decide from inside the netns.
+func linkHasGlobalIPv6(ctx context.Context, link netlink.Link) bool {
+	// netlink can report ErrDumpInterrupted alongside a valid partial answer.
+	// Trust a positive result either way: reporting false on a dual-stack pod
+	// silently strands the actor on IPv4, which is the costlier mistake.
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
+	if err != nil {
+		slog.WarnContext(ctx, "listing IPv6 addresses of the worker pod interface",
+			"link", link.Attrs().Name, "err", err, "addressesRead", len(addrs))
+	}
+	for _, addr := range addrs {
+		if addr.IP.IsGlobalUnicast() {
+			return true
+		}
+	}
+	return false
 }
 
 // MustParseMAC parses a MAC address string into a net.HardwareAddr, panicking on error.
@@ -82,7 +165,9 @@ func MustParseMAC(s string) net.HardwareAddr {
 
 // ConfigureActorVeth configures the actor veth inside the interior netns.
 // It assumes it is already running inside the target network namespace.
-func ConfigureActorVeth(ctx context.Context) error {
+// ipv6 comes from SetupActorNetwork, which decides it in the worker pod netns;
+// this namespace cannot answer the question for itself.
+func ConfigureActorVeth(ctx context.Context, ipv6 bool) error {
 	// Run inside the gVisor interior netns. SetupActorNetwork has already created
 	// the veth peer here, under its final name, so this only has to address it.
 	// gVisor reads link names, addresses, and routes from this namespace when the
@@ -107,6 +192,12 @@ func ConfigureActorVeth(ctx context.Context) error {
 	if err := netlink.AddrReplace(actorLink, ActorVethAddr); err != nil {
 		return fmt.Errorf("while assigning actor veth address: %w", err)
 	}
+	if ipv6 {
+		if err := netlink.AddrReplace(actorLink, ActorVethIPv6Addr); err != nil {
+			return fmt.Errorf("while assigning actor veth ipv6 address: %w", err)
+		}
+	}
+
 	if err := netlink.LinkSetUp(actorLink); err != nil {
 		return fmt.Errorf("while bringing up actor veth: %w", err)
 	}
@@ -116,6 +207,15 @@ func ConfigureActorVeth(ctx context.Context) error {
 		Gw:        ActorVethGwIP,
 	}); err != nil {
 		return fmt.Errorf("while installing actor default route: %w", err)
+	}
+	if ipv6 {
+		if err := netlink.RouteReplace(&netlink.Route{
+			LinkIndex: actorLink.Attrs().Index,
+			Gw:        ActorVethIPv6GwIP,
+			Dst:       &net.IPNet{IP: net.ParseIP("::"), Mask: net.CIDRMask(0, 128)},
+		}); err != nil {
+			return fmt.Errorf("while installing actor default ipv6 route: %w", err)
+		}
 	}
 
 	return nil
@@ -173,7 +273,7 @@ func PodIPv4() (net.IP, error) {
 	// Resolve the worker pod IPv4 address from the pod namespace's real eth0.
 	// Because eth0 now stays in the pod namespace, this IP remains available for
 	// both normal worker connectivity and the temporary inbound DNAT rule.
-	eth0Link, err := netlink.LinkByName("eth0")
+	eth0Link, err := netlink.LinkByName(podPrimaryIfaceName)
 	if err != nil {
 		return nil, fmt.Errorf("while getting pod eth0: %w", err)
 	}
@@ -229,9 +329,6 @@ func InstallActorNftablesRules(egressPort uint16) error {
 	// rules in an ateom-owned table makes cleanup simple and avoids mutating
 	// Kubernetes or CNI-managed chains directly.
 	//
-	// TODO(#246): Add the IPv6 veth addressing and forwarding. The actor
-	// network itself is still IPv4-only.
-	//
 	// The rules do three things:
 	//
 	//   * prerouting: redirect new actor TCP connections to atunnel's local
@@ -265,6 +362,9 @@ func InstallActorNftablesRules(egressPort uint16) error {
 	if redirectRule := ActorEgressRedirectRule(table, prerouting, egressPort); redirectRule != nil {
 		c.AddRule(redirectRule)
 	}
+	if redirectRuleIPv6 := ActorIPv6EgressRedirectRule(table, prerouting, egressPort); redirectRuleIPv6 != nil {
+		c.AddRule(redirectRuleIPv6)
+	}
 
 	postrouting := c.AddChain(&nftables.Chain{
 		Name:     "postrouting",
@@ -277,6 +377,11 @@ func InstallActorNftablesRules(egressPort uint16) error {
 		Table: table,
 		Chain: postrouting,
 		Exprs: append(ipv4SourceEqual(ActorVethIP), &expr.Masq{}),
+	})
+	c.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: postrouting,
+		Exprs: append(ipv6SourceEqual(ActorVethIPv6IP), &expr.Masq{}),
 	})
 
 	acceptPolicy := nftables.ChainPolicyAccept
@@ -366,6 +471,34 @@ func ipv4PayloadEqual(offset uint32, ip string) []expr.Any {
 	}
 }
 
+func ipv6SourceEqual(ip string) []expr.Any {
+	return ipv6PayloadEqual(8, ip)
+}
+
+// ipv6PayloadEqual matches a 16-byte IPv6 network-header field. Offset 8 is the
+// source address, where the IPv4 source sits at 12.
+func ipv6PayloadEqual(offset uint32, ip string) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     []byte{unix.NFPROTO_IPV6},
+		},
+		&expr.Payload{
+			DestRegister: 1,
+			Base:         expr.PayloadBaseNetworkHeader,
+			Offset:       offset,
+			Len:          16,
+		},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     MustParseIPv6(ip),
+		},
+	}
+}
+
 func TCPProtocol() []expr.Any {
 	return []expr.Any{
 		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
@@ -385,6 +518,23 @@ func ActorEgressRedirectRule(table *nftables.Table, chain *nftables.Chain, port 
 		return nil
 	}
 	exprs := append(ipv4SourceEqual(ActorVethIP), TCPProtocol()...)
+	exprs = append(exprs,
+		&expr.Immediate{
+			Register: 1,
+			Data:     binaryutil.BigEndian.PutUint16(port),
+		},
+		&expr.Redir{RegisterProtoMin: 1},
+	)
+	return &nftables.Rule{Table: table, Chain: chain, Exprs: exprs}
+}
+
+// ActorIPv6EgressRedirectRule is ActorEgressRedirectRule for the actor's IPv6
+// source address.
+func ActorIPv6EgressRedirectRule(table *nftables.Table, chain *nftables.Chain, port uint16) *nftables.Rule {
+	if port == 0 {
+		return nil
+	}
+	exprs := append(ipv6SourceEqual(ActorVethIPv6IP), TCPProtocol()...)
 	exprs = append(exprs,
 		&expr.Immediate{
 			Register: 1,
@@ -580,11 +730,35 @@ func SetupActorNetwork(ctx context.Context, cfg NetworkConfig) (retErr error) {
 	if err := netlink.AddrReplace(hostLink, HostVethAddr); err != nil {
 		return fmt.Errorf("while assigning host veth address: %w", err)
 	}
+	// Decided once, here in the worker pod netns, and carried into the interior
+	// netns below. Probing separately on each side would let them disagree: the
+	// interior netns is freshly created, so its sysctl is always the permissive
+	// kernel default whatever the pod's families are.
+	var podIPv6 bool
+	podLink, podLinkErr := netlink.LinkByName(podPrimaryIfaceName)
+	if podLinkErr != nil {
+		slog.WarnContext(ctx, "looking up the worker pod primary interface; actor networking will be IPv4-only",
+			"link", podPrimaryIfaceName, "err", podLinkErr)
+	} else {
+		podIPv6 = linkHasGlobalIPv6(ctx, podLink)
+	}
+	vethIPv6 := linkIPv6Enabled(HostVethName)
+	actorIPv6 := podIPv6 && vethIPv6
+	if actorIPv6 {
+		if err := netlink.AddrReplace(hostLink, HostVethIPv6Addr); err != nil {
+			return fmt.Errorf("while assigning host veth ipv6 address: %w", err)
+		}
+	} else {
+		slog.DebugContext(ctx, "actor networking is IPv4-only",
+			"link", HostVethName, "podHasGlobalIPv6", podIPv6, "vethIPv6Enabled", vethIPv6)
+	}
 	if err := netlink.LinkSetUp(hostLink); err != nil {
 		return fmt.Errorf("while bringing up host veth: %w", err)
 	}
 
-	if err := NetNSDo(ctx, cfg.InteriorNetNS, ConfigureActorVeth); err != nil {
+	if err := NetNSDo(ctx, cfg.InteriorNetNS, func(ctx context.Context) error {
+		return ConfigureActorVeth(ctx, actorIPv6)
+	}); err != nil {
 		return fmt.Errorf("while configuring actor veth in interior netns: %w", err)
 	}
 

--- a/internal/ateomnet/net_linux_test.go
+++ b/internal/ateomnet/net_linux_test.go
@@ -17,6 +17,7 @@
 package ateomnet
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"runtime"
@@ -24,6 +25,8 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/roottest"
 	"github.com/google/nftables"
+	"github.com/google/nftables/binaryutil"
+	"github.com/google/nftables/expr"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
@@ -75,15 +78,46 @@ func withTestNetNS(t *testing.T, fn func(interior netns.NsHandle)) {
 	fn(interior)
 }
 
-// requireNftables skips when the kernel in this environment cannot serve the
-// nftables netlink API at all, which SetupActorNetwork needs and which is a
-// property of the machine rather than of the code under test.
-func requireNftables(t *testing.T) {
+// skipWithoutInetNAT skips when this kernel cannot register an inet nat
+// chain, which needs Linux 5.2 and is a property of the machine rather than
+// of the code under test. Call it inside withTestNetNS: the probe creates
+// and deletes a real table.
+func skipWithoutInetNAT(t *testing.T) {
 	t.Helper()
 	c := &nftables.Conn{}
-	if _, err := c.ListTablesOfFamily(nftables.TableFamilyIPv4); err != nil {
-		t.Skipf("nftables unavailable in this environment: %v", err)
+	probe := c.AddTable(&nftables.Table{Family: nftables.TableFamilyINet, Name: "ateom_nft_probe"})
+	c.AddChain(&nftables.Chain{
+		Name:     "prerouting",
+		Table:    probe,
+		Type:     nftables.ChainTypeNAT,
+		Hooknum:  nftables.ChainHookPrerouting,
+		Priority: nftables.ChainPriorityNATDest,
+	})
+	if err := c.Flush(); err != nil {
+		t.Skipf("nftables inet nat unavailable in this environment: %v", err)
 	}
+	c.DelTable(probe)
+	if err := c.Flush(); err != nil {
+		t.Fatalf("deleting the nftables probe table: %v", err)
+	}
+}
+
+// actorNftTableExists reports whether the actor table is present in family.
+// The family is load-bearing: the kernel filters the dump by it, so a query
+// for the wrong family comes back empty rather than erroring.
+func actorNftTableExists(t *testing.T, family nftables.TableFamily) bool {
+	t.Helper()
+	c := &nftables.Conn{}
+	tables, err := c.ListTablesOfFamily(family)
+	if err != nil {
+		t.Fatalf("listing nftables tables of family %v: %v", family, err)
+	}
+	for _, table := range tables {
+		if table.Name == ActorNftTableName {
+			return true
+		}
+	}
+	return false
 }
 
 // linkByName returns the link, or nil when it does not exist.
@@ -126,7 +160,7 @@ func TestSetupActorNetworkFinalState(t *testing.T) {
 	ctx := context.Background()
 
 	withTestNetNS(t, func(interior netns.NsHandle) {
-		requireNftables(t)
+		skipWithoutInetNAT(t)
 
 		if err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
 			t.Fatalf("SetupActorNetwork: %v", err)
@@ -206,7 +240,7 @@ func TestSetupActorNetworkIsRepeatable(t *testing.T) {
 	ctx := context.Background()
 
 	withTestNetNS(t, func(interior netns.NsHandle) {
-		requireNftables(t)
+		skipWithoutInetNAT(t)
 
 		for i := range 3 {
 			if err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
@@ -215,8 +249,16 @@ func TestSetupActorNetworkIsRepeatable(t *testing.T) {
 			if linkByName(t, HostVethName) == nil {
 				t.Fatalf("host veth %q missing after activation %d", HostVethName, i)
 			}
+			if !actorNftTableExists(t, nftables.TableFamilyINet) {
+				t.Fatalf("nftables table %q missing after activation %d", ActorNftTableName, i)
+			}
 			if err := CleanupActorNetwork(ctx, interior); err != nil {
 				t.Fatalf("CleanupActorNetwork (activation %d): %v", i, err)
+			}
+			// Install and teardown have to name the same family; a mismatch makes
+			// teardown's dump come back empty and report success.
+			if actorNftTableExists(t, nftables.TableFamilyINet) {
+				t.Fatalf("nftables table %q survived cleanup after activation %d", ActorNftTableName, i)
 			}
 		}
 
@@ -227,6 +269,9 @@ func TestSetupActorNetworkIsRepeatable(t *testing.T) {
 		}
 		if stray := linkByName(t, HostVethName); stray != nil {
 			t.Errorf("host veth %q survived cleanup", HostVethName)
+		}
+		if actorNftTableExists(t, nftables.TableFamilyINet) {
+			t.Errorf("nftables table %q survived a repeated cleanup", ActorNftTableName)
 		}
 		if err := NetNSDo(ctx, interior, func(context.Context) error {
 			if stray := linkByName(t, ActorVethName); stray != nil {
@@ -239,6 +284,104 @@ func TestSetupActorNetworkIsRepeatable(t *testing.T) {
 	})
 }
 
+// TestRemoveActorNftablesRules covers cleanup of every family mix, including
+// the upgrade case: a worker whose previous ateom created the actor table in
+// the ip family.
+func TestRemoveActorNftablesRules(t *testing.T) {
+	roottest.Require(t, "creating network namespaces and nftables rules")
+
+	tests := []struct {
+		name     string
+		families []nftables.TableFamily
+	}{{
+		name:     "ip only",
+		families: []nftables.TableFamily{nftables.TableFamilyIPv4},
+	}, {
+		name:     "ip and inet",
+		families: []nftables.TableFamily{nftables.TableFamilyIPv4, nftables.TableFamilyINet},
+	}, {
+		name:     "inet only",
+		families: []nftables.TableFamily{nftables.TableFamilyINet},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			withTestNetNS(t, func(netns.NsHandle) {
+				skipWithoutInetNAT(t)
+
+				c := &nftables.Conn{}
+				for _, family := range test.families {
+					c.AddTable(&nftables.Table{Family: family, Name: ActorNftTableName})
+				}
+				if err := c.Flush(); err != nil {
+					t.Fatalf("creating the stand-in actor tables: %v", err)
+				}
+
+				if err := RemoveActorNftablesRules(); err != nil {
+					t.Fatalf("RemoveActorNftablesRules: %v", err)
+				}
+
+				for _, family := range []nftables.TableFamily{nftables.TableFamilyIPv4, nftables.TableFamilyINet} {
+					if actorNftTableExists(t, family) {
+						t.Errorf("actorNftTableExists(family %v) = true after cleanup, want false", family)
+					}
+				}
+			})
+		})
+	}
+}
+
+// TestSetupActorNetworkEgressRedirect checks that an inet nat chain accepts
+// the redirect: it is separate kernel support from the nat chain type, and it
+// is the rule the whole actor egress path rides on.
+func TestSetupActorNetworkEgressRedirect(t *testing.T) {
+	roottest.Require(t, "creating network namespaces, veth pairs, and nftables rules")
+	ctx := context.Background()
+
+	const egressPort = 15001
+
+	withTestNetNS(t, func(interior netns.NsHandle) {
+		skipWithoutInetNAT(t)
+
+		if err := SetupActorNetwork(ctx, NetworkConfig{
+			InteriorNetNS:      interior,
+			EgressRedirectPort: egressPort,
+		}); err != nil {
+			t.Fatalf("SetupActorNetwork: %v", err)
+		}
+
+		c := &nftables.Conn{}
+		rules, err := c.GetRules(
+			&nftables.Table{Family: nftables.TableFamilyINet, Name: ActorNftTableName},
+			&nftables.Chain{Name: "prerouting"},
+		)
+		if err != nil {
+			t.Fatalf("listing prerouting rules of the actor table: %v", err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("prerouting holds %d rules, want the egress redirect alone", len(rules))
+		}
+
+		// Read back what the kernel stored, not what the builder emitted: what is
+		// in doubt is whether an inet nat chain takes these expressions at all.
+		var haveNFProto, havePort, haveRedir bool
+		for _, e := range rules[0].Exprs {
+			switch e := e.(type) {
+			case *expr.Meta:
+				haveNFProto = haveNFProto || e.Key == expr.MetaKeyNFPROTO
+			case *expr.Immediate:
+				havePort = havePort || bytes.Equal(e.Data, binaryutil.BigEndian.PutUint16(egressPort))
+			case *expr.Redir:
+				haveRedir = true
+			}
+		}
+		if !(haveNFProto && havePort && haveRedir) {
+			t.Errorf("installed redirect has nfproto=%t port=%t redir=%t, want all three, got %v",
+				haveNFProto, havePort, haveRedir, rules[0].Exprs)
+		}
+	})
+}
+
 // TestSetupActorNetworkHostVethHWAddr covers the micro-VM requirement: a CH
 // snapshot freezes the guest's ARP entry for the gateway, so the worker-side
 // veth MAC has to be exactly the one the caller asked for, on every pod.
@@ -247,7 +390,7 @@ func TestSetupActorNetworkHostVethHWAddr(t *testing.T) {
 	ctx := context.Background()
 
 	withTestNetNS(t, func(interior netns.NsHandle) {
-		requireNftables(t)
+		skipWithoutInetNAT(t)
 
 		want := MustParseMAC("02:a8:1e:00:00:01")
 		if err := SetupActorNetwork(ctx, NetworkConfig{
@@ -277,7 +420,7 @@ func TestSetupActorNetworkSweepsInteriorLinks(t *testing.T) {
 	ctx := context.Background()
 
 	withTestNetNS(t, func(interior netns.NsHandle) {
-		requireNftables(t)
+		skipWithoutInetNAT(t)
 
 		const leftover = "stale-tap0"
 		if err := NetNSDo(ctx, interior, func(context.Context) error {

--- a/internal/ateomnet/net_linux_test.go
+++ b/internal/ateomnet/net_linux_test.go
@@ -165,7 +165,7 @@ func TestSetupActorNetworkFinalState(t *testing.T) {
 	withTestNetNS(t, func(interior netns.NsHandle) {
 		skipWithoutInetNAT(t)
 
-		if err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
+		if _, err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
 			t.Fatalf("SetupActorNetwork: %v", err)
 		}
 
@@ -246,7 +246,7 @@ func TestSetupActorNetworkIsRepeatable(t *testing.T) {
 		skipWithoutInetNAT(t)
 
 		for i := range 3 {
-			if err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
+			if _, err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
 				t.Fatalf("SetupActorNetwork (activation %d): %v", i, err)
 			}
 			if linkByName(t, HostVethName) == nil {
@@ -346,7 +346,7 @@ func TestSetupActorNetworkEgressRedirect(t *testing.T) {
 	withTestNetNS(t, func(interior netns.NsHandle) {
 		skipWithoutInetNAT(t)
 
-		if err := SetupActorNetwork(ctx, NetworkConfig{
+		if _, err := SetupActorNetwork(ctx, NetworkConfig{
 			InteriorNetNS:      interior,
 			EgressRedirectPort: egressPort,
 		}); err != nil {
@@ -568,7 +568,7 @@ func TestSetupActorNetworkIPv6Gate(t *testing.T) {
 					tc.disable(t)
 				}
 
-				if err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
+				if _, err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
 					t.Fatalf("SetupActorNetwork: %v", err)
 				}
 
@@ -624,7 +624,7 @@ func TestSetupActorNetworkHostVethHWAddr(t *testing.T) {
 		skipWithoutInetNAT(t)
 
 		want := MustParseMAC("02:a8:1e:00:00:01")
-		if err := SetupActorNetwork(ctx, NetworkConfig{
+		if _, err := SetupActorNetwork(ctx, NetworkConfig{
 			InteriorNetNS:      interior,
 			HostVethHWAddr:     want,
 			SweepInteriorLinks: true,
@@ -660,7 +660,7 @@ func TestSetupActorNetworkSweepsInteriorLinks(t *testing.T) {
 			t.Fatalf("planting a leftover interior link: %v", err)
 		}
 
-		if err := SetupActorNetwork(ctx, NetworkConfig{
+		if _, err := SetupActorNetwork(ctx, NetworkConfig{
 			InteriorNetNS:      interior,
 			SweepInteriorLinks: true,
 		}); err != nil {

--- a/internal/ateomnet/net_linux_test.go
+++ b/internal/ateomnet/net_linux_test.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net"
+	"os"
 	"runtime"
 	"testing"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/google/nftables/expr"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
 )
 
 // withTestNetNS runs fn with the calling thread inside a throwaway netns
@@ -332,8 +335,8 @@ func TestRemoveActorNftablesRules(t *testing.T) {
 }
 
 // TestSetupActorNetworkEgressRedirect checks that an inet nat chain accepts
-// the redirect: it is separate kernel support from the nat chain type, and it
-// is the rule the whole actor egress path rides on.
+// the per-family redirects: they are separate kernel support from the nat
+// chain type, and they are the rules the whole actor egress path rides on.
 func TestSetupActorNetworkEgressRedirect(t *testing.T) {
 	roottest.Require(t, "creating network namespaces, veth pairs, and nftables rules")
 	ctx := context.Background()
@@ -358,28 +361,256 @@ func TestSetupActorNetworkEgressRedirect(t *testing.T) {
 		if err != nil {
 			t.Fatalf("listing prerouting rules of the actor table: %v", err)
 		}
-		if len(rules) != 1 {
-			t.Fatalf("prerouting holds %d rules, want the egress redirect alone", len(rules))
+		if len(rules) != 2 {
+			t.Fatalf("prerouting holds %d rules, want one redirect per family", len(rules))
 		}
 
 		// Read back what the kernel stored, not what the builder emitted: what is
 		// in doubt is whether an inet nat chain takes these expressions at all.
-		var haveNFProto, havePort, haveRedir bool
-		for _, e := range rules[0].Exprs {
-			switch e := e.(type) {
-			case *expr.Meta:
-				haveNFProto = haveNFProto || e.Key == expr.MetaKeyNFPROTO
-			case *expr.Immediate:
-				havePort = havePort || bytes.Equal(e.Data, binaryutil.BigEndian.PutUint16(egressPort))
-			case *expr.Redir:
-				haveRedir = true
+		// Both rules are installed whatever the pod's families are; the one whose
+		// source address the actor never gets simply matches nothing.
+		for i, rule := range rules {
+			var nfproto []byte
+			var havePort, haveRedir bool
+			for _, e := range rule.Exprs {
+				switch e := e.(type) {
+				case *expr.Cmp:
+					if nfproto == nil && len(e.Data) == 1 {
+						nfproto = e.Data
+					}
+				case *expr.Immediate:
+					havePort = havePort || bytes.Equal(e.Data, binaryutil.BigEndian.PutUint16(egressPort))
+				case *expr.Redir:
+					haveRedir = true
+				}
+			}
+			wantNFProto := []byte{unix.NFPROTO_IPV4}
+			if i == 1 {
+				wantNFProto = []byte{unix.NFPROTO_IPV6}
+			}
+			if !bytes.Equal(nfproto, wantNFProto) || !havePort || !haveRedir {
+				t.Errorf("prerouting rule %d has nfproto=%v port=%t redir=%t, want nfproto=%v and both, got %v",
+					i, nfproto, havePort, haveRedir, wantNFProto, rule.Exprs)
 			}
 		}
-		if !(haveNFProto && havePort && haveRedir) {
-			t.Errorf("installed redirect has nfproto=%t port=%t redir=%t, want all three, got %v",
-				haveNFProto, havePort, haveRedir, rules[0].Exprs)
-		}
 	})
+}
+
+// addPodEth0 plants a dummy link carrying cidrs in the current netns, standing
+// in for the worker pod's own primary interface. withTestNetNS hands out a bare
+// namespace, and the families on that interface are what SetupActorNetwork reads
+// to decide the families the actor gets.
+//
+// The name has to be exactly podPrimaryIfaceName: the probe is link-scoped, so
+// under any other name it answers false and the test asserts the opposite of
+// what it means to.
+func addPodEth0(t *testing.T, cidrs ...string) {
+	t.Helper()
+
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: podPrimaryIfaceName}}
+	if err := netlink.LinkAdd(link); err != nil {
+		t.Fatalf("creating the stand-in pod %s: %v", podPrimaryIfaceName, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("bringing up the stand-in pod %s: %v", podPrimaryIfaceName, err)
+	}
+	for _, cidr := range cidrs {
+		addr := MustParseAddr(cidr)
+		addr.Flags |= unix.IFA_F_NODAD // else an IPv6 address stays tentative
+		if err := netlink.AddrAdd(link, addr); err != nil {
+			t.Fatalf("assigning %s to the stand-in pod %s: %v", cidr, podPrimaryIfaceName, err)
+		}
+	}
+}
+
+// disableIPv6 turns an IPv6 knob off in the current netns. "all" flushes the
+// addresses already assigned; "default" only reaches links created afterwards.
+func disableIPv6(t *testing.T, knob string) {
+	t.Helper()
+	path := "/proc/sys/net/ipv6/conf/" + knob + "/disable_ipv6"
+	if err := os.WriteFile(path, []byte("1\n"), 0o644); err != nil {
+		t.Fatalf("disabling IPv6 via %s: %v", path, err)
+	}
+}
+
+// assertIPv6AddrNoDAD requires cidr to be present on link and to carry
+// IFA_F_NODAD.
+//
+// The flag is the whole point: the ateom container is unprivileged, so the
+// accept_dad sysctl this replaced could not be written and setup failed outright
+// on a real worker. It passes as root, where /proc/sys is writable either way,
+// so nothing else here would catch a regression back to the sysctl.
+func assertIPv6AddrNoDAD(t *testing.T, link netlink.Link, cidr string) {
+	t.Helper()
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
+	if err != nil {
+		t.Fatalf("listing IPv6 addresses of %q: %v", link.Attrs().Name, err)
+	}
+	want := MustParseAddr(cidr)
+	for _, addr := range addrs {
+		if addr.IPNet == nil || addr.IPNet.String() != want.IPNet.String() {
+			continue
+		}
+		if addr.Flags&unix.IFA_F_NODAD == 0 {
+			t.Errorf("%s on %q has flags %#x, want IFA_F_NODAD (%#x) set", cidr, link.Attrs().Name, addr.Flags, unix.IFA_F_NODAD)
+		}
+		return
+	}
+	t.Errorf("%q does not carry %s, got %v", link.Attrs().Name, cidr, addrs)
+}
+
+// assertNoGlobalIPv6Addr requires link to carry no IPv6 address beyond the
+// fe80::/64 the kernel gives every up link wherever IPv6 is enabled at all.
+// That link-local is not what strands an actor -- the routable address is.
+func assertNoGlobalIPv6Addr(t *testing.T, link netlink.Link) {
+	t.Helper()
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
+	if err != nil {
+		t.Fatalf("listing IPv6 addresses of %q: %v", link.Attrs().Name, err)
+	}
+	for _, addr := range addrs {
+		if addr.IP.IsGlobalUnicast() {
+			t.Errorf("%q carries global IPv6 address %s, want none", link.Attrs().Name, addr)
+		}
+	}
+}
+
+// assertDefaultRoute requires link to carry -- or, when want is false, to not
+// carry -- a default route via gw in the given family.
+func assertDefaultRoute(t *testing.T, link netlink.Link, family int, gw net.IP, want bool) {
+	t.Helper()
+
+	dst := "0.0.0.0/0"
+	if family == netlink.FAMILY_V6 {
+		dst = "::/0"
+	}
+	routes, err := netlink.RouteList(link, family)
+	if err != nil {
+		t.Fatalf("listing %s routes of %q: %v", dst, link.Attrs().Name, err)
+	}
+	var got bool
+	for _, route := range routes {
+		// A default route reports its destination either as nil or as an
+		// explicit zero-length mask, depending on how the kernel rendered it.
+		ones := 0
+		if route.Dst != nil {
+			ones, _ = route.Dst.Mask.Size()
+		}
+		if ones == 0 && route.Gw.Equal(gw) {
+			got = true
+		}
+	}
+	switch {
+	case want && !got:
+		t.Errorf("%q has no %s route via %s, got %v", link.Attrs().Name, dst, gw, routes)
+	case !want && got:
+		t.Errorf("%q has a %s route via %s, want none, got %v", link.Attrs().Name, dst, gw, routes)
+	}
+}
+
+// TestSetupActorNetworkIPv6Gate is the truth table for who gets actor IPv6.
+// Both halves have to hold: the worker pod needs a global IPv6 address of its
+// own, or the actor prefers the AAAA of a dual-stack destination and the
+// connection dies with nowhere to go; and the veth has to accept an IPv6
+// address at all, or the assignment fails with EPERM on the path of every
+// SetupActorNetwork call and the actor never starts.
+//
+// The IPv4 half must come out identical in every case.
+func TestSetupActorNetworkIPv6Gate(t *testing.T) {
+	roottest.Require(t, "creating network namespaces, veth pairs, and nftables rules")
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name string
+		// podAddrs go on the stand-in pod interface before setup runs.
+		podAddrs []string
+		// disable, when set, runs in the pod netns after podAddrs are assigned.
+		disable  func(*testing.T)
+		wantIPv6 bool
+	}{{
+		name:     "dual-stack pod",
+		podAddrs: []string{"10.244.0.7/24", "fd00:10:244::7/64"},
+		wantIPv6: true,
+	}, {
+		// A probe that reads the wrong link or the wrong scope fails closed,
+		// which every IPv4 case here would happily accept. This one notices.
+		name:     "IPv6-only pod",
+		podAddrs: []string{"fd00:10:244::7/64"},
+		wantIPv6: true,
+	}, {
+		// An IPv4-only cluster whose kernel still has IPv6 compiled in, so every
+		// capability probe says yes. This is the case that turned the IPv4 e2e
+		// job red.
+		name:     "pod without IPv6",
+		podAddrs: []string{"10.244.0.7/24"},
+	}, {
+		// The default on IPv4-only GKE. Writing "all" also flushes the pod's IPv6
+		// address, so both halves of the gate are false here.
+		name:     "IPv6 disabled for the whole netns",
+		podAddrs: []string{"10.244.0.7/24", "fd00:10:244::7/64"},
+		disable: func(t *testing.T) {
+			disableIPv6(t, "all")
+			disableIPv6(t, "default")
+		},
+	}, {
+		// The one case the capability half is there for: the pod keeps its
+		// address, but the veth created next inherits disable_ipv6=1.
+		name:     "IPv6 disabled per link",
+		podAddrs: []string{"10.244.0.7/24", "fd00:10:244::7/64"},
+		disable:  func(t *testing.T) { disableIPv6(t, "default") },
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			withTestNetNS(t, func(interior netns.NsHandle) {
+				skipWithoutInetNAT(t)
+
+				addPodEth0(t, tc.podAddrs...)
+				if tc.disable != nil {
+					tc.disable(t)
+				}
+
+				if err := SetupActorNetwork(ctx, NetworkConfig{InteriorNetNS: interior}); err != nil {
+					t.Fatalf("SetupActorNetwork: %v", err)
+				}
+
+				host := linkByName(t, HostVethName)
+				if host == nil {
+					t.Fatalf("host veth %q missing from the pod netns", HostVethName)
+				}
+				if !hasAddr(t, host, HostVethCIDR) {
+					t.Errorf("host veth %q does not carry %s", HostVethName, HostVethCIDR)
+				}
+				if tc.wantIPv6 {
+					assertIPv6AddrNoDAD(t, host, HostVethIPv6CIDR)
+				} else {
+					assertNoGlobalIPv6Addr(t, host)
+				}
+
+				if err := NetNSDo(ctx, interior, func(context.Context) error {
+					actor := linkByName(t, ActorVethName)
+					if actor == nil {
+						t.Fatalf("actor veth %q missing from the interior netns", ActorVethName)
+					}
+					if !hasAddr(t, actor, ActorVethCIDR) {
+						t.Errorf("actor veth %q does not carry %s", ActorVethName, ActorVethCIDR)
+					}
+					assertDefaultRoute(t, actor, netlink.FAMILY_V4, ActorVethGwIP, true)
+
+					// The interior netns is created fresh, so its own sysctls always
+					// say IPv6 is available whatever the pod's families are. Only a
+					// decision carried across from the pod netns gets this right.
+					if tc.wantIPv6 {
+						assertIPv6AddrNoDAD(t, actor, ActorVethIPv6CIDR)
+					} else {
+						assertNoGlobalIPv6Addr(t, actor)
+					}
+					assertDefaultRoute(t, actor, netlink.FAMILY_V6, ActorVethIPv6GwIP, tc.wantIPv6)
+					return nil
+				}); err != nil {
+					t.Fatalf("inspecting interior netns: %v", err)
+				}
+			})
+		})
+	}
 }
 
 // TestSetupActorNetworkHostVethHWAddr covers the micro-VM requirement: a CH

--- a/internal/ateomnet/rules_linux_test.go
+++ b/internal/ateomnet/rules_linux_test.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ateomnet
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/nftables/expr"
+)
+
+// TestActorNftablesRuleExprs pins the wire encoding of the expressions
+// installed into the inet actor table, notably the nfproto guard in front of
+// every IPv4 match.
+func TestActorNftablesRuleExprs(t *testing.T) {
+	// meta nfproto ipv4; ip saddr 169.254.17.2
+	actorSourceIsIPv4 := []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{2}},
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 12, Len: 4},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{169, 254, 17, 2}},
+	}
+
+	tests := []struct {
+		name string
+		got  []expr.Any
+		want []expr.Any
+	}{{
+		name: "source match guards the payload load with nfproto",
+		got:  ipv4SourceEqual(ActorVethIP),
+		want: actorSourceIsIPv4,
+	}, {
+		name: "egress redirect matches actor IPv4 TCP and redirects to the port",
+		got:  ActorEgressRedirectRule(nil, nil, 15001).Exprs,
+		want: append(append([]expr.Any{}, actorSourceIsIPv4...),
+			// meta l4proto tcp; redirect to :15001
+			&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+			&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{6}},
+			&expr.Immediate{Register: 1, Data: []byte{0x3a, 0x99}},
+			&expr.Redir{RegisterProtoMin: 1},
+		),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !reflect.DeepEqual(test.got, test.want) {
+				t.Errorf("rule exprs mismatch:\ngot:\n%s\nwant:\n%s", formatExprs(test.got), formatExprs(test.want))
+			}
+		})
+	}
+}
+
+// TestActorEgressRedirectRuleDisabled covers the zero port: no rule at all, so
+// actor egress stays on the masquerade path instead of being redirected to a
+// listener that is not there.
+func TestActorEgressRedirectRuleDisabled(t *testing.T) {
+	if rule := ActorEgressRedirectRule(nil, nil, 0); rule != nil {
+		t.Errorf("ActorEgressRedirectRule(0) = %v, want nil", rule.Exprs)
+	}
+}
+
+func formatExprs(exprs []expr.Any) string {
+	var s string
+	for _, e := range exprs {
+		s += fmt.Sprintf("  %T%+v\n", e, e)
+	}
+	return s
+}

--- a/internal/ateomnet/rules_linux_test.go
+++ b/internal/ateomnet/rules_linux_test.go
@@ -36,24 +36,44 @@ func TestActorNftablesRuleExprs(t *testing.T) {
 		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{169, 254, 17, 2}},
 	}
 
+	// meta nfproto ipv6; ip6 saddr fd00:169:254::2
+	actorSourceIsIPv6 := []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{10}},
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 8, Len: 16},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{
+			0xfd, 0x00, 0x01, 0x69, 0x02, 0x54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02,
+		}},
+	}
+
+	// meta l4proto tcp; redirect to :15001
+	tcpRedirectTo15001 := []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{6}},
+		&expr.Immediate{Register: 1, Data: []byte{0x3a, 0x99}},
+		&expr.Redir{RegisterProtoMin: 1},
+	}
+
 	tests := []struct {
 		name string
 		got  []expr.Any
 		want []expr.Any
 	}{{
-		name: "source match guards the payload load with nfproto",
+		name: "IPv4 source match guards the payload load with nfproto",
 		got:  ipv4SourceEqual(ActorVethIP),
 		want: actorSourceIsIPv4,
 	}, {
+		name: "IPv6 source match guards the payload load with nfproto",
+		got:  ipv6SourceEqual(ActorVethIPv6IP),
+		want: actorSourceIsIPv6,
+	}, {
 		name: "egress redirect matches actor IPv4 TCP and redirects to the port",
 		got:  ActorEgressRedirectRule(nil, nil, 15001).Exprs,
-		want: append(append([]expr.Any{}, actorSourceIsIPv4...),
-			// meta l4proto tcp; redirect to :15001
-			&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
-			&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{6}},
-			&expr.Immediate{Register: 1, Data: []byte{0x3a, 0x99}},
-			&expr.Redir{RegisterProtoMin: 1},
-		),
+		want: append(append([]expr.Any{}, actorSourceIsIPv4...), tcpRedirectTo15001...),
+	}, {
+		name: "egress redirect matches actor IPv6 TCP and redirects to the port",
+		got:  ActorIPv6EgressRedirectRule(nil, nil, 15001).Exprs,
+		want: append(append([]expr.Any{}, actorSourceIsIPv6...), tcpRedirectTo15001...),
 	}}
 
 	for _, test := range tests {
@@ -71,6 +91,9 @@ func TestActorNftablesRuleExprs(t *testing.T) {
 func TestActorEgressRedirectRuleDisabled(t *testing.T) {
 	if rule := ActorEgressRedirectRule(nil, nil, 0); rule != nil {
 		t.Errorf("ActorEgressRedirectRule(0) = %v, want nil", rule.Exprs)
+	}
+	if rule := ActorIPv6EgressRedirectRule(nil, nil, 0); rule != nil {
+		t.Errorf("ActorIPv6EgressRedirectRule(0) = %v, want nil", rule.Exprs)
 	}
 }
 


### PR DESCRIPTION
Part of #246. **Do not merge before #979 and #753.**

Actor networking is IPv4-only, so an actor on a dual-stack worker pod cannot
reach an IPv6-only destination at all. `SetupActorNetwork` now assigns the
`fd00:169:254::/126` counterparts of the existing point-to-point pair to both
ends of the actor veth, installs an IPv6 default route in the interior netns,
and adds the matching rules to the inet-family actor table.

Whether the actor gets IPv6 is decided once in the worker pod netns and carried
into the interior one, which is created fresh and so always reports IPv6
available whatever the cluster's families are. Both halves have to hold: the pod
needs a global IPv6 address of its own, and the veth has to accept an IPv6
address — IPv4-only GKE sets `disable_ipv6` and netlink then rejects the
assignment with EPERM.

## Stacked on #1116

The first commit here is #1116, which moves the actor nftables table from the
`ip` family to `inet` with no behaviour change on IPv4. Review it there; GitHub
cannot target a base branch that lives on a fork, so it shows up in this diff
too. **The second and third commits are new in this PR.**

**Update:** a third commit makes `SetupActorNetwork` return the family decision
as an `ActorNetwork` value instead of reporting it only by side effect on the
interior netns. gVisor can read that back (runsc adopts the namespace
wholesale); the micro-VM path cannot — its guest has to be told over the
kata-agent channel — so the upcoming micro-VM parity stack consumes this
return. Also names the /126 the pair lives on (`ActorVethIPv6Subnet`) for the
guest's on-link route. Every current call site still ignores the value, so
there is no behavior change in this PR.

## Dependencies

- **#979** — without `net.ipv6.conf.all.forwarding=1` in the pod netns, the new
  default route is a black hole. Measured: 100% packet loss in a netns replica
  at `all.forwarding=0`, 0% at `=1`.
- **#753** — `atunnel` recovers the destination with
  `getsockopt(SOL_IP, SO_ORIGINAL_DST)` into a 16-byte `RawSockaddrInet4`, so an
  IPv6 connection REDIRECTed into the tunnel is accepted and then dies with no
  usable CONNECT authority. That function's own TODO asks for the IPv6 variant
  "when actor veth setup gains dual-stack support" — which is this PR.

Even with both, dual-stack egress is red: #1089, caught by the test in #1104.
This lands the address, not a working dual-stack egress path.

## Testing

**Green CI here means the family gate stays shut on an IPv4 cluster, not that
the IPv6 datapath works.** There is no dual-stack CI lane, so none of the IPv6
behaviour below is exercised there.

`TestSetupActorNetworkIPv6Gate` is the truth table, root-gated, five cases.
Reverting either half of the gate fails exactly one case and nothing else, and
reverting `IFA_F_NODAD` fails exactly the two that expect IPv6.

`TestActorNftablesRuleExprs` pins the IPv6 rule expressions alongside the IPv4
ones, and needs no root. `TestSetupActorNetworkInstallsEgressRedirect` checks
the kernel takes both redirects in one `inet` nat chain; the IPv6 rule is
installed whatever the gate decided, and simply matches nothing when the actor
has no IPv6 source address.

## Not covered

- The interior `eth0` is not observable under gVisor, so only the netns-level
  setup is asserted.
- Router → worker is still IPv4.
- The micro-VM guest is still configured IPv4-only, so a micro-VM actor gets no
  IPv6 even where the host veth has one. There is a `TODO(#246)` at that call
  site.

🤖 This PR was developed with AI assistance. I have reviewed and tested all changes.
