### PR TITLE
ateapi: move the ActorTemplate functional test into functionaltest (fix test build)

### DIFF
--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_template_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_template_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controlapi
+package functionaltest
 
 import (
 	"context"


### PR DESCRIPTION
The test calls `setupTest`, `namespaceForTest` and `assertGrpcError`, which are defined in the `functionaltest` package, but the file landed in `controlapi` declaring package `controlapi`, so the `controlapi` test binary did not build.

This code passed on the PR branch, but it logically conflicted with a previous refactor without merge conflict.


> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
