### PR TITLE
atenet: give the egress ext_proc filter a message timeout that covers the ateapi lookup

### DIFF
--- a/manifests/ate-install/atenet-egress-with-sdsmint.yaml
+++ b/manifests/ate-install/atenet-egress-with-sdsmint.yaml
@@ -167,6 +167,8 @@ data:
                       cluster_name: ext_proc_server
                     timeout: 2s
                   failure_mode_allow: false
+                  # Set ext_proc timeout to 5s (from default 200ms) to handle slower ext_proc transactions.
+                  message_timeout: 5s
                   # How the ext_proc server tells egress from ingress. It applies
                   # opposite trust models to the two directions, and dispatches on
                   # this Envoy-asserted filter chain name so that no client can

--- a/manifests/ate-install/atenet-egress.yaml
+++ b/manifests/ate-install/atenet-egress.yaml
@@ -123,6 +123,8 @@ data:
                       cluster_name: ext_proc_server
                     timeout: 2s
                   failure_mode_allow: false
+                  # Set ext_proc timeout to 5s (from default 200ms) to handle slower ext_proc transactions.
+                  message_timeout: 5s
                   # How the ext_proc server tells egress from ingress. It applies
                   # opposite trust models to the two directions, and dispatches on
                   # this Envoy-asserted filter chain name so that no client can


### PR DESCRIPTION
    Envoy's ext_proc message_timeout defaults to 200ms, and the egress
    CONNECT filter never set it. That default suits a sidecar answering out
    of its own memory; this one authorizes each CONNECT with a GetActor
    round trip to the ate API, and the first RPC after a router restart also
    pays the lazy gRPC channel's DNS, TCP, and mTLS handshake. Past 200ms
    with failure_mode_allow: false, Envoy abandons the request and answers
    504 Gateway Timeout, discarding the verdict the handler was about to
    give -- so a deny arrives as a 504 rather than the handler's 403, and a
    real actor's first egress after a restart can eat the same 504.
    
    Set message_timeout to 5s.

Fixes #1172 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
