### PR TITLE
atenet: unify the ate.* dataplane attribute namespace

### DIFF
--- a/cmd/ate-setup/internal/steps/overlay.go
+++ b/cmd/ate-setup/internal/steps/overlay.go
@@ -168,7 +168,7 @@ func emitAdditionalEgressExtprocFilter() string {
     failure_mode_allow: false
     message_timeout: 2s
     request_attributes:
-    - filter_state['ate.actor.identity']
+    - filter_state['dev.ate.actor.identity']
     processing_mode:
       request_header_mode: SEND
       response_header_mode: SKIP

--- a/cmd/atenet/internal/router/README.md
+++ b/cmd/atenet/internal/router/README.md
@@ -61,6 +61,48 @@ request (`xds.filter_chain_name`, an Envoy attribute the egress gateway is
 configured to send), never by anything in the request itself, so a client
 cannot pick the egress path by crafting one. `router` itself does the wiring.
 
+## adding a dataplane attribute
+
+The filter-state objects and request attributes a proxy carries alongside
+a request are declared once, in `extproc/attributes.go`. 
+
+### name it
+
+A new key substrate owns is rooted at `dev.ate.`, then a dotted path naming the
+thing it carries: `dev.ate.<area>.<thing>`, or `dev.ate.<thing>` when there is
+no area to disambiguate. These keys live in a namespace owned by the proxy that
+carries them — Envoy filter state, agentgateway CEL — and shared with whatever
+else a deployment configures alongside substrate, so the reverse-DNS root is
+what keeps them from colliding.
+
+A key someone else owns keeps *their* reverse-DNS root; do not re-home it under
+`dev.ate.` to make the set look uniform. `xds.filter_chain_name` is Envoy's own
+attribute and stays in Envoy's namespace. A key defined by a vendor's extension
+or by an additional ext_proc service a deployment splices in belongs under that
+vendor's own root, on the same reasoning that gives substrate `dev.ate.`. The
+prefix is a claim about who may rename the key, so getting it wrong means
+substrate is renaming something it does not own, or holding a name it never
+reserved.
+
+### wire it up
+
+1. **Declare the constant** in `extproc/attributes.go`.
+2. **Set it in the dataplane.**
+3. **Ask for it.** ext_proc only receives the attributes named in its filter's
+   `request_attributes`. A key that is set but not requested arrives as nothing
+   at all, which reads the same as a key that was never set.
+4. **Read it** through `RequestMetadata.Attribute`.
+
+### keep it trustworthy
+
+An attribute is only as trustworthy as the thing that set it. Every value here
+comes from something the dataplane itself derived — a peer certificate Envoy
+verified against the actor-identity CA, an `:authority` captured before the
+request entered a tunnel — never from a client header, which an actor controls
+end to end. That is what makes filter state a sound carrier across the
+CONNECT/MITM boundary in the first place, and a new attribute sourced from a
+header gives the property back.
+
 ## modes
 
 One binary serves both directions. `--mode` selects which:

--- a/cmd/atenet/internal/router/extproc/attributes.go
+++ b/cmd/atenet/internal/router/extproc/attributes.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extproc
+
+// Substrate's dataplane attribute namespace: the filter-state objects and CEL
+// request attributes the gateways carry alongside a request, declared here once
+// so a key means the same thing in the Go that reads it and in the dataplane
+// configuration that sets it.
+//
+// Every substrate-owned key is rooted at the reverse-DNS "dev.ate." prefix.
+// These keys live in namespaces shared with the proxies that carry them -- Envoy
+// filter state, agentgateway CEL -- where a vendor-qualified root is what keeps
+// substrate's keys from colliding with anyone else's. That is a different
+// constraint from the telemetry attributes in internal/ateattr, which are
+// substrate's own metric dimensions and stay on dotted "ate.". Neither is the
+// "ate.dev/" slash form, which is Kubernetes labels only.
+const (
+	// AuthorityFilterStateKey is the filter-state key holding an ingress
+	// request's :authority, set by xds.go's authorityFilterStateFilter.
+	// Ingress-only: it names the actor a request is addressed to.
+	AuthorityFilterStateKey = "dev.ate.authority"
+	// AuthorityFilterStateAttribute is the CEL expression ext_proc evaluates to
+	// read AuthorityFilterStateKey back out.
+	AuthorityFilterStateAttribute = "filter_state['" + AuthorityFilterStateKey + "']"
+
+	// ActorIdentityFilterStateKey is the filter-state key holding the actor
+	// identity the egress gateway read from the peer certificate it verified
+	// against the actor-identity CA. Egress-only, and set and read entirely in
+	// manifests/ate-install/atenet-egress-with-sdsmint.yaml: the MITM access
+	// logs stamp it, and the optional additional ext_proc service
+	// (hack/experimental-additional-egress-extproc.sh) requests it. No Go in
+	// this repository reads it — this handler authenticates the certificate
+	// itself — but it is part of the same namespace and drifts if it is not
+	// declared with the rest.
+	ActorIdentityFilterStateKey = "dev.ate.actor.identity"
+
+	// directionAttribute carries the Direction outright, for dataplanes that
+	// have no Envoy filter chain to name. It is set from a dataplane expression,
+	// never from a client header. No dataplane in this repository sets it today:
+	// Envoy names its filter chain, and agentgateway routes both directions
+	// through its own substrateIngress/substrateEgress policies rather than
+	// ext_proc.
+	directionAttribute = "dev.ate.extproc.direction"
+)
+
+// FilterChainNameAttribute is the CEL attribute carrying the name of the filter
+// chain that accepted the request. Envoy's own, not substrate's, so it is not
+// under "dev.ate.". The egress Envoy asks for it via request_attributes on its
+// ext_proc filter.
+//
+// Do not "improve" this to xds.listener_name: Envoy 1.34 cannot parse that one,
+// and rather than failing config load it logs "error parsing cel expression" at
+// trace level and sends an empty attributes map. An absent attribute means
+// ingress here, so every egress CONNECT would silently take the ingress path and
+// 404 on the actor DNS name parse.
+const FilterChainNameAttribute = "xds.filter_chain_name"

--- a/cmd/atenet/internal/router/extproc/dispatch.go
+++ b/cmd/atenet/internal/router/extproc/dispatch.go
@@ -30,26 +30,10 @@ const (
 	DirectionEgress Direction = "egress"
 )
 
-const (
-	// directionAttribute is set from a dataplane expression, not a client
-	// header, by dataplanes without Envoy filter chains.
-	directionAttribute = "ate.extproc.direction"
-	// EgressFilterChainName is the Envoy filter chain that terminates actor
-	// egress CONNECTs, and so the one that selects the egress handler. It must
-	// stay in sync with the filter chain name in
-	// manifests/ate-install/atenet-egress.yaml.
-	EgressFilterChainName = "egress"
-	// FilterChainNameAttribute is the CEL attribute carrying the name of the
-	// filter chain that accepted the request. The egress Envoy asks for it via
-	// request_attributes on its ext_proc filter.
-	//
-	// Do not "improve" this to xds.listener_name: Envoy 1.34 cannot parse that
-	// one, and rather than failing config load it logs "error parsing cel
-	// expression" at trace level and sends an empty attributes map. An absent
-	// attribute means ingress here, so every egress CONNECT would silently take
-	// the ingress path and 404 on the actor DNS name parse.
-	FilterChainNameAttribute = "xds.filter_chain_name"
-)
+// EgressFilterChainName is the Envoy filter chain that terminates actor egress
+// CONNECTs, and so the one that selects the egress handler. It must stay in sync
+// with the filter chain name in manifests/ate-install/atenet-egress.yaml.
+const EgressFilterChainName = "egress"
 
 // directionOf reports which direction's handler an ext_proc RequestHeaders
 // callback belongs to.

--- a/cmd/atenet/internal/router/ingress/ingress.go
+++ b/cmd/atenet/internal/router/ingress/ingress.go
@@ -56,13 +56,6 @@ const (
 	OriginalDstAddressKey = "local"
 	// OriginalDstPortKey is the actor's target port.
 	OriginalDstPortKey = "port"
-
-	// AuthorityFilterStateKey is the filter-state key holding the request's
-	// :authority, set by xds.go's authorityFilterStateFilter.
-	AuthorityFilterStateKey = "dev.ate.authority"
-	// AuthorityFilterStateAttribute is the CEL expression ext_proc evaluates
-	// to read AuthorityFilterStateKey back out.
-	AuthorityFilterStateAttribute = "filter_state['" + AuthorityFilterStateKey + "']"
 )
 
 // Handler routes ingress requests to the worker hosting their actor.
@@ -97,9 +90,9 @@ func (h *Handler) HandleRequestHeaders(ctx context.Context, md *extproc.RequestM
 	// Resolved from filter state rather than Host/:authority directly: a
 	// reinjected CONNECT tunnel's own :authority has nothing to do with the
 	// actor, so xds.go captures the real one at connect_terminate instead.
-	authority := md.Attribute(AuthorityFilterStateAttribute)
+	authority := md.Attribute(extproc.AuthorityFilterStateAttribute)
 	if authority == "" {
-		return extproc.Result{}, invalidHostErr(md.Host, fmt.Errorf("missing %s request attribute", AuthorityFilterStateAttribute))
+		return extproc.Result{}, invalidHostErr(md.Host, fmt.Errorf("missing %s request attribute", extproc.AuthorityFilterStateAttribute))
 	}
 	actorRef, err := parseActorRef(authority)
 	if err != nil {

--- a/cmd/atenet/internal/router/ingress/ingress_test.go
+++ b/cmd/atenet/internal/router/ingress/ingress_test.go
@@ -53,7 +53,7 @@ func (m *mockClient) ResumeActor(ctx context.Context, in *ateapipb.ResumeActorRe
 // set the header too, since RequestMetadata still logs it.
 func authorityAttributes(t *testing.T, authority string) map[string]*structpb.Struct {
 	t.Helper()
-	s, err := structpb.NewStruct(map[string]any{AuthorityFilterStateAttribute: authority})
+	s, err := structpb.NewStruct(map[string]any{extproc.AuthorityFilterStateAttribute: authority})
 	if err != nil {
 		t.Fatalf("build authority attributes: %v", err)
 	}

--- a/cmd/atenet/internal/router/xds.go
+++ b/cmd/atenet/internal/router/xds.go
@@ -69,6 +69,7 @@ import (
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 
+	"github.com/agent-substrate/substrate/cmd/atenet/internal/router/extproc"
 	"github.com/agent-substrate/substrate/cmd/atenet/internal/router/ingress"
 )
 
@@ -868,7 +869,7 @@ func (x *XdsServer) buildMainInternalListener() *listenerv3.Listener {
 }
 
 // authorityFilterStateFilter captures :authority into
-// ingress.AuthorityFilterStateKey filter state, so main_internal's HTTP leg
+// extproc.AuthorityFilterStateKey filter state, so main_internal's HTTP leg
 // can read it back across the internal-listener hop (see buildHcm,
 // ingress.HandleRequestHeaders). buildConnectTerminateHCM and buildHcm's
 // ingress listeners use it; main_internal itself must not, since that would
@@ -881,9 +882,9 @@ func authorityFilterStateFilter() *hcmv3.HttpFilter {
 				OnRequestHeaders: []*setfilterstatecommonv3.FilterStateValue{
 					{
 						Key: &setfilterstatecommonv3.FilterStateValue_ObjectKey{
-							ObjectKey: ingress.AuthorityFilterStateKey,
+							ObjectKey: extproc.AuthorityFilterStateKey,
 						},
-						// ingress.AuthorityFilterStateKey is a custom (non-well-known)
+						// extproc.AuthorityFilterStateKey is a custom (non-well-known)
 						// key, so the generic string factory is required.
 						FactoryKey: "envoy.string",
 						Value: &setfilterstatecommonv3.FilterStateValue_FormatString{
@@ -1020,10 +1021,10 @@ func (x *XdsServer) buildHcm(statPrefix string, captureAuthority bool) *anypb.An
 			ResponseTrailerMode: extprocv3filter.ProcessingMode_SKIP,
 		},
 		// Passes the resolved actor's authority as a request attribute (see
-		// ingress.AuthorityFilterStateAttribute, ingress.HandleRequestHeaders)
+		// extproc.AuthorityFilterStateAttribute, ingress.HandleRequestHeaders)
 		// and lets the response write the resolved worker address into
 		// ingress.OriginalDstMetadataKey.
-		RequestAttributes: []string{ingress.AuthorityFilterStateAttribute},
+		RequestAttributes: []string{extproc.AuthorityFilterStateAttribute},
 		MetadataOptions: &extprocv3filter.MetadataOptions{
 			ForwardingNamespaces: &extprocv3filter.MetadataOptions_MetadataNamespaces{
 				Untyped: []string{ingress.OriginalDstMetadataKey},

--- a/hack/experimental-additional-egress-extproc.sh
+++ b/hack/experimental-additional-egress-extproc.sh
@@ -80,7 +80,7 @@ emit_additional_egress_extproc_filter() {
     message_timeout: 2s
     # The actor's verified identity
     request_attributes:
-    - filter_state['ate.actor.identity']
+    - filter_state['dev.ate.actor.identity']
     processing_mode:
       request_header_mode: SEND
       response_header_mode: SKIP

--- a/manifests/ate-install/atenet-egress-with-sdsmint.yaml
+++ b/manifests/ate-install/atenet-egress-with-sdsmint.yaml
@@ -143,7 +143,7 @@ data:
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.set_filter_state.v3.Config
                   on_request_headers:
-                  - object_key: ate.actor.identity
+                  - object_key: dev.ate.actor.identity
                     factory_key: envoy.string
                     shared_with_upstream: ONCE
                     skip_if_empty: true
@@ -295,7 +295,7 @@ data:
                     json_format:
                       leg: mitm
                       time: "%START_TIME%"
-                      actor: "%FILTER_STATE(ate.actor.identity:PLAIN)%"
+                      actor: "%FILTER_STATE(dev.ate.actor.identity:PLAIN)%"
                       sni: "%REQUESTED_SERVER_NAME%"
                       authority: "%REQ(:AUTHORITY)%"
                       method: "%REQ(:METHOD)%"
@@ -427,7 +427,7 @@ data:
                     json_format:
                       leg: cleartext
                       time: "%START_TIME%"
-                      actor: "%FILTER_STATE(ate.actor.identity:PLAIN)%"
+                      actor: "%FILTER_STATE(dev.ate.actor.identity:PLAIN)%"
                       authority: "%REQ(:AUTHORITY)%"
                       method: "%REQ(:METHOD)%"
                       path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
@@ -506,7 +506,7 @@ data:
         connect_timeout: 1s
         # Copies every filter state object shared with the upstream onto the
         # internal listener's downstream connection. Two objects ride this hop,
-        # both set on the CONNECT leg above: ate.actor.identity, which the MITM
+        # both set on the CONNECT leg above: dev.ate.actor.identity, which the MITM
         # access logs and the optional ext_proc filter read, and
         # original_dst_address, which egress_tcp_passthrough dials.
         #


### PR DESCRIPTION
Fixes #1117.

## What was inconsistent

The filter-state objects and CEL request attributes the gateways carry alongside a request were declared in three unrelated places under two different prefixes:

| key | declared in |
|---|---|
| `dev.ate.authority` | `cmd/atenet/internal/router/ingress/ingress.go` |
| `ate.extproc.direction` | `cmd/atenet/internal/router/extproc/dispatch.go` |
| `ate.actor.identity` | `manifests/ate-install/atenet-egress-with-sdsmint.yaml` only |

## The change

Use `dev.ate.` prefix consistently.