### PR TITLE
Create reject unknown fields

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -167,6 +167,8 @@ func validateCreateActorRequest(req *ateapipb.CreateActorRequest) field.ErrorLis
 		return errs
 	}
 
+	errs = append(errs, validateNoUnknownFields(actor, actorPath)...)
+
 	metaPath := actorPath.Child("metadata")
 	if val, p := actor.GetMetadata().GetAtespace(), metaPath.Child("atespace"); val == "" {
 		errs = append(errs, field.Required(p, ""))

--- a/cmd/ateapi/internal/controlapi/actor_snapshot.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot.go
@@ -163,6 +163,8 @@ func validateCreateActorSnapshotTagRequest(req *ateapipb.CreateActorSnapshotTagR
 		return errs
 	}
 
+	errs = append(errs, validateNoUnknownFields(tag, tagPath)...)
+
 	errs = append(errs, resources.ValidateObjectRef(&ateapipb.ObjectRef{Atespace: tag.GetMetadata().GetAtespace(), Name: tag.GetMetadata().GetName()}, tagPath.Child("metadata"))...)
 
 	if val, p := tag.Snapshot, tagPath.Child("snapshot"); val == nil {

--- a/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_snapshot_test.go
@@ -503,17 +503,17 @@ func TestUpdateActorSnapshotTag_RejectsUnknownFields(t *testing.T) {
 		{
 			name:               "at the top level",
 			injectUnknownField: func(tag *ateapipb.ActorSnapshotTag) { tag.ProtoReflect().SetUnknown(unknownField(9999)) },
-			wantPath:           field.NewPath("tag"),
+			wantPath:           field.NewPath("actor_snapshot_tag"),
 		},
 		{
 			name:               "nested in metadata",
 			injectUnknownField: func(tag *ateapipb.ActorSnapshotTag) { tag.Metadata.ProtoReflect().SetUnknown(unknownField(9999)) },
-			wantPath:           field.NewPath("tag", "metadata"),
+			wantPath:           field.NewPath("actor_snapshot_tag", "metadata"),
 		},
 		{
 			name:               "nested in snapshot",
 			injectUnknownField: func(tag *ateapipb.ActorSnapshotTag) { tag.Snapshot.ProtoReflect().SetUnknown(unknownField(9999)) },
-			wantPath:           field.NewPath("tag", "snapshot"),
+			wantPath:           field.NewPath("actor_snapshot_tag", "snapshot"),
 		},
 	}
 	for _, tt := range tests {
@@ -526,7 +526,7 @@ func TestUpdateActorSnapshotTag_RejectsUnknownFields(t *testing.T) {
 			in := proto.Clone(stored).(*ateapipb.ActorSnapshotTag)
 			tt.injectUnknownField(in)
 
-			_, err := svc.UpdateActorSnapshotTag(ctx, &ateapipb.UpdateActorSnapshotTagRequest{Tag: in})
+			_, err := svc.UpdateActorSnapshotTag(ctx, &ateapipb.UpdateActorSnapshotTagRequest{ActorSnapshotTag: in})
 			wantErr := toGRPCStatusError(field.ErrorList{
 				field.Invalid(tt.wantPath, field.OmitValueType{}, ""),
 			})
@@ -540,7 +540,7 @@ func TestUpdateActorSnapshotTag_RejectsUnknownFields(t *testing.T) {
 			// The rejection happens before the store is touched, so the tag is
 			// left exactly as it was.
 			after, err := svc.GetActorSnapshotTag(ctx, &ateapipb.GetActorSnapshotTagRequest{
-				Tag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag-1"},
+				ActorSnapshotTag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag-1"},
 			})
 			if err != nil {
 				t.Fatalf("GetActorSnapshotTag() error = %v", err)
@@ -550,4 +550,18 @@ func TestUpdateActorSnapshotTag_RejectsUnknownFields(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateCreateActorSnapshotTagRequestUnknownFields(t *testing.T) {
+	validTag := func() *ateapipb.ActorSnapshotTag {
+		return &ateapipb.ActorSnapshotTag{
+			Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "tag-1"},
+			Snapshot: &ateapipb.ObjectRef{Atespace: "team-a", Name: "snap-1"},
+			Scope:    ateapipb.ActorSnapshotTagScope_ACTOR_SNAPSHOT_TAG_SCOPE_ATESPACE,
+		}
+	}
+	assertValidateErr(t, validateCreateActorSnapshotTagRequest(&ateapipb.CreateActorSnapshotTagRequest{ActorSnapshotTag: validTag()}), nil)
+	assertValidateErr(t,
+		validateCreateActorSnapshotTagRequest(&ateapipb.CreateActorSnapshotTagRequest{ActorSnapshotTag: withUnknown(validTag(), 9999)}),
+		field.ErrorList{field.Invalid(field.NewPath("actor_snapshot_tag"), field.OmitValueType{}, "")})
 }

--- a/cmd/ateapi/internal/controlapi/actor_template.go
+++ b/cmd/ateapi/internal/controlapi/actor_template.go
@@ -76,6 +76,8 @@ func validateCreateActorTemplateRequest(req *ateapipb.CreateActorTemplateRequest
 		return errs
 	}
 
+	errs = append(errs, validateNoUnknownFields(template, templatePath)...)
+
 	// ActorTemplate is Atespaced: metadata.atespace and name are required + valid.
 	metaPath := templatePath.Child("metadata")
 	if val, p := template.GetMetadata().GetAtespace(), metaPath.Child("atespace"); val == "" {

--- a/cmd/ateapi/internal/controlapi/actor_template_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_template_test.go
@@ -51,6 +51,10 @@ func TestValidateCreateActorTemplateRequest(t *testing.T) {
 		&ateapipb.CreateActorTemplateRequest{ActorTemplate: validActorTemplate()},
 		nil,
 	}, {
+		"unknown field on actor_template",
+		&ateapipb.CreateActorTemplateRequest{ActorTemplate: withUnknown(validActorTemplate(), 9999)},
+		field.ErrorList{field.Invalid(field.NewPath("actor_template"), field.OmitValueType{}, "")},
+	}, {
 		"missing actor_template",
 		&ateapipb.CreateActorTemplateRequest{},
 		field.ErrorList{field.Required(field.NewPath("actor_template"), "")},

--- a/cmd/ateapi/internal/controlapi/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_test.go
@@ -86,6 +86,14 @@ func TestValidateCreateActorRequest(t *testing.T) {
 		validActor(nil),
 		nil,
 	}, {
+		"unknown field on actor",
+		validActor(func(a *ateapipb.Actor) { a.ProtoReflect().SetUnknown(unknownField(9999)) }),
+		field.ErrorList{field.Invalid(field.NewPath("actor"), field.OmitValueType{}, "")},
+	}, {
+		"unknown field nested in metadata",
+		validActor(func(a *ateapipb.Actor) { a.Metadata.ProtoReflect().SetUnknown(unknownField(9999)) }),
+		field.ErrorList{field.Invalid(field.NewPath("actor", "metadata"), field.OmitValueType{}, "")},
+	}, {
 		"missing actor",
 		&ateapipb.CreateActorRequest{},
 		field.ErrorList{field.Required(field.NewPath("actor"), "")},

--- a/cmd/ateapi/internal/controlapi/atespace.go
+++ b/cmd/ateapi/internal/controlapi/atespace.go
@@ -60,6 +60,8 @@ func validateCreateAtespaceRequest(req *ateapipb.CreateAtespaceRequest) field.Er
 		return errs
 	}
 
+	errs = append(errs, validateNoUnknownFields(atespace, atespacePath)...)
+
 	// Atespace is global-scoped: metadata.atespace must be empty, name required + valid.
 	metaPath := atespacePath.Child("metadata")
 	if val, p := atespace.GetMetadata().GetAtespace(), metaPath.Child("atespace"); val != "" {

--- a/cmd/ateapi/internal/controlapi/atespace_test.go
+++ b/cmd/ateapi/internal/controlapi/atespace_test.go
@@ -31,6 +31,10 @@ func TestValidateCreateAtespaceRequest(t *testing.T) {
 		&ateapipb.CreateAtespaceRequest{Atespace: &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: "team-a"}}},
 		nil,
 	}, {
+		"unknown field on atespace",
+		&ateapipb.CreateAtespaceRequest{Atespace: withUnknown(&ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: "team-a"}}, 9999)},
+		field.ErrorList{field.Invalid(field.NewPath("atespace"), field.OmitValueType{}, "")},
+	}, {
 		"missing atespace",
 		&ateapipb.CreateAtespaceRequest{},
 		field.ErrorList{field.Required(field.NewPath("atespace"), "")},


### PR DESCRIPTION
Part of #1011 , stack on #1174 

As I was writing [ate upgrade proposal](https://docs.google.com/document/d/1JduAyGZFyqdNp4UhKiv0EN-is3iW5tf5BwGTWbt2ouI/edit?usp=sharing&resourcekey=0-MXG12QCkleIxhY7cOB7g6A), we should have both rejection for unknown fields for creating and updating. Add the creating part here.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
