### PR TITLE
test: reject arbitrary-port routing failures

### DIFF
--- a/internal/e2e/suites/networking/arbitraryport_test.go
+++ b/internal/e2e/suites/networking/arbitraryport_test.go
@@ -118,8 +118,8 @@ func TestActorArbitraryPortAccess(t *testing.T) {
 		}
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		if resp.StatusCode == http.StatusOK {
-			t.Fatalf("tunneled request to an unlisted port unexpectedly returned HTTP 200; body: %s", body)
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("tunneled request to an unlisted port returned HTTP %d; want HTTP %d (Bad Gateway); body: %s", resp.StatusCode, http.StatusBadGateway, body)
 		}
 		t.Logf("tunneled request to an unlisted port correctly returned HTTP %d; body: %s", resp.StatusCode, body)
 	})


### PR DESCRIPTION
Fixes #1102

## Summary

The arbitrary-port E2E test previously treated every non-200 response as a successful rejection. That allowed upstream routing failures such as HTTP 503 or 504 to pass the test.

Require the expected 502 Bad Gateway response emitted by atunnel instead, so the test only passes when the unlisted actor port is actually rejected by the actor ingress path.

## Validation

- `go test ./internal/e2e/suites/networking -run '^$' -count=1` — passed (package compilation)
- `go vet ./internal/e2e/suites/networking` — passed
- `go test ./internal/atunnel -run '^TestServeHTTP' -count=1` — passed
- Full Linux test suite, root-gated tests, and gVisor/microVM E2E — delegated to GitHub Actions because this workstation is Windows without Docker/KinD

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR (no documentation changes are needed for this test-only fix)