### PR TITLE
feat(atepg): project actor state into a column

### DIFF
--- a/cmd/ateapi/internal/store/atepg/atepg.go
+++ b/cmd/ateapi/internal/store/atepg/atepg.go
@@ -583,9 +583,10 @@ func (p *Persistence) CreateActor(ctx context.Context, actor *ateapipb.Actor) (*
 	}
 
 	_, err = p.pool.Exec(ctx, `
-		INSERT INTO actors (atespace, name, uid, version, proto)
-		VALUES ($1, $2, $3, $4, $5)`,
-		atespace, name, dbActor.GetMetadata().GetUid(), dbActor.GetMetadata().GetVersion(), protoBytes)
+		INSERT INTO actors (atespace, name, uid, version, state, proto)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		atespace, name, dbActor.GetMetadata().GetUid(), dbActor.GetMetadata().GetVersion(),
+		int32(dbActor.GetStatus().GetState()), protoBytes)
 	if err != nil {
 		if isUniqueViolation(err) {
 			return nil, store.ErrAlreadyExists
@@ -682,11 +683,14 @@ func (p *Persistence) UpdateActor(ctx context.Context, actorRef resources.ActorR
 	if err != nil {
 		return nil, fmt.Errorf("marshaling actor: %w", err)
 	}
+	// state rides the same statement as the proto, under the same version guard,
+	// so the projection cannot drift from the record it describes.
 	commandTag, err := p.pool.Exec(ctx, `
 			UPDATE actors
-			SET version = $1, proto = $2
-			WHERE atespace = $3 AND name = $4 AND uid = $5 AND version = $6`,
-		dbActor.GetMetadata().GetVersion(), updatedBytes, atespace, name, currentUID, currentVersion)
+			SET version = $1, proto = $2, state = $3
+			WHERE atespace = $4 AND name = $5 AND uid = $6 AND version = $7`,
+		dbActor.GetMetadata().GetVersion(), updatedBytes, int32(dbActor.GetStatus().GetState()),
+		atespace, name, currentUID, currentVersion)
 	if err != nil {
 		return nil, fmt.Errorf("updating actor %s/%s: %w", atespace, name, err)
 	}
@@ -849,6 +853,34 @@ func (p *Persistence) listActorsGlobal(ctx context.Context, pageSize int32, page
 		nextToken = encodePageToken(kindActor, "", []string{last.atespace, last.name})
 	}
 	return result, nextToken, nil
+}
+
+// CountActors tallies by the projected state column, so it never decodes a
+// proto. Deliberately a sequential scan: an index on state is faster only on a
+// freshly vacuumed table, and loses to the scan once ordinary transition churn
+// clears the visibility map.
+func (p *Persistence) CountActors(ctx context.Context) (store.ActorCounts, error) {
+	// Clock before the query: AsOf must never look fresher than the rows behind it.
+	counts := store.ActorCounts{ByState: make(map[ateapipb.ActorState]int64), AsOf: time.Now()}
+
+	rows, err := p.pool.Query(ctx, `SELECT state, count(*) FROM actors GROUP BY state`)
+	if err != nil {
+		return store.ActorCounts{}, fmt.Errorf("counting actors by state: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var state int32
+		var count int64
+		if err := rows.Scan(&state, &count); err != nil {
+			return store.ActorCounts{}, fmt.Errorf("scanning actor count row: %w", err)
+		}
+		counts.ByState[ateapipb.ActorState(state)] = count
+	}
+	if err := rows.Err(); err != nil {
+		return store.ActorCounts{}, fmt.Errorf("counting actors by state: %w", err)
+	}
+	return counts, nil
 }
 
 // --- Actor snapshots ---

--- a/cmd/ateapi/internal/store/atepg/atepg_test.go
+++ b/cmd/ateapi/internal/store/atepg/atepg_test.go
@@ -139,6 +139,48 @@ func createTestAtespace(t *testing.T, s *Persistence, name string) {
 	}
 }
 
+func createTestActor(t *testing.T, s *Persistence, atespace, name string, state ateapipb.ActorState) *ateapipb.Actor {
+	t.Helper()
+	actor, err := s.CreateActor(context.Background(), &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: atespace, Name: name},
+		ActorTemplateNamespace: "default",
+		ActorTemplateName:      "template-a",
+		Status:                 &ateapipb.ActorStatus{State: state},
+	})
+	if err != nil {
+		t.Fatalf("CreateActor(%q/%q) failed: %v", atespace, name, err)
+	}
+	return actor
+}
+
+// setActorState transitions actor and returns the stored result, which carries
+// the version the next transition must guard on.
+func setActorState(t *testing.T, s *Persistence, actor *ateapipb.Actor, state ateapipb.ActorState) *ateapipb.Actor {
+	t.Helper()
+	actorRef := resources.ActorRefFromActor(actor)
+	updated, err := s.UpdateActor(context.Background(), actorRef, store.PreconditionFrom(actor), func(toUpdate *ateapipb.Actor) error {
+		toUpdate.Status.State = state
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateActor(%s) to %v failed: %v", actorRef, state, err)
+	}
+	return updated
+}
+
+// readActorState reads the projected state column directly. It is the value
+// CountActors aggregates, and no accessor on the store exposes it.
+func readActorState(t *testing.T, s *Persistence, actorRef resources.ActorRef) ateapipb.ActorState {
+	t.Helper()
+	var state int32
+	if err := s.pool.QueryRow(context.Background(),
+		`SELECT state FROM actors WHERE atespace = $1 AND name = $2`,
+		actorRef.Atespace, actorRef.Name).Scan(&state); err != nil {
+		t.Fatalf("reading the state column of %s: %v", actorRef, err)
+	}
+	return ateapipb.ActorState(state)
+}
+
 func createTestActorTemplate(t *testing.T, s *Persistence, atespace, name string) {
 	t.Helper()
 	if _, err := s.CreateActorTemplate(context.Background(), &ateapipb.ActorTemplate{
@@ -489,5 +531,41 @@ func TestAcquireLock_ConcurrentTakeover(t *testing.T) {
 	}
 	for lock := range winners {
 		lock.Close()
+	}
+}
+
+// TestActorStateColumnTracksProto guards the invariant CountActors rests on: the
+// projected column is written by the same statement as the proto, so no write
+// path can advance one without the other.
+func TestActorStateColumnTracksProto(t *testing.T) {
+	s := setupPostgresPersistence(t)
+	createTestAtespace(t, s, "team-a")
+
+	const createdState = ateapipb.ActorState_ACTOR_STATE_SUSPENDED
+	actor := createTestActor(t, s, "team-a", "actor-a", createdState)
+	actorRef := resources.ActorRefFromActor(actor)
+	if got := readActorState(t, s, actorRef); got != createdState {
+		t.Errorf("state column after create = %v, want %v", got, createdState)
+	}
+
+	// Sequential by construction: each transition guards on the version the
+	// previous one returned.
+	tests := []struct {
+		name  string
+		state ateapipb.ActorState
+	}{
+		{"resuming", ateapipb.ActorState_ACTOR_STATE_RESUMING},
+		{"running", ateapipb.ActorState_ACTOR_STATE_RUNNING},
+		{"suspending", ateapipb.ActorState_ACTOR_STATE_SUSPENDING},
+		{"crashed", ateapipb.ActorState_ACTOR_STATE_CRASHED},
+		{"deleting", ateapipb.ActorState_ACTOR_STATE_DELETING},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actor = setActorState(t, s, actor, tt.state)
+			if got := readActorState(t, s, actorRef); got != tt.state {
+				t.Errorf("state column = %v, want %v", got, tt.state)
+			}
+		})
 	}
 }

--- a/cmd/ateapi/internal/store/atepg/schema.go
+++ b/cmd/ateapi/internal/store/atepg/schema.go
@@ -16,6 +16,7 @@ package atepg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -40,6 +41,7 @@ CREATE TABLE IF NOT EXISTS actors (
     name      text NOT NULL,
     uid       text NOT NULL,
     version   bigint NOT NULL,
+    state     integer NOT NULL,
     proto     bytea NOT NULL,
     PRIMARY KEY (atespace, name)
 );
@@ -130,6 +132,29 @@ CREATE TABLE IF NOT EXISTS leases (
 CREATE INDEX IF NOT EXISTS leases_expires_at_idx ON leases (expires_at);
 `
 
+// checkActorsStateColumn rejects a database whose actors table predates the
+// state column. CREATE TABLE IF NOT EXISTS skips an existing table silently, so
+// the mismatch would otherwise surface as a bare column error on the first
+// insert.
+func checkActorsStateColumn(ctx context.Context, q querier) error {
+	var tableExists, stateExists bool
+	if err := q.QueryRow(ctx, `
+		SELECT
+			EXISTS (
+				SELECT 1 FROM information_schema.tables
+				WHERE table_schema = current_schema() AND table_name = 'actors'),
+			EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema = current_schema() AND table_name = 'actors'
+				  AND column_name = 'state')`).Scan(&tableExists, &stateExists); err != nil {
+		return fmt.Errorf("inspecting the actors table: %w", err)
+	}
+	if tableExists && !stateExists {
+		return errors.New("actors table has no state column: this database predates it and atepg has no migrations, so recreate the database")
+	}
+	return nil
+}
+
 // applySchema idempotently creates atepg's tables.
 func applySchema(ctx context.Context, pool *pgxpool.Pool) error {
 	tx, err := pool.Begin(ctx)
@@ -154,6 +179,9 @@ func applySchema(ctx context.Context, pool *pgxpool.Pool) error {
 	// so serialize schema application with a transaction-scoped advisory lock.
 	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext('agent-substrate-atepg-schema'))`); err != nil {
 		return fmt.Errorf("locking atepg schema: %w", err)
+	}
+	if err := checkActorsStateColumn(ctx, tx); err != nil {
+		return err
 	}
 	if _, err := tx.Exec(ctx, schema); err != nil {
 		return fmt.Errorf("applying atepg schema: %w", err)

--- a/cmd/ateapi/internal/store/atepg/schema_test.go
+++ b/cmd/ateapi/internal/store/atepg/schema_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atepg
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newSchemaScopedPool returns a pool whose connections resolve unqualified names
+// in a PostgreSQL schema of their own, so a test can apply the atepg schema over
+// a table shape it controls without disturbing the shared one. It also exercises
+// the current_schema() scoping checkActorsState relies on.
+func newSchemaScopedPool(t *testing.T, name string) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+	shared := requirePool(t)
+	quoted := pgx.Identifier{name}.Sanitize()
+	if _, err := shared.Exec(ctx, `DROP SCHEMA IF EXISTS `+quoted+` CASCADE`); err != nil {
+		t.Fatalf("dropping a leftover %q schema: %v", name, err)
+	}
+	if _, err := shared.Exec(ctx, `CREATE SCHEMA `+quoted); err != nil {
+		t.Fatalf("creating the %q schema: %v", name, err)
+	}
+
+	config, err := pgxpool.ParseConfig(containerDSN)
+	if err != nil {
+		t.Fatalf("parsing the testcontainer DSN: %v", err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = name
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("connecting with search_path=%q: %v", name, err)
+	}
+	t.Cleanup(func() {
+		pool.Close()
+		if _, err := shared.Exec(context.Background(), `DROP SCHEMA IF EXISTS `+quoted+` CASCADE`); err != nil {
+			t.Errorf("dropping the %q schema: %v", name, err)
+		}
+	})
+	return pool
+}
+
+func TestApplySchema_RejectsActorsWithoutState(t *testing.T) {
+	pool := newSchemaScopedPool(t, "atepg_legacy_actors")
+	ctx := context.Background()
+
+	// The actors table as it stood before the state column was projected.
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE actors (
+		    atespace  text NOT NULL,
+		    name      text NOT NULL,
+		    uid       text NOT NULL,
+		    version   bigint NOT NULL,
+		    proto     bytea NOT NULL,
+		    PRIMARY KEY (atespace, name)
+		)`); err != nil {
+		t.Fatalf("creating the pre-state actors table: %v", err)
+	}
+
+	err := applySchema(ctx, pool)
+	if err == nil {
+		t.Fatal("applySchema accepted an actors table with no state column")
+	}
+	if !strings.Contains(err.Error(), "state column") {
+		t.Errorf("applySchema error = %q, want it to name the missing state column", err)
+	}
+}
+
+func TestApplySchema_FreshDatabaseIsIdempotent(t *testing.T) {
+	pool := newSchemaScopedPool(t, "atepg_fresh_actors")
+	ctx := context.Background()
+
+	// The second pass must not trip the precheck the first pass satisfied.
+	for pass := 1; pass <= 2; pass++ {
+		if err := applySchema(ctx, pool); err != nil {
+			t.Fatalf("applySchema pass %d failed: %v", pass, err)
+		}
+	}
+}

--- a/cmd/ateapi/internal/store/store.go
+++ b/cmd/ateapi/internal/store/store.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
@@ -103,6 +104,12 @@ type Interface interface {
 	// Removes an actor and returns the deleted resource. Returns ErrNotFound if
 	// missing, or ErrFailedPrecondition if not already deleting.
 	DeleteActor(ctx context.Context, actorRef resources.ActorRef) (*ateapipb.Actor, error)
+
+	// CountActors returns the actor population grouped by state, across all
+	// atespaces. It is linear in the population, so callers should treat it as
+	// periodic rather than per-request and read the returned AsOf rather than
+	// assuming the tally is current.
+	CountActors(ctx context.Context) (ActorCounts, error)
 
 	// Creates an immutable ActorSnapshot. The caller sets snapshot_uri; the
 	// store keeps no location of its own.
@@ -449,4 +456,17 @@ type ListResponse[T any] struct {
 // HasNextPage reports whether another page follows this one.
 func (r ListResponse[T]) HasNextPage() bool {
 	return r.NextPageToken != ""
+}
+
+// ActorCounts is the actor population grouped by state, and the instant the
+// backend computed it.
+type ActorCounts struct {
+	// ByState tallies actors per state, across all atespaces. A state with no
+	// actors is absent rather than zero; a caller that needs a zero-valued
+	// series seeds it itself.
+	ByState map[ateapipb.ActorState]int64
+	// AsOf is when the tally was computed, not when the call was served, so a
+	// backend answering from a cached or materialized count reports its
+	// staleness rather than hiding it.
+	AsOf time.Time
 }

--- a/cmd/ateapi/internal/store/storecontract/contract.go
+++ b/cmd/ateapi/internal/store/storecontract/contract.go
@@ -104,6 +104,32 @@ func mustCreateAtespace(t *testing.T, s store.Interface, name string) {
 	}
 }
 
+// mustSetActorState transitions actor and returns the stored result, which
+// carries the version the next write must guard on.
+func mustSetActorState(t *testing.T, s store.Interface, actor *ateapipb.Actor, state ateapipb.ActorState) *ateapipb.Actor {
+	t.Helper()
+	actorRef := resources.ActorRefFromActor(actor)
+	updated, err := s.UpdateActor(context.Background(), actorRef, store.PreconditionFrom(actor), func(toUpdate *ateapipb.Actor) error {
+		toUpdate.Status.State = state
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateActor(%s) to %v failed: %v", actorRef, state, err)
+	}
+	return updated
+}
+
+func assertActorCounts(t *testing.T, s store.Interface, want map[ateapipb.ActorState]int64) {
+	t.Helper()
+	got, err := s.CountActors(context.Background())
+	if err != nil {
+		t.Fatalf("CountActors failed: %v", err)
+	}
+	if diff := cmp.Diff(want, got.ByState); diff != "" {
+		t.Errorf("CountActors tally mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func actorNameSet(actors []*ateapipb.Actor) map[string]bool {
 	set := make(map[string]bool, len(actors))
 	for _, a := range actors {
@@ -754,6 +780,72 @@ func runActorContractTests(t *testing.T, setup func(t *testing.T) store.Interfac
 		if _, err := s.GetActor(ctx, resources.ActorRef{Name: "a1"}); !errors.Is(err, store.ErrNotFound) {
 			t.Errorf("GetActor(empty, a1) = %v, want ErrNotFound", err)
 		}
+	})
+
+	t.Run("CountActors_EmptyStore", func(t *testing.T) {
+		s := setup(t)
+
+		got, err := s.CountActors(context.Background())
+		if err != nil {
+			t.Fatalf("CountActors failed: %v", err)
+		}
+		if len(got.ByState) != 0 {
+			t.Errorf("CountActors on an empty store = %v, want no states", got.ByState)
+		}
+		if got.AsOf.IsZero() {
+			t.Error("CountActors returned a zero AsOf")
+		}
+	})
+
+	t.Run("CountActors_TalliesByState", func(t *testing.T) {
+		s := setup(t)
+		ctx := context.Background()
+		mustCreateAtespace(t, s, "team-a")
+		mustCreateAtespace(t, s, "team-b")
+
+		mkActor := func(atespace, name string, state ateapipb.ActorState) *ateapipb.Actor {
+			return &ateapipb.Actor{
+				Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: atespace},
+				ActorTemplateNamespace: "ns1",
+				ActorTemplateName:      "tmpl1",
+				Status:                 &ateapipb.ActorStatus{State: state},
+			}
+		}
+		// Spread over two atespaces, so a count that was accidentally scoped to
+		// one of them would come up visibly short.
+		var created []*ateapipb.Actor
+		for _, a := range []*ateapipb.Actor{
+			mkActor("team-a", "a1", ateapipb.ActorState_ACTOR_STATE_SUSPENDED),
+			mkActor("team-a", "a2", ateapipb.ActorState_ACTOR_STATE_SUSPENDED),
+			mkActor("team-b", "b1", ateapipb.ActorState_ACTOR_STATE_RUNNING),
+		} {
+			stored, err := s.CreateActor(ctx, a)
+			if err != nil {
+				t.Fatalf("CreateActor(%s/%s) failed: %v", a.GetMetadata().GetAtespace(), a.GetMetadata().GetName(), err)
+			}
+			created = append(created, stored)
+		}
+		assertActorCounts(t, s, map[ateapipb.ActorState]int64{
+			ateapipb.ActorState_ACTOR_STATE_SUSPENDED: 2,
+			ateapipb.ActorState_ACTOR_STATE_RUNNING:   1,
+		})
+
+		moved := mustSetActorState(t, s, created[0], ateapipb.ActorState_ACTOR_STATE_RUNNING)
+		assertActorCounts(t, s, map[ateapipb.ActorState]int64{
+			ateapipb.ActorState_ACTOR_STATE_SUSPENDED: 1,
+			ateapipb.ActorState_ACTOR_STATE_RUNNING:   2,
+		})
+
+		// A state the fleet has drained drops out of the tally rather than
+		// reporting zero.
+		moved = mustSetActorState(t, s, moved, ateapipb.ActorState_ACTOR_STATE_DELETING)
+		if _, err := s.DeleteActor(ctx, resources.ActorRefFromActor(moved)); err != nil {
+			t.Fatalf("DeleteActor failed: %v", err)
+		}
+		assertActorCounts(t, s, map[ateapipb.ActorState]int64{
+			ateapipb.ActorState_ACTOR_STATE_SUSPENDED: 1,
+			ateapipb.ActorState_ACTOR_STATE_RUNNING:   1,
+		})
 	})
 }
 


### PR DESCRIPTION
This PR adds
- a `state` column to atepg's `actors` table, projected out of the proto and written by the same INSERT/UPDATE, so it can't drift from the record
- `CountActors`, which is a plain `count(*) group by state`

Note that there's no index on`state`, which is the opposite of what I planned to do. Benchmarked it at 10M actors:

| | clean table | bloated (29% dead) |
|---|---|---|
| seq scan | 0.72s | 0.57s |
| index-only scan | 0.33s | 1.70s (13.2M heap fetches) |

Transitions land randomly all over the table, so it takes very little churn to wreck the visibility map. 10.6% dead tuples leaves only 4.9% of pages all-visible, and autovacuum doesn't even wake up until 20%. So the index only wins in the state the table is basically never in. It also costs 14% write throughput and kills HOT updates entirely (0 HOT with the index, 99.8% without), on the hottest write path we have.

Seq scan is flat at ~0.6s no matter how bloated things get, so that's what we're doing.

Tested all this with 10M actors on a single-node container. Scaling to 1B _should_ be linear based on this.

Delivers first half of #796

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
