### PR TITLE
atelet: serialize node-local operations per actor

### DIFF
--- a/cmd/atelet/actorlocks.go
+++ b/cmd/atelet/actorlocks.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// actorLocks serializes concurrent node-local operations for the same actor.
+// The zero value is ready to use.
+type actorLocks struct {
+	mu   sync.Mutex
+	held map[string]struct{}
+}
+
+// tryLock attempts to acquire the lock for actorUID without blocking.
+// It returns ok=true and an idempotent release func on success, or a no-op func and ok=false if busy.
+func (l *actorLocks) tryLock(actorUID string) (release func(), ok bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, busy := l.held[actorUID]; busy {
+		return func() {}, false
+	}
+	if l.held == nil {
+		l.held = map[string]struct{}{}
+	}
+	l.held[actorUID] = struct{}{}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			l.mu.Lock()
+			defer l.mu.Unlock()
+			delete(l.held, actorUID)
+		})
+	}, true
+}
+
+// lockActorFor acquires the lock for actorUID or returns codes.Aborted if another
+// operation for the same actor is already in progress.
+func (s *AteomHerder) lockActorFor(operation, actorUID string) (release func(), _ error) {
+	release, ok := s.actorLocks.tryLock(actorUID)
+	if !ok {
+		return nil, status.Errorf(codes.Aborted, "cannot start %s for actor %s: another operation on this actor is already in progress on this node", operation, actorUID)
+	}
+	return release, nil
+}

--- a/cmd/atelet/actorlocks_test.go
+++ b/cmd/atelet/actorlocks_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestActorLocks(t *testing.T) {
+	var l actorLocks
+
+	releaseA1, ok := l.tryLock("actor-a")
+	if !ok {
+		t.Fatal("tryLock on a free actor returned false")
+	}
+	if _, ok := l.tryLock("actor-a"); ok {
+		t.Error("tryLock on a held actor returned true")
+	}
+
+	// Locks are per actor: a busy actor must not block any other.
+	releaseB, ok := l.tryLock("actor-b")
+	if !ok {
+		t.Error("tryLock on a different actor returned false")
+	}
+	releaseB()
+
+	// Holder 1 releases the lock.
+	releaseA1()
+
+	// Holder 2 acquires the lock for the same actor.
+	releaseA2, ok := l.tryLock("actor-a")
+	if !ok {
+		t.Fatal("tryLock after release returned false")
+	}
+	defer releaseA2()
+
+	// Idempotency: a second release from Holder 1 must not free Holder 2's claim.
+	releaseA1()
+	if _, ok := l.tryLock("actor-a"); ok {
+		t.Error("stale release from earlier holder freed a later holder's lock")
+	}
+
+	// Released entries are dropped rather than accumulating one per actor seen.
+	l.mu.Lock()
+	held := len(l.held)
+	l.mu.Unlock()
+	if held != 1 {
+		t.Errorf("held = %d entries, want 1 (only the outstanding lock)", held)
+	}
+}
+
+func TestActorLocks_ConcurrentContention(t *testing.T) {
+	var l actorLocks
+	const goroutines = 20
+	const iterations = 100
+	const actorUID = "actor-contended"
+
+	var wg sync.WaitGroup
+	var activeHolders atomic.Int32
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				release, ok := l.tryLock(actorUID)
+				if !ok {
+					continue
+				}
+				curr := activeHolders.Add(1)
+				if curr > 1 {
+					t.Errorf("multiple goroutines held the lock concurrently: %d", curr)
+				}
+
+				activeHolders.Add(-1)
+				release()
+				release() // test idempotency under concurrency
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// All entries should be released.
+	l.mu.Lock()
+	held := len(l.held)
+	l.mu.Unlock()
+	if held != 0 {
+		t.Errorf("held = %d entries after all releases, want 0", held)
+	}
+}

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -429,6 +429,9 @@ type AteomHerder struct {
 	volumePlugins            map[string]volume.VolumePluginWorkerPlane
 	csiDriverConfigLister    listersv1alpha1.CSIDriverConfigLister
 	clusterTrustBundleLister certlisters.ClusterTrustBundleLister
+
+	// Serializes node-local operations per actor.
+	actorLocks actorLocks
 }
 
 var _ ateletpb.AteomHerderServer = (*AteomHerder)(nil)
@@ -467,6 +470,13 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (resp *
 
 	actorUID := req.GetActorUid()
 	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
+
+	// Serialize node-local operations per actor.
+	release, err := s.lockActorFor("run", actorUID)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	sandboxRec, err := recordFromRequest(req.GetSandboxAssets())
 	if err != nil {
@@ -575,6 +585,13 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 
 	actorUID := req.GetActorUid()
 	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
+
+	// Serialize node-local operations per actor.
+	release, err := s.lockActorFor("checkpoint", actorUID)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	// Per-phase timing, recorded on the way out so a failed checkpoint still
 	// reports the phases it completed. Phases left at zero never ran.
@@ -811,6 +828,13 @@ func (s *AteomHerder) UploadPausedCheckpoint(ctx context.Context, req *ateletpb.
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	// Serialize node-local operations per actor.
+	release, err := s.lockActorFor("paused-checkpoint upload", req.GetActorUid())
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	tStart := time.Now()
 	var dPersist time.Duration
 	op := snapshotOp{
@@ -941,6 +965,13 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 
 	actorUID := req.GetActorUid()
 	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
+
+	// Serialize node-local operations per actor.
+	release, err := s.lockActorFor("restore", actorUID)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	// Per-step timing so we can attribute resume latency between the rustfs
 	// download/decompress, the OCI image unpack, and ateom's own work. Logged at
@@ -1224,6 +1255,13 @@ func (s *AteomHerder) Terminate(ctx context.Context, req *ateletpb.TerminateRequ
 
 	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
 	actorUID := req.GetActorUid()
+
+	// Serialize node-local operations per actor.
+	release, err := s.lockActorFor("terminate", actorUID)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	var assetPaths map[string]string
 	sandboxRec, err := readSandboxRecord(actorUID)

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -418,6 +418,18 @@ func validCheckpointRequest() *ateletpb.CheckpointRequest {
 	}
 }
 
+func validTerminateRequest() *ateletpb.TerminateRequest {
+	return &ateletpb.TerminateRequest{
+		Atespace:               "ate-demo",
+		ActorName:              "counter-1",
+		ActorTemplateNamespace: "ate-demo",
+		ActorTemplateName:      "counter",
+		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
+		ActorUid:               "123e4567-e89b-12d3-a456-426614174000",
+		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
+	}
+}
+
 func validRestoreRequest() *ateletpb.RestoreRequest {
 	return &ateletpb.RestoreRequest{
 		Atespace:               "ate-demo",
@@ -1962,6 +1974,89 @@ func TestShouldHaveSnapshots(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := shouldHaveSnapshots(tc.req); got != tc.want {
 				t.Errorf("shouldHaveSnapshots() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func useTempActorsDir(t *testing.T) {
+	t.Helper()
+	orig := ateompath.ActorsDir
+	t.Cleanup(func() { ateompath.ActorsDir = orig })
+	ateompath.ActorsDir = t.TempDir()
+}
+
+// Test that a concurrent checkpoint for the same actor is rejected with Aborted.
+func TestCheckpointRejectsConcurrentAttemptForSameActor(t *testing.T) {
+	useTempActorsDir(t)
+	s := &AteomHerder{gcsClient: &recordingObjectStorage{}}
+
+	req := validCheckpointRequest()
+	release, ok := s.actorLocks.tryLock(req.GetActorUid())
+	if !ok {
+		t.Fatal("could not take the actor lock to stand in for an in-flight checkpoint")
+	}
+	defer release()
+
+	_, err := s.Checkpoint(context.Background(), req)
+	if status.Code(err) != codes.Aborted {
+		t.Errorf("Checkpoint code = %v (err=%v), want %v", status.Code(err), err, codes.Aborted)
+	}
+	if ateerrors.ActorCrashRequested(err) {
+		t.Error("the concurrent-attempt rejection asks the control plane to crash the actor")
+	}
+
+	// A checkpoint for a different actor is unaffected.
+	other := validCheckpointRequest()
+	other.ActorUid = "123e4567-e89b-12d3-a456-426614174001"
+	if _, err := s.Checkpoint(context.Background(), other); status.Code(err) == codes.Aborted {
+		t.Error("a checkpoint for a different actor was rejected as concurrent")
+	}
+}
+
+// Test that other node-local operations for a locked actor are rejected with Aborted.
+func TestActorLockExcludesTheOtherNodeLocalOperations(t *testing.T) {
+	ctx := context.Background()
+	const actorUID = "123e4567-e89b-12d3-a456-426614174000"
+
+	tests := []struct {
+		name string
+		call func(*AteomHerder) error
+	}{
+		{"Run", func(s *AteomHerder) error {
+			_, err := s.Run(ctx, validRunRequest())
+			return err
+		}},
+		{"Restore", func(s *AteomHerder) error {
+			_, err := s.Restore(ctx, validRestoreRequest())
+			return err
+		}},
+		{"UploadPausedCheckpoint", func(s *AteomHerder) error {
+			_, err := s.UploadPausedCheckpoint(ctx, validUploadPausedCheckpointRequest())
+			return err
+		}},
+		{"Terminate", func(s *AteomHerder) error {
+			_, err := s.Terminate(ctx, validTerminateRequest())
+			return err
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			useTempActorsDir(t)
+			s := &AteomHerder{gcsClient: &recordingObjectStorage{}}
+
+			release, ok := s.actorLocks.tryLock(actorUID)
+			if !ok {
+				t.Fatal("could not take the actor lock to stand in for an in-flight checkpoint")
+			}
+			defer release()
+
+			err := tt.call(s)
+			if status.Code(err) != codes.Aborted {
+				t.Errorf("%s code = %v (err=%v), want %v", tt.name, status.Code(err), err, codes.Aborted)
+			}
+			if ateerrors.ActorCrashRequested(err) {
+				t.Errorf("%s's concurrent-operation rejection asks the control plane to crash the actor", tt.name)
 			}
 		})
 	}


### PR DESCRIPTION
Towards #372 

Serializes node-local operations (Run, Checkpoint, UploadPausedCheckpoint, Restore, Terminate) on a per-actor basis in atelet to prevent concurrent operations from interfering with each other's on-disk state (e.g. reading or wiping checkpoint directories concurrently).

- [X] Tests pass
- [ ] Appropriate changes to documentation are included in the PR

---
