### PR TITLE
Have worker deploy script wait for worker availability

### DIFF
--- a/benchmarking/automation/orchestrator.py
+++ b/benchmarking/automation/orchestrator.py
@@ -328,7 +328,10 @@ def teardown_microvm_deps() -> None:
 
 
 def deploy_workloads(
-    worker_count: int = 1, sandbox_class: str = "gvisor", actor_memory: str = ""
+    worker_count: int = 1,
+    sandbox_class: str = "gvisor",
+    actor_memory: str = "",
+    wait_timeout: str = "",
 ) -> None:
     cmd = [
         "benchmarking/workloads/deploy.sh",
@@ -342,6 +345,9 @@ def deploy_workloads(
     # minimum); RAM-consuming suites set actorMemory in tests.yaml.
     if actor_memory:
         cmd += ["--actor-memory", actor_memory]
+    # Empty keeps deploy.sh's own default; large fleets set workerWaitTimeout.
+    if wait_timeout:
+        cmd += ["--wait-timeout", wait_timeout]
     run(cmd)
     # Block until ActorTemplates are Ready
     run(
@@ -528,6 +534,7 @@ def main() -> None:
                     test.get("workerCount", 1),
                     sandbox_class,
                     test.get("actorMemory", ""),
+                    test.get("workerWaitTimeout", ""),
                 )
                 try:
                     status = run_test(

--- a/benchmarking/automation/tests.yaml
+++ b/benchmarking/automation/tests.yaml
@@ -35,6 +35,12 @@
 #   actorMemory    Optional (default "256Mi", the smallest size microvm
 #                  admits). Memory limit on the benchmark ActorTemplates;
 #                  raise it for suites that exercise glutton's WriteRAM path.
+#   workerWaitTimeout
+#                  Optional (default "300s", set by workloads/deploy.sh).
+#                  Go duration for the wait after the WorkerPool deploy for
+#                  the ateom worker pods to become ready. Raise it for
+#                  large workerCount fleets whose image pulls or scheduling
+#                  outrun the default.
 #   ateArgs        Optional. List of strings appended verbatim to
 #                  `hack/install-ate.sh --deploy-ate-system` when this
 #                  test's substrate is deployed (e.g. ["--atenet-router=agentgateway"]


### PR DESCRIPTION
For large numbers of workers, we should be able to have custom waits