### PR TITLE
benchmarking: run the observability ladder as one test

### DIFF
--- a/benchmarking/automation/tests.yaml
+++ b/benchmarking/automation/tests.yaml
@@ -48,6 +48,13 @@
 # Optional `flags` is a list of arbitrary strings appended to runner.py's
 # argv; runner.py forwards them to locust verbatim.
 #
+# `--ladder users:duration[:trace_probability],...` in `flags` turns the test
+# into a sequence of steps in one run (benchmarking/locust/shapes/ladder_shape.py).
+# The shape then owns the load and the end of the run, so runner.py stops
+# forwarding `-t` and `users` becomes the count before the first tick only.
+# Keep `duration` at the total of the steps: the orchestrator sizes the Job
+# timeout from it.
+#
 # ---- type: nighthawk-ingress --------------------------------------------------------
 #
 # Runs the Nighthawk adaptive router-capacity benchmark. `duration` is the
@@ -107,6 +114,75 @@ tests:
     flags:
       - "--min-wait-time"
       - "0.5"
+      - "--max-wait-time"
+      - "1.0"
+  # The observability ladder of benchmarking/observability.md. Each entry
+  # runs on glutton, and thus on boomer: Python and gRPC hold each other at
+  # a high number of users, which would make the latency of the load
+  # generator part of the measurement.
+  - name: observability_s0_idle_floor
+    type: locust
+    description: "Observability S0: the telemetry of an idle control plane, 5 minutes"
+    targetCluster: dev
+    file: /app/tests/glutton.py
+    duration: 5m
+    users: 0
+    workerCount: 10
+    flags:
+      # The floor sends no request, thus locust writes no measurement row and
+      # the result of the run is in the telemetry counts only.
+      - "--allow-empty-stats"
+      - "--ladder"
+      - "0:5m"
+      - "--trace-probability"
+      - "0.1"
+  - name: observability_s1_user_sweep
+    type: locust
+    description: "Observability S1: user sweep 5 -> 10 -> 15, 3 minutes for each step"
+    targetCluster: dev
+    file: /app/tests/glutton.py
+    duration: 9m
+    users: 5
+    workerCount: 10
+    flags:
+      - "--ladder"
+      - "5:3m,10:3m,15:3m"
+      - "--trace-probability"
+      - "0.1"
+      - "--min-wait-time"
+      - "1.0"
+      - "--max-wait-time"
+      - "1.0"
+  - name: observability_s2_sample_rate_sweep
+    type: locust
+    description: "Observability S2: sample rate 0 -> 0.1 -> 1.0 at 10 users, 3 minutes for each step"
+    targetCluster: dev
+    file: /app/tests/glutton.py
+    duration: 9m
+    users: 10
+    workerCount: 10
+    flags:
+      - "--ladder"
+      - "10:3m:0,10:3m:0.1,10:3m:1.0"
+      - "--min-wait-time"
+      - "1.0"
+      - "--max-wait-time"
+      - "1.0"
+  - name: observability_s3_soak
+    type: locust
+    description: "Observability S3: 12 users for 10 minutes, 80% of the S1 maximum"
+    targetCluster: dev
+    file: /app/tests/glutton.py
+    duration: 10m
+    users: 12
+    workerCount: 10
+    flags:
+      - "--ladder"
+      - "12:10m"
+      - "--trace-probability"
+      - "0.1"
+      - "--min-wait-time"
+      - "1.0"
       - "--max-wait-time"
       - "1.0"
   - name: durdir_data_baseline

--- a/benchmarking/automation/tests.yaml
+++ b/benchmarking/automation/tests.yaml
@@ -48,12 +48,20 @@
 # Optional `flags` is a list of arbitrary strings appended to runner.py's
 # argv; runner.py forwards them to locust verbatim.
 #
-# `--ladder users:duration[:trace_probability],...` in `flags` turns the test
-# into a sequence of steps in one run (benchmarking/locust/shapes/ladder_shape.py).
-# The shape then owns the load and the end of the run, so runner.py stops
-# forwarding `-t` and `users` becomes the count before the first tick only.
-# Keep `duration` at the total of the steps: the orchestrator sizes the Job
-# timeout from it.
+# `file` is one path, or a comma-separated list of paths that locust reads as
+# one test. Give the test first, then each load shape. A shape changes the
+# load while the run continues; the shapes are in benchmarking/locust/shapes/.
+#
+# `--ladder users:duration[:trace_probability],...` with
+# shapes/ladder_shape.py in `file` makes a sweep one run. The shape owns the
+# load and the end of the run, thus locust ignores `-t` and `users` is the
+# count before the first tick only. Keep `duration` at the total of the steps:
+# the orchestrator sizes the Job timeout from it.
+#
+# A step of the ladder that gives a trace probability changes the sample rate
+# when the step starts, and the new rate stays until another step changes it.
+# `--trace-probability` in `flags` is the rate before the first such step.
+# Thus a ladder with no probability in any step keeps the rate of the flag.
 #
 # ---- type: nighthawk-ingress --------------------------------------------------------
 #
@@ -124,7 +132,7 @@ tests:
     type: locust
     description: "Observability S0: the telemetry of an idle control plane, 5 minutes"
     targetCluster: dev
-    file: /app/tests/glutton.py
+    file: /app/tests/glutton.py,/app/shapes/ladder_shape.py
     duration: 5m
     users: 0
     workerCount: 10
@@ -140,7 +148,7 @@ tests:
     type: locust
     description: "Observability S1: user sweep 5 -> 10 -> 15, 3 minutes for each step"
     targetCluster: dev
-    file: /app/tests/glutton.py
+    file: /app/tests/glutton.py,/app/shapes/ladder_shape.py
     duration: 9m
     users: 5
     workerCount: 10
@@ -157,7 +165,7 @@ tests:
     type: locust
     description: "Observability S2: sample rate 0 -> 0.1 -> 1.0 at 10 users, 3 minutes for each step"
     targetCluster: dev
-    file: /app/tests/glutton.py
+    file: /app/tests/glutton.py,/app/shapes/ladder_shape.py
     duration: 9m
     users: 10
     workerCount: 10
@@ -172,7 +180,7 @@ tests:
     type: locust
     description: "Observability S3: 12 users for 10 minutes, 80% of the S1 maximum"
     targetCluster: dev
-    file: /app/tests/glutton.py
+    file: /app/tests/glutton.py,/app/shapes/ladder_shape.py
     duration: 10m
     users: 12
     workerCount: 10

--- a/benchmarking/locust/common/boomer_config.py
+++ b/benchmarking/locust/common/boomer_config.py
@@ -27,6 +27,8 @@ the operator set in the web UI form:
   * build_config_json(): parses an argv list and returns the JSON payload
     that runner.py hands to boomer-glutton via --config-json in headless
     mode (no web UI to fetch from).
+  * serve_config_headless(): the same /boomer-config payload from a plain
+    HTTP server, for a headless run whose values change while it runs.
 
 Keep _FLAGS aligned with internal/benchmarking/boomer/dynconfig.payload.
 """
@@ -34,7 +36,9 @@ Keep _FLAGS aligned with internal/benchmarking/boomer/dynconfig.payload.
 import argparse
 import json
 import logging
+import threading
 from collections.abc import Iterable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 logger = logging.getLogger(__name__)
 
@@ -71,11 +75,56 @@ def build_config_json(argv: Iterable[str]) -> str:
     return json.dumps(cfg) if cfg else ""
 
 
+def _payload(parsed_options) -> dict[str, float | int | str | None]:
+    return {_attr(f): getattr(parsed_options, _attr(f), None) for f in _FLAGS}
+
+
+def serve_config_headless(environment, port: int) -> None:
+    """Serve /boomer-config on 127.0.0.1:`port` for a headless run.
+
+    A headless master has no Flask app, thus init_boomer_config registers no
+    route and runner.py gives boomer the values one time, through
+    --config-json. That is sufficient for a run that holds one set of values
+    from start to end, and not for a ladder: a step changes the sample rate
+    in the middle of the run (see shapes/ladder_shape.py), and boomer reads
+    the new value only from this endpoint.
+
+    The handler reads the parsed options at each request, thus it gives the
+    value of the step that runs, and not the value of the command line.
+
+    boomer and locust are in one container in a headless run, thus the
+    address of the loopback interface is sufficient and the endpoint is not
+    on the network.
+    """
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - name comes from the library
+            if self.path.split("?", 1)[0] != "/boomer-config":
+                self.send_error(404)
+                return
+            body = json.dumps(_payload(environment.parsed_options)).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, fmt: str, *args) -> None:
+            # One line for each fetch would be one line for each spawn
+            # message, in the middle of the output of the run.
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    logger.info(f"Serving /boomer-config on 127.0.0.1:{port} for boomer workers")
+
+
 def init_boomer_config() -> None:
     """Ensure the owning modules have registered the boomer-tunable flags,
     then expose their current values at /boomer-config so boomer-Go workers
     can fetch them at runtime."""
     from locust import events
+    from locust.argument_parser import LocustArgumentParser
     from locust.env import Environment
 
     from common.durdir_config import add_durdir_arguments
@@ -86,16 +135,35 @@ def init_boomer_config() -> None:
     init_tracing()
     init_wait_time()
 
+    @events.init_command_line_parser.add_listener
+    def on_init_parser(parser: LocustArgumentParser) -> None:
+        parser.add_argument(
+            "--boomer-config-port",
+            type=int,
+            default=0,
+            env_var="LOCUST_BOOMER_CONFIG_PORT",
+            help=(
+                "Serve /boomer-config on this port of the loopback interface "
+                "in a headless run. runner.py sets it, and gives the same "
+                "port to boomer as --master-web-port, when the values of the "
+                "run change while it runs."
+            ),
+        )
+
     @events.init.add_listener
     def on_init(environment: Environment, **kwargs) -> None:
         if environment.web_ui is None:
             # Headless / worker process: no Flask app to register against.
-            # runner.py forwards the same flags to boomer via --config-json.
+            # runner.py forwards the same flags to boomer via --config-json,
+            # and starts serve_config_headless when the values of the run
+            # change while it runs.
+            port = getattr(environment.parsed_options, "boomer_config_port", 0)
+            if port:
+                serve_config_headless(environment, port)
             return
 
         @environment.web_ui.app.route("/boomer-config")
         def boomer_config() -> dict[str, float | int | str | None]:
-            opts = environment.parsed_options
-            return {_attr(f): getattr(opts, _attr(f), None) for f in _FLAGS}
+            return _payload(environment.parsed_options)
 
         logger.info("Registered /boomer-config endpoint for boomer workers")

--- a/benchmarking/locust/common/trace.py
+++ b/benchmarking/locust/common/trace.py
@@ -114,6 +114,19 @@ def init_tracing() -> None:
     _initialized = True
 
 
+def set_trace_probability(probability: float) -> None:
+    """Change the sample rate of this process while a test runs.
+
+    init_tracing sets the rate once, at the start of a test, from the command
+    line. A step of a load ladder changes the rate in the middle of a run
+    (see shapes/ladder_shape.py), and the provider holds one sampler for the
+    life of the process, thus the change goes to that sampler and not to a
+    new provider.
+    """
+    _sampler.update_probability(probability)
+    logger.info(f"Trace probability set to {probability}")
+
+
 def get_tracer(name: str) -> Tracer:
     return trace.get_tracer(name)
 

--- a/benchmarking/locust/runner.py
+++ b/benchmarking/locust/runner.py
@@ -21,6 +21,11 @@ to JSONL, and uploads everything to either GCS or local disk under
 When the test target is glutton.py, also spawns the boomer-glutton Go
 worker as a subprocess (locust runs in --master + --expect-workers=1
 mode) so the GluttonUser load comes from boomer instead of Python+gevent.
+
+With --ladder, the run is a sequence of steps rather than one flat load:
+shapes/ladder_shape.py is loaded next to the test file and drives the user
+count (and optionally the sample rate) from step to step. The shape owns
+the duration in that mode, so -t is not forwarded to locust.
 """
 
 import argparse
@@ -43,6 +48,15 @@ from common.boomer_config import build_config_json
 # Path inside the locust image to the boomer-glutton binary baked in by
 # benchmarking/locust/Dockerfile.
 BOOMER_BINARY = "/app/boomer-glutton"
+
+# Loaded next to the test file for a --ladder run. It holds no user class, so
+# locust must never get it on its own.
+LADDER_SHAPE = str(Path(__file__).resolve().parent / "shapes" / "ladder_shape.py")
+
+# Port for the headless /boomer-config server (common/boomer_config.py), which
+# a --ladder run needs so boomer picks up a step's sample rate. Locust already
+# holds 5557 (master) and 8089 (web UI) in this container.
+BOOMER_CONFIG_PORT = 5560
 
 # Tab-separated columns written to traces.txt. Order matters — readers split
 # on \t and index positionally.
@@ -75,6 +89,15 @@ def parse_args() -> argparse.Namespace:
         required=True,
         help="Root destination (gs://bucket/path or local path)",
     )
+    p.add_argument(
+        "--allow-empty-stats",
+        action="store_true",
+        help=(
+            "Exit 0 when locust produced no measurement rows. For a run whose "
+            "result is not in the locust statistics, such as the idle floor of "
+            "the observability ladder, which sends no request on purpose"
+        ),
+    )
     args, extra = p.parse_known_args()
     args.locust_extra = extra
     return args
@@ -96,6 +119,20 @@ def needs_boomer(test_file: str) -> bool:
     return os.path.basename(test_file) not in PYTHON_TESTS
 
 
+def ladder_spec(locust_extra: list[str]) -> str:
+    """Return the --ladder value in `locust_extra`, or "" when there is none.
+
+    Accepts both `--ladder X` and `--ladder=X`, the two forms tests.yaml can
+    produce from its `flags` list.
+    """
+    for i, arg in enumerate(locust_extra):
+        if arg == "--ladder" and i + 1 < len(locust_extra):
+            return locust_extra[i + 1]
+        if arg.startswith("--ladder="):
+            return arg.split("=", 1)[1]
+    return ""
+
+
 def tee(logs: TextIO, msg: str) -> None:
     print(msg, flush=True)
     logs.write(msg + "\n")
@@ -114,6 +151,8 @@ def log_run_config(args: argparse.Namespace, dest_prefix: str, work_dir: Path, l
         f"  duration:       {args.duration}",
         f"  users:          {args.users}",
         f"  uses_boomer:    {needs_boomer(args.file)}",
+        f"  ladder:         {ladder_spec(args.locust_extra) or '(none)'}",
+        f"  empty stats ok: {args.allow_empty_stats}",
         f"  dest_prefix:    {dest_prefix}",
         f"  work_dir:       {work_dir}",
         f"  extra flags:    {' '.join(args.locust_extra) if args.locust_extra else '(none)'}",
@@ -185,19 +224,31 @@ def run_test(args: argparse.Namespace, csv_prefix: Path, logs: TextIO, traces: T
     siphoned into traces.txt as a deduped one-per-line list.
     """
     with_boomer = needs_boomer(args.file)
+    ladder = ladder_spec(args.locust_extra)
+
+    # A ladder holds a step's user count for the step's duration and then
+    # moves on, so the shape decides both the load and the end of the run.
+    # Passing -t as well would cut the ladder off at an arbitrary step, and
+    # -u would only be the count before the first tick.
+    locust_files = f"{args.file},{LADDER_SHAPE}" if ladder else args.file
 
     locust_cmd = [
         sys.executable, "-m", "locust",
         "--headless",
-        "-f", args.file,
-        "-t", args.duration,
+        "-f", locust_files,
         "-u", str(args.users),
         "--csv", str(csv_prefix),
     ]
+    if not ladder:
+        locust_cmd += ["-t", args.duration]
     if with_boomer:
         # Master mode so boomer can connect as a worker on localhost:5557.
         # --expect-workers=1 makes locust wait for boomer before starting.
         locust_cmd += ["--master", "--expect-workers", "1"]
+    if ladder and with_boomer:
+        # --config-json is read once at boomer start, so a step that changes
+        # the sample rate needs the endpoint instead.
+        locust_cmd += ["--boomer-config-port", str(BOOMER_CONFIG_PORT)]
     locust_cmd += list(args.locust_extra)
 
     tee(logs, f"Running: {' '.join(locust_cmd)}")
@@ -222,6 +273,12 @@ def run_test(args: argparse.Namespace, csv_prefix: Path, logs: TextIO, traces: T
         cfg_json = build_config_json(args.locust_extra)
         if cfg_json:
             boomer_cmd += ["--config-json", cfg_json]
+        if ladder:
+            # Refetch on each spawn message. A step change is a spawn
+            # message, so the step's sample rate reaches boomer as the step
+            # starts. boomer's --master-host already defaults to the
+            # loopback address, which is where the server listens.
+            boomer_cmd += ["--master-web-port", str(BOOMER_CONFIG_PORT)]
         tee(logs, f"Running: {' '.join(boomer_cmd)}")
         boomer_proc = subprocess.Popen(
             boomer_cmd,
@@ -394,7 +451,7 @@ def main() -> None:
         upload(src, dest)
         print(f"Uploaded {src} -> {dest}", flush=True)
 
-    if not stats_generated:
+    if not stats_generated and not args.allow_empty_stats:
         sys.exit(1)
 
 

--- a/benchmarking/locust/runner.py
+++ b/benchmarking/locust/runner.py
@@ -22,10 +22,10 @@ When the test target is glutton.py, also spawns the boomer-glutton Go
 worker as a subprocess (locust runs in --master + --expect-workers=1
 mode) so the GluttonUser load comes from boomer instead of Python+gevent.
 
-With --ladder, the run is a sequence of steps rather than one flat load:
-shapes/ladder_shape.py is loaded next to the test file and drives the user
-count (and optionally the sample rate) from step to step. The shape owns
-the duration in that mode, so -t is not forwarded to locust.
+-f accepts a comma-separated list of files, which locust reads as one test.
+Give the test file first, then a load shape, as in
+`/app/tests/glutton.py,/app/shapes/ladder_shape.py`. A shape holds no user
+class, thus this module finds the test in the list; see test_file().
 """
 
 import argparse
@@ -49,12 +49,8 @@ from common.boomer_config import build_config_json
 # benchmarking/locust/Dockerfile.
 BOOMER_BINARY = "/app/boomer-glutton"
 
-# Loaded next to the test file for a --ladder run. It holds no user class, so
-# locust must never get it on its own.
-LADDER_SHAPE = str(Path(__file__).resolve().parent / "shapes" / "ladder_shape.py")
-
 # Port for the headless /boomer-config server (common/boomer_config.py), which
-# a --ladder run needs so boomer picks up a step's sample rate. Locust already
+# gives boomer the values that change while a run continues. Locust already
 # holds 5557 (master) and 8089 (web UI) in this container.
 BOOMER_CONFIG_PORT = 5560
 
@@ -94,8 +90,8 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help=(
             "Exit 0 when locust produced no measurement rows. For a run whose "
-            "result is not in the locust statistics, such as the idle floor of "
-            "the observability ladder, which sends no request on purpose"
+            "result is not in the locust statistics, such as a run that sends "
+            "no request on purpose"
         ),
     )
     args, extra = p.parse_known_args()
@@ -115,22 +111,50 @@ PYTHON_TESTS = frozenset({
 })
 
 
-def needs_boomer(test_file: str) -> bool:
-    return os.path.basename(test_file) not in PYTHON_TESTS
+def test_file(files: str) -> str:
+    """Return the one file of `files` that holds the user class.
 
+    `files` is the value of -f, which is one path or a comma-separated list
+    of paths. A load shape is a file in that list with no user class, thus
+    the name of the run does not come from it. Two values are wrong if this
+    function takes the last path: needs_boomer below, and the --user-class
+    of boomer.
 
-def ladder_spec(locust_extra: list[str]) -> str:
-    """Return the --ladder value in `locust_extra`, or "" when there is none.
-
-    Accepts both `--ladder X` and `--ladder=X`, the two forms tests.yaml can
-    produce from its `flags` list.
+    Each shape is a file in the shapes directory, thus remove those paths
+    first. A boomer test has no entry in PYTHON_TESTS, thus the test cannot
+    be found by that set alone. What stays is the test, and the result does
+    not change with the order of the paths.
     """
-    for i, arg in enumerate(locust_extra):
-        if arg == "--ladder" and i + 1 < len(locust_extra):
-            return locust_extra[i + 1]
-        if arg.startswith("--ladder="):
-            return arg.split("=", 1)[1]
-    return ""
+    paths = [p for p in files.split(",") if p]
+    tests = [p for p in paths if os.path.basename(os.path.dirname(p)) != "shapes"]
+    if tests:
+        return tests[0]
+    return paths[0] if paths else files
+
+
+def needs_boomer(files: str) -> bool:
+    return os.path.basename(test_file(files)) not in PYTHON_TESTS
+
+
+def pair_flags(locust_extra: list[str]) -> list[str]:
+    """Join each flag of `locust_extra` with its value, for the log.
+
+    tests.yaml gives a flag and its value as two entries of a list, thus one
+    flag becomes two items here. A reader compares the log with tests.yaml,
+    and a value on a line of its own makes that comparison difficult.
+    """
+    pairs: list[str] = []
+    i = 0
+    while i < len(locust_extra):
+        item = locust_extra[i]
+        nxt = locust_extra[i + 1] if i + 1 < len(locust_extra) else None
+        if item.startswith("--") and nxt is not None and not nxt.startswith("--"):
+            pairs.append(f"{item} {nxt}")
+            i += 2
+            continue
+        pairs.append(item)
+        i += 1
+    return pairs
 
 
 def tee(logs: TextIO, msg: str) -> None:
@@ -147,17 +171,21 @@ def log_run_config(args: argparse.Namespace, dest_prefix: str, work_dir: Path, l
         "==== Run config ====",
         f"  name:           {args.name}",
         f"  tag:            {args.tag}",
-        f"  test_file:      {args.file}",
+        f"  files:          {args.file}",
+        f"  test_file:      {test_file(args.file)}",
         f"  duration:       {args.duration}",
         f"  users:          {args.users}",
         f"  uses_boomer:    {needs_boomer(args.file)}",
-        f"  ladder:         {ladder_spec(args.locust_extra) or '(none)'}",
         f"  empty stats ok: {args.allow_empty_stats}",
         f"  dest_prefix:    {dest_prefix}",
         f"  work_dir:       {work_dir}",
-        f"  extra flags:    {' '.join(args.locust_extra) if args.locust_extra else '(none)'}",
-        "====================",
+        # One flag for each line, with its value. A run gives many flags to
+        # locust, and one line holds them in a form that no reader can
+        # compare with the entry in tests.yaml.
+        "  extra flags:",
     ]
+    lines += [f"    {flag}" for flag in pair_flags(args.locust_extra)] or ["    (none)"]
+    lines.append("====================")
     for line in lines:
         tee(logs, line)
 
@@ -224,30 +252,22 @@ def run_test(args: argparse.Namespace, csv_prefix: Path, logs: TextIO, traces: T
     siphoned into traces.txt as a deduped one-per-line list.
     """
     with_boomer = needs_boomer(args.file)
-    ladder = ladder_spec(args.locust_extra)
-
-    # A ladder holds a step's user count for the step's duration and then
-    # moves on, so the shape decides both the load and the end of the run.
-    # Passing -t as well would cut the ladder off at an arbitrary step, and
-    # -u would only be the count before the first tick.
-    locust_files = f"{args.file},{LADDER_SHAPE}" if ladder else args.file
 
     locust_cmd = [
         sys.executable, "-m", "locust",
         "--headless",
-        "-f", locust_files,
+        "-f", args.file,
+        "-t", args.duration,
         "-u", str(args.users),
         "--csv", str(csv_prefix),
     ]
-    if not ladder:
-        locust_cmd += ["-t", args.duration]
     if with_boomer:
         # Master mode so boomer can connect as a worker on localhost:5557.
         # --expect-workers=1 makes locust wait for boomer before starting.
         locust_cmd += ["--master", "--expect-workers", "1"]
-    if ladder and with_boomer:
-        # --config-json is read once at boomer start, so a step that changes
-        # the sample rate needs the endpoint instead.
+        # Serve /boomer-config for the worker. --config-json gives boomer the
+        # values one time, at its start, thus a run that changes a value while
+        # it runs needs the endpoint. A load shape is one such run.
         locust_cmd += ["--boomer-config-port", str(BOOMER_CONFIG_PORT)]
     locust_cmd += list(args.locust_extra)
 
@@ -269,16 +289,15 @@ def run_test(args: argparse.Namespace, csv_prefix: Path, logs: TextIO, traces: T
 
     boomer_proc = None
     if with_boomer:
-        boomer_cmd = [BOOMER_BINARY, "--user-class", Path(args.file).stem]
+        boomer_cmd = [BOOMER_BINARY, "--user-class", Path(test_file(args.file)).stem]
         cfg_json = build_config_json(args.locust_extra)
         if cfg_json:
             boomer_cmd += ["--config-json", cfg_json]
-        if ladder:
-            # Refetch on each spawn message. A step change is a spawn
-            # message, so the step's sample rate reaches boomer as the step
-            # starts. boomer's --master-host already defaults to the
-            # loopback address, which is where the server listens.
-            boomer_cmd += ["--master-web-port", str(BOOMER_CONFIG_PORT)]
+        # Read the endpoint again at each spawn message. Thus a value that
+        # changes while the run continues, such as the sample rate of a load
+        # shape, reaches boomer at the change. boomer's --master-host default
+        # is the loopback address, where the server above listens.
+        boomer_cmd += ["--master-web-port", str(BOOMER_CONFIG_PORT)]
         tee(logs, f"Running: {' '.join(boomer_cmd)}")
         boomer_proc = subprocess.Popen(
             boomer_cmd,

--- a/benchmarking/locust/shapes/ladder_shape.py
+++ b/benchmarking/locust/shapes/ladder_shape.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A scenario ladder as one locust run.
+
+The observability scenarios in benchmarking/observability.md are steps of a
+ladder: hold a number of users and a sample rate for a period, then go to the
+next pair. Each step was a separate run, thus each step also carried a deploy,
+a set of cold caches, and a new baseline for the reader to align.
+
+`--ladder` makes the steps one run. Give the steps as a comma-separated list
+of `users:duration[:trace_probability]`:
+
+    --ladder 5:3m,15:3m,30:3m          the user sweep, S1
+    --ladder 15:3m:0,15:3m:0.1,15:3m:1 the sample-rate sweep, S2
+    --ladder 0:5m                      the idle floor, S0
+
+The shape controls the duration of the run, thus runner.py gives locust no
+`-t` when this flag is present, and the run ends with the last step.
+
+A step that names a trace probability changes the sample rate as it starts.
+The value goes to the parsed options of the master, thus:
+
+  * A Python user class reads it through the sampler of common.trace.
+  * A boomer worker reads it from /boomer-config at the spawn message that
+    the step change makes. boomer fetches that endpoint on each spawn
+    message, and a step change is a spawn message.
+
+Use a boomer user class for a ladder. Python and gRPC hold each other at a
+high number of users, and the latency of that condition is the latency of the
+load generator and not of substrate.
+"""
+
+import logging
+import re
+
+from locust import LoadTestShape, events
+from locust.argument_parser import LocustArgumentParser
+
+logger = logging.getLogger(__name__)
+
+# users:duration[:trace_probability]
+_STEP_RE = re.compile(
+    r"^(?P<users>\d+):(?P<duration>\d+)(?P<unit>[smh]?)"
+    r"(?::(?P<probability>[0-9.]+))?$"
+)
+
+_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600}
+
+# A step of the ladder holds one number of users, for one period, at one
+# sample rate. `probability` is None when the step does not change the rate.
+Step = tuple[int, int, float | None]
+
+
+def parse_ladder(spec: str) -> list[Step]:
+    """Parse a --ladder value into its steps. Raises ValueError on a step
+    that does not parse, because a ladder that runs the wrong scenario gives
+    a table that no reader can tell from a correct one."""
+    steps: list[Step] = []
+    for raw in spec.split(","):
+        item = raw.strip()
+        if not item:
+            continue
+        m = _STEP_RE.match(item)
+        if not m:
+            raise ValueError(
+                f"unrecognized ladder step {item!r}; "
+                f"the form is users:duration[:trace_probability], "
+                f"as in 15:3m or 15:3m:0.1"
+            )
+        seconds = int(m.group("duration")) * _UNIT_SECONDS[m.group("unit") or "s"]
+        if seconds <= 0:
+            raise ValueError(f"ladder step {item!r} has no duration")
+        probability = m.group("probability")
+        if probability is None:
+            steps.append((int(m.group("users")), seconds, None))
+            continue
+        value = float(probability)
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(
+                f"ladder step {item!r} has a trace probability outside 0.0 to 1.0"
+            )
+        steps.append((int(m.group("users")), seconds, value))
+    if not steps:
+        raise ValueError("--ladder has no steps")
+    return steps
+
+
+@events.init_command_line_parser.add_listener
+def _(parser: LocustArgumentParser) -> None:
+    parser.add_argument(
+        "--ladder",
+        type=str,
+        default="",
+        env_var="LOCUST_LADDER",
+        help=(
+            "Run a ladder of steps in one test, as "
+            "users:duration[:trace_probability],... For example "
+            "5:3m,15:3m,30:3m"
+        ),
+        include_in_web_ui=True,
+    )
+    parser.add_argument(
+        "--ladder-spawn-rate",
+        type=float,
+        default=5.0,
+        env_var="LOCUST_LADDER_SPAWN_RATE",
+        help="Users per second at each step change of a --ladder run",
+        include_in_web_ui=True,
+    )
+
+
+def _set_trace_probability(environment, probability: float) -> None:
+    """Apply `probability` to the master, for both kinds of worker.
+
+    The parsed options are what /boomer-config serves, thus a boomer worker
+    reads the new value at the next spawn message. common.trace holds the
+    sampler of a Python user class in this process, which reads no endpoint.
+    """
+    environment.parsed_options.trace_probability = probability
+    from common.trace import set_trace_probability
+
+    set_trace_probability(probability)
+
+
+class LadderShape(LoadTestShape):
+    """Holds each step of `--ladder` in turn, then stops the run.
+
+    locust loads a shape from the locustfile, and this file has no user
+    class, thus runner.py adds it to `-f` next to the test file only when
+    --ladder is present. Without the flag the shape is inert: tick() returns
+    None at once and locust ends the run, which is why the file must not be
+    loaded by itself.
+    """
+
+    # Recomputed from the parsed options at the first tick. The command line
+    # is not available when locust constructs the shape.
+    _steps: list[Step] | None = None
+    _boundaries: list[float] = []
+    _current: int = -1
+
+    def _load(self) -> bool:
+        if self._steps is not None:
+            return bool(self._steps)
+        spec = getattr(self.runner.environment.parsed_options, "ladder", "")
+        self._steps = parse_ladder(spec) if spec else []
+        elapsed = 0.0
+        self._boundaries = []
+        for _, seconds, _ in self._steps:
+            elapsed += seconds
+            self._boundaries.append(elapsed)
+        if self._steps:
+            logger.info(
+                "Ladder: %d steps, %.0fs in total",
+                len(self._steps),
+                self._boundaries[-1],
+            )
+        return bool(self._steps)
+
+    def tick(self) -> tuple[int, float] | None:
+        if not self._load():
+            return None
+        assert self._steps is not None
+
+        run_time = self.get_run_time()
+        index = next(
+            (i for i, end in enumerate(self._boundaries) if run_time < end),
+            None,
+        )
+        if index is None:
+            logger.info("Ladder complete after %.0fs", run_time)
+            return None
+
+        users, _, probability = self._steps[index]
+        spawn_rate = self.runner.environment.parsed_options.ladder_spawn_rate
+
+        if index != self._current:
+            self._current = index
+            if probability is not None:
+                _set_trace_probability(self.runner.environment, probability)
+            logger.info(
+                "Ladder step %d/%d: users=%d trace_probability=%s",
+                index + 1,
+                len(self._steps),
+                users,
+                "unchanged" if probability is None else probability,
+            )
+
+        return (users, spawn_rate)

--- a/benchmarking/locust/shapes/ladder_shape.py
+++ b/benchmarking/locust/shapes/ladder_shape.py
@@ -26,10 +26,18 @@ of `users:duration[:trace_probability]`:
     --ladder 15:3m:0,15:3m:0.1,15:3m:1 the sample-rate sweep, S2
     --ladder 0:5m                      the idle floor, S0
 
-The shape controls the duration of the run, thus runner.py gives locust no
-`-t` when this flag is present, and the run ends with the last step.
+Name this file in the `file` of the test, after the test itself:
 
-A step that names a trace probability changes the sample rate as it starts.
+    file: /app/tests/glutton.py,/app/shapes/ladder_shape.py
+
+The shape controls the duration of the run. locust ignores `-t` when a shape
+is present, thus the run ends with the last step.
+
+A step that names a trace probability changes the sample rate as it starts,
+and the new rate stays until another step changes it. `--trace-probability`
+gives the rate before the first step that names one. Thus a ladder with no
+probability in any step keeps the rate of that flag from start to end.
+
 The value goes to the parsed options of the master, thus:
 
   * A Python user class reads it through the sampler of common.trace.

--- a/benchmarking/observability.md
+++ b/benchmarking/observability.md
@@ -17,32 +17,45 @@ correct.
 
 ## 1. Scenario ladder
 
-`SleepUser` ([`locust/tests/sleep.py`](locust/tests/sleep.py)) does one suspend
-operation and one resume operation for each task. Thus
-`cycles/sec ≈ users / (1.0s + avg_wait_time)`. Change the number of users. Do
-not change the wait time.
+The ladder is in [automation/tests.yaml](automation/tests.yaml), as four tests
+whose names start with `observability_`. Each one is one run of one step or
+more:
 
-| # | Scenario | Duration | Setup |
+| # | Test | Duration | Steps |
 |---|---|---|---|
-| **S0** | Idle floor | 5m | No load |
-| **S1** | Suspend and resume sweep | 3m for each step | `SleepUser`, `--trace-probability 0.1`, users 5 → 15 → 30 |
-| **S2** | Sample-rate sweep | 3m for each step | The number of users stays the same. `--trace-probability` 0 → 0.1 → 1.0 |
-| **S3** | Soak | 15m | 80% of the maximum load above |
+| **S0** | `observability_s0_idle_floor` | 5m | No load |
+| **S1** | `observability_s1_user_sweep` | 3m for each step | Users 5 → 10 → 15, at `--trace-probability 0.1` |
+| **S2** | `observability_s2_sample_rate_sweep` | 3m for each step | 10 users. The sample rate goes 0 → 0.1 → 1.0 |
+| **S3** | `observability_s3_soak` | 10m | 12 users, 80% of the maximum of S1 |
+
+Each test uses `GluttonUser`, thus the load comes from the boomer worker.
+Do not put a ladder on a Python user class. Python and gRPC hold each other at
+a high number of users: the latency then is the latency of the load generator,
+and the run measures the generator and not substrate.
+
+The steps of one run are `--ladder users:duration[:trace_probability]`, which
+[`locust/shapes/ladder_shape.py`](locust/shapes/ladder_shape.py) reads. The
+shape holds each step for its duration and then goes to the next one, thus one
+run gives the whole sweep, with one deploy and one baseline. A step that names
+a probability changes the sample rate as it starts: the value goes to the
+parsed options of the master, and boomer reads it from `/boomer-config` at the
+spawn message that the step change makes.
 
 Do not make a step shorter than 3 minutes. The metrics push interval is 60
 seconds. A shorter step gives less than three datapoints for each series. You
 cannot then tell the difference between a trend and noise.
 
-Do these runs with the headless runner in
-[automation/tests.yaml](automation/tests.yaml). In headless mode, `runner.py`
-sends `--trace-probability` to the boomer worker at start, and writes the value
-in the run config header. Thus each run records the rate that it used.
+The number of users of S1 stops at 15, and not at a higher value, because the
+pool of the run is 10 workers. A step above that measures the queue of the
+scheduler and not the telemetry of a working system. Raise `workerCount` with
+the steps to go higher.
 
-The locust web UI is for manual examination only. Two conditions apply there.
-The `boomer-glutton` sidecar makes its own load for each user class that you
-select in the form. Also, the form changes the sample rate of the boomer worker
-but not of the Python workers: `locust.yaml` gives boomer `--master-web-port`,
-thus boomer reads `/boomer-config` from the master at each spawn message.
+The locust web UI is for manual examination only, and it holds no ladder. Two
+conditions apply there. The `boomer-glutton` sidecar makes its own load for
+each user class that you select in the form. Also, the form changes the sample
+rate of the boomer worker but not of the Python workers: `locust.yaml` gives
+boomer `--master-web-port`, thus boomer reads `/boomer-config` from the master
+at each spawn message.
 
 **Pass criteria.** `otelcol_receiver_refused_*` must be zero.
 `otelcol_exporter_enqueue_failed_*` must be zero. `queue_full` on the client
@@ -58,8 +71,9 @@ exporter that sends nothing looks the same as a good run.
 
 ## 2. Open items
 
-- Add the ladder to [automation/tests.yaml](automation/tests.yaml). Write the
-  results as artifacts of each run.
+- Write the volume for each service as an artifact of each run. `runner.py`
+  writes the locust statistics, and a reader must still query Prometheus for
+  the `substrate_*` counts of the run.
 - Measure the collector CPU and memory from the working set. Do not use
   `kubectl top`, which calculates an average and hides peaks.
 - Record `otelcol_receiver_accepted_*` with each volume table as a positive

--- a/cmd/benchmarking/boomer-glutton/main.go
+++ b/cmd/benchmarking/boomer-glutton/main.go
@@ -38,13 +38,14 @@ import (
 
 func main() {
 	var (
-		apiEndpoint   = flag.String("api-endpoint", "k8s:///api.ate-system.svc.cluster.local:443", "ateapi gRPC dial target.")
-		routerURL     = flag.String("router-url", "http://atenet-router.ate-system.svc.cluster.local", "atenet HTTP router base URL (no trailing slash).")
-		atespace      = flag.String("atespace", "benchmark", "Atespace every actor this worker creates lives in. Ensured (CreateAtespace, AlreadyExists is ok) at startup.")
-		promAddr      = flag.String("prometheus-addr", ":8001", "Address for the Prometheus /metrics endpoint.")
-		configJSON    = flag.String("config-json", "", "Initial dynconfig as a JSON object (keys: trace_probability, min_wait_time, max_wait_time in seconds, durdir_file_size_bytes, resume_mode, durdir_read_mode, durdir_template). Unset fields keep their built-in defaults.")
-		masterWebPort = flag.Int("master-web-port", 0, "If non-zero, fetch dynconfig from http://{master-host}:{master-web-port}/boomer-config on each spawn message and fail fatally on error. {master-host} comes from boomer's existing --master-host flag.")
-		userClass     = flag.String("user-class", "glutton", fmt.Sprintf("Locust user class to run, lowercase; one of %s.", strings.Join(userclass.Names(), "|")))
+		apiEndpoint        = flag.String("api-endpoint", "k8s:///api.ate-system.svc.cluster.local:443", "ateapi gRPC dial target.")
+		routerURL          = flag.String("router-url", "http://atenet-router.ate-system.svc.cluster.local", "atenet HTTP router base URL (no trailing slash).")
+		atespace           = flag.String("atespace", "benchmark", "Atespace every actor this worker creates lives in. Ensured (CreateAtespace, AlreadyExists is ok) at startup.")
+		promAddr           = flag.String("prometheus-addr", ":8001", "Address for the Prometheus /metrics endpoint.")
+		configJSON         = flag.String("config-json", "", "Initial dynconfig as a JSON object (keys: trace_probability, min_wait_time, max_wait_time in seconds, durdir_file_size_bytes, resume_mode, durdir_read_mode, durdir_template). Unset fields keep their built-in defaults.")
+		masterWebPort      = flag.Int("master-web-port", 0, "If non-zero, fetch dynconfig from http://{master-host}:{master-web-port}/boomer-config on each spawn message and fail fatally on error. {master-host} comes from boomer's existing --master-host flag.")
+		configPollInterval = flag.Duration("config-poll-interval", 10*time.Second, "With --master-web-port, also fetch dynconfig on this interval. A spawn message comes only when the number of users or the spawn rate changes, thus a load shape that changes the sample rate alone needs this. Zero stops the polling.")
+		userClass          = flag.String("user-class", "glutton", fmt.Sprintf("Locust user class to run, lowercase; one of %s.", strings.Join(userclass.Names(), "|")))
 	)
 	// boomer.Run will call flag.Parse() if we haven't yet; calling here so
 	// our flag-derived values are usable before that.
@@ -96,7 +97,19 @@ func main() {
 				slog.String("err", err.Error()))
 			os.Exit(1)
 		}
-		slog.Info("dynconfig fetch enabled", slog.String("url", configURL))
+		// A spawn message is not sufficient by itself: locust sends one only
+		// when the number of users or the spawn rate changes. Poll also, thus
+		// a step of a load shape that changes only the sample rate reaches
+		// this worker. A failed poll is not fatal, because the worker holds
+		// the last good value.
+		dynconfig.StartPoll(ctx, configURL, dyn, sampler,
+			*configPollInterval, 5*time.Second, func(err error) {
+				slog.Warn("dynconfig poll failed; keeping the current values",
+					slog.String("url", configURL), slog.String("err", err.Error()))
+			})
+		slog.Info("dynconfig fetch enabled",
+			slog.String("url", configURL),
+			slog.Duration("poll_interval", *configPollInterval))
 	}
 
 	cfg := &userclass.Config{

--- a/internal/benchmarking/boomer/dynconfig/dynconfig.go
+++ b/internal/benchmarking/boomer/dynconfig/dynconfig.go
@@ -195,6 +195,74 @@ func (p payload) merge(current Config) Config {
 	return out
 }
 
+// StartPoll fetches `url` every `interval` until `ctx` is done, and applies
+// each change to `holder` + `sampler`. It returns at once; the loop is in a
+// goroutine. An interval of zero or less starts no loop.
+//
+// SubscribeSpawn below is not sufficient by itself. Locust sends a spawn
+// message only when the number of users or the spawn rate changes, thus a
+// step of a load shape that changes the sample rate and holds the number of
+// users gives no message, and the worker keeps the value of the step before
+// it. The sample-rate sweep of benchmarking/observability.md is one such
+// shape: each of its steps holds 10 users.
+//
+// `onError` gets each failed fetch. A caller must not exit the process there,
+// as it does for a spawn: the worker holds the last good value, and one
+// failed poll of a long run is not a reason to lose the run.
+func StartPoll(
+	ctx context.Context,
+	url string,
+	holder *Holder,
+	sampler ProbabilityUpdater,
+	interval, fetchTimeout time.Duration,
+	onError func(error),
+) {
+	if interval <= 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
+				next, err := Fetch(fetchCtx, url, holder.Load())
+				cancel()
+				if err != nil {
+					// The end of the run stops a fetch that is in
+					// progress. That is not a failed fetch, thus it must
+					// not go to onError.
+					if ctx.Err() != nil {
+						return
+					}
+					onError(err)
+					continue
+				}
+				// Only a change goes to the log. A poll of each few seconds
+				// for the length of a soak makes a log that hides the run.
+				if next == holder.Load() {
+					continue
+				}
+				holder.Store(next)
+				sampler.UpdateProbability(next.TraceProbability)
+				slog.Info("dynconfig applied",
+					slog.String("trigger", "poll"),
+					slog.Float64("trace_probability", next.TraceProbability),
+					slog.Duration("min_wait", next.MinWait),
+					slog.Duration("max_wait", next.MaxWait),
+					slog.Int64("durdir_file_size_bytes", next.DurDirFileSize),
+					slog.String("resume_mode", next.ResumeMode),
+					slog.String("durdir_read_mode", next.DurDirReadMode),
+					slog.String("durdir_template", next.DurDirTemplate),
+				)
+			}
+		}
+	}()
+}
+
 // SubscribeSpawn registers a boomer Events handler that fetches `url` on
 // each spawn message (≈ once per test start) and applies the result to
 // `holder` + `sampler`. `onError` is invoked when a fetch fails; production

--- a/internal/benchmarking/boomer/dynconfig/dynconfig_test.go
+++ b/internal/benchmarking/boomer/dynconfig/dynconfig_test.go
@@ -16,8 +16,11 @@ package dynconfig
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -140,5 +143,106 @@ func TestFetchValidAndInvalid(t *testing.T) {
 	_, err = Fetch(ctx, ts.URL+"/invalid", Config{})
 	if err == nil {
 		t.Errorf("expected Fetch invalid to fail, got nil")
+	}
+}
+
+// fakeSampler records each probability that StartPoll applies.
+type fakeSampler struct {
+	mu   sync.Mutex
+	seen []float64
+}
+
+func (f *fakeSampler) UpdateProbability(p float64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seen = append(f.seen, p)
+}
+
+func (f *fakeSampler) last() (float64, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.seen) == 0 {
+		return -1, 0
+	}
+	return f.seen[len(f.seen)-1], len(f.seen)
+}
+
+// A step of a load shape can change the sample rate and hold the number of
+// users. Locust sends no spawn message for such a step, thus the poll is the
+// only way the new rate reaches the worker.
+func TestStartPollAppliesAChange(t *testing.T) {
+	var probability atomic.Value
+	probability.Store(0.0)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"trace_probability": %v}`, probability.Load())
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	holder := NewHolder(Config{})
+	sampler := &fakeSampler{}
+	StartPoll(ctx, ts.URL, holder, sampler, 10*time.Millisecond, time.Second,
+		func(err error) { t.Errorf("unexpected poll error: %v", err) })
+
+	probability.Store(0.5)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got, _ := sampler.last(); got == 0.5 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := holder.Load().TraceProbability; got != 0.5 {
+		t.Fatalf("holder trace_probability = %v, want 0.5", got)
+	}
+
+	// A value that does not change must not go to the sampler again.
+	_, count := sampler.last()
+	time.Sleep(100 * time.Millisecond)
+	if _, after := sampler.last(); after != count {
+		t.Errorf("sampler got %d more updates with no change", after-count)
+	}
+}
+
+func TestStartPollStopsWithTheContext(t *testing.T) {
+	var hits atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	StartPoll(ctx, ts.URL, NewHolder(Config{}), &fakeSampler{},
+		10*time.Millisecond, time.Second, func(error) {})
+	time.Sleep(60 * time.Millisecond)
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	stopped := hits.Load()
+	time.Sleep(100 * time.Millisecond)
+	if got := hits.Load(); got != stopped {
+		t.Errorf("poll continued after the context stopped: %d -> %d", stopped, got)
+	}
+}
+
+// An interval of zero starts no loop.
+func TestStartPollZeroInterval(t *testing.T) {
+	var hits atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+	}))
+	defer ts.Close()
+
+	StartPoll(context.Background(), ts.URL, NewHolder(Config{}), &fakeSampler{},
+		0, time.Second, func(error) {})
+	time.Sleep(50 * time.Millisecond)
+	if hits.Load() != 0 {
+		t.Errorf("StartPoll with interval 0 made %d requests", hits.Load())
 	}
 }


### PR DESCRIPTION
Follow-up to #749, for comment of adding the ladder design in benchmarking for observability.
