### PR TITLE
Resume actor with sandbox assets that are frozen into the ActorTemplate substrate object at creation time

### DIFF
--- a/cmd/ateapi/internal/controlapi/sandbox_assets.go
+++ b/cmd/ateapi/internal/controlapi/sandbox_assets.go
@@ -15,20 +15,75 @@
 package controlapi
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
+	"github.com/agent-substrate/substrate/internal/resources"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// resolveSandboxAssets determines the sandbox binaries and pause image an actor
+// resolveSandboxAssets picks the sandbox assets to call atelet with.
+func (w *ActorWorkflow) resolveSandboxAssets(ctx context.Context, actor *ateapipb.Actor, poolNamespace, poolName string) (*ateletpb.SandboxAssets, error) {
+	ref := actor.GetActorTemplate()
+	if ref == nil {
+		return resolveSandboxAssetsByWorkerPool(w.workerPoolLister, w.sandboxConfigLister, poolNamespace, poolName)
+	}
+	templateRef := resources.ActorTemplateRefFromObjectRef(ref)
+	tmpl, err := w.store.GetActorTemplate(ctx, templateRef)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %s not found", templateRef)
+		}
+		return nil, fmt.Errorf("while getting ActorTemplate %s: %w", templateRef, err)
+	}
+	frozen := tmpl.GetStatus().GetSandboxAssets()
+	if frozen == nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %s has no sandbox assets frozen in its status", templateRef)
+	}
+	return ateletSandboxAssets(frozen), nil
+}
+
+// ateletSandboxAssets projects a template's frozen ateapipb.SandboxAssets
+// onto the proto atelet fetches.
+func ateletSandboxAssets(in *ateapipb.SandboxAssets) *ateletpb.SandboxAssets {
+	out := &ateletpb.SandboxAssets{
+		SandboxClass: sandboxClassString(in.GetSandboxClass()),
+		PauseImage:   in.GetPauseImage(),
+		Assets:       make(map[string]*ateletpb.ArchAssets, len(in.GetAssets())),
+	}
+	for arch, archAssets := range in.GetAssets() {
+		files := &ateletpb.ArchAssets{Files: make(map[string]*ateletpb.AssetFile, len(archAssets.GetFiles()))}
+		for name, f := range archAssets.GetFiles() {
+			files.Files[name] = &ateletpb.AssetFile{Url: f.GetUrl(), Sha256: f.GetSha256()}
+		}
+		out.Assets[arch] = files
+	}
+	return out
+}
+
+// sandboxClassString maps the API enum onto the class string atelet keys its
+// runtimes on. Unspecified defaults to gvisor, matching resolveSandboxAssets.
+func sandboxClassString(class ateapipb.SandboxClass) string {
+	if class == ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM {
+		return string(atev1alpha1.SandboxClassMicroVM)
+	}
+	return string(atev1alpha1.SandboxClassGvisor)
+}
+
+// resolveSandboxAssetsByWorkerPool determines the sandbox binaries and pause image an actor
 // should boot with and projects them onto the ateletpb.SandboxAssets atelet
 // fetches. It takes the SandboxClass (default gvisor) of a given worker pool,
 // then picks the SandboxConfig named by the pool — or, if none is named, the
 // cluster default SandboxConfig for that class.
-func resolveSandboxAssets(
+func resolveSandboxAssetsByWorkerPool(
 	workerPoolLister listersv1alpha1.WorkerPoolLister,
 	sandboxConfigLister listersv1alpha1.SandboxConfigLister,
 	poolNamespace, poolName string,

--- a/cmd/ateapi/internal/controlapi/sandbox_assets_test.go
+++ b/cmd/ateapi/internal/controlapi/sandbox_assets_test.go
@@ -15,10 +15,17 @@
 package controlapi
 
 import (
+	"context"
 	"testing"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
+	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -42,9 +49,15 @@ func listersFor(t *testing.T, pools []*atev1alpha1.WorkerPool, configs []*atev1a
 	return listersv1alpha1.NewWorkerPoolLister(poolIdx), listersv1alpha1.NewSandboxConfigLister(configIdx)
 }
 
+// Mirrors manifests/ate-install/sandboxconfig-gvisor.yaml.
+const (
+	testGvisorURL    = "gs://gvisor/releases/release/20260803/x86_64/gvisor.tar.bz2"
+	testGvisorSHA256 = "9e7a5fcc2cbd28c9cd4af910a9327abcf07a8efcce242c285b860d79010c2db5"
+)
+
 func testAssets() map[string]map[string]atev1alpha1.AssetFile {
 	return map[string]map[string]atev1alpha1.AssetFile{
-		"amd64": {"gvisor": {URL: "gs://bucket/gvisor.tar.bz2", SHA256: "abc"}},
+		"amd64": {"gvisor": {URL: testGvisorURL, SHA256: testGvisorSHA256}},
 	}
 }
 
@@ -91,12 +104,146 @@ func TestResolveSandboxAssetsCarriesPauseImage(t *testing.T) {
 			poolLister, configLister := listersFor(t, []*atev1alpha1.WorkerPool{pool},
 				[]*atev1alpha1.SandboxConfig{defaultConfig, namedConfig})
 
-			got, err := resolveSandboxAssets(poolLister, configLister, "worker-ns", "pool1")
+			got, err := resolveSandboxAssetsByWorkerPool(poolLister, configLister, "worker-ns", "pool1")
 			if err != nil {
 				t.Fatalf("resolveSandboxAssets() error: %v", err)
 			}
 			if got.GetPauseImage() != tt.wantPauseImage {
 				t.Errorf("pause image = %q, want %q", got.GetPauseImage(), tt.wantPauseImage)
+			}
+		})
+	}
+}
+
+// TestResolveBootSandboxAssets pins how a cold boot picks its sandbox assets:
+// an actor bound to a stored ActorTemplate boots with the assets frozen on
+// the template's status — never touching the pool's SandboxConfig (the
+// listers stay nil, so that path would panic) — and fails FailedPrecondition
+// on a dangling reference or unfrozen assets; an actor without the reference
+// keeps resolving from the pool.
+func TestResolveBootSandboxAssets(t *testing.T) {
+	// Mirrors manifests/microvm/sandboxconfig-microvm.yaml.tmpl (amd64).
+	const (
+		frozenPause     = "registry.k8s.io/pause:3.10.2@sha256:f548e0e8e3dc1896ca956272154dde3314e8cc4fde0a57577ee9fa1c63f5baf4"
+		kataKernelURL   = "gs://ate-cluster-assets/kata-assets/vmlinux"
+		kataKernelSHA   = "6abc48fa83c58e3db314037105d04ec00c1bc80d85eb2dfb2e2854f414573bca"
+		cloudHypervisor = "gs://ate-cluster-assets/kata-assets/cloud-hypervisor"
+		cloudHypSHA     = "448af3d4e59b22c2987f7df94c213ad40fb53a10d437e42b5ee6c4fce7c29ecc"
+		// The gvisor default's in-project mirror, per
+		// manifests/ate-install/sandboxconfig-gvisor.yaml.
+		poolPause = "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
+	)
+	frozen := &ateapipb.SandboxAssets{
+		SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM,
+		PauseImage:   frozenPause,
+		Assets: map[string]*ateapipb.ArchAssets{
+			"amd64": {Files: map[string]*ateapipb.AssetFile{
+				"cloud-hypervisor": {Url: cloudHypervisor, Sha256: cloudHypSHA},
+				"kata-kernel":      {Url: kataKernelURL, Sha256: kataKernelSHA},
+			}},
+		},
+	}
+
+	tests := []struct {
+		name string
+		// template is seeded into the store before the call; nil seeds none.
+		template *ateapipb.ActorTemplate
+		// actorTemplateRef is the actor's stored-template reference; nil
+		// exercises the CRD-actor fallback.
+		actorTemplateRef *ateapipb.ObjectRef
+		// withPoolListers wires pool/config listers serving poolPause.
+		withPoolListers bool
+		wantCode        codes.Code
+		want            *ateletpb.SandboxAssets
+	}{
+		{
+			name: "frozen template assets win",
+			template: &ateapipb.ActorTemplate{
+				Metadata: &ateapipb.ResourceMetadata{Atespace: "ate-1", Name: "tmpl-1"},
+				Status:   &ateapipb.ActorTemplateStatus{SandboxAssets: frozen},
+			},
+			actorTemplateRef: &ateapipb.ObjectRef{Atespace: "ate-1", Name: "tmpl-1"},
+			want: &ateletpb.SandboxAssets{
+				SandboxClass: string(atev1alpha1.SandboxClassMicroVM),
+				PauseImage:   frozenPause,
+				Assets: map[string]*ateletpb.ArchAssets{
+					"amd64": {Files: map[string]*ateletpb.AssetFile{
+						"cloud-hypervisor": {Url: cloudHypervisor, Sha256: cloudHypSHA},
+						"kata-kernel":      {Url: kataKernelURL, Sha256: kataKernelSHA},
+					}},
+				},
+			},
+		},
+		{
+			name:             "template not found",
+			actorTemplateRef: &ateapipb.ObjectRef{Atespace: "ate-1", Name: "missing"},
+			wantCode:         codes.FailedPrecondition,
+		},
+		{
+			name: "assets not frozen",
+			template: &ateapipb.ActorTemplate{
+				Metadata: &ateapipb.ResourceMetadata{Atespace: "ate-1", Name: "no-assets"},
+			},
+			actorTemplateRef: &ateapipb.ObjectRef{Atespace: "ate-1", Name: "no-assets"},
+			wantCode:         codes.FailedPrecondition,
+		},
+		{
+			name:            "no template ref falls back to pool",
+			withPoolListers: true,
+			want: &ateletpb.SandboxAssets{
+				SandboxClass: string(atev1alpha1.SandboxClassGvisor),
+				PauseImage:   poolPause,
+				Assets: map[string]*ateletpb.ArchAssets{
+					"amd64": {Files: map[string]*ateletpb.AssetFile{
+						"gvisor": {Url: testGvisorURL, Sha256: testGvisorSHA256},
+					}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			st, cleanup := storetest.SetupTestStore(t)
+			defer cleanup()
+
+			if tt.template != nil {
+				if _, err := st.CreateActorTemplate(ctx, tt.template); err != nil {
+					t.Fatalf("seed ActorTemplate: %v", err)
+				}
+			}
+			var poolLister listersv1alpha1.WorkerPoolLister
+			var configLister listersv1alpha1.SandboxConfigLister
+			if tt.withPoolListers {
+				pool := &atev1alpha1.WorkerPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool1", Namespace: "worker-ns"},
+				}
+				config := &atev1alpha1.SandboxConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "gvisor-default"},
+					Spec: atev1alpha1.SandboxConfigSpec{
+						SandboxClass: atev1alpha1.SandboxClassGvisor,
+						Default:      true,
+						PauseImage:   poolPause,
+						Assets:       testAssets(),
+					},
+				}
+				poolLister, configLister = listersFor(t, []*atev1alpha1.WorkerPool{pool}, []*atev1alpha1.SandboxConfig{config})
+			}
+
+			w := NewActorWorkflow(st, nil, nil, nil, poolLister, configLister, nil, nil, "", nil)
+			actor := &ateapipb.Actor{ActorTemplate: tt.actorTemplateRef}
+			got, err := w.resolveSandboxAssets(ctx, actor, "worker-ns", "pool1")
+			if tt.wantCode != codes.OK {
+				if code := status.Code(err); code != tt.wantCode {
+					t.Fatalf("status.Code = %v (err %v), want %v", code, err, tt.wantCode)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveBootSandboxAssets() error: %v", err)
+			}
+			if !proto.Equal(got, tt.want) {
+				t.Errorf("resolveBootSandboxAssets() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/ateapi/internal/controlapi/workflow.go
+++ b/cmd/ateapi/internal/controlapi/workflow.go
@@ -113,6 +113,7 @@ func NewActorWorkflow(
 // ActorWorkflow and nothing more.
 type actorWorkflowStore interface {
 	GetActor(ctx context.Context, actorRef resources.ActorRef) (*ateapipb.Actor, error)
+	GetActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef) (*ateapipb.ActorTemplate, error)
 	UpdateActor(ctx context.Context, actorRef resources.ActorRef, precondition store.Precondition, mutate func(toUpdate *ateapipb.Actor) error) (*ateapipb.Actor, error)
 	DeleteActor(ctx context.Context, actorRef resources.ActorRef) (*ateapipb.Actor, error)
 	GetWorker(ctx context.Context, name string) (*ateapipb.Worker, error)

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -714,6 +714,7 @@ func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resou
 			EgressGateway:     egressGateway,
 			CpuMilli:          cpuMilli,
 			MemoryBytes:       memBytes,
+			// TODO: Add sandbox assets to RestoreRequest as well.
 		}
 		_, err = client.Restore(ctx, req)
 		return tele, maybeCrashActor(ctx, w.store, actorRef, err, "while restoring durable snapshot", ateattr.OperationResume)
@@ -721,10 +722,13 @@ func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resou
 		slog.InfoContext(ctx, "Actor has no snapshot; ActorTemplate has no golden snapshot; Booting from ActorTemplate spec")
 		tele.SnapshotKind = ateattr.SnapshotKindBoot
 
-		// Booting from scratch: resolve the sandbox binaries from the pool's
-		// SandboxConfig and send them so atelet can fetch and record them.
-		// (Restores above are self-describing via the snapshot manifest.)
-		sandboxAssets, err := resolveSandboxAssets(w.workerPoolLister, w.sandboxConfigLister, assignment.GetWorkerNamespace(), assignment.GetWorkerPool())
+		// Booting from scratch: send the sandbox binaries so atelet can fetch
+		// and record them.
+		// In the long term, we'll use the ones frozen into the ActorTemplate
+		// SandboxConfig. For now, older actors created using ActorTemplate
+		// CRD use the ones resolved from the pool's SandboxConfig.
+		// Restores above are self-describing via the snapshot manifest.
+		sandboxAssets, err := w.resolveSandboxAssets(ctx, actor, assignment.GetWorkerNamespace(), assignment.GetWorkerPool())
 		if err != nil {
 			return tele, fmt.Errorf("while resolving sandbox assets: %w", err)
 		}


### PR DESCRIPTION
## Problems

Today when an ActorTemplate's golden actor first boots, the sandbox configuration resolved from its assigned worker is frozen into the golden snapshot.

Example of `gs://<bucket>/<actor-template>/<golden-snapshot>/manifest.json`

```
{
  "sandboxClass": "gvisor",
  "assets": {
    "runsc": {
      "url": "gs://gvisor/releases/release/20260622/x86_64/runsc",
      "sha256": "f18a948bf9c8bbb54eb998549a3a8d719a1c7de2efbe8fdd2ff0ee5fecd06f19"
    }
  },
  "snapshotFiles": [
    "fscheckpoint.json",
    "multitar.img",
    "pages.img",
    "pages_meta.img"
  ]
}
```

*Every* subsequent actor of that template inherits it. Updating a `SandboxConfig` only affects future *golden* actors and actors created from it. Every actor that restores from an existing golden snapshot will keep running the frozen version of SandboxConfig. Therefore, existing Actors will never adopt new `SandboxConfig`.

Also, in order to answer the question "which actors use the runsc asset gs://gvisor/releases/release/20260622/x86\_64/runsc@sha…", a scanner must read each snapshot from the remote storage bucket.

## Changes

Now that we are moving ActorTemplate into substrate, we'll

1. Make each ActorTemplate freeze the sandbox assets at creation time, stored in ActorTemplate's `status.sandbox_assets` field  
2. When creating the golden actor, use the sandbox\_assets stored in the ActorTemplate.status field. This is required to make sure golden actor creation stays idempotent.