### PR TITLE
kubectl-ate: add --container  log filters for actor logs

### DIFF
--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -205,6 +205,9 @@ kubectl ate logs actors my-actor -a <atespace>
 # Follow the logs with -f. The stream is aggregated across worker
 # reassignments, so the same actor stays queryable as it teleports between pods.
 kubectl ate logs actors my-actor -a <atespace> -f
+
+# Show only one container's logs with -c/--container.
+kubectl ate logs actors my-actor -a <atespace> -c my-container
 ```
 
 Logs are streamable only while the actor is bound to a worker (i.e., `ACTOR_STATE_RUNNING`). For history across worker migrations, route through a centralized log backend (Cloud Logging, Loki, etc.); see `docs/observability.md`.

--- a/cmd/kubectl-ate/internal/cmd/logs_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors.go
@@ -42,6 +42,7 @@ import (
 
 var followLogs bool
 var logsAtespaceFlag string
+var logsContainerFlag string
 
 var logsActorsCmd = &cobra.Command{
 	Use:     "actors <actor-name>",
@@ -55,6 +56,7 @@ func init() {
 	logsActorsCmd.Flags().BoolVarP(&followLogs, "follow", "f", false, "Specify if the logs should be streamed.")
 	logsActorsCmd.Flags().StringVarP(&logsAtespaceFlag, "atespace", "a", "", "Atespace the actor lives in")
 	_ = logsActorsCmd.MarkFlagRequired("atespace")
+	logsActorsCmd.Flags().StringVarP(&logsContainerFlag, "container", "c", "", "Show only logs from this container.")
 	logsCmd.AddCommand(logsActorsCmd)
 }
 
@@ -86,6 +88,7 @@ type LogsActorRunner struct {
 	stdout            io.Writer
 	stderr            io.Writer
 	follow            bool
+	container         string
 	pollInterval      time.Duration
 	reconnectInterval time.Duration
 	tickerInterval    time.Duration
@@ -133,12 +136,13 @@ func (r *LogsActorRunner) runOneShot(ctx context.Context) error {
 	}
 	defer stream.Close()
 
+	filter := logLineFilter{target: r.actorRef, container: r.container}
 	scanner := bufio.NewScanner(stream)
 	buf := make([]byte, 0, 64*1024)
 	scanner.Buffer(buf, 1024*1024) // Support up to 1MB lines
 	for scanner.Scan() {
 		line := scanner.Text()
-		filterAndDisplayLogLine(line, r.actorRef, r.stdout)
+		filterAndDisplayLogLine(line, filter, r.stdout)
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("error reading log stream: %w", err)
@@ -210,12 +214,13 @@ func (r *LogsActorRunner) runFollow(ctx context.Context) error {
 		var wg sync.WaitGroup
 		r.startMigrationMonitor(streamCtx, streamCancel, &wg, podName)
 
+		filter := logLineFilter{target: r.actorRef, container: r.container}
 		scanner := bufio.NewScanner(stream)
 		buf := make([]byte, 0, 64*1024)
 		scanner.Buffer(buf, 1024*1024) // Support up to 1MB lines
 		for scanner.Scan() {
 			line := scanner.Text()
-			logTime, _ := filterAndDisplayLogLine(line, r.actorRef, r.stdout)
+			logTime, _ := filterAndDisplayLogLine(line, filter, r.stdout)
 			if !logTime.IsZero() {
 				lastSeenTime = logTime
 			}
@@ -298,6 +303,7 @@ func runLogsActor(cmd *cobra.Command, args []string) error {
 		stdout:            os.Stdout,
 		stderr:            os.Stderr,
 		follow:            followLogs,
+		container:         logsContainerFlag,
 		pollInterval:      2 * time.Second,
 		reconnectInterval: 1 * time.Second,
 		tickerInterval:    2 * time.Second,
@@ -306,7 +312,25 @@ func runLogsActor(cmd *cobra.Command, args []string) error {
 	return runner.Run(ctx)
 }
 
-func filterAndDisplayLogLine(line string, target resources.ActorRef, w io.Writer) (time.Time, bool) {
+// logLineFilter selects which of an actor's log lines are displayed: all of
+// them by default, or only the named container's when container is set.
+type logLineFilter struct {
+	target    resources.ActorRef
+	container string
+}
+
+// matches reports whether a line emitted by emitter from containerName (empty
+// for lifecycle events) should be displayed.
+func (f logLineFilter) matches(emitter resources.ActorRef, containerName string) bool {
+	// Actor names are only unique within an atespace, and a worker pod can host
+	// actors from different atespaces over time, so match on both.
+	if emitter != f.target || f.target.Atespace == "" || f.target.Name == "" {
+		return false
+	}
+	return f.container == "" || containerName == f.container
+}
+
+func filterAndDisplayLogLine(line string, filter logLineFilter, w io.Writer) (time.Time, bool) {
 	var m map[string]any
 	dec := json.NewDecoder(strings.NewReader(line))
 	dec.UseNumber()
@@ -324,26 +348,22 @@ func filterAndDisplayLogLine(line string, target resources.ActorRef, w io.Writer
 	}
 
 	var emitter resources.ActorRef
+	var emitterContainer string
 	for _, labelKey := range []string{"logging.googleapis.com/labels", "labels"} {
 		if labelsAny, ok := m[labelKey]; ok {
 			if labels, ok := labelsAny.(map[string]any); ok {
 				if name, ok := labels[string(ateattr.ActorNameKey)].(string); ok && name != "" {
 					emitter.Name = name
 					emitter.Atespace, _ = labels[string(ateattr.AtespaceKey)].(string)
+					emitterContainer, _ = labels[string(ateattr.ActorContainerNameKey)].(string)
 					break
 				}
 			}
 		}
 	}
 
-	// Actor names are only unique within an atespace, and a worker pod can host
-	// actors from different atespaces over time, so match on both. A partial
-	// target never matches: a line missing either label would otherwise be
-	// attributed to whichever actor was asked for.
-	matched := emitter == target && target.Atespace != "" && target.Name != ""
-
-	if !matched {
-		return logTime, false
+	if !filter.matches(emitter, emitterContainer) {
+		return time.Time{}, false
 	}
 
 	// Remove substrate's labels from CLI output. Stripping the whole reserved
@@ -373,7 +393,7 @@ func filterAndDisplayLogLine(line string, target resources.ActorRef, w io.Writer
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(m); err != nil {
-		return logTime, false
+		return time.Time{}, false
 	}
 
 	encodedStr := strings.TrimSpace(buf.String())

--- a/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
+++ b/cmd/kubectl-ate/internal/cmd/logs_actors_test.go
@@ -37,6 +37,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 		name        string
 		line        string
 		target      resources.ActorRef
+		container   string
 		wantMatched bool
 		wantTime    string
 		wantOutput  string
@@ -78,7 +79,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-2"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: false,
-			wantTime:    "2026-05-16T01:03:38Z",
+			wantTime:    "", // zero: another actor's line must not advance follow's resume cursor
 			wantOutput:  "",
 		},
 		{
@@ -86,7 +87,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.atespace":"space-2","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: false,
-			wantTime:    "2026-05-16T01:03:38Z",
+			wantTime:    "",
 			wantOutput:  "",
 		},
 		{
@@ -94,7 +95,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
 			wantMatched: false,
-			wantTime:    "2026-05-16T01:03:38Z",
+			wantTime:    "",
 			wantOutput:  "",
 		},
 		{
@@ -102,7 +103,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.atespace":"","ate.actor.name":"act-1"}}`,
 			target:      resources.ActorRef{Atespace: "", Name: "act-1"},
 			wantMatched: false,
-			wantTime:    "2026-05-16T01:03:38Z",
+			wantTime:    "",
 			wantOutput:  "",
 		},
 		{
@@ -110,7 +111,7 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			line:        `{"time":"2026-05-16T01:03:38Z","message":"Hello world","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":""}}`,
 			target:      resources.ActorRef{Atespace: "space-1", Name: ""},
 			wantMatched: false,
-			wantTime:    "2026-05-16T01:03:38Z",
+			wantTime:    "",
 			wantOutput:  "",
 		},
 		{
@@ -164,12 +165,47 @@ func TestFilterAndDisplayLogLine(t *testing.T) {
 			wantTime:    "2026-05-16T01:03:38Z",
 			wantOutput:  `{"time":"2026-05-16T01:03:38Z","logging.googleapis.com/labels":{"app":"my-app"},"msg":"Hello"}`,
 		},
+		{
+			name:        "no filter shows a container line",
+			line:        `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1","ate.actor.container.name":"counter"}}`,
+			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
+			wantMatched: true,
+			wantTime:    "2026-05-16T01:03:38Z",
+			wantOutput:  `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
+		},
+		{
+			name:        "container filter matches the named container",
+			line:        `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1","ate.actor.container.name":"counter"}}`,
+			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
+			container:   "counter",
+			wantMatched: true,
+			wantTime:    "2026-05-16T01:03:38Z",
+			wantOutput:  `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi"}`,
+		},
+		{
+			name:        "container filter excludes a different container",
+			line:        `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"hi","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1","ate.actor.container.name":"sidecar"}}`,
+			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
+			container:   "counter",
+			wantMatched: false,
+			wantTime:    "", // filtered out: only displayed lines may advance follow's resume cursor
+			wantOutput:  "",
+		},
+		{
+			name:        "container filter excludes a lifecycle event",
+			line:        `{"time":"2026-05-16T01:03:38Z","message":"Actor started","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-1"}}`,
+			target:      resources.ActorRef{Atespace: "space-1", Name: "act-1"},
+			container:   "counter",
+			wantMatched: false,
+			wantTime:    "",
+			wantOutput:  "",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			logTime, matched := filterAndDisplayLogLine(tc.line, tc.target, &buf)
+			logTime, matched := filterAndDisplayLogLine(tc.line, logLineFilter{target: tc.target, container: tc.container}, &buf)
 
 			if matched != tc.wantMatched {
 				t.Errorf("got matched = %v, want %v", matched, tc.wantMatched)
@@ -283,6 +319,84 @@ func TestLogsActorRunner_Run_OneShotSuccess(t *testing.T) {
 	wantOutput := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"Hello world"}`
 	if gotOutput != wantOutput {
 		t.Errorf("got stdout %q, want %q", gotOutput, wantOutput)
+	}
+}
+
+// TestLogsActorRunner_Run_OneShot_ContainerFilter exercises the --container
+// selection against one stream that interleaves two containers and a
+// lifecycle event.
+func TestLogsActorRunner_Run_OneShot_ContainerFilter(t *testing.T) {
+	actorName := "act-123"
+
+	counterLine := `{"time":"2026-05-16T01:03:38Z","level":"info","msg":"from counter","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-123","ate.actor.container.name":"counter"}}`
+	sidecarLine := `{"time":"2026-05-16T01:03:39Z","level":"info","msg":"from sidecar","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-123","ate.actor.container.name":"sidecar"}}`
+	lifecycleLine := `{"time":"2026-05-16T01:03:40Z","message":"Actor started","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-123"}}`
+
+	tests := []struct {
+		name       string
+		container  string
+		wantOutput []string
+	}{
+		{
+			name:       "no filter shows everything",
+			wantOutput: []string{"from counter", "from sidecar", "Actor started"},
+		},
+		{
+			name:       "container filter",
+			container:  "counter",
+			wantOutput: []string{"from counter"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAPI := &mockAteAPIClient{
+				GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
+					return &ateapipb.Actor{
+						Metadata: &ateapipb.ResourceMetadata{Name: actorName},
+						Status: &ateapipb.ActorStatus{
+							State: ateapipb.ActorState_ACTOR_STATE_RUNNING,
+							WorkerAssignment: &ateapipb.WorkerAssignment{
+								WorkerPod:       "pod-xyz",
+								WorkerNamespace: "ns-abc",
+							},
+						},
+					}, nil
+				},
+			}
+			mockStreamer := &mockPodLogsStreamer{
+				StreamLogsFunc: func(ctx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader(counterLine + "\n" + sidecarLine + "\n" + lifecycleLine + "\n")), nil
+				},
+			}
+
+			var stdout, stderr bytes.Buffer
+			runner := &LogsActorRunner{
+				apiClient: mockAPI,
+				actorRef:  resources.ActorRef{Atespace: "space-1", Name: actorName},
+				streamer:  mockStreamer,
+				stdout:    &stdout,
+				stderr:    &stderr,
+				container: tc.container,
+			}
+
+			if err := runner.Run(context.Background()); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var gotLines []string
+			if got := strings.TrimSpace(stdout.String()); got != "" {
+				gotLines = strings.Split(got, "\n")
+			}
+			if len(gotLines) != len(tc.wantOutput) {
+				t.Fatalf("got %d lines %q, want %d", len(gotLines), gotLines, len(tc.wantOutput))
+			}
+			for i, want := range tc.wantOutput {
+				if !strings.Contains(gotLines[i], want) {
+					t.Errorf("line %d = %q, want it to contain %q", i, gotLines[i], want)
+				}
+			}
+		})
 	}
 }
 
@@ -703,5 +817,94 @@ func TestLogsActorRunner_Run_Follow_ActorSuspendedMidStream(t *testing.T) {
 	}
 	if !strings.Contains(stdoutStr, "after resume") {
 		t.Errorf("expected output to contain 'after resume', got %q", stdoutStr)
+	}
+}
+
+// A worker pod's stream carries lines that are not displayed (other actors,
+// filtered-out containers). Those must not advance the follow resume cursor
+// (SinceTime), or a reconnect could skip the lines the user asked for.
+func TestLogsActorRunner_Run_Follow_UndisplayedLineDoesNotAdvanceCursor(t *testing.T) {
+	actorName := "act-123"
+
+	mockAPI := &mockAteAPIClient{
+		GetActorFunc: func(ctx context.Context, in *ateapipb.GetActorRequest, opts ...grpc.CallOption) (*ateapipb.Actor, error) {
+			return &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: actorName},
+				Status: &ateapipb.ActorStatus{
+					State: ateapipb.ActorState_ACTOR_STATE_RUNNING,
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						WorkerPod:       "pod-xyz",
+						WorkerNamespace: "ns-abc",
+					},
+				},
+			}, nil
+		},
+	}
+
+	// A different actor's line and a filtered-out sidecar line of our own actor:
+	// both carry parseable timestamps but neither is displayed.
+	foreignLine := `{"time":"2026-05-16T01:03:38Z","message":"not mine","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"other"}}`
+	sidecarLine := `{"time":"2026-05-16T01:03:39Z","level":"info","msg":"from sidecar","logging.googleapis.com/labels":{"ate.atespace":"space-1","ate.actor.name":"act-123","ate.actor.container.name":"sidecar"}}`
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	var streamCalls int
+	var reconnectHadSinceTime bool
+	secondCall := make(chan struct{})
+
+	mockStreamer := &mockPodLogsStreamer{
+		StreamLogsFunc: func(streamCtx context.Context, ns, name string, opts *corev1.PodLogOptions) (io.ReadCloser, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			streamCalls++
+
+			if streamCalls == 1 {
+				// First connection: only undisplayed lines, then EOF to force a reconnect.
+				return io.NopCloser(strings.NewReader(foreignLine + "\n" + sidecarLine + "\n")), nil
+			}
+			if streamCalls == 2 {
+				reconnectHadSinceTime = opts.SinceTime != nil
+				close(secondCall)
+			}
+			return io.NopCloser(strings.NewReader("")), nil
+		},
+	}
+
+	runner := &LogsActorRunner{
+		apiClient:         mockAPI,
+		actorRef:          resources.ActorRef{Atespace: "space-1", Name: actorName},
+		streamer:          mockStreamer,
+		stdout:            &bytes.Buffer{},
+		stderr:            &bytes.Buffer{},
+		follow:            true,
+		container:         "counter",
+		pollInterval:      1 * time.Millisecond,
+		reconnectInterval: 1 * time.Millisecond,
+		tickerInterval:    time.Hour, // keep the migration monitor out of the way
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = runner.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-secondCall:
+	case <-time.After(2 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("reconnect (second StreamLogs call) never happened")
+	}
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reconnectHadSinceTime {
+		t.Error("reconnect carried a SinceTime cursor; undisplayed lines must not advance it")
 	}
 }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -67,6 +67,12 @@ Actor is currently running on pod ate-demo-counter/counter-ab123-x4y5z
 {"time":"2026-05-22T21:50:02.123456789Z","count":2,"fshash":"mCY7...","level":"INFO","msg":"Count"}
 ```
 
+#### Example 4: Filtering by Container
+An actor can run several containers. By default every line is shown, including the synthetic lifecycle events (`Actor started`, `Actor checkpointing`, ...). `--container` (short form `-c`) restricts the output to the named container's logs:
+
+```bash
+kubectl ate logs actors <actor-name> -a <atespace> -c <container-name>
+```
 
 ---
 


### PR DESCRIPTION
Part of  #294 as #311 has been inactive for over a month.

Example

```
kubectl ate logs actors test -a demo                                      # default: all containers + lifecycle


kubectl ate logs actors test -a demo -c counter                           # only specified containers
```

Scoped this down to --container only after discussing with @BenTheElder  — we are not sure the naming of the container related logs, the supervisor output may end up as a describe/events-style like how k8s does?

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
