### PR TITLE
atenet: forward the actor identity to cluster-local origins

### DIFF
--- a/cmd/atenet/internal/router/README.md
+++ b/cmd/atenet/internal/router/README.md
@@ -39,6 +39,45 @@ Router has several responsibilities:
   `connect_terminate`/`main_internal` listeners and
   `ingress.Handler.HandleRequestHeaders`.
 
+## telling an origin which actor called
+
+An actor's egress is tunneled: everything it sends is composed by the actor,
+including any header naming itself. The one thing it does not control is the
+client certificate it presented to open the CONNECT, so that is where an
+attributable identity has to come from. The egress gateway copies the verified
+SPIFFE ID into the `ate.actor.identity` filter state, and the `mitm_internal`
+cluster's `internal_upstream` transport carries it across the CONNECT/MITM
+boundary — a header set on the CONNECT would not survive, and a header sent
+from inside the tunnel would be the actor's own claim.
+
+On the MITM leg the gateway forwards that identity to the origin as
+`x-ate-actor`, but only for cluster-local destinations, and only over mTLS:
+
+* Requests to `*.svc` match the `internal` virtual host, which overwrites
+  `x-ate-actor` with the authenticated value and routes to
+  `egress_forward_proxy_internal{,_grpc}`. Those clusters present the gateway's
+  podidentity credential and validate the origin against the servicedns trust
+  bundle, so the origin authenticates the gateway before it reads the header.
+  The suffix stops at `.svc` because those clusters also turn on
+  `auto_san_validation`, and the servicedns signer issues
+  `<service>.<namespace>.svc` and no longer form — an actor that dials the
+  `.cluster.local` FQDN falls through to `all`. Covering the FQDN means
+  widening `servicednssigner` first, not the route.
+* Every other virtual host on that listener strips `x-ate-actor`. An internet
+  origin authenticates this gateway not at all, so an identity header there is
+  one any client could forge; the cleartext leg has no client certificate to
+  offer, so it strips without adding.
+
+An origin must therefore require and verify a client certificate against the
+podidentity trust bundle before believing `x-ate-actor` — the header carries no
+proof on its own. The SPIFFE ID identifies the actor and its atespace, not its
+UID; the UID lives in the `ActorIdentity` X.509 extension, which the gateway
+does not forward.
+
+Both halves live in `manifests/ate-install/atenet-egress-with-sdsmint.yaml`,
+where the compiler sees neither. `egress/manifest_test.go` is what keeps them
+together.
+
 ## packages
 
 The ext_proc server handles both traffic directions, and they apply opposite

--- a/cmd/atenet/internal/router/egress/manifest_test.go
+++ b/cmd/atenet/internal/router/egress/manifest_test.go
@@ -1,0 +1,306 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// The contract between the egress gateway and a cluster-local origin. The
+// gateway tells the origin which actor a request belongs to in actorHeader,
+// and the origin may believe it only because the gateway proved who it was in
+// the handshake that carried it. Both halves live in the Envoy bootstrap, so
+// the compiler sees neither; this file is what holds them together.
+const (
+	actorHeader = "x-ate-actor"
+
+	// The filter state the CONNECT listener populates from the verified actor
+	// client certificate. Written on the outer leg and shared upstream, it is
+	// the only actor identity on the MITM leg the actor did not author.
+	actorIdentityFilterState = "ate.actor.identity"
+
+	// The gateway's own credential, which authenticates it to the origin, and
+	// the trust bundle that signs in-cluster service DNS names.
+	podIdentityBundle   = "/run/podidentity.podcert.ate.dev/credential-bundle.pem"
+	serviceDNSTrustFile = "/run/servicedns.podcert.ate.dev/trust-bundle.pem"
+)
+
+// internalVirtualHost is the one virtual host allowed to state an actor
+// identity to an origin, and internalClusters are the upstreams it may use.
+const internalVirtualHost = "internal"
+
+var (
+	internalClusters = []string{"egress_forward_proxy_internal", "egress_forward_proxy_internal_grpc"}
+	// Only what the servicedns signer certifies. auto_san_validation on the
+	// internal clusters checks the dialed name against the origin's SANs, and
+	// the signer issues <service>.<namespace>.svc alone, so a longer suffix
+	// here would fail the handshake rather than extend the feature to it.
+	internalDomains = []string{"*.svc"}
+)
+
+// TestEgressManifestReservesTheActorHeader checks that x-ate-actor means the
+// same thing everywhere it can reach an origin: an actor identity this gateway
+// authenticated and then vouched for over mTLS.
+//
+// The failure this guards is quiet. A tunneled request is the actor's to
+// compose, so an actor can send x-ate-actor itself, naming any actor it likes.
+// Every route out of the MITM listener therefore has to either overwrite the
+// header with the authenticated value or drop it — a virtual host that does
+// neither forwards the actor's own claim to an origin that has been told to
+// trust the header, and nothing about the request looks wrong.
+func TestEgressManifestReservesTheActorHeader(t *testing.T) {
+	for _, rc := range mitmRouteConfigs(t, egressBootstrap(t)) {
+		for _, vh := range rc.VirtualHosts {
+			where := rc.Name + "/" + vh.Name
+			added := vh.added(actorHeader)
+			removed := slices.Contains(vh.RequestHeadersToRemove, actorHeader)
+
+			switch {
+			case vh.Name == internalVirtualHost:
+				if added == nil {
+					t.Errorf("virtual host %s adds no %s; it is the one host that routes to an origin authenticated to read it, and without the header that origin cannot attribute the request at all", where, actorHeader)
+					continue
+				}
+				// OVERWRITE_IF_EXISTS_OR_ADD, not APPEND: appending would
+				// leave the actor's own value in place alongside this one and
+				// let the origin read either.
+				if got := added.AppendAction; got != "OVERWRITE_IF_EXISTS_OR_ADD" {
+					t.Errorf("virtual host %s adds %s with append_action %q, so an actor that sends the header itself keeps its own value; it must be OVERWRITE_IF_EXISTS_OR_ADD", where, actorHeader, got)
+				}
+				// An empty value is worse than none: the origin cannot tell
+				// "no actor" from "an actor whose name did not render".
+				if added.KeepEmptyValue {
+					t.Errorf("virtual host %s sets keep_empty_value on %s; an unresolved identity must be sent as no header rather than as an empty one", where, actorHeader)
+				}
+				if want := "%FILTER_STATE(" + actorIdentityFilterState + ":PLAIN)%"; added.Header.Value != want {
+					t.Errorf("virtual host %s sets %s to %q, which is not the identity the CONNECT listener authenticated; want %q", where, actorHeader, added.Header.Value, want)
+				}
+				// Cluster-local suffixes only. A "*" or a bare-hostname
+				// pattern here would silently widen the set of origins that
+				// are told an actor identity, and widen it to origins this
+				// gateway holds no credential for.
+				if want := internalDomains; !slices.Equal(vh.Domains, want) {
+					t.Errorf("virtual host %s matches %v; it decides which origins are treated as in-cluster and must match exactly %v", where, vh.Domains, want)
+				}
+
+			case added != nil:
+				t.Errorf("virtual host %s adds %s, but only %q reaches origins that authenticate this gateway; anywhere else the header is a claim the origin cannot check", where, actorHeader, internalVirtualHost)
+
+			case !removed:
+				t.Errorf("virtual host %s neither adds nor removes %s, so an actor's own %s is forwarded to the origin looking platform-issued; list it in request_headers_to_remove", where, actorHeader, actorHeader)
+			}
+		}
+	}
+}
+
+// TestEgressManifestBacksTheActorHeaderWithMTLS checks the other half: the
+// internal virtual host routes only to clusters that present the gateway's
+// podidentity credential. Without a client certificate the header is a string
+// anything on the pod network could have sent, and an origin configured to
+// trust it would be trusting exactly that.
+func TestEgressManifestBacksTheActorHeaderWithMTLS(t *testing.T) {
+	bootstrap := egressBootstrap(t)
+
+	for _, rc := range mitmRouteConfigs(t, bootstrap) {
+		for _, vh := range rc.VirtualHosts {
+			for _, r := range vh.Routes {
+				internal := slices.Contains(internalClusters, r.Route.Cluster)
+				if internal != (vh.Name == internalVirtualHost) {
+					t.Errorf("virtual host %s/%s routes to cluster %q; the mTLS clusters %v and the virtual host that adds %s have to be the same set, or a request reaches an origin over a channel that does not match what the header claims", rc.Name, vh.Name, r.Route.Cluster, internalClusters, actorHeader)
+				}
+			}
+		}
+	}
+
+	for _, name := range internalClusters {
+		tls := findCluster(t, bootstrap, name).TransportSocket.TypedConfig.CommonTLSContext
+		if len(tls.TLSCertificates) == 0 {
+			t.Errorf("cluster %s presents no client certificate, so the origin cannot tell this gateway from any other client and %s becomes unverifiable", name, actorHeader)
+			continue
+		}
+		for _, cert := range tls.TLSCertificates {
+			if cert.CertificateChain.Filename != podIdentityBundle || cert.PrivateKey.Filename != podIdentityBundle {
+				t.Errorf("cluster %s presents %s/%s; the origin verifies this gateway against the podidentity trust bundle, so it must present %s", name, cert.CertificateChain.Filename, cert.PrivateKey.Filename, podIdentityBundle)
+			}
+		}
+		// The public roots do not sign cluster-local service DNS names, so
+		// pointing this elsewhere does not weaken the handshake, it breaks it.
+		if got := tls.ValidationContext.TrustedCA.Filename; got != serviceDNSTrustFile {
+			t.Errorf("cluster %s validates the origin against %q; in-cluster service DNS names are signed by the servicedns signer, so it must be %s", name, got, serviceDNSTrustFile)
+		}
+	}
+}
+
+// The slice of the Envoy bootstrap these tests read. Deliberately partial:
+// unmarshalling into the full xDS types would need the manifest to be valid
+// discovery config, and what is under test is a handful of fields.
+
+type bootstrap struct {
+	StaticResources struct {
+		Listeners []listener `json:"listeners"`
+		Clusters  []cluster  `json:"clusters"`
+	} `json:"static_resources"`
+}
+
+type listener struct {
+	Name         string `json:"name"`
+	FilterChains []struct {
+		Filters []struct {
+			TypedConfig struct {
+				RouteConfig routeConfig `json:"route_config"`
+			} `json:"typed_config"`
+		} `json:"filters"`
+	} `json:"filter_chains"`
+}
+
+type routeConfig struct {
+	Name         string        `json:"name"`
+	VirtualHosts []virtualHost `json:"virtual_hosts"`
+}
+
+type virtualHost struct {
+	Name                   string       `json:"name"`
+	Domains                []string     `json:"domains"`
+	RequestHeadersToAdd    []headerAdd  `json:"request_headers_to_add"`
+	RequestHeadersToRemove []string     `json:"request_headers_to_remove"`
+	Routes                 []routeEntry `json:"routes"`
+}
+
+type headerAdd struct {
+	Header struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	} `json:"header"`
+	AppendAction   string `json:"append_action"`
+	KeepEmptyValue bool   `json:"keep_empty_value"`
+}
+
+type routeEntry struct {
+	Route struct {
+		Cluster string `json:"cluster"`
+	} `json:"route"`
+}
+
+type cluster struct {
+	Name            string `json:"name"`
+	TransportSocket struct {
+		TypedConfig struct {
+			CommonTLSContext struct {
+				TLSCertificates []struct {
+					CertificateChain dataSource `json:"certificate_chain"`
+					PrivateKey       dataSource `json:"private_key"`
+				} `json:"tls_certificates"`
+				ValidationContext struct {
+					TrustedCA dataSource `json:"trusted_ca"`
+				} `json:"validation_context"`
+			} `json:"common_tls_context"`
+		} `json:"typed_config"`
+	} `json:"transport_socket"`
+}
+
+type dataSource struct {
+	Filename string `json:"filename"`
+}
+
+// added returns the request_headers_to_add entry for name, or nil.
+func (vh virtualHost) added(name string) *headerAdd {
+	for i, h := range vh.RequestHeadersToAdd {
+		if strings.EqualFold(h.Header.Key, name) {
+			return &vh.RequestHeadersToAdd[i]
+		}
+	}
+	return nil
+}
+
+// mitmRouteConfigs is every route config on the MITM listener: the leg that
+// terminates the actor's tunneled TLS and re-originates it, and so the only
+// place a header this gateway writes reaches an origin. The CONNECT listener's
+// own route config is excluded — its headers set up the tunnel and never
+// become headers of the request inside it.
+func mitmRouteConfigs(t *testing.T, b *bootstrap) []routeConfig {
+	t.Helper()
+	const mitmListener = "mitm_listener"
+
+	var configs []routeConfig
+	for _, l := range b.StaticResources.Listeners {
+		if l.Name != mitmListener {
+			continue
+		}
+		for _, fc := range l.FilterChains {
+			for _, f := range fc.Filters {
+				if rc := f.TypedConfig.RouteConfig; rc.Name != "" {
+					configs = append(configs, rc)
+				}
+			}
+		}
+	}
+	if len(configs) == 0 {
+		t.Fatalf("the egress bootstrap has no route configs on listener %s; either it was renamed or these tests are checking nothing", mitmListener)
+	}
+	return configs
+}
+
+func findCluster(t *testing.T, b *bootstrap, name string) cluster {
+	t.Helper()
+	for _, c := range b.StaticResources.Clusters {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("the egress bootstrap has no cluster named %q", name)
+	return cluster{}
+}
+
+// egressBootstrap is the Envoy config the egress gateway runs.
+func egressBootstrap(t *testing.T) *bootstrap {
+	t.Helper()
+	const (
+		manifestPath  = "../../../../../manifests/ate-install/atenet-egress-with-sdsmint.yaml"
+		configMapName = "atenet-egress"
+		configKey     = "envoy.yaml"
+	)
+
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", manifestPath, err)
+	}
+	for doc := range strings.SplitSeq(string(raw), "\n---\n") {
+		var cm corev1.ConfigMap
+		if err := yaml.Unmarshal([]byte(doc), &cm); err != nil {
+			// Documents of other kinds need not fit a ConfigMap.
+			continue
+		}
+		if cm.Kind != "ConfigMap" || cm.Name != configMapName {
+			continue
+		}
+		envoyYAML, ok := cm.Data[configKey]
+		if !ok {
+			t.Fatalf("ConfigMap %s in %s has no %s key", configMapName, manifestPath, configKey)
+		}
+		var b bootstrap
+		if err := yaml.Unmarshal([]byte(envoyYAML), &b); err != nil {
+			t.Fatalf("parsing %s from ConfigMap %s: %v", configKey, configMapName, err)
+		}
+		return &b
+	}
+	t.Fatalf("%s has no ConfigMap named %s", manifestPath, configMapName)
+	return nil
+}

--- a/manifests/ate-install/atenet-egress-with-sdsmint.yaml
+++ b/manifests/ate-install/atenet-egress-with-sdsmint.yaml
@@ -312,9 +312,71 @@ data:
                       termination: "%CONNECTION_TERMINATION_DETAILS%"
               route_config:
                 name: local
+                # Two virtual hosts, split by whether the origin is inside the
+                # cluster. The split exists because the actor identity is only
+                # worth telling an origin that can tell it came from here:
+                # `internal` reaches the origin over mTLS with the gateway's own
+                # podidentity credential, so the origin authenticates the
+                # channel before it reads the header. `all` keeps today's
+                # one-way TLS to arbitrary internet origins, which authenticate
+                # this gateway not at all -- an identity header there would be
+                # one any client on the internet could forge straight to the
+                # same origin.
                 virtual_hosts:
+                - name: internal
+                  # Cluster-local DNS only. The actor dials a ClusterIP and
+                  # atunnel tunnels it by IP, so this name comes from the
+                  # tunneled request's own Host, which is the name the actor
+                  # asked for and the name dynamic_forward_proxy re-resolves.
+                  #
+                  # <service>.<namespace>.svc and nothing longer, because
+                  # auto_san_validation below checks that name against the
+                  # origin's SANs and the servicedns signer issues exactly that
+                  # form (cmd/podcertcontroller/internal/servicednssigner). An
+                  # actor that dials the .cluster.local FQDN falls through to
+                  # `all` and gets no header -- the same as today. Widening
+                  # this without widening the signer would not grant the header
+                  # to those requests, it would fail their handshake.
+                  domains:
+                  - "*.svc"
+                  # The actor's authenticated identity, for the origin to
+                  # attribute the request to. OVERWRITE_IF_EXISTS_OR_ADD is the
+                  # security property, not a style choice: the tunneled request
+                  # is the actor's to compose, so an actor that sets x-ate-actor
+                  # itself would otherwise name another actor to the origin.
+                  request_headers_to_add:
+                  - header:
+                      key: x-ate-actor
+                      value: "%FILTER_STATE(ate.actor.identity:PLAIN)%"
+                    append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                    # An empty filter state renders as an empty header rather
+                    # than being dropped, and an origin reading "" as "no actor"
+                    # is indistinguishable from one reading it as "some actor
+                    # whose name did not render". Send nothing instead.
+                    keep_empty_value: false
+                  routes:
+                  - match:
+                      prefix: "/"
+                      headers:
+                      - name: content-type
+                        string_match:
+                          prefix: application/grpc
+                    route:
+                      cluster: egress_forward_proxy_internal_grpc
+                      timeout: 0s
+                  - match: { prefix: "/" }
+                    route:
+                      cluster: egress_forward_proxy_internal
+                      timeout: 0s
                 - name: all
                   domains: ["*"]
+                  # Strip what the internal host above adds, so an actor cannot
+                  # smuggle a substrate-issued-looking attribution header out to
+                  # an origin this gateway never vouches to. Every x-ate-*
+                  # header substrate defines belongs on this list; see
+                  # TestEgressManifestReservesTheActorHeader.
+                  request_headers_to_remove:
+                  - x-ate-actor
                   routes:
                   # Upgrade is what cannot cross an h2 upstream: forwarding one
                   # needs RFC 8441 extended CONNECT, which almost no origin
@@ -443,6 +505,16 @@ data:
                 virtual_hosts:
                 - name: all
                   domains: ["*"]
+                  # No x-ate-actor here, on any destination. This leg
+                  # re-originates in the clear, so there is no client
+                  # certificate to authenticate the gateway to the origin and
+                  # nothing stopping anything else on the network from sending
+                  # the same header -- an origin that trusted it would be
+                  # trusting a value it cannot attribute. Stripping is still
+                  # required: an actor's own header would otherwise arrive
+                  # looking platform-issued.
+                  request_headers_to_remove:
+                  - x-ate-actor
                   routes:
                   - match: { prefix: "/" }
                     route:
@@ -650,6 +722,89 @@ data:
               validation_context:
                 trusted_ca:
                   filename: /etc/ssl/certs/ca-certificates.crt
+
+      # The internal virtual host's upstreams. They differ from the two above in
+      # both directions of the handshake, and both differences are the point:
+      #
+      #  - they present the gateway's own podidentity credential, so the origin
+      #    can require a client certificate, verify it against the podidentity
+      #    trust bundle, and know the x-ate-actor header on the request was
+      #    written by this gateway rather than by whoever connected to it. The
+      #    header is worth nothing without this half.
+      #  - they validate the origin against the servicedns trust bundle instead
+      #    of the public roots, because that is what signs in-cluster service
+      #    DNS names (cmd/podcertcontroller/internal/servicednssigner). A
+      #    cluster-local origin has no publicly-rooted certificate, so the
+      #    public-root clusters above cannot complete this handshake at all.
+      #
+      # watched_directory names the podcert CSI mount the material is projected
+      # into, matching the downstream listener above. Envoy honors it for
+      # secrets delivered over SDS; these are read from the bootstrap, so today
+      # a rotation is picked up when the pod restarts.
+      - name: egress_forward_proxy_internal
+        lb_policy: CLUSTER_PROVIDED
+        connect_timeout: 5s
+        cluster_type:
+          name: envoy.clusters.dynamic_forward_proxy
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+            dns_cache_config:
+              name: egress_dns_cache
+              dns_lookup_family: V4_ONLY
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            upstream_http_protocol_options:
+              auto_sni: true
+              auto_san_validation: true
+            explicit_http_config:
+              http_protocol_options: {}
+        transport_socket:
+          name: envoy.transport_sockets.tls
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+            common_tls_context:
+              tls_certificates:
+              - certificate_chain: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
+                private_key: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
+                watched_directory: { path: /run/podidentity.podcert.ate.dev }
+              validation_context:
+                trusted_ca: { filename: /run/servicedns.podcert.ate.dev/trust-bundle.pem }
+                watched_directory: { path: /run/servicedns.podcert.ate.dev }
+
+      # The gRPC counterpart, same split as egress_forward_proxy_grpc: protocol
+      # from upstream ALPN rather than pinned to HTTP/1.1, so trailers survive.
+      - name: egress_forward_proxy_internal_grpc
+        lb_policy: CLUSTER_PROVIDED
+        connect_timeout: 5s
+        cluster_type:
+          name: envoy.clusters.dynamic_forward_proxy
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+            dns_cache_config:
+              name: egress_dns_cache
+              dns_lookup_family: V4_ONLY
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            upstream_http_protocol_options:
+              auto_sni: true
+              auto_san_validation: true
+            auto_config:
+              http_protocol_options: {}
+              http2_protocol_options: {}
+        transport_socket:
+          name: envoy.transport_sockets.tls
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+            common_tls_context:
+              tls_certificates:
+              - certificate_chain: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
+                private_key: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
+                watched_directory: { path: /run/podidentity.podcert.ate.dev }
+              validation_context:
+                trusted_ca: { filename: /run/servicedns.podcert.ate.dev/trust-bundle.pem }
+                watched_directory: { path: /run/servicedns.podcert.ate.dev }
 
       # The cleartext chain's upstream. Identical to egress_forward_proxy but
       # without the TLS transport socket: the actor sent plaintext and this


### PR DESCRIPTION
**Problem**: if there is egress traffic from an actor to an in-cluster user-owned gateway (not Substrate's egress gateway), how should the user-owned gateway identify the actor?


**Solution**
An actor's egress is tunneled, so every header the origin receives was composed by the actor -- including any header naming the actor itself. An origin that wants to attribute a request to a specific actor has had no way to do it, and no way to distinguish a real attribution from one the actor made up.

The egress gateway already authenticates the actor: it verifies the client certificate on the CONNECT against the actor-identity CA and puts the SPIFFE ID in the ate.actor.identity filter state, which the internal_upstream transport carries onto the MITM leg for the access logs. Forward that same value to the origin as x-ate-actor, for cluster-local destinations only.

Restricting it to cluster-local destinations is what makes the header mean anything. A new `internal` virtual host matches *.svc and routes to egress_forward_proxy_internal{,_grpc}, which present the gateway's podidentity credential and validate the origin against the servicedns trust bundle -- so the origin authenticates the gateway before it reads the header, and can require that authentication. The suffix stops at .svc because those clusters use auto_san_validation and the servicedns signer issues <service>.<namespace>.svc and no longer form; the .cluster.local FQDN would fail the handshake, not gain the header. Reaching a cluster-local origin over TLS did not work through this gateway at all before, since the existing clusters validate against the public roots.

Every other virtual host on the MITM listener now strips x-ate-actor. An internet origin authenticates this gateway not at all, so an identity header there is one any client could forge to the same origin; the cleartext leg has no client certificate to offer, so it strips without adding. Without the strip an actor's own x-ate-actor would reach an origin looking platform-issued.

Both halves live in the Envoy bootstrap, where the compiler sees neither, so egress/manifest_test.go pins them: the internal host is the only one that adds the header, it overwrites rather than appends, every other host removes it, and the clusters it routes to are exactly the ones that present a client certificate.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
