### PR TITLE
e2e: make the probe's trust-bundle projection opt-in

### DIFF
--- a/internal/e2e/fixtures/probe/probe.yaml.tmpl
+++ b/internal/e2e/fixtures/probe/probe.yaml.tmpl
@@ -57,12 +57,9 @@ ${TEMPLATE_SANDBOX_CLASS}
             path: atespace
           - field: uid
             path: actor-uid
-      # The name must be on atelet's supported-bundle allowlist. DeployProbe
-      # ensures the bundle exists before applying this template: actors fail
-      # to start while it is missing.
-      - trustBundle:
-          name: egress-mitm.ate.dev
-          path: trust-bundle.pem
+      # Only for suites that pass WithTrustBundle: the bundle is a cluster
+      # singleton, so a suite that merely needs a probe must not depend on it.
+${TEMPLATE_TRUST_BUNDLE}
   containers:
   - name: probe
     image: ko://github.com/agent-substrate/substrate/internal/e2e/fixtures/probe

--- a/internal/e2e/probe.go
+++ b/internal/e2e/probe.go
@@ -14,23 +14,62 @@
 
 package e2e
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // ProbeName is the name of the probe fixture's WorkerPool and ActorTemplate,
 // inside the namespace DeployProbe returns.
 const ProbeName = "probe"
+
+// probeManifest is the fixture template DeployProbe renders.
+const probeManifest = "internal/e2e/fixtures/probe/probe.yaml.tmpl"
+
+// trustBundleDataSource fills ${TEMPLATE_TRUST_BUNDLE}, indented to sit in the
+// template's dataSources list. The name must be on atelet's supported-bundle
+// allowlist.
+const trustBundleDataSource = `      - trustBundle:
+          name: egress-mitm.ate.dev
+          path: trust-bundle.pem`
+
+// ProbeOption adjusts what DeployProbe installs.
+type ProbeOption func(*probeConfig)
+
+type probeConfig struct{ trustBundle bool }
+
+// WithTrustBundle projects the egress trust bundle into the probe's
+// system-info volume, ensuring the cluster-scoped bundle exists first.
+//
+// Only suites that ASSERT the projection ask for it. The bundle is derived
+// from a single cluster-wide Secret, so a suite that merely needs a probe must
+// not depend on it: it would then fail whenever the suite that owns the pool
+// finishes and takes the bundle with it. For the same reason two suites that
+// opt in must not run concurrently — CI runs the egress ones in their own
+// step, leaving the identity suite the only opt-in in the standard lanes.
+func WithTrustBundle() ProbeOption { return func(c *probeConfig) { c.trustBundle = true } }
 
 // DeployProbe builds the probe fixture image and applies its manifest for the
 // sandbox class under test, removing it when the test ends. name distinguishes
 // the caller (by convention its suite name): each suite gets its own copy of
 // the fixture, so no suite's cleanup can delete the fixture out from under
 // another running concurrently. It returns the fixture's namespace.
-func DeployProbe(t *testing.T, bucket, name string) string {
+func DeployProbe(t *testing.T, bucket, name string, opts ...ProbeOption) string {
 	t.Helper()
+
+	var cfg probeConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.trustBundle {
+		// Every actor from this template — the fixture's golden boot included —
+		// fails closed while the bundle is missing, so it has to exist first.
+		EnsureEgressTrustBundle(t, context.Background(), GetClients())
+	}
 
 	// One manifest, rendered for the sandbox class under test, so both apply
 	// and delete consume the same file without any shell involved.
-	manifest := RenderFixtureManifest(t, "internal/e2e/fixtures/probe/probe.yaml.tmpl", bucket, name)
+	manifest := renderProbeManifest(t, bucket, name, cfg)
 	koApply(t, manifest)
 
 	// Unlike the fixtures that live in a namespace CreateNamespace tears down,
@@ -48,4 +87,15 @@ func DeployProbe(t *testing.T, bucket, name string) string {
 	})
 
 	return FixtureName("ate-e2e-probe") + "-" + name
+}
+
+// renderProbeManifest renders the probe fixture for cfg. Split out of
+// DeployProbe so the rendering has a unit test that needs no cluster.
+func renderProbeManifest(t *testing.T, bucket, name string, cfg probeConfig) string {
+	t.Helper()
+	inline, blocks := fixtureSubstitutions(bucket, name)
+	if cfg.trustBundle {
+		blocks["${TEMPLATE_TRUST_BUNDLE}"] = trustBundleDataSource
+	}
+	return renderManifest(t, probeManifest, inline, blocks)
 }

--- a/internal/e2e/probe_test.go
+++ b/internal/e2e/probe_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+)
+
+// TestRenderProbeManifest_TrustBundle pins the opt-in. The bundle is derived
+// from one cluster-wide Secret, so a probe suite that does not ask for the
+// projection must not carry it: it would otherwise fail whenever the suite
+// that owns the pool finishes and takes the bundle with it.
+func TestRenderProbeManifest_TrustBundle(t *testing.T) {
+	t.Setenv(sandboxClassEnv, "")
+	for _, tc := range []struct {
+		name string
+		cfg  probeConfig
+		want bool
+	}{
+		{"default", probeConfig{}, false},
+		{"WithTrustBundle", probeConfig{trustBundle: true}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Strict decoding is what proves the fragment landed at the right
+			// depth: misindented, it would parse as some other field.
+			_, template := decodeFixture(t, probeManifest,
+				renderProbeManifest(t, "test-bucket", "render", tc.cfg))
+
+			var source *v1alpha1.TrustBundleDataSource
+			for _, vol := range template.Spec.Volumes {
+				if vol.SystemInfo == nil {
+					continue
+				}
+				for _, ds := range vol.SystemInfo.DataSources {
+					if ds.TrustBundle != nil {
+						source = ds.TrustBundle
+					}
+				}
+			}
+			if (source != nil) != tc.want {
+				t.Fatalf("trustBundle data source present = %v, want %v", source != nil, tc.want)
+			}
+			if source == nil {
+				return
+			}
+			// The projected name must select the bundle atecontroller
+			// publishes, or actors fail closed on a name atelet rejects.
+			if !strings.HasPrefix(EgressTrustBundleObjectName, source.Name+":") {
+				t.Errorf("trustBundle name = %q, want the bundle backing %q", source.Name, EgressTrustBundleObjectName)
+			}
+			if source.Path == "" {
+				t.Error("trustBundle projection has no path")
+			}
+		})
+	}
+}

--- a/internal/e2e/sandbox.go
+++ b/internal/e2e/sandbox.go
@@ -157,6 +157,8 @@ func fixtureSubstitutions(bucket, name string) (inline, blocks map[string]string
 		"${WORKERPOOL_RUNTIME}":     "",
 		"${TEMPLATE_SANDBOX_CLASS}": "",
 		"${TEMPLATE_RESOURCES}":     "",
+		// Off unless the caller opts in; see WithTrustBundle.
+		"${TEMPLATE_TRUST_BUNDLE}": "",
 	}
 	if !IsMicroVM() {
 		return inline, blocks

--- a/internal/e2e/sandbox_test.go
+++ b/internal/e2e/sandbox_test.go
@@ -40,7 +40,14 @@ var fixtureManifests = []string{
 // a WorkerPool that never gets a micro-VM worker.
 func renderFixture(t *testing.T, relPath string) (*v1alpha1.WorkerPool, *v1alpha1.ActorTemplate) {
 	t.Helper()
-	raw, err := os.ReadFile(RenderFixtureManifest(t, relPath, "test-bucket", "render"))
+	return decodeFixture(t, relPath, RenderFixtureManifest(t, relPath, "test-bucket", "render"))
+}
+
+// decodeFixture strict-decodes an already-rendered manifest, for callers that
+// render a fixture some way other than RenderFixtureManifest.
+func decodeFixture(t *testing.T, relPath, rendered string) (*v1alpha1.WorkerPool, *v1alpha1.ActorTemplate) {
+	t.Helper()
+	raw, err := os.ReadFile(rendered)
 	if err != nil {
 		t.Fatalf("reading the rendered %s: %v", relPath, err)
 	}

--- a/internal/e2e/suites/egressmitm/egressmitm_test.go
+++ b/internal/e2e/suites/egressmitm/egressmitm_test.go
@@ -87,7 +87,7 @@ func TestActorEgressMITMTrust(t *testing.T) {
 	// missing.)
 	e2e.EnsureEgressTrustBundle(t, ctx, clients)
 
-	probeNamespace = e2e.DeployProbe(t, env["BUCKET_NAME"], "egressmitm")
+	probeNamespace = e2e.DeployProbe(t, env["BUCKET_NAME"], "egressmitm", e2e.WithTrustBundle())
 	waitForGolden(t, ctx, clients)
 
 	const id = "probe-mitm"

--- a/internal/e2e/suites/identity/identity_test.go
+++ b/internal/e2e/suites/identity/identity_test.go
@@ -79,7 +79,7 @@ func TestActorIdentity_AfterRestore_IsOwnID_NotGolden(t *testing.T) {
 	// ensures a bundle EXISTS): the assertions below compare the projected
 	// file against this run's CA, and rotation later replaces it again.
 	wantTrust := e2e.ReplaceEgressTrustPool(t, ctx, clients, "ate-e2e-probe-trust")
-	probeNamespace = e2e.DeployProbe(t, env["BUCKET_NAME"], "identity")
+	probeNamespace = e2e.DeployProbe(t, env["BUCKET_NAME"], "identity", e2e.WithTrustBundle())
 	golden := waitForGolden(t, ctx, clients)
 
 	// Two distinct actors from the same golden snapshot.

--- a/internal/e2e/trustbundle.go
+++ b/internal/e2e/trustbundle.go
@@ -44,36 +44,47 @@ const (
 	egressCAPoolSecretKey  = "pool"
 )
 
-// EnsureEgressTrustBundle makes sure the egress trust bundle exists: if the
-// CA pool Secret is absent it provisions one (registering cleanup), then
-// waits until the reconciler-published bundle is non-empty. DeployProbe calls
-// this because the probe template projects the bundle and every actor —
-// including the fixture's golden boot — fails closed while it is missing; a
-// suite that needs to OWN the pool's contents (the identity suite's
-// deterministic assertions and rotation) uses ReplaceEgressTrustPool first,
-// which this then leaves untouched.
+// EnsureEgressTrustBundle makes sure the egress trust bundle exists, then
+// waits until the reconciler-published bundle is non-empty. It provisions a
+// pool only when there is none and never replaces one it finds: the pool is
+// cluster-wide, and the sdsmint gateway mounts the one the install created.
+// A suite that needs to OWN the pool's contents (the identity suite's
+// deterministic assertions and rotation) uses ReplaceEgressTrustPool.
 func EnsureEgressTrustBundle(t *testing.T, ctx context.Context, clients *Clients) {
 	t.Helper()
-	_, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{})
-	if err == nil {
-		waitForEgressTrustBundle(t, ctx, clients, "")
-		return
-	}
-	if !apierrors.IsNotFound(err) {
-		t.Fatalf("reading CA pool secret %s/%s: %v", egressCAPoolNamespace, egressCAPoolSecretName, err)
-	}
-	ReplaceEgressTrustPool(t, ctx, clients, "ate-e2e-trust")
+	secret, _ := newEgressTrustPool(t, "ate-e2e-trust")
+	createEgressTrustPool(t, ctx, clients, secret)
+	waitForEgressTrustBundle(t, ctx, clients, "")
 }
 
-// ReplaceEgressTrustPool creates or replaces the egress CA pool with a fresh
-// single-CA pool (the shape `kubectl-ate admin make-ca-pool` creates for the
-// egress MITM CA), waits for the reconciler to publish the derived bundle,
-// and returns the PEM of the new CA's root certificate — exactly what a
-// trustBundle projection must then deliver. cn keeps successive pools
-// distinguishable in failure output. Cleanup deletes the Secret, whereupon
-// the reconciler deletes the bundle; create-or-replace keeps reruns
-// self-healing after a failed prior run.
+// ReplaceEgressTrustPool installs a fresh single-CA pool, waits for the
+// reconciler to publish the derived bundle, and returns the PEM of the new
+// CA's root certificate — exactly what a trustBundle projection must then
+// deliver. cn keeps successive pools distinguishable in failure output.
+// Create-or-replace keeps reruns self-healing after a failed prior run.
 func ReplaceEgressTrustPool(t *testing.T, ctx context.Context, clients *Clients, cn string) string {
+	t.Helper()
+	secret, wantPEM := newEgressTrustPool(t, cn)
+	if !createEgressTrustPool(t, ctx, clients, secret) {
+		// Took over an existing pool: overwrite its contents without adopting
+		// its cleanup, since whoever created it registered one already.
+		existing, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("reading existing CA pool secret: %v", err)
+		}
+		existing.Data = secret.Data
+		if _, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("updating CA pool secret: %v", err)
+		}
+	}
+	waitForEgressTrustBundle(t, ctx, clients, wantPEM)
+	return wantPEM
+}
+
+// newEgressTrustPool builds a fresh single-CA pool Secret — the shape
+// `kubectl-ate admin make-ca-pool` writes for the egress MITM CA — and the PEM
+// of its root certificate.
+func newEgressTrustPool(t *testing.T, cn string) (*corev1.Secret, string) {
 	t.Helper()
 	ca, err := localca.GenerateCA(localca.GenerateOptions{ID: "mitm", CommonName: cn, KeyType: localca.KeyTypeECDSAP256})
 	if err != nil {
@@ -83,34 +94,29 @@ func ReplaceEgressTrustPool(t *testing.T, ctx context.Context, clients *Clients,
 	if err != nil {
 		t.Fatalf("marshaling the egress pool: %v", err)
 	}
-	wantPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.RootCertificate.Raw}))
-
-	secret := &corev1.Secret{
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Namespace: egressCAPoolNamespace, Name: egressCAPoolSecretName},
 		Data:       map[string][]byte{egressCAPoolSecretKey: poolBytes},
-	}
+	}, string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.RootCertificate.Raw}))
+}
+
+// createEgressTrustPool creates secret and reports whether this call created
+// it, tolerating a pool that already exists so concurrent first users cannot
+// clobber each other. The creator — and only the creator — deletes it when its
+// test ends, whereupon the reconciler deletes the bundle: a run leaves nothing
+// behind, and no caller removes a pool it merely found.
+func createEgressTrustPool(t *testing.T, ctx context.Context, clients *Clients, secret *corev1.Secret) bool {
+	t.Helper()
 	if _, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			t.Fatalf("creating CA pool secret %s/%s: %v", egressCAPoolNamespace, egressCAPoolSecretName, err)
 		}
-		existing, getErr := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Get(ctx, egressCAPoolSecretName, metav1.GetOptions{})
-		if getErr != nil {
-			t.Fatalf("reading existing CA pool secret: %v", getErr)
-		}
-		existing.Data = secret.Data
-		if _, err := clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
-			t.Fatalf("updating CA pool secret: %v", err)
-		}
-		// The replacer takes over an existing pool without adopting its
-		// cleanup: whoever created it registered one already.
-		waitForEgressTrustBundle(t, ctx, clients, wantPEM)
-		return wantPEM
+		return false
 	}
 	t.Cleanup(func() {
 		_ = clients.K8s.CoreV1().Secrets(egressCAPoolNamespace).Delete(context.Background(), egressCAPoolSecretName, metav1.DeleteOptions{})
 	})
-	waitForEgressTrustBundle(t, ctx, clients, wantPEM)
-	return wantPEM
+	return true
 }
 
 // waitForEgressTrustBundle polls the reconciler-owned bundle until its


### PR DESCRIPTION
The egress trust bundle is derived from one cluster-wide Secret, but every probe suite projected it, so whichever suite created the pool deleted it out from under the others when it finished: a concurrent suite's actor then fails its next start or resume with "ClusterTrustBundle ... not found".

Only the suites that assert the projection ask for it now, through DeployProbe's `WithTrustBundle`. Pool ownership follows the same rule — the caller that created the Secret deletes it, one that merely found it leaves it alone — so a run cleans up after itself and nothing removes the pool the sdsmint install mounts into the gateway.

This also restores the ensure-before-apply that the `koApply` refactor dropped (https://github.com/agent-substrate/substrate/pull/1119), for the suites that opt in.

Fixes https://github.com/agent-substrate/substrate/issues/1158

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
