### PR TITLE
hack: an optional ext_proc filter on the MITM leg, behind a flag

### DIFF
--- a/hack/experimental-additional-egress-extproc.sh
+++ b/hack/experimental-additional-egress-extproc.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This is sourced as part of install-ate.sh. Do not run directly.
+#
+# --experimental-additional-egress-extproc-service=NS/SVC:PORT runs an ext_proc
+# authorization filter on the egress gateway's decrypted leg, where a request is
+# a hostname, method, and path rather than the IP:port the CONNECT checkpoint
+# sees.
+
+additional_egress_extproc_enabled() {
+  [[ -n "${ATE_ADDITIONAL_EGRESS_EXTPROC_SERVICE:-}" ]]
+}
+
+# additional_egress_extproc_endpoint validates
+# --experimental-additional-egress-extproc-service and echoes the DNS name to
+# dial, the port, and the name to verify the server certificate against,
+# space-separated.
+#
+# Example input: ate-system/foo:50051
+# Example output: foo.ate-system.svc.cluster.local 50051 foo.ate-system.svc
+additional_egress_extproc_endpoint() {
+  local spec="$1"
+  local label='[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+  if [[ ! "${spec}" =~ ^${label}/${label}:[0-9]+$ ]]; then
+    echo "Error: --experimental-additional-egress-extproc-service must be <namespace>/<service>:<port>, got '${spec}'" >&2
+    return 1
+  fi
+
+  local namespace="${spec%%/*}"
+  local rest="${spec#*/}"
+  local service="${rest%%:*}"
+  local port="${rest##*:}"
+  if (( port < 1 || port > 65535 )); then
+    echo "Error: --experimental-additional-egress-extproc-service port must be 1-65535, got '${port}'" >&2
+    return 1
+  fi
+
+  echo "${service}.${namespace}.svc.cluster.local ${port} ${service}.${namespace}.svc"
+}
+
+# The Envoy cluster the additional ext_proc filter dials.
+readonly ADDITIONAL_EGRESS_EXTPROC_CLUSTER="additional_egress_ext_proc"
+
+# patch_atenet_egress_manifest writes the egress manifest to stdout with the
+# #ATE_MITM_EXTPROC_FILTER and #ATE_MITM_EXTPROC_CLUSTER marker comments in
+# manifests/ate-install/atenet-egress-with-sdsmint.yaml replaced by an ext_proc
+# filter -- and the cluster it dials.
+# Only reached when --experimental-additional-egress-extproc-service is set;
+# without it the file is deployed as committed.
+#
+# Both blocks are heredocs below rather than files under manifests/ate-install,
+# because neither is a manifest: they are fragments of an Envoy bootstrap that
+# only mean anything spliced into one. Kept as files they would also sit in the
+# path of the directory-wide `-f manifests/ate-install` that the apply and
+# delete paths use, which reads whatever .yaml it finds there.
+#
+# Marker comments rather than a Kustomize patch or a YAML tool for the same
+# reason the two variants are whole files: the thing being edited is Envoy's
+# bootstrap, which lives as one inline string inside a ConfigMap, so nothing
+# that understands Kubernetes YAML can reach into it. Markers keep the
+# insertion points visible in the manifest itself instead of encoding them as
+# line numbers or structural guesses in this script.
+patch_atenet_egress_manifest() {
+  local manifest
+  manifest="$(atenet_egress_manifest)"
+
+  # Only the sdsmint manifest carries the markers. Refuse rather than apply an
+  # unpatched manifest: silently ignoring the flag would deploy a gateway with
+  # no additional checkpoint on it while the install reported success.
+  if [[ "${ATE_EXPERIMENTAL_USE_SDSMINT:-false}" != "true" ]]; then
+    echo "Error: --experimental-additional-egress-extproc-service requires --experimental-use-sdsmint" >&2
+    return 1
+  fi
+
+  local endpoint address port server_name
+  endpoint="$(additional_egress_extproc_endpoint "${ATE_ADDITIONAL_EGRESS_EXTPROC_SERVICE}")" || return 1
+  read -r address port server_name <<<"${endpoint}"
+
+  # Both blocks are written at column zero; awk below re-indents each to the
+  # marker it replaces, so the depth they nest to is the manifest's to decide.
+  local filter_block cluster_block
+  filter_block="$(cat <<EOF
+# Added by hack/install-ate.sh
+# --experimental-additional-egress-extproc-service=${ATE_ADDITIONAL_EGRESS_EXTPROC_SERVICE}.
+# Spliced over each #ATE_MITM_EXTPROC_FILTER marker in
+# atenet-egress-with-sdsmint.yaml.
+- name: envoy.filters.http.ext_proc
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+    grpc_service:
+      envoy_grpc:
+        cluster_name: ${ADDITIONAL_EGRESS_EXTPROC_CLUSTER}
+      timeout: 2s
+    failure_mode_allow: false
+    # Default is 200ms, which is tuned for the co-located sidecar
+    # on the CONNECT leg. This processor is a Service somewhere
+    # else in the cluster, and under failure_mode_allow: false a
+    # message that lands late is a denied request rather than a
+    # slow one.
+    message_timeout: 2s
+    # The actor's verified identity
+    request_attributes:
+    - filter_state['ate.actor.identity']
+    processing_mode:
+      request_header_mode: SEND
+      response_header_mode: SKIP
+      request_body_mode: NONE
+      response_body_mode: NONE
+      request_trailer_mode: SKIP
+      response_trailer_mode: SKIP
+    mutation_rules:
+      disallow_system: true
+      disallow_is_error: true
+EOF
+)" || return 1
+
+  cluster_block="$(cat <<EOF
+# Added by hack/install-ate.sh
+# --experimental-additional-egress-extproc-service=${ATE_ADDITIONAL_EGRESS_EXTPROC_SERVICE}.
+# Spliced over the #ATE_MITM_EXTPROC_CLUSTER marker in
+# atenet-egress-with-sdsmint.yaml.
+- name: ${ADDITIONAL_EGRESS_EXTPROC_CLUSTER}
+  type: STRICT_DNS
+  lb_policy: ROUND_ROBIN
+  connect_timeout: 1s
+  # ext_proc is gRPC, so this leg has to be HTTP/2.
+  typed_extension_protocol_options:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicit_http_config:
+        http2_protocol_options: {}
+  transport_socket:
+    name: envoy.transport_sockets.tls
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      sni: ${server_name}
+      common_tls_context:
+        # Pinned, because Envoy's default ceiling for an *upstream*
+        # context is TLS 1.2 -- only downstream defaults to 1.3 -- while
+        # extprocd, like every other Go server in this install, will not
+        # negotiate below 1.3. Left to the defaults the two never agree,
+        # and the handshake fails with TLSV1_ALERT_PROTOCOL_VERSION on a
+        # config where both ends name TLS 1.3.
+        tls_params:
+          tls_minimum_protocol_version: TLSv1_3
+          tls_maximum_protocol_version: TLSv1_3
+        # The gateway's own pod identity.
+        tls_certificates:
+        - certificate_chain: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
+          private_key: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
+          watched_directory: { path: /run/podidentity.podcert.ate.dev }
+        validation_context:
+          trusted_ca:
+            filename: /run/servicedns.podcert.ate.dev/trust-bundle.pem
+            watched_directory: { path: /run/servicedns.podcert.ate.dev }
+          # Chaining to the servicedns CA only proves the peer is some
+          # pod serving some Service. Pinning the name is what makes
+          # this the processor the operator asked for.
+          match_typed_subject_alt_names:
+          - san_type: DNS
+            matcher:
+              exact: ${server_name}
+  load_assignment:
+    cluster_name: ${ADDITIONAL_EGRESS_EXTPROC_CLUSTER}
+    endpoints:
+    - lb_endpoints:
+      - endpoint:
+          address:
+            socket_address:
+              address: ${address}
+              port_value: ${port}
+EOF
+)" || return 1
+
+  # One per HTTP filter chain in mitm_listener.
+  #
+  # mitm_listener has three chains, not two. The passthrough chain is a
+  # tcp_proxy: no http_filters to hold an ext_proc filter, and no request to
+  # authorize, since an opaque stream carries neither Host nor SNI. Traffic
+  # there leaves with only the CONNECT checkpoint's IP:port decision behind it,
+  # flag or no flag. That is a property of the passthrough chain rather than
+  # something this count can enforce, so it is named here instead of guarded.
+  local expected_filter_markers=2
+
+  # Anchored to the start of the line so that prose mentioning a marker -- the
+  # mitm_listener comment in the manifest names both of them -- is not itself
+  # replaced by a config block.
+  awk -v filter="${filter_block}" -v cluster="${cluster_block}" \
+      -v want_filters="${expected_filter_markers}" '
+    /^[ \t]*#ATE_MITM_EXTPROC_FILTER/  { splice(filter);  filters++;  next }
+    /^[ \t]*#ATE_MITM_EXTPROC_CLUSTER/ { splice(cluster); clusters++; next }
+    { print }
+    END {
+      if (filters != want_filters || clusters != 1) {
+        printf("Error: expected %d #ATE_MITM_EXTPROC_FILTER and 1 #ATE_MITM_EXTPROC_CLUSTER marker in %s, found %d and %d\n",
+               want_filters, FILENAME, filters, clusters) > "/dev/stderr"
+        exit 1
+      }
+    }
+    # Prints block at the indentation of the marker line being replaced. The
+    # heredocs above are written at column zero, so the depth each one nests to
+    # is whatever the manifest gives its marker: the filter chains and the
+    # cluster list sit at different depths, and neither has to be restated in
+    # the heredoc or here.
+    function splice(block,   indent, lines, n, i) {
+      match($0, /^[ \t]*/)
+      indent = substr($0, 1, RLENGTH)
+      n = split(block, lines, "\n")
+      for (i = 1; i <= n; i++) {
+        print (lines[i] == "" ? "" : indent lines[i])
+      }
+    }
+  ' "${manifest}"
+}

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -47,6 +47,10 @@ source "${ROOT}"/hack/install-demo-multi-template.sh
 source "${ROOT}"/hack/install-demo-parking.sh
 source "${ROOT}"/hack/install-demo-autoscaled-workerpool.sh
 
+# Include the optional ext_proc filter on the egress gateway's decrypted leg,
+# behind --experimental-additional-egress-extproc-service.
+source "${ROOT}"/hack/experimental-additional-egress-extproc.sh
+
 # ANSI color codes for prettier output
 COLOR_CYAN='\033[1;36m'
 COLOR_RESET='\033[0m'
@@ -75,6 +79,9 @@ function usage() {
   echo "Experiments:"
   echo ""
   echo "  --experimental-use-sdsmint             Deploy the egress gateway with per-SNI certificate minting (experimental)"
+  echo "  --experimental-additional-egress-extproc-service NS/SVC:PORT"
+  echo "                                         Run an additional ext_proc authorization filter, served by that Service."
+  echo "                                         Requires --experimental-use-sdsmint. (experimental)"
   echo ""
   echo "Infrastructure components:"
   echo ""
@@ -261,10 +268,40 @@ atenet_egress_manifest() {
 
 render_atenet_egress_manifest() {
   if [[ "$(atenet_router)" == "agentgateway" ]]; then
+    # The markers live inside Envoy's bootstrap, so there is nowhere here to
+    # put the filter. Refuse for the same reason patch_atenet_egress_manifest
+    # refuses a non-sdsmint manifest: ignoring the flag would report a
+    # successful install of a gateway that has no additional checkpoint on it.
+    if additional_egress_extproc_enabled; then
+      echo "Error: --experimental-additional-egress-extproc-service requires --atenet-router=envoy" >&2
+      return 1
+    fi
     kubectl kustomize manifests/ate-install/agentgateway-egress \
       --load-restrictor LoadRestrictionsNone | run_ko resolve -f -
+  elif additional_egress_extproc_enabled; then
+    patch_atenet_egress_manifest | run_ko resolve -f -
   else
     run_ko resolve -f "$(atenet_egress_manifest)"
+  fi
+}
+
+# apply_atenet_egress deploys the egress gateway.
+apply_atenet_egress() {
+  local manifests=""
+  manifests="$(render_atenet_egress_manifest)"
+
+  # Whether it is already running has to be settled before the apply: a patched
+  # bootstrap arrives as a ConfigMap change, and an otherwise unchanged
+  # Deployment will not pick that up on its own.
+  local running=false
+  if run_kubectl -n ate-system get deployment/atenet-egress >/dev/null 2>&1; then
+    running=true
+  fi
+
+  echo "${manifests}" | run_kubectl apply -f -
+
+  if [[ "${running}" == "true" ]] && additional_egress_extproc_enabled; then
+    run_kubectl -n ate-system rollout restart deployment/atenet-egress
   fi
 }
 
@@ -652,9 +689,7 @@ deploy_ate_system() {
   # --experimental-use-sdsmint composes with every overlay instead of needing a
   # variant of each.
   ensure_egress_mitm_ca_pool_secret
-  local egress_manifests=""
-  egress_manifests="$(render_atenet_egress_manifest)"
-  echo "${egress_manifests}" | run_kubectl apply -f -
+  apply_atenet_egress
 
   log_step "Waiting for ATE system components to be ready..."
   case "$(store_backend)" in
@@ -752,9 +787,7 @@ deploy_atenet() {
   echo "${router_manifest}" | run_kubectl apply -f -
 
   ensure_egress_mitm_ca_pool_secret
-  local egress_manifests=""
-  egress_manifests="$(render_atenet_egress_manifest)"
-  echo "${egress_manifests}" | run_kubectl apply -f -
+  apply_atenet_egress
   run_ko apply -f manifests/ate-install/atenet-dns.yaml
   run_kubectl rollout status deployment/atenet-router -n ate-system --timeout="$(rollout_timeout)"
   run_kubectl rollout status deployment/atenet-egress -n ate-system --timeout="$(rollout_timeout)"
@@ -963,6 +996,16 @@ for ((i = 0; i < ${#prescan_args[@]}; i++)); do
       ATE_ATENET_ROUTER="${prescan_args[$((i + 1))]}"
       ;;
     --experimental-use-sdsmint) ATE_EXPERIMENTAL_USE_SDSMINT=true ;;
+    --experimental-additional-egress-extproc-service=*)
+      ATE_ADDITIONAL_EGRESS_EXTPROC_SERVICE="${prescan_args[i]#*=}"
+      ;;
+    --experimental-additional-egress-extproc-service)
+      if (( i + 1 >= ${#prescan_args[@]} )); then
+        echo "Error: --experimental-additional-egress-extproc-service requires <namespace>/<service>:<port>" >&2
+        exit 1
+      fi
+      ATE_ADDITIONAL_EGRESS_EXTPROC_SERVICE="${prescan_args[$((i + 1))]}"
+      ;;
     --store-backend=*) ATE_INSTALL_STORE_BACKEND="${prescan_args[i]#*=}" ;;
     --store-backend)
       if (( i + 1 >= ${#prescan_args[@]} )); then
@@ -1064,6 +1107,8 @@ while [[ "$#" -gt 0 ]]; do
     # Captured in the pre-scan above; matched here only so the `*)` branch does
     # not reject it as an unknown option.
     --experimental-use-sdsmint) ;;
+    --experimental-additional-egress-extproc-service) shift ;;
+    --experimental-additional-egress-extproc-service=*) ;;
     --store-backend=*) ATE_INSTALL_STORE_BACKEND="${1#*=}" ;;
     --store-backend)
       shift

--- a/manifests/ate-install/atenet-egress-with-sdsmint.yaml
+++ b/manifests/ate-install/atenet-egress-with-sdsmint.yaml
@@ -129,6 +129,30 @@ data:
                       - upgrade_type: CONNECT
                         connect_config: {}
               http_filters:
+              # The actor's identity, carried across the CONNECT/MITM boundary.
+              # Envoy terminates the CONNECT, so the tunnelled request is a
+              # separate transaction: nothing set here as a header reaches
+              # mitm_listener, and a header sent from inside the tunnel is a
+              # channel the actor controls end to end, which would let one actor
+              # name another. Filter state is the only sound carrier, and this
+              # value comes from the peer certificate Envoy already verified
+              # against the actor-identity CA above.
+              - name: envoy.filters.http.set_filter_state
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.set_filter_state.v3.Config
+                  on_request_headers:
+                  - object_key: ate.actor.identity
+                    factory_key: envoy.string
+                    shared_with_upstream: ONCE
+                    # Nothing downstream may overwrite an authenticated identity.
+                    read_only: true
+                    skip_if_empty: true
+                    format_string:
+                      text_format_source:
+                        inline_string: "%DOWNSTREAM_PEER_URI_SAN%"
+                      # Without this an absent SAN renders as "-", which is a
+                      # non-empty string and fails open at whatever reads it.
+                      omit_empty_values: true
               # Actor-identity authorization: on every egress CONNECT, ext_proc
               # reads the actor certificate out of x-forwarded-client-cert,
               # re-verifies it against the actor-identity CA, pulls the
@@ -203,6 +227,17 @@ data:
       # protocol lands on an HTTP connection manager that parses the first bytes
       # of the stream as a request line, finds no request, and drops the
       # connection with nothing in the access log to say why.
+      #
+      # The two HTTP chains carry an #ATE_MITM_EXTPROC_FILTER marker, and the
+      # cluster list a matching #ATE_MITM_EXTPROC_CLUSTER. They are inert
+      # comments until hack/install-ate.sh is run with
+      # --experimental-additional-egress-extproc-service, which replaces each
+      # with a generated block.
+      #
+      # The passthrough chain carries no marker. It is a tcp_proxy, so there is
+      # no HTTP filter chain to put one in, and an opaque stream has no request
+      # to authorize -- which is the limit of what that chain can be policed on,
+      # not an oversight here.
       # ---------------------------------------------------------------------
       - name: mitm_listener
         stat_prefix: mitm
@@ -258,6 +293,7 @@ data:
                     json_format:
                       leg: mitm
                       time: "%START_TIME%"
+                      actor: "%FILTER_STATE(ate.actor.identity:PLAIN)%"
                       sni: "%REQUESTED_SERVER_NAME%"
                       authority: "%REQ(:AUTHORITY)%"
                       method: "%REQ(:METHOD)%"
@@ -315,6 +351,7 @@ data:
                       # SSE or long-poll response needs to survive at all.
                       timeout: 0s
               http_filters:
+              #ATE_MITM_EXTPROC_FILTER -- see the mitm_listener comment above.
               - name: envoy.filters.http.dynamic_forward_proxy
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
@@ -385,6 +422,7 @@ data:
                     json_format:
                       leg: cleartext
                       time: "%START_TIME%"
+                      actor: "%FILTER_STATE(ate.actor.identity:PLAIN)%"
                       authority: "%REQ(:AUTHORITY)%"
                       method: "%REQ(:METHOD)%"
                       path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
@@ -409,6 +447,7 @@ data:
                       cluster: egress_forward_proxy_cleartext
                       timeout: 0s
               http_filters:
+              #ATE_MITM_EXTPROC_FILTER -- Don't modify this line.
               # Same reasoning as the TLS chain: resolve from the request's own
               # Host, so the name that was policed is the name that is dialled.
               - name: envoy.filters.http.dynamic_forward_proxy
@@ -460,6 +499,17 @@ data:
       # the MITM leg has no listening port anywhere in the pod's netns.
       - name: mitm_internal
         connect_timeout: 1s
+        # Copies every filter state object shared with the upstream onto the
+        # internal listener's downstream connection. Two objects ride this hop,
+        # both set on the CONNECT leg above: ate.actor.identity, which the MITM
+        # access logs and the optional ext_proc filter read, and
+        # original_dst_address, which egress_tcp_passthrough dials.
+        #
+        # Without this neither reaches mitm_listener, and nothing reports it:
+        # the request proxies and every read resolves to the zero value, which
+        # looks exactly like the filters above not running. The wrapped socket
+        # is required and is raw_buffer because there is no TLS on this hop --
+        # the tunnelled TLS is terminated on mitm_listener.
         transport_socket:
           name: envoy.transport_sockets.internal_upstream
           typed_config:
@@ -642,6 +692,8 @@ data:
         type: ORIGINAL_DST
         lb_policy: CLUSTER_PROVIDED
         connect_timeout: 5s
+
+      #ATE_MITM_EXTPROC_CLUSTER -- Don't modify this line.
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
`--experimental-additional-egress-extproc-service=NS/SVC:PORT` makes the sdsmint egress gateway consult an external authorization processor on the decrypted leg, where the request is a hostname, method, and path rather than the IP:port the CONNECT checkpoint sees. The actor's identity crosses into that callout as the `dev.ate.actor` filter state, so the processor gets both halves of the decision.

The wiring is generated rather than checked in: atenet-egress-with-sdsmint.yaml carries inert `#ATE_MITM_EXTPROC_FILTER` and `#ATE_MITM_EXTPROC_CLUSTER` markers that the installer substitutes only when the flag is set, so an install without it renders exactly the manifest as committed.

The flag names any Service, so the processor itself is out of scope here.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
