### PR TITLE
Run the networking e2e tests for sdsmint variant

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -133,6 +133,21 @@ jobs:
         E2E_EGRESS_MITM: "1"
         E2E_SANDBOX_CLASS: microvm
       run: hack/run-e2e-kind.sh ./internal/e2e/suites/egressmitm -v -args --no-color
+    - name: Deploy MITM egress demo
+      # The networking suite's egress tests need a fixture that trusts the
+      # CA used by sdsmint.
+      run: |
+        hack/install-ate-kind.sh --deploy-demo-egress-mitm
+        hack/install-ate-kind.sh --deploy-demo-egress-microvm-mitm
+    - name: Run E2E tests (networking, MITM egress)
+      env:
+        E2E_EGRESS_MITM: "1"
+      run: hack/run-e2e-kind.sh ./internal/e2e/suites/networking -v -args --no-color
+    - name: Run E2E tests (networking, MITM egress, micro-VM)
+      env:
+        E2E_EGRESS_MITM: "1"
+        E2E_SANDBOX_CLASS: microvm
+      run: hack/run-e2e-kind.sh ./internal/e2e/suites/networking -v -args --no-color
     - name: Dump diagnostics on failure
       if: failure()
       run: |

--- a/demos/egress/egress-microvm-mitm.yaml.tmpl
+++ b/demos/egress/egress-microvm-mitm.yaml.tmpl
@@ -1,0 +1,110 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Micro-VM (kata + cloud-hypervisor) variant of the MITM egress demo, so the
+# networking suite's egress tests run against the sdsmint gateway on both
+# sandbox classes. Delivery of the projected bundle into the sandbox is what
+# differs by class — a read-only bind for gVisor, the unified virtio-fs share
+# for the guest here — so the projection is worth proving on both.
+#
+# As in egress-mitm.yaml.tmpl, this REQUIRES an sdsmint install
+# (--experimental-use-sdsmint).
+#
+# Kept in step with egress-microvm.yaml.tmpl; the deltas are the names, the
+# projected trust bundle, and the two SSL_CERT_* variables. The cluster-wide
+# `microvm` SandboxConfig referenced below by name is installed by
+# hack/install-microvm-deps.sh.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ate-demo-egress-microvm-mitm
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: WorkerPool
+metadata:
+  name: egress-microvm-mitm
+  namespace: ate-demo-egress-microvm-mitm
+  labels:
+    workload: egress-microvm-mitm
+spec:
+  replicas: 2
+  sandboxClass: microvm
+  sandboxConfigName: microvm
+  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
+  # No template.resources, unlike counter-microvm: an unlimited ateom container
+  # reports no capacity, which the scheduler reads as unconstrained, and the pod
+  # requests nothing so it stays placeable next to the counter-microvm pool's
+  # reservation on CI's single kind node. What actually bounds the memory here
+  # is the ActorTemplate's resources below, which size the guest.
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: ActorTemplate
+metadata:
+  name: egress-microvm-mitm
+  namespace: ate-demo-egress-microvm-mitm
+spec:
+  # Must match the WorkerPool's sandboxClass: a snapshot is not portable across
+  # sandbox classes, so only pools of the same class are eligible to run this
+  # template's actors.
+  sandboxClass: microvm
+  volumes:
+  - name: system-info
+    systemInfo:
+      dataSources:
+      # The trust anchors for the per-SNI leaves the MITM egress gateway mints.
+      # Only allowlisted bundle names resolve; this is the one supported today.
+      - trustBundle:
+          name: egress-mitm.ate.dev
+          path: trust-bundle.pem
+  containers:
+  - name: egress
+    image: ko://github.com/agent-substrate/substrate/demos/egress
+    command: ["/ko-app/egress"]
+    # Both variables, for the reason egress-mitm.yaml.tmpl spells out:
+    # SSL_CERT_FILE replaces the default cert file list but not the default cert
+    # DIRECTORY scan, so SSL_CERT_DIR has to point at the projection too for the
+    # anchor set to be exactly the gateway CA.
+    env:
+    - name: SSL_CERT_FILE
+      value: /run/ate/trust-bundle.pem
+    - name: SSL_CERT_DIR
+      value: /run/ate
+    volumeMounts:
+    - name: system-info
+      mountPath: /run/ate   # the bundle lands at /run/ate/trust-bundle.pem
+    readyz:
+      httpGet:
+        path: /readyz
+        port: 80
+      # See counter-microvm.yaml.tmpl: a micro-VM guest needs more than
+      # readyz's 30s default once CI's single kind node is under load.
+      timeoutSeconds: 120
+  # Sandbox size: without these the guest boots at the kata config's default
+  # (2GiB). ateom applies them to the VM (see internal/sizing).
+  resources:
+    limits:
+      cpu: "1"
+      memory: 512Mi
+  workerSelector:
+    matchLabels:
+      workload: egress-microvm-mitm
+  snapshotsConfig:
+    onPause: Full
+    onCommit: Full
+    location: gs://${BUCKET_NAME}/ate-demo-egress-microvm-mitm/

--- a/demos/egress/egress-mitm.yaml.tmpl
+++ b/demos/egress/egress-mitm.yaml.tmpl
@@ -1,0 +1,94 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# MITM variant of the egress demo: the same workload as egress.yaml.tmpl, but
+# trusting only the egress gateway CA. The networking suite builds its egress
+# actors from this fixture instead of the plain one when E2E_EGRESS_MITM is set,
+# because under an sdsmint gateway TestActorEgressHTTPS's origin certificate is
+# a per-SNI leaf the gateway minted, which chains to no public CA.
+#
+# Kept as its own fixture rather than a flag on the egress demo: it REQUIRES an
+# sdsmint install (--experimental-use-sdsmint).
+#
+# Kept in step with egress.yaml.tmpl; the deltas are the names, the projected
+# trust bundle, and the two SSL_CERT_* variables.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ate-demo-egress-mitm
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: WorkerPool
+metadata:
+  name: egress-mitm
+  namespace: ate-demo-egress-mitm
+  labels:
+    workload: egress-mitm
+spec:
+  replicas: 2
+  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: ActorTemplate
+metadata:
+  name: egress-mitm
+  namespace: ate-demo-egress-mitm
+spec:
+  volumes:
+  - name: system-info
+    systemInfo:
+      dataSources:
+      # The trust anchors for the per-SNI leaves the MITM egress gateway mints.
+      # Only allowlisted bundle names resolve; this is the one supported today.
+      - trustBundle:
+          name: egress-mitm.ate.dev
+          path: trust-bundle.pem
+  containers:
+  - name: egress
+    image: ko://github.com/agent-substrate/substrate/demos/egress
+    command: ["/ko-app/egress"]
+    # The demo fetches with a stock net/http client, so its roots come from
+    # crypto/x509's system pool — which on Unix reads both of these.
+    #
+    # SSL_CERT_FILE alone is not enough to make the projected bundle the whole
+    # story: it replaces the default cert FILE list, but the default cert
+    # DIRECTORY list is still scanned, and the base image keeps its public
+    # roots in /etc/ssl/certs. Pointing SSL_CERT_DIR at the projection too
+    # makes the anchor set exactly the gateway CA, so a successful HTTPS fetch
+    # proves the projected bundle validated the minted leaf. Under sdsmint the
+    # public roots are useless anyway: every origin is fronted by the gateway.
+    env:
+    - name: SSL_CERT_FILE
+      value: /run/ate/trust-bundle.pem
+    - name: SSL_CERT_DIR
+      value: /run/ate
+    volumeMounts:
+    - name: system-info
+      mountPath: /run/ate   # the bundle lands at /run/ate/trust-bundle.pem
+    readyz:
+      httpGet:
+        path: /readyz
+        port: 80
+  workerSelector:
+    matchLabels:
+      workload: egress-mitm
+  snapshotsConfig:
+    onPause: Full
+    onCommit: Full
+    location: gs://${BUCKET_NAME}/ate-demo-egress-mitm/

--- a/hack/install-demo-egress.sh
+++ b/hack/install-demo-egress.sh
@@ -22,6 +22,12 @@ ATE_DEMOS+=(demo-egress) # register demo-egress
 # can be installed side by side (the networking suite runs against whichever the
 # sandbox class under test selects).
 ATE_DEMOS+=(demo-egress-microvm) # register demo-egress-microvm
+# The MITM variants are separate demos for the same reason, plus one of their
+# own: they project the egress gateway trust bundle, which only resolves on an
+# sdsmint install, so they cannot be part of the demos a passthrough install
+# deploys.
+ATE_DEMOS+=(demo-egress-mitm)         # register demo-egress-mitm
+ATE_DEMOS+=(demo-egress-microvm-mitm) # register demo-egress-microvm-mitm
 
 demo-egress_cmdline() {
   case "${1}" in
@@ -38,6 +44,28 @@ demo-egress-microvm_cmdline() {
   case "${1}" in
     --deploy-demo-egress-microvm) demo-egress-microvm_deploy ;;
     --delete-demo-egress-microvm) demo-egress-microvm_delete ;;
+    *)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+demo-egress-mitm_cmdline() {
+  case "${1}" in
+    --deploy-demo-egress-mitm) demo-egress-mitm_deploy ;;
+    --delete-demo-egress-mitm) demo-egress-mitm_delete ;;
+    *)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+demo-egress-microvm-mitm_cmdline() {
+  case "${1}" in
+    --deploy-demo-egress-microvm-mitm) demo-egress-microvm-mitm_deploy ;;
+    --delete-demo-egress-microvm-mitm) demo-egress-microvm-mitm_delete ;;
     *)
       return 1
       ;;
@@ -88,5 +116,59 @@ demo-egress-microvm_delete() {
   log_step "demo-egress-microvm_delete"
   delete_demo_actors ate-demo-egress-microvm egress-microvm
   sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/egress/egress-microvm.yaml.tmpl \
+    | run_kubectl delete --ignore-not-found -f -
+}
+
+demo-egress-mitm_usage() {
+  echo "  Needs an sdsmint install (--deploy-atenet --experimental-use-sdsmint): the actors"
+  echo "  project the egress gateway trust bundle, which does not resolve otherwise."
+}
+
+demo-egress-mitm_deploy() {
+  log_step "demo-egress-mitm_deploy"
+  ensure_crds
+  sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/egress/egress-mitm.yaml.tmpl \
+    | run_ko apply -f -
+
+  log_step "Waiting for MITM egress demo to be ready..."
+  run_kubectl rollout status deployment/egress-mitm -n ate-demo-egress-mitm --timeout=300s
+  # The golden snapshot only becomes Ready once an actor starts, and an actor
+  # whose trust bundle does not resolve never does — so a timeout here is the
+  # symptom of a missing sdsmint install (see demo-egress-mitm_usage).
+  run_kubectl wait --for=condition=Ready actortemplate/egress-mitm \
+    -n ate-demo-egress-mitm --timeout=300s
+}
+
+demo-egress-mitm_delete() {
+  log_step "demo-egress-mitm_delete"
+  delete_demo_actors ate-demo-egress-mitm egress-mitm
+  sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/egress/egress-mitm.yaml.tmpl \
+    | run_kubectl delete --ignore-not-found -f -
+}
+
+demo-egress-microvm-mitm_usage() {
+  echo "  Needs hack/install-microvm-deps.sh --install to have run (cluster-wide microvm SandboxConfig),"
+  echo "  and an sdsmint install (--deploy-atenet --experimental-use-sdsmint) for the trust bundle."
+}
+
+demo-egress-microvm-mitm_deploy() {
+  log_step "demo-egress-microvm-mitm_deploy"
+  ensure_crds
+  sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/egress/egress-microvm-mitm.yaml.tmpl \
+    | run_ko apply -f -
+
+  log_step "Waiting for micro-VM MITM egress demo to be ready..."
+  run_kubectl rollout status deployment/egress-microvm-mitm \
+    -n ate-demo-egress-microvm-mitm --timeout=300s
+  # A micro-VM golden is a cloud-hypervisor cold boot plus a checkpoint, on
+  # nested KVM in CI, so it needs a longer budget than the gVisor one above.
+  run_kubectl wait --for=condition=Ready actortemplate/egress-microvm-mitm \
+    -n ate-demo-egress-microvm-mitm --timeout=600s
+}
+
+demo-egress-microvm-mitm_delete() {
+  log_step "demo-egress-microvm-mitm_delete"
+  delete_demo_actors ate-demo-egress-microvm-mitm egress-microvm-mitm
+  sed "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" demos/egress/egress-microvm-mitm.yaml.tmpl \
     | run_kubectl delete --ignore-not-found -f -
 }

--- a/internal/e2e/suites/networking/grpcegress_test.go
+++ b/internal/e2e/suites/networking/grpcegress_test.go
@@ -75,7 +75,7 @@ func TestActorEgressGRPC(t *testing.T) {
 	ctx := context.Background()
 	target := e2e.DeployServerPod(t, ctx, grpcEcho).Address()
 
-	actorName, _ := createAndResumeActor(t, ctx, "egress-grpc", e2e.EgressFixture())
+	actorName, _ := createAndResumeActor(t, ctx, "egress-grpc", egressFixture())
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
 

--- a/internal/e2e/suites/networking/networking_test.go
+++ b/internal/e2e/suites/networking/networking_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -33,6 +34,35 @@ import (
 )
 
 const networkingAtespace = "networking-e2e"
+
+// egressFixture returns the egress demo the egress tests build their actors
+// from, for the sandbox class under test and the egress gateway variant
+// deployed.
+//
+// Deploy the one matching the lane:
+//
+//	hack/install-ate-kind.sh --deploy-demo-egress                     # passthrough, gVisor
+//	hack/install-ate-kind.sh --deploy-demo-egress-microvm             # passthrough, micro-VM
+//	hack/install-ate-kind.sh --deploy-demo-egress-mitm                # sdsmint, gVisor
+//	hack/install-ate-kind.sh --deploy-demo-egress-microvm-mitm        # sdsmint, micro-VM
+func egressFixture() e2e.Fixture {
+	// E2E_EGRESS_MITM selects the egress gateway variant.
+	if os.Getenv("E2E_EGRESS_MITM") == "" {
+		return e2e.EgressFixture()
+	}
+	if e2e.IsMicroVM() {
+		return e2e.Fixture{
+			Namespace:  "ate-demo-egress-microvm-mitm",
+			Name:       "egress-microvm-mitm",
+			DeployWith: "hack/install-ate-kind.sh --deploy-demo-egress-microvm-mitm",
+		}
+	}
+	return e2e.Fixture{
+		Namespace:  "ate-demo-egress-mitm",
+		Name:       "egress-mitm",
+		DeployWith: "hack/install-ate-kind.sh --deploy-demo-egress-mitm",
+	}
+}
 
 func TestActorDirectAccess(t *testing.T) {
 	ctx := context.Background()
@@ -60,7 +90,7 @@ func TestActorDirectAccess(t *testing.T) {
 // asserts the gateway is deployed and that it did not reject the Actor.
 func TestActorEgress(t *testing.T) {
 	ctx := context.Background()
-	actorName, _ := createAndResumeActor(t, ctx, "egress", e2e.EgressFixture())
+	actorName, _ := createAndResumeActor(t, ctx, "egress", egressFixture())
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
 
@@ -79,7 +109,7 @@ func TestActorEgress(t *testing.T) {
 // between the Actor and the origin.
 func TestActorEgressHTTPS(t *testing.T) {
 	ctx := context.Background()
-	actorName, _ := createAndResumeActor(t, ctx, "egress-https", e2e.EgressFixture())
+	actorName, _ := createAndResumeActor(t, ctx, "egress-https", egressFixture())
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
 
@@ -128,7 +158,7 @@ func TestActorEgressNonStandardPort(t *testing.T) {
 	// resumed Actor idling in the cluster waiting for a destination.
 	target := e2e.DeployServerPod(t, ctx, httpTarget)
 
-	actorName, _ := createAndResumeActor(t, ctx, "egress-port", e2e.EgressFixture())
+	actorName, _ := createAndResumeActor(t, ctx, "egress-port", egressFixture())
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
 


### PR DESCRIPTION
  
    Run the networking suite a second time against the sdsmint (MITM)
    egress gateway, so the egress path is covered on both gateway variants
    rather than only on passthrough.

A part of #823 

From https://github.com/agent-substrate/substrate/actions/runs/32786529664/job/97619491954?pr=1155, this change adds about 70 seconds to the `e2e-test` workflow:

   - Step `Deploy MITM egress demo`: 8s
   - Step `Run E2E tests (networking, MITM egress)`: 33s
   - Step `Run E2E tests (networking, MITM egress, micro-VM)`: 30s

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
