### PR TITLE
Accept both Google LLC and The Agent Substrate Authors in boilerplate

### DIFF
--- a/hack/util/verify-boilerplate.py
+++ b/hack/util/verify-boilerplate.py
@@ -37,7 +37,7 @@ ASLV2_HEADER = [
 ]
 
 def match_copyright(line):
-    match = re.search(r"Copyright\s+(\d{4})\s+Google LLC", line)
+    match = re.search(r"Copyright\s+(\d{4})\s+(?:Google LLC|The Agent Substrate Authors)", line)
     if not match:
         return False
     year = int(match.group(1))


### PR DESCRIPTION
## Summary

This change updates the boilerplate verification to accept either of the approved copyright attribution forms:

- `Copyright YYYY Google LLC`
- `Copyright YYYY The Agent Substrate Authors`

## Why

The repo now allows either owner attribution, and the boilerplate checker should enforce that both valid forms pass without rejecting the other.

I retained the Google LLC so that we didn't have to re-copyright all the existing files.

## Verification

- Ran the focused matcher assertions for both allowed strings and an invalid holder.
- Ran `hack/verify/boilerplate.sh` successfully.

