### PR TITLE
manifests: count telemetry by service on kind

### DIFF
--- a/benchmarking/telemetry/README.md
+++ b/benchmarking/telemetry/README.md
@@ -61,6 +61,35 @@ only to send the actors to a different address than the control plane.
 Keep the load generator on the usual collector. If you do not, the meter counts
 the telemetry of the load generator as telemetry from substrate.
 
+## On a kind cluster
+
+Do not install the meter on kind. The collector there is ours, thus
+[`manifests/ate-install/kind/otel-collector.yaml`](../../manifests/ate-install/kind/otel-collector.yaml)
+holds the same count connector and gives the same two counts. A meter in front
+of it would add a hop and measure nothing new. The meter exists for GKE only,
+where the managed collector cannot hold a connector.
+
+`hack/install-ate.sh` installs the collector and a Prometheus with it, thus a
+kind cluster needs no other step:
+
+```bash
+kubectl port-forward -n otel-system svc/prometheus 9090:9090
+```
+
+The queries below are the same. Three items differ:
+
+- Prometheus and the collector are in `otel-system`, and not in `benchmarking`.
+- Give no `--otlp-endpoint`. The kind `ate-otel-config` ConfigMap already names
+  the collector, and `benchmarking/workloads/deploy.sh` reads that ConfigMap,
+  thus the actors follow the control plane with no flag.
+- The kind ConfigMap sets `OTEL_METRIC_EXPORT_INTERVAL` to 10s, and not to the
+  60s of GKE. Thus a range of `[1m]` is sufficient there.
+
+`monitoring.yaml` and cAdvisor are for GKE. A kind cluster measures volume
+only: its collector is a single replica with no HPA, and the memory of a node
+is the memory of the machine, thus the cost figures do not carry to a real
+cluster.
+
 ## Read the numbers
 
 [`monitoring.yaml`](../monitoring.yaml) scrapes the meter. Read the values
@@ -73,18 +102,28 @@ kubectl port-forward -n benchmarking svc/prometheus 9090:9090
 
 | To find | Query |
 |---|---|
-| Spans/sec for each service | `sum by (svc) (rate(substrate_spans_total[5m]))` |
-| Datapoints/min for each service | `60 * sum by (svc) (rate(substrate_datapoints_total[5m]))` |
+| Spans/sec for each service | `sum by (service_name) (rate(substrate_spans_total[5m]))` |
+| Datapoints/min for each service | `60 * sum by (service_name) (rate(substrate_datapoints_total[5m]))` |
 | If the data arrived | `sum(rate(otelcol_receiver_accepted_spans[5m]))` |
 | If the collector rejected the data | `sum(rate(otelcol_receiver_refused_spans[5m]))` |
+| If the count dropped a series | `sum(otelcol_deltatocumulative_datapoints{error="limit"})` |
+| How near the stream limit is | `otelcol_deltatocumulative_streams_tracked / otelcol_deltatocumulative_streams_limit` |
 
 Keep the range at three times the 60s push interval or more. `[5m]` is a good
 default. A range less than 3m gives noise.
 
-Always read the last two counters. A service that reports zero volume gives no
+Always read the last four counters. A service that reports zero volume gives no
 data by itself: `accepted` must be more than zero and `refused` must be zero
 for the same window. If they are not, the zero shows that the data did not
 arrive, not that the service sent no data.
+
+The last two counters cover the different failure of `max_streams`. The count
+connector copies the resource to each count, and serverboot gives each process
+its own `service.instance.id`, thus one process holds one stream for each
+count. Above the limit `deltatocumulative` drops each new stream with no log
+line, and the series leaves the scrape. The volume then reads low and nothing
+reports an error. The dropped count must be zero, and the ratio must stay below
+1, for the whole window of a run.
 
 ## The meter is a tee
 
@@ -125,10 +164,13 @@ replicas is not, and the effect of connection stickiness disappears.
 the pass criteria:
 
 ```promql
-sum(rate(otelcol_receiver_refused_spans[5m]))   # must be 0
-sum(rate(otelcol_exporter_sent_spans[5m]))      # must be more than 0
-max_over_time(otelcol_exporter_queue_size[5m])  # must stay level
-absent(otelcol_exporter_sent_spans)             # must give no result
+sum(rate(otelcol_receiver_refused_spans[5m]))              # must be 0
+sum(rate(otelcol_exporter_sent_spans[5m]))                 # must be more than 0
+max_over_time(otelcol_exporter_queue_size[5m])             # must stay level
+absent(otelcol_exporter_sent_spans)                        # must give no result
+sum(otelcol_deltatocumulative_datapoints{error="limit"})   # must be 0
+otelcol_deltatocumulative_streams_tracked
+  / otelcol_deltatocumulative_streams_limit                # must stay below 1
 ```
 
 Do not use `otelcol_exporter_send_failed_spans` alone. The default

--- a/benchmarking/telemetry/meter.yaml
+++ b/benchmarking/telemetry/meter.yaml
@@ -19,8 +19,8 @@
 #   http://telemetry-meter.benchmarking.svc.cluster.local:4317
 # for the duration of a measurement, then scrape :8889 for
 #
-#   substrate_spans_total{svc="..."}       the spans from each service
-#   substrate_datapoints_total{svc="..."}  the datapoints from each service
+#   substrate_spans_total{service_name="..."}       spans from each service
+#   substrate_datapoints_total{service_name="..."}  datapoints from each service
 #
 # Scrape :8888 for the otelcol_* receiver counters of the meter.
 #
@@ -62,32 +62,15 @@ data:
       # and the Prometheus exporter reads a new start timestamp as a reset of
       # the counter. Without deltatocumulative the counters do not accumulate,
       # and each scrape shows only the last batch.
+      #
+      # max_streams bounds the memory. A stream is for each process and
+      # count, and not for each service, because serverboot gives each
+      # process its own service.instance.id. 24 processes held 51 streams, at
+      # approximately 5 KiB each. Above the limit new streams drop with no log
+      # line and the totals become too low; README.md holds the pass criteria
+      # that catch it.
       deltatocumulative:
-
-      # The count connector reads the attributes of a span or a datapoint. It
-      # does not read the attributes of the resource, thus service.name is not
-      # visible to it. Copy service.name to a datapoint attribute. Without this
-      # copy the connector has nothing to group by, and it counts all the
-      # services into one bucket.
-      #
-      # This is not a correction for the scrape configuration. honor_labels
-      # changes what Prometheus does with the labels of a scrape, and a scrape
-      # occurs after the connector counts. Thus honor_labels cannot give the
-      # connector an attribute to count by, and it is not an alternative to
-      # this transform.
-      #
-      # The name is svc, and not job, because Prometheus sets job to the name
-      # of the scrape job.
-      transform/svc:
-        error_mode: ignore
-        trace_statements:
-          - context: span
-            statements:
-              - set(attributes["svc"], resource.attributes["service.name"])
-        metric_statements:
-          - context: datapoint
-            statements:
-              - set(attributes["svc"], resource.attributes["service.name"])
+        max_streams: 20000
 
     connectors:
       count:
@@ -95,16 +78,21 @@ data:
           substrate_spans:
             description: Spans received, by emitting service.
             attributes:
+              # The connector reads each key from the attributes of the item,
+              # then the scope, then the resource, thus service.name resolves
+              # from the resource and no transform in front of it is needed.
+              # The Prometheus exporter writes the key as service_name.
+              #
               # Without a default value, the connector removes each item that
               # has no service.name from the count. The item does not show as
               # unknown, and the totals are too low with no error message.
-              - key: svc
+              - key: service.name
                 default_value: unknown
         datapoints:
           substrate_datapoints:
             description: Metric datapoints received, by emitting service.
             attributes:
-              - key: svc
+              - key: service.name
                 default_value: unknown
 
     exporters:
@@ -128,16 +116,15 @@ data:
     service:
       pipelines:
         # The count pipelines and the forward pipelines read the same receiver.
-        # The collector sends a copy of the data to each pipeline, and it clones
-        # the data because transform/svc changes it. Thus the svc attribute that
-        # the count needs does not go to the managed collector.
+        # The count pipelines only count. The connector declares MutatesData
+        # false, thus it changes nothing that goes to the managed collector.
         #
         # memory_limiter is first in each pipeline that reads the receiver.
-        # metrics/counts has no limiter: a refusal there would remove the
+        # metrics/count-out has no limiter: a refusal there would remove the
         # measurement of the run.
         traces/count:
           receivers: [otlp]
-          processors: [memory_limiter, transform/svc]
+          processors: [memory_limiter]
           exporters: [count]
         traces/forward:
           receivers: [otlp]
@@ -145,13 +132,15 @@ data:
           exporters: [otlp/managed]
         metrics/count:
           receivers: [otlp]
-          processors: [memory_limiter, transform/svc]
+          processors: [memory_limiter]
           exporters: [count]
         metrics/forward:
           receivers: [otlp]
           processors: [memory_limiter]
           exporters: [otlp/managed]
-        metrics/counts:
+
+        # The counts that the connector makes, out to the Prometheus exporter.
+        metrics/count-out:
           receivers: [count]
           processors: [deltatocumulative]
           exporters: [prometheus]

--- a/manifests/ate-install/kind/otel-collector.yaml
+++ b/manifests/ate-install/kind/otel-collector.yaml
@@ -33,6 +33,47 @@ data:
             endpoint: 0.0.0.0:4318
     processors:
       batch:
+
+      # The count connector below sends deltas, and the Prometheus exporter
+      # reads the new start timestamp of each batch as a reset. Without
+      # deltatocumulative the counts do not accumulate and each scrape shows
+      # only the last batch.
+      #
+      # max_streams bounds the memory. A stream is for each process and
+      # count, and not for each service, because serverboot gives each
+      # process its own service.instance.id. Above the limit new streams drop
+      # with no log line and the totals become too low.
+      deltatocumulative:
+        max_streams: 10000
+
+    # The volume of telemetry for each service, the same two counts that
+    # benchmarking/telemetry/meter.yaml gives on GKE. On GKE the managed
+    # collector cannot hold a connector, thus a measurement there needs a
+    # second collector in front of it. Here the collector is ours, thus the
+    # counts belong in it and kind needs no meter.
+    connectors:
+      count:
+        spans:
+          substrate_spans:
+            description: Spans received, by emitting service.
+            attributes:
+              # The connector reads each key from the attributes of the item,
+              # then the scope, then the resource, thus service.name resolves
+              # from the resource with no transform in front of it. The
+              # Prometheus exporter writes the key as service_name.
+              #
+              # Without a default value the connector removes each item that
+              # has no service.name from the count. The item does not show as
+              # unknown, and the totals are too low with no error message.
+              - key: service.name
+                default_value: unknown
+        datapoints:
+          substrate_datapoints:
+            description: Metric datapoints received, by emitting service.
+            attributes:
+              - key: service.name
+                default_value: unknown
+
     exporters:
       otlp/jaeger:
         endpoint: jaeger.otel-system.svc.cluster.local:4317
@@ -52,6 +93,39 @@ data:
           receivers: [otlp]
           processors: [batch]
           exporters: [prometheus, debug]
+
+        # The count pipelines read the same receiver as the two pipelines
+        # above, and they only count. The connector declares MutatesData
+        # false, thus it changes nothing that reaches Jaeger or Prometheus.
+        traces/count:
+          receivers: [otlp]
+          exporters: [count]
+        metrics/count:
+          receivers: [otlp]
+          exporters: [count]
+
+        # The counts that the connector makes, out to the Prometheus exporter.
+        metrics/count-out:
+          receivers: [count]
+          processors: [deltatocumulative]
+          exporters: [prometheus]
+
+      # The otelcol_* counters of the collector itself. A service that reports
+      # zero volume gives no data by itself: otelcol_receiver_accepted_* shows
+      # the difference between a service that sent nothing and data that never
+      # arrived. The default reader binds to localhost, thus give the address
+      # of each interface so the Prometheus pod can reach it.
+      #
+      # The level stays at the default. It already gives each counter above,
+      # and detailed adds histograms only, which no query here reads.
+      telemetry:
+        metrics:
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: 0.0.0.0
+                    port: 8888
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -69,6 +143,10 @@ spec:
     metadata:
       labels:
         app: opentelemetry-collector
+      # There is no prometheus.io/scrape annotation here. The annotation can
+      # name one port only, and the collector has two to read: 8889 for the
+      # substrate_* counts and 8888 for the otelcol_* counters. The
+      # otel-collector-self job in prometheus.yaml reads both.
     spec:
       containers:
       - name: otel-collector
@@ -85,6 +163,8 @@ spec:
           containerPort: 4318
         - name: prom
           containerPort: 8889
+        - name: self
+          containerPort: 8888
       volumes:
       - name: config
         configMap:
@@ -112,6 +192,9 @@ spec:
   - name: prom
     port: 8889
     targetPort: 8889
+  - name: self
+    port: 8888
+    targetPort: 8888
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ate-install/kind/prometheus.yaml
+++ b/manifests/ate-install/kind/prometheus.yaml
@@ -107,6 +107,43 @@ data:
           - source_labels: [__meta_kubernetes_pod_phase]
             action: drop
             regex: Pending|Succeeded|Failed
+
+      # The two read ports of the collector: 8889 carries the substrate_*
+      # counts of the count connector, and 8888 the otelcol_* counters of the
+      # collector itself. The two go together: when a service reports zero
+      # volume, otelcol_receiver_accepted_* shows the difference between a
+      # service that sent nothing and data that never arrived.
+      #
+      # This job, and not the annotation job above, reads the collector. The
+      # annotation can name one port only, thus the collector pod carries no
+      # prometheus.io/scrape annotation. Read the two ports here instead.
+      #
+      # 8889 re-exports each metric that the pipelines push, and the pods of
+      # ate-api-server, atelet, and atenet-router already carry the annotation
+      # on 9090. Keep the substrate_* and otelcol_* names only, or every
+      # series of those services arrives twice and sum() gives double.
+      - job_name: otel-collector-self
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - otel-system
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_pod_label_app
+              - __meta_kubernetes_pod_container_port_number
+            action: keep
+            regex: opentelemetry-collector;(8888|8889)
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            action: keep
+            regex: (substrate|otelcol)_.*
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
The volume measurement in current benchmarking repo worked on GKE only. There the managed collector cannot hold a connector, thus benchmarking/telemetry/meter.yaml puts a second collector in front of it and counts the data as it goes through.

This PR adds the support to kind cluster to count the telemetry data.

Follow-up to #749.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
