### PR TITLE
keep MintCert denial errors general

### DIFF
--- a/cmd/ateapi/internal/actoridentity/actoridentity.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity.go
@@ -368,7 +368,7 @@ func (s *Server) authorizeActor(ctx context.Context, caller *ateletCaller, req *
 func (s *Server) denyMint(ctx context.Context, caller *ateletCaller, req *ateapipb.MintCertRequest, reason string, args ...any) error {
 	slog.WarnContext(ctx, "ActorIdentity denied: "+reason,
 		append([]any{slog.String("worker", req.GetWorker().GetName()), slog.String("callerPod", caller.podName), slog.String("callerNode", caller.nodeName)}, args...)...)
-	return status.Errorf(codes.PermissionDenied, "caller is not permitted to mint credentials for this actor: %s", reason)
+	return status.Error(codes.PermissionDenied, "caller is not permitted to mint credentials for this actor")
 }
 
 var errAssignmentMismatch = errors.New("assignment mismatch")

--- a/cmd/ateapi/internal/actoridentity/actoridentity_test.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity_test.go
@@ -679,6 +679,16 @@ func TestMintCertAuthorization(t *testing.T) {
 			if got := status.Code(err); got != tc.wantCode {
 				t.Fatalf("MintCert() code = %v (err = %v), want %v", got, err, tc.wantCode)
 			}
+			if tc.wantCode == codes.PermissionDenied {
+				// Denials are deliberately indistinguishable (see denyMint): the
+				// message must not vary with why the mint was refused, or a
+				// caller could probe workers it is not entitled to.
+				msg := status.Convert(err).Message()
+				if msg != "caller is not permitted to mint actor credentials" &&
+					msg != "caller is not permitted to mint credentials for this actor" {
+					t.Errorf("MintCert() denial leaks its reason: %q", msg)
+				}
+			}
 			if tc.wantCode != codes.OK {
 				if resp != nil {
 					t.Errorf("MintCert() returned a response alongside an error")


### PR DESCRIPTION
[AIP-193](http://go/aip/193)

> error messages must not assume that the user will know anything about its underlying implementation

I think it's necessary that we don't expose `denyMint` failure reason.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
