### PR TITLE
microvm: support Microsoft Hypervisor devices

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"fmt"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +34,15 @@ const ateomOTelResourceAttributes = "k8s.namespace.name=$(POD_NAMESPACE),k8s.pod
 // workerTerminationGracePeriodSeconds is the hardcoded pod termination grace
 // period for worker pods (60 minutes).
 const workerTerminationGracePeriodSeconds int64 = 3600
+
+const (
+	// DefaultMicroVMHypervisorDevice is the device used by KVM-backed workers.
+	DefaultMicroVMHypervisorDevice = "/dev/kvm"
+	// MSHVMicroVMHypervisorDevice is the device used by Microsoft Hypervisor root partitions.
+	MSHVMicroVMHypervisorDevice = "/dev/mshv"
+	// microVMHypervisorLabel distinguishes MSHV nodes from the default KVM workers.
+	microVMHypervisorLabel = "ate.dev/microvm-hypervisor"
+)
 
 // ateomOTelSettings is the telemetry configuration propagated to ateom worker
 // pods. A zero value leaves the pods without telemetry env.
@@ -72,6 +82,14 @@ const (
 // are declared here. otel, when it carries an endpoint, is propagated to the
 // ateom container so it pushes telemetry to that collector.
 func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettings) *appsv1ac.DeploymentApplyConfiguration {
+	return buildDeploymentApplyConfigWithHypervisorDevice(wp, otel, DefaultMicroVMHypervisorDevice)
+}
+
+func buildDeploymentApplyConfigWithHypervisorDevice(
+	wp *atev1alpha1.WorkerPool,
+	otel ateomOTelSettings,
+	hypervisorDevice string,
+) *appsv1ac.DeploymentApplyConfiguration {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	if wp.Spec.Template != nil {
@@ -163,7 +181,7 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettin
 		)
 
 	applyWorkerPoolPodTemplate(podSpecAC, containerAC, wp.Spec.Template)
-	maybeApplyMicroVMPodShape(podSpecAC, containerAC, wp.Spec.SandboxClass)
+	maybeApplyMicroVMPodShape(podSpecAC, containerAC, wp.Spec.SandboxClass, hypervisorDevice)
 	maybeApplyGPUPodShape(podSpecAC, containerAC, wp.Spec.Template, wp.Spec.SandboxClass)
 	podSpecAC.WithContainers(containerAC)
 	podSpecAC.WithTerminationGracePeriodSeconds(workerTerminationGracePeriodSeconds)
@@ -276,7 +294,7 @@ func ateomSecurityContext(class atev1alpha1.SandboxClass) *corev1ac.SecurityCont
 			WithType(corev1.AppArmorProfileTypeUnconfined))
 }
 
-// maybeApplyMicroVMPodShape adds the /dev/kvm device and node placement a
+// maybeApplyMicroVMPodShape adds the configured hypervisor device and node placement a
 // micro-VM (kata + cloud-hypervisor) worker pool needs, on top of any
 // pod-template settings. No-op unless sandboxClass is the micro-VM class.
 //
@@ -289,26 +307,37 @@ func maybeApplyMicroVMPodShape(
 	podSpecAC *corev1ac.PodSpecApplyConfiguration,
 	containerAC *corev1ac.ContainerApplyConfiguration,
 	sandboxClass atev1alpha1.SandboxClass,
+	hypervisorDevice string,
 ) {
 	if sandboxClass != atev1alpha1.SandboxClassMicroVM {
 		return
 	}
+	if hypervisorDevice == "" {
+		hypervisorDevice = DefaultMicroVMHypervisorDevice
+	}
+	volumeName := "dev-kvm"
+	if hypervisorDevice == MSHVMicroVMHypervisorDevice {
+		volumeName = "dev-mshv"
+	}
 
-	// The micro-VM runtime needs /dev/kvm. The container is already privileged
-	// (so it can also reach vhost devices), but we mount /dev/kvm explicitly.
+	// The micro-VM runtime needs the host hypervisor device. The container is
+	// already privileged (so it can also reach vhost devices), but the device is
+	// mounted explicitly because privileged containers do not receive host
+	// devices on every container runtime.
 	containerAC.WithVolumeMounts(corev1ac.VolumeMount().
-		WithName("dev-kvm").
-		WithMountPath("/dev/kvm"))
+		WithName(volumeName).
+		WithMountPath(hypervisorDevice))
 	podSpecAC.WithVolumes(corev1ac.Volume().
-		WithName("dev-kvm").
+		WithName(volumeName).
 		WithHostPath(corev1ac.HostPathVolumeSource().
-			WithPath("/dev/kvm").
+			WithPath(hypervisorDevice).
 			WithType(corev1.HostPathCharDev)))
 
-	// Pin placement to KVM-capable, nested-virt nodes via nodeSelector +
+	// Pin placement to hypervisor-capable nodes via nodeSelector +
 	// toleration on ate.dev/sandboxClass=microvm. This is our own convention
-	// (GKE attaches no label/taint to nested-virt pools): applied to kind nodes
-	// by hack/create-kind-cluster.sh and via --node-labels at GKE pool creation.
+	// (cloud providers attach no portable nested-virt label): applied to kind
+	// nodes by hack/create-kind-cluster.sh and explicitly when creating cloud
+	// node pools.
 	// Additive on top of the WorkerPool's configurable scheduling fields
 	// (spec.template nodeSelector/tolerations/affinity, added in #247) — merge,
 	// don't overwrite.
@@ -316,11 +345,28 @@ func maybeApplyMicroVMPodShape(
 		podSpecAC.NodeSelector = map[string]string{}
 	}
 	podSpecAC.NodeSelector["ate.dev/sandboxClass"] = string(atev1alpha1.SandboxClassMicroVM)
+	if hypervisorDevice == MSHVMicroVMHypervisorDevice {
+		podSpecAC.NodeSelector[microVMHypervisorLabel] = "mshv"
+		podSpecAC.NodeSelector[corev1.LabelArchStable] = "amd64"
+	}
 	podSpecAC.WithTolerations(corev1ac.Toleration().
 		WithKey("ate.dev/sandboxClass").
 		WithOperator(corev1.TolerationOpEqual).
 		WithValue(string(atev1alpha1.SandboxClassMicroVM)).
 		WithEffect(corev1.TaintEffectNoSchedule))
+}
+
+// ValidateMicroVMHypervisorDevice restricts the controller to hypervisor
+// devices supported by Cloud Hypervisor. This value becomes a privileged
+// hostPath mount, so arbitrary paths must not be accepted.
+func ValidateMicroVMHypervisorDevice(device string) error {
+	switch device {
+	case DefaultMicroVMHypervisorDevice, MSHVMicroVMHypervisorDevice:
+		return nil
+	default:
+		return fmt.Errorf("unsupported microVM hypervisor device %q: must be %q or %q",
+			device, DefaultMicroVMHypervisorDevice, MSHVMicroVMHypervisorDevice)
+	}
 }
 
 // nvidiaToolkitContainerPath is where the host toolkit is mounted inside the

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -245,55 +245,79 @@ func TestBuildDeploymentApplyConfigMetadata(t *testing.T) {
 	}
 }
 
-// TestMicroVMPodShape asserts the micro-VM sandbox class adds the /dev/kvm
-// device (volume + container mount) and node placement (nodeSelector +
-// toleration on ate.dev/sandboxClass); other classes get none of it.
+// TestMicroVMPodShape asserts the micro-VM sandbox class adds the configured
+// hypervisor device (volume + container mount) and node placement (nodeSelector
+// + toleration on ate.dev/sandboxClass); other classes get none of it.
 func TestMicroVMPodShape(t *testing.T) {
 	tests := []struct {
-		name        string
-		class       atev1alpha1.SandboxClass
-		wantMicroVM bool
+		name             string
+		class            atev1alpha1.SandboxClass
+		hypervisorDevice string
+		wantDevice       string
+		wantVolume       string
 	}{
-		{"gvisor default", "", false},
-		{"gvisor explicit", atev1alpha1.SandboxClassGvisor, false},
-		{"microvm", atev1alpha1.SandboxClassMicroVM, true},
+		{"gvisor default", "", DefaultMicroVMHypervisorDevice, "", ""},
+		{"gvisor explicit", atev1alpha1.SandboxClassGvisor, DefaultMicroVMHypervisorDevice, "", ""},
+		{"microvm default", atev1alpha1.SandboxClassMicroVM, "", DefaultMicroVMHypervisorDevice, "dev-kvm"},
+		{"microvm kvm", atev1alpha1.SandboxClassMicroVM, DefaultMicroVMHypervisorDevice, DefaultMicroVMHypervisorDevice, "dev-kvm"},
+		{"microvm mshv", atev1alpha1.SandboxClassMicroVM, MSHVMicroVMHypervisorDevice, MSHVMicroVMHypervisorDevice, "dev-mshv"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			wp := testWorkerPoolApplyConfig(nil)
 			wp.Spec.SandboxClass = tt.class
-			ps := buildDeploymentApplyConfig(wp, ateomOTelSettings{}).Spec.Template.Spec
+			ps := buildDeploymentApplyConfigWithHypervisorDevice(wp, ateomOTelSettings{}, tt.hypervisorDevice).Spec.Template.Spec
 
 			hasVol := false
 			for _, v := range ps.Volumes {
-				if v.Name != nil && *v.Name == "dev-kvm" {
+				if v.Name != nil && *v.Name == tt.wantVolume {
 					hasVol = true
-					if v.HostPath == nil || v.HostPath.Path == nil || *v.HostPath.Path != "/dev/kvm" ||
+					if v.HostPath == nil || v.HostPath.Path == nil || *v.HostPath.Path != tt.wantDevice ||
 						v.HostPath.Type == nil || *v.HostPath.Type != corev1.HostPathCharDev {
-						t.Errorf("dev-kvm volume = %+v, want /dev/kvm CharDevice", v.HostPath)
+						t.Errorf("hypervisor-device volume = %+v, want %s CharDevice", v.HostPath, tt.wantDevice)
 					}
 				}
 			}
 			hasMount := false
 			for _, c := range ps.Containers {
 				for _, m := range c.VolumeMounts {
-					if m.MountPath != nil && *m.MountPath == "/dev/kvm" {
+					if m.Name != nil && *m.Name == tt.wantVolume && m.MountPath != nil && *m.MountPath == tt.wantDevice {
 						hasMount = true
 					}
 				}
 			}
 			_, hasSelector := ps.NodeSelector["ate.dev/sandboxClass"]
+			if tt.hypervisorDevice == MSHVMicroVMHypervisorDevice {
+				if got := ps.NodeSelector[microVMHypervisorLabel]; got != "mshv" {
+					t.Errorf("%s selector = %q, want mshv", microVMHypervisorLabel, got)
+				}
+				if got := ps.NodeSelector[corev1.LabelArchStable]; got != "amd64" {
+					t.Errorf("%s selector = %q, want amd64", corev1.LabelArchStable, got)
+				}
+			}
 			hasTol := false
 			for _, tol := range ps.Tolerations {
 				if tol.Key != nil && *tol.Key == "ate.dev/sandboxClass" {
 					hasTol = true
 				}
 			}
-			if hasVol != tt.wantMicroVM || hasMount != tt.wantMicroVM || hasSelector != tt.wantMicroVM || hasTol != tt.wantMicroVM {
+			wantMicroVM := tt.wantDevice != ""
+			if hasVol != wantMicroVM || hasMount != wantMicroVM || hasSelector != wantMicroVM || hasTol != wantMicroVM {
 				t.Errorf("microvm shape: vol=%v mount=%v selector=%v toleration=%v, want all %v",
-					hasVol, hasMount, hasSelector, hasTol, tt.wantMicroVM)
+					hasVol, hasMount, hasSelector, hasTol, wantMicroVM)
 			}
 		})
+	}
+}
+
+func TestValidateMicroVMHypervisorDevice(t *testing.T) {
+	for _, device := range []string{DefaultMicroVMHypervisorDevice, MSHVMicroVMHypervisorDevice} {
+		if err := ValidateMicroVMHypervisorDevice(device); err != nil {
+			t.Errorf("ValidateMicroVMHypervisorDevice(%q) returned %v", device, err)
+		}
+	}
+	if err := ValidateMicroVMHypervisorDevice("/dev/vhost-vsock"); err == nil {
+		t.Fatal("ValidateMicroVMHypervisorDevice accepted an unsupported host path")
 	}
 }
 

--- a/cmd/atecontroller/internal/controllers/workerpool_controller.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller.go
@@ -38,8 +38,9 @@ const workerPoolFieldOwner = "workerpool-controller"
 
 type WorkerPoolReconciler struct {
 	client.Client
-	Scheme       *runtime.Scheme
-	OTelEndpoint string
+	Scheme                  *runtime.Scheme
+	OTelEndpoint            string
+	MicroVMHypervisorDevice string
 	// OTelMetricExportInterval is the OTEL_METRIC_EXPORT_INTERVAL propagated to
 	// ateom pods. Empty keeps the SDK's default.
 	OTelMetricExportInterval string
@@ -110,13 +111,20 @@ func (r *WorkerPoolReconciler) reconcileWorkerPool(ctx context.Context, wp *atev
 }
 
 func (r *WorkerPoolReconciler) applyDeployment(ctx context.Context, wp *atev1alpha1.WorkerPool) error {
-	depAC := buildDeploymentApplyConfig(wp, ateomOTelSettings{
+	device := r.MicroVMHypervisorDevice
+	if device == "" {
+		device = DefaultMicroVMHypervisorDevice
+	}
+	if err := ValidateMicroVMHypervisorDevice(device); err != nil {
+		return err
+	}
+	depAC := buildDeploymentApplyConfigWithHypervisorDevice(wp, ateomOTelSettings{
 		Endpoint:             r.OTelEndpoint,
 		MetricExportInterval: r.OTelMetricExportInterval,
 		MetricExportTimeout:  r.OTelMetricExportTimeout,
 		TracesSampler:        r.OTelTracesSampler,
 		TracesSamplerArg:     r.OTelTracesSamplerArg,
-	})
+	}, device)
 	if err := r.Apply(ctx, depAC, client.FieldOwner(workerPoolFieldOwner), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply Deployment: %w", err)
 	}

--- a/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -730,5 +731,20 @@ func TestWorkerPoolMetrics(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("observed %v, want %v", got, want)
+	}
+}
+
+func TestApplyDeploymentRejectsUnsupportedHypervisorDevice(t *testing.T) {
+	t.Parallel()
+	r := &WorkerPoolReconciler{
+		Client:                  k8sClient,
+		MicroVMHypervisorDevice: "/dev/vhost-vsock",
+	}
+	wp := makeWorkerPool("invalid-hypervisor-device", "default", 1, "ateom:v1")
+	wp.Spec.SandboxClass = atev1alpha1.SandboxClassMicroVM
+
+	err := r.applyDeployment(t.Context(), wp)
+	if err == nil || !strings.Contains(err.Error(), "unsupported microVM hypervisor device") {
+		t.Fatalf("applyDeployment() error = %v, want unsupported-device error", err)
 	}
 }

--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -67,6 +67,9 @@ var (
 	otelTracesSamplerArg = pflag.String("otel-traces-sampler-arg", os.Getenv("OTEL_TRACES_SAMPLER_ARG"),
 		"Trace sampler argument set on ateom worker pods, ignored unless --otel-traces-sampler is set. Defaults to the controller's own OTEL_TRACES_SAMPLER_ARG.")
 
+	microVMHypervisorDevice = pflag.String("microvm-hypervisor-device", envOrDefault("ATE_MICROVM_HYPERVISOR_DEVICE", controllers.DefaultMicroVMHypervisorDevice),
+		"Host hypervisor device mounted into microVM worker pods. Supported values: /dev/kvm and /dev/mshv.")
+
 	ateapiCAFile     = pflag.String("ateapi-ca-file", ateapiauth.DefaultServiceAccountCAFile, "PEM file with CAs trusted to verify the ateapi server cert.")
 	ateapiServerName = pflag.String("ateapi-server-name", "", "SNI / hostname expected on the ateapi server cert. Optional.")
 	ateapiClientCert = pflag.String("ateapi-client-cert", "", "Credential bundle presented as the client certificate when dialing ateapi. Required.")
@@ -75,6 +78,13 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(clientv1alpha1.AddToScheme(scheme)) // Register our CRD
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
 }
 
 const serviceName = "atecontroller"
@@ -91,6 +101,9 @@ func main() {
 	serverboot.InitLogger()
 	if err := serverboot.SetLogLevel(*logLevelFlag); err != nil {
 		serverboot.Fatal(ctx, "Invalid --log-level", err)
+	}
+	if err := controllers.ValidateMicroVMHypervisorDevice(*microVMHypervisorDevice); err != nil {
+		serverboot.Fatal(ctx, "Invalid --microvm-hypervisor-device", err)
 	}
 	ctrl.SetLogger(newControllerRuntimeLogger(slog.Default().Handler()))
 
@@ -172,6 +185,7 @@ func main() {
 		OTelMetricExportTimeout:  *otelMetricExportTimeout,
 		OTelTracesSampler:        *otelTracesSampler,
 		OTelTracesSamplerArg:     *otelTracesSamplerArg,
+		MicroVMHypervisorDevice:  *microVMHypervisorDevice,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkerPool")
 		os.Exit(1)

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -413,7 +413,15 @@ spec:
 
 ### Micro-VM SandboxConfig
 
-A `microvm` `SandboxConfig` supplies the [Kata Containers](https://katacontainers.io/) + [Cloud Hypervisor](https://www.cloudhypervisor.org/) toolchain instead of `runsc`. Each architecture must define the full asset set — `kata-shim`, `cloud-hypervisor`, `virtiofsd`, `kata-kernel`, `kata-image`, and `kata-config` — which a `ValidatingAdmissionPolicy` enforces at apply time. Worker pods for a micro-VM pool require `/dev/kvm` and nested-virtualization-capable nodes labeled `ate.dev/sandboxClass=microvm` (the controller adds the device mount and node placement automatically).
+A `microvm` `SandboxConfig` supplies the [Kata Containers](https://katacontainers.io/) + [Cloud Hypervisor](https://www.cloudhypervisor.org/) toolchain instead of `runsc`. Each architecture must define the full asset set — `cloud-hypervisor`, `virtiofsd`, `kata-kernel`, `kata-image`, and `kata-config` — which a `ValidatingAdmissionPolicy` enforces at apply time. Worker pods for a micro-VM pool require a host hypervisor device and nodes labeled `ate.dev/sandboxClass=microvm` (the controller adds the device mount and node placement automatically). The controller mounts `/dev/kvm` by default. On an x86-64 Microsoft Hypervisor root partition, such as an AKS `KataVmIsolation` node, label the node `ate.dev/microvm-hypervisor=mshv` and configure the controller before creating a micro-VM WorkerPool:
+
+```sh
+kubectl -n ate-system set env deployment/ate-controller ATE_MICROVM_HYPERVISOR_DEVICE=/dev/mshv
+```
+
+The setting applies to every micro-VM WorkerPool managed by that controller.
+Do not mix KVM and MSHV pools or change the setting while snapshots exist;
+snapshot compatibility across hypervisor backends is not guaranteed.
 
 See [`hack/microvm-assets/`](../hack/microvm-assets/) for scripts that assemble and stage these assets, plus a worked counter demo (`demos/counter/counter-microvm.yaml.tmpl`) that suspends and resumes an in-RAM counter across worker pods.
 

--- a/docs/dev/microvm-local.md
+++ b/docs/dev/microvm-local.md
@@ -1,11 +1,46 @@
 # Running the microVM runtime locally
 
 The microVM sandbox class (`ateom-microvm`: a Kata guest on Cloud Hypervisor)
-needs `/dev/kvm`, which takes some extra setup compared to the default gVisor
-path. This guide covers just that delta: getting a KVM-capable Docker
-environment — on Linux, or on Apple Silicon macOS via
+needs a host hypervisor device. It uses `/dev/kvm` by default, which takes some
+extra setup compared to the default gVisor path. This guide covers just that
+delta: getting a KVM-capable Docker environment — on Linux, or on Apple Silicon macOS via
 [Lima](https://lima-vm.io/) — then running the microVM counter demo and
 verifying a guest-memory snapshot round-trip.
+
+Microsoft Hypervisor root partitions expose `/dev/mshv` instead. Configure the
+controller with `ATE_MICROVM_HYPERVISOR_DEVICE=/dev/mshv`; the generated worker
+pods then mount `/dev/mshv` at its native path and Cloud Hypervisor selects its
+MSHV backend. The target nodes must still be labeled
+`ate.dev/sandboxClass=microvm` and `ate.dev/microvm-hypervisor=mshv`.
+
+> [!NOTE]
+> MSHV support is experimental. Kubernetes clusters must also provide the
+> PodCertificateRequest and ClusterTrustBundle APIs required by Agent Substrate.
+> The setting applies to every microVM WorkerPool managed by the controller. Do
+> not mix KVM and MSHV pools or change it while snapshots exist; snapshots are
+> not guaranteed to be portable across hypervisor backends. The current MSHV
+> path is limited to x86-64 nodes.
+
+For example, create an AKS node pool with Pod Sandboxing and apply the Substrate
+scheduling label:
+
+```sh
+az aks nodepool add \
+  --cluster-name "$CLUSTER_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --name mshvpool \
+  --os-sku AzureLinux \
+  --workload-runtime KataVmIsolation \
+  --node-vm-size Standard_D8s_v5 \
+  --labels ate.dev/sandboxClass=microvm ate.dev/microvm-hypervisor=mshv
+
+kubectl -n ate-system set env deployment/ate-controller \
+  ATE_MICROVM_HYPERVISOR_DEVICE=/dev/mshv
+```
+
+The worker pods themselves must continue to use the default container runtime.
+Do not set `runtimeClassName: kata-vm-isolation`: `ateom-microvm` launches and
+manages the nested Cloud Hypervisor VM directly.
 
 ## Prerequisites
 

--- a/manifests/ate-install/generated/ate.dev_workerpools.yaml
+++ b/manifests/ate-install/generated/ate.dev_workerpools.yaml
@@ -82,7 +82,7 @@ spec:
                 default: gvisor
                 description: |-
                   SandboxClass selects the sandbox runtime family for this pool, which drives
-                  the worker pod shape (KVM/vhost device mounts and node placement) and which
+                  the worker pod shape (hypervisor device mounts and node placement) and which
                   SandboxConfigs are eligible. The concrete binary is still selected by
                   AteomImage. Defaults to gvisor.
 

--- a/pkg/api/v1alpha1/sandboxconfig_types.go
+++ b/pkg/api/v1alpha1/sandboxconfig_types.go
@@ -26,7 +26,7 @@ const (
 	// SandboxClassGvisor is the gVisor/runsc runtime (cmd/ateom-gvisor). Default.
 	SandboxClassGvisor SandboxClass = "gvisor"
 	// SandboxClassMicroVM is the micro-VM runtime (cmd/ateom-microvm); needs
-	// /dev/kvm and vhost devices.
+	// a supported host hypervisor device (/dev/kvm or /dev/mshv).
 	SandboxClassMicroVM SandboxClass = "microvm"
 )
 

--- a/pkg/api/v1alpha1/workerpool_types.go
+++ b/pkg/api/v1alpha1/workerpool_types.go
@@ -96,7 +96,7 @@ type WorkerPoolSpec struct {
 	Template *WorkerPoolPodTemplate `json:"template,omitempty"`
 
 	// SandboxClass selects the sandbox runtime family for this pool, which drives
-	// the worker pod shape (KVM/vhost device mounts and node placement) and which
+	// the worker pod shape (hypervisor device mounts and node placement) and which
 	// SandboxConfigs are eligible. The concrete binary is still selected by
 	// AteomImage. Defaults to gvisor.
 	//


### PR DESCRIPTION
> This is an exploratory PR based on an AKS interoperability investigation. I am opening it as a draft to discuss whether hypervisor selection belongs at controller scope or should move into `SandboxConfig` / `WorkerPool` compatibility metadata.

## Summary

- keep `/dev/kvm` as the default MicroVM hypervisor device
- allow `ate-controller` to generate workers using `/dev/mshv`
- restrict MSHV workers to explicitly labeled x86-64 nodes
- reject arbitrary device paths before they become privileged `hostPath` mounts
- document backend and snapshot compatibility constraints

## Why

AKS `KataVmIsolation` nodes use an Azure Linux Microsoft Hypervisor root-partition image. These nodes expose `/dev/mshv`, not `/dev/kvm`, so the existing hard-coded KVM worker pod cannot start even though Cloud Hypervisor is built with MSHV support.

The new controller setting is available as either:

```text
--microvm-hypervisor-device=/dev/mshv
ATE_MICROVM_HYPERVISOR_DEVICE=/dev/mshv
```

Only `/dev/kvm` and `/dev/mshv` are accepted. MSHV workers also require:

```text
ate.dev/sandboxClass=microvm
ate.dev/microvm-hypervisor=mshv
kubernetes.io/arch=amd64
```

## AKS validation

Validated on:

- AKS Kubernetes 1.36.2
- `Standard_D8s_v5`
- `KataVmIsolation`
- `AKSAzureLinux-V3katagen2-202608.06.1`
- host kernel `6.6.137.mshv2-1.azl3`
- Cloud Hypervisor v53.0
- Kata 4.0 guest assets
- virtiofsd v1.14.0

Using the real `ateom-microvm` image and native gRPC API, the following succeeded through `/dev/mshv`:

1. `RunWorkload`
2. Cloud Hypervisor VM boot
3. kata-agent connection over vsock
4. actor container creation and HTTP readiness
5. full `CheckpointWorkload`
6. full `RestoreWorkload`
7. guest-agent resource metrics after restore

The checkpoint contained `base-id`, `config.json`, `memory-ranges`, `rootfs-upper.tar`, and `state.json`. An in-memory counter returned `1` before checkpoint and `2` after restore, confirming memory continuity.

This did not use the host's Kata containerd shim. The outer worker remained a normal `runc` pod; `ateom-microvm` launched Cloud Hypervisor and drove snapshot/restore directly.

## Current AKS limitation

This PR only addresses the MicroVM hypervisor device. A complete stock Substrate deployment is still blocked on managed AKS because Substrate currently requires the `PodCertificateRequest` and `ClusterTrustBundle` APIs for internal mTLS, and AKS 1.35/1.36 do not expose them. AKS integration also needs dedicated storage, registry-auth, DNS, and deployment overlays.

## Compatibility

Hypervisor selection is currently controller-wide. KVM and MSHV pools or snapshots must not be mixed, and the setting should not be changed while snapshots exist. Snapshot portability across the backends is not guaranteed.

## Testing

- [x] `go test -short ./...`
- [x] `go test -race ./cmd/atecontroller`
- [x] focused controller KVM/MSHV tests with `-race`
- [x] `go test ./cmd/ateom-microvm/...`
- [x] `go vet ./cmd/atecontroller/...`
- [x] `hack/verify/go-generate.sh`
- [x] `hack/verify/gofmt.sh`
- [x] `hack/verify/golangci-lint.sh`
- [x] Appropriate documentation changes included
