### PR TITLE
Fix TestActorIdentity_AfterRestore_IsOwnID_NotGolden flaky test

### DIFF
--- a/internal/e2e/router_client.go
+++ b/internal/e2e/router_client.go
@@ -123,7 +123,9 @@ func (c *RouterClient) request(ctx context.Context, method string, actorRef reso
 		}
 	}
 
-	deadline := time.Now().Add(30 * time.Second)
+	retryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	for {
 		var reqBody io.Reader
 		if bodyBytes != nil {
@@ -146,10 +148,10 @@ func (c *RouterClient) request(ctx context.Context, method string, actorRef reso
 		if resp.StatusCode == http.StatusServiceUnavailable {
 			respBodyBytes, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			if strings.Contains(string(respBodyBytes), "upstream connect error") && time.Now().Before(deadline) {
+			if strings.Contains(string(respBodyBytes), "upstream connect error") {
 				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
+				case <-retryCtx.Done():
+					return nil, retryCtx.Err()
 				case <-time.After(1 * time.Second):
 					continue
 				}

--- a/internal/e2e/router_client.go
+++ b/internal/e2e/router_client.go
@@ -114,16 +114,50 @@ func (c *RouterClient) PostJSON(ctx context.Context, actorRef resources.ActorRef
 }
 
 func (c *RouterClient) request(ctx context.Context, method string, actorRef resources.ActorRef, path string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
-	if err != nil {
-		return nil, err
+	var bodyBytes []byte
+	var err error
+	if body != nil {
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return nil, err
+		}
 	}
-	if method == http.MethodPost {
-		req.Header.Set("Content-Type", "application/json")
+
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		var reqBody io.Reader
+		if bodyBytes != nil {
+			reqBody = bytes.NewReader(bodyBytes)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+		if err != nil {
+			return nil, err
+		}
+		if method == http.MethodPost {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.Host = resources.ActorDNSName(actorRef)
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return resp, err
+		}
+
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			respBodyBytes, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if strings.Contains(string(respBodyBytes), "upstream connect error") && time.Now().Before(deadline) {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(1 * time.Second):
+					continue
+				}
+			}
+			resp.Body = io.NopCloser(bytes.NewReader(respBodyBytes))
+		}
+		return resp, nil
 	}
-	// The router routes on the Host/:authority, not a header.
-	req.Host = resources.ActorDNSName(actorRef)
-	return c.http.Do(req)
 }
 
 // Connect opens a CONNECT tunnel through the router to port on actorRef,


### PR DESCRIPTION
`TestActorIdentity_AfterRestore_IsOwnID_NotGolden` (and other E2E tests) failed intermittently with an Envoy 503 "upstream connect error".
For example: https://github.com/agent-substrate/substrate/actions/runs/32400171542/job/96526194319#step:12:549 

Issue: The test called `ResumeActor` and then immediately fired an HTTP request at the actor. While the control plane successfully resumed the actor, it takes a fraction of a second for the new routing information to propagate to the Envoy proxy (via xDS). The test's HTTP request slammed into Envoy before its routing tables were updated to point to the newly restored pod.

Fix: updated the shared test client (`RouterClient.request`in `router_client.go`). It now explicitly intercepts 503 "upstream connect error" responses and retries the request for up to 30 seconds (`time.Sleep(1 * time.Second)`).


- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
