### PR TITLE
atelet: parallel snapshot upload

### DIFF
--- a/cmd/atelet/internal/ategcs/gcs.go
+++ b/cmd/atelet/internal/ategcs/gcs.go
@@ -15,6 +15,7 @@
 package ategcs
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -52,32 +53,31 @@ func (g *gcsClient) GetObject(ctx context.Context, bucket, object string) (io.Re
 // the signal.
 func (g *gcsClient) supportsStreamingPut() {}
 
-// uploadChunkSize is how much of a streamed object the GCS client buffers before it
-// starts a request. A resumable upload sends its chunks one after another, each paying
-// a round trip, so an object that spans several chunks pays for several — which for the
-// snapshots we upload is most of the time, because they are small.
-//
-// Measured on a GKE worker node (c3-standard-4, us-central1-f) uploading to the
-// snapshot bucket through this exact streaming path, three runs of a 24 MiB object
-// (the size of an idle micro-VM golden snapshot):
-//
-//	16 MiB (the client default)  425-530 ms
-//	32 MiB                       331-405 ms
-//	64 MiB                       258-314 ms
-//	128 MiB                      350-487 ms
-//
-// 64 MiB covers a typical snapshot in one request and is the floor here; larger only
-// costs buffer. The buffer is per in-flight upload and is capped by the object size, so
-// a small object still costs only its own bytes.
-//
-// This does nothing for large snapshots: past ~100 MiB the transfer itself dominates
-// and a single stream tops out near 100 MiB/s regardless of chunk size (measured
-// 77-107 MiB/s at 300 MiB for every chunk size from 16 to 128 MiB). Getting past that
-// needs several streams — 4-way parallel parts plus a compose reached 233-257 MiB/s —
-// which is a format change, since each part has to be independently produced.
+// uploadChunkSize is how much of a streamed object the GCS client buffers before
+// starting a request. Each chunk costs a round trip, so a snapshot that fits in one
+// chunk pays only one: measured on a GKE worker node, a 24 MiB object took 425-530ms
+// at the 16 MiB default versus 258-314ms at 64 MiB. The buffer is capped by the object
+// size, so small objects still cost only their own bytes.
 const uploadChunkSize = 64 << 20
 
+// PutObject writes reader to the object, in a single request below
+// uploadCompositeMin and as parallel parts above it. The size is not known up front,
+// so this reads that many bytes to find out which case it is, then hands them on.
 func (g *gcsClient) PutObject(ctx context.Context, bucket, object string, reader io.Reader) error {
+	head := make([]byte, uploadCompositeMin)
+	n, err := io.ReadFull(reader, head)
+	switch {
+	case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+		// The whole object is in hand and fits in one request.
+		return g.putSingle(ctx, bucket, object, bytes.NewReader(head[:n]))
+	case err != nil:
+		return fmt.Errorf("while reading object body: %w", err)
+	}
+	return g.putComposite(ctx, bucket, object, bytes.NewReader(head[:n]), reader)
+}
+
+// putSingle writes the whole body in one resumable request.
+func (g *gcsClient) putSingle(ctx context.Context, bucket, object string, reader io.Reader) error {
 	wc := g.client.Bucket(bucket).Object(object).NewWriter(ctx)
 	wc.ChunkSize = uploadChunkSize
 	// io.Copy reports local read errors; wc.Close() reports the actual

--- a/cmd/atelet/internal/ategcs/gcs.go
+++ b/cmd/atelet/internal/ategcs/gcs.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"cloud.google.com/go/storage"
 	"github.com/agent-substrate/substrate/internal/ateerrors"
@@ -27,6 +28,10 @@ import (
 
 type gcsClient struct {
 	client *storage.Client
+	// pool holds extra clients so concurrent upload parts get their own connections;
+	// built on first use by uploadClient.
+	poolOnce sync.Once
+	pool     []*storage.Client
 }
 
 func NewGCSClient(client *storage.Client) ObjectStorage {

--- a/cmd/atelet/internal/ategcs/gcscompose.go
+++ b/cmd/atelet/internal/ategcs/gcscompose.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ategcs
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/storage"
+	"golang.org/x/sync/errgroup"
+)
+
+// One stream to GCS tops out near 100 MiB/s however it is chunked; several do not
+// (measured at 300 MiB: 82-107 MiB/s on one stream, 233-257 on four). So a large object
+// is cut into parts, uploaded concurrently, and composed server-side. The parts are
+// byte ranges of the same stream, so the result is byte-identical to a single
+// PutObject and the download path is unaffected.
+const (
+	// uploadCompositeMin is the size below which an object goes up as one request.
+	// Small objects lose to parts — 24 MiB measured 258-314ms as one request against
+	// 310-410ms as two — so this sits at the conservative end of that bracket.
+	// uploadPartSize/uploadConcurrency come from s3.go: same peak on both backends.
+	uploadCompositeMin = 64 << 20
+	// maxComposeSources is GCS's limit on sources per compose call. More parts than
+	// this are folded in rounds.
+	maxComposeSources = 32
+)
+
+// putComposite uploads head followed by rest as concurrent parts, then composes them
+// into object. Only for objects past uploadCompositeMin; putSingle handles the rest.
+func (g *gcsClient) putComposite(ctx context.Context, bucket, object string, head io.Reader, rest io.Reader) (err error) {
+	bkt := g.client.Bucket(bucket)
+	// A run id keeps concurrent or retried uploads of the same object from colliding on
+	// part names, and makes leftovers from a crash identifiable.
+	var idBytes [8]byte
+	if _, err := rand.Read(idBytes[:]); err != nil {
+		return fmt.Errorf("while naming upload parts: %w", err)
+	}
+	runID := hex.EncodeToString(idBytes[:])
+
+	var parts []*storage.ObjectHandle
+	defer func() {
+		// Parts are scratch either way, and deleting them must not mask the real error.
+		for _, p := range parts {
+			if delErr := p.Delete(context.WithoutCancel(ctx)); delErr != nil &&
+				!errors.Is(delErr, storage.ErrObjectNotExist) && err == nil {
+				err = fmt.Errorf("while removing upload part %q: %w", p.ObjectName(), delErr)
+			}
+		}
+	}()
+
+	// The stream is read in order here and whole parts handed to the uploaders; buffers
+	// cycle through free so the peak stays at uploadConcurrency of them.
+	free := make(chan []byte, uploadConcurrency)
+	for range uploadConcurrency {
+		free <- make([]byte, uploadPartSize)
+	}
+	g2, gctx := errgroup.WithContext(ctx)
+	g2.SetLimit(uploadConcurrency)
+
+	src := io.MultiReader(head, rest)
+	for i := 0; ; i++ {
+		var buf []byte
+		select {
+		case buf = <-free:
+		case <-gctx.Done():
+			return errors.Join(g2.Wait(), gctx.Err())
+		}
+		n, readErr := io.ReadFull(src, buf)
+		if n > 0 {
+			part := bkt.Object(fmt.Sprintf("%s.part-%s-%04d", object, runID, i))
+			parts = append(parts, part)
+			data := buf[:n]
+			g2.Go(func() error {
+				defer func() { free <- buf }()
+				return writeObject(gctx, part, data, n)
+			})
+		} else {
+			free <- buf
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
+				break
+			}
+			return errors.Join(fmt.Errorf("while reading upload part %d: %w", i, readErr), g2.Wait())
+		}
+	}
+	if err := g2.Wait(); err != nil {
+		return fmt.Errorf("while uploading parts of %q: %w", object, err)
+	}
+	return composeAll(ctx, bkt, object, parts, runID)
+}
+
+// writeObject writes data to obj in one request.
+func writeObject(ctx context.Context, obj *storage.ObjectHandle, data []byte, size int) error {
+	w := obj.NewWriter(ctx)
+	// The part is already in memory; no reason to let the client cut it up again.
+	w.ChunkSize = size
+	if _, err := w.Write(data); err != nil {
+		_ = w.Close()
+		return err
+	}
+	return w.Close()
+}
+
+// composeAll composes parts into object, folding in rounds when there are more parts
+// than GCS accepts in one call. Intermediates are cleaned up as they are consumed.
+func composeAll(ctx context.Context, bkt *storage.BucketHandle, object string, parts []*storage.ObjectHandle, runID string) error {
+	if len(parts) == 0 {
+		return fmt.Errorf("no parts to compose into %q", object)
+	}
+	round := 0
+	for len(parts) > maxComposeSources {
+		var next []*storage.ObjectHandle
+		for i := 0; i < len(parts); i += maxComposeSources {
+			end := min(i+maxComposeSources, len(parts))
+			group := parts[i:end]
+			if len(group) == 1 {
+				next = append(next, group[0])
+				continue
+			}
+			mid := bkt.Object(fmt.Sprintf("%s.compose-%s-%d-%04d", object, runID, round, i))
+			if _, err := mid.ComposerFrom(group...).Run(ctx); err != nil {
+				return fmt.Errorf("while composing parts of %q: %w", object, err)
+			}
+			// The sources are dead once folded; the caller's deferred cleanup only
+			// knows about the leaf parts.
+			for _, s := range group {
+				_ = s.Delete(context.WithoutCancel(ctx))
+			}
+			next = append(next, mid)
+		}
+		parts = next
+		round++
+	}
+	if len(parts) == 1 {
+		// Exactly one part long: copy, since compose needs two or more sources.
+		if _, err := bkt.Object(object).CopierFrom(parts[0]).Run(ctx); err != nil {
+			return fmt.Errorf("while copying single part into %q: %w", object, err)
+		}
+		return nil
+	}
+	if _, err := bkt.Object(object).ComposerFrom(parts...).Run(ctx); err != nil {
+		return fmt.Errorf("while composing %q: %w", object, err)
+	}
+	return nil
+}

--- a/cmd/atelet/internal/ategcs/gcscompose.go
+++ b/cmd/atelet/internal/ategcs/gcscompose.go
@@ -21,10 +21,38 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 
 	"cloud.google.com/go/storage"
 	"golang.org/x/sync/errgroup"
 )
+
+// uploadPoolSize is how many storage.Clients the parallel part upload spreads its
+// parts over. One client keeps a single HTTP/2 connection per host and multiplexes
+// every part onto it, so parts that should be independent share one TCP stream:
+// measured on a GKE worker node at 8 streams, 334 MB/s shared against 518 MB/s with a
+// connection each.
+const uploadPoolSize = 8
+
+// uploadClient returns the client part i should use, or the default client if the pool
+// could not be built (a pool failure costs throughput, not correctness).
+func (g *gcsClient) uploadClient(ctx context.Context, i int) *storage.Client {
+	g.poolOnce.Do(func() {
+		for range uploadPoolSize {
+			// The clients outlive this call, so they must not hold its cancellation.
+			c, err := storage.NewClient(context.WithoutCancel(ctx))
+			if err != nil {
+				slog.WarnContext(ctx, "Falling back to one client for part uploads", slog.Any("err", err))
+				return
+			}
+			g.pool = append(g.pool, c)
+		}
+	})
+	if len(g.pool) == 0 {
+		return g.client
+	}
+	return g.pool[i%len(g.pool)]
+}
 
 // One stream to GCS tops out near 100 MiB/s however it is chunked; several do not
 // (measured at 300 MiB: 82-107 MiB/s on one stream, 233-257 on four). So a large object
@@ -86,10 +114,11 @@ func (g *gcsClient) putComposite(ctx context.Context, bucket, object string, hea
 		if n > 0 {
 			part := bkt.Object(fmt.Sprintf("%s.part-%s-%04d", object, runID, i))
 			parts = append(parts, part)
+			upPart := g.uploadClient(ctx, i).Bucket(bucket).Object(part.ObjectName())
 			data := buf[:n]
 			g2.Go(func() error {
 				defer func() { free <- buf }()
-				return writeObject(gctx, part, data, n)
+				return writeObject(gctx, upPart, data, n)
 			})
 		} else {
 			free <- buf

--- a/cmd/atelet/internal/ategcs/gcscompose_test.go
+++ b/cmd/atelet/internal/ategcs/gcscompose_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ategcs
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"io"
+	"math/rand/v2"
+	"os"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+)
+
+// emulatorClient returns a storage client bound to a GCS emulator, or skips. The Go
+// client honours STORAGE_EMULATOR_HOST, so:
+//
+//	docker run -d -p 4443:4443 fsouza/fake-gcs-server -scheme http -public-host localhost:4443
+//	STORAGE_EMULATOR_HOST=localhost:4443 go test ./cmd/atelet/internal/ategcs -run Composite
+func emulatorClient(t *testing.T) (*storage.Client, string) {
+	t.Helper()
+	if os.Getenv("STORAGE_EMULATOR_HOST") == "" {
+		t.Skip("set STORAGE_EMULATOR_HOST to run against a GCS emulator")
+	}
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("storage client: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+	bucket := "ategcs-test"
+	if err := client.Bucket(bucket).Create(ctx, "test-project", nil); err != nil &&
+		!strings.Contains(err.Error(), "Conflict") && !strings.Contains(err.Error(), "exist") {
+		t.Logf("create bucket (ignored if it exists): %v", err)
+	}
+	return client, bucket
+}
+
+// body returns n bytes of deterministic pseudo-random data — incompressible and
+// position-sensitive, so a part uploaded out of order or dropped shows up as a hash
+// mismatch rather than passing by luck.
+func body(n int) []byte {
+	r := rand.New(rand.NewPCG(42, 7))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(r.Uint32())
+	}
+	return b
+}
+
+// A composed upload must be byte-identical to what a single request would have
+// written: the parts are ranges of one stream, and the snapshot format on top of this
+// has no idea it was split.
+func TestPutObjectCompositeRoundTrip(t *testing.T) {
+	client, bucket := emulatorClient(t)
+	g := &gcsClient{client: client}
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name string
+		size int
+	}{
+		{name: "single request, under the threshold", size: 3 << 20},
+		{name: "exactly the threshold", size: uploadCompositeMin},
+		{name: "one part past the threshold", size: uploadCompositeMin + 1},
+		{name: "several parts, last one partial", size: uploadCompositeMin + 2*uploadPartSize + 12345},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			want := body(tc.size)
+			object := "snap/" + strings.ReplaceAll(tc.name, " ", "-")
+			if err := g.PutObject(ctx, bucket, object, bytes.NewReader(want)); err != nil {
+				t.Fatalf("PutObject: %v", err)
+			}
+			rc, err := client.Bucket(bucket).Object(object).NewReader(ctx)
+			if err != nil {
+				t.Fatalf("reading back: %v", err)
+			}
+			got, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				t.Fatalf("reading back: %v", err)
+			}
+			if len(got) != len(want) {
+				t.Fatalf("read back %d bytes, want %d", len(got), len(want))
+			}
+			if sha256.Sum256(got) != sha256.Sum256(want) {
+				t.Fatalf("content differs after round trip (%d bytes)", len(got))
+			}
+		})
+	}
+
+	// Parts are scratch and must not outlive the upload: they would otherwise be
+	// billed forever and confuse anything listing a snapshot's files.
+	it := client.Bucket(bucket).Objects(ctx, &storage.Query{Prefix: "snap/"})
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatalf("listing: %v", err)
+		}
+		if strings.Contains(attrs.Name, ".part-") || strings.Contains(attrs.Name, ".compose-") {
+			t.Errorf("upload left scratch object %q behind", attrs.Name)
+		}
+	}
+}

--- a/cmd/atelet/internal/ategcs/gcscompose_test.go
+++ b/cmd/atelet/internal/ategcs/gcscompose_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 // emulatorClient returns a storage client bound to a GCS emulator, or skips. The Go
-// client honours STORAGE_EMULATOR_HOST, so:
+// client honors STORAGE_EMULATOR_HOST, so:
 //
 //	docker run -d -p 4443:4443 fsouza/fake-gcs-server -scheme http -public-host localhost:4443
 //	STORAGE_EMULATOR_HOST=localhost:4443 go test ./cmd/atelet/internal/ategcs -run Composite

--- a/cmd/atelet/internal/ategcs/gcssparse.go
+++ b/cmd/atelet/internal/ategcs/gcssparse.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ategcs
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+
+	"cloud.google.com/go/storage"
+	"golang.org/x/sync/errgroup"
+)
+
+// partWriterChunk is how much of a part the GCS client buffers before it sends. This
+// bounds the memory a parallel upload holds: sparseMaxParts * this.
+const partWriterChunk = 16 << 20
+
+// PutSparseFile compresses and uploads a sparse file as parts that are composed back
+// into one object, fanning the WHOLE pipeline out by file range: each part reads its
+// own extents (ReadAt), compresses them, and streams into its own object over its own
+// connection, so every stream starts at once.
+//
+// Piping one compressed stream into a part splitter instead serializes the fan-out
+// behind a single compressor: measured on a GKE worker node, a 541 MB actor took 1.78s
+// that way against 87 MB/s-per-stream x 8 streams available from the node.
+//
+// The parts are consecutive byte ranges of the same sparse-extent stream — part 0
+// carries the header, the last carries the end sentinel — so the composed object is
+// exactly what the single-stream writer would have produced.
+func (g *gcsClient) PutSparseFile(ctx context.Context, bucket, object string, f *os.File) (res writeContentResult, err error) {
+	fi, err := f.Stat()
+	if err != nil {
+		return res, err
+	}
+	size := fi.Size()
+	exts, populated, err := sparseExtents(f, size)
+	if err != nil {
+		return res, err
+	}
+	res = writeContentResult{logicalBytes: size, populatedBytes: populated, sparse: true}
+
+	n := sparsePartCount(populated)
+	if n < 2 {
+		// Too small to be worth splitting; the plain streaming path handles it.
+		return res, errSparseTooSmall
+	}
+	groups := planSparseParts(exts, populated, n)
+
+	var idBytes [8]byte
+	if _, err := rand.Read(idBytes[:]); err != nil {
+		return res, fmt.Errorf("while naming upload parts: %w", err)
+	}
+	runID := hex.EncodeToString(idBytes[:])
+
+	bkt := g.client.Bucket(bucket)
+	parts := make([]*storage.ObjectHandle, len(groups))
+	for i := range groups {
+		parts[i] = bkt.Object(fmt.Sprintf("%s.part-%s-%04d", object, runID, i))
+	}
+	defer func() {
+		for _, p := range parts {
+			if delErr := p.Delete(context.WithoutCancel(ctx)); delErr != nil &&
+				!errors.Is(delErr, storage.ErrObjectNotExist) && err == nil {
+				err = fmt.Errorf("while removing upload part %q: %w", p.ObjectName(), delErr)
+			}
+		}
+	}()
+
+	grp, gctx := errgroup.WithContext(ctx)
+	for i, ranges := range groups {
+		grp.Go(func() error {
+			// Each part uploads over its own connection; see uploadClient.
+			obj := g.uploadClient(gctx, i).Bucket(bucket).Object(parts[i].ObjectName())
+			w := obj.NewWriter(gctx)
+			w.ChunkSize = partWriterChunk
+			if err := writeSparsePart(w, f, size, ranges, i == 0, i == len(groups)-1); err != nil {
+				_ = w.Close()
+				return fmt.Errorf("while writing part %d of %q: %w", i, object, err)
+			}
+			return w.Close()
+		})
+	}
+	if err := grp.Wait(); err != nil {
+		return res, err
+	}
+	return res, composeAll(ctx, bkt, object, parts, runID)
+}
+
+// errSparseTooSmall says the object is not worth splitting, so the caller should fall
+// back to the single-stream path.
+var errSparseTooSmall = errors.New("sparse file below the parallel-part threshold")

--- a/cmd/atelet/internal/ategcs/objects.go
+++ b/cmd/atelet/internal/ategcs/objects.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -117,6 +118,14 @@ func SendLocalFileToGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL
 	return nil
 }
 
+// sparseFilePutter marks a backend that can upload a sparse FILE directly, splitting
+// compression and upload by file range instead of piping one compressed stream into a
+// part splitter. Reports errSparseTooSmall when the file is not worth splitting, in
+// which case the caller falls back to the streaming path.
+type sparseFilePutter interface {
+	PutSparseFile(ctx context.Context, bucket, object string, f *os.File) (writeContentResult, error)
+}
+
 // streamingPutter marks an ObjectStorage whose PutObject accepts a non-seekable
 // streaming body without buffering (e.g. GCS): implementing the interface is the
 // signal, so the marker method is never called. See gcsClient.
@@ -174,6 +183,27 @@ func sendZstd(ctx context.Context, client ObjectStorage, gsURL string, content i
 		return fmt.Errorf("while parsing URL: %w", err)
 	}
 	tStart := time.Now()
+	if sp, ok := client.(sparseFilePutter); ok {
+		if f, isFile := content.(*os.File); isFile {
+			res, err := sp.PutSparseFile(ctx, bucket, object, f)
+			switch {
+			case err == nil:
+				slog.InfoContext(ctx, "Compressed zstd upload",
+					slog.String("object", object), slog.Bool("sparse", true),
+					slog.Bool("ranged", true),
+					slog.Int64("logical_bytes", res.logicalBytes),
+					slog.Int64("populated_bytes", res.populatedBytes),
+					slog.Duration("total", time.Since(tStart)))
+				return nil
+			case !errors.Is(err, errSparseTooSmall):
+				return fmt.Errorf("while putting object %q: %w", object, err)
+			}
+			// Too small to split: fall through to the streaming path.
+			if _, err := f.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+		}
+	}
 	if _, ok := client.(streamingPutter); ok {
 		return sendStreamingZstd(ctx, client, bucket, object, content, tStart)
 	}

--- a/cmd/atelet/internal/ategcs/parzstd.go
+++ b/cmd/atelet/internal/ategcs/parzstd.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ategcs
+
+import (
+	"io"
+	"runtime"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// zstd's streaming encoder compresses one block at a time however many cores it is
+// given — WithEncoderConcurrency only lets the next block be filled while the
+// current one encodes. That caps a snapshot upload at one core of compression
+// (measured on a GKE worker node: ~190 MB/s of compressed output, below what the
+// parallel part upload underneath it can absorb, so the uploader starved).
+//
+// parZstd instead cuts the stream into chunks and compresses each as its own zstd
+// FRAME on its own core. Concatenated frames decode as one stream, so the output
+// still reads back through a plain zstd reader and the snapshot format is unchanged.
+// Independent chunks cost a little ratio (no matches across a boundary), which
+// parZstdChunk is sized to keep negligible.
+const (
+	// parZstdChunk is the per-frame chunk size.
+	parZstdChunk = 8 << 20
+	// parZstdQueue is how many chunks may be outstanding per worker, so the producer
+	// can run ahead while workers compress.
+	parZstdQueue = 2
+)
+
+// parZstd is an io.WriteCloser that compresses what it is given as parallel zstd
+// frames, written to dst in order. Close flushes the tail and reports the first
+// error from any worker or from dst.
+type parZstd struct {
+	dst     io.Writer
+	workers int
+
+	buf     []byte
+	free    chan []byte
+	jobs    chan parZstdJob
+	ordered chan chan []byte
+	done    chan struct{}
+	err     error
+}
+
+type parZstdJob struct {
+	buf []byte
+	out chan []byte
+}
+
+// newParZstd starts the worker pool, capped at GOMAXPROCS (workers <= 0 asks for it).
+func newParZstd(dst io.Writer, workers int) *parZstd {
+	if workers <= 0 || workers > runtime.GOMAXPROCS(0) {
+		workers = runtime.GOMAXPROCS(0)
+	}
+	p := &parZstd{
+		dst:     dst,
+		workers: workers,
+		free:    make(chan []byte, workers*parZstdQueue),
+		jobs:    make(chan parZstdJob, workers),
+		ordered: make(chan chan []byte, workers*parZstdQueue),
+		done:    make(chan struct{}),
+	}
+	for range workers * parZstdQueue {
+		p.free <- make([]byte, 0, parZstdChunk)
+	}
+	for range workers {
+		go p.worker()
+	}
+	go p.writer()
+	p.buf = <-p.free
+	return p
+}
+
+// worker compresses whole chunks. Each holds its own encoder: the encoders are
+// single-shot EncodeAll users, so one per worker keeps their state private.
+func (p *parZstd) worker() {
+	enc, err := zstd.NewWriter(nil,
+		zstd.WithEncoderLevel(zstd.SpeedFastest),
+		zstd.WithEncoderConcurrency(1))
+	if err != nil {
+		// NewWriter only fails on bad options, which are compile-time constants here.
+		panic(err)
+	}
+	defer enc.Close()
+	for j := range p.jobs {
+		j.out <- enc.EncodeAll(j.buf, make([]byte, 0, len(j.buf)+len(j.buf)/16))
+		p.free <- j.buf[:0]
+	}
+}
+
+// writer drains the per-chunk result channels in dispatch order, so the frames land
+// in the same order the bytes arrived.
+func (p *parZstd) writer() {
+	defer close(p.done)
+	for out := range p.ordered {
+		frame := <-out
+		if p.err == nil {
+			_, p.err = p.dst.Write(frame)
+		}
+	}
+}
+
+func (p *parZstd) Write(b []byte) (int, error) {
+	total := len(b)
+	for len(b) > 0 {
+		n := min(cap(p.buf)-len(p.buf), len(b))
+		p.buf = append(p.buf, b[:n]...)
+		b = b[n:]
+		if len(p.buf) == cap(p.buf) {
+			p.flush()
+		}
+	}
+	return total, nil
+}
+
+// flush dispatches the current chunk and takes a fresh buffer.
+func (p *parZstd) flush() {
+	if len(p.buf) == 0 {
+		return
+	}
+	out := make(chan []byte, 1)
+	p.ordered <- out
+	p.jobs <- parZstdJob{buf: p.buf, out: out}
+	p.buf = <-p.free
+}
+
+func (p *parZstd) Close() error {
+	p.flush()
+	close(p.jobs)
+	close(p.ordered)
+	<-p.done
+	return p.err
+}
+
+// newSerialZstd is a plain streaming encoder, for callers that are already running one
+// per parallel unit of work (an upload part) and so need no fan-out of their own.
+func newSerialZstd(dst io.Writer) *zstd.Encoder {
+	// NewWriter only errors on bad options, which are compile-time constants here.
+	enc, err := zstd.NewWriter(dst,
+		zstd.WithEncoderLevel(zstd.SpeedFastest),
+		zstd.WithEncoderConcurrency(1))
+	if err != nil {
+		panic(err)
+	}
+	return enc
+}

--- a/cmd/atelet/internal/ategcs/sparseparts.go
+++ b/cmd/atelet/internal/ategcs/sparseparts.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ategcs
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// Sizing for the range-parallel sparse upload. Measured on a GKE worker node writing
+// 64 MiB objects to GCS: one stream 87 MB/s, 4 streams 254, 8 streams 518, 12 streams
+// 622 — so the node is nowhere near a ceiling and what limits a snapshot upload is how
+// early the streams can all start.
+const (
+	// sparsePartTarget is the populated source bytes per part. Parts smaller than this
+	// stop amortizing the ~0.25s a part upload costs before it transfers anything.
+	sparsePartTarget = 64 << 20
+	// sparseMaxParts caps the fan-out: past a dozen streams per-stream throughput falls
+	// faster than the extra parallelism gains.
+	sparseMaxParts = 12
+)
+
+// extentRange is a populated byte range of the source file.
+type extentRange struct{ off, length int64 }
+
+// sparseExtents lists the populated extents of src via SEEK_DATA/SEEK_HOLE, and their
+// total size. A guest memory image is mostly holes, so this is what actually has to be
+// compressed and uploaded.
+func sparseExtents(src *os.File, size int64) (exts []extentRange, populated int64, err error) {
+	fd := int(src.Fd())
+	for off := int64(0); off < size; {
+		ds, serr := unix.Seek(fd, off, unix.SEEK_DATA)
+		if serr != nil {
+			if serr == unix.ENXIO { // the rest of the file is a hole
+				break
+			}
+			return nil, 0, fmt.Errorf("SEEK_DATA: %w", serr)
+		}
+		de, serr := unix.Seek(fd, ds, unix.SEEK_HOLE)
+		if serr != nil {
+			return nil, 0, fmt.Errorf("SEEK_HOLE: %w", serr)
+		}
+		exts = append(exts, extentRange{off: ds, length: de - ds})
+		populated += de - ds
+		off = de
+	}
+	return exts, populated, nil
+}
+
+// planSparseParts splits extents into n groups of roughly equal populated bytes,
+// splitting an extent across a boundary when that balances better. Groups keep file
+// order, so concatenating the parts reproduces the single-stream byte order.
+func planSparseParts(exts []extentRange, populated int64, n int) [][]extentRange {
+	if n < 1 {
+		n = 1
+	}
+	per := populated / int64(n)
+	if per < 1 {
+		per = 1
+	}
+	groups := make([][]extentRange, 0, n)
+	cur := []extentRange{}
+	var curBytes int64
+	for _, e := range exts {
+		for e.length > 0 {
+			room := per - curBytes
+			// The last group takes whatever is left rather than starting an n+1th.
+			if len(groups) == n-1 {
+				room = e.length
+			}
+			take := min(room, e.length)
+			cur = append(cur, extentRange{off: e.off, length: take})
+			curBytes += take
+			e.off += take
+			e.length -= take
+			if curBytes >= per && len(groups) < n-1 {
+				groups = append(groups, cur)
+				cur, curBytes = []extentRange{}, 0
+			}
+		}
+	}
+	if len(cur) > 0 {
+		groups = append(groups, cur)
+	}
+	return groups
+}
+
+// sparsePartCount picks how many parts to split a snapshot into.
+func sparsePartCount(populated int64) int {
+	n := int(populated / sparsePartTarget)
+	if n < 1 {
+		n = 1
+	}
+	return min(n, sparseMaxParts)
+}
+
+// writeSparsePart writes one part's share of the sparse-extent stream: the header and
+// totalSize when it is the first part, its own extents, and the end sentinel when it is
+// the last. Reads use ReadAt so every part can read the same file concurrently.
+func writeSparsePart(dst io.Writer, src *os.File, size int64, ranges []extentRange, first, last bool) error {
+	if first {
+		if _, err := io.WriteString(dst, sparseMagic); err != nil {
+			return err
+		}
+		if err := binary.Write(dst, binary.LittleEndian, sparseVersion); err != nil {
+			return err
+		}
+	}
+	zw := newSerialZstd(dst)
+	if first {
+		if err := binary.Write(zw, binary.LittleEndian, size); err != nil {
+			zw.Close()
+			return err
+		}
+	}
+	buf := make([]byte, 1<<20)
+	for _, e := range ranges {
+		if err := binary.Write(zw, binary.LittleEndian, e.off); err != nil {
+			zw.Close()
+			return err
+		}
+		if err := binary.Write(zw, binary.LittleEndian, e.length); err != nil {
+			zw.Close()
+			return err
+		}
+		for at, end := e.off, e.off+e.length; at < end; {
+			n := min(int64(len(buf)), end-at)
+			read, err := src.ReadAt(buf[:n], at)
+			if read > 0 {
+				if _, werr := zw.Write(buf[:read]); werr != nil {
+					zw.Close()
+					return werr
+				}
+				at += int64(read)
+			}
+			if err != nil {
+				zw.Close()
+				return fmt.Errorf("reading extent @%d+%d: %w", e.off, e.length, err)
+			}
+		}
+	}
+	if last {
+		if err := binary.Write(zw, binary.LittleEndian, sparseEndOffset); err != nil {
+			zw.Close()
+			return err
+		}
+	}
+	return zw.Close()
+}

--- a/cmd/atelet/internal/ategcs/sparseparts_test.go
+++ b/cmd/atelet/internal/ategcs/sparseparts_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ategcs
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"os"
+	"testing"
+)
+
+// TestSparsePartsRoundTrip checks the range-split upload: the parts concatenated must
+// decode to exactly the source file, for any number of parts.
+func TestSparsePartsRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		size   int64
+		writes []int64 // offsets of 1 MiB populated extents
+		parts  int
+	}{
+		{name: "one part", size: 8 << 20, writes: []int64{0, 4 << 20}, parts: 1},
+		{name: "two parts", size: 8 << 20, writes: []int64{0, 4 << 20}, parts: 2},
+		{name: "more parts than extents", size: 16 << 20, writes: []int64{1 << 20, 9 << 20}, parts: 5},
+		{name: "leading and trailing holes", size: 32 << 20, writes: []int64{8 << 20}, parts: 3},
+		{name: "adjacent extents", size: 16 << 20, writes: []int64{0, 1 << 20, 2 << 20}, parts: 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := sparseFileWith(t, tc.size, tc.writes)
+			exts, populated, err := sparseExtents(src, tc.size)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := int64(len(tc.writes)) << 20; populated < want {
+				t.Fatalf("populated = %d, want at least %d", populated, want)
+			}
+
+			groups := planSparseParts(exts, populated, tc.parts)
+			var got bytes.Buffer
+			for i, g := range groups {
+				if err := writeSparsePart(&got, src, tc.size, g, i == 0, i == len(groups)-1); err != nil {
+					t.Fatalf("part %d: %v", i, err)
+				}
+			}
+
+			// The parts must land the same bytes as the single-stream writer.
+			var want bytes.Buffer
+			if _, _, err := writeSparseZstd(&want, src); err != nil {
+				t.Fatal(err)
+			}
+			if g, w := decodeSparse(t, &got), decodeSparse(t, &want); !bytes.Equal(g, w) {
+				t.Errorf("range-split output differs from single stream (%d vs %d bytes)", len(g), len(w))
+			}
+		})
+	}
+}
+
+// TestPlanSparsePartsBalances checks every populated byte lands in exactly one part,
+// in file order.
+func TestPlanSparsePartsBalances(t *testing.T) {
+	exts := []extentRange{{off: 0, length: 10}, {off: 100, length: 30}, {off: 500, length: 60}}
+	const populated = 100
+	for n := 1; n <= 8; n++ {
+		groups := planSparseParts(exts, populated, n)
+		var total int64
+		var last int64 = -1
+		for _, g := range groups {
+			for _, r := range g {
+				if r.off < last {
+					t.Fatalf("n=%d: ranges out of order at %d after %d", n, r.off, last)
+				}
+				last = r.off
+				total += r.length
+			}
+		}
+		if total != populated {
+			t.Errorf("n=%d: covered %d bytes, want %d", n, total, populated)
+		}
+		if len(groups) > n {
+			t.Errorf("n=%d: got %d groups", n, len(groups))
+		}
+	}
+}
+
+// sparseFileWith builds a sparse file of size with 1 MiB of random data at each offset.
+func sparseFileWith(t *testing.T, size int64, offsets []int64) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp("", "sparseparts-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(f.Name()); f.Close() })
+	if err := f.Truncate(size); err != nil {
+		t.Fatal(err)
+	}
+	rng := rand.New(rand.NewSource(7))
+	buf := make([]byte, 1<<20)
+	for _, off := range offsets {
+		rng.Read(buf)
+		if _, err := f.WriteAt(buf, off); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+// decodeSparse expands an encoded sparse stream back to the full file contents.
+func decodeSparse(t *testing.T, r io.Reader) []byte {
+	t.Helper()
+	magic := make([]byte, len(sparseMagic))
+	if _, err := io.ReadFull(r, magic); err != nil {
+		t.Fatal(err)
+	}
+	if string(magic) != sparseMagic {
+		t.Fatalf("bad magic %q", magic)
+	}
+	out, err := os.CreateTemp("", "sparsedecode-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(out.Name())
+	defer out.Close()
+	if _, err := readSparseZstd(out, r); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := out.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	b, err := io.ReadAll(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/cmd/atelet/internal/ategcs/sparsezstd.go
+++ b/cmd/atelet/internal/ategcs/sparsezstd.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 
 	"github.com/klauspost/compress/zstd"
 	"golang.org/x/sys/unix"
@@ -79,12 +78,8 @@ func writeSparseZstd(dst io.Writer, src *os.File) (logical, dataBytes int64, err
 		return 0, 0, err
 	}
 
-	zw, err := zstd.NewWriter(dst,
-		zstd.WithEncoderLevel(zstd.SpeedFastest),
-		zstd.WithEncoderConcurrency(runtime.GOMAXPROCS(0)))
-	if err != nil {
-		return 0, 0, err
-	}
+	// One worker per chunk the file can fill, so a small object does not pay for a pool.
+	zw := newParZstd(dst, int(size/parZstdChunk)+1)
 	// fail closes the encoder before returning err (Close flushes/frees state).
 	fail := func(e error) (int64, int64, error) {
 		zw.Close()


### PR DESCRIPTION
GCS doesn't offer something like the S3 upload manager package (https://github.com/agent-substrate/substrate/pull/1068) but the same thing holds ... uploading decent sized chunks in parallel can really speed up snapshot upload, we just have to implement it ourselves.

This PR implements parallel uploading for GCS.

Along the way, I discovered that atelet's current approach to compression bottlenecks parallel upload, so the second commit splits that into chunks as well.

For some test data, we wind up with epsilon the same bytes than before but with a 451 MB working set we go from 4.66s (before this PR) to 1.51s (after both commits).

For a tiny counter demo with snapshot mode full (NOTE: the default counter demo we use for e2e uses only data mode for uploads, and full only for pause), we go from 0.79s to 0.62s (22% faster), purely from the parallelized compression (second commit) as it stays under the upload chunk size.

Also relevant: https://github.com/agent-substrate/substrate/pull/1130