### PR TITLE
test(e2e): paginate resource lookups

### DIFF
--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -160,12 +160,15 @@ func TestActorSnapshotLifecycle(t *testing.T) {
 	if got := tagToUpdate.GetStatus().GetSnapshot().GetSnapshotUri(); got != wantTagURI.String() {
 		t.Errorf("tag snapshot URI = %q, want UID-based URI %q", got, wantTagURI)
 	}
-	listed, err := clients.SubstrateAPI.ListTags(ctx, &ateapipb.ListTagsRequest{Atespace: demoAtespace})
-	if err != nil {
-		t.Fatalf("failed to list Tags: %v", err)
-	}
+	tags := listAllPages(t, func(token string) ([]*ateapipb.Tag, string) {
+		resp, err := clients.SubstrateAPI.ListTags(ctx, &ateapipb.ListTagsRequest{Atespace: demoAtespace, PageToken: token})
+		if err != nil {
+			t.Fatalf("failed to list Tags: %v", err)
+		}
+		return resp.GetTags(), resp.GetNextPageToken()
+	})
 	found := false
-	for _, candidate := range listed.GetTags() {
+	for _, candidate := range tags {
 		if candidate.GetMetadata().GetName() == tagRef.GetName() {
 			found = true
 			break
@@ -726,13 +729,16 @@ func createActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj 
 		})
 	}()
 
-	listResp, err := clients.SubstrateAPI.ListActors(ctx, &ateapipb.ListActorsRequest{Atespace: demoAtespace})
-	if err != nil {
-		t.Fatalf("ListActors RPC failed: %v", err)
-	}
+	actors := listAllPages(t, func(token string) ([]*ateapipb.Actor, string) {
+		resp, err := clients.SubstrateAPI.ListActors(ctx, &ateapipb.ListActorsRequest{Atespace: demoAtespace, PageToken: token})
+		if err != nil {
+			t.Fatalf("ListActors RPC failed: %v", err)
+		}
+		return resp.GetActors(), resp.GetNextPageToken()
+	})
 
 	var myActors []*ateapipb.Actor
-	for _, actor := range listResp.GetActors() {
+	for _, actor := range actors {
 		if actor.GetActorTemplate().GetName() == at.GetMetadata().GetName() && actor.GetMetadata().GetName() == actorName {
 			myActors = append(myActors, actor)
 		}
@@ -755,7 +761,7 @@ func createActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj 
 	}
 
 	t.Logf("Successfully queried Substrate API. Found %d active actors total, %d from our template %s.",
-		len(listResp.GetActors()), len(myActors), at.GetMetadata().GetName())
+		len(actors), len(myActors), at.GetMetadata().GetName())
 
 	return nil
 }
@@ -1170,6 +1176,21 @@ func createActorTemplateWithTwoDurableDirs(ctx context.Context, t *testing.T, cl
 func hasStorageClass(ctx context.Context, clients *e2e.Clients, name string) bool {
 	_, err := clients.K8s.StorageV1().StorageClasses().Get(ctx, name, metav1.GetOptions{})
 	return err == nil
+}
+
+// listAllPages drains every page: results are ordered by name, so a
+// just-created resource can land on any page.
+func listAllPages[T any](t *testing.T, page func(token string) ([]T, string)) []T {
+	t.Helper()
+	var all []T
+	for token := ""; ; {
+		items, next := page(token)
+		all = append(all, items...)
+		if next == "" {
+			return all
+		}
+		token = next
+	}
 }
 
 func waitForActorState(ctx context.Context, t *testing.T, clients *e2e.Clients, actorName string, expectedState ateapipb.ActorState) {


### PR DESCRIPTION
Part of #1126

The demo e2e suite can report a newly created Tag or Actor as missing on a long-lived cluster even though the object exists.

`TestActorSnapshotLifecycle` called `ListTags` once, and `createActor` did the same with `ListActors`. Both APIs are paginated and name-ordered, so a newly created object can land after the first page.

Both checks now drain every page through one generic helper before searching the results. This changes only test assertions; product behavior is unchanged.

The ActorSnapshot resource and the original `ListActorSnapshots` failure described in #1126 were removed from `main` while this PR was pending. The rebased PR therefore retains only the two sibling pagination fixes that still exist.

The remaining pagination path requires more than one page and is not exercised by fresh CI clusters. The affected package still passes with the race detector:

```
ok  github.com/agent-substrate/substrate/internal/e2e/suites/demo  1.632s
```
