### PR TITLE
Actor JWT extension: s/actorUid/actorUID/

### DIFF
--- a/cmd/ateapi/internal/actoridentity/actoridentity.go
+++ b/cmd/ateapi/internal/actoridentity/actoridentity.go
@@ -125,7 +125,7 @@ func (s *Server) MintJWT(ctx context.Context, req *ateapipb.MintJWTRequest) (*at
 		Substrate: actoridjwt.SubstrateClaims{
 			Atespace:  req.GetAtespace(),
 			ActorName: req.GetActorName(),
-			ActorUid:  req.GetActorUid(),
+			ActorUID:  req.GetActorUid(),
 		},
 	}
 

--- a/cmd/ateapi/internal/actoridjwt/actoridjwt.go
+++ b/cmd/ateapi/internal/actoridjwt/actoridjwt.go
@@ -44,7 +44,7 @@ type Claims struct {
 type SubstrateClaims struct {
 	Atespace  string
 	ActorName string
-	ActorUid  string
+	ActorUID  string
 }
 
 type wireHeader struct {
@@ -70,7 +70,7 @@ type WireClaims struct {
 type WireSubstrateClaims struct {
 	Atespace  string `json:"atespace,omitempty"`
 	ActorName string `json:"actorName,omitempty"`
-	ActorUid  string `json:"actorUid,omitempty"`
+	ActorUID  string `json:"actorUID,omitempty"`
 }
 
 func ClaimsToWire(claims *Claims) (*WireClaims, error) {
@@ -90,7 +90,7 @@ func ClaimsToWire(claims *Claims) (*WireClaims, error) {
 		Substrate: WireSubstrateClaims{
 			Atespace:  claims.Substrate.Atespace,
 			ActorName: claims.Substrate.ActorName,
-			ActorUid:  claims.Substrate.ActorUid,
+			ActorUID:  claims.Substrate.ActorUID,
 		},
 	}
 


### PR DESCRIPTION
I noticed this while writing a Workload Identity Federation guide.  UID is an acronym, so it should be all uppercase or all lowercase.