### PR TITLE
microvm: find a restored actor's CH api-socket without ateom's record

### DIFF
--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -105,11 +105,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	// The actor's CH was booted by RunWorkload or relaunched by RestoreWorkload;
 	// either way ateom owns it and tracks its api-socket.
 	ra := s.running[actorUID]
-	chSocket := kata.CLHSocketPath(actorUID)
-	if ra != nil && ra.apiSocket != "" {
-		chSocket = ra.apiSocket
-	}
-	client := ch.NewClient(chSocket)
+	client := ch.NewClient(chSocketFor(actorUID, ra))
 	if _, err := client.WaitReady(ctx, 10*time.Second); err != nil {
 		return nil, fmt.Errorf("while waiting for CH api-socket: %w", err)
 	}
@@ -266,6 +262,34 @@ func (s *AteomService) snapshotVMState(ctx context.Context, client *ch.Client, r
 	return dSnapshot, nil
 }
 
+// chSocketFor returns the actor's recorded API socket, or the first existing candidate
+// path on disk when ateom has no in-memory state for the actor (e.g. after a restart).
+func chSocketFor(actorUID string, ra *runningActor) string {
+	return firstExistingPath(chSocketCandidates(actorUID, ra))
+}
+
+// chSocketCandidates returns potential API socket paths for the actor.
+func chSocketCandidates(actorUID string, ra *runningActor) []string {
+	if ra != nil && ra.apiSocket != "" {
+		return []string{ra.apiSocket}
+	}
+	return []string{kata.CLHSocketPath(actorUID), kata.RestoredCLHSocketPath(actorUID)}
+}
+
+// firstExistingPath returns the first existing path among candidates, or the
+// first candidate if none exist on disk.
+func firstExistingPath(candidates []string) string {
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
+}
+
 // listFiles returns the (relative) names of regular files directly under dir.
 func listFiles(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
@@ -374,11 +398,7 @@ func (s *AteomService) terminateWorkload(ctx context.Context, actorUID string) e
 	}
 
 	ra := s.running[actorUID]
-	chSocket := kata.CLHSocketPath(actorUID)
-	if ra != nil && ra.apiSocket != "" {
-		chSocket = ra.apiSocket
-	}
-	client := ch.NewClient(chSocket)
+	client := ch.NewClient(chSocketFor(actorUID, ra))
 
 	if err := s.teardownActor(ctx, actorUID, ra, client); err != nil {
 		errs = append(errs, fmt.Errorf("while tearing down actor: %w", err))

--- a/cmd/ateom-microvm/checkpoint_test.go
+++ b/cmd/ateom-microvm/checkpoint_test.go
@@ -1,0 +1,113 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
+)
+
+func TestChSocketCandidates(t *testing.T) {
+	const uid = "actor-123"
+
+	for _, tc := range []struct {
+		name string
+		ra   *runningActor
+		want []string
+	}{
+		{
+			name: "with recorded apiSocket",
+			ra:   &runningActor{apiSocket: "/custom/path/clh.sock"},
+			want: []string{"/custom/path/clh.sock"},
+		},
+		{
+			name: "nil runningActor fallback",
+			ra:   nil,
+			want: []string{kata.CLHSocketPath(uid), kata.RestoredCLHSocketPath(uid)},
+		},
+		{
+			name: "empty apiSocket fallback",
+			ra:   &runningActor{apiSocket: ""},
+			want: []string{kata.CLHSocketPath(uid), kata.RestoredCLHSocketPath(uid)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := chSocketCandidates(uid, tc.ra); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("chSocketCandidates(%q, %v) = %v, want %v", uid, tc.ra, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFirstExistingPath(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		candidates []string
+		existing   []string
+		want       string
+	}{
+		{
+			name:       "nil candidates",
+			candidates: nil,
+			want:       "",
+		},
+		{
+			name:       "none existing returns first candidate",
+			candidates: []string{"sock1", "sock2"},
+			want:       "sock1",
+		},
+		{
+			name:       "second candidate exists",
+			candidates: []string{"sock1", "sock2"},
+			existing:   []string{"sock2"},
+			want:       "sock2",
+		},
+		{
+			name:       "first candidate takes priority when both exist",
+			candidates: []string{"sock1", "sock2"},
+			existing:   []string{"sock1", "sock2"},
+			want:       "sock1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tc.existing {
+				if err := os.WriteFile(filepath.Join(dir, f), nil, 0o600); err != nil {
+					t.Fatalf("failed to create dummy file: %v", err)
+				}
+			}
+			var fullCandidates []string
+			if tc.candidates != nil {
+				fullCandidates = make([]string, len(tc.candidates))
+				for i, c := range tc.candidates {
+					fullCandidates[i] = filepath.Join(dir, c)
+				}
+			}
+			want := ""
+			if tc.want != "" {
+				want = filepath.Join(dir, tc.want)
+			}
+			if got := firstExistingPath(fullCandidates); got != want {
+				t.Errorf("firstExistingPath(%v) = %q, want %q", fullCandidates, got, want)
+			}
+		})
+	}
+}

--- a/cmd/ateom-microvm/internal/kata/kata.go
+++ b/cmd/ateom-microvm/internal/kata/kata.go
@@ -31,9 +31,12 @@ import (
 // cloud-hypervisor API socket and the hybrid-vsock socket).
 const vcVMDir = "/run/vc/vm"
 
-// CLHSocketPath returns the default cloud-hypervisor API socket path for the
-// sandbox with the given id (the per-sandbox runtime dir). ateom records the
-// actual api-socket it launched the VMM on, but uses this as the fallback.
+// CLHSocketPath returns the cloud-hypervisor API socket path for a booted actor.
 func CLHSocketPath(id string) string {
 	return filepath.Join(vcVMDir, id, "clh-api.sock")
+}
+
+// RestoredCLHSocketPath returns the cloud-hypervisor API socket path for a restored actor.
+func RestoredCLHSocketPath(id string) string {
+	return filepath.Join(vcVMDir, id, "clh-api-restore.sock")
 }

--- a/cmd/ateom-microvm/internal/kata/kata_test.go
+++ b/cmd/ateom-microvm/internal/kata/kata_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kata
+
+import "testing"
+
+func TestSocketPaths(t *testing.T) {
+	const id = "test-sandbox-id"
+
+	if got, want := CLHSocketPath(id), "/run/vc/vm/test-sandbox-id/clh-api.sock"; got != want {
+		t.Errorf("CLHSocketPath(%q) = %q, want %q", id, got, want)
+	}
+
+	if got, want := RestoredCLHSocketPath(id), "/run/vc/vm/test-sandbox-id/clh-api-restore.sock"; got != want {
+		t.Errorf("RestoredCLHSocketPath(%q) = %q, want %q", id, got, want)
+	}
+}

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -325,7 +325,7 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 
 	// Relaunch CH and restore with the tap FDs attached (SCM_RIGHTS). CH reopens
 	// /dev/vda (image) + each /dev/vd{b+i} (actor rootfs) from the snapshot config paths.
-	apiSocket := filepath.Join(kata.VMDir(actorUID), "clh-api-restore.sock")
+	apiSocket := kata.RestoredCLHSocketPath(actorUID)
 	tTap := time.Now()
 	chCmd, client, err := ch.LaunchVMM(ctx, ch.LaunchVMMOptions{
 		Binary: rr.chBinary, APISocket: apiSocket, Stdout: slogWriter{ctx}, Stderr: slogWriter{ctx},

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -488,7 +488,7 @@ func (s *AteomService) coldBootActor(ctx context.Context, p actorBootParams) (re
 	}()
 
 	// Launch a bare VMM (CH + api-socket); ateom owns this process for teardown.
-	apiSocket := filepath.Join(kata.VMDir(actorUID), "clh-api.sock")
+	apiSocket := kata.CLHSocketPath(actorUID)
 	chCmd, client, err := ch.LaunchVMM(ctx, ch.LaunchVMMOptions{
 		Binary:    rr.chBinary,
 		APISocket: apiSocket,


### PR DESCRIPTION
Towards #372

When `ateom` restarts, it loses in-memory actor records and falls back to socket lookup on disk. Restored actors listen on `clh-api-restore.sock` rather than `clh-api.sock`, causing `terminateWorkload` to miss the VMM (leaving orphan guests running) and `CheckpointWorkload` to time out.

This change:
- Uses `chSocketFor` to probe disk for whichever API socket exists when no in-memory record is present.
- Adds `kata.RestoredCLHSocketPath` alongside `kata.CLHSocketPath` for consistent socket naming across launch, restore, and teardown.

AI has assisted with this PR and I have verified all the changes.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR