### PR TITLE
atenet: cap Envoy worker concurrency

### DIFF
--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -72,6 +72,8 @@ function usage() {
   echo "  --delete-all                           Delete core system and all registered demos"
   echo "  --atenet-router=envoy|agentgateway     Select the ingress and egress dataplane (default: envoy)"
   echo "  --podcert-workers-per-signer N         Concurrent workers per podcertificate-controller signer (default: 1)"
+  echo "  --atenet-router-concurrency N          Envoy worker threads in atenet-router (default: 4)"
+  echo "  --atenet-egress-concurrency N          Envoy worker threads in atenet-egress (default: 4)"
   echo "  --rollout-timeout DURATION             Per-workload readiness wait timeout, kubectl-style Go duration (default: 60s)"
   echo "  --otlp-endpoint URL                    Send all control plane telemetry to URL, not to the cluster default (see benchmarking/telemetry/README.md)"
   echo ""
@@ -183,6 +185,21 @@ podcert_workers_per_signer() {
   local workers="${ATE_INSTALL_PODCERT_WORKERS_PER_SIGNER:-1}"
   if ! [[ "${workers}" =~ ^[1-9][0-9]*$ ]]; then
     echo "Error: --podcert-workers-per-signer must be a positive integer, got '${workers}'" >&2
+    exit 1
+  fi
+  echo "${workers}"
+}
+
+# atenet_concurrency validates one proxy's Envoy worker thread count and echoes
+# it. The two atenet proxies take separate flags: the router accepts short
+# request/response connections, while the egress gateway holds CONNECT tunnels
+# open for the life of an actor's connection, and Envoy pins a connection to a
+# worker for its lifetime.
+atenet_concurrency() {
+  local flag="$1"
+  local workers="${2:-4}"
+  if ! [[ "${workers}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: ${flag} must be a positive integer, got '${workers}'" >&2
     exit 1
   fi
   echo "${workers}"
@@ -476,6 +493,45 @@ apply_podcert_workers_override() {
     WORKERS_PER_SIGNER="${workers}"
 }
 
+# set_envoy_concurrency updates one atenet proxy's Envoy worker thread count.
+# It edits the live Deployment rather than the rendered YAML because the egress
+# gateway is applied as a whole file rather than through an overlay, so there is
+# no single render path to parameterize.
+set_envoy_concurrency() {
+  local deployment="$1"
+  local flag="$2"
+  local requested="$3"
+
+  if [[ -z "${requested}" ]]; then
+    return 0
+  fi
+
+  local workers=""
+  workers="$(atenet_concurrency "${flag}" "${requested}")"
+
+  # Empty under the agentgateway data plane, which runs no Envoy container and
+  # so has no variable to read.
+  local current=""
+  current="$(run_kubectl -n ate-system get "deployment/${deployment}" \
+    -o jsonpath='{.spec.template.spec.containers[?(@.name=="envoy")].env[?(@.name=="ENVOY_CONCURRENCY")].value}' 2>/dev/null || true)"
+  if [[ -z "${current}" || "${current}" == "${workers}" ]]; then
+    return 0
+  fi
+
+  echo "Overriding ${deployment} ENVOY_CONCURRENCY with ${workers}"
+  # --containers=envoy because both Deployments run a Go container alongside
+  # Envoy, and the default is to set the variable on every container.
+  run_kubectl -n ate-system set env "deployment/${deployment}" --containers=envoy \
+    ENVOY_CONCURRENCY="${workers}"
+}
+
+apply_atenet_concurrency_override() {
+  set_envoy_concurrency atenet-router --atenet-router-concurrency \
+    "${ATE_INSTALL_ATENET_ROUTER_CONCURRENCY:-}"
+  set_envoy_concurrency atenet-egress --atenet-egress-concurrency \
+    "${ATE_INSTALL_ATENET_EGRESS_CONCURRENCY:-}"
+}
+
 create_api_authentication_config() {
   log_step "create_api_authentication_config"
   run_kubectl create namespace ate-system --dry-run=client -o yaml \
@@ -583,6 +639,7 @@ deploy_ate_system() {
   # variant of each.
   ensure_egress_mitm_ca_pool_secret
   apply_atenet_egress
+  apply_atenet_concurrency_override
 
   log_step "Waiting for ATE system components to be ready..."
   run_kubectl rollout status statefulset/postgres -n ate-system --timeout="$(rollout_timeout)"
@@ -671,6 +728,7 @@ deploy_atenet() {
 
   ensure_egress_mitm_ca_pool_secret
   apply_atenet_egress
+  apply_atenet_concurrency_override
   run_ko apply -f manifests/ate-install/atenet-dns.yaml
   run_kubectl rollout status deployment/atenet-router -n ate-system --timeout="$(rollout_timeout)"
   run_kubectl rollout status deployment/atenet-egress -n ate-system --timeout="$(rollout_timeout)"
@@ -896,6 +954,22 @@ for ((i = 0; i < ${#prescan_args[@]}; i++)); do
       fi
       ATE_INSTALL_PODCERT_WORKERS_PER_SIGNER="${prescan_args[$((i + 1))]}"
       ;;
+    --atenet-router-concurrency=*) ATE_INSTALL_ATENET_ROUTER_CONCURRENCY="${prescan_args[i]#*=}" ;;
+    --atenet-router-concurrency)
+      if (( i + 1 >= ${#prescan_args[@]} )); then
+        echo "Error: --atenet-router-concurrency requires a positive integer" >&2
+        exit 1
+      fi
+      ATE_INSTALL_ATENET_ROUTER_CONCURRENCY="${prescan_args[$((i + 1))]}"
+      ;;
+    --atenet-egress-concurrency=*) ATE_INSTALL_ATENET_EGRESS_CONCURRENCY="${prescan_args[i]#*=}" ;;
+    --atenet-egress-concurrency)
+      if (( i + 1 >= ${#prescan_args[@]} )); then
+        echo "Error: --atenet-egress-concurrency requires a positive integer" >&2
+        exit 1
+      fi
+      ATE_INSTALL_ATENET_EGRESS_CONCURRENCY="${prescan_args[$((i + 1))]}"
+      ;;
     --rollout-timeout=*) ATE_INSTALL_ROLLOUT_TIMEOUT="${prescan_args[i]#*=}" ;;
     --rollout-timeout)
       if (( i + 1 >= ${#prescan_args[@]} )); then
@@ -952,6 +1026,8 @@ case "${BENCHMARK_SANDBOX_CLASS}" in
     ;;
 esac
 podcert_workers_per_signer >/dev/null
+atenet_concurrency --atenet-router-concurrency "${ATE_INSTALL_ATENET_ROUTER_CONCURRENCY:-4}" >/dev/null
+atenet_concurrency --atenet-egress-concurrency "${ATE_INSTALL_ATENET_EGRESS_CONCURRENCY:-4}" >/dev/null
 rollout_timeout >/dev/null
 
 while [[ "$#" -gt 0 ]]; do
@@ -990,6 +1066,24 @@ while [[ "$#" -gt 0 ]]; do
         exit 1
       fi
       ATE_INSTALL_PODCERT_WORKERS_PER_SIGNER="$1"
+      ;;
+    --atenet-router-concurrency=*) ATE_INSTALL_ATENET_ROUTER_CONCURRENCY="${1#*=}" ;;
+    --atenet-router-concurrency)
+      shift
+      if [[ "$#" -eq 0 ]]; then
+        echo "Error: --atenet-router-concurrency requires a positive integer" >&2
+        exit 1
+      fi
+      ATE_INSTALL_ATENET_ROUTER_CONCURRENCY="$1"
+      ;;
+    --atenet-egress-concurrency=*) ATE_INSTALL_ATENET_EGRESS_CONCURRENCY="${1#*=}" ;;
+    --atenet-egress-concurrency)
+      shift
+      if [[ "$#" -eq 0 ]]; then
+        echo "Error: --atenet-egress-concurrency requires a positive integer" >&2
+        exit 1
+      fi
+      ATE_INSTALL_ATENET_EGRESS_CONCURRENCY="$1"
       ;;
     --rollout-timeout=*) ATE_INSTALL_ROLLOUT_TIMEOUT="${1#*=}" ;;
     --rollout-timeout)

--- a/manifests/ate-install/atenet-egress-with-sdsmint.yaml
+++ b/manifests/ate-install/atenet-egress-with-sdsmint.yaml
@@ -845,6 +845,19 @@ spec:
         - atenet-egress
         - --service-cluster
         - atenet-egress
+        # Without this Envoy sizes its worker pool from the host cpu count,
+        # which cgroup limits do not constrain, so a many-core node exhausts the
+        # default nofile before startup finishes. Envoy pins a connection to a
+        # worker for that connection's lifetime, and the CONNECT tunnels
+        # described below outlive ordinary requests by a long way, so this
+        # number is worth raising sooner here than on the router.
+        # hack/install-ate.sh --atenet-egress-concurrency overrides it.
+        #
+        # Flag and value stay separate tokens. Envoy's parser rejects
+        # --concurrency=N outright ("Couldn't find match for argument") and the
+        # container then crashloops on a usage dump.
+        - --concurrency
+        - "$(ENVOY_CONCURRENCY)"
         # Prevents Envoy from fast-exiting on SIGTERM before the ext-proc
         # sidecar finishes its drain sequence. Polls for the drain-complete
         # marker the sidecar writes on the shared emptyDir, terminating Envoy
@@ -865,6 +878,9 @@ spec:
           preStop:
             exec:
               command: ["sh", "-c", "while [ ! -f /var/run/atenet/drain-complete ]; do sleep 0.5; done"]
+        env:
+        - name: ENVOY_CONCURRENCY
+          value: "4"
         ports:
         - name: https
           containerPort: 443

--- a/manifests/ate-install/atenet-egress.yaml
+++ b/manifests/ate-install/atenet-egress.yaml
@@ -226,6 +226,19 @@ spec:
         - atenet-egress
         - --service-cluster
         - atenet-egress
+        # Without this Envoy sizes its worker pool from the host cpu count,
+        # which cgroup limits do not constrain, so a many-core node exhausts the
+        # default nofile before startup finishes. Envoy pins a connection to a
+        # worker for that connection's lifetime, and the CONNECT tunnels
+        # described below outlive ordinary requests by a long way, so this
+        # number is worth raising sooner here than on the router.
+        # hack/install-ate.sh --atenet-egress-concurrency overrides it.
+        #
+        # Flag and value stay separate tokens. Envoy's parser rejects
+        # --concurrency=N outright ("Couldn't find match for argument") and the
+        # container then crashloops on a usage dump.
+        - --concurrency
+        - "$(ENVOY_CONCURRENCY)"
         # Prevents Envoy from fast-exiting on SIGTERM before the ext-proc
         # sidecar finishes its drain sequence. Polls for the drain-complete
         # marker the sidecar writes on the shared emptyDir, terminating Envoy
@@ -246,6 +259,9 @@ spec:
           preStop:
             exec:
               command: ["sh", "-c", "while [ ! -f /var/run/atenet/drain-complete ]; do sleep 0.5; done"]
+        env:
+        - name: ENVOY_CONCURRENCY
+          value: "4"
         ports:
         - name: https
           containerPort: 443

--- a/manifests/ate-install/atenet-router.yaml
+++ b/manifests/ate-install/atenet-router.yaml
@@ -272,8 +272,23 @@ spec:
         - "/usr/local/bin/envoy"
         - "-c"
         - "/etc/envoy/envoy.yaml"
+        # Without this Envoy sizes its worker pool from the host cpu count,
+        # which cgroup limits do not constrain, so a many-core node exhausts the
+        # default nofile before startup finishes. Four is ample for the short
+        # request/response connections this proxy accepts and, unlike the
+        # default, does not vary with the machine it lands on.
+        # hack/install-ate.sh --atenet-router-concurrency overrides it.
+        #
+        # Flag and value stay separate tokens. Envoy's parser rejects
+        # --concurrency=N outright ("Couldn't find match for argument") and the
+        # container then crashloops on a usage dump.
+        - "--concurrency"
+        - "$(ENVOY_CONCURRENCY)"
         - "--component-log-level"
         - "upstream:debug,router:debug,ext_proc:debug"
+        env:
+        - name: ENVOY_CONCURRENCY
+          value: "4"
         # Prevents Envoy from fast-exiting on SIGTERM before atenet-router finishes
         # its drain sequence. Polls for the drain-complete marker written by the
         # router on the shared emptyDir, terminating Envoy as soon as the drain


### PR DESCRIPTION
Fixes #1193

With `--concurrency` unset, Envoy sizes its worker pool from the host CPU count, which cgroup limits do not constrain. On a many-core node it exhausts the default nofile during startup and both atenet pods crashloop, with the Go container beside each one healthy:

```
[warn] evutil_make_internal_pipe_: pipe: Too many open files
[err]  evsig_init_: socketpair: Too many open files
```

Each Envoy container now takes its worker count from a variable defaulting to 4, so a cluster can be resized without editing manifests:

```yaml
- --concurrency
- "$(ENVOY_CONCURRENCY)"
env:
- name: ENVOY_CONCURRENCY
  value: "4"
```

`hack/install-ate.sh` gains `--atenet-router-concurrency` and `--atenet-egress-concurrency`, following the shape of `--podcert-workers-per-signer`. They are separate flags because Envoy pins a connection to a worker for its lifetime, and egress holds CONNECT tunnels open far longer than the router's request/response connections. `atenet-egress-with-sdsmint.yaml` carries a third Envoy that no overlay reaches, so it is changed directly.

No CPU requests or limits are added. #1193 lists deriving the count from a cpu request as the other option; the measurements against it are in a comment there.

Tested on kind: full install, both proxies healthy, and the flags verified against Envoy's own `server.concurrency`. Whether 4 is the right number is still open, and #665 would answer it.

## Known gap

`--atenet-router=agentgateway` runs no Envoy, so this does nothing there. agentgateway sizes its tokio runtime from `num_cpus` and needs its own change.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR

