### PR TITLE
fix(atunnel): close both relay ends

### DIFF
--- a/internal/atunnel/ingress.go
+++ b/internal/atunnel/ingress.go
@@ -309,12 +309,6 @@ func (s *Server) serveH2Connect(w http.ResponseWriter, r *http.Request, upstream
 // stream ends, it half-closes the actor connection and continues forwarding
 // actor output until that stream ends too.
 func relayIngressWithHalfClose(ctx context.Context, upstream net.Conn, clientReader io.Reader, clientWriter io.Writer, clientCloser io.Closer) {
-	stop := context.AfterFunc(ctx, func() {
-		_ = upstream.Close()
-		_ = clientCloser.Close()
-	})
-	defer stop()
-
 	done := make(chan struct{}, 2)
 	go func() {
 		_, _ = io.Copy(upstream, clientReader)
@@ -328,6 +322,8 @@ func relayIngressWithHalfClose(ctx context.Context, upstream net.Conn, clientRea
 	for range 2 {
 		select {
 		case <-ctx.Done():
+			_ = upstream.Close()
+			_ = clientCloser.Close()
 			return
 		case <-done:
 		}

--- a/internal/atunnel/ingress_test.go
+++ b/internal/atunnel/ingress_test.go
@@ -113,19 +113,18 @@ func TestRelayIngressCancellationClosesBothSides(t *testing.T) {
 	}()
 
 	cancel()
-	if err := actor.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-		t.Fatal(err)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("relay did not return after cancellation")
 	}
+	// Deadline only guards against hanging; it fails once the relay closed the pipe.
+	_ = actor.SetReadDeadline(time.Now().Add(time.Second))
 	if _, err := actor.Read(make([]byte, 1)); err == nil {
 		t.Fatal("actor connection remained open after relay cancellation")
 	}
 	if _, err := io.WriteString(clientInput, "request"); err == nil {
 		t.Fatal("client stream remained open after relay cancellation")
-	}
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("relay did not return after cancellation")
 	}
 }
 


### PR DESCRIPTION
Fixes #1100

`TestRelayIngressCancellationClosesBothSides` fails on about 1% of `-race` runs, on branches unrelated to the relay.

## Root cause

The test asserts a close that happens on a goroutine it never waits for.

`relayIngressWithHalfClose` closed both sides from a `context.AfterFunc` callback, which runs on its own goroutine. `cancel()` returning therefore says nothing about whether the streams are closed — and the test asserted right after it.

The client side is an unbuffered `io.Pipe`, where a `Write` cannot complete on its own; it needs someone on the other end. Two goroutines can be that someone:

| Whichever gets there first | Outcome |
|---|---|
| the `AfterFunc` callback closes the pipe | `Write` fails → **test passes** |
| the relay's `io.Copy`, still parked in `Read` | it takes the bytes, `Write` returns nil → **test fails** |

The scheduler picks the winner, so the test is a coin flip. `-race` widens the window by two orders of magnitude — 1 failure per 10000 plain, 89 with `-race` — and CI runs `go test -race -v ./...`.

The `actor.Read` assertion just above races the same close, but carries a one-second deadline and so almost always wins. The `Write` has no such slack, which is why the failure is always line 123.

## Fix

**Production.** Close both sides in the `ctx.Done()` branch the relay loop already selects on, rather than from a detached goroutine. This turns

> both sides are *eventually* closed

into

> both sides are closed *before this returns*

which is what a caller can build on, and it drops a goroutine plus its `stop()` bookkeeping.

**Test.** Wait for the relay to return, then assert. The `SetReadDeadline` error check goes with it: once the relay has closed the pipe, setting a deadline on it fails by design, and the deadline was only ever a guard against hanging if the connection had been left open.

Nothing changes about the bytes the relay moves — this is a shutdown-ordering fix, not a data-plane one.

## Before / after

```
$ go test ./internal/atunnel/ -race -run TestRelayIngressCancellationClosesBothSides -count=10000
--- FAIL: TestRelayIngressCancellationClosesBothSides (0.00s)
    ingress_test.go:123: client stream remained open after relay cancellation
... 89 of 10000 iterations
FAIL	github.com/agent-substrate/substrate/internal/atunnel

$ go test ./internal/atunnel/ -race -run TestRelayIngressCancellationClosesBothSides -count=10000
ok  	github.com/agent-substrate/substrate/internal/atunnel	3.035s
```

Linux/x86_64, 4 cores, matching CI. On darwin/arm64 the same runs give 202 failures before and 0 after.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
