### PR TITLE
Fix upstream mtls cert rotation

### DIFF
--- a/cmd/atenet/internal/router/xds.go
+++ b/cmd/atenet/internal/router/xds.go
@@ -81,6 +81,15 @@ const (
 	OtlpClusterName      = "otel_collector_cluster"
 	HTTPSCertSecretName  = "https_serving_cert"
 
+	// UpstreamCertSecretName and UpstreamTrustSecretName are the SDS secrets
+	// backing the actor-facing mTLS transport socket: the podidentity client
+	// cert the router presents to atunnel, and the CA bundle it validates
+	// atunnel with. Both are delivered over SDS rather than inlined into the
+	// transport socket so that Envoy re-reads them after kubelet rotates the
+	// projected volume (see buildCertSecret).
+	UpstreamCertSecretName  = "upstream_client_cert"
+	UpstreamTrustSecretName = "upstream_trust_bundle"
+
 	// httpProtocolOptionsName is the well-known extension key Envoy looks for in
 	// a cluster's typed_extension_protocol_options. It must match the message's
 	// full proto type name exactly; a typo is silently ignored rather than
@@ -455,6 +464,15 @@ func (x *XdsServer) UpdateSnapshot() error {
 	if needsCert {
 		secrets = append(secrets, x.buildTlsSecret())
 	}
+	// Mirrors buildUpstreamTransportSocket's gating: the actor-facing socket
+	// exists only when the credential bundle is configured, and it references
+	// the trust secret only when the trust bundle is too.
+	if x.upstreamCredentialBundlePath != "" {
+		secrets = append(secrets, x.buildUpstreamCertSecret())
+		if x.upstreamTrustBundlePath != "" {
+			secrets = append(secrets, x.buildUpstreamTrustSecret())
+		}
+	}
 
 	// Snapshot
 	snapshot, err := cachev3.NewSnapshot(ver, map[resourcev3.Type][]types.Resource{
@@ -618,35 +636,37 @@ func (x *XdsServer) buildOtlpCollectorCluster() *clusterv3.Cluster {
 // client cert and validates the atunnel ingress server against the trust
 // bundle. Validation is by the SPIFFE URI SAN prefix (see upstreamSpiffePrefix)
 // rather than the dialed pod IP.
+//
+// Both the client cert and the trust bundle are referenced as SDS secrets
+// served by this same control plane over ADS, never inlined as file
+// DataSources: Envoy reads an inline file once when the cluster warms and
+// caches the bytes for the process lifetime, so an inlined podidentity leaf
+// goes stale at its 24h expiry and every actor dial then fails the handshake.
 func (x *XdsServer) buildUpstreamTransportSocket() *corev3.TransportSocket {
 	if x.upstreamCredentialBundlePath == "" {
 		return nil
 	}
 
 	commonTls := &tlsv3.CommonTlsContext{
-		TlsCertificates: []*tlsv3.TlsCertificate{
+		TlsCertificateSdsSecretConfigs: []*tlsv3.SdsSecretConfig{
 			{
-				CertificateChain: &corev3.DataSource{
-					Specifier: &corev3.DataSource_Filename{Filename: x.upstreamCredentialBundlePath},
-				},
-				PrivateKey: &corev3.DataSource{
-					Specifier: &corev3.DataSource_Filename{Filename: x.upstreamCredentialBundlePath},
-				},
+				Name:      UpstreamCertSecretName,
+				SdsConfig: adsConfigSource(),
 			},
 		},
 	}
 	if x.upstreamTrustBundlePath != "" {
-		validationCtx := &tlsv3.CertificateValidationContext{
-			TrustedCa: &corev3.DataSource{
-				Specifier: &corev3.DataSource_Filename{Filename: x.upstreamTrustBundlePath},
-			},
-		}
+		// The trusted CA arrives over SDS (see buildUpstreamTrustSecret) so it
+		// tracks ClusterTrustBundle rotation, while the SAN matcher stays
+		// inline in the default context. Envoy merges the two, which is why
+		// this is a combined rather than a plain SDS validation context.
+		defaultCtx := &tlsv3.CertificateValidationContext{}
 		// Validate the atunnel server by its SPIFFE URI SAN (trust-domain
 		// prefix) rather than the dialed pod IP. Without this, Envoy checks the
 		// cert SAN against the ephemeral pod IP, which the SPIFFE-only cert
 		// never matches.
 		if x.upstreamSpiffePrefix != "" {
-			validationCtx.MatchTypedSubjectAltNames = []*tlsv3.SubjectAltNameMatcher{
+			defaultCtx.MatchTypedSubjectAltNames = []*tlsv3.SubjectAltNameMatcher{
 				{
 					SanType: tlsv3.SubjectAltNameMatcher_URI,
 					Matcher: &matcherv3.StringMatcher{
@@ -655,8 +675,14 @@ func (x *XdsServer) buildUpstreamTransportSocket() *corev3.TransportSocket {
 				},
 			}
 		}
-		commonTls.ValidationContextType = &tlsv3.CommonTlsContext_ValidationContext{
-			ValidationContext: validationCtx,
+		commonTls.ValidationContextType = &tlsv3.CommonTlsContext_CombinedValidationContext{
+			CombinedValidationContext: &tlsv3.CommonTlsContext_CombinedCertificateValidationContext{
+				DefaultValidationContext: defaultCtx,
+				ValidationContextSdsSecretConfig: &tlsv3.SdsSecretConfig{
+					Name:      UpstreamTrustSecretName,
+					SdsConfig: adsConfigSource(),
+				},
+			},
 		}
 	}
 
@@ -1147,13 +1173,8 @@ func buildDownstreamTlsTransportSocket() *corev3.TransportSocket {
 		CommonTlsContext: &tlsv3.CommonTlsContext{
 			TlsCertificateSdsSecretConfigs: []*tlsv3.SdsSecretConfig{
 				{
-					Name: HTTPSCertSecretName,
-					SdsConfig: &corev3.ConfigSource{
-						ConfigSourceSpecifier: &corev3.ConfigSource_Ads{
-							Ads: &corev3.AggregatedConfigSource{},
-						},
-						ResourceApiVersion: corev3.ApiVersion_V3,
-					},
+					Name:      HTTPSCertSecretName,
+					SdsConfig: adsConfigSource(),
 				},
 			},
 		},
@@ -1262,9 +1283,22 @@ func (x *XdsServer) buildConnectTerminateTLSListener() *listenerv3.Listener {
 	}
 }
 
-func (x *XdsServer) buildTlsSecret() *tlsv3.Secret {
+// adsConfigSource points an SDS secret reference at this control plane's own
+// ADS stream, which the Envoy bootstrap already establishes.
+func adsConfigSource() *corev3.ConfigSource {
+	return &corev3.ConfigSource{
+		ConfigSourceSpecifier: &corev3.ConfigSource_Ads{
+			Ads: &corev3.AggregatedConfigSource{},
+		},
+		ResourceApiVersion: corev3.ApiVersion_V3,
+	}
+}
+
+// buildCertSecret returns the SDS secret named name, serving the credential
+// bundle at path.
+func buildCertSecret(name, path string) *tlsv3.Secret {
 	return &tlsv3.Secret{
-		Name: HTTPSCertSecretName,
+		Name: name,
 		Type: &tlsv3.Secret_TlsCertificate{
 			TlsCertificate: &tlsv3.TlsCertificate{
 				// The pod certificate is projected as a single PEM bundle
@@ -1272,18 +1306,52 @@ func (x *XdsServer) buildTlsSecret() *tlsv3.Secret {
 				// DataSources point at the same file.
 				CertificateChain: &corev3.DataSource{
 					Specifier: &corev3.DataSource_Filename{
-						Filename: x.certPath,
+						Filename: path,
 					},
 				},
 				PrivateKey: &corev3.DataSource{
 					Specifier: &corev3.DataSource_Filename{
-						Filename: x.certPath,
+						Filename: path,
 					},
 				},
 				// By specifying WatchedDirectory, we tell envoy to watch changes to the mounted pod certificate file.
 				// See documentation in https://pkg.go.dev/github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3#:~:text=This%20only%20applies%20when%20a%20%E2%80%9CTlsCertificate%E2%80%9C%20is%20delivered%20by%20SDS
 				WatchedDirectory: &corev3.WatchedDirectory{
-					Path: filepath.Dir(x.certPath),
+					Path: filepath.Dir(path),
+				},
+			},
+		},
+	}
+}
+
+func (x *XdsServer) buildTlsSecret() *tlsv3.Secret {
+	return buildCertSecret(HTTPSCertSecretName, x.certPath)
+}
+
+// buildUpstreamCertSecret serves the podidentity credential bundle the router
+// presents to the actor's atunnel ingress server.
+func (x *XdsServer) buildUpstreamCertSecret() *tlsv3.Secret {
+	return buildCertSecret(UpstreamCertSecretName, x.upstreamCredentialBundlePath)
+}
+
+// buildUpstreamTrustSecret serves the CA bundle the router validates the
+// atunnel ingress server against. WatchedDirectory applies to a validation
+// context for the same reason it does to a certificate: the podidentity
+// ClusterTrustBundle is a projected volume, and without the watch Envoy keeps
+// the CA set it read at cluster warm-up and rejects certificates issued by a
+// rotated CA with "unknown CA".
+func (x *XdsServer) buildUpstreamTrustSecret() *tlsv3.Secret {
+	return &tlsv3.Secret{
+		Name: UpstreamTrustSecretName,
+		Type: &tlsv3.Secret_ValidationContext{
+			ValidationContext: &tlsv3.CertificateValidationContext{
+				TrustedCa: &corev3.DataSource{
+					Specifier: &corev3.DataSource_Filename{
+						Filename: x.upstreamTrustBundlePath,
+					},
+				},
+				WatchedDirectory: &corev3.WatchedDirectory{
+					Path: filepath.Dir(x.upstreamTrustBundlePath),
 				},
 			},
 		},

--- a/cmd/atenet/internal/router/xds_test.go
+++ b/cmd/atenet/internal/router/xds_test.go
@@ -635,6 +635,220 @@ func rotateProjectedVolume(t *testing.T, dir, newTsDir, oldTsDir string, bundle 
 	}
 }
 
+// TestUpstreamTransportSocket_DeliversCertsOverSds guards the actor-facing
+// mTLS socket against inline file DataSources. Envoy reads those once, as the
+// ORIGINAL_DST cluster warms, and caches the bytes for the process lifetime:
+// with the certs inlined the 24h podidentity leaf expires in place and every
+// actor dial fails the atunnel handshake, and a rotated ClusterTrustBundle is
+// likewise never picked up.
+func TestUpstreamTransportSocket_DeliversCertsOverSds(t *testing.T) {
+	const (
+		credPath     = "/run/podidentity.podcert.ate.dev/credential-bundle.pem"
+		trustPath    = "/run/podidentity.podcert.ate.dev/trust-bundle.pem"
+		spiffePrefix = "spiffe://cluster.local/"
+	)
+
+	server := NewXdsServer(18000)
+	server.SetUpstreamTls(credPath, trustPath, spiffePrefix)
+
+	ts := server.buildUpstreamTransportSocket()
+	if ts == nil {
+		t.Fatal("Expected an upstream transport socket when the credential bundle is configured")
+	}
+	utc := &tlsv3.UpstreamTlsContext{}
+	if err := ts.GetTypedConfig().UnmarshalTo(utc); err != nil {
+		t.Fatalf("Failed to unmarshal UpstreamTlsContext: %v", err)
+	}
+	common := utc.GetCommonTlsContext()
+
+	if got := common.GetTlsCertificates(); len(got) != 0 {
+		t.Errorf("Expected no inline TlsCertificates, got %d", len(got))
+	}
+	sds := common.GetTlsCertificateSdsSecretConfigs()
+	if len(sds) != 1 {
+		t.Fatalf("Expected 1 client cert SDS secret config, got %d", len(sds))
+	}
+	if got := sds[0].GetName(); got != UpstreamCertSecretName {
+		t.Errorf("Expected SDS secret name '%s', got '%s'", UpstreamCertSecretName, got)
+	}
+	if sds[0].GetSdsConfig().GetAds() == nil {
+		t.Error("Expected the client cert SDS config to use the ADS config source")
+	}
+
+	if common.GetValidationContext() != nil {
+		t.Error("Expected no inline ValidationContext; the trusted CA must arrive over SDS")
+	}
+	combined := common.GetCombinedValidationContext()
+	if combined == nil {
+		t.Fatal("Expected a combined validation context carrying the SDS trust bundle")
+	}
+	if got := combined.GetDefaultValidationContext().GetTrustedCa().GetFilename(); got != "" {
+		t.Errorf("Expected no inline TrustedCa filename, got '%s'", got)
+	}
+	if got := combined.GetValidationContextSdsSecretConfig().GetName(); got != UpstreamTrustSecretName {
+		t.Errorf("Expected trust bundle SDS secret name '%s', got '%s'", UpstreamTrustSecretName, got)
+	}
+	if combined.GetValidationContextSdsSecretConfig().GetSdsConfig().GetAds() == nil {
+		t.Error("Expected the trust bundle SDS config to use the ADS config source")
+	}
+
+	// The SPIFFE SAN matcher has to survive the move into the combined
+	// context's default half. Losing it silently downgrades validation to a
+	// SAN check against the dialed pod IP, which the SPIFFE-only atunnel
+	// server cert never carries.
+	sans := combined.GetDefaultValidationContext().GetMatchTypedSubjectAltNames()
+	if len(sans) != 1 {
+		t.Fatalf("Expected 1 SAN matcher, got %d", len(sans))
+	}
+	if got := sans[0].GetSanType(); got != tlsv3.SubjectAltNameMatcher_URI {
+		t.Errorf("Expected a URI SAN matcher, got %v", got)
+	}
+	if got := sans[0].GetMatcher().GetPrefix(); got != spiffePrefix {
+		t.Errorf("Expected SAN prefix '%s', got '%s'", spiffePrefix, got)
+	}
+}
+
+// TestXdsServer_UpdateSnapshot_UpstreamSecrets checks the secrets the upstream
+// socket references are actually published: an SDS reference to a secret
+// missing from the snapshot leaves Envoy warming the cluster forever.
+func TestXdsServer_UpdateSnapshot_UpstreamSecrets(t *testing.T) {
+	const (
+		credPath  = "/run/podidentity.podcert.ate.dev/credential-bundle.pem"
+		trustPath = "/run/podidentity.podcert.ate.dev/trust-bundle.pem"
+		bundleDir = "/run/podidentity.podcert.ate.dev"
+	)
+
+	t.Run("PublishedWhenConfigured", func(t *testing.T) {
+		server := NewXdsServer(18000)
+		server.SetConfig(8085, 50053, "127.0.0.1")
+		server.SetUpstreamTls(credPath, trustPath, "spiffe://cluster.local/")
+
+		secrets := snapshotSecrets(t, server)
+		if len(secrets) != 2 {
+			t.Fatalf("Expected 2 secrets, got %d", len(secrets))
+		}
+
+		cert, exists := secrets[UpstreamCertSecretName]
+		if !exists {
+			t.Fatalf("Secret '%s' is missing from snapshot secrets", UpstreamCertSecretName)
+		}
+		tlsCert := cert.GetTlsCertificate()
+		if got := tlsCert.GetCertificateChain().GetFilename(); got != credPath {
+			t.Errorf("Expected certificate chain filename '%s', got '%s'", credPath, got)
+		}
+		if got := tlsCert.GetPrivateKey().GetFilename(); got != credPath {
+			t.Errorf("Expected private key filename '%s', got '%s'", credPath, got)
+		}
+		if got := tlsCert.GetWatchedDirectory().GetPath(); got != bundleDir {
+			t.Errorf("Expected client cert watched directory '%s', got '%s'", bundleDir, got)
+		}
+
+		trust, exists := secrets[UpstreamTrustSecretName]
+		if !exists {
+			t.Fatalf("Secret '%s' is missing from snapshot secrets", UpstreamTrustSecretName)
+		}
+		validation := trust.GetValidationContext()
+		if got := validation.GetTrustedCa().GetFilename(); got != trustPath {
+			t.Errorf("Expected trusted CA filename '%s', got '%s'", trustPath, got)
+		}
+		if got := validation.GetWatchedDirectory().GetPath(); got != bundleDir {
+			t.Errorf("Expected trust bundle watched directory '%s', got '%s'", bundleDir, got)
+		}
+	})
+
+	t.Run("AbsentWhenUpstreamMtlsDisabled", func(t *testing.T) {
+		server := NewXdsServer(18000)
+		server.SetConfig(8085, 50053, "127.0.0.1")
+
+		if got := len(snapshotSecrets(t, server)); got != 0 {
+			t.Fatalf("Expected no secrets when upstream mTLS is disabled, got %d", got)
+		}
+	})
+
+	t.Run("TrustSecretOmittedWithoutTrustBundle", func(t *testing.T) {
+		server := NewXdsServer(18000)
+		server.SetConfig(8085, 50053, "127.0.0.1")
+		server.SetUpstreamTls(credPath, "", "")
+
+		secrets := snapshotSecrets(t, server)
+		if len(secrets) != 1 {
+			t.Fatalf("Expected only the client cert secret, got %d", len(secrets))
+		}
+		if _, exists := secrets[UpstreamCertSecretName]; !exists {
+			t.Errorf("Secret '%s' is missing from snapshot secrets", UpstreamCertSecretName)
+		}
+	})
+}
+
+// TestUpstreamCertSecret_ProjectedVolumeRotation is the client-cert twin of
+// TestTlsSecret_ProjectedVolumeRotation: the podidentity bundle rotates the
+// same way the servicedns one does, and the upstream secret has to follow it.
+func TestUpstreamCertSecret_ProjectedVolumeRotation(t *testing.T) {
+	dir := t.TempDir()
+	certA := "upstream-client-cert-a"
+	certB := "upstream-client-cert-b"
+	credPath := filepath.Join(dir, "credential-bundle.pem")
+	bundleA := makeServingBundle(t, certA)
+	bundleB := makeServingBundle(t, certB)
+
+	const tsDirA = "..2026_07_25_00_00_00.0000000001"
+	const tsDirB = "..2026_07_25_00_00_00.0000000002"
+	writeProjectedVolume(t, dir, tsDirA, bundleA)
+
+	server := NewXdsServer(18000)
+	server.SetUpstreamTls(credPath, "", "")
+	tlsCert := server.buildUpstreamCertSecret().GetTlsCertificate()
+
+	chainPath := tlsCert.GetCertificateChain().GetFilename()
+	if got := readServingCN(t, chainPath); got != certA {
+		t.Fatalf("Expected initial bundle to present %q, got %q", certA, got)
+	}
+
+	swapPath := filepath.Join(tlsCert.GetWatchedDirectory().GetPath(), dataDirName)
+	before, err := os.Readlink(swapPath)
+	if err != nil {
+		t.Fatalf("The rotation symlink is not a direct child of WatchedDirectory: %v", err)
+	}
+
+	rotateProjectedVolume(t, dir, tsDirB, tsDirA, bundleB)
+
+	after, err := os.Readlink(swapPath)
+	if err != nil {
+		t.Fatalf("The rotation symlink left WatchedDirectory after rotation: %v", err)
+	}
+	if after == before {
+		t.Fatalf("Rotation did not retarget the %s symlink (still %q); an in-place write would not trigger Envoy's reload", dataDirName, after)
+	}
+	if got := readServingCN(t, chainPath); got != certB {
+		t.Fatalf("Expected rotated bundle to present %q, got %q", certB, got)
+	}
+}
+
+// snapshotSecrets publishes a snapshot and returns its SDS secrets by name.
+func snapshotSecrets(t *testing.T, server *XdsServer) map[string]*tlsv3.Secret {
+	t.Helper()
+	if err := server.UpdateSnapshot(); err != nil {
+		t.Fatalf("UpdateSnapshot failed: %v", err)
+	}
+	res, err := server.snapshot.GetSnapshot(NodeID)
+	if err != nil {
+		t.Fatalf("Failed to get snapshot: %v", err)
+	}
+	snap, ok := res.(*cachev3.Snapshot)
+	if !ok {
+		t.Fatalf("Snapshot doesn't conform to type *cachev3.Snapshot, got %T", res)
+	}
+	secrets := make(map[string]*tlsv3.Secret)
+	for name, raw := range snap.GetResources(resourcev3.SecretType) {
+		secret, ok := raw.(*tlsv3.Secret)
+		if !ok {
+			t.Fatalf("Secret '%s' doesn't conform to type *tlsv3.Secret, got %T", name, raw)
+		}
+		secrets[name] = secret
+	}
+	return secrets
+}
+
 func TestXdsServer_ExtProcCircuitBreaker(t *testing.T) {
 	t.Run("DefaultCoversLotPlusHeadroom", func(t *testing.T) {
 		x := NewXdsServer(0)


### PR DESCRIPTION
Fixes #1066 

- [x] Tests pass
- [x] ~~Appropriate changes to documentation are included in the PR~~ No documentation changes needed.

## Summary

- Move actor-facing Envoy upstream mTLS credentials from inline file `DataSource`s to SDS secrets served over ADS.
- Publish separate SDS secrets for the upstream podidentity client cert and upstream trust bundle.
- Preserve SPIFFE URI SAN validation by using a combined validation context: trust bundle via SDS, SAN matcher inline.
- Reuse the ADS config source helper for downstream TLS SDS references.
- Add tests covering upstream SDS references, snapshot secret publication, and projected-volume rotation behavior.
