### PR TITLE
fix(e2e): preserve shared trust bundle

### DIFF
--- a/hack/cleanup-e2e.sh
+++ b/hack/cleanup-e2e.sh
@@ -16,13 +16,16 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Deletes the namespaces a failed e2e run left behind.
+# Deletes the cluster state an e2e run leaves behind.
 #
 # A failed suite keeps its namespaces so the worker pods — and the ateom logs
 # inside them, which is where an actor failure is actually explained — survive
 # long enough to read (see RetainNamespaces in internal/e2e/namespace.go).
 # Nothing reclaims them afterwards, and each holds a WorkerPool's worth of
 # running pods, so run this once the logs have served their purpose.
+#
+# The egress CA pool Secret goes too: every probe suite shares it, so no single
+# test may own it (see ReplaceEgressTrustPool in internal/e2e/trustbundle.go).
 #
 # This deletes EVERY e2e namespace in the cluster, so don't run it while a suite
 # is running.
@@ -38,10 +41,14 @@ if [[ -n "${KUBECTL_CONTEXT:-}" ]]; then
   kubectl_args+=("--context=${KUBECTL_CONTEXT}")
 fi
 
+# Dropping the pool makes atecontroller delete the ClusterTrustBundle every
+# probe actor projects, so this must not run mid-suite.
+kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} delete secret -n ate-system egress-mitm-ca-pool --ignore-not-found
+
 # The label CreateNamespace stamps on every namespace the suites create.
 selector="ate.dev/e2e"
 
-leftover="$(kubectl "${kubectl_args[@]}" get namespaces -l "${selector}" -o name)"
+leftover="$(kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} get namespaces -l "${selector}" -o name)"
 if [[ -z "${leftover}" ]]; then
   echo "No leftover e2e namespaces."
   exit 0
@@ -49,4 +56,4 @@ fi
 
 echo "Deleting leftover e2e namespaces:"
 echo "${leftover}"
-kubectl "${kubectl_args[@]}" delete namespaces -l "${selector}" --ignore-not-found
+kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} delete namespaces -l "${selector}" --ignore-not-found

--- a/internal/e2e/trustbundle.go
+++ b/internal/e2e/trustbundle.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Constants of atecontroller's EgressMITMTrustReconciler (#946): the CA pool
@@ -44,36 +45,60 @@ const (
 	egressCAPoolSecretKey  = "pool"
 )
 
-// EnsureEgressTrustBundle makes sure the egress trust bundle exists: if the
-// CA pool Secret is absent it provisions one (registering cleanup), then
-// waits until the reconciler-published bundle is non-empty. DeployProbe calls
-// this because the probe template projects the bundle and every actor —
-// including the fixture's golden boot — fails closed while it is missing; a
-// suite that needs to OWN the pool's contents (the identity suite's
-// deterministic assertions and rotation) uses ReplaceEgressTrustPool first,
-// which this then leaves untouched.
+// EnsureEgressTrustBundle creates the CA pool only when absent, then waits for
+// its trust bundle. It never replaces the pool because probe suites share it.
 func EnsureEgressTrustBundle(t *testing.T, ctx context.Context, clients *Clients) {
 	t.Helper()
-	_, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{})
+	ensureEgressTrustBundle(t, ctx, clients.K8s)
+}
+
+func ensureEgressTrustBundle(t *testing.T, ctx context.Context, k8s kubernetes.Interface) {
+	t.Helper()
+	_, err := k8s.CoreV1().Secrets(egressCAPoolNamespace).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{})
 	if err == nil {
-		waitForEgressTrustBundle(t, ctx, clients, "")
+		waitForEgressTrustBundle(t, ctx, k8s, "")
 		return
 	}
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("reading CA pool secret %s/%s: %v", egressCAPoolNamespace, egressCAPoolSecretName, err)
 	}
-	ReplaceEgressTrustPool(t, ctx, clients, "ate-e2e-trust")
+	secret, _ := newEgressTrustPool(t, "ate-e2e-trust")
+	if _, err := k8s.CoreV1().Secrets(egressCAPoolNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating CA pool secret %s/%s: %v", egressCAPoolNamespace, egressCAPoolSecretName, err)
+	}
+	waitForEgressTrustBundle(t, ctx, k8s, "")
 }
 
-// ReplaceEgressTrustPool creates or replaces the egress CA pool with a fresh
-// single-CA pool (the shape `kubectl-ate admin make-ca-pool` creates for the
-// egress MITM CA), waits for the reconciler to publish the derived bundle,
-// and returns the PEM of the new CA's root certificate — exactly what a
-// trustBundle projection must then deliver. cn keeps successive pools
-// distinguishable in failure output. Cleanup deletes the Secret, whereupon
-// the reconciler deletes the bundle; create-or-replace keeps reruns
-// self-healing after a failed prior run.
+// ReplaceEgressTrustPool installs a fresh single-CA pool and waits for its
+// trust bundle. It deliberately leaves cleanup to hack/cleanup-e2e.sh because
+// concurrently running probe suites share the pool.
 func ReplaceEgressTrustPool(t *testing.T, ctx context.Context, clients *Clients, cn string) string {
+	t.Helper()
+	return replaceEgressTrustPool(t, ctx, clients.K8s, cn)
+}
+
+func replaceEgressTrustPool(t *testing.T, ctx context.Context, k8s kubernetes.Interface, cn string) string {
+	t.Helper()
+	secret, wantPEM := newEgressTrustPool(t, cn)
+
+	if _, err := k8s.CoreV1().Secrets(egressCAPoolNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("creating CA pool secret %s/%s: %v", egressCAPoolNamespace, egressCAPoolSecretName, err)
+		}
+		existing, getErr := k8s.CoreV1().Secrets(egressCAPoolNamespace).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{})
+		if getErr != nil {
+			t.Fatalf("reading existing CA pool secret: %v", getErr)
+		}
+		existing.Data = secret.Data
+		if _, err := k8s.CoreV1().Secrets(egressCAPoolNamespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("updating CA pool secret: %v", err)
+		}
+	}
+	waitForEgressTrustBundle(t, ctx, k8s, wantPEM)
+	return wantPEM
+}
+
+func newEgressTrustPool(t *testing.T, cn string) (*corev1.Secret, string) {
 	t.Helper()
 	ca, err := localca.GenerateCA(localca.GenerateOptions{ID: "mitm", CommonName: cn, KeyType: localca.KeyTypeECDSAP256})
 	if err != nil {
@@ -85,32 +110,10 @@ func ReplaceEgressTrustPool(t *testing.T, ctx context.Context, clients *Clients,
 	}
 	wantPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.RootCertificate.Raw}))
 
-	secret := &corev1.Secret{
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Namespace: egressCAPoolNamespace, Name: egressCAPoolSecretName},
 		Data:       map[string][]byte{egressCAPoolSecretKey: poolBytes},
-	}
-	if _, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			t.Fatalf("creating CA pool secret %s/%s: %v", egressCAPoolNamespace, egressCAPoolSecretName, err)
-		}
-		existing, getErr := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{})
-		if getErr != nil {
-			t.Fatalf("reading existing CA pool secret: %v", getErr)
-		}
-		existing.Data = secret.Data
-		if _, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
-			t.Fatalf("updating CA pool secret: %v", err)
-		}
-		// The replacer takes over an existing pool without adopting its
-		// cleanup: whoever created it registered one already.
-		waitForEgressTrustBundle(t, ctx, clients, wantPEM)
-		return wantPEM
-	}
-	t.Cleanup(func() {
-		_ = clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Delete(context.Background(), egressCAPoolSecretName, metav1.DeleteOptions{})
-	})
-	waitForEgressTrustBundle(t, ctx, clients, wantPEM)
-	return wantPEM
+	}, wantPEM
 }
 
 // waitForEgressTrustBundle polls the reconciler-owned bundle until its
@@ -119,12 +122,12 @@ func ReplaceEgressTrustPool(t *testing.T, ctx context.Context, clients *Clients,
 // apiserver while atelet resolves from its informer cache, but the suites'
 // start/resume latency dwarfs watch delivery — if a rotated-bundle
 // assertion ever flakes, this lag is the first suspect.
-func waitForEgressTrustBundle(t *testing.T, ctx context.Context, clients *Clients, want string) {
+func waitForEgressTrustBundle(t *testing.T, ctx context.Context, k8s kubernetes.Interface, want string) {
 	t.Helper()
 	var last string
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
-		ctb, err := clients.K8s.CertificatesV1beta1().ClusterTrustBundles().Get(ctx, EgressTrustBundleObjectName, metav1.GetOptions{})
+		ctb, err := k8s.CertificatesV1beta1().ClusterTrustBundles().Get(ctx, EgressTrustBundleObjectName, metav1.GetOptions{})
 		if err == nil {
 			if got := ctb.Spec.TrustBundle; got == want || (want == "" && got != "") {
 				return

--- a/internal/e2e/trustbundle_test.go
+++ b/internal/e2e/trustbundle_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"testing"
+
+	"github.com/agent-substrate/substrate/internal/localca"
+	certsv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestReplaceEgressTrustPoolLeavesSharedSecret(t *testing.T) {
+	ctx := context.Background()
+	k8s := kubernetesfake.NewSimpleClientset()
+	var trustBundle string
+	k8s.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		secret := action.(k8stesting.CreateAction).GetObject().(*corev1.Secret)
+		pool, err := localca.Unmarshal(secret.Data[egressCAPoolSecretKey])
+		if err != nil {
+			return true, nil, err
+		}
+		trustBundle = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: pool.CAs[0].RootCertificate.Raw}))
+		return false, nil, nil
+	})
+	k8s.PrependReactor("get", "clustertrustbundles", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &certsv1beta1.ClusterTrustBundle{
+			ObjectMeta: metav1.ObjectMeta{Name: EgressTrustBundleObjectName},
+			Spec:       certsv1beta1.ClusterTrustBundleSpec{TrustBundle: trustBundle},
+		}, nil
+	})
+
+	t.Run("creator exits", func(t *testing.T) {
+		replaceEgressTrustPool(t, ctx, k8s, "test-egress-trust")
+	})
+
+	if _, err := k8s.CoreV1().Secrets(egressCAPoolNamespace).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			t.Fatal("ReplaceEgressTrustPool deleted the shared CA pool when its creating test exited")
+		}
+		t.Fatalf("reading shared CA pool after its creating test exited: %v", err)
+	}
+}
+
+func TestEnsureEgressTrustBundleConcurrentCreatorsDoNotReplace(t *testing.T) {
+	ctx := context.Background()
+	k8s := kubernetesfake.NewSimpleClientset()
+	k8s.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(action.GetResource().GroupResource(), egressCAPoolSecretName)
+	})
+	k8s.PrependReactor("get", "clustertrustbundles", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &certsv1beta1.ClusterTrustBundle{
+			ObjectMeta: metav1.ObjectMeta{Name: EgressTrustBundleObjectName},
+			Spec:       certsv1beta1.ClusterTrustBundleSpec{TrustBundle: "shared trust"},
+		}, nil
+	})
+
+	t.Run("callers", func(t *testing.T) {
+		for i := range 2 {
+			t.Run(fmt.Sprintf("caller %d", i), func(t *testing.T) {
+				t.Parallel()
+				ensureEgressTrustBundle(t, ctx, k8s)
+			})
+		}
+	})
+
+	var creates, updates int
+	for _, action := range k8s.Actions() {
+		if action.GetResource().Resource != "secrets" {
+			continue
+		}
+		switch action.GetVerb() {
+		case "create":
+			creates++
+		case "update":
+			updates++
+		}
+	}
+	if creates != 2 {
+		t.Fatalf("Secret create actions = %d, want 2 concurrent attempts", creates)
+	}
+	if updates != 0 {
+		t.Fatalf("Secret update actions = %d, want 0 from EnsureEgressTrustBundle", updates)
+	}
+}


### PR DESCRIPTION
Fixes #1158

`TestImageVolume` intermittently cannot resume its actor because the shared egress trust bundle disappears while E2E packages run concurrently.

The identity suite created the cluster-scoped CA pool with a per-test cleanup. When that suite finished first, the cleanup deleted the Secret and the reconciler deleted `egress-mitm.ate.dev:mitm:primary-bundle` while neighboring suites still needed it.

Keep the shared pool alive across probe suites and reclaim it through `hack/cleanup-e2e.sh` after the run. Ensure operations are now create-only, so concurrent first users accept `AlreadyExists` without replacing each other's CA; only the identity rotation path may replace the pool. Deterministic tests cover both creator exit and concurrent ensure behavior.

The identity suite still intentionally rotates the shared pool, but ordinary suites require only a present, valid bundle and never mutate it.

Before:

```text
imagevolume_test.go:255: ResumeActor: rpc error: code = Internal desc = while populating system-info volume "system-info": system-info projection "trust-bundle.pem": trust bundle "egress-mitm.ate.dev": ClusterTrustBundle "egress-mitm.ate.dev:mitm:primary-bundle" not found
--- FAIL: TestImageVolume (33.47s)
```

After:

```text
--- PASS: TestActorIdentity_AfterRestore_IsOwnID_NotGolden (21.80s)
--- PASS: TestImageVolume (16.15s)
PASS
secret/egress-mitm-ca-pool
clustertrustbundle.certificates.k8s.io/egress-mitm.ate.dev:mitm:primary-bundle
ok  github.com/agent-substrate/substrate/internal/e2e  1.652s
secret "egress-mitm-ca-pool" deleted from ate-system namespace
cleanup: secret=0 ctb=0
```
