### PR TITLE
ateom-microvm: break down guest RAM by what is holding it

### DIFF
--- a/cmd/ateom-microvm/guestmem.go
+++ b/cmd/ateom-microvm/guestmem.go
@@ -1,0 +1,190 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/agentstats"
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/guestmem"
+	"github.com/agent-substrate/substrate/internal/ateattr"
+)
+
+// guestMemoryMetric is the gauge the breakdown is published on: one series per
+// slice, distinguished by guestMemComponentKey, all of them adding up to the
+// guest's MemTotal.
+//
+// Deliberately NOT the same shape as GetWorkloadStats. That RPC answers "how
+// much is this actor using", is pulled per actor by whoever is attributing
+// cost, and is the same question on both sandbox classes. This answers "what is
+// inside a micro-VM's RAM", is pushed on the ateom's own metric interval, and
+// has no gVisor counterpart to be consistent with — the sentry gives no
+// equivalent decomposition.
+const guestMemoryMetric = "ate.microvm.guest.memory.bytes"
+
+// guestMemComponentKey labels which slice of the guest a point is. Its values
+// are the guestMemComponent* constants and nothing else: the set is closed, so
+// a dashboard can stack them and trust the total.
+const guestMemComponentKey = attribute.Key("ate.guest.memory.component")
+
+const (
+	guestMemFree           = "free"
+	guestMemPageCache      = "page_cache"
+	guestMemContainers     = "containers"
+	guestMemTmpfs          = "tmpfs"
+	guestMemAgent          = "kata_agent"
+	guestMemKernelAndOther = "kernel_and_other"
+)
+
+// registerGuestMemoryMetrics publishes the guest memory breakdown as an
+// observable gauge.
+//
+// The sample is taken inside the callback rather than by a goroutine of its
+// own. That looks like an RPC in a collection path, and would be a bad idea if
+// the callback had to synchronize with the ateom's lifecycle — but it does not:
+// the two pieces of state it reads are the same atomics GetWorkloadStats reads,
+// which exist precisely so a reader never waits on a boot, a snapshot or a
+// restore. With no lock to take, a background sampler would add a goroutine to
+// start, stop and leak, and a staleness window between its tick and the export,
+// to buy nothing. The SDK gives the callback a context carrying the reader's
+// timeout, and the guest calls below respect it.
+func (s *AteomService) registerGuestMemoryMetrics(mp metric.MeterProvider) error {
+	meter := mp.Meter("ateom-microvm")
+
+	gauge, err := meter.Int64ObservableGauge(
+		guestMemoryMetric,
+		metric.WithUnit("By"),
+		metric.WithDescription("Guest RAM of the micro-VM this ateom is running, split by what is holding it. The components sum to the guest kernel's MemTotal, which is itself less than the RAM assigned to the VM. Everything but 'free' costs snapshot bytes on a Full checkpoint, and so costs suspend and resume latency."),
+	)
+	if err != nil {
+		return fmt.Errorf("creating the %s gauge: %w", guestMemoryMetric, err)
+	}
+
+	_, err = meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
+		b, attrs, ok := s.sampleGuestMemory(ctx)
+		if !ok {
+			// No guest to measure: the ateom is available, or a boot or restore
+			// is still running. Observing nothing is the correct report — a zero
+			// would read as "the guest is empty" — and this is the common case
+			// on an idle worker, so it is not worth a log line per interval.
+			return nil
+		}
+		observe := func(component string, v int64) {
+			o.ObserveInt64(gauge, v, metric.WithAttributes(append(attrs, guestMemComponentKey.String(component))...))
+		}
+		observe(guestMemFree, int64(b.Free))
+		observe(guestMemPageCache, int64(b.PageCache))
+		observe(guestMemContainers, int64(b.Containers))
+		observe(guestMemTmpfs, int64(b.Tmpfs))
+		observe(guestMemAgent, int64(b.Agent))
+		observe(guestMemKernelAndOther, b.KernelAndOther)
+		return nil
+	}, gauge)
+	if err != nil {
+		return fmt.Errorf("registering the %s callback: %w", guestMemoryMetric, err)
+	}
+	return nil
+}
+
+// sampleGuestMemory takes one breakdown of the live guest, with the attributes
+// to file it under. ok is false when there is nothing to measure or the guest
+// declined to answer.
+//
+// Attribution is by TEMPLATE, not by actor. Actor name and uid are unbounded
+// here — a worker is recycled through actor after actor, and each one would
+// leave a series behind — and the repo already draws that line the same way
+// (see ateattr.ActorMetricAttributes, which omits atespace, actor name and
+// actor uid for exactly this reason). The template is what a reader of this
+// metric is comparing anyway: "does this image sit in more page cache than that
+// one" is a template question.
+func (s *AteomService) sampleGuestMemory(ctx context.Context) (guestmem.Breakdown, []attribute.KeyValue, bool) {
+	// Same two atomics, read in the same order and re-checked the same way, as
+	// GetWorkloadStats. See its doc comment for why neither may be reached
+	// through s.lock.
+	active := s.activeActor.Load()
+	if active == nil {
+		return guestmem.Breakdown{}, nil, false
+	}
+	target := s.guestStats.Load()
+	if target == nil || target.actorUID != active.UID {
+		return guestmem.Breakdown{}, nil, false
+	}
+
+	scrapeCtx, cancel := context.WithTimeout(ctx, statsCallTimeout)
+	scrape, err := target.agent.GetMetrics(scrapeCtx)
+	cancel()
+	if err != nil {
+		// Debug, not warn: a guest that has stopped answering is routine here
+		// (a teardown racing the interval looks exactly like this), and this
+		// runs on every collection, so a louder level would turn one sick
+		// worker into a flood.
+		slog.DebugContext(ctx, "No guest memory breakdown: the agent scrape failed",
+			slog.String("actor.uid", active.UID), slog.Any("error", err))
+		return guestmem.Breakdown{}, nil, false
+	}
+
+	g, err := guestmem.Parse(scrape)
+	if err != nil {
+		// Warn, and unlike the case above this one deserves it: the agent
+		// answered and its scrape was not what this ateom knows how to read,
+		// which is a kata-agent version having moved under us rather than a
+		// transient. It will repeat every interval for as long as that is true,
+		// which is the point — it is not self-healing.
+		slog.WarnContext(ctx, "No guest memory breakdown: the agent scrape could not be parsed. This usually means the kata-agent's metric names have changed; see cmd/ateom-microvm/internal/guestmem",
+			slog.String("actor.uid", active.UID), slog.Any("error", err))
+		return guestmem.Breakdown{}, nil, false
+	}
+
+	// A container the agent cannot report contributes zero, exactly as in
+	// sumContainerStats, and for the same reason: a container that has exited
+	// took its guest cgroup with it and holds nothing. Here it does not even
+	// cost accuracy in silence — whatever a missing container was holding is
+	// still in the guest's MemTotal, so it shifts into the residual and stays
+	// visible there.
+	var containers agentstats.Sample
+	for _, id := range target.workloadIDs {
+		if ctx.Err() != nil {
+			return guestmem.Breakdown{}, nil, false
+		}
+		callCtx, cancel := context.WithTimeout(ctx, statsCallTimeout)
+		cs, err := target.agent.StatsContainer(callCtx, id)
+		cancel()
+		if err != nil {
+			continue
+		}
+		containers = containers.Plus(agentstats.FromCgroupStats(cs))
+	}
+
+	// Re-check that no transition happened underneath the sample, as
+	// GetWorkloadStats does and for the same reason: the reads above hold no
+	// lock, so a checkpoint plus a fresh run can complete across them and the
+	// numbers would be filed under the wrong template.
+	if s.activeActor.Load() != active {
+		return guestmem.Breakdown{}, nil, false
+	}
+
+	attrs := []attribute.KeyValue{
+		ateattr.TemplateNamespaceKey.String(active.TemplateNamespace),
+		ateattr.TemplateNameKey.String(active.TemplateName),
+	}
+	return guestmem.Compute(g, containers.MemoryAnonBytes), attrs, true
+}

--- a/cmd/ateom-microvm/guestmem_test.go
+++ b/cmd/ateom-microvm/guestmem_test.go
@@ -1,0 +1,301 @@
+//go:build linux
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/third_party/kata/agentpb"
+	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/resources"
+)
+
+// testScrape is a trimmed kata-agent scrape for a guest of 2048 MiB, in the
+// units and spelling /proc/meminfo uses. The exhaustive parsing cases live in
+// internal/guestmem; what these tests need from it is a guest whose slices are
+// far enough apart to be told from each other.
+// Cached is 256 MiB of which 128 MiB is Shmem, so the page-cache and tmpfs
+// slices come out unequal — a scrape where they matched would pass even if the
+// callback observed one of them twice.
+const testScrape = `# TYPE kata_guest_meminfo gauge
+kata_guest_meminfo{item="mem_total"} 2013204
+kata_guest_meminfo{item="mem_free"} 1048576
+kata_guest_meminfo{item="cached"} 262144
+kata_guest_meminfo{item="shmem"} 131072
+kata_guest_meminfo{item="buffers"} 0
+kata_guest_meminfo{item="s_reclaimable"} 0
+kata_agent_total_rss 15728640
+`
+
+// containerStatsWithAnon is containerStats plus the anonymous figure, which is
+// the one the breakdown charges to the workload (containerStats reports only
+// the reclaimable key, which is what GetWorkloadStats needs).
+func containerStatsWithAnon(usage, inactiveFile, anon uint64) *agentpb.CgroupStats {
+	return &agentpb.CgroupStats{
+		MemoryStats: &agentpb.MemoryStats{
+			Usage: &agentpb.MemoryData{Usage: usage},
+			Stats: map[string]uint64{"inactive_file": inactiveFile, "anon": anon},
+		},
+	}
+}
+
+// components collects one sample of the guest memory gauge into a map from
+// component to value, going through a real MeterProvider so the registration,
+// the callback and the attributes are all exercised the way the export does it.
+func components(t *testing.T, s *AteomService) (map[string]int64, []attribute.KeyValue) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	if err := s.registerGuestMemoryMetrics(mp); err != nil {
+		t.Fatalf("registerGuestMemoryMetrics: %v", err)
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	got := make(map[string]int64)
+	var other []attribute.KeyValue
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != guestMemoryMetric {
+				continue
+			}
+			g, ok := m.Data.(metricdata.Gauge[int64])
+			if !ok {
+				t.Fatalf("%s is %T, want an int64 gauge (the residual must be able to go negative)", m.Name, m.Data)
+			}
+			for _, dp := range g.DataPoints {
+				component, rest := splitComponent(t, dp.Attributes)
+				if _, dup := got[component]; dup {
+					t.Errorf("component %q observed twice in one collection", component)
+				}
+				got[component] = dp.Value
+				other = rest
+			}
+		}
+	}
+	return got, other
+}
+
+// splitComponent pulls the component attribute out of a data point, returning
+// it and everything else the point was labelled with.
+func splitComponent(t *testing.T, set attribute.Set) (string, []attribute.KeyValue) {
+	t.Helper()
+	var component string
+	var rest []attribute.KeyValue
+	for _, kv := range set.ToSlice() {
+		if kv.Key == guestMemComponentKey {
+			component = kv.Value.AsString()
+			continue
+		}
+		rest = append(rest, kv)
+	}
+	if component == "" {
+		t.Fatalf("data point has no %s attribute: %v", guestMemComponentKey, set.ToSlice())
+	}
+	return component, rest
+}
+
+// The whole point of the metric: six slices that tile the guest's MemTotal.
+// If this ever stops holding, a stacked chart of it is lying.
+func TestGuestMemoryComponentsTileMemTotal(t *testing.T) {
+	agent := &fakeAgent{
+		scrape: testScrape,
+		stats: map[string]*agentpb.CgroupStats{
+			"app_ovl": containerStatsWithAnon(400<<20, 100<<20, 256<<20),
+		},
+	}
+	got, _ := components(t, newStatsService(agent, "app_ovl"))
+
+	want := map[string]int64{
+		guestMemFree: 1048576 * 1024,
+		// Cached minus Shmem: the tmpfs half is the next line, not this one.
+		guestMemPageCache:  131072 * 1024,
+		guestMemContainers: 256 << 20,
+		guestMemTmpfs:      131072 * 1024,
+		guestMemAgent:      15728640,
+	}
+	for component, v := range want {
+		if got[component] != v {
+			t.Errorf("%s = %d, want %d", component, got[component], v)
+		}
+	}
+	if _, ok := got[guestMemKernelAndOther]; !ok {
+		t.Fatalf("no %s point; got %v", guestMemKernelAndOther, got)
+	}
+	if len(got) != len(want)+1 {
+		t.Errorf("observed %d components, want %d: the set must be closed for a stack to be meaningful", len(got), len(want)+1)
+	}
+
+	var sum int64
+	for _, v := range got {
+		sum += v
+	}
+	if wantTotal := int64(2013204 * 1024); sum != wantTotal {
+		t.Errorf("components sum to %d, want MemTotal %d", sum, wantTotal)
+	}
+}
+
+// The container slice is the ANONYMOUS figure, not the cgroup usage. Using
+// usage would double-count the container's file pages against the page-cache
+// slice and the total would come out over MemTotal.
+func TestGuestMemoryChargesContainersTheirAnonOnly(t *testing.T) {
+	agent := &fakeAgent{
+		scrape: testScrape,
+		stats: map[string]*agentpb.CgroupStats{
+			// Usage far above anon: most of what this container is charged is
+			// file-backed, and those pages are the page-cache slice's.
+			"app_ovl": containerStatsWithAnon(900<<20, 700<<20, 64<<20),
+		},
+	}
+	got, _ := components(t, newStatsService(agent, "app_ovl"))
+
+	if got[guestMemContainers] != 64<<20 {
+		t.Errorf("containers = %d, want the anon figure %d and not the cgroup usage", got[guestMemContainers], 64<<20)
+	}
+}
+
+// Each actor container is two guest containers and only the workload half is
+// summed; the multi-container case is where a double-count would show up.
+func TestGuestMemorySumsEveryWorkloadContainer(t *testing.T) {
+	agent := &fakeAgent{
+		scrape: testScrape,
+		stats: map[string]*agentpb.CgroupStats{
+			"app_ovl":     containerStatsWithAnon(200<<20, 0, 100<<20),
+			"sidecar_ovl": containerStatsWithAnon(80<<20, 0, 40<<20),
+		},
+	}
+	got, _ := components(t, newStatsService(agent, "app_ovl", "sidecar_ovl"))
+
+	if want := int64(140 << 20); got[guestMemContainers] != want {
+		t.Errorf("containers = %d, want %d", got[guestMemContainers], want)
+	}
+}
+
+// A container the agent cannot report contributes zero rather than failing the
+// breakdown, as in sumContainerStats. Here it costs nothing in silence: what it
+// was holding is still inside MemTotal, so it lands in the residual.
+func TestGuestMemorySurvivesAnUnreadableContainer(t *testing.T) {
+	agent := &fakeAgent{
+		scrape: testScrape,
+		stats: map[string]*agentpb.CgroupStats{
+			"app_ovl": containerStatsWithAnon(200<<20, 0, 100<<20),
+		},
+		errs: map[string]error{"gone_ovl": errors.New("container not found")},
+	}
+	got, _ := components(t, newStatsService(agent, "app_ovl", "gone_ovl"))
+
+	if want := int64(100 << 20); got[guestMemContainers] != want {
+		t.Errorf("containers = %d, want %d from the one readable container", got[guestMemContainers], want)
+	}
+}
+
+// Attribution is by template. Actor name and uid are unbounded on a worker that
+// is recycled through actor after actor, and each would leave a dead series
+// behind; the repo draws the same line in ateattr.ActorMetricAttributes.
+func TestGuestMemoryAttributesByTemplateNotActor(t *testing.T) {
+	agent := &fakeAgent{scrape: testScrape}
+	_, attrs := components(t, newStatsService(agent))
+
+	got := make(map[attribute.Key]string, len(attrs))
+	for _, kv := range attrs {
+		got[kv.Key] = kv.Value.Emit()
+	}
+	if got[ateattr.TemplateNamespaceKey] != testActor.TemplateNamespace {
+		t.Errorf("%s = %q, want %q", ateattr.TemplateNamespaceKey, got[ateattr.TemplateNamespaceKey], testActor.TemplateNamespace)
+	}
+	if got[ateattr.TemplateNameKey] != testActor.TemplateName {
+		t.Errorf("%s = %q, want %q", ateattr.TemplateNameKey, got[ateattr.TemplateNameKey], testActor.TemplateName)
+	}
+	for _, banned := range []attribute.Key{ateattr.ActorNameKey, ateattr.ActorUIDKey, ateattr.AtespaceKey} {
+		if v, ok := got[banned]; ok {
+			t.Errorf("high-cardinality attribute %s = %q must not label this metric", banned, v)
+		}
+	}
+}
+
+// Observing nothing is the right report when there is no guest. A zero would
+// read as "the guest is empty", which is a different and false claim.
+func TestGuestMemoryObservesNothingWithoutAGuest(t *testing.T) {
+	available := &AteomService{}
+
+	booting := &AteomService{}
+	booting.activeActor.Store(&testActor)
+
+	// A target left behind by a transition, disagreeing with the attribution:
+	// belt and braces against reporting one actor's guest under another's
+	// template.
+	mismatched := &AteomService{}
+	mismatched.activeActor.Store(&testActor)
+	mismatched.guestStats.Store(&guestStatsTarget{actorUID: "some-other-actor", agent: &fakeAgent{scrape: testScrape}})
+
+	tests := map[string]*AteomService{
+		"available":          available,
+		"booting":            booting,
+		"mismatched target":  mismatched,
+		"agent unreachable":  newStatsService(&fakeAgent{scrapeErr: errors.New("vsock closed")}),
+		"unparseable scrape": newStatsService(&fakeAgent{scrape: "# nothing this ateom can read\n"}),
+	}
+	for name, s := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got, _ := components(t, s); len(got) != 0 {
+				t.Errorf("observed %v, want no points at all", got)
+			}
+		})
+	}
+}
+
+// A checkpoint plus a fresh run can complete across the unlocked reads above,
+// and the numbers would then be filed under a template that did not produce
+// them.
+func TestGuestMemoryDropsASampleOverwrittenMidFlight(t *testing.T) {
+	s := newStatsService(nil)
+	other := resources.ActorAttribution{
+		Ref:               resources.ActorRef{Atespace: "space-b", Name: "actor-b"},
+		UID:               "uid-b",
+		TemplateNamespace: "ns-b",
+		TemplateName:      "template-b",
+	}
+	// Swap the active actor from under the sample, at the last moment the
+	// handler can still notice: while the containers are being read.
+	s.guestStats.Store(&guestStatsTarget{
+		actorUID: testActor.UID,
+		agent: &fakeAgent{
+			scrape: testScrape,
+			stats:  map[string]*agentpb.CgroupStats{"app_ovl": containerStatsWithAnon(1<<20, 0, 1<<20)},
+			onCall: func() {
+				s.activeActor.Store(&other)
+			},
+		},
+		workloadIDs: []string{"app_ovl"},
+	})
+
+	if got, _ := components(t, s); len(got) != 0 {
+		t.Errorf("observed %v, want no points: the actor changed while the sample was being taken", got)
+	}
+}

--- a/cmd/ateom-microvm/internal/agentstats/agentstats.go
+++ b/cmd/ateom-microvm/internal/agentstats/agentstats.go
@@ -58,21 +58,63 @@ type Sample struct {
 	// for free under pressure.
 	MemoryWorkingSetBytes uint64
 
+	// MemoryAnonBytes is the container's anonymous memory: what it allocated
+	// that no file backs, and that therefore cannot be reclaimed by dropping
+	// it. Zero when the guest's memory.stat names it something anonKeys does
+	// not know.
+	//
+	// Not reported on the wire, and not one of the four fields above. It exists
+	// for the guest-wide breakdown in internal/guestmem, which needs a
+	// per-container figure that does NOT overlap the guest's global page cache.
+	// MemoryWorkingSetBytes cannot be that figure: it only removes the INACTIVE
+	// file pages, so a container's active file pages remain in it while also
+	// being counted in the guest's Cached, and a breakdown built on it would add
+	// up to more memory than the guest has.
+	MemoryAnonBytes uint64
+
 	// CPUUsageUsec is cumulative CPU time consumed by the container, as seen by
 	// the guest kernel.
 	CPUUsageUsec uint64
 }
 
-// Keys of the memory.stat entry holding reclaimable file-backed pages. The
-// agent passes the guest's memory.stat through verbatim, so which one is
-// present depends on the cgroup version the guest kernel gave the container:
-// v2 names it inactive_file, v1 has a per-cgroup inactive_file and the
-// hierarchical total_inactive_file, and the total is the one that matches what
-// v2's figure means.
-const (
-	inactiveFileV2 = "inactive_file"
-	inactiveFileV1 = "total_inactive_file"
-)
+// The agent passes the guest's memory.stat through verbatim — rustjail's
+// get_memory_stats sets stats = memory.stat.raw — so which keys are present
+// depends on the cgroup version the guest kernel gave the container, and each
+// list below carries both spellings.
+//
+// On this runtime it is always the FIRST key that hits, and that is settled at
+// boot rather than observed: kata 4.0.0 ships configuration-clh.toml with
+// kernel_params = "cgroup_no_v1=all systemd.unified_cgroup_hierarchy=1"
+// (src/runtime/arch/{arm64,amd64}-options.mk, substituted into the toml at
+// build time), ParseConfig reads that field and buildVMConfig appends it to the
+// cloud-hypervisor cmdline verbatim. So the guest kernel will not mount a v1
+// controller at all, systemd mounts cgroup2 on /sys/fs/cgroup, and the agent's
+// cgroups-rs hierarchies::auto() — which picks by the magic number of that
+// mount — resolves to v2 for every container.
+//
+// The v1 spellings stay anyway. None of that chain is this package's to
+// guarantee: a kata bump, an arch options file or an operator's kernel_params
+// could each move the guest back to v1, and the failure mode would be a
+// silently zeroed slice rather than an error. Two extra map lookups on a path
+// that runs once per collection is the right price for that.
+
+// Keys of the memory.stat entry holding reclaimable file-backed pages: v2 names
+// it inactive_file, v1 has a per-cgroup inactive_file and the hierarchical
+// total_inactive_file, and the total is the one that matches what v2's figure
+// means.
+var inactiveFileKeys = []string{"inactive_file", "total_inactive_file"}
+
+// Keys of the memory.stat entry holding anonymous pages, in the order to try
+// them. Same version split as the reclaimable keys above: v2 calls it anon, v1
+// calls it rss and also publishes the hierarchical total_rss, which is the one
+// that matches what v2's figure means — so it is tried first.
+//
+// v2's anon excludes tmpfs, which it charges to shmem (and counts again in
+// file). That is what keeps this figure disjoint from the breakdown's Tmpfs
+// slice, which reads the guest-wide Shmem: a page a container writes to a tmpfs
+// moves shmem and leaves anon alone, so the two slices cannot claim the same
+// page however much a workload writes.
+var anonKeys = []string{"anon", "total_rss", "rss"}
 
 // FromCgroupStats converts one container's guest cgroup accounting.
 //
@@ -90,18 +132,21 @@ func FromCgroupStats(cs *agentpb.CgroupStats) Sample {
 	// read beside it; on uint64 the naive subtraction gives an absurd number
 	// instead of the near-zero the reading means.
 	workingSet := current
-	if inactiveFile, ok := inactiveFileBytes(cs); ok {
+	if inactiveFile, ok := statByKey(cs, inactiveFileKeys); ok {
 		workingSet = 0
 		if inactiveFile < current {
 			workingSet = current - inactiveFile
 		}
 	}
 
+	anon, _ := statByKey(cs, anonKeys)
+
 	return Sample{
 		MemoryCurrentBytes: current,
 		MemoryPeakBytes:    mem.GetMaxUsage(),
 
 		MemoryWorkingSetBytes: workingSet,
+		MemoryAnonBytes:       anon,
 
 		// The agent reports CPU time in nanoseconds, matching the runc stats
 		// struct its own is modeled on; the proto wants microseconds. Truncating
@@ -111,14 +156,18 @@ func FromCgroupStats(cs *agentpb.CgroupStats) Sample {
 	}
 }
 
-// inactiveFileBytes returns the reclaimable page cache the guest reported, and
-// whether it reported one at all. Absent, the working set collapses to usage,
-// which over-reports by however much reclaimable cache the container holds —
-// the safe direction, since it never claims the workload is using less than it
-// is.
-func inactiveFileBytes(cs *agentpb.CgroupStats) (uint64, bool) {
+// statByKey returns the first memory.stat entry among keys that the guest
+// reported, and whether it reported any of them.
+//
+// Both callers treat "reported none" as a miss rather than a zero, but they
+// want different things from it. The working set collapses to usage, which
+// over-reports by however much reclaimable cache the container holds — the safe
+// direction, since it never claims the workload is using less than it is. The
+// anon figure has no such fallback and stays zero, which pushes the weight into
+// the breakdown's residual rather than into the container slice.
+func statByKey(cs *agentpb.CgroupStats, keys []string) (uint64, bool) {
 	stats := cs.GetMemoryStats().GetStats()
-	for _, key := range []string{inactiveFileV2, inactiveFileV1} {
+	for _, key := range keys {
 		if v, ok := stats[key]; ok {
 			return v, true
 		}
@@ -150,6 +199,7 @@ func (s Sample) Plus(o Sample) Sample {
 		MemoryCurrentBytes:    addSaturating(s.MemoryCurrentBytes, o.MemoryCurrentBytes),
 		MemoryPeakBytes:       addSaturating(s.MemoryPeakBytes, o.MemoryPeakBytes),
 		MemoryWorkingSetBytes: addSaturating(s.MemoryWorkingSetBytes, o.MemoryWorkingSetBytes),
+		MemoryAnonBytes:       addSaturating(s.MemoryAnonBytes, o.MemoryAnonBytes),
 		CPUUsageUsec:          addSaturating(s.CPUUsageUsec, o.CPUUsageUsec),
 	}
 }

--- a/cmd/ateom-microvm/internal/agentstats/agentstats_test.go
+++ b/cmd/ateom-microvm/internal/agentstats/agentstats_test.go
@@ -90,7 +90,7 @@ func TestFromCgroupStats(t *testing.T) {
 		{
 			name: "memory.stat without a reclaimable-cache entry",
 			cs:   cgroupStats(1000, 0, map[string]uint64{"anon": 900}, 0),
-			want: Sample{MemoryCurrentBytes: 1000, MemoryWorkingSetBytes: 1000},
+			want: Sample{MemoryCurrentBytes: 1000, MemoryWorkingSetBytes: 1000, MemoryAnonBytes: 900},
 		},
 		{
 			// Guests below Linux 5.19 have no cgroup v2 high-water mark. The rest
@@ -150,6 +150,37 @@ func TestFromCgroupStats(t *testing.T) {
 	}
 }
 
+// Which key holds the anonymous pages depends on the cgroup version the guest
+// kernel gave the container, and the guest is not something ateom picks. A
+// version whose key this package does not know must read as zero rather than as
+// some other entry that happens to be nearby.
+func TestFromCgroupStatsAnonKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		stats map[string]uint64
+		want  uint64
+	}{
+		{"cgroup v2 anon", map[string]uint64{"anon": 900}, 900},
+		{"cgroup v1 total_rss", map[string]uint64{"total_rss": 900}, 900},
+		{"cgroup v1 rss alone", map[string]uint64{"rss": 900}, 900},
+		{
+			// v1 publishes both, and the hierarchical total is the one that
+			// matches what v2's figure means: it includes the children.
+			name:  "v1 prefers the hierarchical total over the per-cgroup rss",
+			stats: map[string]uint64{"rss": 400, "total_rss": 900},
+			want:  900,
+		},
+		{"no anon entry", map[string]uint64{"inactive_file": 100}, 0},
+		{"no stats at all", nil, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FromCgroupStats(cgroupStats(1000, 0, tc.stats, 0)).MemoryAnonBytes; got != tc.want {
+				t.Errorf("MemoryAnonBytes = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSamplePlus(t *testing.T) {
 	maxUint64 := ^uint64(0)
 
@@ -160,17 +191,17 @@ func TestSamplePlus(t *testing.T) {
 	}{
 		{
 			name: "adds every field",
-			a:    Sample{MemoryCurrentBytes: 100, MemoryPeakBytes: 200, MemoryWorkingSetBytes: 90, CPUUsageUsec: 10},
-			b:    Sample{MemoryCurrentBytes: 1, MemoryPeakBytes: 2, MemoryWorkingSetBytes: 3, CPUUsageUsec: 4},
-			want: Sample{MemoryCurrentBytes: 101, MemoryPeakBytes: 202, MemoryWorkingSetBytes: 93, CPUUsageUsec: 14},
+			a:    Sample{MemoryCurrentBytes: 100, MemoryPeakBytes: 200, MemoryWorkingSetBytes: 90, MemoryAnonBytes: 50, CPUUsageUsec: 10},
+			b:    Sample{MemoryCurrentBytes: 1, MemoryPeakBytes: 2, MemoryWorkingSetBytes: 3, MemoryAnonBytes: 5, CPUUsageUsec: 4},
+			want: Sample{MemoryCurrentBytes: 101, MemoryPeakBytes: 202, MemoryWorkingSetBytes: 93, MemoryAnonBytes: 55, CPUUsageUsec: 14},
 		},
 		{
 			// The accumulator starts here, so a zero left operand must be the
 			// identity or every actor's first container would be dropped.
 			name: "zero is the identity",
 			a:    Sample{},
-			b:    Sample{MemoryCurrentBytes: 7, MemoryPeakBytes: 8, MemoryWorkingSetBytes: 9, CPUUsageUsec: 10},
-			want: Sample{MemoryCurrentBytes: 7, MemoryPeakBytes: 8, MemoryWorkingSetBytes: 9, CPUUsageUsec: 10},
+			b:    Sample{MemoryCurrentBytes: 7, MemoryPeakBytes: 8, MemoryWorkingSetBytes: 9, MemoryAnonBytes: 6, CPUUsageUsec: 10},
+			want: Sample{MemoryCurrentBytes: 7, MemoryPeakBytes: 8, MemoryWorkingSetBytes: 9, MemoryAnonBytes: 6, CPUUsageUsec: 10},
 		},
 		{
 			// A wrapped total would read as a nearly idle actor, which is the one

--- a/cmd/ateom-microvm/internal/guestmem/guestmem.go
+++ b/cmd/ateom-microvm/internal/guestmem/guestmem.go
@@ -1,0 +1,463 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package guestmem answers "where did the micro-VM's guest RAM actually go".
+//
+// GetWorkloadStats reports the workload's containers, which is the right answer
+// to "how much is this actor using" and no answer at all to "why is a 2048 MiB
+// guest full". The containers are one slice of the guest; the guest kernel, the
+// kata-agent, the page cache charged to no container, the tmpfs mounts the
+// guest carries, and whatever is still free are the rest, and none of them
+// appear in a per-container cgroup read.
+//
+// The split is also what connects guest RAM to snapshot cost. A Full checkpoint
+// writes the guest's touched pages to a sparse memory-ranges file, so how big a
+// snapshot is — and therefore how long a suspend and a resume take — is decided
+// by the slices below. They are not equally hard to shrink: page cache could be
+// dropped before a checkpoint without changing what the guest computes, tmpfs
+// pages could not — nothing backs them, so the kernel has nowhere to drop them
+// to — and container anon is the workload itself. A single "the guest is using
+// 1.2 GiB" tells a reader none of that.
+//
+// The missing slices come from the kata-agent's own Prometheus registry
+// (grpc.AgentService/GetMetrics), which carries the guest's /proc/meminfo. This
+// package parses that scrape and subtracts the pieces down to a residual, so
+// the result adds up to the guest's own MemTotal by construction — see
+// Breakdown.
+//
+// Deliberately pure, like agentstats: it converts an already-fetched scrape and
+// never talks to a guest, so it is testable without a live micro-VM and needs
+// no linux build tag.
+package guestmem
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Names of the two metric families this package reads out of the agent's
+// scrape. Everything else in it (vmstat, loadavg, per-CPU /proc/stat, diskstat,
+// netdev) is ignored.
+// Both verified against kata-agent 4.0.0 (src/agent/src/metrics.rs), which is
+// the kata-static release hack/microvm-assets/assemble.sh pins. The agent hand
+// rolls its registry rather than using the Prometheus process collector, so
+// neither name follows the collector's conventions and neither can be guessed.
+const (
+	// meminfoFamily is the guest kernel's /proc/meminfo, which the agent
+	// republishes as one gauge labelled by entry: kata_guest_meminfo{item=...}.
+	meminfoFamily = "kata_guest_meminfo"
+
+	// agentRSSMetric is the agent process's own resident set. Bytes: the agent
+	// reads stat.rss, which the kernel reports in pages, and multiplies by the
+	// page size before setting the gauge. The name carries no unit suffix and
+	// no "process" namespace, so it looks nothing like what the standard
+	// collector would publish.
+	agentRSSMetric = "kata_agent_total_rss"
+)
+
+// meminfoUnitFloor is the MemTotal below which the meminfo entries are read as
+// kibibytes rather than bytes.
+//
+// The units are genuinely ambiguous at the wire. /proc/meminfo is kB, and
+// whether the agent passes that through or converts depends on how it reads the
+// file — the Rust procfs crate normalizes to bytes, a hand-rolled parse
+// typically does not. Neither is visible in the scrape: the family name carries
+// no unit suffix.
+//
+// So infer it from magnitude. A value under this floor cannot be a plausible
+// guest's RAM in bytes, and reading it as kibibytes is the only interpretation
+// that is not absurd. The rule only misfires on a guest assigned less than 64
+// MiB, which this runtime never boots — the kata config default is 2048 MiB and
+// right-sizing moves it up, not down.
+const meminfoUnitFloor = 64 << 20
+
+// Guest is the subset of the guest's own accounting the breakdown needs, in
+// bytes. Zero means "the agent did not report it", which for every field except
+// Total is a survivable gap rather than an error.
+type Guest struct {
+	// Total is MemTotal: RAM the guest kernel can hand out. Strictly less than
+	// the RAM the VMM assigned the VM — firmware and the kernel's own early
+	// reservations come off the top before the kernel counts what is left — so
+	// it is the right denominator for a breakdown of what the guest can see,
+	// and the wrong one for a breakdown of what the host paid for.
+	Total uint64
+
+	// Free is MemFree: never handed out. Not MemAvailable, which adds an
+	// estimate of the reclaimable cache and would double-count against
+	// PageCache below.
+	Free uint64
+
+	// Buffers, Cached, SReclaimable and Shmem are the page-cache constituents.
+	// Cached includes Shmem (tmpfs pages), which is not reclaimable, so Compute
+	// subtracts it back out of PageCache and reports it as its own slice.
+	Buffers      uint64
+	Cached       uint64
+	SReclaimable uint64
+	Shmem        uint64
+
+	// AgentRSS is the kata-agent process's resident set. Small in absolute
+	// terms and interesting anyway: it is pure overhead, it is per-VM, and at
+	// this density it is the kind of number that only looks negligible until it
+	// is multiplied by the actors on a node.
+	AgentRSS uint64
+}
+
+// Breakdown is one guest's RAM split into slices that do not overlap and, by
+// construction, add up to Total.
+//
+// "By construction" is doing real work here: KernelAndOther is a RESIDUAL, not
+// a measurement. Everything the five measured slices fail to account for lands
+// in it, so the slices always tile Total exactly and the sum is not a
+// consistency check. What the residual is good for is the opposite — its SIGN
+// and its MAGNITUDE are the check. See the field.
+type Breakdown struct {
+	// Total is Guest.Total, repeated so a consumer holding only a Breakdown can
+	// still compute proportions.
+	Total uint64
+
+	// Free is memory the guest kernel has not handed to anybody.
+	Free uint64
+
+	// PageCache is file-backed memory the kernel would give back under
+	// pressure: Buffers + (Cached - Shmem) + SReclaimable. On a guest that has
+	// just booted a container image this is usually the largest slice after
+	// Free, and it is the one most often mistaken for a leak.
+	PageCache uint64
+
+	// Containers is the sum of the workload containers' ANONYMOUS memory, not
+	// their cgroup usage. Anonymous is what makes this slice disjoint from
+	// PageCache: a container's file pages are already counted there, and
+	// counting its cgroup usage here would count them twice.
+	//
+	// The flip side is that this slice under-reports what a container "costs" —
+	// its kernel memory is real and lands in KernelAndOther instead, and the
+	// files it wrote land in Tmpfs or PageCache. For "who is using the guest's
+	// RAM" that is the wrong bias; for "do these slices tile the guest" it is
+	// the only one that works. Read this against GetWorkloadStats' working-set
+	// figure, which answers the first question and does not have to tile
+	// anything.
+	Containers uint64
+
+	// Tmpfs is Shmem: pages of a filesystem that lives in RAM, plus shared
+	// memory segments. Whatever puts them there, they are:
+	//
+	//   - not reclaimable, unlike PageCache — there is no backing store to
+	//     write them out to, so the kernel cannot drop them under pressure;
+	//   - not visible in Containers, because the cgroup charges them to shmem
+	//     rather than anon;
+	//   - captured by a Full checkpoint, because they are guest RAM, so they
+	//     cost snapshot bytes and therefore suspend and resume latency.
+	//
+	// Folding them into PageCache would say they are reclaimable, which is
+	// wrong in the expensive direction: a reader would conclude the guest has
+	// headroom it does not have. Leaving them in KernelAndOther, which is what
+	// this package did before the slice existed, attributes them to the guest
+	// kernel, which is wrong about who to go ask.
+	//
+	// On the CURRENT runtime a workload's file writes do NOT land here. Each
+	// container's overlay upper is a host directory served over virtio-fs (see
+	// cmd/ateom-microvm/rootfsupper.go), so rootfs writes cost host disk, and
+	// durable-dir volumes are host directories on the same share. What is left
+	// is the small fixed set the runtime mounts — /dev, /dev/shm and /run, 64
+	// MiB each at most (see cmd/ateom-microvm/spec.go) — plus anything the
+	// workload mounts itself.
+	//
+	// It still earns a slice of its own, for two reasons that outlive the
+	// current arrangement. Snapshots from the retired guest-tmpfs-upper era
+	// still restore, and their upper does ride in guest RAM (see
+	// cmd/ateom-microvm/restore.go). And this is the slice that moves if write
+	// storage ever goes back inside the guest: a design that trades virtio-fs
+	// for guest-side storage shows up here as RAM, and therefore as snapshot
+	// bytes, which is precisely the regression worth being able to see before
+	// it is shipped rather than after.
+	//
+	// Guest-wide, not per container: Shmem comes from /proc/meminfo, so it
+	// covers every tmpfs the guest mounts at once. Separating them would mean a
+	// per-cgroup shmem read that only the container slice could use.
+	Tmpfs uint64
+
+	// Agent is the kata-agent's resident set.
+	Agent uint64
+
+	// KernelAndOther is what is left: Total minus the five above. Genuinely a
+	// mix — the guest kernel's non-reclaimable slab, page tables, kernel
+	// stacks, vmalloc, plus any process in the guest that is not a workload
+	// container, plus the container kernel memory that Containers declines to
+	// claim.
+	//
+	// SIGNED, and negative is meaningful rather than a bug to clamp away. It
+	// means the measured slices overlapped — the same pages counted twice —
+	// which is the failure mode this decomposition can actually have, and the
+	// only way it becomes visible. Flooring it at zero would hide exactly the
+	// case worth seeing. A healthy guest sits at a modest positive value; a
+	// large negative one says the container figure and the page-cache figure
+	// are fighting over the same pages and the split needs revisiting.
+	KernelAndOther int64
+}
+
+// Parse extracts the guest accounting from one kata-agent GetMetrics scrape.
+//
+// It fails only when MemTotal is missing or unparseable, because without a
+// denominator there is no breakdown to compute. Every other entry it wants is
+// optional and absent reads as zero: a missing Shmem shifts a little weight
+// between two slices, a missing MemTotal makes the whole thing meaningless.
+//
+// The lookups are deliberately loose about spelling. The agent may publish
+// meminfo either as one family labelled by entry
+// (kata_guest_meminfo{item="mem_total"}) or flattened into the metric name
+// (kata_guest_meminfo_mem_total), and the entry names themselves may keep
+// /proc/meminfo's CamelCase or be snake_cased on the way through. All of those
+// normalize to the same key, so a kata-agent version bump that changes the
+// spelling does not silently zero a slice.
+func Parse(scrape string) (Guest, error) {
+	s := parseScrape(scrape)
+
+	total, ok := s.meminfo("MemTotal")
+	if !ok {
+		// Name what the agent DID publish, not just what was wanted. This error
+		// has one likely cause — a kata-agent whose metric naming has moved —
+		// and the fix is to teach this package the new name, so the error is
+		// only useful if it carries the new name. Without that a reader is left
+		// to reproduce a guest and dump the scrape by hand.
+		return Guest{}, fmt.Errorf("no %s MemTotal entry in the agent scrape (%d metrics parsed); the families it did publish are: %s",
+			meminfoFamily, len(s), strings.Join(familyNames(scrape), ", "))
+	}
+	if total == 0 {
+		return Guest{}, errors.New("the agent scrape reports a guest with zero MemTotal")
+	}
+
+	// One scale factor for every meminfo entry, decided by the only entry whose
+	// plausible range is known. Deciding per entry would be worse: a nearly-idle
+	// guest's Shmem is small enough to look like kibibytes whichever it is.
+	scale := uint64(1)
+	if total < meminfoUnitFloor {
+		scale = 1024
+	}
+	get := func(name string) uint64 {
+		v, _ := s.meminfo(name)
+		return v * scale
+	}
+
+	agentRSS, _ := s.value(agentRSSMetric)
+
+	return Guest{
+		Total:        total * scale,
+		Free:         get("MemFree"),
+		Buffers:      get("Buffers"),
+		Cached:       get("Cached"),
+		SReclaimable: get("SReclaimable"),
+		Shmem:        get("Shmem"),
+		AgentRSS:     agentRSS,
+	}, nil
+}
+
+// Compute slices g up, charging containersAnon to the workload.
+//
+// containersAnon is the sum of the actor's containers' Sample.MemoryAnonBytes;
+// see Breakdown.Containers for why it is the anonymous figure and not the
+// cgroup usage.
+func Compute(g Guest, containersAnon uint64) Breakdown {
+	// Cached counts tmpfs pages, which are not cache in the sense that matters
+	// here — nothing reclaims them by dropping them. Take them out and report
+	// them as Tmpfs instead. Saturating, because the kernel assembles
+	// /proc/meminfo without a lock and Shmem can read a hair above the Cached
+	// line beside it.
+	cached := g.Cached
+	if g.Shmem < cached {
+		cached -= g.Shmem
+	} else {
+		cached = 0
+	}
+	pageCache := g.Buffers + cached + g.SReclaimable
+
+	measured := g.Free + pageCache + containersAnon + g.Shmem + g.AgentRSS
+
+	return Breakdown{
+		Total:      g.Total,
+		Free:       g.Free,
+		PageCache:  pageCache,
+		Containers: containersAnon,
+		Tmpfs:      g.Shmem,
+		Agent:      g.AgentRSS,
+		// int64 across the whole guest range: a Total that would overflow it is
+		// an 8-exbibyte VM. The subtraction is the point — see the field.
+		KernelAndOther: int64(g.Total) - int64(measured),
+	}
+}
+
+// scrape is a parsed Prometheus text exposition, keyed by normalized metric
+// identity: the normalized family name, plus "/" and the normalized "item"
+// label when the sample carries one. Both halves go through normalize so that
+// the labelled and flattened spellings of one /proc entry land on keys the
+// lookups below can derive from the same input.
+type scrape map[string]uint64
+
+// parseScrape reads the exposition format loosely enough for a scrape produced
+// by another project's registry.
+//
+// It ignores what it does not understand rather than failing: HELP/TYPE
+// comments, samples with labels other than item, values it cannot read as a
+// number. A kata-agent that grows a metric this package has never heard of must
+// not break the parse of the ones it has.
+func parseScrape(text string) scrape {
+	out := make(scrape)
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// name[{labels}] value [timestamp]. The name part cannot contain a
+		// space, and a label value could, so split at the LAST brace rather than
+		// on whitespace.
+		nameEnd := strings.LastIndex(line, "}")
+		if nameEnd < 0 {
+			nameEnd = strings.IndexAny(line, " \t")
+			if nameEnd < 0 {
+				continue
+			}
+		} else {
+			nameEnd++
+		}
+		key, ok := metricKey(line[:nameEnd])
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(line[nameEnd:])
+		if len(fields) == 0 {
+			continue
+		}
+		// Prometheus values are floats even when the source is an integer
+		// counter, so "2013204" and "2013204.0" both have to read.
+		f, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil || f < 0 {
+			continue
+		}
+		out[key] = uint64(f)
+	}
+	return out
+}
+
+// maxReportedFamilies caps how many names an unparseable scrape names back. A
+// kata-agent publishes on the order of a dozen families and this only runs on
+// the error path, but the scrape is remote input and the result goes in a log
+// line, so it is bounded rather than trusted to be small.
+const maxReportedFamilies = 24
+
+// familyNames lists the distinct metric families a scrape carries, in the
+// spelling the agent used rather than the normalized one, for the error above.
+//
+// A second walk of the text rather than something the parse kept: the parse
+// runs on every collection and this runs when one has already failed, so the
+// cost is in the right place and the hot path stays a plain map.
+func familyNames(text string) []string {
+	seen := make(map[string]struct{})
+	var names []string
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name := line
+		if i := strings.IndexAny(line, "{ \t"); i >= 0 {
+			name = line[:i]
+		}
+		if name == "" {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+		if len(names) == maxReportedFamilies {
+			names = append(names, "...")
+			break
+		}
+	}
+	if len(names) == 0 {
+		return []string{"(none: the scrape held no metric lines at all)"}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// metricKey turns a sample's name-and-labels into the map key, or reports that
+// the sample is not one this package can index (a labelled sample whose labels
+// do not include item).
+func metricKey(nameAndLabels string) (string, bool) {
+	open := strings.Index(nameAndLabels, "{")
+	if open < 0 {
+		return normalize(nameAndLabels), true
+	}
+	name := nameAndLabels[:open]
+	labels := strings.TrimSuffix(nameAndLabels[open+1:], "}")
+	item, ok := itemLabel(labels)
+	if !ok {
+		return "", false
+	}
+	return normalize(name) + "/" + normalize(item), true
+}
+
+// itemLabel pulls the item label out of a sample's label set, which is what
+// the agent keys its /proc-derived gauges by.
+//
+// Hand-rolled rather than a real label parser: the values here are /proc field
+// names, so they contain no commas, quotes or escapes, and a full parse would
+// buy nothing. A value that did contain one simply fails to match and its slice
+// reads zero.
+func itemLabel(labels string) (string, bool) {
+	for _, pair := range strings.Split(labels, ",") {
+		name, value, found := strings.Cut(strings.TrimSpace(pair), "=")
+		if !found || strings.TrimSpace(name) != "item" {
+			continue
+		}
+		return strings.Trim(strings.TrimSpace(value), `"`), true
+	}
+	return "", false
+}
+
+// meminfo looks up one /proc/meminfo entry, trying both shapes the agent might
+// have published it in: labelled by entry, then flattened into the name.
+func (s scrape) meminfo(entry string) (uint64, bool) {
+	if v, ok := s[normalize(meminfoFamily)+"/"+normalize(entry)]; ok {
+		return v, true
+	}
+	return s.value(meminfoFamily + "_" + entry)
+}
+
+// value looks up an unlabelled metric by name, normalized the same way the
+// stored keys are so the two agree.
+func (s scrape) value(name string) (uint64, bool) {
+	v, ok := s[normalize(name)]
+	return v, ok
+}
+
+// normalize folds the spellings of one /proc entry onto a single key:
+// "MemTotal", "mem_total" and "memtotal" are the same entry.
+func normalize(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/cmd/ateom-microvm/internal/guestmem/guestmem_test.go
+++ b/cmd/ateom-microvm/internal/guestmem/guestmem_test.go
@@ -1,0 +1,452 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guestmem
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// labelledScrape is the shape where the agent publishes /proc/meminfo as one
+// family keyed by an item label. Values in kibibytes, as /proc/meminfo has
+// them, for a guest given 2048 MiB. Trimmed to the entries this package reads
+// plus a few it must ignore.
+const labelledScrape = `# HELP kata_guest_meminfo Statistics about memory usage on the system.
+# TYPE kata_guest_meminfo gauge
+kata_guest_meminfo{item="mem_total"} 2013204
+kata_guest_meminfo{item="mem_free"} 1310720
+kata_guest_meminfo{item="mem_available"} 1800000
+kata_guest_meminfo{item="buffers"} 8192
+kata_guest_meminfo{item="cached"} 409600
+kata_guest_meminfo{item="s_reclaimable"} 32768
+kata_guest_meminfo{item="shmem"} 4096
+kata_guest_meminfo{item="slab"} 51200
+# HELP kata_guest_load Load average.
+# TYPE kata_guest_load gauge
+kata_guest_load{item="load1"} 0.08
+kata_guest_stat{cpu="cpu0",item="user"} 1234
+# TYPE kata_agent_total_rss gauge
+kata_agent_total_rss 15728640
+`
+
+// flattenedScrape is the other shape: the entry folded into the metric name,
+// CamelCase kept from /proc/meminfo, and values already converted to bytes.
+// Same guest as labelledScrape, so both must parse to the same Guest.
+const flattenedScrape = `# TYPE kata_guest_meminfo_MemTotal gauge
+kata_guest_meminfo_MemTotal 2.061520896e+09
+kata_guest_meminfo_MemFree 1.34217728e+09
+kata_guest_meminfo_Buffers 8388608
+kata_guest_meminfo_Cached 419430400
+kata_guest_meminfo_SReclaimable 33554432
+kata_guest_meminfo_Shmem 4194304
+kata_agent_total_rss 1.572864e+07
+`
+
+// wantGuest is the guest both scrapes above describe, in bytes.
+var wantGuest = Guest{
+	Total:        2013204 * 1024,
+	Free:         1310720 * 1024,
+	Buffers:      8192 * 1024,
+	Cached:       409600 * 1024,
+	SReclaimable: 32768 * 1024,
+	Shmem:        4096 * 1024,
+	AgentRSS:     15728640,
+}
+
+// agent400Scrape reproduces what kata-agent 4.0.0 actually publishes — the
+// release hack/microvm-assets/assemble.sh pins — rather than a shape this
+// package hoped for. Transcribed from src/agent/src/metrics.rs: the family
+// names come from NAMESPACE_KATA_GUEST/NAMESPACE_KATA_AGENT, the item labels
+// from set_gauge_vec_meminfo, and the values are bytes because the agent reads
+// /proc/meminfo through the procfs crate, which scales kB away.
+//
+// Every family the agent emits and this package ignores is kept, in the order
+// the registry gathers them, because "ignores the rest of a real scrape" is
+// most of what Parse has to get right. Trimmed only in the number of meminfo
+// entries and CPUs, which are long and uninteresting.
+//
+// Not captured from a live guest — this is still transcription, and a real
+// capture should replace it. It is pinned to a version, which the hand-built
+// fixtures above are not.
+const agent400Scrape = `# HELP kata_agent_scrape_count Metrics scrape count
+# TYPE kata_agent_scrape_count counter
+kata_agent_scrape_count 41
+# HELP kata_agent_threads Agent process threads
+# TYPE kata_agent_threads gauge
+kata_agent_threads 12
+# HELP kata_agent_total_rss Agent process total RSS size
+# TYPE kata_agent_total_rss gauge
+kata_agent_total_rss 15728640
+# HELP kata_agent_total_time Agent process total time
+# TYPE kata_agent_total_time gauge
+kata_agent_total_time 0.34
+# HELP kata_agent_total_vm Agent process total VM size
+# TYPE kata_agent_total_vm gauge
+kata_agent_total_vm 1250037760
+# HELP kata_guest_load Guest system load.
+# TYPE kata_guest_load gauge
+kata_guest_load{item="load1"} 0.08
+# HELP kata_guest_meminfo Statistics about memory usage in the system.
+# TYPE kata_guest_meminfo gauge
+kata_guest_meminfo{item="active"} 209715200
+kata_guest_meminfo{item="anon_pages"} 178257920
+kata_guest_meminfo{item="buffers"} 8388608
+kata_guest_meminfo{item="cached"} 419430400
+kata_guest_meminfo{item="dirty"} 131072
+kata_guest_meminfo{item="inactive"} 314572800
+kata_guest_meminfo{item="inactive_file"} 289406976
+kata_guest_meminfo{item="mapped"} 41943040
+kata_guest_meminfo{item="mem_available"} 1843200000
+kata_guest_meminfo{item="mem_free"} 1342177280
+kata_guest_meminfo{item="mem_total"} 2061520896
+kata_guest_meminfo{item="page_tables"} 2097152
+kata_guest_meminfo{item="s_reclaimable"} 33554432
+kata_guest_meminfo{item="s_unreclaim"} 19922944
+kata_guest_meminfo{item="shmem"} 4194304
+kata_guest_meminfo{item="slab"} 53477376
+kata_guest_meminfo{item="swap_free"} 0
+kata_guest_meminfo{item="swap_total"} 0
+# HELP kata_guest_vm_stat Guest virtual memory statistics.
+# TYPE kata_guest_vm_stat gauge
+kata_guest_vm_stat{item="pgfault"} 92341
+`
+
+// The one assumption in this package nothing else can check: that the family
+// names, the item spellings and the units are what the pinned agent emits. A
+// wrong guess here does not fail loudly — an unmatched optional entry reads as
+// zero and its bytes drift into the residual — so it has to be asserted.
+func TestParseReadsARealAgentScrape(t *testing.T) {
+	got, err := Parse(agent400Scrape)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	want := Guest{
+		Total:        2061520896,
+		Free:         1342177280,
+		Buffers:      8388608,
+		Cached:       419430400,
+		SReclaimable: 33554432,
+		Shmem:        4194304,
+		AgentRSS:     15728640,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Parse mismatch (-want +got):\n%s", diff)
+	}
+	// The agent reports bytes, so the kibibyte heuristic must stay out of it.
+	// Scaling a real scrape by 1024 would claim a 2 TiB guest.
+	if got.Total != 2061520896 {
+		t.Errorf("Total = %d: a byte-valued scrape was rescaled", got.Total)
+	}
+}
+
+// The two spellings are the thing this parser exists to be indifferent to: the
+// kata-agent's metric naming is not a contract ateom controls, and a bump that
+// changes it must not silently zero a slice.
+func TestParseAcceptsBothMetricShapes(t *testing.T) {
+	for name, scrape := range map[string]string{
+		"labelled":  labelledScrape,
+		"flattened": flattenedScrape,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := Parse(scrape)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if diff := cmp.Diff(wantGuest, got); diff != "" {
+				t.Errorf("Parse mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// The unit heuristic is the other half of that indifference, and the half that
+// fails silently rather than loudly if it is wrong: a scrape misread by 1024x
+// still parses.
+func TestParseInfersUnits(t *testing.T) {
+	tests := map[string]struct {
+		memTotal  string
+		wantTotal uint64
+	}{
+		"kibibytes are scaled": {"2013204", 2013204 * 1024},
+		"bytes are left alone": {"2061520896", 2061520896},
+		// The floor sits at 64 MiB, well under any guest this runtime boots and
+		// well over any value that could only be kibibytes.
+		"just under the floor is kibibytes": {"67108863", 67108863 * 1024},
+		"just over the floor is bytes":      {"67108865", 67108865},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			g, err := Parse("kata_guest_meminfo{item=\"mem_total\"} " + tc.memTotal + "\n")
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if g.Total != tc.wantTotal {
+				t.Errorf("Total = %d, want %d", g.Total, tc.wantTotal)
+			}
+		})
+	}
+}
+
+// One scale factor for the whole scrape, not one per entry: a nearly-idle
+// guest's Shmem is small enough to look like kibibytes whichever unit it is in,
+// so deciding per entry would corrupt the small slices of a large guest.
+func TestParseScalesEveryEntryTogether(t *testing.T) {
+	g, err := Parse(`kata_guest_meminfo{item="mem_total"} 2013204
+kata_guest_meminfo{item="shmem"} 64
+`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if g.Shmem != 64*1024 {
+		t.Errorf("Shmem = %d, want %d (the small entry must take MemTotal's scale)", g.Shmem, 64*1024)
+	}
+}
+
+func TestParseNeedsMemTotal(t *testing.T) {
+	for name, scrape := range map[string]string{
+		"empty":          "",
+		"comments only":  "# HELP kata_guest_meminfo x\n# TYPE kata_guest_meminfo gauge\n",
+		"other entries":  "kata_guest_meminfo{item=\"mem_free\"} 1310720\n",
+		"zero mem_total": "kata_guest_meminfo{item=\"mem_total\"} 0\n",
+		"unparseable":    "kata_guest_meminfo{item=\"mem_total\"} nonsense\n",
+		"negative":       "kata_guest_meminfo{item=\"mem_total\"} -1\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse(scrape); err == nil {
+				t.Error("Parse must fail without a usable MemTotal rather than report a zero-sized guest")
+			}
+		})
+	}
+}
+
+// The failure this error reports has one likely cause — the agent's metric
+// naming moved — and the fix is to teach the package the new name. So the error
+// has to carry the new name, or the reader has to go reproduce a guest and dump
+// the scrape by hand to learn it.
+func TestParseErrorNamesWhatTheAgentDidPublish(t *testing.T) {
+	_, err := Parse(`# HELP some_other_meminfo x
+some_other_meminfo{item="mem_total"} 2013204
+kata_guest_vmstat{item="pgfault"} 17
+some_other_meminfo{item="mem_free"} 1310720
+`)
+	if err == nil {
+		t.Fatal("Parse must fail when it cannot find MemTotal")
+	}
+	for _, want := range []string{"some_other_meminfo", "kata_guest_vmstat"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not name the family %q, so it does not say how to fix itself: %v", want, err)
+		}
+	}
+	// Named once, not once per sample.
+	if n := strings.Count(err.Error(), "some_other_meminfo"); n != 1 {
+		t.Errorf("family named %d times, want 1: %v", n, err)
+	}
+}
+
+// The scrape is remote input and this text goes into a log line.
+func TestParseErrorBoundsTheFamilyList(t *testing.T) {
+	var b strings.Builder
+	for i := range maxReportedFamilies * 3 {
+		fmt.Fprintf(&b, "family_%03d 1\n", i)
+	}
+	_, err := Parse(b.String())
+	if err == nil {
+		t.Fatal("Parse must fail when it cannot find MemTotal")
+	}
+	if n := strings.Count(err.Error(), "family_"); n > maxReportedFamilies {
+		t.Errorf("error names %d families, want at most %d", n, maxReportedFamilies)
+	}
+	if !strings.Contains(err.Error(), "...") {
+		t.Error("a truncated list must say it was truncated")
+	}
+}
+
+// Every entry but MemTotal is optional: a missing one shifts weight between
+// slices, which the residual absorbs, and is not worth losing the whole
+// breakdown over.
+func TestParseToleratesMissingEntries(t *testing.T) {
+	g, err := Parse("kata_guest_meminfo{item=\"mem_total\"} 2013204\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if g.Free != 0 || g.Cached != 0 || g.AgentRSS != 0 {
+		t.Errorf("absent entries must read as zero, got %+v", g)
+	}
+}
+
+// A kata-agent that grows a metric shape this package has never seen must not
+// take the ones it does know down with it.
+func TestParseIgnoresWhatItCannotRead(t *testing.T) {
+	g, err := Parse(`# HELP kata_guest_meminfo x
+kata_guest_meminfo{item="mem_total"} 2013204
+this_line_has_no_value
+kata_guest_netdev_stat{interface="eth0",item="recv_bytes"} 4096
+kata_guest_meminfo{unexpected_label="mem_free"} 999
+malformed{ 12
+kata_guest_meminfo{item="mem_free"} 1310720
+`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if g.Total != 2013204*1024 || g.Free != 1310720*1024 {
+		t.Errorf("surrounding junk changed the parse: %+v", g)
+	}
+}
+
+// sumOf adds every slice including the signed residual. Kept as a helper so a
+// slice added later has to be added here too, and the tiling tests below fail
+// loudly if it is not.
+func sumOf(b Breakdown) int64 {
+	return int64(b.Free) + int64(b.PageCache) + int64(b.Containers) +
+		int64(b.Tmpfs) + int64(b.Agent) + b.KernelAndOther
+}
+
+func TestComputeTilesTotal(t *testing.T) {
+	// 512 MiB of anonymous memory across the actor's containers.
+	const containersAnon = 512 << 20
+	b := Compute(wantGuest, containersAnon)
+
+	if sum := sumOf(b); sum != int64(b.Total) {
+		t.Errorf("components sum to %d, want Total %d — the slices must tile the guest by construction", sum, b.Total)
+	}
+	if b.Containers != containersAnon {
+		t.Errorf("Containers = %d, want %d", b.Containers, containersAnon)
+	}
+
+	// Shmem is in Cached and is not reclaimable, so it must not be in PageCache.
+	wantCache := wantGuest.Buffers + (wantGuest.Cached - wantGuest.Shmem) + wantGuest.SReclaimable
+	if b.PageCache != wantCache {
+		t.Errorf("PageCache = %d, want %d (Cached must have Shmem taken out of it)", b.PageCache, wantCache)
+	}
+	if b.Tmpfs != wantGuest.Shmem {
+		t.Errorf("Tmpfs = %d, want %d — what PageCache gives up, Tmpfs must claim", b.Tmpfs, wantGuest.Shmem)
+	}
+}
+
+// The case the Tmpfs slice exists for: a workload writing to a guest tmpfs
+// allocates guest RAM under an API that looks like disk. The current runtime
+// keeps rootfs and volume writes on the host (see rootfsupper.go), so this is
+// the shape a snapshot from the retired guest-tmpfs-upper era has, and the
+// shape any future move of write storage back inside the guest would take.
+// Those pages land in Shmem: not in the container's cgroup anon, and taken back
+// out of Cached because they cannot be reclaimed. Without a slice of their own
+// they are invisible — they fall through into the residual and read as the
+// guest kernel having grown.
+func TestComputeAttributesAFileWrittenToTmpfs(t *testing.T) {
+	const write = 256 << 20
+
+	before := Compute(wantGuest, 0)
+
+	after := wantGuest
+	after.Free -= write
+	after.Shmem += write
+	after.Cached += write // the kernel counts tmpfs pages in Cached too
+	got := Compute(after, 0)
+
+	if delta := got.Tmpfs - before.Tmpfs; delta != write {
+		t.Errorf("Tmpfs moved by %d, want %d", delta, write)
+	}
+	if got.PageCache != before.PageCache {
+		t.Errorf("PageCache moved from %d to %d; tmpfs pages are not reclaimable and must not read as cache",
+			before.PageCache, got.PageCache)
+	}
+	if got.Containers != before.Containers {
+		t.Errorf("Containers moved from %d to %d; the cgroup charges tmpfs to shmem, not anon",
+			before.Containers, got.Containers)
+	}
+	if got.KernelAndOther != before.KernelAndOther {
+		t.Errorf("KernelAndOther moved from %d to %d; a container's file write is not the guest kernel growing",
+			before.KernelAndOther, got.KernelAndOther)
+	}
+	if sum := sumOf(got); sum != int64(got.Total) {
+		t.Errorf("components sum to %d, want Total %d", sum, got.Total)
+	}
+}
+
+// The comparison the slice is meant to support: the same bytes written to a
+// durable-dir volume are host-backed, so the guest holds them as ordinary
+// reclaimable page cache instead. Same workload, same byte count, different
+// slice — and only one of the two costs memory-snapshot bytes.
+func TestComputeSeparatesTmpfsFromRealPageCache(t *testing.T) {
+	const write = 256 << 20
+
+	toTmpfs := wantGuest
+	toTmpfs.Free -= write
+	toTmpfs.Shmem += write
+	toTmpfs.Cached += write
+
+	toDurableDir := wantGuest
+	toDurableDir.Free -= write
+	toDurableDir.Cached += write // a file page with a backing store: no Shmem
+
+	tmpfs, durable := Compute(toTmpfs, 0), Compute(toDurableDir, 0)
+
+	if tmpfs.Tmpfs-durable.Tmpfs != write {
+		t.Errorf("Tmpfs: %d vs %d, want a %d difference", tmpfs.Tmpfs, durable.Tmpfs, write)
+	}
+	if durable.PageCache-tmpfs.PageCache != write {
+		t.Errorf("PageCache: %d vs %d, want a %d difference", durable.PageCache, tmpfs.PageCache, write)
+	}
+	if tmpfs.Free != durable.Free {
+		t.Errorf("Free differs (%d vs %d); both writes cost the guest the same RAM", tmpfs.Free, durable.Free)
+	}
+}
+
+// The residual is the only place an overlap between the measured slices can
+// show up, so it must be allowed to go negative. Clamping it at zero would make
+// the one failure mode this decomposition has invisible.
+func TestComputeResidualGoesNegativeOnOverlap(t *testing.T) {
+	g := Guest{Total: 1 << 30, Free: 1 << 29, Cached: 1 << 29}
+	b := Compute(g, 1<<29) // containers claiming half the guest on top of that
+
+	if b.KernelAndOther >= 0 {
+		t.Fatalf("KernelAndOther = %d, want negative: the slices claim more than the guest has", b.KernelAndOther)
+	}
+	if b.KernelAndOther != -(1 << 29) {
+		t.Errorf("KernelAndOther = %d, want %d", b.KernelAndOther, -(1 << 29))
+	}
+}
+
+// The guest assembles /proc/meminfo without a lock, so Shmem can legitimately
+// read a hair above the Cached line next to it. On uint64 the naive subtraction
+// gives an absurd number instead of the near-zero the reading means.
+func TestComputeSaturatesShmemAboveCached(t *testing.T) {
+	g := Guest{Total: 1 << 30, Cached: 1000, Shmem: 2000, Buffers: 4096}
+	b := Compute(g, 0)
+	if b.PageCache != 4096 {
+		t.Errorf("PageCache = %d, want 4096: Cached-Shmem must floor at zero, not wrap", b.PageCache)
+	}
+	// The floor changes what PageCache gives up, not what Tmpfs claims: Shmem
+	// is reported as read, so the residual absorbs the inconsistency instead of
+	// a slice silently shrinking to hide it.
+	if b.Tmpfs != 2000 {
+		t.Errorf("Tmpfs = %d, want 2000", b.Tmpfs)
+	}
+}
+
+func TestNormalizeFoldsSpellings(t *testing.T) {
+	want := normalize("MemTotal")
+	for _, spelling := range []string{"mem_total", "memtotal", "MEM_TOTAL", "Mem-Total"} {
+		if got := normalize(spelling); got != want {
+			t.Errorf("normalize(%q) = %q, want %q", spelling, got, want)
+		}
+	}
+	if strings.Contains(want, "_") {
+		t.Errorf("normalize left a separator in %q", want)
+	}
+}

--- a/cmd/ateom-microvm/internal/kata/agentclient.go
+++ b/cmd/ateom-microvm/internal/kata/agentclient.go
@@ -280,6 +280,29 @@ func (a *AgentClient) StatsContainer(ctx context.Context, containerID string) (*
 	return resp.GetCgroupStats(), nil
 }
 
+// GetMetrics returns the kata-agent's own Prometheus scrape, taken from inside
+// the guest. Mirrors grpc.AgentService/GetMetrics.
+//
+// The reply is one blob of Prometheus text exposition rather than a structured
+// message — the agent serializes its registry as-is — so the caller has to parse
+// it (see internal/guestmem). What makes that worth doing is that the registry
+// carries the guest kernel's /proc/meminfo alongside the agent process's own
+// counters, which makes this the only call that sees the guest AS A WHOLE.
+// StatsContainer sees one container's cgroup, and the sum of those cgroups is
+// not the guest: it leaves out the kernel, the agent itself, and every page of
+// cache charged to no container.
+//
+// Safe to call while the stdout/stderr forwarding goroutines are reading over
+// the same client, for the same reason StatsContainer is: ttrpc multiplexes.
+func (a *AgentClient) GetMetrics(ctx context.Context) (string, error) {
+	resp := &agentpb.Metrics{}
+	req := &agentpb.GetMetricsRequest{}
+	if err := a.client.Call(ctx, "grpc.AgentService", "GetMetrics", req, resp); err != nil {
+		return "", fmt.Errorf("agent GetMetrics: %w", err)
+	}
+	return resp.GetMetrics(), nil
+}
+
 // StreamReader adapts the agent's repeated ReadStdout/ReadStderr unary calls into
 // an io.Reader, so the consumer can pump the container's output through the shared
 // actorlog forwarder like any other stream. Each Read issues one RPC with Len set

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -254,6 +254,12 @@ func do(ctx context.Context) error {
 	slog.InfoContext(ctx, "atunnel egress serving", slog.String("address", *atunnelEgressListenAddress))
 
 	ateomService := NewService(*podUID, *chBinary, *kataConfig, *kataDebug, *vmmMemReserve, interiorNetNS, actorLogger, atunnelIngress, atunnelEgress, atunnelEgressPort, *workerCredentialBundle, *podIdentityTrustBundle, *egressGatewayTrustBundle)
+	if err := ateomService.registerGuestMemoryMetrics(mp); err != nil {
+		// Not fatal: the breakdown is observability, and an ateom that cannot
+		// publish it can still run actors. Failing the boot over it would trade
+		// a blind spot for an outage.
+		slog.ErrorContext(ctx, "Failed to register the guest memory breakdown; the micro-VM's internal memory split will not be reported", slog.Any("error", err))
+	}
 
 	svr := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),

--- a/cmd/ateom-microvm/stats.go
+++ b/cmd/ateom-microvm/stats.go
@@ -38,12 +38,18 @@ import (
 // file reads inside the guest, and far short of the lifecycle calls' 20-30s.
 const statsCallTimeout = 2 * time.Second
 
-// containerStatsReader is the one guest-agent call GetWorkloadStats makes.
-// *kata.AgentClient satisfies it; the narrow interface is what lets the handler
-// be tested without a live micro-VM, which is otherwise the only way to get an
-// agent to talk to.
-type containerStatsReader interface {
+// guestStatsReader is the guest-agent surface the telemetry paths use, and
+// nothing else. *kata.AgentClient satisfies it; the narrow interface is what
+// lets both be tested without a live micro-VM, which is otherwise the only way
+// to get an agent to talk to.
+//
+// StatsContainer answers GetWorkloadStats — one container's cgroup, summed
+// across the actor. GetMetrics answers the guest-wide memory breakdown, which
+// the cgroups cannot: they account for the containers and for nothing else in
+// the guest.
+type guestStatsReader interface {
 	StatsContainer(ctx context.Context, containerID string) (*agentpb.CgroupStats, error)
+	GetMetrics(ctx context.Context) (string, error)
 }
 
 // guestStatsTarget is everything GetWorkloadStats needs to sample a live guest.
@@ -61,7 +67,7 @@ type guestStatsTarget struct {
 	// agent is the kata-agent client the actor's log forwarding already keeps
 	// open for its lifetime, borrowed rather than dialed again. ttrpc
 	// multiplexes, so a poll and the forwarding reads share it safely.
-	agent containerStatsReader
+	agent guestStatsReader
 
 	// workloadIDs are the guest containers to sum, one per actor container.
 	// Each actor container exists in the guest as TWO kata containers (see

--- a/cmd/ateom-microvm/stats_test.go
+++ b/cmd/ateom-microvm/stats_test.go
@@ -129,6 +129,12 @@ type fakeAgent struct {
 	// so flipping it here lands in the window the re-check guards.
 	onCall func()
 
+	// scrape and scrapeErr are the canned GetMetrics reply, for the guest
+	// memory breakdown's tests; the GetWorkloadStats tests below leave them
+	// unset.
+	scrape    string
+	scrapeErr error
+
 	// calls records the container ids asked for, in order, so a test can tell
 	// "summed two containers" from "read one twice".
 	calls []string
@@ -150,6 +156,13 @@ func (f *fakeAgent) StatsContainer(ctx context.Context, containerID string) (*ag
 	return f.stats[containerID], nil
 }
 
+func (f *fakeAgent) GetMetrics(ctx context.Context) (string, error) {
+	if f.scrapeErr != nil {
+		return "", f.scrapeErr
+	}
+	return f.scrape, nil
+}
+
 // containerStats is one container's guest reading: usage bytes, peak bytes,
 // reclaimable page cache, and cumulative CPU nanoseconds.
 func containerStats(usage, peak, inactiveFile, cpuNanos uint64) *agentpb.CgroupStats {
@@ -166,7 +179,7 @@ func containerStats(usage, peak, inactiveFile, cpuNanos uint64) *agentpb.CgroupS
 // containers published to GetWorkloadStats. lock is constructed like NewService
 // does, since it is a pointer with no usable zero value and
 // TestGetWorkloadStatsDoesNotTakeLock holds it.
-func newStatsService(agent containerStatsReader, workloadIDs ...string) *AteomService {
+func newStatsService(agent guestStatsReader, workloadIDs ...string) *AteomService {
 	s := &AteomService{lock: newCancelableMutex()}
 	s.activeActor.Store(&testActor)
 	s.guestStats.Store(&guestStatsTarget{actorUID: testActor.UID, agent: agent, workloadIDs: workloadIDs})

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -140,6 +140,7 @@ Agent Substrate emits foundational OpenTelemetry system and server metrics to mo
 | `ate.actor.restore.duration` | atelet | histogram | how long each phase of a restore takes on the worker node, which is where cold-start latency actually goes once ateapi hands off (labels `ate.snapshot.phase`, `ate.snapshot.kind`, `ate.snapshot.scope`, `ate.template.namespace`, `ate.template.name`, `ate.sandbox.class`, plus `ate.failure.reason` on failure) |
 | `ate.actor.checkpoint.duration` | atelet | histogram | the same phase breakdown for writing a snapshot, so a slow suspend can be attributed to ateom or to the upload (same labels as the restore histogram) |
 | `ate.imagecache.requests` | atelet | counter | image lookups in the node-local image cache, by outcome (`ate.imagecache.outcome`), with `error.type` on the `error` outcome. A miss pays for the pull and the unpack, so the hit ratio per node is a leading indicator of resume latency |
+| `ate.microvm.guest.memory.bytes` | ateom-microvm | gauge | guest RAM of a running micro-VM, split by what is holding it (labels `ate.guest.memory.component`, `ate.template.namespace`, `ate.template.name`). microVM only: the gVisor sentry publishes no equivalent decomposition |
 
 The table lists the OpenTelemetry instrument names. How a name appears in a query depends on the backend (Cloud Monitoring (GMP) / Kind collector).
 
@@ -157,6 +158,11 @@ For `ate.scheduler.eligible_workers`:
 For `ate.imagecache.requests`:
 * `ate.imagecache.outcome` is `hit` when the node holds a complete image record — every layer directory the record names is present — and `miss` when the lookup must pull. A failed lookup is neither: `error` is a failed lookup whatever the cause, and `cancelled` or `timeout` is the caller giving up, as on `ate.router.outcome`. So the hit ratio is `hit / (hit + miss)`, with failures and abandoned lookups out of the denominator.
 * `error.type` is present only on the `error` outcome, and carries the registry's own HTTP status for its rejection, from a fixed set: `401`, `403`, `404`, `429`, `500`, `502`, `503`, `504`. The set is an allow-list because the registry client reports whatever the remote returned. Each other status, and each failure that carries no status, reports `_OTHER`.
+
+For `ate.microvm.guest.memory.bytes`:
+* `ate.guest.memory.component` is a closed set that tiles the guest kernel's MemTotal, so the series stack: `free`, `page_cache`, `containers` (the workload cgroups' anonymous pages), `tmpfs`, `kata_agent`, and `kernel_and_other` as the residual. MemTotal is itself below the RAM assigned to the VM, so the stack does not add up to the actor's memory size.
+* Attribution is by template, not by actor: a worker is recycled through actor after actor and each would leave a series behind, the same reason `ateattr.ActorMetricAttributes` omits actor identity.
+* Everything outside `free` is a page a Full checkpoint has to write, so this is the metric that explains a snapshot's size — and through it the `persist` and `download` phases of the suspend and resume histograms.
 
 `ate.workerpool.namespace` and `ate.workerpool.name` identify a pool together, on every instrument that names one. A WorkerPool is a namespaced resource, so the name on its own merges same-named pools from different namespaces into one series. The pair means that capacity (`ate.workerpool.workers`, `ate.workerpool.desired_workers`, `ate.workerpool.ready_workers`) joins to demand (`ate.scheduler.assignment.duration`, `ate.actor.lifecycle.operation.duration`, `ate.actor.crashes`) by pool.
 

--- a/internal/e2e/collector_metrics.go
+++ b/internal/e2e/collector_metrics.go
@@ -51,6 +51,28 @@ var PlatformMetricPrefixes = []string{
 	"ate_scheduler_eligible_workers",
 }
 
+// MicroVMMetricPrefixes are the prefixes a micro-VM worker emits and a gVisor
+// one cannot, so they are asserted on top of PlatformMetricPrefixes only when
+// the suite runs against SandboxClassMicroVM. The guest memory breakdown reads
+// the kata-agent's view of the guest kernel; the sentry publishes no equivalent.
+var MicroVMMetricPrefixes = []string{
+	"ate_microvm_guest_memory_bytes",
+}
+
+// GuestMemoryComponents are every value of ate_guest_memory_component. The set
+// is closed and its members tile the guest's MemTotal (see
+// cmd/ateom-microvm/guestmem.go), which is the property that lets a dashboard
+// stack them: one missing means the breakdown has stopped being a partition and
+// the stack silently understates the guest.
+var GuestMemoryComponents = []string{
+	"free",
+	"page_cache",
+	"containers",
+	"tmpfs",
+	"kata_agent",
+	"kernel_and_other",
+}
+
 // ScrapeCollectorMetrics port-forwards the kind stack's OTel Collector and reads
 // its Prometheus exporter surface, returning the raw exposition text.
 func ScrapeCollectorMetrics(ctx context.Context) (string, error) {

--- a/internal/e2e/suites/metrics/metrics_test.go
+++ b/internal/e2e/suites/metrics/metrics_test.go
@@ -23,6 +23,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -88,6 +89,14 @@ func TestPlatformMetricsEmitted(t *testing.T) {
 	// because it deletes the worker pod.
 	triggerActorCrash(t, ctx, clients, actorID)
 
+	// The micro-VM prefixes are additive and only on that class: gVisor emits no
+	// guest memory breakdown, so asserting them everywhere would fail every
+	// gVisor run.
+	want := slices.Clone(e2e.PlatformMetricPrefixes)
+	if e2e.IsMicroVM() {
+		want = append(want, e2e.MicroVMMetricPrefixes...)
+	}
+
 	deadline := time.Now().Add(2 * time.Minute)
 	var missing []string
 	var ateomSeen, controllerSeen bool
@@ -97,7 +106,7 @@ func TestPlatformMetricsEmitted(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ScrapeCollectorMetrics: %v", err)
 		}
-		missing = e2e.MissingPlatformMetrics(scrape, e2e.PlatformMetricPrefixes)
+		missing = e2e.MissingPlatformMetrics(scrape, want)
 		ateomSeen = e2e.CollectorHasService(scrape, "ateom-gvisor", "ateom-microvm")
 		// atecontroller bridges controller-runtime's Prometheus registry onto its OTLP
 		// reader, so the reconcile families are what prove the bridge, not just that
@@ -272,6 +281,12 @@ func TestPlatformMetricsEmitted(t *testing.T) {
 				errs = append(errs, err.Error())
 			}
 
+			if e2e.IsMicroVM() {
+				if err := validateGuestMemoryComponents(scrape); err != nil {
+					errs = append(errs, err.Error())
+				}
+			}
+
 			if len(errs) == 0 {
 				return
 			}
@@ -355,6 +370,48 @@ func validateSnapshotPhaseLabels(scrape string) error {
 		if !labelled {
 			return fmt.Errorf("no %s line carried all of ate_snapshot_kind, ate_snapshot_scope and ate_sandbox_class", m)
 		}
+	}
+	return nil
+}
+
+// validateGuestMemoryComponents guards the property that makes the guest memory
+// breakdown worth charting: the components partition the guest's MemTotal, so
+// every one of them must be observed. A slice that quietly stopped being
+// reported leaves a stack that still renders and still understates the guest.
+// Attribution is by template, so those labels must be there too — without them
+// the series cannot be compared across images, which is the question the metric
+// exists to answer.
+func validateGuestMemoryComponents(scrape string) error {
+	seen := make(map[string]bool, len(e2e.GuestMemoryComponents))
+	var lines int
+	for _, line := range strings.Split(scrape, "\n") {
+		if !strings.HasPrefix(line, "ate_microvm_guest_memory_bytes") {
+			continue
+		}
+		lines++
+		component := extractLabelValue(line, "ate_guest_memory_component")
+		if component == "" {
+			return fmt.Errorf("ate_microvm_guest_memory_bytes line is missing ate_guest_memory_component: %q", line)
+		}
+		if !slices.Contains(e2e.GuestMemoryComponents, component) {
+			return fmt.Errorf("ate_guest_memory_component %q is not one of %v; the closed set is what makes the series stackable", component, e2e.GuestMemoryComponents)
+		}
+		if extractLabelValue(line, "ate_template_namespace") == "" || extractLabelValue(line, "ate_template_name") == "" {
+			return fmt.Errorf("ate_microvm_guest_memory_bytes line is missing the template labels: %q", line)
+		}
+		seen[component] = true
+	}
+	if lines == 0 {
+		return fmt.Errorf("no ate_microvm_guest_memory_bytes line in the collector scrape")
+	}
+	var missing []string
+	for _, component := range e2e.GuestMemoryComponents {
+		if !seen[component] {
+			missing = append(missing, component)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("guest memory components %v were never observed, so the breakdown no longer partitions MemTotal", missing)
 	}
 	return nil
 }


### PR DESCRIPTION
A micro-VM's guest RAM is a black box from the host. `ateom` knows the VM was given N MiB; it has no way to say whether that memory is empty, page cache, the workload's anonymous pages, or the kata-agent. That matters beyond curiosity: CH's snapshot is sparse and faulted-only, so everything that is *not* free is a
page a Full checkpoint has to write — and therefore bytes in `ate.actor.checkpoint.duration` and `ate.actor.restore.duration`.

This adds `ate.microvm.guest.memory.bytes`, an observable gauge that splits the guest into six components which tile the guest kernel's MemTotal:

| component | what it is |
|---|---|
| `free` | pages the guest kernel considers free |
| `page_cache` | file-backed pages, minus shmem |
| `containers` | the workload cgroups' anonymous pages |
| `tmpfs` | shmem, given a slice of its own |
| `kata_agent` | the agent's RSS |
| `kernel_and_other` | the residual |

The source is the kata-agent's own metrics scrape (`kata_guest_meminfo` plus per-container cgroup stats), so it measures the guest kernel's accounting rather than this code's model of it: whatever holds RAM lands in one of the six.

Notes on the choices:

* **Closed set, sums to MemTotal.** That is the property that makes a stacked chart honest, and the e2e assertion checks all six are present for exactly that reason. `kernel_and_other` is a residual, so something new that starts holding memory shows up rather than disappearing.
* **`tmpfs` is separate from `page_cache` on purpose.** It is where write storage living in guest RAM would appear — see the retired guest-tmpfs-upper design in `rootfsupper.go`, which "pinned every written byte in guest memory". Folding it into page cache would hide exactly the regression worth catching.
* **`containers` charges anonymous pages, not cgroup usage.** Usage would double-count the container's file pages against `page_cache` and push the total over MemTotal.
* **Attribution is by template, not by actor.** A worker is recycled through actor after actor and each would leave a dead series behind; the repo draws the same line in `ateattr.ActorMetricAttributes`.
* **The sample is taken in the callback, not by a background goroutine.** The two pieces of state it reads are the same atomics `GetWorkloadStats` reads, which exist so a reader never waits on a boot, snapshot or restore. With no lock to take, a sampler goroutine would add a staleness window and a lifecycle to get wrong, for nothing.
* **Registration failure is not fatal.** An ateom that cannot publish the breakdown can still run actors; failing the boot would trade a blind spot for an outage.
* **Nothing is observed when there is no guest.** A zero would read as "the guest is empty", which is a different and false claim.

micro-VM only — the gVisor sentry publishes no equivalent decomposition — so the e2e assertion is gated on `SandboxClassMicroVM` and the prefix list is additive.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
