### PR TITLE
microvm: drop retired fs tags

### DIFF
--- a/cmd/ateom-microvm/internal/kata/restore.go
+++ b/cmd/ateom-microvm/internal/kata/restore.go
@@ -37,15 +37,3 @@ func ConsoleLogPath(id string) string { return filepath.Join(VMDir(id), "console
 // SerialLogPath is where the emulated UART is captured. Only wired up in debug mode,
 // where it carries the early-boot messages hvc0 is too late to see.
 func SerialLogPath(id string) string { return filepath.Join(VMDir(id), "serial.log") }
-
-// DurableVirtiofsdSocketPath is the vhost-user-fs socket for the actor's writable
-// durable-dir share, served by a second virtiofsd alongside the rootfs share's.
-func DurableVirtiofsdSocketPath(id string) string {
-	return filepath.Join(VMDir(id), "virtiofsd-durable.sock")
-}
-
-// CsiVirtiofsdSocketPath is the vhost-user-fs socket for the actor's writable
-// CSI volumes share.
-func CsiVirtiofsdSocketPath(id string) string {
-	return filepath.Join(VMDir(id), "virtiofsd-csi.sock")
-}

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -490,12 +490,6 @@ func rewriteSnapshotSocketPaths(snapshotDir, id string) error {
 			switch tag, _ := fm["tag"].(string); tag {
 			case kata.FsTag:
 				fm["socket"] = kata.VirtiofsdSocketPath(id)
-			case "ateDurable":
-				// Legacy multi-virtiofs snapshot backward compatibility.
-				fm["socket"] = kata.DurableVirtiofsdSocketPath(id)
-			case "ateCSI":
-				// Legacy multi-virtiofs snapshot backward compatibility.
-				fm["socket"] = kata.CsiVirtiofsdSocketPath(id)
 			default:
 				return fmt.Errorf("snapshot config %q has fs device with unknown tag %q", cfgPath, tag)
 			}

--- a/cmd/ateom-microvm/restore_test.go
+++ b/cmd/ateom-microvm/restore_test.go
@@ -88,33 +88,11 @@ func TestRewriteSnapshotSocketPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("legacy multi-share snapshots repoint each tag", func(t *testing.T) {
-		// Ordered with the rootfs share last to catch a rewrite that assumes it
-		// comes first, which would hand the guest the wrong filesystem.
-		dir := writeSnapshotConfig(t, []map[string]any{
-			{"tag": "ateDurable", "socket": "/run/vc/vm/golden/virtiofsd-durable.sock"},
-			{"tag": kata.FsTag, "socket": "/run/vc/vm/golden/virtiofsd.sock"},
-		})
-		if err := rewriteSnapshotSocketPaths(dir, id); err != nil {
-			t.Fatalf("rewriteSnapshotSocketPaths: %v", err)
-		}
-		got := readFsSockets(t, dir)
-		if got[kata.FsTag] != kata.VirtiofsdSocketPath(id) {
-			t.Errorf("%s socket = %q, want %q", kata.FsTag, got[kata.FsTag], kata.VirtiofsdSocketPath(id))
-		}
-		if got["ateDurable"] != kata.DurableVirtiofsdSocketPath(id) {
-			t.Errorf("ateDurable socket = %q, want %q", got["ateDurable"], kata.DurableVirtiofsdSocketPath(id))
-		}
-		if got[kata.FsTag] == got["ateDurable"] {
-			t.Error("both shares were pointed at the same socket")
-		}
-	})
-
 	t.Run("unknown tag is an error", func(t *testing.T) {
-		// "ateUpper" is the retired third share's tag: it never appears in
-		// snapshots this code produces, and one showing up must fail loudly
-		// rather than be silently repointed.
-		for _, tag := range []string{"somethingElse", "ateUpper"} {
+		// "ateUpper", "ateDurable", and "ateCSI" are retired multi-share tags:
+		// they never appear in snapshots this code produces, and one showing up
+		// must fail loudly rather than be silently repointed.
+		for _, tag := range []string{"somethingElse", "ateUpper", "ateDurable", "ateCSI"} {
 			dir := writeSnapshotConfig(t, []map[string]any{
 				{"tag": tag, "socket": "/run/vc/vm/golden/other.sock"},
 			})


### PR DESCRIPTION
Follow-up to #840.

Collapse `rewriteSnapshotSocketPaths` to only handle the single unified `kataShared` virtiofs device, rejecting retired multi-share tags (`ateDurable`, `ateCSI`) alongside `ateUpper`.

- Retire `DurableVirtiofsdSocketPath` and `CsiVirtiofsdSocketPath` in `cmd/ateom-microvm/internal/kata/restore.go`.
- Update `restore_test.go` to assert that retired multi-share tags fail loudly.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR