### PR TITLE
Reject object updates containing unknown fields

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -273,8 +273,9 @@ func (s *RPCService) UpdateActor(ctx context.Context, req *ateapipb.UpdateActorR
 	storedActor, err := s.persistence.UpdateActor(ctx, actorRef, store.PreconditionFrom(in), func(toUpdate *ateapipb.Actor) error {
 		// Status and Metadata are server-owned fields.
 		status, metadata := toUpdate.GetStatus(), toUpdate.GetMetadata()
-		// Reset + merge from the input actor.
-		// TODO: Drop unknwown fields from the input actor.
+		// Whole-object replace: clear first, so a field the client left unset is
+		// cleared rather than kept from the stored actor.
+		// Merge cannot smuggle in unknown fields because validation already rejected them.
 		proto.Reset(toUpdate)
 		proto.Merge(toUpdate, in)
 		// Restore status and metadata from the server.
@@ -314,6 +315,8 @@ func validateUpdateActorRequest(req *ateapipb.UpdateActorRequest) field.ErrorLis
 	if actor == nil {
 		return field.ErrorList{field.Required(actorPath, "")}
 	}
+
+	errs = append(errs, validateNoUnknownFields(actor, actorPath)...)
 
 	errs = append(errs, resources.ValidateUpdateMetadataRef(actor.GetMetadata(), actorPath.Child("metadata"))...)
 

--- a/cmd/ateapi/internal/controlapi/actor_snapshot.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot.go
@@ -186,8 +186,9 @@ func (s *RPCService) UpdateActorSnapshotTag(ctx context.Context, req *ateapipb.U
 	storedTag, err := s.persistence.UpdateActorSnapshotTag(ctx, atespace, name, store.PreconditionFrom(in), func(toUpdate *ateapipb.ActorSnapshotTag) error {
 		// Metadata is a server-owned field.
 		metadata := toUpdate.GetMetadata()
-		// Reset + merge from the input tag.
-		// TODO: Drop unknwown fields from the input actor.
+		// Whole-object replace: clear first, so a field the client left unset is
+		// cleared rather than kept from the stored tag. Merge cannot smuggle in
+		// unknown fields because validation already rejected them.
 		proto.Reset(toUpdate)
 		proto.Merge(toUpdate, in)
 		// Restore metadata from the server.
@@ -224,6 +225,8 @@ func validateUpdateActorSnapshotTagRequest(req *ateapipb.UpdateActorSnapshotTagR
 	if tag == nil {
 		return field.ErrorList{field.Required(tagPath, "")}
 	}
+
+	errs = append(errs, validateNoUnknownFields(tag, tagPath)...)
 
 	errs = append(errs, resources.ValidateUpdateMetadataRef(tag.GetMetadata(), tagPath.Child("metadata"))...)
 

--- a/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -482,5 +483,71 @@ func TestUpdateActorSnapshotTag_ConcurrentUpdate(t *testing.T) {
 	}
 	if got, want := storedTag.GetScope(), ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE; got != want {
 		t.Errorf("Stored scope = %v, want %v: the rejected update was applied anyway", got, want)
+	}
+}
+
+// TestUpdateActorSnapshotTag_RejectsUnknownFields checks that an update carrying
+// a field this binary has no descriptor for is refused.
+// Update replaces the whole object, so a field the server cannot see would
+// otherwise be persisted unexamined.
+func TestUpdateActorSnapshotTag_RejectsUnknownFields(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		// injectUnknownField attaches the unknown field somewhere in the request's tag.
+		injectUnknownField func(*ateapipb.ActorSnapshotTag)
+		// wantPath is where the resulting error points.
+		wantPath *field.Path
+	}{
+		{
+			name:               "at the top level",
+			injectUnknownField: func(tag *ateapipb.ActorSnapshotTag) { tag.ProtoReflect().SetUnknown(unknownField(9999)) },
+			wantPath:           field.NewPath("tag"),
+		},
+		{
+			name:               "nested in metadata",
+			injectUnknownField: func(tag *ateapipb.ActorSnapshotTag) { tag.Metadata.ProtoReflect().SetUnknown(unknownField(9999)) },
+			wantPath:           field.NewPath("tag", "metadata"),
+		},
+		{
+			name:               "nested in snapshot",
+			injectUnknownField: func(tag *ateapipb.ActorSnapshotTag) { tag.Snapshot.ProtoReflect().SetUnknown(unknownField(9999)) },
+			wantPath:           field.NewPath("tag", "snapshot"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, stored := rpcServiceWithActorSnapshotTag(t, &ateapipb.ActorSnapshotTag{
+				Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "tag-1"},
+				Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
+			})
+
+			in := proto.Clone(stored).(*ateapipb.ActorSnapshotTag)
+			tt.injectUnknownField(in)
+
+			_, err := svc.UpdateActorSnapshotTag(ctx, &ateapipb.UpdateActorSnapshotTagRequest{Tag: in})
+			wantErr := toGRPCStatusError(field.ErrorList{
+				field.Invalid(tt.wantPath, field.OmitValueType{}, ""),
+			})
+			if got, want := status.Code(err), status.Code(wantErr); got != want {
+				t.Fatalf("UpdateActorSnapshotTag() error code = %v, want %v (error: %v)", got, want, err)
+			}
+			if got, want := status.Convert(err).Message(), status.Convert(wantErr).Message(); got != want {
+				t.Errorf("UpdateActorSnapshotTag() error message = %q, want %q", got, want)
+			}
+
+			// The rejection happens before the store is touched, so the tag is
+			// left exactly as it was.
+			after, err := svc.GetActorSnapshotTag(ctx, &ateapipb.GetActorSnapshotTagRequest{
+				Tag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag-1"},
+			})
+			if err != nil {
+				t.Fatalf("GetActorSnapshotTag() error = %v", err)
+			}
+			if diff := cmp.Diff(stored, after, protocmp.Transform()); diff != "" {
+				t.Errorf("tag changed despite the rejection (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/cmd/ateapi/internal/controlapi/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -748,6 +749,83 @@ func TestValidateSuspendActorRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assertValidateErr(t, validateSuspendActorRequest(tt.req), tt.want)
+		})
+	}
+}
+
+// TestUpdateActor_RejectsUnknownFields checks that an update carrying a field
+// this binary has no descriptor for is refused.
+// Update replaces the whole object, so a field the server cannot see would
+// otherwise be persisted unexamined.
+func TestUpdateActor_RejectsUnknownFields(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		// placeUnknownField attaches the unknown field somewhere in the request's actor.
+		placeUnknownField func(*ateapipb.Actor)
+		// wantPath is where the resulting error points.
+		wantPath *field.Path
+	}{
+		{
+			name:              "at the top level",
+			placeUnknownField: func(a *ateapipb.Actor) { a.ProtoReflect().SetUnknown(unknownField(9999)) },
+			wantPath:          field.NewPath("actor"),
+		},
+		{
+			name:              "nested in metadata",
+			placeUnknownField: func(a *ateapipb.Actor) { a.Metadata.ProtoReflect().SetUnknown(unknownField(9999)) },
+			wantPath:          field.NewPath("actor", "metadata"),
+		},
+		{
+			name: "nested in worker_selector",
+			placeUnknownField: func(a *ateapipb.Actor) {
+				a.WorkerSelector = &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}}
+				a.WorkerSelector.ProtoReflect().SetUnknown(unknownField(9999))
+			},
+			wantPath: field.NewPath("actor", "worker_selector"),
+		},
+		{
+			name: "nested in metadata.update_time",
+			placeUnknownField: func(a *ateapipb.Actor) {
+				a.Metadata.UpdateTime.ProtoReflect().SetUnknown(unknownField(9999))
+			},
+			wantPath: field.NewPath("actor", "metadata", "update_time"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, stored := rpcServiceWithActor(t, &ateapipb.Actor{
+				Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+				ActorTemplateNamespace: "ns1",
+				ActorTemplateName:      "tmpl1",
+			})
+
+			in := proto.Clone(stored).(*ateapipb.Actor)
+			tt.placeUnknownField(in)
+
+			_, err := svc.UpdateActor(ctx, &ateapipb.UpdateActorRequest{Actor: in})
+			wantErr := toGRPCStatusError(field.ErrorList{
+				field.Invalid(tt.wantPath, field.OmitValueType{}, ""),
+			})
+			if got, want := status.Code(err), status.Code(wantErr); got != want {
+				t.Fatalf("UpdateActor() error code = %v, want %v (error: %v)", got, want, err)
+			}
+			if got, want := status.Convert(err).Message(), status.Convert(wantErr).Message(); got != want {
+				t.Errorf("UpdateActor() error message = %q, want %q", got, want)
+			}
+
+			// The rejection happens before the store is touched, so the actor
+			// is left exactly as it was.
+			after, err := svc.GetActor(ctx, &ateapipb.GetActorRequest{
+				Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: testActorID},
+			})
+			if err != nil {
+				t.Fatalf("GetActor() error = %v", err)
+			}
+			if diff := cmp.Diff(stored, after, protocmp.Transform()); diff != "" {
+				t.Errorf("actor changed despite the rejection (-want +got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/cmd/ateapi/internal/controlapi/validate.go
+++ b/cmd/ateapi/internal/controlapi/validate.go
@@ -17,9 +17,57 @@ package controlapi
 import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protopath"
+	"google.golang.org/protobuf/reflect/protorange"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func toGRPCStatusError(errs field.ErrorList) error {
 	return status.Error(codes.InvalidArgument, errs.ToAggregate().Error())
+}
+
+// validateNoUnknownFields reports an error for every unknown field in m, at
+// every level of nesting.
+//
+// A client newer than this binary can set fields this binary has no descriptor
+// for. protobuf keeps those bytes on the parsed message, so an Update — which
+// replaces the whole object — would persist them. The server cannot validate
+// such a field.
+func validateNoUnknownFields(m proto.Message, fldPath *field.Path) field.ErrorList {
+	r := m.ProtoReflect()
+	if !r.IsValid() {
+		return nil
+	}
+
+	var errs field.ErrorList
+	if err := protorange.Range(r, func(p protopath.Values) error {
+		msg, ok := p.Index(-1).Value.Interface().(protoreflect.Message)
+		if !ok || len(msg.GetUnknown()) == 0 {
+			return nil
+		}
+		// Report the path of the unknwown field
+		errs = append(errs, field.Invalid(toFieldPath(p.Path, fldPath), field.OmitValueType{}, ""))
+		return nil
+	}); err != nil {
+		errs = append(errs, field.InternalError(fldPath, err))
+	}
+	return errs
+}
+
+// toFieldPath renders a protopath as a field.Path rooted at root.
+func toFieldPath(p protopath.Path, root *field.Path) *field.Path {
+	out := root
+	for _, step := range p {
+		switch step.Kind() {
+		case protopath.FieldAccessStep:
+			out = out.Child(step.FieldDescriptor().TextName())
+		case protopath.ListIndexStep:
+			out = out.Index(step.ListIndex())
+		case protopath.MapIndexStep:
+			out = out.Key(step.MapIndex().String())
+		}
+	}
+	return out
 }

--- a/cmd/ateapi/internal/controlapi/validate_test.go
+++ b/cmd/ateapi/internal/controlapi/validate_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+)
+
+// unknownField encodes a varint field that no descriptor in this binary
+// declares, standing in for a field added by a newer client.
+func unknownField(num protowire.Number) []byte {
+	b := protowire.AppendTag(nil, num, protowire.VarintType)
+	return protowire.AppendVarint(b, 42)
+}
+
+// withUnknown attaches an unknown field to m and returns m, so cases below read
+// as a single expression.
+func withUnknown[M proto.Message](m M, num protowire.Number) M {
+	m.ProtoReflect().SetUnknown(unknownField(num))
+	return m
+}
+
+func TestValidateNoUnknownFields(t *testing.T) {
+	root := field.NewPath("actor")
+
+	tests := []struct {
+		name string
+		in   func() proto.Message
+		want field.ErrorList
+	}{
+		{
+			name: "no unknown fields",
+			in: func() proto.Message {
+				return &ateapipb.Actor{
+					Metadata:          &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "actor-1"},
+					ActorTemplateName: "tmpl1",
+					WorkerSelector:    &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
+				}
+			},
+			want: nil,
+		},
+		{
+			name: "nil message",
+			in: func() proto.Message {
+				return (*ateapipb.Actor)(nil)
+			},
+			want: nil,
+		},
+		{
+			name: "unknown field at the top level",
+			in: func() proto.Message {
+				return withUnknown(&ateapipb.Actor{ActorTemplateName: "tmpl1"}, 9999)
+			},
+			want: field.ErrorList{field.Invalid(root, field.OmitValueType{}, "")},
+		},
+		{
+			name: "unknown field nested in a singular message",
+			in: func() proto.Message {
+				return &ateapipb.Actor{
+					Metadata: withUnknown(&ateapipb.ResourceMetadata{Name: "actor-1"}, 9999),
+				}
+			},
+			want: field.ErrorList{field.Invalid(root.Child("metadata"), field.OmitValueType{}, "")},
+		},
+		{
+			name: "unknown field several levels deep",
+			in: func() proto.Message {
+				return &ateapipb.Actor{
+					Metadata: &ateapipb.ResourceMetadata{
+						Name:       "actor-1",
+						UpdateTime: withUnknown(timestamppb.New(time.Unix(1, 0)), 9999),
+					},
+				}
+			},
+			want: field.ErrorList{field.Invalid(root.Child("metadata").Child("update_time"), field.OmitValueType{}, "")},
+		},
+		{
+			name: "unknown fields at several levels are all reported",
+			in: func() proto.Message {
+				return withUnknown(&ateapipb.Actor{
+					Metadata:       withUnknown(&ateapipb.ResourceMetadata{Name: "actor-1"}, 9998),
+					WorkerSelector: withUnknown(&ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}}, 9997),
+				}, 9999)
+			},
+			want: field.ErrorList{
+				field.Invalid(root, field.OmitValueType{}, ""),
+				field.Invalid(root.Child("metadata"), field.OmitValueType{}, ""),
+				field.Invalid(root.Child("worker_selector"), field.OmitValueType{}, ""),
+			},
+		},
+		{
+			name: "several unknown fields on one message collapse to a single error",
+			in: func() proto.Message {
+				m := &ateapipb.Actor{ActorTemplateName: "tmpl1"}
+				m.ProtoReflect().SetUnknown(append(unknownField(9998), unknownField(9999)...))
+				return m
+			},
+			want: field.ErrorList{field.Invalid(root, field.OmitValueType{}, "")},
+		},
+		{
+			name: "unknown field inside a repeated message element",
+			in: func() proto.Message {
+				return &ateapipb.ListActorsResponse{
+					Actors: []*ateapipb.Actor{
+						{ActorTemplateName: "tmpl1"},
+						withUnknown(&ateapipb.Actor{ActorTemplateName: "tmpl2"}, 9999),
+					},
+				}
+			},
+			want: field.ErrorList{field.Invalid(root.Child("actors").Index(1), field.OmitValueType{}, "")},
+		},
+		{
+			name: "unknown field inside a map value message",
+			in: func() proto.Message {
+				return &ateapipb.SandboxAssets{
+					Assets: map[string]*ateapipb.ArchAssets{
+						"amd64": withUnknown(&ateapipb.ArchAssets{}, 9999),
+					},
+				}
+			},
+			want: field.ErrorList{field.Invalid(root.Child("assets").Key("amd64"), field.OmitValueType{}, "")},
+		},
+		{
+			name: "scalar map values cannot carry unknown fields",
+			in: func() proto.Message {
+				return &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid", "region": "us"}}
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertValidateErr(t, validateNoUnknownFields(tt.in(), root), tt.want)
+		})
+	}
+}

--- a/vendor/google.golang.org/protobuf/reflect/protopath/path.go
+++ b/vendor/google.golang.org/protobuf/reflect/protopath/path.go
@@ -1,0 +1,122 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package protopath provides functionality for
+// representing a sequence of protobuf reflection operations on a message.
+package protopath
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/internal/msgfmt"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// NOTE: The Path and Values are separate types here since there are use cases
+// where you would like to "address" some value in a message with just the path
+// and don't have the value information available.
+//
+// This is different from how github.com/google/go-cmp/cmp.Path operates,
+// which combines both path and value information together.
+// Since the cmp package itself is the only one ever constructing a cmp.Path,
+// it will always have the value available.
+
+// Path is a sequence of protobuf reflection steps applied to some root
+// protobuf message value to arrive at the current value.
+// The first step must be a [Root] step.
+type Path []Step
+
+// TODO: Provide a Parse function that parses something similar to or
+// perhaps identical to the output of Path.String.
+
+// Index returns the ith step in the path and supports negative indexing.
+// A negative index starts counting from the tail of the Path such that -1
+// refers to the last step, -2 refers to the second-to-last step, and so on.
+// It returns a zero Step value if the index is out-of-bounds.
+func (p Path) Index(i int) Step {
+	if i < 0 {
+		i = len(p) + i
+	}
+	if i < 0 || i >= len(p) {
+		return Step{}
+	}
+	return p[i]
+}
+
+// String returns a structured representation of the path
+// by concatenating the string representation of every path step.
+func (p Path) String() string {
+	var b []byte
+	for _, s := range p {
+		b = s.appendString(b)
+	}
+	return string(b)
+}
+
+// Values is a Path paired with a sequence of values at each step.
+// The lengths of [Values.Path] and [Values.Values] must be identical.
+// The first step must be a [Root] step and
+// the first value must be a concrete message value.
+type Values struct {
+	Path   Path
+	Values []protoreflect.Value
+}
+
+// Len reports the length of the path and values.
+// If the path and values have differing length, it returns the minimum length.
+func (p Values) Len() int {
+	n := len(p.Path)
+	if n > len(p.Values) {
+		n = len(p.Values)
+	}
+	return n
+}
+
+// Index returns the ith step and value and supports negative indexing.
+// A negative index starts counting from the tail of the Values such that -1
+// refers to the last pair, -2 refers to the second-to-last pair, and so on.
+func (p Values) Index(i int) (out struct {
+	Step  Step
+	Value protoreflect.Value
+}) {
+	// NOTE: This returns a single struct instead of two return values so that
+	// callers can make use of the the value in an expression:
+	//	vs.Index(i).Value.Interface()
+	n := p.Len()
+	if i < 0 {
+		i = n + i
+	}
+	if i < 0 || i >= n {
+		return out
+	}
+	out.Step = p.Path[i]
+	out.Value = p.Values[i]
+	return out
+}
+
+// String returns a humanly readable representation of the path and last value.
+// Do not depend on the output being stable.
+//
+// For example:
+//
+//	(path.to.MyMessage).list_field[5].map_field["hello"] = {hello: "world"}
+func (p Values) String() string {
+	n := p.Len()
+	if n == 0 {
+		return ""
+	}
+
+	// Determine the field descriptor associated with the last step.
+	var fd protoreflect.FieldDescriptor
+	last := p.Index(-1)
+	switch last.Step.kind {
+	case FieldAccessStep:
+		fd = last.Step.FieldDescriptor()
+	case MapIndexStep, ListIndexStep:
+		fd = p.Index(-2).Step.FieldDescriptor()
+	}
+
+	// Format the full path with the last value.
+	return fmt.Sprintf("%v = %v", p.Path[:n], msgfmt.FormatValue(last.Value, fd))
+}

--- a/vendor/google.golang.org/protobuf/reflect/protopath/step.go
+++ b/vendor/google.golang.org/protobuf/reflect/protopath/step.go
@@ -1,0 +1,241 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package protopath
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/internal/encoding/text"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// StepKind identifies the kind of step operation.
+// Each kind of step corresponds with some protobuf reflection operation.
+type StepKind int
+
+const (
+	invalidStep StepKind = iota
+	// RootStep identifies a step as the Root step operation.
+	RootStep
+	// FieldAccessStep identifies a step as the FieldAccess step operation.
+	FieldAccessStep
+	// UnknownAccessStep identifies a step as the UnknownAccess step operation.
+	UnknownAccessStep
+	// ListIndexStep identifies a step as the ListIndex step operation.
+	ListIndexStep
+	// MapIndexStep identifies a step as the MapIndex step operation.
+	MapIndexStep
+	// AnyExpandStep identifies a step as the AnyExpand step operation.
+	AnyExpandStep
+)
+
+func (k StepKind) String() string {
+	switch k {
+	case invalidStep:
+		return "<invalid>"
+	case RootStep:
+		return "Root"
+	case FieldAccessStep:
+		return "FieldAccess"
+	case UnknownAccessStep:
+		return "UnknownAccess"
+	case ListIndexStep:
+		return "ListIndex"
+	case MapIndexStep:
+		return "MapIndex"
+	case AnyExpandStep:
+		return "AnyExpand"
+	default:
+		return fmt.Sprintf("<unknown:%d>", k)
+	}
+}
+
+// Step is a union where only one step operation may be specified at a time.
+// The different kinds of steps are specified by the constants defined for
+// the StepKind type.
+type Step struct {
+	kind StepKind
+	desc protoreflect.Descriptor
+	key  protoreflect.Value
+}
+
+// Root indicates the root message that a path is relative to.
+// It should always (and only ever) be the first step in a path.
+func Root(md protoreflect.MessageDescriptor) Step {
+	if md == nil {
+		panic("nil message descriptor")
+	}
+	return Step{kind: RootStep, desc: md}
+}
+
+// FieldAccess describes access of a field within a message.
+// Extension field accesses are also represented using a FieldAccess and
+// must be provided with a protoreflect.FieldDescriptor
+//
+// Within the context of Values,
+// the type of the previous step value is always a message, and
+// the type of the current step value is determined by the field descriptor.
+func FieldAccess(fd protoreflect.FieldDescriptor) Step {
+	if fd == nil {
+		panic("nil field descriptor")
+	} else if _, ok := fd.(protoreflect.ExtensionTypeDescriptor); !ok && fd.IsExtension() {
+		panic(fmt.Sprintf("extension field %q must implement protoreflect.ExtensionTypeDescriptor", fd.FullName()))
+	}
+	return Step{kind: FieldAccessStep, desc: fd}
+}
+
+// UnknownAccess describes access to the unknown fields within a message.
+//
+// Within the context of Values,
+// the type of the previous step value is always a message, and
+// the type of the current step value is always a bytes type.
+func UnknownAccess() Step {
+	return Step{kind: UnknownAccessStep}
+}
+
+// ListIndex describes index of an element within a list.
+//
+// Within the context of Values,
+// the type of the previous, previous step value is always a message,
+// the type of the previous step value is always a list, and
+// the type of the current step value is determined by the field descriptor.
+func ListIndex(i int) Step {
+	if i < 0 {
+		panic(fmt.Sprintf("invalid list index: %v", i))
+	}
+	return Step{kind: ListIndexStep, key: protoreflect.ValueOfInt64(int64(i))}
+}
+
+// MapIndex describes index of an entry within a map.
+// The key type is determined by field descriptor that the map belongs to.
+//
+// Within the context of Values,
+// the type of the previous previous step value is always a message,
+// the type of the previous step value is always a map, and
+// the type of the current step value is determined by the field descriptor.
+func MapIndex(k protoreflect.MapKey) Step {
+	if !k.IsValid() {
+		panic("invalid map index")
+	}
+	return Step{kind: MapIndexStep, key: k.Value()}
+}
+
+// AnyExpand describes expansion of a google.protobuf.Any message into
+// a structured representation of the underlying message.
+//
+// Within the context of Values,
+// the type of the previous step value is always a google.protobuf.Any message, and
+// the type of the current step value is always a message.
+func AnyExpand(md protoreflect.MessageDescriptor) Step {
+	if md == nil {
+		panic("nil message descriptor")
+	}
+	return Step{kind: AnyExpandStep, desc: md}
+}
+
+// MessageDescriptor returns the message descriptor for Root or AnyExpand steps,
+// otherwise it returns nil.
+func (s Step) MessageDescriptor() protoreflect.MessageDescriptor {
+	switch s.kind {
+	case RootStep, AnyExpandStep:
+		return s.desc.(protoreflect.MessageDescriptor)
+	default:
+		return nil
+	}
+}
+
+// FieldDescriptor returns the field descriptor for FieldAccess steps,
+// otherwise it returns nil.
+func (s Step) FieldDescriptor() protoreflect.FieldDescriptor {
+	switch s.kind {
+	case FieldAccessStep:
+		return s.desc.(protoreflect.FieldDescriptor)
+	default:
+		return nil
+	}
+}
+
+// ListIndex returns the list index for ListIndex steps,
+// otherwise it returns 0.
+func (s Step) ListIndex() int {
+	switch s.kind {
+	case ListIndexStep:
+		return int(s.key.Int())
+	default:
+		return 0
+	}
+}
+
+// MapIndex returns the map key for MapIndex steps,
+// otherwise it returns an invalid map key.
+func (s Step) MapIndex() protoreflect.MapKey {
+	switch s.kind {
+	case MapIndexStep:
+		return s.key.MapKey()
+	default:
+		return protoreflect.MapKey{}
+	}
+}
+
+// Kind reports which kind of step this is.
+func (s Step) Kind() StepKind {
+	return s.kind
+}
+
+func (s Step) String() string {
+	return string(s.appendString(nil))
+}
+
+func (s Step) appendString(b []byte) []byte {
+	switch s.kind {
+	case RootStep:
+		b = append(b, '(')
+		b = append(b, s.desc.FullName()...)
+		b = append(b, ')')
+	case FieldAccessStep:
+		b = append(b, '.')
+		if fd := s.desc.(protoreflect.FieldDescriptor); fd.IsExtension() {
+			b = append(b, '(')
+			b = append(b, strings.Trim(fd.TextName(), "[]")...)
+			b = append(b, ')')
+		} else {
+			b = append(b, fd.TextName()...)
+		}
+	case UnknownAccessStep:
+		b = append(b, '.')
+		b = append(b, '?')
+	case ListIndexStep:
+		b = append(b, '[')
+		b = strconv.AppendInt(b, s.key.Int(), 10)
+		b = append(b, ']')
+	case MapIndexStep:
+		b = append(b, '[')
+		switch k := s.key.Interface().(type) {
+		case bool:
+			b = strconv.AppendBool(b, bool(k)) // e.g., "true" or "false"
+		case int32:
+			b = strconv.AppendInt(b, int64(k), 10) // e.g., "-32"
+		case int64:
+			b = strconv.AppendInt(b, int64(k), 10) // e.g., "-64"
+		case uint32:
+			b = strconv.AppendUint(b, uint64(k), 10) // e.g., "32"
+		case uint64:
+			b = strconv.AppendUint(b, uint64(k), 10) // e.g., "64"
+		case string:
+			b = text.AppendString(b, k) // e.g., `"hello, world"`
+		}
+		b = append(b, ']')
+	case AnyExpandStep:
+		b = append(b, '.')
+		b = append(b, '(')
+		b = append(b, s.desc.FullName()...)
+		b = append(b, ')')
+	default:
+		b = append(b, "<invalid>"...)
+	}
+	return b
+}

--- a/vendor/google.golang.org/protobuf/reflect/protorange/range.go
+++ b/vendor/google.golang.org/protobuf/reflect/protorange/range.go
@@ -1,0 +1,316 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package protorange provides functionality to traverse a message value.
+package protorange
+
+import (
+	"bytes"
+	"errors"
+
+	"google.golang.org/protobuf/internal/genid"
+	"google.golang.org/protobuf/internal/order"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protopath"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+var (
+	// Break breaks traversal of children in the current value.
+	// It has no effect when traversing values that are not composite types
+	// (e.g., messages, lists, and maps).
+	Break = errors.New("break traversal of children in current value")
+
+	// Terminate terminates the entire range operation.
+	// All necessary Pop operations continue to be called.
+	Terminate = errors.New("terminate range operation")
+)
+
+// Range performs a depth-first traversal over reachable values in a message.
+//
+// See [Options.Range] for details.
+func Range(m protoreflect.Message, f func(protopath.Values) error) error {
+	return Options{}.Range(m, f, nil)
+}
+
+// Options configures traversal of a message value tree.
+type Options struct {
+	// Stable specifies whether to visit message fields and map entries
+	// in a stable ordering. If false, then the ordering is undefined and
+	// may be non-deterministic.
+	//
+	// Message fields are visited in ascending order by field number.
+	// Map entries are visited in ascending order, where
+	// boolean keys are ordered such that false sorts before true,
+	// numeric keys are ordered based on the numeric value, and
+	// string keys are lexicographically ordered by Unicode codepoints.
+	Stable bool
+
+	// Resolver is used for looking up types when expanding google.protobuf.Any
+	// messages. If nil, this defaults to using protoregistry.GlobalTypes.
+	// To prevent expansion of Any messages, pass an empty protoregistry.Types:
+	//
+	//	Options{Resolver: (*protoregistry.Types)(nil)}
+	//
+	Resolver interface {
+		protoregistry.ExtensionTypeResolver
+		protoregistry.MessageTypeResolver
+	}
+}
+
+// Range performs a depth-first traversal over reachable values in a message.
+// The first push and the last pop are to push/pop a [protopath.Root] step.
+// If push or pop return any non-nil error (other than [Break] or [Terminate]),
+// it terminates the traversal and is returned by Range.
+//
+// The rules for traversing a message is as follows:
+//
+//   - For messages, iterate over every populated known and extension field.
+//     Each field is preceded by a push of a [protopath.FieldAccess] step,
+//     followed by recursive application of the rules on the field value,
+//     and succeeded by a pop of that step.
+//     If the message has unknown fields, then push an [protopath.UnknownAccess] step
+//     followed immediately by pop of that step.
+//
+//   - As an exception to the above rule, if the current message is a
+//     google.protobuf.Any message, expand the underlying message (if resolvable).
+//     The expanded message is preceded by a push of a [protopath.AnyExpand] step,
+//     followed by recursive application of the rules on the underlying message,
+//     and succeeded by a pop of that step. Mutations to the expanded message
+//     are written back to the Any message when popping back out.
+//
+//   - For lists, iterate over every element. Each element is preceded by a push
+//     of a [protopath.ListIndex] step, followed by recursive application of the rules
+//     on the list element, and succeeded by a pop of that step.
+//
+//   - For maps, iterate over every entry. Each entry is preceded by a push
+//     of a [protopath.MapIndex] step, followed by recursive application of the rules
+//     on the map entry value, and succeeded by a pop of that step.
+//
+// Mutations should only be made to the last value, otherwise the effects on
+// traversal will be undefined. If the mutation is made to the last value
+// during to a push, then the effects of the mutation will affect traversal.
+// For example, if the last value is currently a message, and the push function
+// populates a few fields in that message, then the newly modified fields
+// will be traversed.
+//
+// The [protopath.Values] provided to push functions is only valid until the
+// corresponding pop call and the values provided to a pop call is only valid
+// for the duration of the pop call itself.
+func (o Options) Range(m protoreflect.Message, push, pop func(protopath.Values) error) error {
+	var err error
+	p := new(protopath.Values)
+	if o.Resolver == nil {
+		o.Resolver = protoregistry.GlobalTypes
+	}
+
+	pushStep(p, protopath.Root(m.Descriptor()), protoreflect.ValueOfMessage(m))
+	if push != nil {
+		err = amendError(err, push(*p))
+	}
+	if err == nil {
+		err = o.rangeMessage(p, m, push, pop)
+	}
+	if pop != nil {
+		err = amendError(err, pop(*p))
+	}
+	popStep(p)
+
+	if err == Break || err == Terminate {
+		err = nil
+	}
+	return err
+}
+
+func (o Options) rangeMessage(p *protopath.Values, m protoreflect.Message, push, pop func(protopath.Values) error) (err error) {
+	if ok, err := o.rangeAnyMessage(p, m, push, pop); ok {
+		return err
+	}
+
+	fieldOrder := order.AnyFieldOrder
+	if o.Stable {
+		fieldOrder = order.NumberFieldOrder
+	}
+	order.RangeFields(m, fieldOrder, func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		pushStep(p, protopath.FieldAccess(fd), v)
+		if push != nil {
+			err = amendError(err, push(*p))
+		}
+		if err == nil {
+			switch {
+			case fd.IsMap():
+				err = o.rangeMap(p, fd, v.Map(), push, pop)
+			case fd.IsList():
+				err = o.rangeList(p, fd, v.List(), push, pop)
+			case fd.Message() != nil:
+				err = o.rangeMessage(p, v.Message(), push, pop)
+			}
+		}
+		if pop != nil {
+			err = amendError(err, pop(*p))
+		}
+		popStep(p)
+		return err == nil
+	})
+
+	if b := m.GetUnknown(); len(b) > 0 && err == nil {
+		pushStep(p, protopath.UnknownAccess(), protoreflect.ValueOfBytes(b))
+		if push != nil {
+			err = amendError(err, push(*p))
+		}
+		if pop != nil {
+			err = amendError(err, pop(*p))
+		}
+		popStep(p)
+	}
+
+	if err == Break {
+		err = nil
+	}
+	return err
+}
+
+func (o Options) rangeAnyMessage(p *protopath.Values, m protoreflect.Message, push, pop func(protopath.Values) error) (ok bool, err error) {
+	md := m.Descriptor()
+	if md.FullName() != "google.protobuf.Any" {
+		return false, nil
+	}
+
+	fds := md.Fields()
+	url := m.Get(fds.ByNumber(genid.Any_TypeUrl_field_number)).String()
+	val := m.Get(fds.ByNumber(genid.Any_Value_field_number)).Bytes()
+	mt, errFind := o.Resolver.FindMessageByURL(url)
+	if errFind != nil {
+		return false, nil
+	}
+
+	// Unmarshal the raw encoded message value into a structured message value.
+	m2 := mt.New()
+	errUnmarshal := proto.UnmarshalOptions{
+		Merge:        true,
+		AllowPartial: true,
+		Resolver:     o.Resolver,
+	}.Unmarshal(val, m2.Interface())
+	if errUnmarshal != nil {
+		// If the the underlying message cannot be unmarshaled,
+		// then just treat this as an normal message type.
+		return false, nil
+	}
+
+	// Marshal Any before ranging to detect possible mutations.
+	b1, errMarshal := proto.MarshalOptions{
+		AllowPartial:  true,
+		Deterministic: true,
+	}.Marshal(m2.Interface())
+	if errMarshal != nil {
+		return true, errMarshal
+	}
+
+	pushStep(p, protopath.AnyExpand(m2.Descriptor()), protoreflect.ValueOfMessage(m2))
+	if push != nil {
+		err = amendError(err, push(*p))
+	}
+	if err == nil {
+		err = o.rangeMessage(p, m2, push, pop)
+	}
+	if pop != nil {
+		err = amendError(err, pop(*p))
+	}
+	popStep(p)
+
+	// Marshal Any after ranging to detect possible mutations.
+	b2, errMarshal := proto.MarshalOptions{
+		AllowPartial:  true,
+		Deterministic: true,
+	}.Marshal(m2.Interface())
+	if errMarshal != nil {
+		return true, errMarshal
+	}
+
+	// Mutations detected, write the new sequence of bytes to the Any message.
+	if !bytes.Equal(b1, b2) {
+		m.Set(fds.ByNumber(genid.Any_Value_field_number), protoreflect.ValueOfBytes(b2))
+	}
+
+	if err == Break {
+		err = nil
+	}
+	return true, err
+}
+
+func (o Options) rangeList(p *protopath.Values, fd protoreflect.FieldDescriptor, ls protoreflect.List, push, pop func(protopath.Values) error) (err error) {
+	for i := 0; i < ls.Len() && err == nil; i++ {
+		v := ls.Get(i)
+		pushStep(p, protopath.ListIndex(i), v)
+		if push != nil {
+			err = amendError(err, push(*p))
+		}
+		if err == nil && fd.Message() != nil {
+			err = o.rangeMessage(p, v.Message(), push, pop)
+		}
+		if pop != nil {
+			err = amendError(err, pop(*p))
+		}
+		popStep(p)
+	}
+
+	if err == Break {
+		err = nil
+	}
+	return err
+}
+
+func (o Options) rangeMap(p *protopath.Values, fd protoreflect.FieldDescriptor, ms protoreflect.Map, push, pop func(protopath.Values) error) (err error) {
+	keyOrder := order.AnyKeyOrder
+	if o.Stable {
+		keyOrder = order.GenericKeyOrder
+	}
+	order.RangeEntries(ms, keyOrder, func(k protoreflect.MapKey, v protoreflect.Value) bool {
+		pushStep(p, protopath.MapIndex(k), v)
+		if push != nil {
+			err = amendError(err, push(*p))
+		}
+		if err == nil && fd.MapValue().Message() != nil {
+			err = o.rangeMessage(p, v.Message(), push, pop)
+		}
+		if pop != nil {
+			err = amendError(err, pop(*p))
+		}
+		popStep(p)
+		return err == nil
+	})
+
+	if err == Break {
+		err = nil
+	}
+	return err
+}
+
+func pushStep(p *protopath.Values, s protopath.Step, v protoreflect.Value) {
+	p.Path = append(p.Path, s)
+	p.Values = append(p.Values, v)
+}
+
+func popStep(p *protopath.Values) {
+	p.Path = p.Path[:len(p.Path)-1]
+	p.Values = p.Values[:len(p.Values)-1]
+}
+
+// amendError amends the previous error with the current error if it is
+// considered more serious. The precedence order for errors is:
+//
+//	nil < Break < Terminate < previous non-nil < current non-nil
+func amendError(prev, curr error) error {
+	switch {
+	case curr == nil:
+		return prev
+	case curr == Break && prev != nil:
+		return prev
+	case curr == Terminate && prev != nil && prev != Break:
+		return prev
+	default:
+		return curr
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1305,6 +1305,8 @@ google.golang.org/protobuf/internal/version
 google.golang.org/protobuf/proto
 google.golang.org/protobuf/protoadapt
 google.golang.org/protobuf/reflect/protodesc
+google.golang.org/protobuf/reflect/protopath
+google.golang.org/protobuf/reflect/protorange
 google.golang.org/protobuf/reflect/protoreflect
 google.golang.org/protobuf/reflect/protoregistry
 google.golang.org/protobuf/runtime/protoiface


### PR DESCRIPTION
https://github.com/agent-substrate/substrate/issues/1011

An update containing unknown fields during a RMW indicates there's a version skew between client and server. 

So, the server enforces a policy to fail explicitly when it receives an unknown proto field: so that  it does not silently drop fields that the user intended to set but the current server version cannot process 

This also helps to avoid behaviour drift during rolling upgrades: During rolling upgrades, different components (like the data plane and control plane) can be on different versions. If an older server replica . If an older server replica processes a request coming from a newer client, it will reject it (it doesn't know how to validate/handle it) and it's the client's responsibility to retry.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
