### PR TITLE
benchmarking: wait for worker pool rollout in deploy scripts

### DIFF
--- a/benchmarking/deploy_locust.sh
+++ b/benchmarking/deploy_locust.sh
@@ -31,6 +31,7 @@ SKIP_BUILD=0
 OTLP_ENDPOINT=""
 # Empty keeps the default in workloads/deploy.sh (256Mi, the microvm minimum).
 ACTOR_MEMORY=""
+WAIT_TIMEOUT=""
 
 usage() {
   echo "Usage: $0 [options]"
@@ -45,6 +46,8 @@ usage() {
   echo "                          instrumented actor container sends telemetry."
   echo "  --actor-memory SIZE     Forwarded to workloads/deploy.sh. Memory limit for the"
   echo "                          benchmark ActorTemplates (default: 256Mi, the microvm minimum)."
+  echo "  --wait-timeout DURATION Forwarded to workloads/deploy.sh. The timeout for waiting"
+  echo "                          for the ateom workers to be ready (default: 300s)"
   echo "  --skip-build            Skip locust image build/push (use the existing :latest image)"
   echo "  -h|--help               Show this help message"
   echo ""
@@ -71,6 +74,8 @@ while [[ "$#" -gt 0 ]]; do
     --otlp-endpoint=*) OTLP_ENDPOINT="${1#*=}" ;;
     --actor-memory) shift; ACTOR_MEMORY="$1" ;;
     --actor-memory=*) ACTOR_MEMORY="${1#*=}" ;;
+    --wait-timeout) shift; WAIT_TIMEOUT="$1" ;;
+    --wait-timeout=*) WAIT_TIMEOUT="${1#*=}" ;;
     --skip-build) SKIP_BUILD=1 ;;
     -h|--help) usage; exit 0 ;;
     *)
@@ -90,6 +95,11 @@ case "${SANDBOX_CLASS}" in
     ;;
 esac
 
+if [[ -n "${WAIT_TIMEOUT}" ]] && ! [[ "${WAIT_TIMEOUT}" =~ ^([0-9]+(h|m|s))+$ ]]; then
+  echo "Error: --wait-timeout must be a Go duration like 300s, 10m, or 1h30m, got '${WAIT_TIMEOUT}'" >&2
+  exit 1
+fi
+
 if [[ "${action}" == "deploy" ]]; then
   echo "=== Deploying benchmark workloads (worker_count=${WORKER_COUNT}, sandbox_class=${SANDBOX_CLASS}) ==="
   # An empty OTLP_ENDPOINT must not become an empty --otlp-endpoint argument,
@@ -101,6 +111,9 @@ if [[ "${action}" == "deploy" ]]; then
   fi
   if [[ -n "${ACTOR_MEMORY}" ]]; then
     workload_args+=(--actor-memory "${ACTOR_MEMORY}")
+  fi
+  if [[ -n "${WAIT_TIMEOUT}" ]]; then
+    workload_args+=(--wait-timeout "${WAIT_TIMEOUT}")
   fi
   "${BENCHMARKING_DIR}/workloads/deploy.sh" "${workload_args[@]}"
 

--- a/benchmarking/workloads/deploy.sh
+++ b/benchmarking/workloads/deploy.sh
@@ -47,6 +47,8 @@ ACTOR_MEMORY="256Mi"
 # --otlp-endpoint sets it. Without the flag, resolve_otlp_endpoint reads the
 # address that the control plane uses.
 OTLP_ENDPOINT=""
+# The timeout for waiting for the ateom worker pods to be ready.
+WAIT_TIMEOUT="300s"
 
 usage() {
   echo "Usage: $0 [options]"
@@ -62,6 +64,7 @@ usage() {
   echo "  --otlp-endpoint URL         The address to which an instrumented actor container"
   echo "                              sends telemetry (default: the endpoint in the"
   echo "                              ate-otel-config ConfigMap)"
+  echo "  --wait-timeout DURATION     The timeout for waiting for the ateom workers to be ready (default: 300s)"
   echo "  -h, --help                  Show this help message"
 }
 
@@ -118,6 +121,11 @@ deploy() {
   kubectl delete actortemplate --namespace=benchmark-workloads \
     --all --ignore-not-found
   substitute | hack/run-tool.sh ko apply -f -
+  echo "Waiting for worker pool to be ready (timeout: ${WAIT_TIMEOUT})..."
+  kubectl wait --for=create deployment/benchmark-ateom \
+    --namespace=benchmark-workloads --timeout="${WAIT_TIMEOUT}"
+  kubectl rollout status deployment/benchmark-ateom \
+    --namespace=benchmark-workloads --timeout="${WAIT_TIMEOUT}"
 }
 
 delete() {
@@ -169,6 +177,13 @@ while [[ "$#" -gt 0 ]]; do
     --actor-memory=*)
       ACTOR_MEMORY="${1#*=}"
       ;;
+    --wait-timeout)
+      shift
+      WAIT_TIMEOUT="$1"
+      ;;
+    --wait-timeout=*)
+      WAIT_TIMEOUT="${1#*=}"
+      ;;
     -h|--help)
       usage
       exit 0
@@ -189,6 +204,11 @@ case "${SANDBOX_CLASS}" in
     exit 1
     ;;
 esac
+
+if ! [[ "${WAIT_TIMEOUT}" =~ ^([0-9]+(h|m|s))+$ ]]; then
+  echo "Error: --wait-timeout must be a Go duration like 300s, 10m, or 1h30m, got '${WAIT_TIMEOUT}'" >&2
+  exit 1
+fi
 
 if [[ "${action}" == "deploy" ]]; then
   deploy


### PR DESCRIPTION
## Summary

Wait for the benchmark worker pool deployment to roll out before returning from `benchmarking/workloads/deploy.sh`, preventing downstream suites from racing against unready workers.

## Key Changes

- **Rollout Wait:** Added `kubectl wait --for=create` followed by `kubectl rollout status` on `deployment/benchmark-ateom` in `benchmarking/workloads/deploy.sh`.
- **Configurable Timeout:** Added `--wait-timeout DURATION` flag (default: `300s`) to `workloads/deploy.sh` and forwarded it through `deploy_locust.sh`.
- **Validation:** Added duration regex validation (`^([0-9]+(h|m|s))+$`) to catch invalid formats/missing units early.

## Testing

- Verified successful rollout wait on GKE: `deploy.sh --deploy --worker-count 2 --wait-timeout 300s`
- Verified timeout failure handling: `deploy.sh --deploy --worker-count 5 --wait-timeout 1s`
- Verified flag validation rejects invalid formats (`180`, `0`, `invalid`).

