### PR TITLE
benchmark: Add benchmarking for csi external volumes

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -13,6 +13,12 @@ scenario ladder, read [observability.md](observability.md).
 > [!IMPORTANT]
 > Source the environment configuration file (e.g., `source .ate-dev-env.sh`)
 > first so `PROJECT_ID`, `BUCKET_NAME`, etc. are set.
+>
+> **For Local Kind Clusters**: Set `KO_DOCKER_REPO` to the local registry so images are pulled without remote cloud credentials:
+> ```bash
+> export KO_DOCKER_REPO="localhost:5001"
+> export BUCKET_NAME="ate-snapshots"
+> ```
 
 Note that deploying the benchmarks does not run them. You must visit Locust's
 web UI to start a test.
@@ -108,6 +114,25 @@ and state restoration latency when a durable directory is attached to the actor.
 * `DurDirServeAfterResume`: First read after resume (measures page faults / lazy load overhead on restored volume).
 * `DurDirServeWarm`: Subsequent read within the same active cycle (cached state baseline).
 * `DurDirOverwrite`: In-place file overwrite with checksum verification.
+
+### External Volume Storage Benchmark (`glutton_storage`)
+
+The `glutton_storage` benchmark evaluates Substrate External Volume lifecycle performance (CSI volume dynamic provisioning, worker node attachment, sandbox mounting, and direct write I/O durability) under concurrent user load and oversubscription.
+
+#### Storage Configuration Knobs
+
+* `--storage-class-name`: Underlying CSI StorageClass name (default `csi-nfs-sc`, or e.g. `csi-hostpath-sc`, `standard-rwo`, `premium-rwo`). Can also be passed via `STORAGE_CLASS_NAME` env var to `deploy.sh` or `storageClassName` in `tests.yaml`.
+* `--template-name`: ActorTemplate name (default `glutton-storage`).
+
+#### Storage Reported Metrics
+
+* `CreateAtespace`: Latency to ensure the benchmark atespace exists.
+* `CreateActor`: Latency to create actor CRDs with external volume templates.
+* `ResumeActorColdStart`: First resume latency, including direct CSI volume dynamic provisioning (`CreateVolume`), worker node attachment (`ControllerPublishVolume`), and sandbox mounting.
+* `ResumeActor`: Warm volume re-attachment and sandbox mount latency.
+* `GluttonWriteDisk`: HTTP/1.1 write I/O latency to `/mnt/storage` with `f.Sync()` disk durability flush.
+* `SuspendActor`: Actor suspend latency including sandbox filesystem unmount and CSI volume detachment (`ControllerUnpublishVolume`).
+* `DeleteActor`: Actor deletion and CSI volume destruction (`DeleteVolume`).
 
 ### Viewing Traces
 You must have enabled otel tracing for your cluster to view traces.

--- a/benchmarking/automation/orchestrator.py
+++ b/benchmarking/automation/orchestrator.py
@@ -328,7 +328,10 @@ def teardown_microvm_deps() -> None:
 
 
 def deploy_workloads(
-    worker_count: int = 1, sandbox_class: str = "gvisor", actor_memory: str = ""
+    worker_count: int = 1,
+    sandbox_class: str = "gvisor",
+    actor_memory: str = "",
+    storage_class_name: str = "csi-nfs-sc",
 ) -> None:
     cmd = [
         "benchmarking/workloads/deploy.sh",
@@ -337,6 +340,8 @@ def deploy_workloads(
         str(worker_count),
         "--sandbox-class",
         sandbox_class,
+        "--storage-class-name",
+        storage_class_name,
     ]
     # Empty keeps the default in workloads/deploy.sh (256Mi, the microvm
     # minimum); RAM-consuming suites set actorMemory in tests.yaml.
@@ -528,6 +533,7 @@ def main() -> None:
                     test.get("workerCount", 1),
                     sandbox_class,
                     test.get("actorMemory", ""),
+                    test.get("storageClassName", "csi-nfs-sc"),
                 )
                 try:
                     status = run_test(

--- a/benchmarking/automation/tests.yaml
+++ b/benchmarking/automation/tests.yaml
@@ -17,24 +17,26 @@
 #
 # Fields shared by every entry:
 #
-#   type           Required. Selects the runner: "locust" | "nighthawk-ingress".
-#                  Each type's own fields are described in its section.
-#   targetCluster  Required. Names a config file under
-#                  /etc/orchestrator/target-clusters/ (e.g. `targetCluster:
-#                  dev` -> /etc/orchestrator/target-clusters/dev.sh). The
-#                  orchestrator copies that file into the cloned repo as
-#                  .ate-dev-env.sh before the test runs and deletes it
-#                  after, so different tests can target different clusters
-#                  / projects from one CronJob run.
-#   sandboxClass   Optional (default "gvisor"). Sandbox runtime for the
-#                  benchmark WorkerPool: "gvisor" | "microvm".
-#   workerCount    Optional (default 1). WorkerPool replica count for the
-#                  deploy that runs before this test. The orchestrator
-#                  redeploys workloads between tests, so each test can
-#                  pick its own scale.
-#   actorMemory    Optional (default "256Mi", the smallest size microvm
-#                  admits). Memory limit on the benchmark ActorTemplates;
-#                  raise it for suites that exercise glutton's WriteRAM path.
+#   type               Required. Selects the runner: "locust" | "nighthawk-ingress".
+#                      Each type's own fields are described in its section.
+#   targetCluster      Required. Names a config file under
+#                      /etc/orchestrator/target-clusters/ (e.g. `targetCluster:
+#                      dev` -> /etc/orchestrator/target-clusters/dev.sh). The
+#                      orchestrator copies that file into the cloned repo as
+#                      .ate-dev-env.sh before the test runs and deletes it
+#                      after, so different tests can target different clusters
+#                      / projects from one CronJob run.
+#   sandboxClass       Optional (default "gvisor"). Sandbox runtime for the
+#                      benchmark WorkerPool: "gvisor" | "microvm".
+#   workerCount        Optional (default 1). WorkerPool replica count for the
+#                      deploy that runs before this test. The orchestrator
+#                      redeploys workloads between tests, so each test can
+#                      pick its own scale.
+#   actorMemory        Optional (default "256Mi", the smallest size microvm
+#                      admits). Memory limit on the benchmark ActorTemplates;
+#                      raise it for suites that exercise glutton's WriteRAM path.
+#   storageClassName   Optional (default "csi-nfs-sc"). StorageClass name
+#                      for external volumes in storage benchmarks.
 #
 # ---- type: locust -----------------------------------------------------------
 #
@@ -49,8 +51,6 @@
 # Runs the Nighthawk adaptive router-capacity benchmark. `duration` is the
 # job-wait budget only; the test knobs live in a `nighthawk-ingress:` block — see
 # the "Configuration knobs" table in benchmarking/nighthawk-ingress/README.md.
-# `workerCount` is required: the benchmark warms one actor per worker, so
-# it is also the actor fleet size.
 
 tests:
   - name: glutton_baseline_1_user
@@ -261,3 +261,42 @@ tests:
     nighthawk-ingress:
       envoyCpu: 16
       tailLatencySloMs: 25
+  - name: glutton_storage_baseline_1_user
+    description: "GluttonStorage baseline: 1 concurrent user for 1 minute with CSI volume"
+    targetCluster: dev
+    file: /app/tests/glutton_storage.py
+    duration: 1m
+    users: 1
+    workerCount: 1
+    storageClassName: csi-nfs-sc
+    flags:
+      - "--min-wait-time"
+      - "1.0"
+      - "--max-wait-time"
+      - "1.0"
+  - name: glutton_storage_baseline_10_users
+    description: "GluttonStorage baseline: 10 concurrent users for 2 minutes (1:1 worker allocation)"
+    targetCluster: dev
+    file: /app/tests/glutton_storage.py
+    duration: 2m
+    users: 10
+    workerCount: 10
+    storageClassName: csi-nfs-sc
+    flags:
+      - "--min-wait-time"
+      - "1.0"
+      - "--max-wait-time"
+      - "2.0"
+  - name: glutton_storage_oversubscribe_15_users
+    description: "GluttonStorage oversubscribed: 15 users across 10 workers for 2 minutes (50% oversubscribed with volume attach churn)"
+    targetCluster: dev
+    file: /app/tests/glutton_storage.py
+    duration: 2m
+    users: 15
+    workerCount: 10
+    storageClassName: csi-nfs-sc
+    flags:
+      - "--min-wait-time"
+      - "0.5"
+      - "--max-wait-time"
+      - "1.0"

--- a/benchmarking/deploy_locust.sh
+++ b/benchmarking/deploy_locust.sh
@@ -31,6 +31,7 @@ SKIP_BUILD=0
 OTLP_ENDPOINT=""
 # Empty keeps the default in workloads/deploy.sh (256Mi, the microvm minimum).
 ACTOR_MEMORY=""
+STORAGE_CLASS_NAME=""
 
 usage() {
   echo "Usage: $0 [options]"
@@ -45,6 +46,7 @@ usage() {
   echo "                          instrumented actor container sends telemetry."
   echo "  --actor-memory SIZE     Forwarded to workloads/deploy.sh. Memory limit for the"
   echo "                          benchmark ActorTemplates (default: 256Mi, the microvm minimum)."
+  echo "  --storage-class-name S  Forwarded to workloads/deploy.sh. StorageClass name for external volumes."
   echo "  --skip-build            Skip locust image build/push (use the existing :latest image)"
   echo "  -h|--help               Show this help message"
   echo ""
@@ -71,6 +73,8 @@ while [[ "$#" -gt 0 ]]; do
     --otlp-endpoint=*) OTLP_ENDPOINT="${1#*=}" ;;
     --actor-memory) shift; ACTOR_MEMORY="$1" ;;
     --actor-memory=*) ACTOR_MEMORY="${1#*=}" ;;
+    --storage-class-name) shift; STORAGE_CLASS_NAME="$1" ;;
+    --storage-class-name=*) STORAGE_CLASS_NAME="${1#*=}" ;;
     --skip-build) SKIP_BUILD=1 ;;
     -h|--help) usage; exit 0 ;;
     *)
@@ -101,6 +105,9 @@ if [[ "${action}" == "deploy" ]]; then
   fi
   if [[ -n "${ACTOR_MEMORY}" ]]; then
     workload_args+=(--actor-memory "${ACTOR_MEMORY}")
+  fi
+  if [[ -n "${STORAGE_CLASS_NAME}" ]]; then
+    workload_args+=(--storage-class-name "${STORAGE_CLASS_NAME}")
   fi
   "${BENCHMARKING_DIR}/workloads/deploy.sh" "${workload_args[@]}"
 

--- a/benchmarking/locust/build_and_push.sh
+++ b/benchmarking/locust/build_and_push.sh
@@ -24,12 +24,18 @@ if [[ -f .ate-dev-env.sh ]]; then
   source .ate-dev-env.sh
 fi
 
-if [ -z "${PROJECT_ID:-}" ]; then
-  echo "Error: PROJECT_ID environment variable must be set." >&2
+if [[ -z "${PROJECT_ID:-}" && -z "${KO_DOCKER_REPO:-}" && -z "${LOCUST_IMAGE:-}" ]]; then
+  echo "Error: PROJECT_ID or KO_DOCKER_REPO environment variable must be set." >&2
   exit 1
 fi
 
-IMAGE="us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest"
+if [[ -n "${LOCUST_IMAGE:-}" ]]; then
+  IMAGE="${LOCUST_IMAGE}"
+elif [[ -n "${KO_DOCKER_REPO:-}" ]]; then
+  IMAGE="${KO_DOCKER_REPO}/locust-test:latest"
+else
+  IMAGE="us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest"
+fi
 
 # Target platform must match the cluster's nodes, not the build host.
 PLATFORM="${LOCUST_IMAGE_PLATFORM:-linux/amd64}"

--- a/benchmarking/locust/deploy.sh
+++ b/benchmarking/locust/deploy.sh
@@ -24,10 +24,28 @@ if [[ -f .ate-dev-env.sh ]]; then
   source .ate-dev-env.sh
 fi
 
-if [ -z "${PROJECT_ID:-}" ]; then
-  echo "Error: PROJECT_ID environment variable must be set." >&2
+if [[ -z "${PROJECT_ID:-}" && -z "${KO_DOCKER_REPO:-}" && -z "${LOCUST_IMAGE:-}" ]]; then
+  echo "Error: PROJECT_ID or KO_DOCKER_REPO environment variable must be set." >&2
   exit 1
 fi
+
+if [[ -z "${LOCUST_IMAGE:-}" ]]; then
+  if [[ -n "${KO_DOCKER_REPO:-}" ]]; then
+    LOCUST_IMAGE="${KO_DOCKER_REPO}/locust-test:latest"
+  else
+    LOCUST_IMAGE="us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest"
+  fi
+fi
+
+if [[ -z "${LOCUST_IMAGE_PULL_POLICY:-}" ]]; then
+  if [[ "${LOCUST_IMAGE}" =~ ^localhost: ]]; then
+    LOCUST_IMAGE_PULL_POLICY="IfNotPresent"
+  else
+    LOCUST_IMAGE_PULL_POLICY="Always"
+  fi
+fi
+
+export LOCUST_IMAGE LOCUST_IMAGE_PULL_POLICY
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MANIFEST="${SCRIPT_DIR}/manifests/locust.yaml"
@@ -51,7 +69,7 @@ deploy() {
   # benchmarking/monitoring.yaml is otherwise optional.
   echo "Ensuring benchmarking namespace exists..."
   kubectl create namespace benchmarking --dry-run=client -o yaml | kubectl apply -f -
-  echo "Deploying Locust load (PROJECT_ID=${PROJECT_ID}, user_class=${BENCHMARK_USER_CLASS})..."
+  echo "Deploying Locust load (image=${LOCUST_IMAGE}, pull_policy=${LOCUST_IMAGE_PULL_POLICY}, user_class=${BENCHMARK_USER_CLASS})..."
   envsubst < "${MANIFEST}" | kubectl apply -f -
 }
 

--- a/benchmarking/locust/manifests/locust.yaml
+++ b/benchmarking/locust/manifests/locust.yaml
@@ -46,8 +46,8 @@ spec:
     spec:
       containers:
       - name: locust-master
-        image: us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest
-        imagePullPolicy: Always
+        image: ${LOCUST_IMAGE}
+        imagePullPolicy: ${LOCUST_IMAGE_PULL_POLICY}
         args:
         - "-m"
         - "locust"
@@ -81,8 +81,8 @@ spec:
             memory: "512Mi"
       # Python and boomer workers do not play nicely together, leaving this in for reference.
       # - name: locust-python-worker
-      #   image: us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest
-      #   imagePullPolicy: Always
+      #   image: ${LOCUST_IMAGE}
+      #   imagePullPolicy: ${LOCUST_IMAGE_PULL_POLICY}
       #   args:
       #   - "-m"
       #   - "locust"
@@ -117,8 +117,8 @@ spec:
       - name: boomer-glutton
         # Same image as the master/worker — the boomer-glutton Go binary is
         # baked in at /app/boomer-glutton by benchmarking/locust/Dockerfile.
-        image: us-docker.pkg.dev/${PROJECT_ID}/gcr.io/ate-images/locust-test:latest
-        imagePullPolicy: Always
+        image: ${LOCUST_IMAGE}
+        imagePullPolicy: ${LOCUST_IMAGE_PULL_POLICY}
         command: ["/app/boomer-glutton"]
         args:
         - "--prometheus-addr=:8001"

--- a/benchmarking/locust/tests/glutton_storage.py
+++ b/benchmarking/locust/tests/glutton_storage.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stub GluttonStorageUser declaration.
+
+The real load implementation lives in the boomer-Go worker at
+cmd/benchmarking/boomer-storage/; this Python class is declared only so the master's
+--class-picker enumerates the name. The Python worker container sets
+LOCUST_NO_GLUTTON_STORAGE_USER=1 to skip loading this file, leaving boomer as the
+sole owner of GluttonStorageUser load.
+"""
+
+import os
+
+if os.environ.get("LOCUST_NO_GLUTTON_STORAGE_USER") != "1":
+    from locust import User, task
+    from common.boomer_config import init_boomer_config
+
+    # Master serves /boomer-config so the boomer-storage workers can fetch
+    # runtime flag values (trace probability, wait times) the operator set
+    # in the web UI form. No-op on workers without a web UI.
+    init_boomer_config()
+
+    class GluttonStorageUser(User):
+        host = "api.ate-system.svc.cluster.local:443"
+
+        @task
+        def noop(self) -> None:
+            # Unreached under normal operation: the Python worker container
+            # does not load this file (LOCUST_NO_GLUTTON_STORAGE_USER=1). Body is
+            # required because locust validates that every User has at least
+            # one @task method.
+            pass

--- a/benchmarking/workloads/deploy.sh
+++ b/benchmarking/workloads/deploy.sh
@@ -43,6 +43,7 @@ SANDBOX_CLASS="gvisor"
 # so benchmark actors do not inherit the 2 GiB kata default and drag its page
 # cache into every memory snapshot. Raise it for RAM-consuming suites.
 ACTOR_MEMORY="256Mi"
+STORAGE_CLASS_NAME="${STORAGE_CLASS_NAME:-csi-nfs-sc}"
 # The address to which an instrumented actor container sends its telemetry.
 # --otlp-endpoint sets it. Without the flag, resolve_otlp_endpoint reads the
 # address that the control plane uses.
@@ -59,6 +60,7 @@ usage() {
   echo "                              microvm requires hack/install-microvm-deps.sh --install to have run."
   echo "  --actor-memory SIZE         Memory limit for the benchmark ActorTemplates (default: 256Mi,"
   echo "                              the smallest size microvm admits)"
+  echo "  --storage-class-name NAME   StorageClass for external volume ActorTemplates (default: csi-nfs-sc)"
   echo "  --otlp-endpoint URL         The address to which an instrumented actor container"
   echo "                              sends telemetry (default: the endpoint in the"
   echo "                              ate-otel-config ConfigMap)"
@@ -103,12 +105,13 @@ substitute() {
       -e "s|\${SANDBOX_CONFIG_NAME}|${sandbox_config_name}|g" \
       -e "s|\${OTLP_ENDPOINT}|${OTLP_ENDPOINT}|g" \
       -e "s|\${ACTOR_MEMORY}|${ACTOR_MEMORY}|g" \
+      -e "s|\${STORAGE_CLASS_NAME}|${STORAGE_CLASS_NAME}|g" \
       "${MANIFEST_TEMPLATE}"
 }
 
 deploy() {
   resolve_otlp_endpoint
-  echo "Deploying workloads (worker_count=${WORKER_COUNT}, actor_memory=${ACTOR_MEMORY}, otlp_endpoint=${OTLP_ENDPOINT})..."
+  echo "Deploying workloads (worker_count=${WORKER_COUNT}, actor_memory=${ACTOR_MEMORY}, storage_class=${STORAGE_CLASS_NAME}, otlp_endpoint=${OTLP_ENDPOINT})..."
   # ActorTemplate.spec has the rule `self == oldSelf` (see
   # pkg/api/v1alpha1/actortemplate_types.go). Thus the API server rejects an
   # apply that changes a template. A value that changes for each run — the OTLP
@@ -168,6 +171,13 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --actor-memory=*)
       ACTOR_MEMORY="${1#*=}"
+      ;;
+    --storage-class-name)
+      shift
+      STORAGE_CLASS_NAME="$1"
+      ;;
+    --storage-class-name=*)
+      STORAGE_CLASS_NAME="${1#*=}"
       ;;
     -h|--help)
       usage

--- a/benchmarking/workloads/manifests/workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/workloads.yaml.tmpl
@@ -188,3 +188,42 @@ spec:
     onPause: Full
     onCommit: Full
     location: gs://${BUCKET_NAME}/benchmark-workloads/glutton-durdir-full/
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: ActorTemplate
+metadata:
+  name: glutton-storage
+  namespace: benchmark-workloads
+spec:
+  sandboxClass: ${SANDBOX_CLASS}
+  volumes:
+  - name: external-storage
+    externalVolumeTemplate:
+      capacity: 1Gi
+      storageClassName: ${STORAGE_CLASS_NAME}
+  containers:
+  - name: glutton-storage
+    image: ko://github.com/agent-substrate/substrate/cmd/benchmarking/glutton
+    # Port 80 is the only inbound port nftables forwards from the worker pod
+    # into the actor sandbox. HTTP/1.1 mode lets the atenet router reach Ping and WriteDisk.
+    command:
+    - "/ko-app/glutton"
+    - "--grpc-listen-addr=:80"
+    - "--metrics-listen-addr=:9090"
+    - "--data-dir=/mnt/storage"
+    - "--mode=http"
+    volumeMounts:
+    - name: external-storage
+      mountPath: /mnt/storage
+    # Hold ResumeActor open until port 80 answers and /mnt/storage is writable.
+    readyz:
+      httpGet:
+        path: /readyz
+        port: 80
+  workerSelector:
+    matchLabels:
+      workload: benchmark-ateom
+  snapshotsConfig:
+    location: gs://${BUCKET_NAME}/benchmark-workloads/glutton-storage/

--- a/cmd/benchmarking/boomer-glutton/main.go
+++ b/cmd/benchmarking/boomer-glutton/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/benchmarking/boomer/dynconfig"
 	"github.com/agent-substrate/substrate/internal/benchmarking/boomer/glutton"
 	bmetrics "github.com/agent-substrate/substrate/internal/benchmarking/boomer/metrics"
+	_ "github.com/agent-substrate/substrate/internal/benchmarking/boomer/storage"
 	btrace "github.com/agent-substrate/substrate/internal/benchmarking/boomer/trace"
 	"github.com/agent-substrate/substrate/internal/benchmarking/boomer/userclass"
 	"github.com/myzhan/boomer"

--- a/cmd/benchmarking/glutton/main.go
+++ b/cmd/benchmarking/glutton/main.go
@@ -174,6 +174,13 @@ func splitGRPC(grpcSrv, rest http.Handler) http.Handler {
 func readyzMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if *dataDir != "" {
+			canary := filepath.Join(*dataDir, ".readyz_canary")
+			if err := os.WriteFile(canary, []byte("ok"), 0o600); err != nil {
+				http.Error(w, fmt.Sprintf("data-dir not writable: %v", err), http.StatusServiceUnavailable)
+				return
+			}
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 	return mux
@@ -450,6 +457,9 @@ func (s *gluttonService) WriteDisk(ctx context.Context, req *glutton.WriteDiskRe
 	size := int64(req.GetSize())
 	if err := streamRandomBytes(io.MultiWriter(f, h), size); err != nil {
 		return nil, status.Errorf(codes.Internal, "write %s: %v", path, err)
+	}
+	if err := f.Sync(); err != nil {
+		return nil, status.Errorf(codes.Internal, "sync %s: %v", path, err)
 	}
 
 	// OVERWRITE has no O_TRUNC, bytes from a larger, earlier write will persist.

--- a/cmd/benchmarking/glutton/main_test.go
+++ b/cmd/benchmarking/glutton/main_test.go
@@ -451,3 +451,42 @@ func TestHTTPRoutes(t *testing.T) {
 	}
 	res.Body.Close()
 }
+
+// TestReadyzDataDirCheck verifies that the readyz probe checks that dataDir is writable.
+func TestReadyzDataDirCheck(t *testing.T) {
+	dataDir := t.TempDir()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if dataDir != "" {
+			canary := filepath.Join(dataDir, ".readyz_canary")
+			if err := os.WriteFile(canary, []byte("ok"), 0o600); err != nil {
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := newServer(mux)
+	go srv.Serve(lis)
+	defer srv.Close()
+
+	resp, err := http.Get("http://" + lis.Addr().String() + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /readyz = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// Canary file must exist
+	if _, err := os.Stat(filepath.Join(dataDir, ".readyz_canary")); err != nil {
+		t.Errorf("expected canary file in dataDir: %v", err)
+	}
+}

--- a/internal/benchmarking/boomer/storage/lifecycle.go
+++ b/internal/benchmarking/boomer/storage/lifecycle.go
@@ -1,0 +1,364 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package storage implements the boomer-Go storage workload runner (GluttonStorageUser).
+package storage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand/v2"
+	"net/http"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agent-substrate/substrate/internal/ateinterceptors"
+	bmetrics "github.com/agent-substrate/substrate/internal/benchmarking/boomer/metrics"
+	"github.com/agent-substrate/substrate/internal/benchmarking/boomer/userclass"
+	gluttonpb "github.com/agent-substrate/substrate/internal/proto/glutton"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	userClass     = "GluttonStorageUser"
+	templateName  = "glutton-storage"
+	templateNS    = "benchmark-workloads"
+	actorDomain   = "actors.resources.substrate.ate.dev"
+	writeDiskPath = "/writedisk"
+	pingPath      = "/ping"
+
+	defaultWriteSize int32 = 1048576 // 1 MiB
+
+	sourceClient = "client"
+	sourceServer = "server"
+)
+
+func init() {
+	userclass.Add(userclass.Entry{
+		Name:       "glutton_storage",
+		LocustFile: "glutton_storage.py",
+		UserClass:  userClass,
+		Init:       InitStorage,
+	})
+}
+
+// InitStorage creates a runtime tied to cfg and returns a boomer-compatible task
+// function plus a Shutdown hook the caller should run before exit.
+func InitStorage(cfg *userclass.Config) (taskFn func(), shutdown func(context.Context)) {
+	if cfg.Tracer == nil {
+		cfg.Tracer = otel.Tracer("substrate-boomer/storage")
+	}
+	rt := &taskRuntime{cfg: cfg}
+	return rt.iterate, rt.shutdown
+}
+
+type taskRuntime struct {
+	cfg   *userclass.Config
+	users sync.Map // goroutineID → *gluttonStorageUser
+}
+
+// iterate is the task function boomer calls in a loop on each VU goroutine.
+func (r *taskRuntime) iterate() {
+	gid := goroutineID()
+	val, loaded := r.users.Load(gid)
+	if !loaded {
+		u, err := r.startUser(context.Background())
+		if err != nil {
+			slog.Warn("glutton storage on_start failed; goroutine will retry next iter",
+				slog.String("err", err.Error()))
+			return
+		}
+		val, _ = r.users.LoadOrStore(gid, u)
+	}
+	user := val.(*gluttonStorageUser)
+
+	ctx := context.Background()
+	if !user.resume(ctx) {
+		return
+	}
+	user.writeDisk(ctx)
+	user.suspend(ctx)
+
+	time.Sleep(r.dynamicWait())
+}
+
+func (r *taskRuntime) startUser(ctx context.Context) (*gluttonStorageUser, error) {
+	u := &gluttonStorageUser{
+		cfg:         r.cfg,
+		actorName:   "sb-st-" + uuid.NewString(),
+		firstResume: true,
+	}
+	u.hostHeader = u.actorName + "." + u.cfg.Atespace + "." + actorDomain
+	bmetrics.UpdateUsers(userClass, 1)
+	if err := u.ensureAtespace(ctx); err != nil {
+		bmetrics.UpdateUsers(userClass, -1)
+		return nil, err
+	}
+	if err := u.create(ctx); err != nil {
+		bmetrics.UpdateUsers(userClass, -1)
+		return nil, err
+	}
+	return u, nil
+}
+
+func (r *taskRuntime) shutdown(ctx context.Context) {
+	r.users.Range(func(_, val any) bool {
+		u := val.(*gluttonStorageUser)
+		if u.actorRunning {
+			u.suspend(ctx)
+		}
+		u.delete(ctx)
+		bmetrics.UpdateUsers(userClass, -1)
+		return true
+	})
+}
+
+func (r *taskRuntime) dynamicWait() time.Duration {
+	cfg := r.cfg.Dyn.Load()
+	if cfg.MaxWait <= cfg.MinWait {
+		return cfg.MinWait
+	}
+	jitter := cfg.MaxWait - cfg.MinWait
+	return cfg.MinWait + time.Duration(rand.Float64()*float64(jitter))
+}
+
+type gluttonStorageUser struct {
+	cfg          *userclass.Config
+	actorName    string
+	hostHeader   string
+	firstResume  bool
+	actorRunning bool
+	epoch        int64
+}
+
+func (u *gluttonStorageUser) ref() *ateapipb.ObjectRef {
+	return &ateapipb.ObjectRef{Atespace: u.cfg.Atespace, Name: u.actorName}
+}
+
+func (u *gluttonStorageUser) ensureAtespace(ctx context.Context) error {
+	return u.tracedCall(ctx, "CreateAtespace", func(callCtx context.Context, tr *metadata.MD) error {
+		_, err := u.cfg.APIStub.CreateAtespace(callCtx, &ateapipb.CreateAtespaceRequest{
+			Atespace: &ateapipb.Atespace{
+				Metadata: &ateapipb.ResourceMetadata{
+					Name: u.cfg.Atespace,
+				},
+			},
+		}, grpc.Trailer(tr))
+		if err == nil {
+			return nil
+		}
+		if s, ok := status.FromError(err); ok && s.Code() == codes.AlreadyExists {
+			return nil
+		}
+		return err
+	})
+}
+
+func (u *gluttonStorageUser) create(ctx context.Context) error {
+	return u.tracedCall(ctx, "CreateActor", func(callCtx context.Context, tr *metadata.MD) error {
+		_, err := u.cfg.APIStub.CreateActor(callCtx, &ateapipb.CreateActorRequest{
+			Actor: &ateapipb.Actor{
+				Metadata:               &ateapipb.ResourceMetadata{Atespace: u.cfg.Atespace, Name: u.actorName},
+				ActorTemplateNamespace: templateNS,
+				ActorTemplateName:      templateName,
+			},
+		}, grpc.Trailer(tr))
+		return err
+	})
+}
+
+func (u *gluttonStorageUser) resume(ctx context.Context) bool {
+	metricName := "ResumeActor"
+	if u.firstResume {
+		metricName = "ResumeActorColdStart"
+	}
+	err := u.tracedCall(ctx, metricName, func(callCtx context.Context, tr *metadata.MD) error {
+		_, err := u.cfg.APIStub.ResumeActor(callCtx, &ateapipb.ResumeActorRequest{
+			Actor: u.ref(),
+			Boot:  u.firstResume,
+		}, grpc.Trailer(tr))
+		return err
+	})
+	if err != nil {
+		return false
+	}
+	u.firstResume = false
+	u.actorRunning = true
+	return true
+}
+
+func (u *gluttonStorageUser) suspend(ctx context.Context) {
+	_ = u.tracedCall(ctx, "SuspendActor", func(callCtx context.Context, tr *metadata.MD) error {
+		_, err := u.cfg.APIStub.SuspendActor(callCtx, &ateapipb.SuspendActorRequest{
+			Actor: u.ref(),
+		}, grpc.Trailer(tr))
+		return err
+	})
+	u.actorRunning = false
+}
+
+func (u *gluttonStorageUser) delete(ctx context.Context) {
+	_ = u.tracedCall(ctx, "DeleteActor", func(callCtx context.Context, tr *metadata.MD) error {
+		_, err := u.cfg.APIStub.DeleteActor(callCtx, &ateapipb.DeleteActorRequest{
+			Actor: u.ref(),
+		}, grpc.Trailer(tr))
+		return err
+	})
+}
+
+func (u *gluttonStorageUser) tracedCall(ctx context.Context, name string, do func(context.Context, *metadata.MD) error) error {
+	ctx, span := u.cfg.Tracer.Start(ctx, name)
+	defer span.End()
+
+	start := time.Now()
+	var tr metadata.MD
+	err := do(ctx, &tr)
+	clientLatency := time.Since(start)
+
+	latency, source := elapsedFromMD(tr, ateinterceptors.ServerElapsedTrailer, clientLatency)
+	if source == sourceServer {
+		span.SetAttributes(attribute.Float64("server.elapsed_ms", msFloat(latency)))
+	}
+	logSampledTrace(span, name, latency, source, err)
+	if err != nil {
+		bmetrics.RecordFailure("grpc", name, userClass, latency, err.Error())
+		return err
+	}
+	bmetrics.RecordSuccess("grpc", name, userClass, latency, 0)
+	return nil
+}
+
+func (u *gluttonStorageUser) writeDisk(ctx context.Context) {
+	ctx, span := u.cfg.Tracer.Start(ctx, "GluttonWriteDisk")
+	defer span.End()
+
+	key := fmt.Sprintf("bench_%d", u.epoch)
+	u.epoch++
+
+	body, err := proto.Marshal(&gluttonpb.WriteDiskRequest{
+		Key:       key,
+		Size:      defaultWriteSize,
+		WriteMode: gluttonpb.WriteMode_WRITE_MODE_TRUNCATE,
+	})
+	if err != nil {
+		bmetrics.RecordFailure("http", "GluttonWriteDisk", userClass, 0, err.Error())
+		return
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.cfg.RouterURL+writeDiskPath, bytes.NewReader(body))
+	if err != nil {
+		bmetrics.RecordFailure("http", "GluttonWriteDisk", userClass, 0, err.Error())
+		return
+	}
+	httpReq.Host = u.hostHeader
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(httpReq.Header))
+
+	start := time.Now()
+	resp, err := u.cfg.HTTPClient.Do(httpReq)
+	clientLatency := time.Since(start)
+	if err != nil {
+		bmetrics.RecordFailure("http", "GluttonWriteDisk", userClass, clientLatency, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		bmetrics.RecordFailure("http", "GluttonWriteDisk", userClass, clientLatency, readErr.Error())
+		return
+	}
+
+	if resp.StatusCode >= 400 {
+		httpErr := fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		logSampledTrace(span, "GluttonWriteDisk", clientLatency, sourceClient, httpErr)
+		bmetrics.RecordFailure("http", "GluttonWriteDisk", userClass, clientLatency, httpErr.Error())
+		return
+	}
+
+	writeResp := &gluttonpb.WriteDiskResponse{}
+	if err := proto.Unmarshal(respBody, writeResp); err != nil {
+		logSampledTrace(span, "GluttonWriteDisk", clientLatency, sourceClient, err)
+		bmetrics.RecordFailure("http", "GluttonWriteDisk", userClass, clientLatency, err.Error())
+		return
+	}
+
+	logSampledTrace(span, "GluttonWriteDisk", clientLatency, sourceClient, nil)
+	bmetrics.RecordSuccess("http", "GluttonWriteDisk", userClass, clientLatency, int64(defaultWriteSize))
+}
+
+func logSampledTrace(span trace.Span, name string, latency time.Duration, source string, err error) {
+	sc := span.SpanContext()
+	if !sc.IsSampled() {
+		return
+	}
+	attrs := []any{
+		slog.String("name", name),
+		slog.String("trace_id", sc.TraceID().String()),
+		slog.Float64("duration_ms", msFloat(latency)),
+		slog.String("source", source),
+	}
+	if err != nil {
+		attrs = append(attrs, slog.String("err", err.Error()))
+		slog.Info("traced span (failed)", attrs...)
+		return
+	}
+	slog.Info("traced span", attrs...)
+}
+
+func elapsedFromMD(tr metadata.MD, key string, fallback time.Duration) (time.Duration, string) {
+	vals := tr.Get(key)
+	if len(vals) == 0 {
+		return fallback, sourceClient
+	}
+	us, err := strconv.ParseInt(vals[0], 10, 64)
+	if err != nil {
+		return fallback, sourceClient
+	}
+	return time.Duration(us) * time.Microsecond, sourceServer
+}
+
+func msFloat(d time.Duration) float64 { return float64(d.Nanoseconds()) / 1e6 }
+
+func goroutineID() int64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	line := string(buf[:n])
+	const prefix = "goroutine "
+	if !strings.HasPrefix(line, prefix) {
+		return 0
+	}
+	end := strings.IndexByte(line[len(prefix):], ' ')
+	if end < 0 {
+		return 0
+	}
+	id, _ := strconv.ParseInt(line[len(prefix):len(prefix)+end], 10, 64)
+	return id
+}

--- a/internal/benchmarking/boomer/storage/lifecycle_test.go
+++ b/internal/benchmarking/boomer/storage/lifecycle_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/agent-substrate/substrate/internal/ateinterceptors"
+	"github.com/agent-substrate/substrate/internal/benchmarking/boomer/dynconfig"
+	"github.com/agent-substrate/substrate/internal/benchmarking/boomer/userclass"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestElapsedFromMD(t *testing.T) {
+	fallback := 100 * time.Millisecond
+
+	// Case 1: Empty metadata returns fallback and sourceClient
+	mdEmpty := metadata.MD{}
+	latency, source := elapsedFromMD(mdEmpty, ateinterceptors.ServerElapsedTrailer, fallback)
+	if latency != fallback || source != sourceClient {
+		t.Errorf("empty MD: got (%v, %v), want (%v, %v)", latency, source, fallback, sourceClient)
+	}
+
+	// Case 2: Server elapsed trailer in microseconds
+	mdValid := metadata.Pairs(ateinterceptors.ServerElapsedTrailer, "1500")
+	latency, source = elapsedFromMD(mdValid, ateinterceptors.ServerElapsedTrailer, fallback)
+	wantLatency := 1500 * time.Microsecond
+	if latency != wantLatency || source != sourceServer {
+		t.Errorf("valid MD: got (%v, %v), want (%v, %v)", latency, source, wantLatency, sourceServer)
+	}
+
+	// Case 3: Malformed value falls back
+	mdInvalid := metadata.Pairs(ateinterceptors.ServerElapsedTrailer, "not-a-number")
+	latency, source = elapsedFromMD(mdInvalid, ateinterceptors.ServerElapsedTrailer, fallback)
+	if latency != fallback || source != sourceClient {
+		t.Errorf("invalid MD: got (%v, %v), want (%v, %v)", latency, source, fallback, sourceClient)
+	}
+}
+
+func TestDynamicWait(t *testing.T) {
+	holder := dynconfig.NewHolder(dynconfig.Config{
+		MinWait: 50 * time.Millisecond,
+		MaxWait: 100 * time.Millisecond,
+	})
+	rt := &taskRuntime{cfg: &userclass.Config{Dyn: holder}}
+
+	for i := 0; i < 20; i++ {
+		wait := rt.dynamicWait()
+		if wait < 50*time.Millisecond || wait > 100*time.Millisecond {
+			t.Errorf("dynamicWait() = %v, want between 50ms and 100ms", wait)
+		}
+	}
+}
+
+func TestMsFloat(t *testing.T) {
+	d := 1500 * time.Microsecond
+	got := msFloat(d)
+	if got != 1.5 {
+		t.Errorf("msFloat(1500us) = %v, want 1.5", got)
+	}
+}


### PR DESCRIPTION
#232 

Extend Substrate's benchmarking infrastructure to support load and scale testing of External Volumes backed by configurable CSI StorageClasses (defaulting to csi-nfs-sc for in-cluster testing).

Changes include:
- Glutton workload (cmd/benchmarking/glutton):
  * Add HTTP /write_disk endpoint to accept protobuf WriteDiskRequest and write to --data-dir with f.Sync() write durability.
  * Update /readyz probe to check --data-dir writability.
  * When deployed for compute, --data-dir points to local disk (/tmp/glutton).
  * When deployed for storage, --data-dir points to the external mount (/mnt/storage).
- Boomer storage worker (cmd/benchmarking/boomer-storage, internal/benchmarking/boomer/storage):
  * Implement GluttonStorageUser lifecycle driving Actor creation with glutton-storage template, measuring volume attachment on resume, storage write latency via /write_disk, unmount/detachment on suspend, and volume deletion on teardown.
- Headless runner & Locust integration (benchmarking/locust):
  * Add Python GluttonStorageUser stub for master UI class enumeration.
  * Route glutton_storage.py to boomer-storage binary in runner.py.
  * Build boomer-storage in benchmarking/locust/Dockerfile.
- Workload manifests & automation (benchmarking/workloads, benchmarking/automation):
  * Add glutton-storage ActorTemplate with externalVolumeTemplate using ${STORAGE_CLASS_NAME}.
  * Support --storage-class-name flag in deploy.sh.
  * Parameterize storageClassName in tests.yaml and orchestrator.py.

TAG=agy
CONV=5deb540d-5ad5-4deb-9b0f-f1ab385a0721



- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
