### PR TITLE
atelet: fall back to a dense stream when a checkpoint source lacks SEEK_DATA

### DIFF
--- a/cmd/atelet/internal/ategcs/objects.go
+++ b/cmd/atelet/internal/ategcs/objects.go
@@ -150,10 +150,17 @@ type writeContentResult struct {
 func writeContent(out io.Writer, content io.Reader) (writeContentResult, error) {
 	if f, ok := content.(*os.File); ok {
 		logical, populated, err := writeSparseZstd(out, f)
-		if err != nil {
+		switch {
+		case err == nil:
+			return writeContentResult{logicalBytes: logical, populatedBytes: populated, sparse: true}, nil
+		case !errors.Is(err, errSparseUnsupported):
 			return writeContentResult{}, err
 		}
-		return writeContentResult{logicalBytes: logical, populatedBytes: populated, sparse: true}, nil
+		// Unsupported: writeSparseZstd wrote nothing to out, but the probe moved
+		// f's read offset, so rewind before the dense stream below.
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return writeContentResult{}, err
+		}
 	}
 	logical, err := plainZstd(out, content)
 	if err != nil {

--- a/cmd/atelet/internal/ategcs/objects_test.go
+++ b/cmd/atelet/internal/ategcs/objects_test.go
@@ -506,3 +506,52 @@ func TestCopyZstdSparseClearsStaleData(t *testing.T) {
 		t.Fatalf("stale data not cleared / wrong size: len(got)=%d len(want)=%d", len(got), len(want))
 	}
 }
+
+// TestWriteContentFallsBackWhenSparseUnsupported forces writeSparseZstd's SEEK_DATA
+// probe to fail with an error other than ENXIO, the same failure a filesystem
+// without SEEK_DATA support gives for real, and checks writeContent falls back to
+// a plain dense stream rather than failing the whole upload.
+func TestWriteContentFallsBackWhenSparseUnsupported(t *testing.T) {
+	orig := probeSeekDataWhence
+	probeSeekDataWhence = 99 // not a real whence value: Seek fails with EINVAL
+	t.Cleanup(func() { probeSeekDataWhence = orig })
+
+	const size = 1 << 20
+	want := make([]byte, size)
+	for i := range want[:4096] {
+		want[i] = byte(i%251 + 1)
+	}
+
+	srcPath := filepath.Join(t.TempDir(), "src")
+	src, err := os.Create(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	if _, err := src.Write(want); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	wres, err := writeContent(&buf, src)
+	if err != nil {
+		t.Fatalf("writeContent: %v", err)
+	}
+	if wres.sparse {
+		t.Error("writeContent: sparse=true, want a dense fallback")
+	}
+	if wres.logicalBytes != size {
+		t.Errorf("writeContent logicalBytes=%d, want %d", wres.logicalBytes, size)
+	}
+
+	var out bytes.Buffer
+	if _, err := decodeContent(&out, &buf); err != nil {
+		t.Fatalf("decodeContent: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), want) {
+		t.Fatalf("fallback round-trip mismatch: len(got)=%d len(want)=%d", out.Len(), len(want))
+	}
+}

--- a/cmd/atelet/internal/ategcs/sparsezstd.go
+++ b/cmd/atelet/internal/ategcs/sparsezstd.go
@@ -17,6 +17,7 @@ package ategcs
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,6 +25,17 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"golang.org/x/sys/unix"
 )
+
+// errSparseUnsupported means the source filesystem cannot report holes, so the
+// caller should fall back to a dense zstd stream. Mirrors atelet's copySparse,
+// which makes the same guarantee for local checkpoint copies.
+var errSparseUnsupported = errors.New("filesystem cannot report holes")
+
+// probeSeekDataWhence is unix.SEEK_DATA, used only for the initial probe in
+// writeSparseZstd. It is a var, not a literal, only so tests can force it to an
+// unrecognized whence value and exercise the sparse-unsupported fallback below
+// without needing an actual filesystem that lacks SEEK_DATA.
+var probeSeekDataWhence = unix.SEEK_DATA
 
 // sparseMagic marks the sparse-extent snapshot format (see writeSparseZstd). It is
 // 8 bytes and deliberately NOT a valid zstd frame magic, so a reader can tell this
@@ -66,6 +78,15 @@ func writeSparseZstd(dst io.Writer, src *os.File) (logical, dataBytes int64, err
 	}
 	size := fi.Size()
 
+	// Probe SEEK_DATA before writing anything to dst, so a filesystem that cannot
+	// report holes falls back to a dense stream with dst untouched. ENXIO means the
+	// probe ran fine and found no data at all (the file is one big hole), which the
+	// loop below already handles correctly.
+	fd := int(src.Fd())
+	if _, err := unix.Seek(fd, 0, probeSeekDataWhence); err != nil && err != unix.ENXIO {
+		return 0, 0, errSparseUnsupported
+	}
+
 	// magic + version in the clear (buffered: a couple of tiny writes).
 	bw := bufio.NewWriter(dst)
 	if _, err := bw.WriteString(sparseMagic); err != nil {
@@ -89,7 +110,6 @@ func writeSparseZstd(dst io.Writer, src *os.File) (logical, dataBytes int64, err
 		return fail(err)
 	}
 
-	fd := int(src.Fd())
 	off := int64(0)
 	for off < size {
 		ds, serr := unix.Seek(fd, off, unix.SEEK_DATA)


### PR DESCRIPTION
writeSparseZstd only special-cased ENXIO from the initial SEEK_DATA call. Any other error, for example a filesystem that does not support SEEK_DATA/SEEK_HOLE at all, hard-failed the whole checkpoint upload, which the caller turns into a DataLoss error and crashes the actor. The local checkpoint copy path (copySparse) already falls back to a dense copy in this situation. This gives the upload path the same fallback: probe SEEK_DATA before writing anything to the output, and if it is unsupported, rewind and stream a plain dense zstd instead of failing the upload.
