### PR TITLE
atenet: cap proxy worker concurrency

### DIFF
--- a/manifests/ate-install/atenet-egress-with-sdsmint.yaml
+++ b/manifests/ate-install/atenet-egress-with-sdsmint.yaml
@@ -845,6 +845,13 @@ spec:
         - atenet-egress
         - --service-cluster
         - atenet-egress
+        # Envoy sizes its worker pool from the HOST cpu count, which cgroup
+        # limits do not constrain -- so on a many-core node it opens far more
+        # sockets than the default nofile allows and dies at startup with
+        # "Too many open files". A fixed pool is both sufficient here and
+        # independent of the machine it lands on.
+        - --concurrency
+        - "4"
         # Prevents Envoy from fast-exiting on SIGTERM before the ext-proc
         # sidecar finishes its drain sequence. Polls for the drain-complete
         # marker the sidecar writes on the shared emptyDir, terminating Envoy

--- a/manifests/ate-install/atenet-egress.yaml
+++ b/manifests/ate-install/atenet-egress.yaml
@@ -226,6 +226,13 @@ spec:
         - atenet-egress
         - --service-cluster
         - atenet-egress
+        # Envoy sizes its worker pool from the HOST cpu count, which cgroup
+        # limits do not constrain -- so on a many-core node it opens far more
+        # sockets than the default nofile allows and dies at startup with
+        # "Too many open files". A fixed pool is both sufficient here and
+        # independent of the machine it lands on.
+        - --concurrency
+        - "4"
         # Prevents Envoy from fast-exiting on SIGTERM before the ext-proc
         # sidecar finishes its drain sequence. Polls for the drain-complete
         # marker the sidecar writes on the shared emptyDir, terminating Envoy

--- a/manifests/ate-install/atenet-router.yaml
+++ b/manifests/ate-install/atenet-router.yaml
@@ -272,6 +272,13 @@ spec:
         - "/usr/local/bin/envoy"
         - "-c"
         - "/etc/envoy/envoy.yaml"
+        # Envoy sizes its worker pool from the HOST cpu count, which cgroup
+        # limits do not constrain -- so on a many-core node it opens far more
+        # sockets than the default nofile allows and dies at startup with
+        # "Too many open files". A fixed pool is both sufficient here and
+        # independent of the machine it lands on.
+        - "--concurrency"
+        - "4"
         - "--component-log-level"
         - "upstream:debug,router:debug,ext_proc:debug"
         # Prevents Envoy from fast-exiting on SIGTERM before atenet-router finishes

--- a/manifests/ate-install/components/agentgateway/kustomization.yaml
+++ b/manifests/ate-install/components/agentgateway/kustomization.yaml
@@ -67,6 +67,12 @@ patches:
           env:
           - name: AGENTGATEWAY_OTLP_ADDRESS
             value: opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
+          # agentgateway sizes its tokio runtime from the host cpu count unless
+          # WORKER_THREADS or CPU_LIMIT says otherwise, so on a many-core node it
+          # spawns a worker per host thread. Same cap, and same reasoning, as
+          # --concurrency on the Envoy dataplane.
+          - name: WORKER_THREADS
+            value: "4"
           ports:
           - name: http
             containerPort: 8080
@@ -121,6 +127,13 @@ patches:
           args:
           - -f
           - /etc/agentgateway/config.yaml
+          env:
+          # agentgateway sizes its tokio runtime from the host cpu count unless
+          # WORKER_THREADS or CPU_LIMIT says otherwise, so on a many-core node it
+          # spawns a worker per host thread. Same cap, and same reasoning, as
+          # --concurrency on the Envoy dataplane.
+          - name: WORKER_THREADS
+            value: "4"
           ports:
           - name: https
             containerPort: 8443


### PR DESCRIPTION
Fixes #1193

Envoy sizes its worker pool from the host CPU count and ignores the container's cgroup limit, so on a 128 CPU node it tries to start a worker per host thread and runs out of file descriptors before it finishes starting:

```
[warn] evutil_make_internal_pipe_: pipe: Too many open files
[err]  evsig_init_: socketpair: Too many open files
```

Both atenet-router and atenet-egress crashloop with the Go container beside them healthy, which makes it read as an atenet fault rather than a sizing one. Four workers is ample for these proxies and, unlike the default, does not change with the machine underneath.

`atenet-egress-with-sdsmint.yaml` runs a third Envoy. It is selected by `--experimental-use-sdsmint` rather than by an overlay, so it inherits nothing from the other two manifests and needs the flag set separately.

agentgateway sizes its tokio runtime from `num_cpus` the same way, so the `--atenet-router=agentgateway` dataplane carried the identical fault. Its config exposes `WORKER_THREADS` for exactly this, so both agentgateway containers pin the same value the Envoy containers use.

The value is a fixed number rather than one derived from the container's cpu request. #1193 covers why, and what deriving it would cost.

## Testing

The atenet-router and atenet-egress change ran on the 128 CPU node and cleared the crashloop.

The sdsmint and agentgateway paths are not exercised on hardware. For those I built `base`, `kind`, `agentgateway-router`, `agentgateway-egress` and `kind-agentgateway`, and confirmed all three Envoy containers resolve to `--concurrency 4`, both agentgateway containers to `WORKER_THREADS=4`, and that the kind overlay's `AGENTGATEWAY_OTLP_ADDRESS` override still merges rather than being replaced.

There is no unit test here: the change is manifest content only, and the failure it prevents needs a many-core node to reproduce. The overlay assertions above are the closest equivalent, and nothing in the repo currently tests rendered manifest content.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
