### PR TITLE
[WIP] ci: add a dual-stack kind e2e job

### DIFF
--- a/.github/workflows/e2e-dualstack.yaml
+++ b/.github/workflows/e2e-dualstack.yaml
@@ -1,0 +1,399 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: e2e-dualstack
+# Dual-stack kind e2e. Gates nothing -- it stays out of `e2e-test` -- and exists
+# so the changes that make IPv6 work can assert against a cluster that has both
+# families before they merge.
+#
+# Only this lane catches truncation: code reading one address where there are
+# two, invisible on either single-family lane because there the one address is
+# the right one. It cannot show IPv6 works -- a broken v6 ingress path falls
+# back to v4 and reads green -- that is the IPv6-only lane's job.
+#
+# Both sandbox classes run, off one cluster and the one E2E_SANDBOX_CLASS knob.
+# A gVisor guest adopts the interior netns and gets the actor's IPv6 for free
+# while a micro-VM guest has to be told, so gVisor alone cannot tell a working
+# micro-VM guest from one that never got an address.
+#
+# Only the networking suite, because every family-aware test is in it. The
+# demos still deploy -- networking builds its actors from their templates.
+#
+# Three triggers, none of them a pull request: a merge to main touching the
+# paths that could break it, nightly, and dispatch. Ten minutes per review round
+# buys little when the job gates nothing -- a red one is read after the fact
+# either way -- while a merge run pins the break to the commit that caused it,
+# which nightly alone cannot. Dispatch is how a change gets a result before it
+# merges, and it also merges a list of pull requests onto main first, which is
+# the only way to exercise a feature no single request delivers alone.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/atenet/**'
+      - 'cmd/ateom-gvisor/**'
+      - 'cmd/ateom-microvm/**'
+      - 'internal/ateomnet/**'
+      - 'internal/atunnel/**'
+      - 'internal/e2e/**'
+      - 'manifests/**'
+      - 'hack/create-kind-cluster.sh'
+      - 'hack/install-ate-kind.sh'
+      - '.github/workflows/e2e-dualstack.yaml'
+  schedule:
+    # 07:00 UTC daily, after the weekly asset-cache refresh has a chance to land.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      prs:
+        description: 'Pull requests to merge onto main, in order, e.g. "911 1080 874 938 1082 1057". Blank runs main alone.'
+        required: false
+        type: string
+permissions:
+  contents: read
+jobs:
+  e2e-test-dualstack:
+    runs-on: ubuntu-latest
+    # A green run is about ten minutes; the slack is for the golden snapshot,
+    # which is allowed ten of its own and is the one step that can stall.
+    timeout-minutes: 45
+    env:
+      KIND_CLUSTER_NAME: ate-dual
+      KUBECTL_CONTEXT: kind-ate-dual
+    steps:
+    - name: Checkout
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      with:
+        # The stacking step below fetches refs this clone does not have.
+        fetch-depth: 0
+    - name: Stack the pull requests under test
+      # Merge, not cherry-pick: a request squash-merged since it was opened
+      # re-applies as a revert of what is already on main, and only a merge
+      # notices there is nothing to do. Order is the order given, so a conflict
+      # names the request that has to rebase. This builds and runs the
+      # requests' code, so: read-only token, no secrets, manual trigger only.
+      if: github.event_name == 'workflow_dispatch' && inputs.prs != ''
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PRS: ${{ inputs.prs }}
+        # The numbers in `prs` are always upstream pull requests, so they are
+        # resolved against upstream by name rather than against whichever repo
+        # the run happens to be in -- a fork has no ref for them. Reading them
+        # needs no token.
+        UPSTREAM: https://github.com/agent-substrate/substrate
+      run: |
+        git config user.name  'e2e-dualstack'
+        git config user.email 'e2e-dualstack@invalid'
+        {
+          echo "### Stack under test"
+          echo ""
+          echo "Merged onto \`main\` at \`$(git rev-parse --short HEAD)\`, in order:"
+          echo ""
+          echo "| pull request | head | title |"
+          echo "|---|---|---|"
+        } >> "$GITHUB_STEP_SUMMARY"
+        for pr in ${PRS//,/ }; do
+          case "${pr}" in
+            ''|*[!0-9]*) echo "::error::'${pr}' is not a pull request number"; exit 1 ;;
+          esac
+          git fetch -q "${UPSTREAM}" "refs/pull/${pr}/head:pr-${pr}" \
+            || { echo "::error::no such pull request: #${pr}"; exit 1; }
+          if ! git merge --no-edit -q "pr-${pr}"; then
+            echo "::error::#${pr} does not merge onto the stack; it needs a rebase"
+            git merge --abort || true
+            exit 1
+          fi
+          title=$(gh pr view "${pr}" --repo "${UPSTREAM}" --json title -q .title 2>/dev/null || echo '?')
+          echo "| #${pr} | \`$(git rev-parse --short "pr-${pr}")\` | ${title} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "merged #${pr}: ${title}"
+        done
+    - name: Setup Go
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      with:
+        go-version-file: 'go.mod'
+    - name: Free disk space
+      # The micro-VM guest image/kernel + cloud-hypervisor + kind node image +
+      # control-plane images + snapshots are tight on the ~14GB runner disk.
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        df -h /
+    - name: Cache micro-VM assets
+      # Restore-only: pr-workflow.yaml's e2e-test writes this key on every push
+      # to main and a second saver would race it for nothing. A miss just means
+      # run-microvm-demo-kind.sh assembles the assets itself.
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: bin/microvm-assets/amd64
+        key: microvm-assets-amd64-${{ hashFiles('hack/microvm-assets/assemble.sh') }}
+    - name: Enable IPv6 in the Docker daemon
+      # ubuntu-latest ships dockerd with IPv6 off, so kind would create its
+      # network v4-only. Merge the two keys into whatever daemon.json the runner
+      # image ships rather than replacing the file.
+      run: |
+        sudo mkdir -p /etc/docker
+        [ -s /etc/docker/daemon.json ] || echo '{}' | sudo tee /etc/docker/daemon.json >/dev/null
+        sudo cat /etc/docker/daemon.json \
+          | jq '. + {"ipv6": true, "ip6tables": true}' \
+          | sudo tee /etc/docker/daemon.json.new >/dev/null
+        sudo mv /etc/docker/daemon.json.new /etc/docker/daemon.json
+        sudo systemctl restart docker
+        # The default bridge is the network the daemon's own `ipv6` key governs,
+        # so it is how we know the restart took. Not kind's network: that one
+        # create-kind-cluster.sh rejects itself, and the cluster's families are
+        # asserted after create.
+        docker network inspect bridge --format '{{.EnableIPv6}}' | grep -qx true \
+          || { echo "::error::dockerd restarted without IPv6 -- the daemon.json edit did not take"; exit 1; }
+    - name: Enable KVM
+      # create-kind-cluster.sh makes /dev/kvm usable inside the node only if its
+      # `docker run --device /dev/kvm` probe passes, so this has to follow the
+      # dockerd restart above. No node label follows from it: a micro-VM
+      # WorkerPool reaches the node through the ate.dev/kvm extended resource
+      # atelet's device plugin advertises, asserted after the install below.
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+          | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+    - name: Create cluster
+      env:
+        IP_FAMILY: dual
+      run: hack/create-kind-cluster.sh
+    - name: Assert the node has /dev/kvm
+      # When the KVM probe fails create-kind-cluster.sh prints a notice and
+      # builds a node without it, so the miss surfaces ten minutes later as a
+      # golden snapshot that never goes Ready -- or as a micro-VM lane that was
+      # never a micro-VM lane.
+      run: |
+        for node in $(hack/kind.sh get nodes --name "$KIND_CLUSTER_NAME"); do
+          docker exec "${node}" test -c /dev/kvm \
+            || { echo "::error::${node} has no /dev/kvm -- the micro-VM lane would be gVisor in disguise"; exit 1; }
+          echo "  ${node}: /dev/kvm present"
+        done
+    - name: Wait for the node to be ready
+      # create-kind-cluster.sh returns before kube-controller-manager allocates
+      # node.spec.podCIDRs, which the next step reads: without this, 2 of 5 runs
+      # on 2026-08-20 failed with "no IPv4 in podCIDRs=" on a healthy cluster.
+      run: |
+        for _ in $(seq 1 60); do
+          cidrs=$(kubectl --context="$KUBECTL_CONTEXT" get nodes \
+            -o jsonpath='{.items[*].spec.podCIDRs[*]}' 2>/dev/null || true)
+          [ -n "${cidrs}" ] && break
+          sleep 2
+        done
+        kubectl --context="$KUBECTL_CONTEXT" wait --for=condition=Ready nodes --all --timeout=180s
+    - name: Assert the cluster is dual-stack
+      # `dual` is the only IP_FAMILY value whose cluster still comes up when it
+      # is ignored, so a dropped second family would otherwise leave a green run
+      # that is really a second IPv4 lane. default/kubernetes is SingleStack
+      # even here and useless as a probe; a throwaway PreferDualStack Service
+      # exercises the allocator the router Service will need.
+      run: |
+        k() { kubectl --context="$KUBECTL_CONTEXT" "$@"; }
+        k -n default delete svc ipfamily-probe --ignore-not-found >/dev/null
+        echo '{"apiVersion":"v1","kind":"Service","metadata":{"name":"ipfamily-probe"},
+               "spec":{"ipFamilyPolicy":"PreferDualStack","ports":[{"port":80}],
+                       "selector":{"ate.dev/matches-nothing":"true"}}}' \
+          | k -n default create -f - >/dev/null
+        probe_ips=$(k -n default get svc ipfamily-probe -o jsonpath='{.spec.clusterIPs[*]}')
+        k -n default delete svc ipfamily-probe >/dev/null
+        pod_cidrs=$(k get nodes -o jsonpath='{.items[*].spec.podCIDRs[*]}')
+        node_ips=$(k get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+        for pair in "podCIDRs=${pod_cidrs}" "node.InternalIP=${node_ips}" "PreferDualStack.clusterIPs=${probe_ips}"; do
+          value=${pair#*=}
+          case "${value}" in
+            *.*) ;;
+            *) echo "::error::no IPv4 in ${pair}"; exit 1 ;;
+          esac
+          case "${value}" in
+            *:*) ;;
+            *) echo "::error::no IPv6 in ${pair}"; exit 1 ;;
+          esac
+          echo "  ${pair}"
+        done
+        echo "dual-stack confirmed"
+    - name: Install Agent Substrate
+      run: hack/install-ate-kind.sh --deploy-ate-system
+    - name: Assert the node advertises ate.dev/kvm
+      # The resource a micro-VM WorkerPool's pods request, so without it they
+      # stay Pending and the micro-VM lane becomes a second gVisor lane that
+      # hangs until its golden-snapshot deadline. Only checkable here: atelet's
+      # device plugin registers it a moment after the DaemonSet reports rolled
+      # out, so it does not exist before the install, hence the poll.
+      run: |
+        k() { kubectl --context="$KUBECTL_CONTEXT" "$@"; }
+        k -n ate-system rollout status daemonset/atelet --timeout=120s
+        for node in $(hack/kind.sh get nodes --name "$KIND_CLUSTER_NAME"); do
+          kvm=""
+          for _ in $(seq 30); do
+            n=$(k get node "${node}" -o jsonpath='{.status.allocatable.ate\.dev/kvm}')
+            case "${n}" in ''|0) sleep 2 ;; *) kvm="${n}"; break ;; esac
+          done
+          [ -n "${kvm}" ] || {
+            echo "::error::${node} does not advertise ate.dev/kvm -- atelet's device plugin never registered it, so no micro-VM worker can be scheduled"
+            k -n ate-system logs -l app=atelet --tail=50 --prefix || true
+            exit 1
+          }
+          echo "  ${node}: allocatable ate.dev/kvm=${kvm}"
+        done
+    - name: Report the Service IP families
+      # Report, not assert: atenet-router has no ipFamilyPolicy, so it is
+      # SingleStack even here and the family-comparing tests skip themselves.
+      # The hard check belongs with the change that makes the router dual-stack,
+      # so it fails as that change regressing.
+      run: |
+        kubectl --context="$KUBECTL_CONTEXT" -n ate-system get svc \
+          -o custom-columns=NAME:.metadata.name,POLICY:.spec.ipFamilyPolicy,IPS:.spec.clusterIPs
+    - name: Deploy substrate micro-VM counter demo
+      # First of the demos: its golden snapshot is the long pole, so it bakes
+      # while the gVisor fixtures go up. The substrate demo handler waits for
+      # that snapshot itself.
+      run: |
+        hack/run-microvm-demo-kind.sh --substrate
+        df -h /
+    - name: Deploy substrate gVisor counter demo
+      run: hack/install-ate-kind.sh --deploy-demo-counter-substrate
+    - name: Deploy egress demos
+      # One per class: networking builds its egress Actor from the fixture for
+      # the class under test, so both have to exist before either lane runs.
+      run: |
+        hack/install-ate-kind.sh --deploy-demo-egress
+        hack/install-ate-kind.sh --deploy-demo-egress-microvm
+    - name: Assert the demo fixtures exist
+      # A failed demo deploy exits 0: install-ate.sh dispatches demos through
+      # `if "${demo}_cmdline" "$1"`, which suspends errexit, and _cmdline ends in
+      # an unconditional `return 0`. Without this the suites fail later with
+      # "ActorTemplate not found", pointing at the tests instead of the install.
+      #
+      # Two lookups, because the two fixtures live in different layers: the
+      # egress template is a CRD, while the substrate counter's is a store
+      # object the CRD API never sees.
+      run: |
+        for ns_tmpl in ate-demo-egress/egress ate-demo-egress-microvm/egress-microvm; do
+          ns=${ns_tmpl%/*}; tmpl=${ns_tmpl#*/}
+          kubectl --context="$KUBECTL_CONTEXT" -n "${ns}" get actortemplate "${tmpl}" \
+            || { echo "::error::${ns_tmpl} was not created -- the demo deploy failed silently"; exit 1; }
+        done
+        for as_tmpl in ate-demo-counter-substrate/counter \
+                       ate-demo-counter-substrate-microvm/counter-microvm; do
+          as=${as_tmpl%/*}; tmpl=${as_tmpl#*/}
+          go run ./cmd/kubectl-ate --context="$KUBECTL_CONTEXT" \
+            get actor-template "${tmpl}" -a "${as}" \
+            || { echo "::error::${as_tmpl} was not created -- the demo deploy failed silently"; exit 1; }
+        done
+    - name: Run E2E tests (networking)
+      id: e2e-networking
+      run: |
+        set -o pipefail
+        hack/run-e2e-kind.sh ./internal/e2e/suites/networking -v -args --no-color 2>&1 \
+          | tee /tmp/e2e-networking.log
+    - name: Run E2E tests (networking, micro-VM)
+      # The same suite with every fixture repointed at its micro-VM variant by
+      # the one E2E_SANDBOX_CLASS knob (internal/e2e/sandbox.go). Sequential,
+      # not concurrent: there is one kind node, and a suite releases its
+      # namespace and worker pods as each test passes.
+      id: e2e-networking-microvm
+      if: always() && steps.e2e-networking.outcome != 'skipped'
+      env:
+        E2E_SANDBOX_CLASS: microvm
+      run: |
+        set -o pipefail
+        hack/run-e2e-kind.sh ./internal/e2e/suites/networking -v -args --no-color 2>&1 \
+          | tee /tmp/e2e-networking-microvm.log
+    - name: Guard against a vacuously green run
+      # One real PASS per lane, not zero skips -- some skips are correct. Skips
+      # are printed because a growing list is the symptom here: a test that
+      # compares the families skips itself rather than failing when a clusterIP
+      # is missing, so a lane that stopped being dual-stack would still be green.
+      if: always() && steps.e2e-networking.outcome != 'skipped'
+      env:
+        MICROVM_RAN: ${{ steps.e2e-networking-microvm.outcome != 'skipped' }}
+      run: |
+        logs="/tmp/e2e-networking.log"
+        # Asked of the micro-VM lane only when it ran. When the golden never
+        # arrived the job has already failed on that step, and demanding its
+        # logs here would report a second, misleading cause.
+        if [ "${MICROVM_RAN}" = "true" ]; then
+          logs="${logs} /tmp/e2e-networking-microvm.log"
+        fi
+        for f in ${logs}; do
+          [ -s "$f" ] || { echo "::error::${f} is missing or empty"; exit 1; }
+          passed=$(grep -c -- '--- PASS' "$f" || true)
+          echo "${f}: ${passed} passed, $(grep -c -- '--- SKIP' "$f" || true) skipped"
+          grep -h -- '--- SKIP' "$f" || true
+          if [ "${passed}" -eq 0 ]; then
+            echo "::error::${f} has no passing tests -- a suite that only skips proves nothing"
+            exit 1
+          fi
+        done
+    - name: Assert the family-critical tests were not skipped
+      # Counting passes does not catch how this suite goes vacuously green.
+      # Every other test reaches an actor by port-forwarding the router with the
+      # actor name as a Host header, so none of them queries the actor DNS zone
+      # or picks a family: they pass whether the zone is right or not. These six
+      # are the ones that look.
+      #
+      # Absent is fine -- they arrive with the changes that need them. Present
+      # and skipped is not: each of them skips on a missing address, so a skip
+      # means the run proves nothing about IPv6. The grep is a substring match,
+      # which also catches a per-family case skipping inside a parent that still
+      # reports PASS, and it runs per lane -- whether the actor's own families
+      # are right is the one thing the two classes answer differently.
+      if: always() && steps.e2e-networking.outcome != 'skipped'
+      env:
+        MICROVM_RAN: ${{ steps.e2e-networking-microvm.outcome != 'skipped' }}
+      run: |
+        lanes="gVisor:/tmp/e2e-networking.log"
+        if [ "${MICROVM_RAN}" = "true" ]; then
+          lanes="${lanes} micro-VM:/tmp/e2e-networking-microvm.log"
+        fi
+        rc=0
+        for lane in ${lanes}; do
+          name=${lane%%:*}; log=${lane#*:}
+          echo "${name}:"
+          [ -s "${log}" ] || { echo "::error::${log} is missing or empty"; exit 1; }
+          for t in TestActorDNSZone TestActorDNSAAAA TestRouterListenerAddresses \
+                   TestActorIngressPerFamily TestActorEgressPerFamily \
+                   TestActorAddressFamilies; do
+            if grep -q -- "--- SKIP: ${t}" "${log}"; then
+              echo "::error::${name}: ${t} skipped on a dual-stack cluster -- it needs two address families to be reachable, so this run proves nothing about IPv6"
+              rc=1
+            elif grep -q -- "--- PASS: ${t}" "${log}"; then
+              echo "    ${t}: ran"
+            else
+              echo "    ${t}: not in this tree yet"
+            fi
+          done
+        done
+        exit "${rc}"
+    - name: Dump diagnostics on failure
+      if: failure()
+      run: |
+        kubectl --context="$KUBECTL_CONTEXT" get actortemplate,workerpool,pods -A -o wide || true
+        dump() {
+          echo "=== logs: $1/$2 ==="
+          kubectl --context="$KUBECTL_CONTEXT" logs -n "$1" "$2" --all-containers --tail=300 2>/dev/null || true
+        }
+        for p in $(kubectl --context="$KUBECTL_CONTEXT" get pods -n ate-system -o name 2>/dev/null); do
+          dump ate-system "$p"
+        done
+        # The failing actor runs in one of these, so this is where its ateom
+        # logs -- and, for a micro-VM worker, the guest console tail -- live.
+        kubectl --context="$KUBECTL_CONTEXT" get pods -A -l ate.dev/worker-pool \
+          -o 'custom-columns=:.metadata.namespace,:.metadata.name' --no-headers 2>/dev/null \
+          | while read -r ns name; do dump "$ns" "$name"; done
+        # Which family each Service got is the subject of this job, and the
+        # rendered zone is what the DNS assertions read.
+        kubectl --context="$KUBECTL_CONTEXT" get svc -A \
+          -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,POLICY:.spec.ipFamilyPolicy,IPS:.spec.clusterIPs || true
+        kubectl --context="$KUBECTL_CONTEXT" -n ate-system logs -l app=dns --all-containers --tail=100 || true


### PR DESCRIPTION
Part of #246.

No CI lane runs a cluster with both address families, so nothing catches truncation — code reading one address where there are two — or IPv4 breaking once IPv6 works. Neither single-family lane can: on each of them the one address present is the right one. This adds a non-gating job that builds a dual-stack kind cluster, asserts it really has both families before installing anything, and runs the networking suite on both sandbox classes. Counting passes would not be enough, because the tests that compare families skip rather than fail when an address is missing — so the job names them and treats present-and-skipped as an error, per class.

It runs after a merge rather than before one: a push to main touching the paths that could break it, nightly, and dispatch with a list of pull requests merged onto main for the length of the run. Ten minutes per review round buys little when the job gates nothing, while a merge run pins a break to the commit that caused it — and dispatch is still there for a change that wants a result before it merges. Most of the IPv6 changes do nothing apart, so only a stack shows the feature working — `911 938 1083` passes with no skips. On main today none of the six named tests exists yet, so the job currently proves only that a dual-stack cluster installs and that both sandbox classes work on one; it earns the rest as those changes land. A green run is about ten minutes; the last one is [here](https://github.com/agent-substrate/substrate/actions/runs/32878195629), from the pull-request trigger this revision removes.

🤖 This PR was developed with AI assistance. I have reviewed and tested all changes.

