### PR TITLE
atecontroller: enable leader election

### DIFF
--- a/cmd/atecontroller/internal/controllers/gen.go
+++ b/cmd/atecontroller/internal/controllers/gen.go
@@ -23,3 +23,7 @@ package controllers
 //+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch,namespace=ate-system
 
 //go:generate bash ../../../../hack/run-tool.sh controller-gen rbac:headerFile=../../../../hack/boilerplate/sh.txt,roleName=ate-controller paths="./..." output:rbac:artifacts:config=../../../../manifests/ate-install/generated/
+
+// The manager's leader-election lease and the events it records on it.
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete,namespace=ate-system
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch,namespace=ate-system

--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -155,6 +155,9 @@ func main() {
 	egressMITMCAPool := controllers.EgressMITMCAPoolRef()
 	mgr, err := ctrl.NewManager(k8sConfig, ctrl.Options{
 		Scheme: scheme,
+		// A Deployment rollout briefly runs two replicas; the lease keeps one active.
+		LeaderElection:   true,
+		LeaderElectionID: "ate-controller.ate.dev",
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.Secret{}: {

--- a/manifests/ate-install/generated/role.yaml
+++ b/manifests/ate-install/generated/role.yaml
@@ -105,6 +105,25 @@ metadata:
   namespace: ate-system
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices


### PR DESCRIPTION
A Deployment rollout briefly runs old and new controller replicas side by side. Take a `coordination.k8s.io` lease (`ate-controller.ate.dev`, in the pod's own namespace) so only one manager reconciles the WorkerPool CR at a time.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
