### PR TITLE
test(e2e): require 502 for rejected ports

### DIFF
--- a/internal/e2e/suites/networking/arbitraryport_test.go
+++ b/internal/e2e/suites/networking/arbitraryport_test.go
@@ -120,8 +120,10 @@ func TestActorArbitraryPortAccess(t *testing.T) {
 		}
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		if resp.StatusCode == http.StatusOK {
-			t.Fatalf("tunneled request to an unlisted port unexpectedly returned HTTP 200; body: %s", body)
+		// 502 is atunnel's own ErrorHandler failing to dial. Any other code
+		// means the request never reached it, so nothing was rejected.
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("tunneled request to an unlisted port returned HTTP %d, want 502 from atunnel's failed dial; body: %s", resp.StatusCode, body)
 		}
 		t.Logf("tunneled request to an unlisted port correctly returned HTTP %d; body: %s", resp.StatusCode, body)
 	})


### PR DESCRIPTION
Fixes #1102

`TestActorArbitraryPortAccess/unlisted_port_rejected` passes when the worker is unreachable, which is the one situation it most needs to catch.

## Root cause

The subtest asserts only that the response is not 200:

```go
if resp.StatusCode == http.StatusOK {
    t.Fatalf("...unexpectedly returned HTTP 200; body: %s", body)
}
```

Three different outcomes satisfy that, and only one of them is the behaviour under test:

| Response | What happened | Correct? |
|---|---|---|
| 502 `bad gateway` | atunnel dialled the unlisted port and failed | yes |
| 503 `upstream connect error` | Envoy never reached the worker (#1050) | no — nothing was rejected |
| 504 `actor ... request timed out` | the router's own ext_proc timed out | no |

Six recent `pr-workflow` runs logged the 503 as a pass; `correctly` there is the test's own word:

```
tunneled request to an unlisted port correctly returned HTTP 503;
  body: upstream connect error or disconnect/reset before headers. reset reason: connection timeout
```

In run 32200086998 the other three tests #1050 names failed while this one passed, on the same worker in the same run.

## Fix

Require 502. That is what atunnel's `ErrorHandler` returns when its dial to the unlisted port fails, and it is the only outcome that means the rejection actually happened. Checking the code rather than matching Envoy's error text also covers the 504 and does not depend on wording that can change between Envoy versions.

The read-error branch above still returns early and counts as a pass. That path is not what #1050 produces, so it is left alone rather than widened without evidence.

This makes CI redder until #1050 is fixed: a failure that used to be silent now shows up. That is the point — while the assertion stays loose, `TestActorArbitraryPortAccess` cannot tell anyone whether #1050 has been fixed.

## Before / after

Injected #1050's exact failure — SYN from the router to the worker pods dropped, control plane and established connections untouched, `atenet-router` restarted first so Envoy has no pooled connection. Both arms received the same 503 at 5.01s, matching `OriginalDstCluster`'s 5s `connect_timeout`:

```
before  --- PASS: TestActorArbitraryPortAccess/unlisted_port_rejected (5.01s)
            tunneled request to an unlisted port correctly returned HTTP 503;
              body: upstream connect error or disconnect/reset before headers. reset reason: connection timeout

after   --- FAIL: TestActorArbitraryPortAccess/unlisted_port_rejected (5.01s)
            tunneled request to an unlisted port returned HTTP 503, want 502 from atunnel's failed dial;
              body: upstream connect error or disconnect/reset before headers. reset reason: connection timeout
```

Healthy path, no injection, three consecutive runs:

```
rc=0  all subtests PASS  ...correctly returned HTTP 502; body: bad gateway
```

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
