### PR TITLE
atelet: size the GCS upload chunk to fit a snapshot in one request

### DIFF
--- a/cmd/atelet/internal/ategcs/gcs.go
+++ b/cmd/atelet/internal/ategcs/gcs.go
@@ -52,8 +52,34 @@ func (g *gcsClient) GetObject(ctx context.Context, bucket, object string) (io.Re
 // the signal.
 func (g *gcsClient) supportsStreamingPut() {}
 
+// uploadChunkSize is how much of a streamed object the GCS client buffers before it
+// starts a request. A resumable upload sends its chunks one after another, each paying
+// a round trip, so an object that spans several chunks pays for several — which for the
+// snapshots we upload is most of the time, because they are small.
+//
+// Measured on a GKE worker node (c3-standard-4, us-central1-f) uploading to the
+// snapshot bucket through this exact streaming path, three runs of a 24 MiB object
+// (the size of an idle micro-VM golden snapshot):
+//
+//	16 MiB (the client default)  425-530 ms
+//	32 MiB                       331-405 ms
+//	64 MiB                       258-314 ms
+//	128 MiB                      350-487 ms
+//
+// 64 MiB covers a typical snapshot in one request and is the floor here; larger only
+// costs buffer. The buffer is per in-flight upload and is capped by the object size, so
+// a small object still costs only its own bytes.
+//
+// This does nothing for large snapshots: past ~100 MiB the transfer itself dominates
+// and a single stream tops out near 100 MiB/s regardless of chunk size (measured
+// 77-107 MiB/s at 300 MiB for every chunk size from 16 to 128 MiB). Getting past that
+// needs several streams — 4-way parallel parts plus a compose reached 233-257 MiB/s —
+// which is a format change, since each part has to be independently produced.
+const uploadChunkSize = 64 << 20
+
 func (g *gcsClient) PutObject(ctx context.Context, bucket, object string, reader io.Reader) error {
 	wc := g.client.Bucket(bucket).Object(object).NewWriter(ctx)
+	wc.ChunkSize = uploadChunkSize
 	// io.Copy reports local read errors; wc.Close() reports the actual
 	// GCS upload (auth, permissions, transient). Join both so the caller
 	// doesn't lose either.


### PR DESCRIPTION
Snapshot upload is the largest single item in a micro-VM bake or suspend — ~800 ms of a ~1.65 s server-side bake — and for the snapshots we actually upload it is round-trip bound rather than byte bound.

The GCS client's resumable upload sends 16 MiB chunks one after another, each paying a round trip. An idle micro-VM golden snapshot is ~24 MiB compressed, so it spans two chunks and pays twice. Setting `ChunkSize` to 64 MiB puts a typical snapshot in one request.

16MiB is reasonable for clients on poor connections sending small files. It's not reasonable for data centers and large files.

### Measurements

Uploads through this exact streaming path (non-seekable body into a `storage.Writer`), from a pod on a GKE worker node (c3-standard-4, us-central1-f) using atelet's service account and the snapshot bucket. Three runs at 24 MiB:

| chunk size | 24 MiB upload |
|---|---|
| 16 MiB (client default) | 425 / 438 / 530 ms |
| 32 MiB | 331 / 361 / 405 ms |
| **64 MiB** | **258 / 313 / 314 ms** |
| 128 MiB | 350 / 391 / 487 ms |

About 35% off an idle actor's snapshot upload. The client buffers at most `min(object, ChunkSize)`, so a small object still costs only its own bytes.

### What this deliberately does not do

Nothing for large snapshots. At 300 MiB a single stream measured 77–107 MiB/s for *every* chunk size from 16 to 128 MiB, because the transfer dominates:

| config | 300 MiB |
|---|---|
| 16 / 32 / 64 / 128 MiB chunks | 82–107 MiB/s |
| composite, 2 parts | 150–163 MiB/s |
| composite, 4 parts | **233–257 MiB/s** |
| composite, 8 parts | 224–231 MiB/s |

Beating the single-stream ceiling needs parallel parts plus a compose, which is a format change (each part has to be independently produced and decodable), so it is left as a follow-up.

For context on why this is not a compression problem: on the same node `zstd -1` compresses real guest memory at 549 MiB/s on two cores (167 ms of a ~700 ms upload), while the whole pipeline moves ~105 MiB/s. Raising the compression level trades CPU for fewer bytes on a wire that is not the constraint at these sizes.

### Testing

- `go build`, `go vet`, `hack/verify/golangci-lint.sh` and `go test ./cmd/atelet/...` pass.
- The chunk-size effect is measured against the real GCS backend from a real worker node, as above. I did not roll a patched atelet on the shared cluster, so the end-to-end effect on a live suspend (~700 → ~400 ms) is inferred from the benchmark rather than observed in situ.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR (none needed; the rationale and numbers live in the code comment)
