### PR TITLE
api: rename ateomImage to workerImage and make it optional

### DIFF
--- a/benchmarking/automation/README.md
+++ b/benchmarking/automation/README.md
@@ -44,7 +44,7 @@ the router capacity benchmark — see
 
 Each entry in `tests.yaml` may set `sandboxClass: gvisor | microvm` (default
 `gvisor`). This controls both `spec.sandboxClass` on the benchmark WorkerPool
-and its `ateomImage` (`ateom-gvisor` vs `ateom-microvm`).
+and its `workerImage` (`ateom-gvisor` vs `ateom-microvm`).
 
 For `microvm` tests the target cluster must have KVM-capable nodes and the
 object store bucket named in its `.ate-dev-env.sh` must be writable by the

--- a/benchmarking/workloads/manifests/full_workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/full_workloads.yaml.tmpl
@@ -36,7 +36,7 @@ metadata:
     workload: benchmark-ateom
 spec:
   replicas: 5
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
 
 ---
 

--- a/benchmarking/workloads/manifests/workloads.yaml.tmpl
+++ b/benchmarking/workloads/manifests/workloads.yaml.tmpl
@@ -30,7 +30,7 @@ spec:
   replicas: ${WORKER_COUNT}
   sandboxClass: ${SANDBOX_CLASS}
   sandboxConfigName: ${SANDBOX_CONFIG_NAME}
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-${SANDBOX_CLASS}
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-${SANDBOX_CLASS}
 
 ---
 

--- a/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
@@ -422,8 +422,8 @@ func createWorkerPool(t *testing.T, tc *testContext, ns string, name string, lab
 			Labels:    labels,
 		},
 		Spec: atev1alpha1.WorkerPoolSpec{
-			Replicas:   1,
-			AteomImage: "ateom@sha256:abc",
+			Replicas:    1,
+			WorkerImage: "ateom@sha256:abc",
 		},
 	}
 	_, err := tc.substrateClient.ApiV1alpha1().WorkerPools(ns).Create(context.Background(), wp, metav1.CreateOptions{})

--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -86,7 +86,7 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettin
 
 	containerAC := corev1ac.Container().
 		WithName("ateom").
-		WithImage(wp.Spec.AteomImage).
+		WithImage(wp.Spec.WorkerImage).
 		WithArgs(
 			"--pod-uid=$(POD_UID)",
 			"--atunnel-listen-address=0.0.0.0:443",

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -550,7 +550,7 @@ func TestGPUPoolMountsToolkit(t *testing.T) {
 	wp := &atev1alpha1.WorkerPool{
 		ObjectMeta: metav1.ObjectMeta{Name: "wp", Namespace: "ns"},
 		Spec: atev1alpha1.WorkerPoolSpec{
-			AteomImage: "img",
+			WorkerImage: "img",
 			Template: &atev1alpha1.WorkerPoolPodTemplate{
 				Resources: &corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{"nvidia.com/gpu": gpu},
@@ -608,7 +608,7 @@ func TestGPUPoolDriverRootEnv(t *testing.T) {
 		return &atev1alpha1.WorkerPool{
 			ObjectMeta: metav1.ObjectMeta{Name: "wp", Namespace: "ns"},
 			Spec: atev1alpha1.WorkerPoolSpec{
-				AteomImage: "img",
+				WorkerImage: "img",
 				Template: &atev1alpha1.WorkerPoolPodTemplate{
 					Resources: &corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{"nvidia.com/gpu": gpu},
@@ -642,7 +642,7 @@ func TestGPUPoolDriverRootEnv(t *testing.T) {
 func TestNonGPUPoolHasNoToolkit(t *testing.T) {
 	wp := &atev1alpha1.WorkerPool{
 		ObjectMeta: metav1.ObjectMeta{Name: "wp", Namespace: "ns"},
-		Spec:       atev1alpha1.WorkerPoolSpec{AteomImage: "img"},
+		Spec:       atev1alpha1.WorkerPoolSpec{WorkerImage: "img"},
 	}
 	dep := buildDeploymentApplyConfig(wp, ateomOTelSettings{})
 	pod := dep.Spec.Template.Spec
@@ -681,7 +681,7 @@ func TestGPUMicroVMPoolHasNoGPUPodShape(t *testing.T) {
 	wp := &atev1alpha1.WorkerPool{
 		ObjectMeta: metav1.ObjectMeta{Name: "wp", Namespace: "ns"},
 		Spec: atev1alpha1.WorkerPoolSpec{
-			AteomImage:   "img",
+			WorkerImage:  "img",
 			SandboxClass: atev1alpha1.SandboxClassMicroVM,
 			Template: &atev1alpha1.WorkerPoolPodTemplate{
 				Resources: &corev1.ResourceRequirements{
@@ -715,9 +715,9 @@ func testWorkerPoolApplyConfig(tmpl *atev1alpha1.WorkerPoolPodTemplate) *atev1al
 	return &atev1alpha1.WorkerPool{
 		ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "default", UID: "uid"},
 		Spec: atev1alpha1.WorkerPoolSpec{
-			Replicas:   2,
-			AteomImage: "ateom:v1",
-			Template:   tmpl,
+			Replicas:    2,
+			WorkerImage: "ateom:v1",
+			Template:    tmpl,
 		},
 	}
 }
@@ -767,7 +767,7 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 		).
 		WithContainers(corev1ac.Container().
 			WithName("ateom").
-			WithImage(wp.Spec.AteomImage).
+			WithImage(wp.Spec.WorkerImage).
 			WithArgs(
 				"--pod-uid=$(POD_UID)",
 				"--atunnel-listen-address=0.0.0.0:443",

--- a/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_controller_test.go
@@ -173,7 +173,7 @@ func TestWorkerPoolReplicasUpdate(t *testing.T) {
 	})
 }
 
-// TestWorkerPoolImageUpdate verifies that changing spec.ateomImage on a
+// TestWorkerPoolImageUpdate verifies that changing spec.workerImage on a
 // WorkerPool propagates to the managed Deployment.
 func TestWorkerPoolImageUpdate(t *testing.T) {
 	t.Parallel()
@@ -190,7 +190,7 @@ func TestWorkerPoolImageUpdate(t *testing.T) {
 	})
 
 	updateWorkerPoolSpec(t, ctx, wp, "update WorkerPool image", func(current *atev1alpha1.WorkerPool) {
-		current.Spec.AteomImage = "ateom:v2"
+		current.Spec.WorkerImage = "ateom:v2"
 	})
 
 	eventually(t, func(ctx context.Context) (bool, error) {
@@ -569,8 +569,8 @@ func makeWorkerPool(name, ns string, replicas int32, image string) *atev1alpha1.
 	return &atev1alpha1.WorkerPool{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 		Spec: atev1alpha1.WorkerPoolSpec{
-			Replicas:   replicas,
-			AteomImage: image,
+			Replicas:    replicas,
+			WorkerImage: image,
 		},
 	}
 }

--- a/demos/autoscaled-workerpool/autoscaled-workerpool.yaml.tmpl
+++ b/demos/autoscaled-workerpool/autoscaled-workerpool.yaml.tmpl
@@ -35,7 +35,7 @@ metadata:
     workload: counter-autoscaled
 spec:
   replicas: 5
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
 
 ---
 

--- a/demos/claude-code-multiplex/claude-code-multiplex.yaml.tmpl
+++ b/demos/claude-code-multiplex/claude-code-multiplex.yaml.tmpl
@@ -39,7 +39,7 @@ metadata:
     workload: claude-multiplex
 spec:
   replicas: 2
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
 
 ---
 

--- a/demos/counter/counter-microvm-csi-test.yaml
+++ b/demos/counter/counter-microvm-csi-test.yaml
@@ -30,7 +30,7 @@ spec:
   replicas: 1
   sandboxClass: microvm
   sandboxConfigName: microvm
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
 
 ---
 

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -37,7 +37,7 @@ spec:
   replicas: 2
   sandboxClass: microvm
   sandboxConfigName: microvm
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
   template:
     # Per-worker resources: these size the worker POD and advertise its
     # scheduling capacity (the per-actor ceiling). The micro-VM sandbox itself is

--- a/demos/counter/counter.yaml.tmpl
+++ b/demos/counter/counter.yaml.tmpl
@@ -33,7 +33,7 @@ spec:
   # pool that cannot place every replica is worse than a smaller one -- the
   # deploy blocks on a rollout that never completes.
   replicas: 3
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
   template:
     # Per-worker resources: these size the worker POD and advertise its
     # scheduling capacity (the per-actor ceiling). The sandbox itself is sized by

--- a/demos/egress/egress-microvm-mitm.yaml.tmpl
+++ b/demos/egress/egress-microvm-mitm.yaml.tmpl
@@ -44,7 +44,7 @@ spec:
   replicas: 2
   sandboxClass: microvm
   sandboxConfigName: microvm
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
   # No template.resources, unlike counter-microvm: an unlimited ateom container
   # reports no capacity, which the scheduler reads as unconstrained, and the pod
   # requests nothing so it stays placeable next to the counter-microvm pool's

--- a/demos/egress/egress-microvm.yaml.tmpl
+++ b/demos/egress/egress-microvm.yaml.tmpl
@@ -40,7 +40,7 @@ spec:
   replicas: 2
   sandboxClass: microvm
   sandboxConfigName: microvm
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-microvm
   # No template.resources, unlike counter-microvm: an unlimited ateom container
   # reports no capacity, which the scheduler reads as unconstrained, and the pod
   # requests nothing so it stays placeable next to the counter-microvm pool's

--- a/demos/egress/egress-mitm.yaml.tmpl
+++ b/demos/egress/egress-mitm.yaml.tmpl
@@ -40,7 +40,7 @@ metadata:
     workload: egress-mitm
 spec:
   replicas: 2
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
 
 ---
 

--- a/demos/egress/egress.yaml.tmpl
+++ b/demos/egress/egress.yaml.tmpl
@@ -28,7 +28,7 @@ metadata:
     workload: egress
 spec:
   replicas: 2
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
 
 ---
 

--- a/demos/multi-template/multi-template.yaml.tmpl
+++ b/demos/multi-template/multi-template.yaml.tmpl
@@ -46,7 +46,7 @@ metadata:
     workload: multi-template-shared
 spec:
   replicas: 3
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
 ---
 apiVersion: ate.dev/v1alpha1
 kind: ActorTemplate

--- a/demos/parking/parking.yaml.tmpl
+++ b/demos/parking/parking.yaml.tmpl
@@ -40,7 +40,7 @@ spec:
   # Intentionally small: 2 workers, so 3+ concurrently-active actors saturate
   # the pool and exercise the parking path.
   replicas: 2
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
 
 ---
 

--- a/demos/sandbox/manual-test-multi.yaml
+++ b/demos/sandbox/manual-test-multi.yaml
@@ -26,7 +26,7 @@ metadata:
     workload: sandbox
 spec:
   replicas: 1
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
 ---
 apiVersion: ate.dev/v1alpha1
 kind: ActorTemplate

--- a/demos/sandbox/sandbox.yaml.tmpl
+++ b/demos/sandbox/sandbox.yaml.tmpl
@@ -26,7 +26,7 @@ metadata:
     workload: sandbox
 spec:
   replicas: 2
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
   template:
     # Per-worker resources: these size the worker POD and advertise its
     # scheduling capacity (the per-actor ceiling). The sandbox itself is sized by

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -11,7 +11,7 @@ The `WorkerPool` defines the pool of physical "warm" compute capacity. It manage
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `replicas` | `int32` | **Required.** Number of physical standby pods to maintain in the cluster. |
-| `ateomImage` | `string` | **Required.** The container image for the `ateom` herder process (e.g. `ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor`). |
+| `workerImage` | `string` | Optional. The container image for the `ateom` herder process (e.g. `ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor`). When unset, the controller injects a versioned default image for the pool's `sandboxClass`. |
 | `sandboxClass` | `string` | Optional. The sandbox runtime family for the pool: `gvisor` (default) or `microvm`. Drives the worker pod shape (e.g. KVM device mounts, node placement) and which `SandboxConfig`s are eligible. |
 | `sandboxConfigName` | `string` | Optional. Name of a cluster-scoped [`SandboxConfig`](#3-sandboxconfig-the-sandbox-itself) providing the sandbox binaries and pause image. If empty, the cluster default `SandboxConfig` for the pool's `sandboxClass` is used. |
 | `template` | `WorkerPoolPodTemplate` | **Optional.** Metadata, scheduling, and resource settings for worker workloads. |
@@ -56,7 +56,7 @@ metadata:
     workload: secret-agent
 spec:
   replicas: 10
-  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+  workerImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
   template:
     labels:
       project: agent-platform
@@ -83,7 +83,7 @@ metadata:
 spec:
   replicas: 5
   # GPU pools need a glibc ateom-gvisor build — see Requirements below.
-  ateomImage: <your-registry>/ateom-gvisor-glibc@sha256:...
+  workerImage: <your-registry>/ateom-gvisor-glibc@sha256:...
   template:
     # (1) schedule onto GPU nodes
     nodeSelector:
@@ -124,7 +124,7 @@ it rather than replaced.
 
 **Requirements**
 
-- **A glibc `ateom-gvisor` image**, set as `spec.ateomImage`. The distroless default
+- **A glibc `ateom-gvisor` image**, set as `spec.workerImage`. The distroless default
   cannot exec `nvidia-ctk`. Build one with
   `KO_DEFAULTBASEIMAGE=debian:stable-slim ko build ./cmd/ateom-gvisor`.
 - **`nvidia-ctk` on the node**, at the path mounted into the worker — by default

--- a/internal/e2e/fixtures/capabilities/capabilities.yaml.tmpl
+++ b/internal/e2e/fixtures/capabilities/capabilities.yaml.tmpl
@@ -40,7 +40,7 @@ spec:
   # One worker per template for its golden snapshot, plus headroom for the
   # actors the suite resumes.
   replicas: 4
-  ateomImage: ${ATEOM_IMAGE}
+  workerImage: ${ATEOM_IMAGE}
 ${WORKERPOOL_RUNTIME}
 
 ---

--- a/internal/e2e/fixtures/probe/probe-sized.yaml.tmpl
+++ b/internal/e2e/fixtures/probe/probe-sized.yaml.tmpl
@@ -39,7 +39,7 @@ metadata:
     workload: probe-sized
 spec:
   replicas: 3
-  ateomImage: ${ATEOM_IMAGE}
+  workerImage: ${ATEOM_IMAGE}
 ${WORKERPOOL_RUNTIME}
 
 ---

--- a/internal/e2e/fixtures/probe/probe.yaml.tmpl
+++ b/internal/e2e/fixtures/probe/probe.yaml.tmpl
@@ -33,7 +33,7 @@ metadata:
     workload: probe
 spec:
   replicas: 3
-  ateomImage: ${ATEOM_IMAGE}
+  workerImage: ${ATEOM_IMAGE}
 ${WORKERPOOL_RUNTIME}
 
 ---

--- a/internal/e2e/sandbox_test.go
+++ b/internal/e2e/sandbox_test.go
@@ -91,8 +91,8 @@ func TestRenderFixtureManifest_GVisor(t *testing.T) {
 		t.Run(relPath, func(t *testing.T) {
 			pool, template := renderFixture(t, relPath)
 
-			if !strings.HasSuffix(pool.Spec.AteomImage, "/cmd/ateom-gvisor") {
-				t.Errorf("WorkerPool ateomImage = %q, want the gVisor ateom", pool.Spec.AteomImage)
+			if !strings.HasSuffix(pool.Spec.WorkerImage, "/cmd/ateom-gvisor") {
+				t.Errorf("WorkerPool workerImage = %q, want the gVisor ateom", pool.Spec.WorkerImage)
 			}
 			if pool.Spec.SandboxClass != "" || pool.Spec.SandboxConfigName != "" {
 				t.Errorf("WorkerPool carries micro-VM runtime fields: class=%q config=%q",
@@ -125,8 +125,8 @@ func TestRenderFixtureManifest_MicroVM(t *testing.T) {
 		t.Run(relPath, func(t *testing.T) {
 			pool, template := renderFixture(t, relPath)
 
-			if !strings.HasSuffix(pool.Spec.AteomImage, "/cmd/ateom-microvm") {
-				t.Errorf("WorkerPool ateomImage = %q, want the micro-VM ateom", pool.Spec.AteomImage)
+			if !strings.HasSuffix(pool.Spec.WorkerImage, "/cmd/ateom-microvm") {
+				t.Errorf("WorkerPool workerImage = %q, want the micro-VM ateom", pool.Spec.WorkerImage)
 			}
 			if pool.Spec.SandboxClass != SandboxClassMicroVM || pool.Spec.SandboxConfigName != "microvm" {
 				t.Errorf("WorkerPool runtime = class %q / config %q, want microvm / microvm",

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -1122,7 +1122,7 @@ func createActorTemplateInternal(ctx context.Context, t *testing.T, clients *e2e
 		},
 		Spec: v1alpha1.WorkerPoolSpec{
 			Replicas:          5,
-			AteomImage:        existingWp.Spec.AteomImage,
+			WorkerImage:       existingWp.Spec.WorkerImage,
 			SandboxClass:      existingWp.Spec.SandboxClass,
 			SandboxConfigName: existingWp.Spec.SandboxConfigName,
 		},

--- a/internal/e2e/suites/imagevolume/imagevolume_test.go
+++ b/internal/e2e/suites/imagevolume/imagevolume_test.go
@@ -156,7 +156,7 @@ func createTemplate(ctx context.Context, t *testing.T, clients *e2e.Clients, ns 
 		ObjectMeta: metav1.ObjectMeta{Name: probeName, Namespace: ns.Name, Labels: poolLabels},
 		Spec: v1alpha1.WorkerPoolSpec{
 			Replicas:          2,
-			AteomImage:        srcPool.Spec.AteomImage,
+			WorkerImage:       srcPool.Spec.WorkerImage,
 			SandboxClass:      srcPool.Spec.SandboxClass,
 			SandboxConfigName: srcPool.Spec.SandboxConfigName,
 		},

--- a/internal/e2e/suites/networkpolicy/networkpolicy_test.go
+++ b/internal/e2e/suites/networkpolicy/networkpolicy_test.go
@@ -52,8 +52,8 @@ func TestNetworkPolicyLifecycleAndReconciliation(t *testing.T) {
 			Namespace: nsObj.Name,
 		},
 		Spec: v1alpha1.WorkerPoolSpec{
-			Replicas:   1,
-			AteomImage: "ateom:v1",
+			Replicas:    1,
+			WorkerImage: "ateom:v1",
 		},
 	}
 
@@ -300,7 +300,7 @@ func setupDemoCounterTemplate(ctx context.Context, t *testing.T, clients *e2e.Cl
 		},
 		Spec: v1alpha1.WorkerPoolSpec{
 			Replicas:          1,
-			AteomImage:        existingWp.Spec.AteomImage,
+			WorkerImage:       existingWp.Spec.WorkerImage,
 			SandboxClass:      existingWp.Spec.SandboxClass,
 			SandboxConfigName: existingWp.Spec.SandboxConfigName,
 		},

--- a/internal/e2e/suites/parking/parking_test.go
+++ b/internal/e2e/suites/parking/parking_test.go
@@ -191,7 +191,7 @@ func createParkingFixture(ctx context.Context, t *testing.T, clients *e2e.Client
 		},
 		Spec: v1alpha1.WorkerPoolSpec{
 			Replicas:          1, // deliberately undersized: 2 actors will contend for it
-			AteomImage:        existingWp.Spec.AteomImage,
+			WorkerImage:       existingWp.Spec.WorkerImage,
 			SandboxClass:      existingWp.Spec.SandboxClass,
 			SandboxConfigName: existingWp.Spec.SandboxConfigName,
 		},

--- a/manifests/ate-install/generated/ate.dev_workerpools.yaml
+++ b/manifests/ate-install/generated/ate.dev_workerpools.yaml
@@ -68,11 +68,6 @@ spec:
           spec:
             description: spec defines the desired state of WorkerPool
             properties:
-              ateomImage:
-                description: AteomImage is the ateom container image to deploy as
-                  workers.
-                minLength: 1
-                type: string
               replicas:
                 description: Replicas is the number of worker pods to run.
                 format: int32
@@ -84,7 +79,7 @@ spec:
                   SandboxClass selects the sandbox runtime family for this pool, which drives
                   the worker pod shape (KVM/vhost device mounts and node placement) and which
                   SandboxConfigs are eligible. The concrete binary is still selected by
-                  AteomImage. Defaults to gvisor.
+                  WorkerImage. Defaults to gvisor.
 
                   See Also: TODOs in ActorTemplate SandboxClass
                 enum:
@@ -447,8 +442,13 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              workerImage:
+                description: |-
+                  WorkerImage is the ateom container image to deploy as workers. When
+                  unset, the controller injects a versioned default image for the pool's
+                  SandboxClass.
+                type: string
             required:
-            - ateomImage
             - replicas
             type: object
             x-kubernetes-validations:

--- a/pkg/api/v1alpha1/workerpool_types.go
+++ b/pkg/api/v1alpha1/workerpool_types.go
@@ -85,10 +85,11 @@ type WorkerPoolSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	Replicas int32 `json:"replicas"`
 
-	// AteomImage is the ateom container image to deploy as workers.
-	// +kubebuilder:validation:MinLength=1
-	// +required
-	AteomImage string `json:"ateomImage"`
+	// WorkerImage is the ateom container image to deploy as workers. When
+	// unset, the controller injects a versioned default image for the pool's
+	// SandboxClass.
+	// +optional
+	WorkerImage string `json:"workerImage,omitempty"`
 
 	// Template holds optional metadata, scheduling, and resource settings for worker workloads.
 	//
@@ -98,7 +99,7 @@ type WorkerPoolSpec struct {
 	// SandboxClass selects the sandbox runtime family for this pool, which drives
 	// the worker pod shape (KVM/vhost device mounts and node placement) and which
 	// SandboxConfigs are eligible. The concrete binary is still selected by
-	// AteomImage. Defaults to gvisor.
+	// WorkerImage. Defaults to gvisor.
 	//
 	// See Also: TODOs in ActorTemplate SandboxClass
 	//

--- a/pkg/api/v1alpha1/workerpool_validation_test.go
+++ b/pkg/api/v1alpha1/workerpool_validation_test.go
@@ -42,8 +42,8 @@ func TestWorkerPoolValidation(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: WorkerPoolSpec{
-			Replicas:   1,
-			AteomImage: "ateom:latest",
+			Replicas:    1,
+			WorkerImage: "ateom:latest",
 		},
 	}
 
@@ -64,12 +64,11 @@ func TestWorkerPoolValidation(t *testing.T) {
 		wantErr: true,
 		errMsg:  "spec.replicas: Invalid value: -1: spec.replicas in body should be greater than or equal to 0",
 	}, {
-		name: "missing ateomImage",
+		name: "unset workerImage is allowed",
 		mutate: func(wp *WorkerPool) {
-			wp.Spec.AteomImage = ""
+			wp.Spec.WorkerImage = ""
 		},
-		wantErr: true,
-		errMsg:  "spec.ateomImage: Invalid value: \"\": spec.ateomImage in body should be at least 1 chars long",
+		wantErr: false,
 	}, {
 		name: "valid template",
 		mutate: func(wp *WorkerPool) {
@@ -268,8 +267,8 @@ func TestWorkerPoolReservedMetadataUpdate(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: WorkerPoolSpec{
-			Replicas:   1,
-			AteomImage: "example.com/ateom:latest",
+			Replicas:    1,
+			WorkerImage: "example.com/ateom:latest",
 		},
 	}
 	if err := k8sClient.Create(ctx, wp); err != nil {


### PR DESCRIPTION
Rename `WorkerPoolSpec.AteomImage`to `WorkerImage` and drop the constraints so the field can be left unset. 

This is the basis for let an empty workerImage lets the controller inject a versioned default image chosen by the pool's sandbox class.

Part of #861

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
