### PR TITLE
e2e flakes: wait out worker-pool saturation when resuming actors

### DIFF
--- a/internal/e2e/resume.go
+++ b/internal/e2e/resume.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// resumeCapacityWait bounds how long ResumeActorAwaitCapacity waits for a
+// worker to free up. Neighboring suites hold workers for the length of a
+// test, so this covers several of their actor lifetimes.
+const resumeCapacityWait = 90 * time.Second
+
+// ResumeActorAwaitCapacity resumes the actor, retrying while its worker pool
+// is saturated. The control plane returns ResourceExhausted when no worker
+// is free and expects callers to wait (the router's parking resumer retries
+// the same condition); suites running concurrently against shared pools make
+// that a normal state in e2e, not a failure. Any other error, or saturation
+// outlasting the wait budget, is returned to the caller. Each retry is
+// logged so a pass that had to wait stays visible in the test output.
+func ResumeActorAwaitCapacity(t *testing.T, ctx context.Context, clients *Clients, req *ateapipb.ResumeActorRequest) (*ateapipb.ResumeActorResponse, error) {
+	t.Helper()
+	deadline := time.Now().Add(resumeCapacityWait)
+	for {
+		resp, err := clients.SubstrateAPI.ResumeActor(ctx, req)
+		if status.Code(err) != codes.ResourceExhausted || time.Now().After(deadline) {
+			return resp, err
+		}
+		t.Logf("ResumeActor %s/%s: pool saturated (%v); retrying", req.GetActor().GetAtespace(), req.GetActor().GetName(), err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}

--- a/internal/e2e/suites/capabilities/capabilities_test.go
+++ b/internal/e2e/suites/capabilities/capabilities_test.go
@@ -208,7 +208,7 @@ func createAndResumeActor(t *testing.T, ctx context.Context, clients *e2e.Client
 		_, _ = clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{Actor: &ateapipb.ObjectRef{Atespace: namespace, Name: id}})
 	})
 
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: namespace, Name: id},
 	}); err != nil {
 		t.Fatalf("ResumeActor %q: %v", id, err)

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -124,7 +124,7 @@ func TestActorSnapshotLifecycle(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("failed to create source Actor: %v", err)
 	}
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: sourceName}}); err != nil {
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: sourceName}}); err != nil {
 		t.Fatalf("failed to resume source Actor: %v", err)
 	}
 	waitForActorState(ctx, t, clients, sourceName, ateapipb.ActorState_ACTOR_STATE_RUNNING)
@@ -193,7 +193,7 @@ func TestActorSnapshotLifecycle(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("failed to create Actor from snapshot tag: %v", err)
 	}
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: cloneName}}); err != nil {
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: cloneName}}); err != nil {
 		t.Fatalf("failed to resume cloned Actor: %v", err)
 	}
 	waitForActorState(ctx, t, clients, cloneName, ateapipb.ActorState_ACTOR_STATE_RUNNING)
@@ -464,7 +464,7 @@ func TestDeleteActorAnyStateWithExternalVolume(t *testing.T) {
 	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
 
 	t.Logf("Resuming Actor %q...", actorName)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
@@ -584,7 +584,7 @@ func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(
 
 	// Resuming the actor
 	t.Logf("Resuming Actor %q...", actorID)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
@@ -613,7 +613,7 @@ func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(
 
 	// Resuming the actor
 	t.Logf("Resuming Actor %q again...", actorID)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor again: %v", err)
@@ -669,7 +669,7 @@ func runActorLifecycleTestCase(t *testing.T, prefix string, createTemplate func(
 
 	// Resuming the actor
 	t.Logf("Resuming Actor %q again...", actorID)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor again: %v", err)
@@ -803,7 +803,7 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 
 	// Resuming the actor
 	t.Logf("Resuming Actor %q...", actorName)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
@@ -828,7 +828,7 @@ func pauseActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj *
 
 	// Resuming the actor again
 	t.Logf("Resuming Actor %q again...", actorName)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor again: %v", err)
@@ -883,7 +883,7 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 
 	// Resuming the actor
 	t.Logf("Resuming Actor %q...", actorName)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
@@ -907,7 +907,7 @@ func suspendActor(ctx context.Context, t *testing.T, clients *e2e.Clients, nsObj
 
 	// Resuming the actor again
 	t.Logf("Resuming Actor %q again...", actorName)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor again: %v", err)
@@ -981,7 +981,7 @@ func deleteActorAnyState(ctx context.Context, t *testing.T, clients *e2e.Clients
 	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
 
 	t.Logf("Resuming Actor %q...", actorName)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
@@ -1055,7 +1055,7 @@ func deletePausedActorAnyState(ctx context.Context, t *testing.T, clients *e2e.C
 
 	// 2. Resuming the actor
 	t.Logf("Resuming Actor %q...", actorName)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
@@ -1472,7 +1472,7 @@ func TestWorkerPodDeletion(t *testing.T) {
 
 	// Resuming the actor
 	t.Logf("Resuming Actor %q...", actorName)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)

--- a/internal/e2e/suites/demo/termination_test.go
+++ b/internal/e2e/suites/demo/termination_test.go
@@ -66,7 +66,7 @@ func TestGracefulWorkerTermination(t *testing.T) {
 	}()
 
 	// Bring the actor up on a worker so it is bound to a pod.
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
@@ -177,7 +177,7 @@ func TestGracefulWorkerTerminationTimeout(t *testing.T) {
 	}()
 
 	// Bring the actor up on a worker so it is bound to a pod.
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)
@@ -264,7 +264,7 @@ func TestGracefulWorkerTerminationSuspend(t *testing.T) {
 	}()
 
 	// Bring the actor up on a worker so it is bound to a pod.
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)

--- a/internal/e2e/suites/identity/identity_test.go
+++ b/internal/e2e/suites/identity/identity_test.go
@@ -143,7 +143,7 @@ func TestActorIdentity_AfterRestore_IsOwnID_NotGolden(t *testing.T) {
 		t.Fatalf("SuspendActor %q: %v", id, err)
 	}
 	waitForActorState(t, ctx, clients, id, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: ref}); err != nil {
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{Actor: ref}); err != nil {
 		t.Fatalf("ResumeActor %q (after suspend): %v", id, err)
 	}
 	waitForActorState(t, ctx, clients, id, ateapipb.ActorState_ACTOR_STATE_RUNNING)
@@ -241,7 +241,7 @@ func createAndResumeActor(t *testing.T, ctx context.Context, clients *e2e.Client
 	})
 
 	// Resume from the golden snapshot (the restore path, not --boot).
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: probeNamespace, Name: id}}); err != nil {
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: probeNamespace, Name: id}}); err != nil {
 		t.Fatalf("ResumeActor %q: %v", id, err)
 	}
 }

--- a/internal/e2e/suites/imagevolume/imagevolume_test.go
+++ b/internal/e2e/suites/imagevolume/imagevolume_test.go
@@ -251,7 +251,7 @@ func TestImageVolume(t *testing.T) {
 		_, _ = clients.SubstrateAPI.DeleteActor(cleanupCtx, &ateapipb.DeleteActorRequest{Actor: actorRef.ToObjectRef()})
 	})
 
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef.ToObjectRef()}); err != nil {
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{Actor: actorRef.ToObjectRef()}); err != nil {
 		t.Fatalf("ResumeActor: %v", err)
 	}
 

--- a/internal/e2e/suites/metrics/metrics_test.go
+++ b/internal/e2e/suites/metrics/metrics_test.go
@@ -321,7 +321,7 @@ func triggerActorCrash(t *testing.T, ctx context.Context, clients *e2e.Clients, 
 
 func resume(t *testing.T, ctx context.Context, clients *e2e.Clients, actorID string) {
 	t.Helper()
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: metricsAtespace, Name: actorID},
 	}); err != nil {
 		t.Fatalf("ResumeActor: %v", err)

--- a/internal/e2e/suites/networking/networking_test.go
+++ b/internal/e2e/suites/networking/networking_test.go
@@ -238,7 +238,7 @@ func createAndResumeActor(t *testing.T, ctx context.Context, prefix string, temp
 		_, _ = clients.SubstrateAPI.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{Actor: actorRef})
 	})
 
-	resumeResponse, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef})
+	resumeResponse, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{Actor: actorRef})
 	if err != nil {
 		t.Fatalf("ResumeActor: %v", err)
 	}

--- a/internal/e2e/suites/networkpolicy/networkpolicy_test.go
+++ b/internal/e2e/suites/networkpolicy/networkpolicy_test.go
@@ -173,7 +173,7 @@ func TestNetworkPolicyDataPlaneEnforcement(t *testing.T) {
 	}()
 
 	t.Logf("Resuming Actor %q...", actorName)
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
 		Actor: &ateapipb.ObjectRef{Atespace: nsObj.Name, Name: actorName},
 	}); err != nil {
 		t.Fatalf("failed to resume Actor: %v", err)

--- a/internal/e2e/suites/sizing/sizing_test.go
+++ b/internal/e2e/suites/sizing/sizing_test.go
@@ -178,7 +178,7 @@ func createAndResumeActor(t *testing.T, ctx context.Context, clients *e2e.Client
 	})
 
 	// Resume from the golden snapshot (the restore path, not --boot).
-	if _, err := clients.SubstrateAPI.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: sizingNamespace, Name: id}}); err != nil {
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{Actor: &ateapipb.ObjectRef{Atespace: sizingNamespace, Name: id}}); err != nil {
 		t.Fatalf("ResumeActor %q: %v", id, err)
 	}
 }


### PR DESCRIPTION
## Problem

`ResumeActor` returns `ResourceExhausted` ("no free workers available") when the target pool has no free worker. The control plane treats this as a transient condition callers should wait out — the router's parking resumer (`cmd/atenet/internal/router/ingress/resumer.go`) retries exactly this error within its parking budget. The e2e suites are the only resume caller that treats it as fatal.

Since suite packages run concurrently (up to `GOMAXPROCS`) and some share pools (the demo and metrics suites both drive the 3-worker counter demo pool), any unlucky timing overlap fails a lifecycle test on the spot. This is currently the most frequent flake signature in the e2e lane: recent failed main-branch runs contain 50+ occurrences each (e.g. runs [32516335516](https://github.com/agent-substrate/substrate/actions/runs/32516335516), [32429542405](https://github.com/agent-substrate/substrate/actions/runs/32429542405)), and it also produced red runs on #941 for code it doesn't touch.

## Change

- New `e2e.ResumeActorAwaitCapacity(t, ctx, clients, req)`: calls `ResumeActor` and retries only `ResourceExhausted`, every 2s within a 90s budget (several neighbor-suite actor lifetimes). Every retry is `t.Logf`'d so a pass that had to wait stays visible in the output — the helper hides the coin-flip, not a capacity regression. Any other error, or saturation outlasting the budget, returns to the caller unchanged.
- Mechanical sweep of the 24 resume call sites whose intent is "get the actor running" (demo, termination, metrics, capabilities, identity, networking, sizing, imagevolume, networkpolicy).

## Deliberately not swept

- The **parking suite**: park-on-saturation is the behavior it exists to test; its calls stay raw.
- sdsmint's `createLiveActor`: the helper is deliberately `*testing.T`-free (error-returning), and the suite skips in presubmit lanes; not worth replumbing for the retry.

Scope note: this only removes the `ResourceExhausted` flake class. The lane's other pre-existing failure class (sandbox processes killed under node memory pressure) is separate and tracked independently.