### PR TITLE
hack/microvm-assets: stage assets to rustfs over IPv6

### DIFF
--- a/hack/microvm-assets/stage-to-rustfs.sh
+++ b/hack/microvm-assets/stage-to-rustfs.sh
@@ -46,7 +46,8 @@ KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 
 # Keep in sync with the rustfs-bucket-init Job in
 # manifests/ate-install/kind/rustfs.yaml, which creates the bucket we upload into.
-AWS_CLI_IMAGE="amazon/aws-cli:2.17.0@sha256:643507c10ada7964ca6157b3d799f030b90577643da9955d319a77399ed80d73"
+# 2.17's botocore rejected a bracketed IPv6 endpoint, which is all this script can build.
+AWS_CLI_IMAGE="amazon/aws-cli:2.31.0@sha256:3b018ce74732c98acf6f1de59b3a89587cb7f9eb6ea0d1447d1779091b2bf057"
 
 ASSETS=(cloud-hypervisor virtiofsd vmlinux rootfs.img configuration-clh.toml)
 
@@ -76,7 +77,12 @@ if [[ -z "${NODE}" ]]; then
   echo "error: no nodes found for kind cluster '${KIND_CLUSTER_NAME}'" >&2
   exit 1
 fi
-ENDPOINT="http://$(run_kubectl get svc rustfs -o jsonpath='{.spec.clusterIP}'):9000"
+RUSTFS_IP="$(run_kubectl get svc rustfs -o jsonpath='{.spec.clusterIP}')"
+# A v6 ClusterIP needs brackets to be a URL.
+if [[ "${RUSTFS_IP}" == *:* ]]; then
+  RUSTFS_IP="[${RUSTFS_IP}]"
+fi
+ENDPOINT="http://${RUSTFS_IP}:9000"
 
 echo ">> Uploading assets to s3://${BUCKET}/kata-assets/ via ${ENDPOINT} (netns of ${NODE})..."
 aws_cli() {

--- a/manifests/ate-install/kind/rustfs.yaml
+++ b/manifests/ate-install/kind/rustfs.yaml
@@ -102,7 +102,9 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: create-bucket
-        image: amazon/aws-cli:2.17.0@sha256:643507c10ada7964ca6157b3d799f030b90577643da9955d319a77399ed80d73
+        # Keep in sync with hack/microvm-assets/stage-to-rustfs.sh, which needs 2.31
+        # for its bracketed IPv6 endpoint. This Job uses a DNS name and is unaffected.
+        image: amazon/aws-cli:2.31.0@sha256:3b018ce74732c98acf6f1de59b3a89587cb7f9eb6ea0d1447d1779091b2bf057
         env:
         - name: AWS_ACCESS_KEY_ID
           value: rustfsadmin


### PR DESCRIPTION
The endpoint is built from the rustfs ClusterIP, which on an IPv6-only cluster
is a bare v6 literal and needs brackets to be a URL. aws-cli 2.17 does not
accept the bracketed form, so both pins move to 2.31.0.

Verified on an `IP_FAMILY=ipv6` kind cluster: `hack/run-microvm-demo-kind.sh`
completes and the `counter-microvm` golden snapshot reaches Ready.

Part of #246.

🤖 This PR was developed with AI assistance. I have reviewed and tested all changes.

