### PR TITLE
feat: fix Envoy router to support WebSockets and add Jupyter notebook demo

### DIFF
--- a/cmd/atenet/internal/router/xds.go
+++ b/cmd/atenet/internal/router/xds.go
@@ -921,6 +921,9 @@ func (x *XdsServer) buildConnectTerminateHCM(statPrefix string) *anypb.Any {
 			{
 				UpgradeType: ConnectUpgradeType,
 			},
+			{
+				UpgradeType: "websocket",
+			},
 		},
 		CodecType: hcmv3.HttpConnectionManager_AUTO,
 		HttpFilters: []*hcmv3.HttpFilter{
@@ -1050,7 +1053,10 @@ func (x *XdsServer) buildHcm(statPrefix string, captureAuthority bool) *anypb.An
 	hcm := newAny(&hcmv3.HttpConnectionManager{
 		StatPrefix:        statPrefix,
 		GenerateRequestId: &wrapperspb.BoolValue{Value: true},
-		Tracing:           x.buildTracing(),
+		UpgradeConfigs: []*hcmv3.HttpConnectionManager_UpgradeConfig{
+			{UpgradeType: "websocket"},
+		},
+		Tracing: x.buildTracing(),
 		AccessLog: []*accesslogv3.AccessLog{
 			{
 				Name: "envoy.access_loggers.stdout",

--- a/cmd/atenet/internal/router/xds_test.go
+++ b/cmd/atenet/internal/router/xds_test.go
@@ -38,6 +38,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	secretgrpc "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
@@ -77,6 +78,39 @@ func assertDualStackIngress(t *testing.T, l *listenerv3.Listener, wantPort uint3
 		t.Errorf("Expected additional port %d, got %d", wantPort, asa.GetPortValue())
 	}
 }
+
+func assertHCMWebsocketUpgrade(t *testing.T, l *listenerv3.Listener) {
+	t.Helper()
+	if len(l.GetFilterChains()) == 0 || len(l.GetFilterChains()[0].GetFilters()) == 0 {
+		t.Fatalf("Expected at least one filter chain and filter")
+	}
+	filter := l.GetFilterChains()[0].GetFilters()[0]
+	if filter.GetName() != "envoy.filters.network.http_connection_manager" {
+		t.Errorf("Expected HCM filter, got '%s'", filter.GetName())
+	}
+
+	hcmAny := filter.GetTypedConfig()
+	hcm := &hcmv3.HttpConnectionManager{}
+	if err := hcmAny.UnmarshalTo(hcm); err != nil {
+		t.Fatalf("Failed to unmarshal HCM config: %v", err)
+	}
+
+	if len(hcm.GetUpgradeConfigs()) == 0 {
+		t.Errorf("Expected UpgradeConfigs to be populated")
+	} else {
+		upgradeFound := false
+		for _, cfg := range hcm.GetUpgradeConfigs() {
+			if cfg.GetUpgradeType() == "websocket" {
+				upgradeFound = true
+				break
+			}
+		}
+		if !upgradeFound {
+			t.Errorf("Expected 'websocket' in UpgradeConfigs")
+		}
+	}
+}
+
 
 func TestXdsServer_UpdateSnapshot(t *testing.T) {
 	server := NewXdsServer(18000)
@@ -180,7 +214,10 @@ func TestXdsServer_UpdateSnapshot(t *testing.T) {
 	if raw, exists := listenersMap[IngressHTTPListener]; !exists {
 		t.Errorf("Listener name '%s' is missing from snapshot listeners", IngressHTTPListener)
 	} else {
-		assertDualStackIngress(t, raw.(*listenerv3.Listener), 8081)
+		l := raw.(*listenerv3.Listener)
+		assertDualStackIngress(t, l, 8081)
+
+			assertHCMWebsocketUpgrade(t, l)
 	}
 }
 
@@ -375,13 +412,16 @@ func TestXdsServer_UpdateSnapshot_WithConnect(t *testing.T) {
 	if raw, exists := listenersMap["connect_terminate"]; !exists {
 		t.Error("connect_terminate listener missing")
 	} else {
-		assertDualStackIngress(t, raw.(*listenerv3.Listener), 8081)
+			l := raw.(*listenerv3.Listener)
+			assertDualStackIngress(t, l, 8081)
+			assertHCMWebsocketUpgrade(t, l)
 	}
 	if raw, exists := listenersMap["connect_terminate_tls"]; !exists {
 		t.Error("connect_terminate_tls listener missing")
 	} else {
 		l := raw.(*listenerv3.Listener)
-		assertDualStackIngress(t, l, 8444)
+			assertDualStackIngress(t, l, 8444)
+			assertHCMWebsocketUpgrade(t, l)
 		ts := l.GetFilterChains()[0].GetTransportSocket()
 		if ts.GetName() != "envoy.transport_sockets.tls" {
 			t.Errorf("Expected connect_terminate_tls to be TLS-wrapped, got transport socket %q", ts.GetName())

--- a/cmd/atenet/internal/router/xds_test.go
+++ b/cmd/atenet/internal/router/xds_test.go
@@ -111,7 +111,6 @@ func assertHCMWebsocketUpgrade(t *testing.T, l *listenerv3.Listener) {
 	}
 }
 
-
 func TestXdsServer_UpdateSnapshot(t *testing.T) {
 	server := NewXdsServer(18000)
 	server.SetConfig(8081, 50052, "10.0.0.1")
@@ -217,7 +216,7 @@ func TestXdsServer_UpdateSnapshot(t *testing.T) {
 		l := raw.(*listenerv3.Listener)
 		assertDualStackIngress(t, l, 8081)
 
-			assertHCMWebsocketUpgrade(t, l)
+		assertHCMWebsocketUpgrade(t, l)
 	}
 }
 
@@ -412,16 +411,16 @@ func TestXdsServer_UpdateSnapshot_WithConnect(t *testing.T) {
 	if raw, exists := listenersMap["connect_terminate"]; !exists {
 		t.Error("connect_terminate listener missing")
 	} else {
-			l := raw.(*listenerv3.Listener)
-			assertDualStackIngress(t, l, 8081)
-			assertHCMWebsocketUpgrade(t, l)
+		l := raw.(*listenerv3.Listener)
+		assertDualStackIngress(t, l, 8081)
+		assertHCMWebsocketUpgrade(t, l)
 	}
 	if raw, exists := listenersMap["connect_terminate_tls"]; !exists {
 		t.Error("connect_terminate_tls listener missing")
 	} else {
 		l := raw.(*listenerv3.Listener)
-			assertDualStackIngress(t, l, 8444)
-			assertHCMWebsocketUpgrade(t, l)
+		assertDualStackIngress(t, l, 8444)
+		assertHCMWebsocketUpgrade(t, l)
 		ts := l.GetFilterChains()[0].GetTransportSocket()
 		if ts.GetName() != "envoy.transport_sockets.tls" {
 			t.Errorf("Expected connect_terminate_tls to be TLS-wrapped, got transport socket %q", ts.GetName())

--- a/demos/jupyter/README.md
+++ b/demos/jupyter/README.md
@@ -95,7 +95,7 @@ To **resume** the notebook, you can either explicitly resume it via CLI:
 kubectl ate resume actor jupyter-notebook -a demo
 ```
 
-Or, even easier, you can rely on "transparent resume" — just refresh the page in your browser or make another request to the URL while it's suspended! Substrate will automatically restore its state and serve your request without any downtime. The kernel state (including any variables you defined) will be exactly as you left it.
+Or, even easier, you can rely on "transparent resume" — just refresh the page in your browser or make another request to the URL while it's suspended. Substrate will automatically restore its state and serve your request without any downtime. 
 
 ### Clean up
 

--- a/demos/jupyter/README.md
+++ b/demos/jupyter/README.md
@@ -1,0 +1,116 @@
+# Jupyter Notebook Demo
+
+This demo runs a Jupyter Notebook on Agent Substrate. It demonstrates how standard unmodified container images (like `jupyter/base-notebook`) can be deployed as Substrate actors that transparently suspend when idle and resume when you access them via your browser.
+
+## Prerequisites
+
+- A local Kubernetes cluster via Kind (or GKE).
+- `ko` installed for building images.
+- A GCS bucket for storing snapshots, or an in-cluster snapshot repository (handled automatically by the kind install script).
+
+## Quickstart on Kind
+
+For local development, Agent Substrate provides helper scripts to get a Kind cluster running and configured.
+
+1. **Create the Kind cluster:**
+
+   ```bash
+   ./hack/create-kind-cluster.sh
+   # This will create a local cluster named "ate-demo" and configure a local registry.
+   ```
+
+2. **Install Agent Substrate core system to the Kind cluster:**
+
+   ```bash
+   ./hack/install-ate-kind.sh --deploy-ate-system
+   ```
+
+3. **Deploy the Jupyter Notebook Demo:**
+
+   ```bash
+   ./hack/install-ate-kind.sh --deploy-demo-jupyter
+   ```
+
+## Creating and Accessing Your Jupyter Actor
+
+Once the infrastructure and template are deployed, you can create instances (actors) of Jupyter Notebook.
+
+### 1. Create the Actor
+
+First, ensure you have the `kubectl-ate` CLI installed:
+
+```bash
+go install ./cmd/kubectl-ate
+```
+
+Then create an `atespace` and your `jupyter` actor:
+
+```bash
+# Create an atespace (required before creating actors)
+kubectl ate create atespace demo
+
+# Create the actor in the atespace via the jupyter template
+kubectl ate create actor jupyter-notebook -a demo --template ate-demo-jupyter/jupyter
+```
+
+### 2. Access Jupyter via the Proxy!
+
+Substrate routes HTTP traffic using the `Host` header. To make this easy without modifying local `/etc/hosts` files, this demo includes a lightweight NGINX reverse proxy (`jupyter-proxy`) that automatically injects the proper `Host` header (`jupyter-notebook.demo.actors.resources.substrate.ate.dev`) and forwards traffic internally to the Substrate router.
+
+1. **Port-forward the lightweight proxy to your local machine:**
+
+   Keep this running in a separate terminal:
+   ```bash
+   kubectl port-forward --address 0.0.0.0 -n ate-demo-jupyter svc/jupyter-proxy 8888:80
+   ```
+
+2. **Open your browser!**
+
+   Now, open your web browser and visit:
+   `http://localhost:8888`
+
+You should see the Jupyter Notebook interface without any password (because we passed `--ServerApp.password=''` in our template config)!
+Create a new notebook and try running:
+```python
+print("hello world")
+```
+
+### 4. Suspending and Resuming the Notebook
+
+When you're not using the notebook, instead of leaving the container running, Substrate can checkpoint and suspend it to disk. 
+
+```bash
+kubectl ate suspend actor jupyter-notebook -a demo
+```
+
+Check the actor status to confirm it's suspended:
+```bash
+kubectl ate get actor jupyter-notebook -a demo
+```
+Notice how it shows `STATUS_SUSPENDED`.
+
+To **resume** the notebook, you can either explicitly resume it via CLI:
+
+```bash
+kubectl ate resume actor jupyter-notebook -a demo
+```
+
+Or, even easier, you can rely on "transparent resume" — just refresh the page in your browser or make another request to the URL while it's suspended! Substrate will automatically restore its state and serve your request without any downtime. The kernel state (including any variables you defined) will be exactly as you left it.
+
+### Clean up
+
+Delete the actor and atespace:
+```bash
+kubectl ate delete actor jupyter-notebook -a demo
+kubectl ate delete atespace demo
+```
+
+Uninstall the demo deployment:
+```bash
+./hack/install-ate-kind.sh --delete-demo-jupyter
+```
+
+Uninstall the entire local Kind cluster:
+```bash
+./hack/delete-kind-cluster.sh
+```

--- a/demos/jupyter/jupyter.yaml.tmpl
+++ b/demos/jupyter/jupyter.yaml.tmpl
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/demos/jupyter/jupyter.yaml.tmpl
+++ b/demos/jupyter/jupyter.yaml.tmpl
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ate-demo-jupyter
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: WorkerPool
+metadata:
+  name: jupyter
+  namespace: ate-demo-jupyter
+  labels:
+    workload: jupyter
+spec:
+  replicas: 1
+  ateomImage: ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor
+
+---
+
+apiVersion: ate.dev/v1alpha1
+kind: ActorTemplate
+metadata:
+  name: jupyter
+  namespace: ate-demo-jupyter
+spec:
+  containers:
+  - name: jupyter
+    image: "quay.io/jupyter/base-notebook@sha256:23fbe16371af3c0fdc833fa0962b42fd07811e152b821ff51d19a8d6e9cc86cf"
+    command:
+    - jupyter
+    - lab
+    - "--allow-root"
+    - "--ServerApp.token=''"
+    - "--ServerApp.password=''"
+    - "--ServerApp.allow_origin='*'"
+    - "--ServerApp.disable_check_xsrf=True"
+    - "--port=80"
+    - "--ip=0.0.0.0"
+    readyz:
+      httpGet:
+        path: /api
+        port: 80
+  workerSelector:
+    matchLabels:
+      workload: jupyter
+  snapshotsConfig:
+    onPause: Full
+    location: gs://${BUCKET_NAME}/ate-demo-jupyter/
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jupyter-proxy-config
+  namespace: ate-demo-jupyter
+data:
+  nginx.conf: |
+    events {}
+    http {
+      server {
+        listen 80;
+        location / {
+          proxy_pass http://atenet-router.ate-system.svc.cluster.local;
+          proxy_set_header Host jupyter-notebook.demo.actors.resources.substrate.ate.dev;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jupyter-proxy
+  namespace: ate-demo-jupyter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jupyter-proxy
+  template:
+    metadata:
+      labels:
+        app: jupyter-proxy
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+      volumes:
+      - name: config
+        configMap:
+          name: jupyter-proxy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jupyter-proxy
+  namespace: ate-demo-jupyter
+spec:
+  type: ClusterIP
+  selector:
+    app: jupyter-proxy
+  ports:
+  - port: 80
+    targetPort: 80

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -41,6 +41,7 @@ ATE_DEMOS=()
 # Include demos.
 source "${ROOT}"/hack/install-demo-counter.sh
 source "${ROOT}"/hack/install-demo-egress.sh
+source "${ROOT}"/hack/install-demo-jupyter.sh
 source "${ROOT}"/hack/install-demo-sandbox.sh
 source "${ROOT}"/hack/install-demo-claude-code-multiplex.sh
 source "${ROOT}"/hack/install-demo-multi-template.sh

--- a/hack/install-demo-jupyter.sh
+++ b/hack/install-demo-jupyter.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This is sourced as part of install-ate.sh. Do not run directly.
+
+ATE_DEMOS+=(demo-jupyter) # register demo-jupyter
+
+demo-jupyter_usage() {
+  echo "  --deploy-demo-jupyter                         Deploy demo-jupyter"
+}
+
+demo-jupyter_cmdline() {
+  case "${1}" in
+    --deploy-demo-jupyter) demo-jupyter_deploy ;;
+    --delete-demo-jupyter) demo-jupyter_delete ;;
+    *)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+demo-jupyter_deploy() {
+  log_step "demo-jupyter_deploy"
+  ensure_crds
+
+  sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
+      demos/jupyter/jupyter.yaml.tmpl \
+    | run_ko apply -f -
+
+  log_step "Waiting for jupyter demo to be ready..."
+  run_kubectl wait --for=condition=Ready actortemplate/jupyter -n ate-demo-jupyter --timeout=300s
+}
+
+demo-jupyter_delete() {
+  log_step "demo-jupyter_delete"
+  delete_demo_actors ate-demo-jupyter jupyter
+  sed -e "s|\${BUCKET_NAME}|${BUCKET_NAME}|g" \
+      demos/jupyter/jupyter.yaml.tmpl \
+    | run_kubectl delete --ignore-not-found -f -
+}


### PR DESCRIPTION
- Configured atenet-router (Envoy HttpConnectionManager) to explicitly allow `Upgrade: websocket`.
- Added a Substrate Jupyter notebook demo under `demos/jupyter/` that's browser friendly (handles CORS etc).
- Added a small proxy service to help with host-based routing in demo/exploration usage.

Fixes #1201

- [x] Tests pass
