### PR TITLE
hack: make the egress ext_proc script run on macOS

### DIFF
--- a/hack/experimental-additional-egress-extproc.sh
+++ b/hack/experimental-additional-egress-extproc.sh
@@ -92,8 +92,10 @@ patch_atenet_egress_manifest() {
 
   # Both blocks are written at column zero; awk below re-indents each to the
   # marker it replaces, so the depth they nest to is the manifest's to decide.
+  # bash 3.2, which macOS ships, mis-parses a heredoc inside $( ) whose body
+  # holds an apostrophe. read keeps the trailing newline that $( ) would strip.
   local filter_block cluster_block
-  filter_block="$(cat <<EOF
+  IFS= read -r -d '' filter_block <<EOF || true
 # Added by hack/install-ate.sh
 # --experimental-additional-egress-extproc-service=${ATE_ADDITIONAL_EGRESS_EXTPROC_SERVICE}.
 # Spliced over each #ATE_MITM_EXTPROC_FILTER marker in
@@ -126,9 +128,9 @@ patch_atenet_egress_manifest() {
       disallow_system: true
       disallow_is_error: true
 EOF
-)" || return 1
+  filter_block="${filter_block%$'\n'}"
 
-  cluster_block="$(cat <<EOF
+  IFS= read -r -d '' cluster_block <<EOF || true
 # Added by hack/install-ate.sh
 # --experimental-additional-egress-extproc-service=${ATE_ADDITIONAL_EGRESS_EXTPROC_SERVICE}.
 # Spliced over the #ATE_MITM_EXTPROC_CLUSTER marker in
@@ -184,7 +186,7 @@ EOF
               address: ${address}
               port_value: ${port}
 EOF
-)" || return 1
+  cluster_block="${cluster_block%$'\n'}"
 
   # One per HTTP filter chain in mitm_listener.
   #
@@ -199,10 +201,12 @@ EOF
   # Anchored to the start of the line so that prose mentioning a marker -- the
   # mitm_listener comment in the manifest names both of them -- is not itself
   # replaced by a config block.
-  awk -v filter="${filter_block}" -v cluster="${cluster_block}" \
-      -v want_filters="${expected_filter_markers}" '
-    /^[ \t]*#ATE_MITM_EXTPROC_FILTER/  { splice(filter);  filters++;  next }
-    /^[ \t]*#ATE_MITM_EXTPROC_CLUSTER/ { splice(cluster); clusters++; next }
+  # Blocks reach awk through the environment, not -v: the awk macOS ships
+  # rejects a newline inside a -v assignment.
+  ATE_FILTER_BLOCK="${filter_block}" ATE_CLUSTER_BLOCK="${cluster_block}" \
+  awk -v want_filters="${expected_filter_markers}" '
+    /^[ \t]*#ATE_MITM_EXTPROC_FILTER/  { splice(ENVIRON["ATE_FILTER_BLOCK"]);  filters++;  next }
+    /^[ \t]*#ATE_MITM_EXTPROC_CLUSTER/ { splice(ENVIRON["ATE_CLUSTER_BLOCK"]); clusters++; next }
     { print }
     END {
       if (filters != want_filters || clusters != 1) {


### PR DESCRIPTION
Fixes #1124

`hack/install-ate.sh` exits after one second and installs nothing on macOS, with no error saying so.

It sources `experimental-additional-egress-extproc.sh` unconditionally, and that file hits two things macOS's tools reject: bash 3.2 mis-parses the heredocs inside `$( )` because a comment in one holds an apostrophe, and awk refuses a newline inside a `-v` assignment. The first breaks every install, not only runs passing the experimental flag.

Both blocks now use `read -r -d ''` and reach awk through `ENVIRON[]`. Not "delete the apostrophe": three more are already in the file and only happen to pair up. `read` keeps the trailing newline `$( )` strips, hence the two `%$'\n'` lines — without them each spliced block gains a blank line.

Verified on macOS 26 (bash 3.2.57, awk 20200816) and a Linux container (bash 5.2.37, mawk 1.3.4). The manifest is byte-identical before and after on Linux, and identical on macOS to what Linux produces (56115 bytes all three). This does not make the experimental flag usable end to end on macOS — deploying a real ext_proc service is out of scope.

```
$ bash hack/install-ate-kind.sh --deploy-ate-system --store-backend=postgres \
    --experimental-use-sdsmint \
    --experimental-additional-egress-extproc-service=ate-system/extprocd:50051
hack/experimental-additional-egress-extproc.sh: line 96: unexpected EOF while looking for matching `)'
$ echo $?; kubectl -n ate-system get pods --no-headers | wc -l
2
0

$ bash hack/install-ate-kind.sh --deploy-ate-system --store-backend=postgres \
    --experimental-use-sdsmint \
    --experimental-additional-egress-extproc-service=ate-system/extprocd:50051
...
deployment "atenet-egress" successfully rolled out
$ echo $?; kubectl -n ate-system get cm atenet-egress -o yaml | grep -c additional_egress_ext_proc
0
5
```
