### PR TITLE
Convert ActorTemplate CRDs to the substrate proto during actor workflows

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -23,7 +23,6 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/resources"
-	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
@@ -75,12 +74,16 @@ func (s *ServiceImpl) CreateActor(ctx context.Context, inActor *ateapipb.Actor) 
 	// UX inconsistent, at best.  Is it actually worth checking at all?
 	templateNamespace := inActor.GetActorTemplateNamespace()
 	templateName := inActor.GetActorTemplateName()
-	template, err := s.actorTemplateLister.ActorTemplates(templateNamespace).Get(templateName)
+	crdTemplate, err := s.actorTemplateLister.ActorTemplates(templateNamespace).Get(templateName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %s/%s not found", templateNamespace, templateName)
 		}
 		return nil, fmt.Errorf("while getting ActorTemplate: %w", err)
+	}
+	template, err := actorTemplateFromCRD(crdTemplate)
+	if err != nil {
+		return nil, err
 	}
 
 	// If a source snapshot tag is requested, resolve it to a concrete
@@ -132,7 +135,7 @@ func (s *ServiceImpl) CreateActor(ctx context.Context, inActor *ateapipb.Actor) 
 // resolveSnapshotSource resolves a CreateActor request's source snapshot tag
 // and checks that its scope and ActorSnapshot are compatible with creating
 // an Actor in actorAtespace from template.
-func (s *ServiceImpl) resolveSnapshotSource(ctx context.Context, actorAtespace string, tagRef *ateapipb.ObjectRef, template *atev1alpha1.ActorTemplate) (*ateapipb.ActorSourceSnapshotStatus, error) {
+func (s *ServiceImpl) resolveSnapshotSource(ctx context.Context, actorAtespace string, tagRef *ateapipb.ObjectRef, template *ateapipb.ActorTemplate) (*ateapipb.ActorSourceSnapshotStatus, error) {
 	tag, err := s.store.GetActorSnapshotTag(ctx, resources.ActorSnapshotTagRefFromObjectRef(tagRef))
 	if errors.Is(err, store.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "ActorSnapshot not found")
@@ -157,11 +160,11 @@ func (s *ServiceImpl) resolveSnapshotSource(ctx context.Context, actorAtespace s
 		return nil, status.Error(codes.FailedPrecondition, "source ActorSnapshot tag has an invalid scope")
 	}
 	// TODO: Permit compatible DATA snapshots when runtimes can extract portable data.
-	if snapshot.GetStatus().GetActorTemplateUid() != string(template.GetUID()) {
+	if snapshot.GetStatus().GetActorTemplateUid() != template.GetMetadata().GetUid() {
 		return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot requires the source ActorTemplate")
 	}
-	for _, volume := range template.Spec.Volumes {
-		if volume.ExternalVolumeTemplate != nil {
+	for _, volume := range template.GetVolumes() {
+		if volume.GetExternalVolumeTemplate() != nil {
 			// TODO: Permit cloning after CSI volume snapshots are supported.
 			return nil, status.Error(codes.FailedPrecondition, "ActorSnapshot cloning does not support external volumes")
 		}

--- a/cmd/ateapi/internal/controlapi/actor_sizing_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_sizing_test.go
@@ -70,8 +70,11 @@ func TestActorResourceLimits(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{Resources: tc.res}}
-			cpu, mem := actorResourceLimits(tmpl)
+			tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{Resources: tc.res}})
+			cpu, mem, err := actorResourceLimits(tmpl)
+			if err != nil {
+				t.Fatalf("actorResourceLimits() error: %v", err)
+			}
 			if cpu != tc.wantCPU || mem != tc.wantMemory {
 				t.Fatalf("actorResourceLimits() = (%d, %d), want (%d, %d)", cpu, mem, tc.wantCPU, tc.wantMemory)
 			}

--- a/cmd/ateapi/internal/controlapi/converter.go
+++ b/cmd/ateapi/internal/controlapi/converter.go
@@ -15,25 +15,10 @@
 package controlapi
 
 import (
-	"log/slog"
-
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 )
-
-// convert atev1alpha1.SnapshotScope to ateletpb.SnapshotScope
-func toAteletSnapshotScope(in atev1alpha1.SnapshotScope) ateletpb.SnapshotScope {
-	switch in {
-	case atev1alpha1.SnapshotScopeFull:
-		return ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL
-	case atev1alpha1.SnapshotScopeData:
-		return ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
-	default:
-		slog.Warn("unknown SnapshotScope; falling back to Full", "scope", string(in))
-		return ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL
-	}
-}
 
 func toActorSnapshotContentScope(in atev1alpha1.SnapshotScope) ateapipb.SnapshotContentScope {
 	if in == atev1alpha1.SnapshotScopeData {
@@ -47,4 +32,26 @@ func actorSnapshotContentScopeToAtelet(in ateapipb.SnapshotContentScope) ateletp
 		return ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA
 	}
 	return ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL
+}
+
+// effectiveContentScope normalizes a template snapshot scope for comparisons:
+// UNSPECIFIED means FULL, on both the converted CRD and the stored resource.
+func effectiveContentScope(in ateapipb.SnapshotContentScope) ateapipb.SnapshotContentScope {
+	if in == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED {
+		return ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL
+	}
+	return in
+}
+
+// sandboxClassString renders the proto enum in the CRD's lower-case string
+// form, which the scheduler and the metric labels share.
+func sandboxClassString(in ateapipb.SandboxClass) string {
+	switch in {
+	case ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR:
+		return string(atev1alpha1.SandboxClassGvisor)
+	case ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM:
+		return string(atev1alpha1.SandboxClassMicroVM)
+	default:
+		return ""
+	}
 }

--- a/cmd/ateapi/internal/controlapi/converter_test.go
+++ b/cmd/ateapi/internal/controlapi/converter_test.go
@@ -19,9 +19,13 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 )
 
-func TestToAteletSnapshotScope(t *testing.T) {
+// TestSnapshotScopeToAtelet covers the wire scope derivation for CRD scopes
+// converted to proto content scopes: unknown and empty CRD scopes fall back
+// to Full, matching the CRD's default.
+func TestSnapshotScopeToAtelet(t *testing.T) {
 	tests := []struct {
 		name     string
 		in       atev1alpha1.SnapshotScope
@@ -51,10 +55,45 @@ func TestToAteletSnapshotScope(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := toAteletSnapshotScope(tt.in)
+			result := actorSnapshotContentScopeToAtelet(toActorSnapshotContentScope(tt.in))
 			if result != tt.expected {
-				t.Errorf("toAteletSnapshotScope(%q) = %v, want %v", tt.in, result, tt.expected)
+				t.Errorf("actorSnapshotContentScopeToAtelet(toActorSnapshotContentScope(%q)) = %v, want %v", tt.in, result, tt.expected)
 			}
 		})
+	}
+}
+
+// TestEffectiveContentScope pins UNSPECIFIED-means-FULL: stored substrate
+// templates may legitimately leave scopes unset.
+func TestEffectiveContentScope(t *testing.T) {
+	tests := []struct {
+		in, expected ateapipb.SnapshotContentScope
+	}{
+		{ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED, ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL},
+		{ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL, ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL},
+		{ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA, ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA},
+	}
+	for _, tt := range tests {
+		if got := effectiveContentScope(tt.in); got != tt.expected {
+			t.Errorf("effectiveContentScope(%v) = %v, want %v", tt.in, got, tt.expected)
+		}
+	}
+}
+
+// TestSandboxClassString pins the label values the scheduler and metrics
+// share with the CRD's lower-case enum.
+func TestSandboxClassString(t *testing.T) {
+	tests := []struct {
+		in       ateapipb.SandboxClass
+		expected string
+	}{
+		{ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR, "gvisor"},
+		{ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM, "microvm"},
+		{ateapipb.SandboxClass_SANDBOX_CLASS_UNSPECIFIED, ""},
+	}
+	for _, tt := range tests {
+		if got := sandboxClassString(tt.in); got != tt.expected {
+			t.Errorf("sandboxClassString(%v) = %q, want %q", tt.in, got, tt.expected)
+		}
 	}
 }

--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -178,6 +178,51 @@ func TestCreateActor_TemplateNotFound(t *testing.T) {
 	assertGrpcError(t, err, codes.FailedPrecondition, fmt.Sprintf("ActorTemplate %s/non-existent not found", ns))
 }
 
+// TestCreateActor_RejectsTemplateMatchExpressions pins the equality-only
+// selector contract: converting the template drops matchExpressions, which
+// would schedule the actor wider than the template declares, so CreateActor
+// must refuse instead.
+func TestCreateActor_RejectsTemplateMatchExpressions(t *testing.T) {
+	ns := namespaceForTest("ns-create-matchexpr")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	template := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "tmpl-expr", Namespace: ns},
+		Spec: atev1alpha1.ActorTemplateSpec{
+			SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://fake-fake-fake"},
+			Containers: []atev1alpha1.Container{{
+				Name:    "main",
+				Image:   "main@sha256:abc",
+				Command: []string{"/main"},
+			}},
+			WorkerSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{poolLabelKey: ns},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "tier", Operator: metav1.LabelSelectorOpIn, Values: []string{"1"}},
+				},
+			},
+		},
+	}
+	if _, err := tc.substrateClient.ApiV1alpha1().ActorTemplates(ns).Create(context.Background(), template, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create actor template: %v", err)
+	}
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := tc.actorTemplateLister.ActorTemplates(ns).Get("tmpl-expr")
+		return err == nil, nil
+	}); err != nil {
+		t.Fatalf("template never appeared in the lister: %v", err)
+	}
+
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      "tmpl-expr",
+	}})
+	assertGrpcError(t, err, codes.FailedPrecondition,
+		fmt.Sprintf("ActorTemplate %s/tmpl-expr workerSelector uses matchExpressions; only matchLabels is supported", ns))
+}
+
 // TestCreateActor_Duplicate tests that creating an actor with an existing ID fails.
 func TestCreateActor_Duplicate(t *testing.T) {
 	ns := namespaceForTest("ns-create-dup")

--- a/cmd/ateapi/internal/controlapi/metrics.go
+++ b/cmd/ateapi/internal/controlapi/metrics.go
@@ -181,7 +181,7 @@ func (i *Instruments) recordLifecycleOp(ctx context.Context, op string, start ti
 // restore; snapshotScope applies to all three and is what separates a restore
 // combined with the template's golden state from a plain one of the same kind.
 // The pool keys are set together or not at all; see ateattr.WorkerPoolAttributes.
-func lifecycleOpAttrs(actor *ateapipb.Actor, template *atev1alpha1.ActorTemplate, snapshotKind, snapshotScope string) []attribute.KeyValue {
+func lifecycleOpAttrs(actor *ateapipb.Actor, template *ateapipb.ActorTemplate, snapshotKind, snapshotScope string) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		ateattr.TemplateNameKey.String(actor.GetActorTemplateName()),
 		ateattr.TemplateNamespaceKey.String(actor.GetActorTemplateNamespace()),
@@ -189,7 +189,7 @@ func lifecycleOpAttrs(actor *ateapipb.Actor, template *atev1alpha1.ActorTemplate
 	ass := actor.GetStatus().GetWorkerAssignment()
 	attrs = append(attrs, ateattr.WorkerPoolAttributes(ass.GetWorkerNamespace(), ass.GetWorkerPool())...)
 	if template != nil {
-		attrs = append(attrs, ateattr.SandboxClassKey.String(string(template.Spec.SandboxClass)))
+		attrs = append(attrs, ateattr.SandboxClassKey.String(sandboxClassString(template.GetSandboxConfig().GetSandboxClass())))
 	}
 	if snapshotKind != "" {
 		attrs = append(attrs, ateattr.SnapshotKindKey.String(snapshotKind))

--- a/cmd/ateapi/internal/controlapi/metrics_test.go
+++ b/cmd/ateapi/internal/controlapi/metrics_test.go
@@ -214,9 +214,9 @@ func TestLifecycleOpDurationShape(t *testing.T) {
 			WorkerAssignment: &ateapipb.WorkerAssignment{WorkerNamespace: "ate-workers", WorkerPool: "pool-a"},
 		},
 	}
-	template := &atev1alpha1.ActorTemplate{
+	template := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor},
-	}
+	})
 	inst.recordLifecycleOp(context.Background(), ateattr.OperationResume, time.Now(), nil,
 		lifecycleOpAttrs(actor, template, ateattr.SnapshotKindLatest, ateattr.SnapshotScopeDataOnGolden)...)
 

--- a/cmd/ateapi/internal/controlapi/template_convert.go
+++ b/cmd/ateapi/internal/controlapi/template_convert.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"maps"
+	"sort"
+
+	"github.com/agent-substrate/substrate/internal/resources"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// actorTemplateFromCRD projects an ActorTemplate CRD onto the substrate
+// ActorTemplate proto, so the workflows handle a single template type while
+// both the CRD and the substrate resource exist during the migration.
+// It refuses a template whose workerSelector uses matchExpressions: the
+// substrate Selector supports equality matching only, and dropping the
+// expressions would schedule actors onto a wider pool set than declared.
+func actorTemplateFromCRD(t *atev1alpha1.ActorTemplate) (*ateapipb.ActorTemplate, error) {
+	if t == nil {
+		return nil, status.Error(codes.Internal, "nil ActorTemplate")
+	}
+	if sel := t.Spec.WorkerSelector; sel != nil && len(sel.MatchExpressions) > 0 {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"ActorTemplate %s/%s workerSelector uses matchExpressions; only matchLabels is supported",
+			t.Namespace, t.Name)
+	}
+	out := &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{
+			// Using the t.Namespace as Atespace is ok because this is used in memory only,
+			// never persists to store.
+			Atespace: t.Namespace,
+			Name:     t.Name,
+			Uid:      string(t.GetUID()),
+		},
+		WorkerSelector: selectorFromLabelSelector(t.Spec.WorkerSelector),
+		SnapshotsConfig: &ateapipb.SnapshotsConfig{
+			StorageLocation: t.Spec.SnapshotsConfig.Location,
+			OnPause:         toActorSnapshotContentScope(t.Spec.SnapshotsConfig.OnPause),
+			OnCommit:        toActorSnapshotContentScope(t.Spec.SnapshotsConfig.OnCommit),
+			OnResume: &ateapipb.OnResumeConfig{
+				FromData: resumeSourceFromCRD(t.Spec.SnapshotsConfig.OnResume.FromData),
+			},
+		},
+		// The CRD names no SandboxConfig object: CRD-backed actors resolve
+		// sandbox assets from their worker pool instead.
+		SandboxConfig: &ateapipb.SandboxConfig{
+			SandboxClass: sandboxClassFromCRD(t.Spec.SandboxClass),
+		},
+		Resources: resourcesFromCRD(t.Spec.Resources),
+		Status:    templateStatusFromCRD(t.Status),
+	}
+	for i := range t.Spec.Containers {
+		out.Containers = append(out.Containers, containerFromCRD(&t.Spec.Containers[i]))
+	}
+	for i := range t.Spec.Volumes {
+		out.Volumes = append(out.Volumes, volumeFromCRD(&t.Spec.Volumes[i]))
+	}
+	return out, nil
+}
+
+// selectorFromLabelSelector converts the equality half of the CRD selector;
+// actorTemplateFromCRD has already rejected any matchExpressions.
+func selectorFromLabelSelector(sel *metav1.LabelSelector) *ateapipb.Selector {
+	if sel == nil {
+		return nil
+	}
+	out := &ateapipb.Selector{}
+	if len(sel.MatchLabels) > 0 {
+		out.MatchLabels = maps.Clone(sel.MatchLabels)
+	}
+	return out
+}
+
+func resumeSourceFromCRD(in atev1alpha1.ResumeSource) ateapipb.ResumeSource {
+	// Unset defaults to ColdBoot, mirroring the CRD's kubebuilder default.
+	if in == atev1alpha1.ResumeSourceGolden {
+		return ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN
+	}
+	return ateapipb.ResumeSource_RESUME_SOURCE_COLD_BOOT
+}
+
+func sandboxClassFromCRD(in atev1alpha1.SandboxClass) ateapipb.SandboxClass {
+	switch in {
+	case atev1alpha1.SandboxClassGvisor:
+		return ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR
+	case atev1alpha1.SandboxClassMicroVM:
+		return ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM
+	default:
+		return ateapipb.SandboxClass_SANDBOX_CLASS_UNSPECIFIED
+	}
+}
+
+func resourcesFromCRD(in *corev1.ResourceRequirements) *ateapipb.Resources {
+	if in == nil {
+		return nil
+	}
+	return limitsFromCRD(in.Limits)
+}
+
+func limitsFromCRD(limits map[corev1.ResourceName]resource.Quantity) *ateapipb.Resources {
+	if len(limits) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(limits))
+	for name := range limits {
+		names = append(names, string(name))
+	}
+	// Map iteration is unordered; sort for a deterministic proto.
+	sort.Strings(names)
+	out := &ateapipb.Resources{}
+	for _, name := range names {
+		q := limits[corev1.ResourceName(name)]
+		out.Limits = append(out.Limits, &ateapipb.Limits{Name: name, Quantity: q.String()})
+	}
+	return out
+}
+
+func containerFromCRD(c *atev1alpha1.Container) *ateapipb.Container {
+	out := &ateapipb.Container{
+		Name:    c.Name,
+		Image:   c.Image,
+		Command: append([]string(nil), c.Command...),
+		Args:    append([]string(nil), c.Args...),
+	}
+	for _, env := range c.Env {
+		out.Env = append(out.Env, &ateapipb.EnvVar{Name: env.Name, Value: env.Value})
+	}
+	if r := c.Readyz; r != nil {
+		out.Readyz = &ateapipb.ContainerReadyz{TimeoutSeconds: r.TimeoutSeconds}
+		if r.HTTPGet != nil {
+			out.Readyz.HttpGet = &ateapipb.HTTPGetAction{Path: r.HTTPGet.Path, Port: r.HTTPGet.Port}
+		}
+	}
+	for _, m := range c.VolumeMounts {
+		out.VolumeMounts = append(out.VolumeMounts, &ateapipb.VolumeMount{Name: m.Name, MountPath: m.MountPath})
+	}
+	if sc := c.SecurityContext; sc != nil && sc.Capabilities != nil {
+		out.SecurityContext = &ateapipb.SecurityContext{
+			Capabilities: &ateapipb.Capabilities{
+				Add:  capabilityNames(sc.Capabilities.Add),
+				Drop: capabilityNames(sc.Capabilities.Drop),
+			},
+		}
+	}
+	if r := c.Resources; r != nil {
+		out.Resources = limitsFromCRD(r.Limits)
+	}
+	return out
+}
+
+func capabilityNames(in []atev1alpha1.Capability) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, c := range in {
+		out = append(out, string(c))
+	}
+	return out
+}
+
+func volumeFromCRD(v *atev1alpha1.Volume) *ateapipb.Volume {
+	out := &ateapipb.Volume{Name: v.Name}
+	switch {
+	case v.DurableDir != nil:
+		out.Type = "DurableDir"
+		out.DurableDir = &ateapipb.DurableDirVolumeSource{}
+	case v.ExternalVolumeTemplate != nil:
+		out.Type = "ExternalVolumeTemplate"
+		out.ExternalVolumeTemplate = &ateapipb.ExternalVolumeTemplate{
+			Capacity:         v.ExternalVolumeTemplate.Capacity.String(),
+			StorageClassName: v.ExternalVolumeTemplate.StorageClassName,
+		}
+	case v.Image != nil:
+		out.Type = "Image"
+		out.Image = &ateapipb.ImageVolumeSource{Reference: v.Image.Reference}
+	case v.SystemInfo != nil:
+		out.Type = "SystemInfo"
+		out.SystemInfo = systemInfoFromCRD(v.SystemInfo)
+	}
+	return out
+}
+
+func systemInfoFromCRD(in *atev1alpha1.SystemInfoVolumeSource) *ateapipb.SystemInfoVolumeSource {
+	out := &ateapipb.SystemInfoVolumeSource{}
+	for _, ds := range in.DataSources {
+		switch {
+		case ds.ActorMetadata != nil:
+			meta := &ateapipb.ActorMetadataDataSource{}
+			for _, item := range ds.ActorMetadata.Items {
+				meta.Items = append(meta.Items, &ateapipb.ActorMetadataItem{
+					Field: actorMetadataFieldFromCRD(item.Field),
+					Path:  item.Path,
+				})
+			}
+			out.DataSources = append(out.DataSources, &ateapipb.SystemInfoDataSource{ActorMetadata: meta})
+		case ds.TrustBundle != nil:
+			out.DataSources = append(out.DataSources, &ateapipb.SystemInfoDataSource{
+				TrustBundle: &ateapipb.TrustBundleDataSource{Name: ds.TrustBundle.Name, Path: ds.TrustBundle.Path},
+			})
+		}
+	}
+	return out
+}
+
+func actorMetadataFieldFromCRD(in atev1alpha1.ActorMetadataField) ateapipb.ActorMetadataField {
+	switch in {
+	case atev1alpha1.ActorMetadataFieldName:
+		return ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_NAME
+	case atev1alpha1.ActorMetadataFieldAtespace:
+		return ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_ATESPACE
+	case atev1alpha1.ActorMetadataFieldUID:
+		return ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_UID
+	default:
+		return ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_UNSPECIFIED
+	}
+}
+
+// templateStatusFromCRD maps only what the substrate proto models: the CRD's
+// phase machinery belongs to the CRD controller, while converted templates
+// are consumed by the actor workflows, which need the golden snapshot ref.
+func templateStatusFromCRD(in atev1alpha1.ActorTemplateStatus) *ateapipb.ActorTemplateStatus {
+	out := &ateapipb.ActorTemplateStatus{}
+	if in.GoldenSnapshot != "" {
+		// The CRD stores only the snapshot name; golden snapshots always live
+		// in the reserved golden atespace.
+		out.GoldenSnapshotStatus = &ateapipb.GoldenSnapshotStatus{
+			GoldenSnapshot: &ateapipb.ObjectRef{
+				Atespace: resources.GoldenActorAtespace,
+				Name:     in.GoldenSnapshot,
+			},
+		}
+	}
+	return out
+}

--- a/cmd/ateapi/internal/controlapi/template_convert_test.go
+++ b/cmd/ateapi/internal/controlapi/template_convert_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/internal/resources"
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestActorTemplateFromCRD pins the full CRD-to-proto projection: every field
+// the workflows consume must survive the conversion, since both template
+// sources share the proto code path during the migration.
+func TestActorTemplateFromCRD(t *testing.T) {
+	crd := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ate-demo-counter-microvm-csi",
+			Name:      "counter-microvm-csi",
+			UID:       types.UID("9a1b6f9e-6a3f-4a3e-9a51-0c2f3a34d001"),
+		},
+		Spec: atev1alpha1.ActorTemplateSpec{
+			SandboxClass: atev1alpha1.SandboxClassMicroVM,
+			WorkerSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"workload": "counter-microvm-csi"},
+			},
+			Containers: []atev1alpha1.Container{{
+				Name:    "counter",
+				Image:   "ko://github.com/agent-substrate/substrate/demos/counter",
+				Command: []string{"/ko-app/counter"},
+				Args:    []string{"--port=80"},
+				Env:     []atev1alpha1.EnvVar{{Name: "COUNTER_DATA_DIR", Value: "/home/counter"}},
+				Readyz: &atev1alpha1.ContainerReadyz{
+					HTTPGet:        &atev1alpha1.HTTPGetAction{Path: "/readyz", Port: 80},
+					TimeoutSeconds: 30,
+				},
+				VolumeMounts: []atev1alpha1.VolumeMount{{Name: "data", MountPath: "/home/counter"}},
+				SecurityContext: &atev1alpha1.SecurityContext{
+					Capabilities: &atev1alpha1.Capabilities{
+						Add:  []atev1alpha1.Capability{"NET_BIND_SERVICE"},
+						Drop: []atev1alpha1.Capability{"ALL"},
+					},
+				},
+			}},
+			Volumes: []atev1alpha1.Volume{
+				{Name: "durable", VolumeSource: atev1alpha1.VolumeSource{DurableDir: &atev1alpha1.DurableDirVolumeSource{}}},
+				{Name: "data", VolumeSource: atev1alpha1.VolumeSource{
+					ExternalVolumeTemplate: &atev1alpha1.ExternalVolumeTemplate{
+						Capacity:         resource.MustParse("1Gi"),
+						StorageClassName: "csi-hostpath-sc",
+					},
+				}},
+				{Name: "model", VolumeSource: atev1alpha1.VolumeSource{
+					Image: &atev1alpha1.ImageVolumeSource{Reference: "ko://github.com/agent-substrate/substrate/demos/counter"},
+				}},
+				{Name: "system", VolumeSource: atev1alpha1.VolumeSource{
+					SystemInfo: &atev1alpha1.SystemInfoVolumeSource{
+						DataSources: []atev1alpha1.SystemInfoDataSource{
+							{ActorMetadata: &atev1alpha1.ActorMetadataDataSource{Items: []atev1alpha1.ActorMetadataItem{
+								{Field: atev1alpha1.ActorMetadataFieldName, Path: "actor/name"},
+								{Field: atev1alpha1.ActorMetadataFieldAtespace, Path: "actor/atespace"},
+								{Field: atev1alpha1.ActorMetadataFieldUID, Path: "actor/uid"},
+							}}},
+							{TrustBundle: &atev1alpha1.TrustBundleDataSource{Name: "egress-mitm.ate.dev", Path: "tls/egress-ca.pem"}},
+						},
+					},
+				}},
+			},
+			SnapshotsConfig: atev1alpha1.SnapshotsConfig{
+				Location: "gs://ate-snapshots/ate-demo-counter-microvm-csi/",
+				OnPause:  atev1alpha1.SnapshotScopeFull,
+				OnCommit: atev1alpha1.SnapshotScopeData,
+				OnResume: atev1alpha1.OnResumeConfig{FromData: atev1alpha1.ResumeSourceGolden},
+			},
+			Resources: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+		},
+		Status: atev1alpha1.ActorTemplateStatus{
+			Phase:          atev1alpha1.PhaseReady,
+			GoldenSnapshot: "2026-01-01t00-00-00z-abc",
+		},
+	}
+
+	want := &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{
+			Atespace: "ate-demo-counter-microvm-csi",
+			Name:     "counter-microvm-csi",
+			Uid:      "9a1b6f9e-6a3f-4a3e-9a51-0c2f3a34d001",
+		},
+		WorkerSelector: &ateapipb.Selector{
+			MatchLabels: map[string]string{"workload": "counter-microvm-csi"},
+		},
+		Containers: []*ateapipb.Container{{
+			Name:    "counter",
+			Image:   "ko://github.com/agent-substrate/substrate/demos/counter",
+			Command: []string{"/ko-app/counter"},
+			Args:    []string{"--port=80"},
+			Env:     []*ateapipb.EnvVar{{Name: "COUNTER_DATA_DIR", Value: "/home/counter"}},
+			Readyz: &ateapipb.ContainerReadyz{
+				HttpGet:        &ateapipb.HTTPGetAction{Path: "/readyz", Port: 80},
+				TimeoutSeconds: 30,
+			},
+			VolumeMounts: []*ateapipb.VolumeMount{{Name: "data", MountPath: "/home/counter"}},
+			SecurityContext: &ateapipb.SecurityContext{
+				Capabilities: &ateapipb.Capabilities{Add: []string{"NET_BIND_SERVICE"}, Drop: []string{"ALL"}},
+			},
+		}},
+		Volumes: []*ateapipb.Volume{
+			{Name: "durable", Type: "DurableDir", DurableDir: &ateapipb.DurableDirVolumeSource{}},
+			{Name: "data", Type: "ExternalVolumeTemplate", ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				Capacity:         "1Gi",
+				StorageClassName: "csi-hostpath-sc",
+			}},
+			{Name: "model", Type: "Image", Image: &ateapipb.ImageVolumeSource{Reference: "ko://github.com/agent-substrate/substrate/demos/counter"}},
+			{Name: "system", Type: "SystemInfo", SystemInfo: &ateapipb.SystemInfoVolumeSource{
+				DataSources: []*ateapipb.SystemInfoDataSource{
+					{ActorMetadata: &ateapipb.ActorMetadataDataSource{Items: []*ateapipb.ActorMetadataItem{
+						{Field: ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_NAME, Path: "actor/name"},
+						{Field: ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_ATESPACE, Path: "actor/atespace"},
+						{Field: ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_UID, Path: "actor/uid"},
+					}}},
+					{TrustBundle: &ateapipb.TrustBundleDataSource{Name: "egress-mitm.ate.dev", Path: "tls/egress-ca.pem"}},
+				},
+			}},
+		},
+		SnapshotsConfig: &ateapipb.SnapshotsConfig{
+			StorageLocation: "gs://ate-snapshots/ate-demo-counter-microvm-csi/",
+			OnPause:         ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
+			OnCommit:        ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA,
+			OnResume:        &ateapipb.OnResumeConfig{FromData: ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN},
+		},
+		SandboxConfig: &ateapipb.SandboxConfig{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_MICROVM},
+		Resources: &ateapipb.Resources{Limits: []*ateapipb.Limits{
+			{Name: "cpu", Quantity: "1500m"},
+			{Name: "memory", Quantity: "512Mi"},
+		}},
+		Status: &ateapipb.ActorTemplateStatus{
+			GoldenSnapshotStatus: &ateapipb.GoldenSnapshotStatus{
+				GoldenSnapshot: &ateapipb.ObjectRef{
+					Atespace: resources.GoldenActorAtespace,
+					Name:     "2026-01-01t00-00-00z-abc",
+				},
+			},
+		},
+	}
+
+	got := mustTemplateFromCRD(crd)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("actorTemplateFromCRD mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestActorTemplateFromCRD_Defaults pins the conversion of a minimal CRD:
+// unset scopes normalize to the CRD defaults (Full / ColdBoot), and no
+// golden snapshot yields an empty status.
+func TestActorTemplateFromCRD_Defaults(t *testing.T) {
+	got := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "tmpl1"},
+	})
+
+	want := &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "tmpl1"},
+		SnapshotsConfig: &ateapipb.SnapshotsConfig{
+			OnPause:  ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
+			OnCommit: ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
+			OnResume: &ateapipb.OnResumeConfig{FromData: ateapipb.ResumeSource_RESUME_SOURCE_COLD_BOOT},
+		},
+		SandboxConfig: &ateapipb.SandboxConfig{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_UNSPECIFIED},
+		Status:        &ateapipb.ActorTemplateStatus{},
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("actorTemplateFromCRD mismatch (-want +got):\n%s", diff)
+	}
+
+	if _, err := actorTemplateFromCRD(nil); status.Code(err) != codes.Internal {
+		t.Errorf("actorTemplateFromCRD(nil) error = %v, want Internal", err)
+	}
+}
+
+// TestActorTemplateFromCRD_RejectsMatchExpressions pins the equality-only
+// selector contract: conversion refuses a template with matchExpressions
+// rather than dropping them and scheduling onto a wider pool set.
+func TestActorTemplateFromCRD_RejectsMatchExpressions(t *testing.T) {
+	_, err := actorTemplateFromCRD(&atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "tmpl1"},
+		Spec: atev1alpha1.ActorTemplateSpec{
+			WorkerSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "tier", Operator: metav1.LabelSelectorOpIn, Values: []string{"1"}},
+				},
+			},
+		},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("actorTemplateFromCRD error = %v, want FailedPrecondition", err)
+	}
+}
+
+// mustTemplateFromCRD converts a fixture that must be convertible; rejection
+// paths call actorTemplateFromCRD directly.
+func mustTemplateFromCRD(crd *atev1alpha1.ActorTemplate) *ateapipb.ActorTemplate {
+	out, err := actorTemplateFromCRD(crd)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}

--- a/cmd/ateapi/internal/controlapi/volumes.go
+++ b/cmd/ateapi/internal/controlapi/volumes.go
@@ -21,7 +21,6 @@ import (
 	"log/slog"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
-	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -30,11 +29,11 @@ import (
 )
 
 // initialActorVolumes constructs initial volume objects in PENDING state before volume creation.
-func initialActorVolumes(ctx context.Context, scLister storagev1listers.StorageClassLister, template *atev1alpha1.ActorTemplate) ([]*ateapipb.ExternalVolume, error) {
+func initialActorVolumes(ctx context.Context, scLister storagev1listers.StorageClassLister, template *ateapipb.ActorTemplate) ([]*ateapipb.ExternalVolume, error) {
 	var volumes []*ateapipb.ExternalVolume
-	for _, vol := range template.Spec.Volumes {
-		if vol.ExternalVolumeTemplate != nil {
-			scName := vol.ExternalVolumeTemplate.StorageClassName
+	for _, vol := range template.GetVolumes() {
+		if vol.GetExternalVolumeTemplate() != nil {
+			scName := vol.GetExternalVolumeTemplate().GetStorageClassName()
 			sc, err := scLister.Get(scName)
 			if err != nil {
 				if k8serrors.IsNotFound(err) {
@@ -44,7 +43,7 @@ func initialActorVolumes(ctx context.Context, scLister storagev1listers.StorageC
 			}
 
 			volumes = append(volumes, &ateapipb.ExternalVolume{
-				VolumeName: vol.Name,
+				VolumeName: vol.GetName(),
 				VolumeType: sc.Provisioner,
 				Status:     ateapipb.ExternalVolume_STATUS_PENDING,
 			})
@@ -56,7 +55,7 @@ func initialActorVolumes(ctx context.Context, scLister storagev1listers.StorageC
 // createActorVolumes provisions external volumes specified in volumesToCreate using the provided volume plugin.
 // It returns the list of external volumes (with updated status and storage IDs), or an error if any creation fails.
 // Any volumes processed before or during a failure are returned alongside the error so they can be persisted on the actor.
-func createActorVolumes(ctx context.Context, registry VolumePluginRegistry, scLister storagev1listers.StorageClassLister, actorUID string, template *atev1alpha1.ActorTemplate, volumesToCreate []*ateapipb.ExternalVolume) (resultVolumes []*ateapipb.ExternalVolume, err error) {
+func createActorVolumes(ctx context.Context, registry VolumePluginRegistry, scLister storagev1listers.StorageClassLister, actorUID string, template *ateapipb.ActorTemplate, volumesToCreate []*ateapipb.ExternalVolume) (resultVolumes []*ateapipb.ExternalVolume, err error) {
 	resultVolumes = make([]*ateapipb.ExternalVolume, 0, len(volumesToCreate))
 
 	var currentIdx int
@@ -71,15 +70,15 @@ func createActorVolumes(ctx context.Context, registry VolumePluginRegistry, scLi
 	for idx, vol := range volumesToCreate {
 		currentIdx = idx
 
-		var specVol *atev1alpha1.Volume
+		var specVol *ateapipb.Volume
 		volName := vol.GetVolumeName()
-		for i := range template.Spec.Volumes {
-			if template.Spec.Volumes[i].Name == volName {
-				specVol = &template.Spec.Volumes[i]
+		for _, tVol := range template.GetVolumes() {
+			if tVol.GetName() == volName {
+				specVol = tVol
 				break
 			}
 		}
-		if specVol == nil || specVol.ExternalVolumeTemplate == nil {
+		if specVol == nil || specVol.GetExternalVolumeTemplate() == nil {
 			return resultVolumes, status.Errorf(codes.NotFound, "volume %q not found in template", volName)
 		}
 
@@ -97,7 +96,7 @@ func createActorVolumes(ctx context.Context, registry VolumePluginRegistry, scLi
 
 		actVolID := actorVolumeID(actorUID, volName)
 
-		scName := specVol.ExternalVolumeTemplate.StorageClassName
+		scName := specVol.GetExternalVolumeTemplate().GetStorageClassName()
 		sc, err := scLister.Get(scName)
 		if err != nil {
 			return resultVolumes, status.Errorf(codes.Internal, "failed to get StorageClass %q: %v", scName, err)
@@ -112,9 +111,9 @@ func createActorVolumes(ctx context.Context, registry VolumePluginRegistry, scLi
 			return resultVolumes, status.Errorf(codes.FailedPrecondition, "failed to get volume plugin for driver %q (StorageClass %q): %v", sc.Provisioner, scName, err)
 		}
 
-		storageVolumeID, volCtx, volErr := plugin.CreateVolume(ctx, actVolID, specVol.ExternalVolumeTemplate.Capacity.String(), sc.Provisioner, sc.Parameters)
+		storageVolumeID, volCtx, volErr := plugin.CreateVolume(ctx, actVolID, specVol.GetExternalVolumeTemplate().GetCapacity(), sc.Provisioner, sc.Parameters)
 		if volErr != nil {
-			return resultVolumes, status.Errorf(codes.Internal, "failed to create volume %q: %v", specVol.Name, volErr)
+			return resultVolumes, status.Errorf(codes.Internal, "failed to create volume %q: %v", specVol.GetName(), volErr)
 		}
 
 		resultVolumes = append(resultVolumes, &ateapipb.ExternalVolume{
@@ -161,14 +160,14 @@ func deleteActorVolumes(ctx context.Context, registry VolumePluginRegistry, acto
 }
 
 // getMountedActorVolumes filters the actor's volumes and returns only those that are declared and mounted in the ActorTemplate.
-func getMountedActorVolumes(ctx context.Context, ref *ateapipb.ObjectRef, volumes []*ateapipb.ExternalVolume, template *atev1alpha1.ActorTemplate) []*ateapipb.ExternalVolume {
+func getMountedActorVolumes(ctx context.Context, ref *ateapipb.ObjectRef, volumes []*ateapipb.ExternalVolume, template *ateapipb.ActorTemplate) []*ateapipb.ExternalVolume {
 	var mounted []*ateapipb.ExternalVolume
 	for _, vol := range volumes {
 		// Find the corresponding volume in the ActorTemplate to check if it's mounted
-		var matchedTemplateVol *atev1alpha1.Volume
-		for _, tVol := range template.Spec.Volumes {
-			if vol.GetVolumeName() == tVol.Name {
-				matchedTemplateVol = &tVol
+		var matchedTemplateVol *ateapipb.Volume
+		for _, tVol := range template.GetVolumes() {
+			if vol.GetVolumeName() == tVol.GetName() {
+				matchedTemplateVol = tVol
 				break
 			}
 		}
@@ -178,7 +177,7 @@ func getMountedActorVolumes(ctx context.Context, ref *ateapipb.ObjectRef, volume
 			continue
 		}
 
-		if !isVolumeMounted(matchedTemplateVol.Name, template) {
+		if !isVolumeMounted(matchedTemplateVol.GetName(), template) {
 			slog.InfoContext(ctx, "Volume not mounted in template, skipping", slog.String("volume_id", vol.GetStorageVolumeId()))
 			continue
 		}
@@ -192,7 +191,7 @@ func actorVolumeID(actorUID string, volumeName string) string {
 }
 
 // detachActorVolumes detaches all mounted external volumes for an actor from its worker node.
-func detachActorVolumes(ctx context.Context, st detachActorVolumesStore, registry VolumePluginRegistry, actor *ateapipb.Actor, template *atev1alpha1.ActorTemplate, action string) error {
+func detachActorVolumes(ctx context.Context, st detachActorVolumesStore, registry VolumePluginRegistry, actor *ateapipb.Actor, template *ateapipb.ActorTemplate, action string) error {
 	assignment := actor.GetStatus().GetWorkerAssignment()
 	if assignment == nil {
 		slog.WarnContext(ctx, fmt.Sprintf("Actor has no assigned worker pod during %s, skipping detach volumes", action), slog.String("actor_id", actor.GetMetadata().GetName()))

--- a/cmd/ateapi/internal/controlapi/volumes_test.go
+++ b/cmd/ateapi/internal/controlapi/volumes_test.go
@@ -51,7 +51,7 @@ func (f *fakeStorageClassLister) Get(name string) (*storagev1.StorageClass, erro
 var _ storagev1listers.StorageClassLister = (*fakeStorageClassLister)(nil)
 
 func TestInitialActorVolumes_PendingState(t *testing.T) {
-	tmpl := &atev1alpha1.ActorTemplate{
+	tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		Spec: atev1alpha1.ActorTemplateSpec{
 			Volumes: []atev1alpha1.Volume{
 				{
@@ -81,7 +81,7 @@ func TestInitialActorVolumes_PendingState(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	want := []*ateapipb.ExternalVolume{
 		{
@@ -120,7 +120,7 @@ func TestInitialActorVolumes_PendingState(t *testing.T) {
 func TestCreateActorVolumes(t *testing.T) {
 	ctx := context.Background()
 
-	standardTmpl := &atev1alpha1.ActorTemplate{
+	standardTmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		Spec: atev1alpha1.ActorTemplateSpec{
 			Volumes: []atev1alpha1.Volume{
 				{
@@ -133,9 +133,9 @@ func TestCreateActorVolumes(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
-	multiVolTmpl := &atev1alpha1.ActorTemplate{
+	multiVolTmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		Spec: atev1alpha1.ActorTemplateSpec{
 			Volumes: []atev1alpha1.Volume{
 				{
@@ -164,11 +164,11 @@ func TestCreateActorVolumes(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	tests := []struct {
 		name         string
-		tmpl         *atev1alpha1.ActorTemplate
+		tmpl         *ateapipb.ActorTemplate
 		inputVolumes []*ateapipb.ExternalVolume
 		wantErr      bool
 		wantRes      []*ateapipb.ExternalVolume
@@ -247,11 +247,11 @@ func TestCreateActorVolumes(t *testing.T) {
 		},
 		{
 			name: "volume not found in template returns error",
-			tmpl: &atev1alpha1.ActorTemplate{
+			tmpl: mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 				Spec: atev1alpha1.ActorTemplateSpec{
 					Volumes: []atev1alpha1.Volume{},
 				},
-			},
+			}),
 			inputVolumes: []*ateapipb.ExternalVolume{
 				{
 					VolumeName: "missing-vol",

--- a/cmd/ateapi/internal/controlapi/workflow_delete.go
+++ b/cmd/ateapi/internal/controlapi/workflow_delete.go
@@ -23,7 +23,6 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/resources"
-	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -52,13 +51,19 @@ func (w *ActorWorkflow) DeleteActor(ctx context.Context, actorRef resources.Acto
 	// is retained in the store in the DELETING state.
 	// TODO: Ensure GC collects all the remaining resources if the cleanup fails.
 	var errs []error
-	actorTemplate := (*atev1alpha1.ActorTemplate)(nil)
+	actorTemplate := (*ateapipb.ActorTemplate)(nil)
 	if actor.GetActorTemplateNamespace() != "" && actor.GetActorTemplateName() != "" {
 		tmpl, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
 		if err != nil && !k8serrors.IsNotFound(err) {
 			errs = append(errs, fmt.Errorf("while fetching actor template: %w", err))
 		}
-		actorTemplate = tmpl
+		// Cleanup stays best-effort: an unconvertible template is recorded and
+		// the remaining steps run without it, like a missing one.
+		if tmpl != nil {
+			if actorTemplate, err = actorTemplateFromCRD(tmpl); err != nil {
+				errs = append(errs, fmt.Errorf("while converting actor template: %w", err))
+			}
+		}
 	}
 
 	var atletTerminatedErr, volumesDetachedErr error
@@ -109,7 +114,7 @@ func (w *ActorWorkflow) loadActorForDelete(ctx context.Context, actorRef resourc
 }
 
 // ensureAteletTerminated calls atelet to terminate the workload.
-func (w *ActorWorkflow) ensureAteletTerminated(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (err error) {
+func (w *ActorWorkflow) ensureAteletTerminated(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (err error) {
 	ctx, done := stepSpan(ctx, "CallAteletTerminate")
 	defer func() { err = done(err) }()
 
@@ -206,7 +211,7 @@ func (w *ActorWorkflow) ensureAteletTerminated(ctx context.Context, actorRef res
 }
 
 // ensureVolumesDetachedForDelete detaches external volumes.
-func (w *ActorWorkflow) ensureVolumesDetachedForDelete(ctx context.Context, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (err error) {
+func (w *ActorWorkflow) ensureVolumesDetachedForDelete(ctx context.Context, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (err error) {
 	ctx, done := stepSpan(ctx, "DetachVolumesForDelete")
 	defer func() { err = done(err) }()
 

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -25,7 +25,6 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/resources"
-	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
@@ -38,7 +37,7 @@ import (
 func (w *ActorWorkflow) PauseActor(ctx context.Context, actorRef resources.ActorRef) (_ *ateapipb.Actor, err error) {
 	start := time.Now()
 	var actor *ateapipb.Actor
-	var actorTemplate *atev1alpha1.ActorTemplate
+	var actorTemplate *ateapipb.ActorTemplate
 	var wireSnapshotScope string
 	// Set just before finalize; nil until then, so earlier exits label
 	// themselves from the record they hold.
@@ -95,7 +94,7 @@ func (w *ActorWorkflow) PauseActor(ctx context.Context, actorRef resources.Actor
 }
 
 // loadActorForPause fetches the current actor record and its template.
-func (w *ActorWorkflow) loadActorForPause(ctx context.Context, actorRef resources.ActorRef) (_ *ateapipb.Actor, _ *atev1alpha1.ActorTemplate, err error) {
+func (w *ActorWorkflow) loadActorForPause(ctx context.Context, actorRef resources.ActorRef) (_ *ateapipb.Actor, _ *ateapipb.ActorTemplate, err error) {
 	ctx, done := stepSpan(ctx, "LoadActorForPause")
 	defer func() { err = done(err) }()
 
@@ -103,9 +102,13 @@ func (w *ActorWorkflow) loadActorForPause(ctx context.Context, actorRef resource
 	if err != nil {
 		return nil, nil, err
 	}
-	actorTemplate, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
+	crdTemplate, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
 	if err != nil {
 		return nil, nil, fmt.Errorf("while getting ActorTemplate: %w", err)
+	}
+	actorTemplate, err := actorTemplateFromCRD(crdTemplate)
+	if err != nil {
+		return nil, nil, err
 	}
 	return actor, actorTemplate, nil
 }
@@ -153,7 +156,7 @@ func (w *ActorWorkflow) ensureMarkedPausing(ctx context.Context, actorRef resour
 // the once-minted snapshot name, so a re-entered workflow re-sends the same
 // semantic request; once atelet's Checkpoint is idempotent on those keys this
 // step becomes fully reentrant with no changes here.
-func (w *ActorWorkflow) ensureAteletPaused(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (wireSnapshotScope string, err error) {
+func (w *ActorWorkflow) ensureAteletPaused(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (wireSnapshotScope string, err error) {
 	ctx, done := stepSpan(ctx, "CallAteletPause")
 	defer func() { err = done(err) }()
 
@@ -200,7 +203,7 @@ func (w *ActorWorkflow) ensureAteletPaused(ctx context.Context, actorRef resourc
 				SnapshotName: actor.GetStatus().GetInProgressLocalSnapshotName(),
 			},
 		},
-		Scope:    toAteletSnapshotScope(actorTemplate.Spec.SnapshotsConfig.OnPause),
+		Scope:    actorSnapshotContentScopeToAtelet(actorTemplate.GetSnapshotsConfig().GetOnPause()),
 		ActorUid: actor.GetMetadata().Uid,
 	}
 	wireSnapshotScope = ateattr.SnapshotScopeValue(req.Scope)
@@ -216,7 +219,7 @@ func (w *ActorWorkflow) ensureAteletPaused(ctx context.Context, actorRef resourc
 // never be resumed. It re-reads the actor first so an out-of-band transition
 // (e.g. the syncer crashing the actor after its worker died) is not
 // overwritten: with no assignment left there is nothing to finalize.
-func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef resources.ActorRef, actorTemplate *atev1alpha1.ActorTemplate) (_ *ateapipb.Actor, err error) {
+func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef resources.ActorRef, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "FinalizePaused")
 	defer func() { err = done(err) }()
 
@@ -269,7 +272,7 @@ func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef reso
 			slog.ErrorContext(ctx, "Node name not found during finalize pause, crashing actor", slog.Any("actor", actorRef))
 			newState = ateapipb.ActorState_ACTOR_STATE_CRASHED
 		}
-		contentScope := toActorSnapshotContentScope(actorTemplate.Spec.SnapshotsConfig.OnPause)
+		contentScope := effectiveContentScope(actorTemplate.GetSnapshotsConfig().GetOnPause())
 		sandboxClass := ""
 		if worker != nil {
 			sandboxClass = worker.GetSandboxClass()

--- a/cmd/ateapi/internal/controlapi/workflow_pause_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause_test.go
@@ -60,7 +60,7 @@ func TestEnsurePausedFinalized_WorkerGone(t *testing.T) {
 	// Intentionally NOT creating the worker in store, simulates worker already gone.
 
 	w := &ActorWorkflow{store: st}
-	finalized, err := w.ensurePausedFinalized(ctx, actorRef, &atev1alpha1.ActorTemplate{})
+	finalized, err := w.ensurePausedFinalized(ctx, actorRef, mustTemplateFromCRD(&atev1alpha1.ActorTemplate{}))
 	if err != nil {
 		t.Fatalf("ensurePausedFinalized: %v", err)
 	}
@@ -137,9 +137,9 @@ func TestEnsurePausedFinalized_RecordsContentScope(t *testing.T) {
 			}
 
 			w := &ActorWorkflow{store: st}
-			tmpl := &atev1alpha1.ActorTemplate{
+			tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 				Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{OnPause: tc.onPause}},
-			}
+			})
 			got, err := w.ensurePausedFinalized(ctx, actorRef, tmpl)
 			if err != nil {
 				t.Fatalf("ensurePausedFinalized: %v", err)
@@ -284,7 +284,7 @@ func TestEnsureAteletPaused_DanglingWorkerDoesNotRecordPhantomSnapshot(t *testin
 			created := storetest.MustCreateActor(t, ctx, persistence, actor)
 
 			w := &ActorWorkflow{store: persistence, dialer: newDanglingDialer()}
-			if _, err := w.ensureAteletPaused(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, created, &atev1alpha1.ActorTemplate{}); err == nil {
+			if _, err := w.ensureAteletPaused(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, created, mustTemplateFromCRD(&atev1alpha1.ActorTemplate{})); err == nil {
 				t.Fatal("ensureAteletPaused: want error for dangling worker, got nil")
 			}
 

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -26,12 +26,11 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/resources"
-	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -67,7 +66,7 @@ type restoreTelemetry struct {
 func (w *ActorWorkflow) ResumeActor(ctx context.Context, actorRef resources.ActorRef, boot bool) (_ *ateapipb.Actor, resumed bool, err error) {
 	start := time.Now()
 	var actor *ateapipb.Actor
-	var actorTemplate *atev1alpha1.ActorTemplate
+	var actorTemplate *ateapipb.ActorTemplate
 	var tele restoreTelemetry
 	var wasRunning bool
 
@@ -153,7 +152,7 @@ func validateGoldenSnapshotScope(snapshot *ateapipb.ActorSnapshot) error {
 
 // loadActorForResume fetches the current actor record and its template, and
 // resolves the boot source for the pending restore.
-func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resources.ActorRef, boot bool) (_ *ateapipb.Actor, _ *atev1alpha1.ActorTemplate, _ resumeSnapshotSource, err error) {
+func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resources.ActorRef, boot bool) (_ *ateapipb.Actor, _ *ateapipb.ActorTemplate, _ resumeSnapshotSource, err error) {
 	ctx, done := stepSpan(ctx, "LoadActorForResume")
 	defer func() { err = done(err) }()
 
@@ -173,9 +172,13 @@ func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resourc
 		return actor, nil, src, nil
 	}
 
-	actorTemplate, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
+	crdTemplate, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
 	if err != nil {
 		return nil, nil, src, fmt.Errorf("while getting ActorTemplate: %w", err)
+	}
+	actorTemplate, err := actorTemplateFromCRD(crdTemplate)
+	if err != nil {
+		return nil, nil, src, err
 	}
 	if ref := actor.GetStatus().GetLatestSnapshot(); ref != nil {
 		snapshot, err := w.store.GetActorSnapshot(ctx, resources.ActorSnapshotRefFromObjectRef(ref))
@@ -189,8 +192,8 @@ func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resourc
 			return nil, nil, src, status.Errorf(codes.DataLoss, "ActorSnapshot %s/%s: %v", ref.GetAtespace(), ref.GetName(), err)
 		}
 		src.Scope = snapshot.GetStatus().GetContentScope()
-	} else if actorTemplate.Status.GoldenSnapshot != "" && !boot {
-		snapshot, err := w.store.GetActorSnapshot(ctx, resources.ActorSnapshotRef{Atespace: resources.GoldenActorAtespace, Name: actorTemplate.Status.GoldenSnapshot})
+	} else if goldenRef := actorTemplate.GetStatus().GetGoldenSnapshotStatus().GetGoldenSnapshot(); goldenRef != nil && !boot {
+		snapshot, err := w.store.GetActorSnapshot(ctx, resources.ActorSnapshotRefFromObjectRef(goldenRef))
 		if errors.Is(err, store.ErrNotFound) {
 			return nil, nil, src, status.Error(codes.DataLoss, "ActorTemplate golden snapshot data is missing")
 		}
@@ -201,7 +204,7 @@ func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resourc
 			return nil, nil, src, err
 		}
 		if src.SnapshotURI, err = resources.ParseSnapshotURI(snapshot.GetStatus().GetSnapshotUri()); err != nil {
-			return nil, nil, src, status.Errorf(codes.DataLoss, "golden ActorSnapshot %s: %v", actorTemplate.Status.GoldenSnapshot, err)
+			return nil, nil, src, status.Errorf(codes.DataLoss, "golden ActorSnapshot %s: %v", goldenRef.GetName(), err)
 		}
 		src.Scope = snapshot.GetStatus().GetContentScope()
 	}
@@ -214,18 +217,19 @@ func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resourc
 	// (the local snapshot takes precedence at restore), or when its durable
 	// snapshot holds Data. Valid Full snapshots restore from their own
 	// content and ignore the policy.
-	if actorTemplate.Spec.SnapshotsConfig.OnResume.FromData == atev1alpha1.ResumeSourceGolden {
+	if actorTemplate.GetSnapshotsConfig().GetOnResume().GetFromData() == ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN {
 		dataOnly := false
 		if actor.GetStatus().GetLocalSnapshotInfo() != nil {
-			dataOnly = actorTemplate.Spec.SnapshotsConfig.OnPause == atev1alpha1.SnapshotScopeData
+			dataOnly = effectiveContentScope(actorTemplate.GetSnapshotsConfig().GetOnPause()) == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
 		} else if actor.GetStatus().GetLatestSnapshot() != nil {
 			dataOnly = src.Scope == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
 		}
 		if dataOnly {
-			if actorTemplate.Status.GoldenSnapshot == "" {
+			goldenRef := actorTemplate.GetStatus().GetGoldenSnapshotStatus().GetGoldenSnapshot()
+			if goldenRef == nil {
 				return nil, nil, src, status.Error(codes.FailedPrecondition, "a Golden data resume requires the ActorTemplate golden snapshot, which is not available")
 			}
-			goldenSnapshot, err := w.store.GetActorSnapshot(ctx, resources.ActorSnapshotRef{Atespace: resources.GoldenActorAtespace, Name: actorTemplate.Status.GoldenSnapshot})
+			goldenSnapshot, err := w.store.GetActorSnapshot(ctx, resources.ActorSnapshotRefFromObjectRef(goldenRef))
 			if errors.Is(err, store.ErrNotFound) {
 				return nil, nil, src, status.Error(codes.DataLoss, "ActorTemplate golden snapshot data is missing")
 			}
@@ -236,7 +240,7 @@ func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resourc
 				return nil, nil, src, err
 			}
 			if src.GoldenSnapshotURI, err = resources.ParseSnapshotURI(goldenSnapshot.GetStatus().GetSnapshotUri()); err != nil {
-				return nil, nil, src, status.Errorf(codes.DataLoss, "golden ActorSnapshot %s: %v", actorTemplate.Status.GoldenSnapshot, err)
+				return nil, nil, src, status.Errorf(codes.DataLoss, "golden ActorSnapshot %s: %v", goldenRef.GetName(), err)
 			}
 		}
 	}
@@ -247,7 +251,7 @@ func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resourc
 // ensureVolumesCreated provisions any initial actor volumes that are in
 // PENDING state, persisting the resulting volume state (even when creation
 // partially failed, so progress is not lost) and returning the stored copy.
-func (w *ActorWorkflow) ensureVolumesCreated(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (_ *ateapipb.Actor, err error) {
+func (w *ActorWorkflow) ensureVolumesCreated(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "CreateVolumes")
 	defer func() { err = done(err) }()
 
@@ -299,7 +303,7 @@ func (w *ActorWorkflow) ensureVolumesCreated(ctx context.Context, actorRef resou
 // assignment. A version conflict there is retried under a bounded backoff
 // only after re-reading the actor and revalidating it can still be resumed —
 // the conflicting writer may have crashed, drained, or deleted it.
-func (w *ActorWorkflow) ensureWorkerAssigned(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (_ *ateapipb.Actor, _ *ateapipb.Worker, err error) {
+func (w *ActorWorkflow) ensureWorkerAssigned(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, _ *ateapipb.Worker, err error) {
 	ctx, done := stepSpan(ctx, "AssignWorker")
 	defer func() { err = done(err) }()
 
@@ -354,7 +358,7 @@ func (w *ActorWorkflow) ensureWorkerAssigned(ctx context.Context, actorRef resou
 // against the current worker record. Every invalid outcome crashes the actor:
 // a RESUMING actor whose worker vanished, drained, was reassigned, or is no
 // longer eligible can never make progress on its own.
-func (w *ActorWorkflow) validateAssignedWorker(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (*ateapipb.Worker, error) {
+func (w *ActorWorkflow) validateAssignedWorker(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (*ateapipb.Worker, error) {
 	assignment := actor.GetStatus().GetWorkerAssignment()
 	if assignment == nil {
 		slog.ErrorContext(ctx, "expected a worker assignment on a RESUMING actor, found none")
@@ -433,14 +437,14 @@ func schedulerRecordable(err error) bool {
 // re-reads the actor: if the fresh copy can still be resumed the refreshed
 // actor is returned along with the conflict so the caller retries with clean
 // inputs; any other status aborts the resume.
-func (w *ActorWorkflow) assignWorkerAttempt(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (_ *ateapipb.Actor, _ *ateapipb.Worker, err error) {
+func (w *ActorWorkflow) assignWorkerAttempt(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, _ *ateapipb.Worker, err error) {
 	start := time.Now()
 	outcome := ateattr.SchedulerOutcomeError
 	poolNamespace := ""
 	pool := ""
 	class := ""
 	if actorTemplate != nil {
-		class = string(actorTemplate.Spec.SandboxClass)
+		class = sandboxClassString(actorTemplate.GetSandboxConfig().GetSandboxClass())
 	}
 	defer func() {
 		if schedulerRecordable(err) {
@@ -582,35 +586,36 @@ func workerAssignmentFrom(w *ateapipb.Worker) *ateapipb.WorkerAssignment {
 // (bytes) limits from its ActorTemplate, or 0 for a dimension the template did
 // not set. These size the sandbox (supplied over the actor RPCs) and gate
 // scheduling (a worker must have >= capacity).
-func actorResourceLimits(tmpl *atev1alpha1.ActorTemplate) (cpuMilli, memBytes int64) {
-	res := tmpl.Spec.Resources
-	if res == nil {
-		return 0, 0
+func actorResourceLimits(tmpl *ateapipb.ActorTemplate) (cpuMilli, memBytes int64, err error) {
+	for _, limit := range tmpl.GetResources().GetLimits() {
+		q, perr := resource.ParseQuantity(limit.GetQuantity())
+		if perr != nil {
+			return 0, 0, fmt.Errorf("invalid template resource limit %s=%q: %w", limit.GetName(), limit.GetQuantity(), perr)
+		}
+		switch limit.GetName() {
+		case "cpu":
+			cpuMilli = q.MilliValue()
+		case "memory":
+			memBytes = q.Value()
+		}
 	}
-	if c := res.Limits.Cpu(); c != nil {
-		cpuMilli = c.MilliValue()
-	}
-	if m := res.Limits.Memory(); m != nil {
-		memBytes = m.Value()
-	}
-	return cpuMilli, memBytes
+	return cpuMilli, memBytes, nil
 }
 
-func schedulingConstraints(actor *ateapipb.Actor, tmpl *atev1alpha1.ActorTemplate) (scheduling.Constraints, error) {
-	cpuMilli, memBytes := actorResourceLimits(tmpl)
+func schedulingConstraints(actor *ateapipb.Actor, tmpl *ateapipb.ActorTemplate) (scheduling.Constraints, error) {
+	cpuMilli, memBytes, err := actorResourceLimits(tmpl)
+	if err != nil {
+		return scheduling.Constraints{}, err
+	}
 	c := scheduling.Constraints{
-		SandboxClass:  string(tmpl.Spec.SandboxClass),
+		SandboxClass:  sandboxClassString(tmpl.GetSandboxConfig().GetSandboxClass()),
 		ActorSelector: labels.SelectorFromSet(labels.Set(actor.GetWorkerSelector().GetMatchLabels())),
 		RequiredNodes: actor.GetStatus().GetLocalSnapshotInfo().GetNodeVmsWithLocalSnapshots(),
 		CPUMilli:      cpuMilli,
 		MemoryBytes:   memBytes,
 	}
-	if tmpl.Spec.WorkerSelector != nil {
-		sel, err := metav1.LabelSelectorAsSelector(tmpl.Spec.WorkerSelector)
-		if err != nil {
-			return scheduling.Constraints{}, fmt.Errorf("invalid template worker selector: %w", err)
-		}
-		c.TemplateSelector = sel
+	if sel := tmpl.GetWorkerSelector(); sel != nil {
+		c.TemplateSelector = labels.SelectorFromSet(labels.Set(sel.GetMatchLabels()))
 	}
 	return c, nil
 }
@@ -619,7 +624,7 @@ func schedulingConstraints(actor *ateapipb.Actor, tmpl *atev1alpha1.ActorTemplat
 // assigned worker's node. Attachment is idempotent, so a re-entered workflow
 // safely runs it again.
 // TODO replace re-execution with a proper check on the volumes' attach state.
-func (w *ActorWorkflow) ensureVolumesAttached(ctx context.Context, actor *ateapipb.Actor, worker *ateapipb.Worker, actorTemplate *atev1alpha1.ActorTemplate) (err error) {
+func (w *ActorWorkflow) ensureVolumesAttached(ctx context.Context, actor *ateapipb.Actor, worker *ateapipb.Worker, actorTemplate *ateapipb.ActorTemplate) (err error) {
 	ctx, done := stepSpan(ctx, "AttachVolumes")
 	defer func() { err = done(err) }()
 
@@ -649,7 +654,7 @@ func (w *ActorWorkflow) ensureVolumesAttached(ctx context.Context, actor *ateapi
 // the worker pod UID, so a re-entered workflow re-sends the same semantic
 // request; once atelet's Restore/Run are idempotent on those keys this step
 // becomes fully reentrant with no changes here.
-func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate, src resumeSnapshotSource) (tele restoreTelemetry, err error) {
+func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate, src resumeSnapshotSource) (tele restoreTelemetry, err error) {
 	ctx, done := stepSpan(ctx, "CallAteletRestore")
 	defer func() { err = done(err) }()
 
@@ -668,7 +673,10 @@ func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resou
 
 	// The actor's declared limits ride the RPC down to the sandbox so it is sized
 	// to the actor (replacing the worker-pod downward-API approach).
-	cpuMilli, memBytes := actorResourceLimits(actorTemplate)
+	cpuMilli, memBytes, err := actorResourceLimits(actorTemplate)
+	if err != nil {
+		return tele, err
+	}
 
 	if local := actor.GetStatus().GetLocalSnapshotInfo(); local != nil {
 		slog.InfoContext(ctx, "Actor has snapshot; Restoring from snapshot")
@@ -696,7 +704,7 @@ func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resou
 		// pause snapshot restores as DATA_ON_GOLDEN — atelet combines the
 		// golden snapshot's guest state with the actor's data. Otherwise the
 		// scope mirrors what the pause captured.
-		req.Scope = toAteletSnapshotScope(actorTemplate.Spec.SnapshotsConfig.OnPause)
+		req.Scope = actorSnapshotContentScopeToAtelet(actorTemplate.GetSnapshotsConfig().GetOnPause())
 		if !src.GoldenSnapshotURI.IsZero() {
 			req.Scope = ateletpb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN
 			req.GoldenSnapshotUri = src.GoldenSnapshotURI.String()

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -112,7 +112,7 @@ func TestAssignWorkerAttempt_MissingSelectedWorkerIsRetried(t *testing.T) {
 	actor, wc := seedAssignFixture(t, ctx, persistence)
 	st := &updateWorkerErrorStore{Interface: persistence, err: store.ErrNotFound}
 	w := &ActorWorkflow{store: st, workerCache: wc, scheduler: scheduling.New(wc)}
-	tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor}}
+	tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor}})
 
 	_, _, err := w.assignWorkerAttempt(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, actor, tmpl)
 	if !errors.Is(err, store.ErrVersionConflict) {
@@ -133,7 +133,7 @@ func TestEnsureWorkerAssigned_ConflictExhaustionIsRetryable(t *testing.T) {
 	actor, wc := seedAssignFixture(t, ctx, persistence)
 	st := &updateWorkerErrorStore{Interface: persistence, err: store.ErrVersionConflict}
 	w := &ActorWorkflow{store: st, workerCache: wc, scheduler: scheduling.New(wc)}
-	tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor}}
+	tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor}})
 
 	_, _, err := w.ensureWorkerAssigned(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, actor, tmpl)
 	if !errors.Is(err, store.ErrVersionConflict) {
@@ -177,9 +177,9 @@ func TestAssignWorkerAttempt_SkipsWorkerAssignedInOtherAtespace(t *testing.T) {
 	actor := &ateapipb.Actor{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "shared", Uid: "actor-uid"},
 	}
-	tmpl := &atev1alpha1.ActorTemplate{
+	tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor},
-	}
+	})
 	_, _, err := w.assignWorkerAttempt(ctx, resources.ActorRef{Atespace: "team-a", Name: "shared"}, actor, tmpl)
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("assignWorkerAttempt() error = %v, want ResourceExhausted (no free workers)", err)
@@ -252,9 +252,9 @@ func TestAssignWorkerAttempt_ReleasesIneligibleStaleWorkerInBackground(t *testin
 	}
 
 	w := &ActorWorkflow{store: persistence, workerCache: wc, scheduler: scheduling.New(wc)}
-	tmpl := &atev1alpha1.ActorTemplate{
+	tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor},
-	}
+	})
 	_, worker, err := w.assignWorkerAttempt(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, actor, tmpl)
 	if err != nil {
 		t.Fatalf("assignWorkerAttempt() error = %v, want nil (release must not fail the resume)", err)
@@ -350,9 +350,9 @@ func TestAssignWorkerAttempt_RetryAfterConflictPicksFreshWorker(t *testing.T) {
 	}
 
 	w := &ActorWorkflow{store: persistence, workerCache: wc, scheduler: scheduling.New(wc)}
-	tmpl := &atev1alpha1.ActorTemplate{
+	tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor},
-	}
+	})
 	_, worker, err := w.assignWorkerAttempt(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, actor, tmpl)
 	if err != nil {
 		t.Fatalf("assignWorkerAttempt() on retry = %v, want nil (must re-pick a free worker)", err)
@@ -496,9 +496,9 @@ func TestAssignWorkerAttempt_ConflictRefreshesActor(t *testing.T) {
 			}}
 
 			w := &ActorWorkflow{store: st, workerCache: wc, scheduler: scheduling.New(wc)}
-			tmpl := &atev1alpha1.ActorTemplate{
+			tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 				Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor},
-			}
+			})
 			refreshed, _, err := w.assignWorkerAttempt(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, actor, tmpl)
 
 			if tc.wantRetry {
@@ -624,7 +624,7 @@ func TestEnsureWorkerAssigned_RejectsNonResumableStates(t *testing.T) {
 			continue
 		}
 		actor := &ateapipb.Actor{Status: &ateapipb.ActorStatus{State: st}, Metadata: &ateapipb.ResourceMetadata{Name: "id1", Uid: "actor-uid-1"}}
-		_, _, err := w.ensureWorkerAssigned(ctx, resources.ActorRef{Name: "id1"}, actor, &atev1alpha1.ActorTemplate{})
+		_, _, err := w.ensureWorkerAssigned(ctx, resources.ActorRef{Name: "id1"}, actor, mustTemplateFromCRD(&atev1alpha1.ActorTemplate{}))
 		assertPrerequisiteResult(t, st, err, false)
 	}
 }
@@ -823,7 +823,7 @@ func TestValidateAssignedWorker_WorkerOwnership(t *testing.T) {
 					},
 				},
 			}
-			tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor}}
+			tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SandboxClass: atev1alpha1.SandboxClassGvisor}})
 			_, err = w.validateAssignedWorker(ctx, resources.ActorRef{Atespace: "team-a", Name: "shared"}, resumingActor, tmpl)
 			if got := status.Code(err); got != tt.wantCode {
 				t.Fatalf("status.Code(err) = %v, want %v (err: %v)", got, tt.wantCode, err)

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -25,7 +25,6 @@ import (
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/resources"
-	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
@@ -40,7 +39,7 @@ import (
 func (w *ActorWorkflow) SuspendActor(ctx context.Context, actorRef resources.ActorRef) (_ *ateapipb.Actor, err error) {
 	start := time.Now()
 	var actor *ateapipb.Actor
-	var actorTemplate *atev1alpha1.ActorTemplate
+	var actorTemplate *ateapipb.ActorTemplate
 	var wireSnapshotScope string
 	// Set just before finalize; nil until then, so earlier exits label
 	// themselves from the record they hold.
@@ -102,7 +101,7 @@ func (w *ActorWorkflow) SuspendActor(ctx context.Context, actorRef resources.Act
 }
 
 // loadActorForSuspend fetches the current actor record and its template.
-func (w *ActorWorkflow) loadActorForSuspend(ctx context.Context, actorRef resources.ActorRef) (_ *ateapipb.Actor, _ *atev1alpha1.ActorTemplate, err error) {
+func (w *ActorWorkflow) loadActorForSuspend(ctx context.Context, actorRef resources.ActorRef) (_ *ateapipb.Actor, _ *ateapipb.ActorTemplate, err error) {
 	ctx, done := stepSpan(ctx, "LoadActorForSuspend")
 	defer func() { err = done(err) }()
 
@@ -110,9 +109,13 @@ func (w *ActorWorkflow) loadActorForSuspend(ctx context.Context, actorRef resour
 	if err != nil {
 		return nil, nil, err
 	}
-	actorTemplate, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
+	crdTemplate, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
 	if err != nil {
 		return nil, nil, fmt.Errorf("while getting ActorTemplate: %w", err)
+	}
+	actorTemplate, err := actorTemplateFromCRD(crdTemplate)
+	if err != nil {
+		return nil, nil, err
 	}
 	return actor, actorTemplate, nil
 }
@@ -122,7 +125,7 @@ func (w *ActorWorkflow) loadActorForSuspend(ctx context.Context, actorRef resour
 // actor version the snapshot will capture. Skips when a previous attempt
 // already marked the actor; the persisted location and source version then
 // stay authoritative for the rest of the workflow.
-func (w *ActorWorkflow) ensureMarkedSuspending(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (_ *ateapipb.Actor, err error) {
+func (w *ActorWorkflow) ensureMarkedSuspending(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "MarkSuspending")
 	defer func() { err = done(err) }()
 
@@ -138,8 +141,8 @@ func (w *ActorWorkflow) ensureMarkedSuspending(ctx context.Context, actorRef res
 	// Reject before leaving PAUSED so the actor stays resumable.
 	if actor.GetStatus().GetState() == ateapipb.ActorState_ACTOR_STATE_PAUSED &&
 		pausedContentScope(actor.GetStatus().GetLocalSnapshotInfo(), actorTemplate) == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA &&
-		commitSnapshotScope(actorRef.Atespace, actorTemplate) == atev1alpha1.SnapshotScopeFull {
-		return nil, status.Errorf(codes.FailedPrecondition, "actor %s paused with a %s snapshot; the template commits %s, which a paused-origin suspend cannot produce", actorRef, atev1alpha1.SnapshotScopeData, atev1alpha1.SnapshotScopeFull)
+		commitSnapshotScope(actorRef.Atespace, actorTemplate) == ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL {
+		return nil, status.Errorf(codes.FailedPrecondition, "actor %s paused with a Data snapshot; the template commits Full, which a paused-origin suspend cannot produce", actorRef)
 	}
 
 	name := resources.NewSnapshotName()
@@ -168,22 +171,22 @@ func (w *ActorWorkflow) ensureMarkedSuspending(ctx context.Context, actorRef res
 // onCommit: the golden snapshot is the base an OnGolden data resume is
 // combined with at restore, so it must carry the guest memory and filesystem
 // — a data-only golden would leave nothing to restore the guest from.
-func commitSnapshotScope(atespace string, tmpl *atev1alpha1.ActorTemplate) atev1alpha1.SnapshotScope {
+func commitSnapshotScope(atespace string, tmpl *ateapipb.ActorTemplate) ateapipb.SnapshotContentScope {
 	if atespace == resources.GoldenActorAtespace {
-		return atev1alpha1.SnapshotScopeFull
+		return ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL
 	}
-	return tmpl.Spec.SnapshotsConfig.OnCommit
+	return effectiveContentScope(tmpl.GetSnapshotsConfig().GetOnCommit())
 }
 
 // pausedContentScope returns the scope a paused actor's local snapshot was
 // captured with: the value recorded at pause finalization, or — for actors
 // paused before content_scope existed — the template's onPause, the same
 // derivation resume uses for local snapshots.
-func pausedContentScope(local *ateapipb.LocalSnapshotInfo, tmpl *atev1alpha1.ActorTemplate) ateapipb.SnapshotContentScope {
+func pausedContentScope(local *ateapipb.LocalSnapshotInfo, tmpl *ateapipb.ActorTemplate) ateapipb.SnapshotContentScope {
 	if scope := local.GetContentScope(); scope != ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_UNSPECIFIED {
 		return scope
 	}
-	return toActorSnapshotContentScope(tmpl.Spec.SnapshotsConfig.OnPause)
+	return effectiveContentScope(tmpl.GetSnapshotsConfig().GetOnPause())
 }
 
 // isPausedOriginSuspend reports whether the suspend must upload a PAUSED
@@ -205,7 +208,7 @@ func isPausedOriginSuspend(actor *ateapipb.Actor) bool {
 // once-minted snapshot location, so a re-entered workflow re-sends the same
 // semantic request; once atelet's Checkpoint is idempotent on those keys this
 // step becomes fully reentrant with no changes here.
-func (w *ActorWorkflow) ensureAteletSuspended(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (wireSnapshotScope string, err error) {
+func (w *ActorWorkflow) ensureAteletSuspended(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (wireSnapshotScope string, err error) {
 	ctx, done := stepSpan(ctx, "CallAteletSuspend")
 	defer func() { err = done(err) }()
 
@@ -257,7 +260,7 @@ func (w *ActorWorkflow) ensureAteletSuspended(ctx context.Context, actorRef reso
 				SnapshotUri: snapshotURI.String(),
 			},
 		},
-		Scope:    toAteletSnapshotScope(commitSnapshotScope(actor.GetMetadata().GetAtespace(), actorTemplate)),
+		Scope:    actorSnapshotContentScopeToAtelet(commitSnapshotScope(actor.GetMetadata().GetAtespace(), actorTemplate)),
 		ActorUid: actor.GetMetadata().Uid,
 	}
 	wireSnapshotScope = ateattr.SnapshotScopeValue(req.Scope)
@@ -272,7 +275,7 @@ func (w *ActorWorkflow) ensureAteletSuspended(ctx context.Context, actorRef reso
 // ateom to checkpoint. Retries re-send the same semantic request: the
 // destination is minted once and the upload overwrites deterministic object
 // names, with the remote manifest as the commit marker.
-func (w *ActorWorkflow) ensurePausedSnapshotUploaded(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate) (wireSnapshotScope string, err error) {
+func (w *ActorWorkflow) ensurePausedSnapshotUploaded(ctx context.Context, actorRef resources.ActorRef, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate) (wireSnapshotScope string, err error) {
 	ctx, done := stepSpan(ctx, "UploadPausedCheckpoint")
 	defer func() { err = done(err) }()
 
@@ -310,7 +313,7 @@ func (w *ActorWorkflow) ensurePausedSnapshotUploaded(ctx context.Context, actorR
 		DestinationSnapshotUri: snapshotURI.String(),
 		// The commit scope, like a running-origin suspend; atelet converts
 		// from the captured scope in the snapshot's manifest where possible.
-		DesiredScope: toAteletSnapshotScope(commitSnapshotScope(actor.GetMetadata().GetAtespace(), actorTemplate)),
+		DesiredScope: actorSnapshotContentScopeToAtelet(commitSnapshotScope(actor.GetMetadata().GetAtespace(), actorTemplate)),
 	}
 	wireSnapshotScope = ateattr.SnapshotScopeValue(req.DesiredScope)
 
@@ -318,8 +321,8 @@ func (w *ActorWorkflow) ensurePausedSnapshotUploaded(ctx context.Context, actorR
 	return wireSnapshotScope, maybeCrashActor(ctx, w.store, actorRef, err, "while uploading paused snapshot", ateattr.OperationSuspend)
 }
 
-func inProgressSnapshotURI(actorTemplate *atev1alpha1.ActorTemplate, atespace, name string) (resources.SnapshotURI, error) {
-	uri, err := resources.NewSnapshotURI(actorTemplate.Spec.SnapshotsConfig.Location, atespace, name)
+func inProgressSnapshotURI(actorTemplate *ateapipb.ActorTemplate, atespace, name string) (resources.SnapshotURI, error) {
+	uri, err := resources.NewSnapshotURI(actorTemplate.GetSnapshotsConfig().GetStorageLocation(), atespace, name)
 	if err != nil {
 		return resources.SnapshotURI{}, fmt.Errorf("while building the snapshot URI for actor %s/%s: %w", atespace, name, err)
 	}
@@ -331,7 +334,7 @@ func inProgressSnapshotURI(actorTemplate *atev1alpha1.ActorTemplate, atespace, n
 // runs it again. spanName distinguishes the suspend and pause steps in
 // traces; op labels the volume metrics.
 // TODO replace re-execution with a proper check on the volumes' attach state.
-func (w *ActorWorkflow) ensureVolumesDetached(ctx context.Context, actor *ateapipb.Actor, actorTemplate *atev1alpha1.ActorTemplate, spanName, op string) (err error) {
+func (w *ActorWorkflow) ensureVolumesDetached(ctx context.Context, actor *ateapipb.Actor, actorTemplate *ateapipb.ActorTemplate, spanName, op string) (err error) {
 	ctx, done := stepSpan(ctx, spanName)
 	defer func() { err = done(err) }()
 
@@ -344,7 +347,7 @@ func (w *ActorWorkflow) ensureVolumesDetached(ctx context.Context, actor *ateapi
 // single update. It re-reads the actor first so an out-of-band transition
 // (e.g. the syncer crashing the actor after its worker died) is not
 // overwritten: with no assignment left there is nothing to finalize.
-func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef resources.ActorRef, actorTemplate *atev1alpha1.ActorTemplate) (_ *ateapipb.Actor, err error) {
+func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef resources.ActorRef, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "FinalizeSuspended")
 	defer func() { err = done(err) }()
 
@@ -385,8 +388,8 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 				SourceActorVersion:     latestActor.GetStatus().GetInProgressSnapshotSourceActorVersion(),
 				ActorTemplateNamespace: latestActor.GetActorTemplateNamespace(),
 				ActorTemplateName:      latestActor.GetActorTemplateName(),
-				ActorTemplateUid:       string(actorTemplate.GetUID()),
-				ContentScope:           toActorSnapshotContentScope(commitSnapshotScope(actorRef.Atespace, actorTemplate)),
+				ActorTemplateUid:       actorTemplate.GetMetadata().GetUid(),
+				ContentScope:           commitSnapshotScope(actorRef.Atespace, actorTemplate),
 				SnapshotUri:            snapshotURI.String(),
 			},
 		}

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -38,9 +38,9 @@ func TestEnsureMarkedSuspending_SnapshotName(t *testing.T) {
 		Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "actor-1"},
 		Status:   &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
 	})
-	tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{
+	tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{
 		SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://bucket/root/"},
-	}}
+	}})
 	w := &ActorWorkflow{store: persistence}
 	marked, err := w.ensureMarkedSuspending(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, actor, tmpl)
 	if err != nil {
@@ -56,7 +56,7 @@ func TestEnsureMarkedSuspending_SnapshotName(t *testing.T) {
 	}
 	// The URI the later steps rebuild from that name nests under the actor's
 	// atespace so each tenant gets a distinct storage prefix.
-	uri, err := resources.NewSnapshotURI(tmpl.Spec.SnapshotsConfig.Location, "team-a", snapshotName)
+	uri, err := resources.NewSnapshotURI(tmpl.GetSnapshotsConfig().GetStorageLocation(), "team-a", snapshotName)
 	if err != nil {
 		t.Fatalf("NewSnapshotURI(%q): %v", snapshotName, err)
 	}
@@ -80,7 +80,7 @@ func TestEnsureMarkedSuspending_ReentryKeepsPersistedSnapshotLocation(t *testing
 		},
 	})
 	w := &ActorWorkflow{store: persistence}
-	marked, err := w.ensureMarkedSuspending(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, actor, &atev1alpha1.ActorTemplate{})
+	marked, err := w.ensureMarkedSuspending(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, actor, mustTemplateFromCRD(&atev1alpha1.ActorTemplate{}))
 	if err != nil {
 		t.Fatalf("ensureMarkedSuspending: %v", err)
 	}
@@ -171,9 +171,9 @@ func TestEnsureMarkedSuspending_StateMatrix(t *testing.T) {
 			Status:   &ateapipb.ActorStatus{State: seedState},
 		})
 
-		tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{
+		tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{
 			SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"},
-		}}
+		}})
 		marked, err := w.ensureMarkedSuspending(ctx, actorRef, actor, tmpl)
 		assertPrerequisiteResult(t, seedState, err, allowed[seedState])
 		if err == nil && marked.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_SUSPENDING {
@@ -259,7 +259,7 @@ func TestEnsureAteletSuspended_DanglingWorkerDoesNotRecordPhantomSnapshot(t *tes
 			created := storetest.MustCreateActor(t, ctx, persistence, actor)
 
 			w := &ActorWorkflow{store: persistence, dialer: newDanglingDialer()}
-			if _, err := w.ensureAteletSuspended(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, created, &atev1alpha1.ActorTemplate{}); err == nil {
+			if _, err := w.ensureAteletSuspended(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, created, mustTemplateFromCRD(&atev1alpha1.ActorTemplate{})); err == nil {
 				t.Fatal("ensureAteletSuspended: want error for dangling worker, got nil")
 			}
 
@@ -310,7 +310,7 @@ func TestEnsureSuspendedFinalized_NoAssignment(t *testing.T) {
 	created := storetest.MustCreateActor(t, ctx, persistence, actor)
 
 	w := &ActorWorkflow{store: persistence}
-	tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"}}}
+	tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"}}})
 	stored, err := w.ensureSuspendedFinalized(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, tmpl)
 	if err != nil {
 		t.Fatalf("ensureSuspendedFinalized: %v", err)
@@ -414,7 +414,7 @@ func TestEnsureSuspendedFinalized_ReleasesOnlyOwnWorker(t *testing.T) {
 			}
 
 			w := &ActorWorkflow{store: persistence}
-			tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://bucket/root"}}}
+			tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://bucket/root"}}})
 			if _, err := w.ensureSuspendedFinalized(ctx, resources.ActorRef{Atespace: "team-a", Name: "shared"}, tmpl); err != nil {
 				t.Fatalf("ensureSuspendedFinalized: %v", err)
 			}
@@ -455,7 +455,7 @@ func TestEnsureSuspendedFinalized_SnapshotSourceActorVersion(t *testing.T) {
 	})
 
 	w := &ActorWorkflow{store: persistence}
-	tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"}}}
+	tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"}}})
 	final, err := w.ensureSuspendedFinalized(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, tmpl)
 	if err != nil {
 		t.Fatalf("ensureSuspendedFinalized: %v", err)
@@ -480,21 +480,23 @@ func TestEnsureSuspendedFinalized_SnapshotSourceActorVersion(t *testing.T) {
 // golden snapshot is the base an OnGolden data resume combines into, so the
 // template's onCommit must not thin it down to a data-only capture.
 func TestCommitSnapshotScope(t *testing.T) {
-	tmpl := func(onCommit atev1alpha1.SnapshotScope) *atev1alpha1.ActorTemplate {
-		return &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{
+	tmpl := func(onCommit atev1alpha1.SnapshotScope) *ateapipb.ActorTemplate {
+		return mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{
 			SnapshotsConfig: atev1alpha1.SnapshotsConfig{OnCommit: onCommit},
-		}}
+		}})
 	}
+	fullScope := ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL
+	dataScope := ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA
 	tests := []struct {
 		name     string
 		atespace string
 		onCommit atev1alpha1.SnapshotScope
-		want     atev1alpha1.SnapshotScope
+		want     ateapipb.SnapshotContentScope
 	}{
-		{"golden actor ignores Data onCommit", resources.GoldenActorAtespace, atev1alpha1.SnapshotScopeData, atev1alpha1.SnapshotScopeFull},
-		{"golden actor keeps Full onCommit", resources.GoldenActorAtespace, atev1alpha1.SnapshotScopeFull, atev1alpha1.SnapshotScopeFull},
-		{"regular actor uses Data onCommit", "team-a", atev1alpha1.SnapshotScopeData, atev1alpha1.SnapshotScopeData},
-		{"regular actor uses Full onCommit", "team-a", atev1alpha1.SnapshotScopeFull, atev1alpha1.SnapshotScopeFull},
+		{"golden actor ignores Data onCommit", resources.GoldenActorAtespace, atev1alpha1.SnapshotScopeData, fullScope},
+		{"golden actor keeps Full onCommit", resources.GoldenActorAtespace, atev1alpha1.SnapshotScopeFull, fullScope},
+		{"regular actor uses Data onCommit", "team-a", atev1alpha1.SnapshotScopeData, dataScope},
+		{"regular actor uses Full onCommit", "team-a", atev1alpha1.SnapshotScopeFull, fullScope},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -535,15 +537,15 @@ func TestIsPausedOriginSuspend(t *testing.T) {
 // suspend is rejected before the actor leaves PAUSED when the pause captured
 // Data but the template commits Full: an upload cannot fabricate memory.
 func TestEnsureMarkedSuspending_PausedScopeRejection(t *testing.T) {
-	tmpl := func(onPause, onCommit atev1alpha1.SnapshotScope) *atev1alpha1.ActorTemplate {
-		return &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{
+	tmpl := func(onPause, onCommit atev1alpha1.SnapshotScope) *ateapipb.ActorTemplate {
+		return mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{
 			SnapshotsConfig: atev1alpha1.SnapshotsConfig{OnPause: onPause, OnCommit: onCommit, Location: "gs://snapshots"},
-		}}
+		}})
 	}
 	tests := []struct {
 		name     string
 		captured ateapipb.SnapshotContentScope
-		tmpl     *atev1alpha1.ActorTemplate
+		tmpl     *ateapipb.ActorTemplate
 		wantErr  bool
 	}{
 		{"data capture cannot commit full", ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA, tmpl(atev1alpha1.SnapshotScopeData, atev1alpha1.SnapshotScopeFull), true},
@@ -600,7 +602,7 @@ func TestEnsurePausedSnapshotUploaded_Preconditions(t *testing.T) {
 			},
 		})
 
-		if _, err := w.ensurePausedSnapshotUploaded(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, created, &atev1alpha1.ActorTemplate{}); err == nil {
+		if _, err := w.ensurePausedSnapshotUploaded(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, created, mustTemplateFromCRD(&atev1alpha1.ActorTemplate{})); err == nil {
 			t.Fatal("ensurePausedSnapshotUploaded = nil, want error for missing node record")
 		}
 
@@ -627,7 +629,7 @@ func TestEnsurePausedSnapshotUploaded_Preconditions(t *testing.T) {
 			},
 		})
 
-		tmpl := &atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"}}}
+		tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"}}})
 		_, err := w.ensurePausedSnapshotUploaded(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, created, tmpl)
 		if !errors.Is(err, ErrNoAteletOnNode) {
 			t.Fatalf("ensurePausedSnapshotUploaded = %v, want ErrNoAteletOnNode", err)

--- a/cmd/ateapi/internal/controlapi/workload_spec.go
+++ b/cmd/ateapi/internal/controlapi/workload_spec.go
@@ -18,59 +18,61 @@ import (
 	"fmt"
 
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
-	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
-	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // toAteletResources resolves a container's declared limits into the scalars
 // atelet and the ateoms consume; everything downstream compares numbers.
 // Returns nil when the container declares no limits, so the OCI spec stays
 // untouched for templates that do not use them.
-func toAteletResources(r *atev1alpha1.ContainerResources) *ateletpb.ResourceLimits {
-	if r == nil || len(r.Limits) == 0 {
-		return nil
-	}
+func toAteletResources(r *ateapipb.Resources) (*ateletpb.ResourceLimits, error) {
 	out := &ateletpb.ResourceLimits{}
-	if q, ok := r.Limits[corev1.ResourceMemory]; ok {
-		out.MemoryBytes = q.Value()
-	}
-	if q, ok := r.Limits[corev1.ResourceCPU]; ok {
-		out.CpuMillis = q.MilliValue()
+	for _, limit := range r.GetLimits() {
+		q, err := resource.ParseQuantity(limit.GetQuantity())
+		if err != nil {
+			return nil, fmt.Errorf("invalid container resource limit %s=%q: %w", limit.GetName(), limit.GetQuantity(), err)
+		}
+		switch limit.GetName() {
+		case "cpu":
+			out.CpuMillis = q.MilliValue()
+		case "memory":
+			out.MemoryBytes = q.Value()
+		}
 	}
 	if out.MemoryBytes == 0 && out.CpuMillis == 0 {
-		return nil
+		return nil, nil
 	}
-	return out
+	return out, nil
 }
 
 // workloadSpecFromActorTemplate builds a WorkloadSpec from the template;
 // container env is copied verbatim.
-func workloadSpecFromActorTemplate(actorTemplate *atev1alpha1.ActorTemplate, actor *ateapipb.Actor) (*ateletpb.WorkloadSpec, error) {
+func workloadSpecFromActorTemplate(actorTemplate *ateapipb.ActorTemplate, actor *ateapipb.Actor) (*ateletpb.WorkloadSpec, error) {
 	workloadSpec := &ateletpb.WorkloadSpec{}
 
 	// Convert volumes to atelet's representation.  ActorTemplate validation has
 	// already ensured that only one source is set.
-	for _, vol := range actorTemplate.Spec.Volumes {
+	for _, vol := range actorTemplate.GetVolumes() {
 		switch {
-		case vol.VolumeSource.DurableDir != nil:
+		case vol.GetDurableDir() != nil:
 			workloadSpec.Volumes = append(workloadSpec.Volumes, &ateletpb.Volume{
-				Name: vol.Name,
+				Name: vol.GetName(),
 				Source: &ateletpb.Volume_DurableDir{
 					DurableDir: &ateletpb.DurableDirVolume{},
 				},
 			})
 
-		case vol.VolumeSource.SystemInfo != nil:
+		case vol.GetSystemInfo() != nil:
 			ateletSystemInfo := &ateletpb.SystemInfoVolume{}
-			for _, dataSource := range vol.VolumeSource.SystemInfo.DataSources {
+			for _, dataSource := range vol.GetSystemInfo().GetDataSources() {
 				switch {
-				case dataSource.ActorMetadata != nil:
+				case dataSource.GetActorMetadata() != nil:
 					actorMetadata := &ateletpb.ActorMetadataDataSource{}
-					for _, item := range dataSource.ActorMetadata.Items {
+					for _, item := range dataSource.GetActorMetadata().GetItems() {
 						actorMetadata.Items = append(actorMetadata.Items, &ateletpb.ActorMetadataItem{
-							Field: toAteletActorMetadataField(item.Field),
-							Path:  item.Path,
+							Field: toAteletActorMetadataField(item.GetField()),
+							Path:  item.GetPath(),
 						})
 					}
 					ateletSystemInfo.DataSources = append(ateletSystemInfo.DataSources, &ateletpb.SystemInfoDataSource{
@@ -78,14 +80,14 @@ func workloadSpecFromActorTemplate(actorTemplate *atev1alpha1.ActorTemplate, act
 							ActorMetadata: actorMetadata,
 						},
 					})
-				case dataSource.TrustBundle != nil:
+				case dataSource.GetTrustBundle() != nil:
 					// atelet resolves named trustBundles against its allowlist
 					// and ClusterTrustBundle informer at write time
 					ateletSystemInfo.DataSources = append(ateletSystemInfo.DataSources, &ateletpb.SystemInfoDataSource{
 						DataSource: &ateletpb.SystemInfoDataSource_TrustBundle{
 							TrustBundle: &ateletpb.TrustBundleDataSource{
-								Name: dataSource.TrustBundle.Name,
-								Path: dataSource.TrustBundle.Path,
+								Name: dataSource.GetTrustBundle().GetName(),
+								Path: dataSource.GetTrustBundle().GetPath(),
 							},
 						},
 					})
@@ -94,18 +96,18 @@ func workloadSpecFromActorTemplate(actorTemplate *atev1alpha1.ActorTemplate, act
 				}
 			}
 			workloadSpec.Volumes = append(workloadSpec.Volumes, &ateletpb.Volume{
-				Name: vol.Name,
+				Name: vol.GetName(),
 				Source: &ateletpb.Volume_SystemInfo{
 					SystemInfo: ateletSystemInfo,
 				},
 			})
 
-		case vol.VolumeSource.Image != nil:
+		case vol.GetImage() != nil:
 			workloadSpec.Volumes = append(workloadSpec.Volumes, &ateletpb.Volume{
-				Name: vol.Name,
+				Name: vol.GetName(),
 				Source: &ateletpb.Volume_Image{
 					Image: &ateletpb.ImageVolumeSource{
-						Reference: vol.VolumeSource.Image.Reference,
+						Reference: vol.GetImage().GetReference(),
 					},
 				},
 			})
@@ -121,26 +123,30 @@ func workloadSpecFromActorTemplate(actorTemplate *atev1alpha1.ActorTemplate, act
 		return nil, err
 	}
 
-	for _, ctr := range actorTemplate.Spec.Containers {
-		ateletCtr := &ateletpb.Container{
-			Name:            ctr.Name,
-			Image:           ctr.Image,
-			Command:         ctr.Command,
-			Args:            ctr.Args,
-			Readyz:          toAteletReadyz(ctr.Readyz),
-			SecurityContext: toAteletSecurityContext(ctr.SecurityContext),
-			Resources:       toAteletResources(ctr.Resources),
+	for _, ctr := range actorTemplate.GetContainers() {
+		ctrResources, err := toAteletResources(ctr.GetResources())
+		if err != nil {
+			return nil, err
 		}
-		for _, env := range ctr.Env {
+		ateletCtr := &ateletpb.Container{
+			Name:            ctr.GetName(),
+			Image:           ctr.GetImage(),
+			Command:         ctr.GetCommand(),
+			Args:            ctr.GetArgs(),
+			Readyz:          toAteletReadyz(ctr.GetReadyz()),
+			SecurityContext: toAteletSecurityContext(ctr.GetSecurityContext()),
+			Resources:       ctrResources,
+		}
+		for _, env := range ctr.GetEnv() {
 			ateletCtr.Env = append(ateletCtr.Env, &ateletpb.EnvEntry{
-				Name:  env.Name,
-				Value: env.Value,
+				Name:  env.GetName(),
+				Value: env.GetValue(),
 			})
 		}
-		for _, mount := range ctr.VolumeMounts {
+		for _, mount := range ctr.GetVolumeMounts() {
 			ateletCtr.VolumeMounts = append(ateletCtr.VolumeMounts, &ateletpb.VolumeMount{
-				Name:      mount.Name,
-				MountPath: mount.MountPath,
+				Name:      mount.GetName(),
+				MountPath: mount.GetMountPath(),
 			})
 		}
 		workloadSpec.Containers = append(workloadSpec.Containers, ateletCtr)
@@ -151,13 +157,13 @@ func workloadSpecFromActorTemplate(actorTemplate *atev1alpha1.ActorTemplate, act
 
 // appendExternalVolumes maps template external volumes to resolved actor volumes and appends them to workloadSpec
 // if they are referenced in container volumeMounts.
-func appendExternalVolumes(workloadSpec *ateletpb.WorkloadSpec, template *atev1alpha1.ActorTemplate, actor *ateapipb.Actor) error {
+func appendExternalVolumes(workloadSpec *ateletpb.WorkloadSpec, template *ateapipb.ActorTemplate, actor *ateapipb.Actor) error {
 	if template == nil {
 		return nil
 	}
-	for _, vol := range template.Spec.Volumes {
-		if vol.ExternalVolumeTemplate != nil {
-			if !isVolumeMounted(vol.Name, template) {
+	for _, vol := range template.GetVolumes() {
+		if vol.GetExternalVolumeTemplate() != nil {
+			if !isVolumeMounted(vol.GetName(), template) {
 				continue
 			}
 			if actor == nil {
@@ -168,7 +174,7 @@ func appendExternalVolumes(workloadSpec *ateletpb.WorkloadSpec, template *atev1a
 			var volType string
 			var volCtx map[string]string
 			for _, dbVol := range actor.GetStatus().GetActorVolumes() {
-				if dbVol.GetVolumeName() == vol.Name {
+				if dbVol.GetVolumeName() == vol.GetName() {
 					storageVolID = dbVol.GetStorageVolumeId()
 					volType = dbVol.GetVolumeType()
 					volCtx = dbVol.GetVolumeContext()
@@ -176,10 +182,10 @@ func appendExternalVolumes(workloadSpec *ateletpb.WorkloadSpec, template *atev1a
 				}
 			}
 			if storageVolID == "" {
-				return fmt.Errorf("volume %s not found for actor %s", vol.Name, actor.GetMetadata().GetName())
+				return fmt.Errorf("volume %s not found for actor %s", vol.GetName(), actor.GetMetadata().GetName())
 			}
 			workloadSpec.Volumes = append(workloadSpec.Volumes, &ateletpb.Volume{
-				Name: vol.Name,
+				Name: vol.GetName(),
 				Source: &ateletpb.Volume_External{
 					External: &ateletpb.ExternalVolumeSource{
 						StorageVolumeId: storageVolID,
@@ -193,10 +199,10 @@ func appendExternalVolumes(workloadSpec *ateletpb.WorkloadSpec, template *atev1a
 	return nil
 }
 
-func isVolumeMounted(volumeName string, template *atev1alpha1.ActorTemplate) bool {
-	for _, ctr := range template.Spec.Containers {
-		for _, mount := range ctr.VolumeMounts {
-			if mount.Name == volumeName {
+func isVolumeMounted(volumeName string, template *ateapipb.ActorTemplate) bool {
+	for _, ctr := range template.GetContainers() {
+		for _, mount := range ctr.GetVolumeMounts() {
+			if mount.GetName() == volumeName {
 				return true
 			}
 		}
@@ -204,65 +210,51 @@ func isVolumeMounted(volumeName string, template *atev1alpha1.ActorTemplate) boo
 	return false
 }
 
-// toAteletReadyz projects the CRD readyz field onto the ateletpb wire type.
-// Returns nil when the source is nil so containers without a probe stay
-// unchanged on the wire.
-// toAteletActorMetadataField projects the CRD field selector onto the atelet
-// wire enum. Unknown values map to UNSPECIFIED, which atelet skips; CRD enum
-// validation makes that unreachable for stored templates.
-func toAteletActorMetadataField(in atev1alpha1.ActorMetadataField) ateletpb.ActorMetadataField {
+// toAteletActorMetadataField projects the template field selector onto the
+// atelet wire enum. Unknown values map to UNSPECIFIED, which atelet skips;
+// template validation makes that unreachable for stored templates.
+func toAteletActorMetadataField(in ateapipb.ActorMetadataField) ateletpb.ActorMetadataField {
 	switch in {
-	case atev1alpha1.ActorMetadataFieldName:
+	case ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_NAME:
 		return ateletpb.ActorMetadataField_ACTOR_METADATA_FIELD_NAME
-	case atev1alpha1.ActorMetadataFieldAtespace:
+	case ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_ATESPACE:
 		return ateletpb.ActorMetadataField_ACTOR_METADATA_FIELD_ATESPACE
-	case atev1alpha1.ActorMetadataFieldUID:
+	case ateapipb.ActorMetadataField_ACTOR_METADATA_FIELD_UID:
 		return ateletpb.ActorMetadataField_ACTOR_METADATA_FIELD_UID
 	default:
 		return ateletpb.ActorMetadataField_ACTOR_METADATA_FIELD_UNSPECIFIED
 	}
 }
 
-func toAteletReadyz(in *atev1alpha1.ContainerReadyz) *ateletpb.Readyz {
+// toAteletReadyz projects the template readyz field onto the ateletpb wire
+// type. Returns nil when the source is nil so containers without a probe
+// stay unchanged on the wire.
+func toAteletReadyz(in *ateapipb.ContainerReadyz) *ateletpb.Readyz {
 	if in == nil {
 		return nil
 	}
-	out := &ateletpb.Readyz{TimeoutSeconds: in.TimeoutSeconds}
-	if in.HTTPGet != nil {
+	out := &ateletpb.Readyz{TimeoutSeconds: in.GetTimeoutSeconds()}
+	if in.GetHttpGet() != nil {
 		out.HttpGet = &ateletpb.HTTPGetAction{
-			Path: in.HTTPGet.Path,
-			Port: in.HTTPGet.Port,
+			Path: in.GetHttpGet().GetPath(),
+			Port: in.GetHttpGet().GetPort(),
 		}
 	}
 	return out
 }
 
-// toAteletSecurityContext projects the CRD securityContext onto the ateletpb
-// wire type. Returns nil when the source is nil or carries nothing, so
-// containers that set no security settings stay unchanged on the wire.
-func toAteletSecurityContext(in *atev1alpha1.SecurityContext) *ateletpb.SecurityContext {
-	if in == nil || in.Capabilities == nil {
-		return nil
-	}
-	caps := in.Capabilities
-	if len(caps.Add) == 0 && len(caps.Drop) == 0 {
+// toAteletSecurityContext projects the template securityContext onto the
+// ateletpb wire type. Returns nil when the source is nil or carries nothing,
+// so containers that set no security settings stay unchanged on the wire.
+func toAteletSecurityContext(in *ateapipb.SecurityContext) *ateletpb.SecurityContext {
+	caps := in.GetCapabilities()
+	if caps == nil || (len(caps.GetAdd()) == 0 && len(caps.GetDrop()) == 0) {
 		return nil
 	}
 	return &ateletpb.SecurityContext{
 		Capabilities: &ateletpb.Capabilities{
-			Add:  capabilityNames(caps.Add),
-			Drop: capabilityNames(caps.Drop),
+			Add:  caps.GetAdd(),
+			Drop: caps.GetDrop(),
 		},
 	}
-}
-
-func capabilityNames(in []atev1alpha1.Capability) []string {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(in))
-	for _, c := range in {
-		out = append(out, string(c))
-	}
-	return out
 }

--- a/cmd/ateapi/internal/controlapi/workload_spec_test.go
+++ b/cmd/ateapi/internal/controlapi/workload_spec_test.go
@@ -355,7 +355,7 @@ func TestWorkloadSpecFromActorTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := workloadSpecFromActorTemplate(tt.template, nil)
+			got, err := workloadSpecFromActorTemplate(mustTemplateFromCRD(tt.template), nil)
 			if err != nil {
 				t.Fatalf("workloadSpecFromActorTemplate failed: %v", err)
 			}
@@ -367,7 +367,7 @@ func TestWorkloadSpecFromActorTemplate(t *testing.T) {
 }
 
 func TestWorkloadSpecFromActorTemplatePropagatesReadyz(t *testing.T) {
-	got, err := workloadSpecFromActorTemplate(&atev1alpha1.ActorTemplate{
+	got, err := workloadSpecFromActorTemplate(mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "tmpl-readyz", Namespace: "agent-ns"},
 		Spec: atev1alpha1.ActorTemplateSpec{
 			Containers: []atev1alpha1.Container{
@@ -385,7 +385,7 @@ func TestWorkloadSpecFromActorTemplatePropagatesReadyz(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}), nil)
 	if err != nil {
 		t.Fatalf("workloadSpecFromActorTemplate failed: %v", err)
 	}
@@ -412,7 +412,7 @@ func TestWorkloadSpecFromActorTemplatePropagatesReadyz(t *testing.T) {
 }
 
 func TestAppendExternalVolumes(t *testing.T) {
-	template := &atev1alpha1.ActorTemplate{
+	template := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		Spec: atev1alpha1.ActorTemplateSpec{
 			Containers: []atev1alpha1.Container{
 				{
@@ -447,7 +447,7 @@ func TestAppendExternalVolumes(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	actor := &ateapipb.Actor{
 		Metadata: &ateapipb.ResourceMetadata{
@@ -504,7 +504,7 @@ func TestAppendExternalVolumes(t *testing.T) {
 }
 
 func TestWorkloadSpecFromActorTemplatePropagatesSecurityContext(t *testing.T) {
-	got, err := workloadSpecFromActorTemplate(&atev1alpha1.ActorTemplate{
+	got, err := workloadSpecFromActorTemplate(mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "tmpl-caps", Namespace: "agent-ns"},
 		Spec: atev1alpha1.ActorTemplateSpec{
 			Containers: []atev1alpha1.Container{
@@ -531,7 +531,7 @@ func TestWorkloadSpecFromActorTemplatePropagatesSecurityContext(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}), nil)
 	if err != nil {
 		t.Fatalf("workloadSpecFromActorTemplate failed: %v", err)
 	}
@@ -565,41 +565,51 @@ func TestWorkloadSpecFromActorTemplatePropagatesSecurityContext(t *testing.T) {
 
 func TestToAteletResources(t *testing.T) {
 	tests := []struct {
-		name string
-		in   *atev1alpha1.ContainerResources
-		want *ateletpb.ResourceLimits
+		name    string
+		in      *ateapipb.Resources
+		want    *ateletpb.ResourceLimits
+		wantErr bool
 	}{{
 		name: "nil resources",
 		in:   nil,
 		want: nil,
 	}, {
 		name: "empty limits",
-		in:   &atev1alpha1.ContainerResources{},
+		in:   &ateapipb.Resources{},
 		want: nil,
 	}, {
 		name: "memory only",
-		in: &atev1alpha1.ContainerResources{Limits: atev1alpha1.ContainerResourceList{
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
-		}},
+		in:   &ateapipb.Resources{Limits: []*ateapipb.Limits{{Name: "memory", Quantity: "256Mi"}}},
 		want: &ateletpb.ResourceLimits{MemoryBytes: 268435456},
 	}, {
 		name: "cpu only",
-		in: &atev1alpha1.ContainerResources{Limits: atev1alpha1.ContainerResourceList{
-			corev1.ResourceCPU: resource.MustParse("200m"),
-		}},
+		in:   &ateapipb.Resources{Limits: []*ateapipb.Limits{{Name: "cpu", Quantity: "200m"}}},
 		want: &ateletpb.ResourceLimits{CpuMillis: 200},
 	}, {
 		name: "both",
-		in: &atev1alpha1.ContainerResources{Limits: atev1alpha1.ContainerResourceList{
-			corev1.ResourceMemory: resource.MustParse("1Gi"),
-			corev1.ResourceCPU:    resource.MustParse("1"),
+		in: &ateapipb.Resources{Limits: []*ateapipb.Limits{
+			{Name: "cpu", Quantity: "1"},
+			{Name: "memory", Quantity: "1Gi"},
 		}},
 		want: &ateletpb.ResourceLimits{MemoryBytes: 1073741824, CpuMillis: 1000},
+	}, {
+		name:    "invalid quantity",
+		in:      &ateapipb.Resources{Limits: []*ateapipb.Limits{{Name: "cpu", Quantity: "banana"}}},
+		wantErr: true,
 	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := toAteletResources(tc.in)
+			got, err := toAteletResources(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("toAteletResources() error = nil, want parse error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("toAteletResources() failed: %v", err)
+			}
 			if tc.want == nil {
 				if got != nil {
 					t.Fatalf("toAteletResources() = %v, want nil", got)
@@ -624,7 +634,7 @@ func TestToAteletResources(t *testing.T) {
 // literal leaves every test in the repository green while limits never leave
 // ate-api-server.
 func TestWorkloadSpecFromActorTemplatePropagatesResources(t *testing.T) {
-	got, err := workloadSpecFromActorTemplate(&atev1alpha1.ActorTemplate{
+	got, err := workloadSpecFromActorTemplate(mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "tmpl-limits", Namespace: "agent-ns"},
 		Spec: atev1alpha1.ActorTemplateSpec{
 			SandboxClass: atev1alpha1.SandboxClassMicroVM,
@@ -642,7 +652,7 @@ func TestWorkloadSpecFromActorTemplatePropagatesResources(t *testing.T) {
 				{Name: "unlimited", Image: "main"},
 			},
 		},
-	}, nil)
+	}), nil)
 	if err != nil {
 		t.Fatalf("workloadSpecFromActorTemplate failed: %v", err)
 	}

--- a/cmd/ateapi/internal/controlapi/zz_generated.validation.go
+++ b/cmd/ateapi/internal/controlapi/zz_generated.validation.go
@@ -1621,6 +1621,7 @@ func Validate_Volume(
 		errs = append(errs, fn(fldPath.Child("system_info"), obj.SystemInfo, oldVal, oldObj != nil)...)
 	}
 
+	// field ateapipb.Volume.Image has no validation
 	// field ateapipb.Volume.Type has no validation
 	return errs
 }

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -2156,8 +2156,14 @@ type Container struct {
 	Env  []*EnvVar `protobuf:"bytes,5,rep,name=env,proto3" json:"env,omitempty"`
 	// readyz is an optional HTTP readiness probe; when set the actor is not
 	// ready until the endpoint returns 200.
-	Readyz        *ContainerReadyz `protobuf:"bytes,6,opt,name=readyz,proto3" json:"readyz,omitempty"`
-	VolumeMounts  []*VolumeMount   `protobuf:"bytes,7,rep,name=volume_mounts,json=volumeMounts,proto3" json:"volume_mounts,omitempty"`
+	Readyz       *ContainerReadyz `protobuf:"bytes,6,opt,name=readyz,proto3" json:"readyz,omitempty"`
+	VolumeMounts []*VolumeMount   `protobuf:"bytes,7,rep,name=volume_mounts,json=volumeMounts,proto3" json:"volume_mounts,omitempty"`
+	// security_context adjusts the container's security settings. Unset leaves
+	// the default capability set.
+	SecurityContext *SecurityContext `protobuf:"bytes,8,opt,name=security_context,json=securityContext,proto3" json:"security_context,omitempty"`
+	// resources carries this container's compute limits, enforced inside the
+	// actor's sandbox. Only cpu and memory limits are supported.
+	Resources     *Resources `protobuf:"bytes,9,opt,name=resources,proto3" json:"resources,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2241,6 +2247,122 @@ func (x *Container) GetVolumeMounts() []*VolumeMount {
 	return nil
 }
 
+func (x *Container) GetSecurityContext() *SecurityContext {
+	if x != nil {
+		return x.SecurityContext
+	}
+	return nil
+}
+
+func (x *Container) GetResources() *Resources {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
+// SecurityContext holds security settings for a container's process,
+// modeling a subset of the Kubernetes container securityContext.
+type SecurityContext struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Capabilities  *Capabilities          `protobuf:"bytes,1,opt,name=capabilities,proto3" json:"capabilities,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SecurityContext) Reset() {
+	*x = SecurityContext{}
+	mi := &file_ateapi_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SecurityContext) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SecurityContext) ProtoMessage() {}
+
+func (x *SecurityContext) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SecurityContext.ProtoReflect.Descriptor instead.
+func (*SecurityContext) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *SecurityContext) GetCapabilities() *Capabilities {
+	if x != nil {
+		return x.Capabilities
+	}
+	return nil
+}
+
+// Capabilities adjusts a container's Linux capabilities relative to the
+// default set. Drop applies first, then add, so a capability in both is
+// granted. Capabilities are named without the "CAP_" prefix; "ALL" in drop
+// removes the whole default set.
+type Capabilities struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Add           []string               `protobuf:"bytes,1,rep,name=add,proto3" json:"add,omitempty"`
+	Drop          []string               `protobuf:"bytes,2,rep,name=drop,proto3" json:"drop,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Capabilities) Reset() {
+	*x = Capabilities{}
+	mi := &file_ateapi_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Capabilities) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Capabilities) ProtoMessage() {}
+
+func (x *Capabilities) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Capabilities.ProtoReflect.Descriptor instead.
+func (*Capabilities) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *Capabilities) GetAdd() []string {
+	if x != nil {
+		return x.Add
+	}
+	return nil
+}
+
+func (x *Capabilities) GetDrop() []string {
+	if x != nil {
+		return x.Drop
+	}
+	return nil
+}
+
 // EnvVar supplies one environment variable to a container. Values are not
 // expanded with Kubernetes-style $(VAR) references.
 type EnvVar struct {
@@ -2255,7 +2377,7 @@ type EnvVar struct {
 
 func (x *EnvVar) Reset() {
 	*x = EnvVar{}
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2267,7 +2389,7 @@ func (x *EnvVar) String() string {
 func (*EnvVar) ProtoMessage() {}
 
 func (x *EnvVar) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[22]
+	mi := &file_ateapi_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2280,7 +2402,7 @@ func (x *EnvVar) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvVar.ProtoReflect.Descriptor instead.
 func (*EnvVar) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{22}
+	return file_ateapi_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *EnvVar) GetName() string {
@@ -2311,7 +2433,7 @@ type ContainerReadyz struct {
 
 func (x *ContainerReadyz) Reset() {
 	*x = ContainerReadyz{}
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2323,7 +2445,7 @@ func (x *ContainerReadyz) String() string {
 func (*ContainerReadyz) ProtoMessage() {}
 
 func (x *ContainerReadyz) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[23]
+	mi := &file_ateapi_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2336,7 +2458,7 @@ func (x *ContainerReadyz) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerReadyz.ProtoReflect.Descriptor instead.
 func (*ContainerReadyz) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{23}
+	return file_ateapi_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ContainerReadyz) GetHttpGet() *HTTPGetAction {
@@ -2365,7 +2487,7 @@ type HTTPGetAction struct {
 
 func (x *HTTPGetAction) Reset() {
 	*x = HTTPGetAction{}
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2377,7 +2499,7 @@ func (x *HTTPGetAction) String() string {
 func (*HTTPGetAction) ProtoMessage() {}
 
 func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[24]
+	mi := &file_ateapi_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2390,7 +2512,7 @@ func (x *HTTPGetAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPGetAction.ProtoReflect.Descriptor instead.
 func (*HTTPGetAction) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{24}
+	return file_ateapi_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *HTTPGetAction) GetPath() string {
@@ -2411,14 +2533,15 @@ type Volume struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// name of the volume. Must be a DNS label.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Exactly one of durable_dir / external_volume_template / system_info
-	// must be set.
+	// Exactly one of durable_dir / external_volume_template / image /
+	// system_info must be set.
 	DurableDir             *DurableDirVolumeSource `protobuf:"bytes,2,opt,name=durable_dir,json=durableDir,proto3" json:"durable_dir,omitempty"`
 	ExternalVolumeTemplate *ExternalVolumeTemplate `protobuf:"bytes,3,opt,name=external_volume_template,json=externalVolumeTemplate,proto3" json:"external_volume_template,omitempty"`
 	// +k8s:optional
 	SystemInfo *SystemInfoVolumeSource `protobuf:"bytes,5,opt,name=system_info,json=systemInfo,proto3" json:"system_info,omitempty"`
+	Image      *ImageVolumeSource      `protobuf:"bytes,6,opt,name=image,proto3" json:"image,omitempty"`
 	// type discriminates the source union: "DurableDir",
-	// "ExternalVolumeTemplate" or "SystemInfo".
+	// "ExternalVolumeTemplate", "Image" or "SystemInfo".
 	Type          string `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2426,7 +2549,7 @@ type Volume struct {
 
 func (x *Volume) Reset() {
 	*x = Volume{}
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2438,7 +2561,7 @@ func (x *Volume) String() string {
 func (*Volume) ProtoMessage() {}
 
 func (x *Volume) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[25]
+	mi := &file_ateapi_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2451,7 +2574,7 @@ func (x *Volume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Volume.ProtoReflect.Descriptor instead.
 func (*Volume) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{25}
+	return file_ateapi_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Volume) GetName() string {
@@ -2482,9 +2605,63 @@ func (x *Volume) GetSystemInfo() *SystemInfoVolumeSource {
 	return nil
 }
 
+func (x *Volume) GetImage() *ImageVolumeSource {
+	if x != nil {
+		return x.Image
+	}
+	return nil
+}
+
 func (x *Volume) GetType() string {
 	if x != nil {
 		return x.Type
+	}
+	return ""
+}
+
+// ImageVolumeSource mounts the contents of an OCI image, read-only. The
+// reference must be pinned by digest: changing the image invalidates
+// snapshots.
+type ImageVolumeSource struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Reference     string                 `protobuf:"bytes,1,opt,name=reference,proto3" json:"reference,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ImageVolumeSource) Reset() {
+	*x = ImageVolumeSource{}
+	mi := &file_ateapi_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ImageVolumeSource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ImageVolumeSource) ProtoMessage() {}
+
+func (x *ImageVolumeSource) ProtoReflect() protoreflect.Message {
+	mi := &file_ateapi_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ImageVolumeSource.ProtoReflect.Descriptor instead.
+func (*ImageVolumeSource) Descriptor() ([]byte, []int) {
+	return file_ateapi_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *ImageVolumeSource) GetReference() string {
+	if x != nil {
+		return x.Reference
 	}
 	return ""
 }
@@ -2499,7 +2676,7 @@ type DurableDirVolumeSource struct {
 
 func (x *DurableDirVolumeSource) Reset() {
 	*x = DurableDirVolumeSource{}
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2511,7 +2688,7 @@ func (x *DurableDirVolumeSource) String() string {
 func (*DurableDirVolumeSource) ProtoMessage() {}
 
 func (x *DurableDirVolumeSource) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[26]
+	mi := &file_ateapi_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2524,7 +2701,7 @@ func (x *DurableDirVolumeSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DurableDirVolumeSource.ProtoReflect.Descriptor instead.
 func (*DurableDirVolumeSource) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{26}
+	return file_ateapi_proto_rawDescGZIP(), []int{29}
 }
 
 // ExternalVolumeTemplate provisions an external volume per actor; the volume
@@ -2543,7 +2720,7 @@ type ExternalVolumeTemplate struct {
 
 func (x *ExternalVolumeTemplate) Reset() {
 	*x = ExternalVolumeTemplate{}
-	mi := &file_ateapi_proto_msgTypes[27]
+	mi := &file_ateapi_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2555,7 +2732,7 @@ func (x *ExternalVolumeTemplate) String() string {
 func (*ExternalVolumeTemplate) ProtoMessage() {}
 
 func (x *ExternalVolumeTemplate) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[27]
+	mi := &file_ateapi_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2568,7 +2745,7 @@ func (x *ExternalVolumeTemplate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExternalVolumeTemplate.ProtoReflect.Descriptor instead.
 func (*ExternalVolumeTemplate) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{27}
+	return file_ateapi_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ExternalVolumeTemplate) GetCapacity() string {
@@ -2603,7 +2780,7 @@ type SystemInfoVolumeSource struct {
 
 func (x *SystemInfoVolumeSource) Reset() {
 	*x = SystemInfoVolumeSource{}
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2615,7 +2792,7 @@ func (x *SystemInfoVolumeSource) String() string {
 func (*SystemInfoVolumeSource) ProtoMessage() {}
 
 func (x *SystemInfoVolumeSource) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[28]
+	mi := &file_ateapi_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2628,7 +2805,7 @@ func (x *SystemInfoVolumeSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemInfoVolumeSource.ProtoReflect.Descriptor instead.
 func (*SystemInfoVolumeSource) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{28}
+	return file_ateapi_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *SystemInfoVolumeSource) GetDataSources() []*SystemInfoDataSource {
@@ -2654,7 +2831,7 @@ type SystemInfoDataSource struct {
 
 func (x *SystemInfoDataSource) Reset() {
 	*x = SystemInfoDataSource{}
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2666,7 +2843,7 @@ func (x *SystemInfoDataSource) String() string {
 func (*SystemInfoDataSource) ProtoMessage() {}
 
 func (x *SystemInfoDataSource) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[29]
+	mi := &file_ateapi_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2679,7 +2856,7 @@ func (x *SystemInfoDataSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemInfoDataSource.ProtoReflect.Descriptor instead.
 func (*SystemInfoDataSource) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{29}
+	return file_ateapi_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SystemInfoDataSource) GetActorMetadata() *ActorMetadataDataSource {
@@ -2716,7 +2893,7 @@ type ActorMetadataDataSource struct {
 
 func (x *ActorMetadataDataSource) Reset() {
 	*x = ActorMetadataDataSource{}
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2728,7 +2905,7 @@ func (x *ActorMetadataDataSource) String() string {
 func (*ActorMetadataDataSource) ProtoMessage() {}
 
 func (x *ActorMetadataDataSource) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[30]
+	mi := &file_ateapi_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2741,7 +2918,7 @@ func (x *ActorMetadataDataSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActorMetadataDataSource.ProtoReflect.Descriptor instead.
 func (*ActorMetadataDataSource) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{30}
+	return file_ateapi_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ActorMetadataDataSource) GetItems() []*ActorMetadataItem {
@@ -2767,7 +2944,7 @@ type ActorMetadataItem struct {
 
 func (x *ActorMetadataItem) Reset() {
 	*x = ActorMetadataItem{}
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2779,7 +2956,7 @@ func (x *ActorMetadataItem) String() string {
 func (*ActorMetadataItem) ProtoMessage() {}
 
 func (x *ActorMetadataItem) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[31]
+	mi := &file_ateapi_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2792,7 +2969,7 @@ func (x *ActorMetadataItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActorMetadataItem.ProtoReflect.Descriptor instead.
 func (*ActorMetadataItem) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{31}
+	return file_ateapi_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ActorMetadataItem) GetField() ActorMetadataField {
@@ -2827,7 +3004,7 @@ type TrustBundleDataSource struct {
 
 func (x *TrustBundleDataSource) Reset() {
 	*x = TrustBundleDataSource{}
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2839,7 +3016,7 @@ func (x *TrustBundleDataSource) String() string {
 func (*TrustBundleDataSource) ProtoMessage() {}
 
 func (x *TrustBundleDataSource) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[32]
+	mi := &file_ateapi_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2852,7 +3029,7 @@ func (x *TrustBundleDataSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TrustBundleDataSource.ProtoReflect.Descriptor instead.
 func (*TrustBundleDataSource) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{32}
+	return file_ateapi_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *TrustBundleDataSource) GetName() string {
@@ -2882,7 +3059,7 @@ type VolumeMount struct {
 
 func (x *VolumeMount) Reset() {
 	*x = VolumeMount{}
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2894,7 +3071,7 @@ func (x *VolumeMount) String() string {
 func (*VolumeMount) ProtoMessage() {}
 
 func (x *VolumeMount) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[33]
+	mi := &file_ateapi_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2907,7 +3084,7 @@ func (x *VolumeMount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeMount.ProtoReflect.Descriptor instead.
 func (*VolumeMount) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{33}
+	return file_ateapi_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *VolumeMount) GetName() string {
@@ -2941,7 +3118,7 @@ type SandboxAssets struct {
 
 func (x *SandboxAssets) Reset() {
 	*x = SandboxAssets{}
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2953,7 +3130,7 @@ func (x *SandboxAssets) String() string {
 func (*SandboxAssets) ProtoMessage() {}
 
 func (x *SandboxAssets) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[34]
+	mi := &file_ateapi_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2966,7 +3143,7 @@ func (x *SandboxAssets) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxAssets.ProtoReflect.Descriptor instead.
 func (*SandboxAssets) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{34}
+	return file_ateapi_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *SandboxAssets) GetSandboxClass() SandboxClass {
@@ -3000,7 +3177,7 @@ type ArchAssets struct {
 
 func (x *ArchAssets) Reset() {
 	*x = ArchAssets{}
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3012,7 +3189,7 @@ func (x *ArchAssets) String() string {
 func (*ArchAssets) ProtoMessage() {}
 
 func (x *ArchAssets) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[35]
+	mi := &file_ateapi_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3025,7 +3202,7 @@ func (x *ArchAssets) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchAssets.ProtoReflect.Descriptor instead.
 func (*ArchAssets) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{35}
+	return file_ateapi_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ArchAssets) GetFiles() map[string]*AssetFile {
@@ -3049,7 +3226,7 @@ type AssetFile struct {
 
 func (x *AssetFile) Reset() {
 	*x = AssetFile{}
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3061,7 +3238,7 @@ func (x *AssetFile) String() string {
 func (*AssetFile) ProtoMessage() {}
 
 func (x *AssetFile) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[36]
+	mi := &file_ateapi_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3074,7 +3251,7 @@ func (x *AssetFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetFile.ProtoReflect.Descriptor instead.
 func (*AssetFile) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{36}
+	return file_ateapi_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *AssetFile) GetUrl() string {
@@ -3103,7 +3280,7 @@ type CreateAtespaceRequest struct {
 
 func (x *CreateAtespaceRequest) Reset() {
 	*x = CreateAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3115,7 +3292,7 @@ func (x *CreateAtespaceRequest) String() string {
 func (*CreateAtespaceRequest) ProtoMessage() {}
 
 func (x *CreateAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[37]
+	mi := &file_ateapi_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3128,7 +3305,7 @@ func (x *CreateAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*CreateAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{37}
+	return file_ateapi_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *CreateAtespaceRequest) GetAtespace() *Atespace {
@@ -3149,7 +3326,7 @@ type GetAtespaceRequest struct {
 
 func (x *GetAtespaceRequest) Reset() {
 	*x = GetAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3161,7 +3338,7 @@ func (x *GetAtespaceRequest) String() string {
 func (*GetAtespaceRequest) ProtoMessage() {}
 
 func (x *GetAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[38]
+	mi := &file_ateapi_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3174,7 +3351,7 @@ func (x *GetAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*GetAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{38}
+	return file_ateapi_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetAtespaceRequest) GetAtespace() *ObjectRef {
@@ -3205,7 +3382,7 @@ type ListAtespacesRequest struct {
 
 func (x *ListAtespacesRequest) Reset() {
 	*x = ListAtespacesRequest{}
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3217,7 +3394,7 @@ func (x *ListAtespacesRequest) String() string {
 func (*ListAtespacesRequest) ProtoMessage() {}
 
 func (x *ListAtespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[39]
+	mi := &file_ateapi_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3230,7 +3407,7 @@ func (x *ListAtespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAtespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListAtespacesRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{39}
+	return file_ateapi_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ListAtespacesRequest) GetPageSize() int32 {
@@ -3259,7 +3436,7 @@ type ListAtespacesResponse struct {
 
 func (x *ListAtespacesResponse) Reset() {
 	*x = ListAtespacesResponse{}
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3271,7 +3448,7 @@ func (x *ListAtespacesResponse) String() string {
 func (*ListAtespacesResponse) ProtoMessage() {}
 
 func (x *ListAtespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[40]
+	mi := &file_ateapi_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3284,7 +3461,7 @@ func (x *ListAtespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAtespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListAtespacesResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{40}
+	return file_ateapi_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ListAtespacesResponse) GetAtespaces() []*Atespace {
@@ -3312,7 +3489,7 @@ type DeleteAtespaceRequest struct {
 
 func (x *DeleteAtespaceRequest) Reset() {
 	*x = DeleteAtespaceRequest{}
-	mi := &file_ateapi_proto_msgTypes[41]
+	mi := &file_ateapi_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3324,7 +3501,7 @@ func (x *DeleteAtespaceRequest) String() string {
 func (*DeleteAtespaceRequest) ProtoMessage() {}
 
 func (x *DeleteAtespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[41]
+	mi := &file_ateapi_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3337,7 +3514,7 @@ func (x *DeleteAtespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAtespaceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAtespaceRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{41}
+	return file_ateapi_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *DeleteAtespaceRequest) GetAtespace() *ObjectRef {
@@ -3360,7 +3537,7 @@ type CreateActorTemplateRequest struct {
 
 func (x *CreateActorTemplateRequest) Reset() {
 	*x = CreateActorTemplateRequest{}
-	mi := &file_ateapi_proto_msgTypes[42]
+	mi := &file_ateapi_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3372,7 +3549,7 @@ func (x *CreateActorTemplateRequest) String() string {
 func (*CreateActorTemplateRequest) ProtoMessage() {}
 
 func (x *CreateActorTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[42]
+	mi := &file_ateapi_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3385,7 +3562,7 @@ func (x *CreateActorTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateActorTemplateRequest.ProtoReflect.Descriptor instead.
 func (*CreateActorTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{42}
+	return file_ateapi_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *CreateActorTemplateRequest) GetActorTemplate() *ActorTemplate {
@@ -3405,7 +3582,7 @@ type GetActorTemplateRequest struct {
 
 func (x *GetActorTemplateRequest) Reset() {
 	*x = GetActorTemplateRequest{}
-	mi := &file_ateapi_proto_msgTypes[43]
+	mi := &file_ateapi_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3417,7 +3594,7 @@ func (x *GetActorTemplateRequest) String() string {
 func (*GetActorTemplateRequest) ProtoMessage() {}
 
 func (x *GetActorTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[43]
+	mi := &file_ateapi_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3430,7 +3607,7 @@ func (x *GetActorTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorTemplateRequest.ProtoReflect.Descriptor instead.
 func (*GetActorTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{43}
+	return file_ateapi_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GetActorTemplateRequest) GetActorTemplate() *ObjectRef {
@@ -3458,7 +3635,7 @@ type ListActorTemplatesRequest struct {
 
 func (x *ListActorTemplatesRequest) Reset() {
 	*x = ListActorTemplatesRequest{}
-	mi := &file_ateapi_proto_msgTypes[44]
+	mi := &file_ateapi_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3470,7 +3647,7 @@ func (x *ListActorTemplatesRequest) String() string {
 func (*ListActorTemplatesRequest) ProtoMessage() {}
 
 func (x *ListActorTemplatesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[44]
+	mi := &file_ateapi_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3483,7 +3660,7 @@ func (x *ListActorTemplatesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorTemplatesRequest.ProtoReflect.Descriptor instead.
 func (*ListActorTemplatesRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{44}
+	return file_ateapi_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ListActorTemplatesRequest) GetAtespace() string {
@@ -3520,7 +3697,7 @@ type ListActorTemplatesResponse struct {
 
 func (x *ListActorTemplatesResponse) Reset() {
 	*x = ListActorTemplatesResponse{}
-	mi := &file_ateapi_proto_msgTypes[45]
+	mi := &file_ateapi_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3532,7 +3709,7 @@ func (x *ListActorTemplatesResponse) String() string {
 func (*ListActorTemplatesResponse) ProtoMessage() {}
 
 func (x *ListActorTemplatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[45]
+	mi := &file_ateapi_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3545,7 +3722,7 @@ func (x *ListActorTemplatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorTemplatesResponse.ProtoReflect.Descriptor instead.
 func (*ListActorTemplatesResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{45}
+	return file_ateapi_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ListActorTemplatesResponse) GetActorTemplates() []*ActorTemplate {
@@ -3572,7 +3749,7 @@ type DeleteActorTemplateRequest struct {
 
 func (x *DeleteActorTemplateRequest) Reset() {
 	*x = DeleteActorTemplateRequest{}
-	mi := &file_ateapi_proto_msgTypes[46]
+	mi := &file_ateapi_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3584,7 +3761,7 @@ func (x *DeleteActorTemplateRequest) String() string {
 func (*DeleteActorTemplateRequest) ProtoMessage() {}
 
 func (x *DeleteActorTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[46]
+	mi := &file_ateapi_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3597,7 +3774,7 @@ func (x *DeleteActorTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorTemplateRequest.ProtoReflect.Descriptor instead.
 func (*DeleteActorTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{46}
+	return file_ateapi_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *DeleteActorTemplateRequest) GetActorTemplate() *ObjectRef {
@@ -3617,7 +3794,7 @@ type GetActorRequest struct {
 
 func (x *GetActorRequest) Reset() {
 	*x = GetActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[47]
+	mi := &file_ateapi_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3629,7 +3806,7 @@ func (x *GetActorRequest) String() string {
 func (*GetActorRequest) ProtoMessage() {}
 
 func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[47]
+	mi := &file_ateapi_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3642,7 +3819,7 @@ func (x *GetActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorRequest.ProtoReflect.Descriptor instead.
 func (*GetActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{47}
+	return file_ateapi_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *GetActorRequest) GetActor() *ObjectRef {
@@ -3665,7 +3842,7 @@ type CreateActorRequest struct {
 
 func (x *CreateActorRequest) Reset() {
 	*x = CreateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[48]
+	mi := &file_ateapi_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3677,7 +3854,7 @@ func (x *CreateActorRequest) String() string {
 func (*CreateActorRequest) ProtoMessage() {}
 
 func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[48]
+	mi := &file_ateapi_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3690,7 +3867,7 @@ func (x *CreateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateActorRequest.ProtoReflect.Descriptor instead.
 func (*CreateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{48}
+	return file_ateapi_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *CreateActorRequest) GetActor() *Actor {
@@ -3721,7 +3898,7 @@ type UpdateActorRequest struct {
 
 func (x *UpdateActorRequest) Reset() {
 	*x = UpdateActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[49]
+	mi := &file_ateapi_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3733,7 +3910,7 @@ func (x *UpdateActorRequest) String() string {
 func (*UpdateActorRequest) ProtoMessage() {}
 
 func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[49]
+	mi := &file_ateapi_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3746,7 +3923,7 @@ func (x *UpdateActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorRequest.ProtoReflect.Descriptor instead.
 func (*UpdateActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{49}
+	return file_ateapi_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *UpdateActorRequest) GetActor() *Actor {
@@ -3766,7 +3943,7 @@ type SuspendActorRequest struct {
 
 func (x *SuspendActorRequest) Reset() {
 	*x = SuspendActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[50]
+	mi := &file_ateapi_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3778,7 +3955,7 @@ func (x *SuspendActorRequest) String() string {
 func (*SuspendActorRequest) ProtoMessage() {}
 
 func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[50]
+	mi := &file_ateapi_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3791,7 +3968,7 @@ func (x *SuspendActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorRequest.ProtoReflect.Descriptor instead.
 func (*SuspendActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{50}
+	return file_ateapi_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *SuspendActorRequest) GetActor() *ObjectRef {
@@ -3810,7 +3987,7 @@ type SuspendActorResponse struct {
 
 func (x *SuspendActorResponse) Reset() {
 	*x = SuspendActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[51]
+	mi := &file_ateapi_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3822,7 +3999,7 @@ func (x *SuspendActorResponse) String() string {
 func (*SuspendActorResponse) ProtoMessage() {}
 
 func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[51]
+	mi := &file_ateapi_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3835,7 +4012,7 @@ func (x *SuspendActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuspendActorResponse.ProtoReflect.Descriptor instead.
 func (*SuspendActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{51}
+	return file_ateapi_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *SuspendActorResponse) GetActor() *Actor {
@@ -3855,7 +4032,7 @@ type PauseActorRequest struct {
 
 func (x *PauseActorRequest) Reset() {
 	*x = PauseActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[52]
+	mi := &file_ateapi_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3867,7 +4044,7 @@ func (x *PauseActorRequest) String() string {
 func (*PauseActorRequest) ProtoMessage() {}
 
 func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[52]
+	mi := &file_ateapi_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3880,7 +4057,7 @@ func (x *PauseActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorRequest.ProtoReflect.Descriptor instead.
 func (*PauseActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{52}
+	return file_ateapi_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *PauseActorRequest) GetActor() *ObjectRef {
@@ -3899,7 +4076,7 @@ type PauseActorResponse struct {
 
 func (x *PauseActorResponse) Reset() {
 	*x = PauseActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[53]
+	mi := &file_ateapi_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3911,7 +4088,7 @@ func (x *PauseActorResponse) String() string {
 func (*PauseActorResponse) ProtoMessage() {}
 
 func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[53]
+	mi := &file_ateapi_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3924,7 +4101,7 @@ func (x *PauseActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseActorResponse.ProtoReflect.Descriptor instead.
 func (*PauseActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{53}
+	return file_ateapi_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *PauseActorResponse) GetActor() *Actor {
@@ -3946,7 +4123,7 @@ type ResumeActorRequest struct {
 
 func (x *ResumeActorRequest) Reset() {
 	*x = ResumeActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[54]
+	mi := &file_ateapi_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3958,7 +4135,7 @@ func (x *ResumeActorRequest) String() string {
 func (*ResumeActorRequest) ProtoMessage() {}
 
 func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[54]
+	mi := &file_ateapi_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3971,7 +4148,7 @@ func (x *ResumeActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorRequest.ProtoReflect.Descriptor instead.
 func (*ResumeActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{54}
+	return file_ateapi_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ResumeActorRequest) GetActor() *ObjectRef {
@@ -4000,7 +4177,7 @@ type ResumeActorResponse struct {
 
 func (x *ResumeActorResponse) Reset() {
 	*x = ResumeActorResponse{}
-	mi := &file_ateapi_proto_msgTypes[55]
+	mi := &file_ateapi_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4012,7 +4189,7 @@ func (x *ResumeActorResponse) String() string {
 func (*ResumeActorResponse) ProtoMessage() {}
 
 func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[55]
+	mi := &file_ateapi_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4025,7 +4202,7 @@ func (x *ResumeActorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeActorResponse.ProtoReflect.Descriptor instead.
 func (*ResumeActorResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{55}
+	return file_ateapi_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ResumeActorResponse) GetActor() *Actor {
@@ -4053,7 +4230,7 @@ type DeleteActorRequest struct {
 
 func (x *DeleteActorRequest) Reset() {
 	*x = DeleteActorRequest{}
-	mi := &file_ateapi_proto_msgTypes[56]
+	mi := &file_ateapi_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4065,7 +4242,7 @@ func (x *DeleteActorRequest) String() string {
 func (*DeleteActorRequest) ProtoMessage() {}
 
 func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[56]
+	mi := &file_ateapi_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4078,7 +4255,7 @@ func (x *DeleteActorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorRequest.ProtoReflect.Descriptor instead.
 func (*DeleteActorRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{56}
+	return file_ateapi_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *DeleteActorRequest) GetActor() *ObjectRef {
@@ -4105,7 +4282,7 @@ type GetActorSnapshotRequest struct {
 
 func (x *GetActorSnapshotRequest) Reset() {
 	*x = GetActorSnapshotRequest{}
-	mi := &file_ateapi_proto_msgTypes[57]
+	mi := &file_ateapi_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4117,7 +4294,7 @@ func (x *GetActorSnapshotRequest) String() string {
 func (*GetActorSnapshotRequest) ProtoMessage() {}
 
 func (x *GetActorSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[57]
+	mi := &file_ateapi_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4130,7 +4307,7 @@ func (x *GetActorSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*GetActorSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{57}
+	return file_ateapi_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *GetActorSnapshotRequest) GetActorSnapshot() *ObjectRef {
@@ -4150,7 +4327,7 @@ type GetActorSnapshotTagRequest struct {
 
 func (x *GetActorSnapshotTagRequest) Reset() {
 	*x = GetActorSnapshotTagRequest{}
-	mi := &file_ateapi_proto_msgTypes[58]
+	mi := &file_ateapi_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4162,7 +4339,7 @@ func (x *GetActorSnapshotTagRequest) String() string {
 func (*GetActorSnapshotTagRequest) ProtoMessage() {}
 
 func (x *GetActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[58]
+	mi := &file_ateapi_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4175,7 +4352,7 @@ func (x *GetActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetActorSnapshotTagRequest.ProtoReflect.Descriptor instead.
 func (*GetActorSnapshotTagRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{58}
+	return file_ateapi_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *GetActorSnapshotTagRequest) GetActorSnapshotTag() *ObjectRef {
@@ -4196,7 +4373,7 @@ type ListActorSnapshotsRequest struct {
 
 func (x *ListActorSnapshotsRequest) Reset() {
 	*x = ListActorSnapshotsRequest{}
-	mi := &file_ateapi_proto_msgTypes[59]
+	mi := &file_ateapi_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4208,7 +4385,7 @@ func (x *ListActorSnapshotsRequest) String() string {
 func (*ListActorSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListActorSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[59]
+	mi := &file_ateapi_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4221,7 +4398,7 @@ func (x *ListActorSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListActorSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{59}
+	return file_ateapi_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ListActorSnapshotsRequest) GetAtespace() string {
@@ -4255,7 +4432,7 @@ type ListActorSnapshotsResponse struct {
 
 func (x *ListActorSnapshotsResponse) Reset() {
 	*x = ListActorSnapshotsResponse{}
-	mi := &file_ateapi_proto_msgTypes[60]
+	mi := &file_ateapi_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4267,7 +4444,7 @@ func (x *ListActorSnapshotsResponse) String() string {
 func (*ListActorSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListActorSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[60]
+	mi := &file_ateapi_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4280,7 +4457,7 @@ func (x *ListActorSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListActorSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{60}
+	return file_ateapi_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListActorSnapshotsResponse) GetActorSnapshots() []*ActorSnapshot {
@@ -4307,7 +4484,7 @@ type CreateActorSnapshotTagRequest struct {
 
 func (x *CreateActorSnapshotTagRequest) Reset() {
 	*x = CreateActorSnapshotTagRequest{}
-	mi := &file_ateapi_proto_msgTypes[61]
+	mi := &file_ateapi_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4319,7 +4496,7 @@ func (x *CreateActorSnapshotTagRequest) String() string {
 func (*CreateActorSnapshotTagRequest) ProtoMessage() {}
 
 func (x *CreateActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[61]
+	mi := &file_ateapi_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4332,7 +4509,7 @@ func (x *CreateActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateActorSnapshotTagRequest.ProtoReflect.Descriptor instead.
 func (*CreateActorSnapshotTagRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{61}
+	return file_ateapi_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *CreateActorSnapshotTagRequest) GetActorSnapshotTag() *ActorSnapshotTag {
@@ -4358,7 +4535,7 @@ type UpdateActorSnapshotTagRequest struct {
 
 func (x *UpdateActorSnapshotTagRequest) Reset() {
 	*x = UpdateActorSnapshotTagRequest{}
-	mi := &file_ateapi_proto_msgTypes[62]
+	mi := &file_ateapi_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4370,7 +4547,7 @@ func (x *UpdateActorSnapshotTagRequest) String() string {
 func (*UpdateActorSnapshotTagRequest) ProtoMessage() {}
 
 func (x *UpdateActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[62]
+	mi := &file_ateapi_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4383,7 +4560,7 @@ func (x *UpdateActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateActorSnapshotTagRequest.ProtoReflect.Descriptor instead.
 func (*UpdateActorSnapshotTagRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{62}
+	return file_ateapi_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *UpdateActorSnapshotTagRequest) GetActorSnapshotTag() *ActorSnapshotTag {
@@ -4403,7 +4580,7 @@ type DeleteActorSnapshotTagRequest struct {
 
 func (x *DeleteActorSnapshotTagRequest) Reset() {
 	*x = DeleteActorSnapshotTagRequest{}
-	mi := &file_ateapi_proto_msgTypes[63]
+	mi := &file_ateapi_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4415,7 +4592,7 @@ func (x *DeleteActorSnapshotTagRequest) String() string {
 func (*DeleteActorSnapshotTagRequest) ProtoMessage() {}
 
 func (x *DeleteActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[63]
+	mi := &file_ateapi_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4428,7 +4605,7 @@ func (x *DeleteActorSnapshotTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteActorSnapshotTagRequest.ProtoReflect.Descriptor instead.
 func (*DeleteActorSnapshotTagRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{63}
+	return file_ateapi_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *DeleteActorSnapshotTagRequest) GetActorSnapshotTag() *ObjectRef {
@@ -4458,7 +4635,7 @@ type DeleteOptions struct {
 
 func (x *DeleteOptions) Reset() {
 	*x = DeleteOptions{}
-	mi := &file_ateapi_proto_msgTypes[64]
+	mi := &file_ateapi_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4470,7 +4647,7 @@ func (x *DeleteOptions) String() string {
 func (*DeleteOptions) ProtoMessage() {}
 
 func (x *DeleteOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[64]
+	mi := &file_ateapi_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4483,7 +4660,7 @@ func (x *DeleteOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteOptions.ProtoReflect.Descriptor instead.
 func (*DeleteOptions) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{64}
+	return file_ateapi_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *DeleteOptions) GetVersion() int64 {
@@ -4515,7 +4692,7 @@ type ListWorkersRequest struct {
 
 func (x *ListWorkersRequest) Reset() {
 	*x = ListWorkersRequest{}
-	mi := &file_ateapi_proto_msgTypes[65]
+	mi := &file_ateapi_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4527,7 +4704,7 @@ func (x *ListWorkersRequest) String() string {
 func (*ListWorkersRequest) ProtoMessage() {}
 
 func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[65]
+	mi := &file_ateapi_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4540,7 +4717,7 @@ func (x *ListWorkersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkersRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{65}
+	return file_ateapi_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ListWorkersRequest) GetPageSize() int32 {
@@ -4569,7 +4746,7 @@ type ListWorkersResponse struct {
 
 func (x *ListWorkersResponse) Reset() {
 	*x = ListWorkersResponse{}
-	mi := &file_ateapi_proto_msgTypes[66]
+	mi := &file_ateapi_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4581,7 +4758,7 @@ func (x *ListWorkersResponse) String() string {
 func (*ListWorkersResponse) ProtoMessage() {}
 
 func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[66]
+	mi := &file_ateapi_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4594,7 +4771,7 @@ func (x *ListWorkersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkersResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkersResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{66}
+	return file_ateapi_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *ListWorkersResponse) GetWorkers() []*Worker {
@@ -4622,7 +4799,7 @@ type GetWorkerRequest struct {
 
 func (x *GetWorkerRequest) Reset() {
 	*x = GetWorkerRequest{}
-	mi := &file_ateapi_proto_msgTypes[67]
+	mi := &file_ateapi_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4634,7 +4811,7 @@ func (x *GetWorkerRequest) String() string {
 func (*GetWorkerRequest) ProtoMessage() {}
 
 func (x *GetWorkerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[67]
+	mi := &file_ateapi_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4647,7 +4824,7 @@ func (x *GetWorkerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkerRequest.ProtoReflect.Descriptor instead.
 func (*GetWorkerRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{67}
+	return file_ateapi_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *GetWorkerRequest) GetWorker() *ObjectRef {
@@ -4667,7 +4844,7 @@ type CreateWorkerRequest struct {
 
 func (x *CreateWorkerRequest) Reset() {
 	*x = CreateWorkerRequest{}
-	mi := &file_ateapi_proto_msgTypes[68]
+	mi := &file_ateapi_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4679,7 +4856,7 @@ func (x *CreateWorkerRequest) String() string {
 func (*CreateWorkerRequest) ProtoMessage() {}
 
 func (x *CreateWorkerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[68]
+	mi := &file_ateapi_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4692,7 +4869,7 @@ func (x *CreateWorkerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkerRequest.ProtoReflect.Descriptor instead.
 func (*CreateWorkerRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{68}
+	return file_ateapi_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *CreateWorkerRequest) GetWorker() *Worker {
@@ -4722,7 +4899,7 @@ type UpdateWorkerRequest struct {
 
 func (x *UpdateWorkerRequest) Reset() {
 	*x = UpdateWorkerRequest{}
-	mi := &file_ateapi_proto_msgTypes[69]
+	mi := &file_ateapi_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4734,7 +4911,7 @@ func (x *UpdateWorkerRequest) String() string {
 func (*UpdateWorkerRequest) ProtoMessage() {}
 
 func (x *UpdateWorkerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[69]
+	mi := &file_ateapi_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4747,7 +4924,7 @@ func (x *UpdateWorkerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateWorkerRequest.ProtoReflect.Descriptor instead.
 func (*UpdateWorkerRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{69}
+	return file_ateapi_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *UpdateWorkerRequest) GetWorker() *Worker {
@@ -4770,7 +4947,7 @@ type DeleteWorkerRequest struct {
 
 func (x *DeleteWorkerRequest) Reset() {
 	*x = DeleteWorkerRequest{}
-	mi := &file_ateapi_proto_msgTypes[70]
+	mi := &file_ateapi_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4782,7 +4959,7 @@ func (x *DeleteWorkerRequest) String() string {
 func (*DeleteWorkerRequest) ProtoMessage() {}
 
 func (x *DeleteWorkerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[70]
+	mi := &file_ateapi_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4795,7 +4972,7 @@ func (x *DeleteWorkerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkerRequest.ProtoReflect.Descriptor instead.
 func (*DeleteWorkerRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{70}
+	return file_ateapi_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *DeleteWorkerRequest) GetWorker() *ObjectRef {
@@ -4823,7 +5000,7 @@ type DrainWorkerRequest struct {
 
 func (x *DrainWorkerRequest) Reset() {
 	*x = DrainWorkerRequest{}
-	mi := &file_ateapi_proto_msgTypes[71]
+	mi := &file_ateapi_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4835,7 +5012,7 @@ func (x *DrainWorkerRequest) String() string {
 func (*DrainWorkerRequest) ProtoMessage() {}
 
 func (x *DrainWorkerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[71]
+	mi := &file_ateapi_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4848,7 +5025,7 @@ func (x *DrainWorkerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DrainWorkerRequest.ProtoReflect.Descriptor instead.
 func (*DrainWorkerRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{71}
+	return file_ateapi_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *DrainWorkerRequest) GetWorker() *ObjectRef {
@@ -4877,7 +5054,7 @@ type ListActorsRequest struct {
 
 func (x *ListActorsRequest) Reset() {
 	*x = ListActorsRequest{}
-	mi := &file_ateapi_proto_msgTypes[72]
+	mi := &file_ateapi_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4889,7 +5066,7 @@ func (x *ListActorsRequest) String() string {
 func (*ListActorsRequest) ProtoMessage() {}
 
 func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[72]
+	mi := &file_ateapi_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4902,7 +5079,7 @@ func (x *ListActorsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsRequest.ProtoReflect.Descriptor instead.
 func (*ListActorsRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{72}
+	return file_ateapi_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *ListActorsRequest) GetAtespace() string {
@@ -4938,7 +5115,7 @@ type ListActorsResponse struct {
 
 func (x *ListActorsResponse) Reset() {
 	*x = ListActorsResponse{}
-	mi := &file_ateapi_proto_msgTypes[73]
+	mi := &file_ateapi_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4950,7 +5127,7 @@ func (x *ListActorsResponse) String() string {
 func (*ListActorsResponse) ProtoMessage() {}
 
 func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[73]
+	mi := &file_ateapi_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4963,7 +5140,7 @@ func (x *ListActorsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListActorsResponse.ProtoReflect.Descriptor instead.
 func (*ListActorsResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{73}
+	return file_ateapi_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *ListActorsResponse) GetActors() []*Actor {
@@ -5019,7 +5196,7 @@ type Worker struct {
 
 func (x *Worker) Reset() {
 	*x = Worker{}
-	mi := &file_ateapi_proto_msgTypes[74]
+	mi := &file_ateapi_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5031,7 +5208,7 @@ func (x *Worker) String() string {
 func (*Worker) ProtoMessage() {}
 
 func (x *Worker) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[74]
+	mi := &file_ateapi_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5044,7 +5221,7 @@ func (x *Worker) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Worker.ProtoReflect.Descriptor instead.
 func (*Worker) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{74}
+	return file_ateapi_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *Worker) GetMetadata() *ResourceMetadata {
@@ -5135,7 +5312,7 @@ type WorkerStatus struct {
 
 func (x *WorkerStatus) Reset() {
 	*x = WorkerStatus{}
-	mi := &file_ateapi_proto_msgTypes[75]
+	mi := &file_ateapi_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5147,7 +5324,7 @@ func (x *WorkerStatus) String() string {
 func (*WorkerStatus) ProtoMessage() {}
 
 func (x *WorkerStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[75]
+	mi := &file_ateapi_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5160,7 +5337,7 @@ func (x *WorkerStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkerStatus.ProtoReflect.Descriptor instead.
 func (*WorkerStatus) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{75}
+	return file_ateapi_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *WorkerStatus) GetState() WorkerState {
@@ -5193,7 +5370,7 @@ type WorkerCapacity struct {
 
 func (x *WorkerCapacity) Reset() {
 	*x = WorkerCapacity{}
-	mi := &file_ateapi_proto_msgTypes[76]
+	mi := &file_ateapi_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5205,7 +5382,7 @@ func (x *WorkerCapacity) String() string {
 func (*WorkerCapacity) ProtoMessage() {}
 
 func (x *WorkerCapacity) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[76]
+	mi := &file_ateapi_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5218,7 +5395,7 @@ func (x *WorkerCapacity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkerCapacity.ProtoReflect.Descriptor instead.
 func (*WorkerCapacity) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{76}
+	return file_ateapi_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *WorkerCapacity) GetCpuMilli() int64 {
@@ -5251,7 +5428,7 @@ type ActorAssignment struct {
 
 func (x *ActorAssignment) Reset() {
 	*x = ActorAssignment{}
-	mi := &file_ateapi_proto_msgTypes[77]
+	mi := &file_ateapi_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5263,7 +5440,7 @@ func (x *ActorAssignment) String() string {
 func (*ActorAssignment) ProtoMessage() {}
 
 func (x *ActorAssignment) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[77]
+	mi := &file_ateapi_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5276,7 +5453,7 @@ func (x *ActorAssignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActorAssignment.ProtoReflect.Descriptor instead.
 func (*ActorAssignment) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{77}
+	return file_ateapi_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *ActorAssignment) GetActorTemplate() *KubeNamespacedObjectRef {
@@ -5310,7 +5487,7 @@ type KubeNamespacedObjectRef struct {
 
 func (x *KubeNamespacedObjectRef) Reset() {
 	*x = KubeNamespacedObjectRef{}
-	mi := &file_ateapi_proto_msgTypes[78]
+	mi := &file_ateapi_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5322,7 +5499,7 @@ func (x *KubeNamespacedObjectRef) String() string {
 func (*KubeNamespacedObjectRef) ProtoMessage() {}
 
 func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[78]
+	mi := &file_ateapi_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5335,7 +5512,7 @@ func (x *KubeNamespacedObjectRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubeNamespacedObjectRef.ProtoReflect.Descriptor instead.
 func (*KubeNamespacedObjectRef) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{78}
+	return file_ateapi_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *KubeNamespacedObjectRef) GetNamespace() string {
@@ -5360,7 +5537,7 @@ type DebugClearRequest struct {
 
 func (x *DebugClearRequest) Reset() {
 	*x = DebugClearRequest{}
-	mi := &file_ateapi_proto_msgTypes[79]
+	mi := &file_ateapi_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5372,7 +5549,7 @@ func (x *DebugClearRequest) String() string {
 func (*DebugClearRequest) ProtoMessage() {}
 
 func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[79]
+	mi := &file_ateapi_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5385,7 +5562,7 @@ func (x *DebugClearRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearRequest.ProtoReflect.Descriptor instead.
 func (*DebugClearRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{79}
+	return file_ateapi_proto_rawDescGZIP(), []int{82}
 }
 
 type DebugClearResponse struct {
@@ -5396,7 +5573,7 @@ type DebugClearResponse struct {
 
 func (x *DebugClearResponse) Reset() {
 	*x = DebugClearResponse{}
-	mi := &file_ateapi_proto_msgTypes[80]
+	mi := &file_ateapi_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5408,7 +5585,7 @@ func (x *DebugClearResponse) String() string {
 func (*DebugClearResponse) ProtoMessage() {}
 
 func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[80]
+	mi := &file_ateapi_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5421,7 +5598,7 @@ func (x *DebugClearResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugClearResponse.ProtoReflect.Descriptor instead.
 func (*DebugClearResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{80}
+	return file_ateapi_proto_rawDescGZIP(), []int{83}
 }
 
 type MintJWTRequest struct {
@@ -5436,7 +5613,7 @@ type MintJWTRequest struct {
 
 func (x *MintJWTRequest) Reset() {
 	*x = MintJWTRequest{}
-	mi := &file_ateapi_proto_msgTypes[81]
+	mi := &file_ateapi_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5448,7 +5625,7 @@ func (x *MintJWTRequest) String() string {
 func (*MintJWTRequest) ProtoMessage() {}
 
 func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[81]
+	mi := &file_ateapi_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5461,7 +5638,7 @@ func (x *MintJWTRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTRequest.ProtoReflect.Descriptor instead.
 func (*MintJWTRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{81}
+	return file_ateapi_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *MintJWTRequest) GetAudience() []string {
@@ -5522,7 +5699,7 @@ type MintJWTResponse struct {
 
 func (x *MintJWTResponse) Reset() {
 	*x = MintJWTResponse{}
-	mi := &file_ateapi_proto_msgTypes[82]
+	mi := &file_ateapi_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5534,7 +5711,7 @@ func (x *MintJWTResponse) String() string {
 func (*MintJWTResponse) ProtoMessage() {}
 
 func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[82]
+	mi := &file_ateapi_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5547,7 +5724,7 @@ func (x *MintJWTResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintJWTResponse.ProtoReflect.Descriptor instead.
 func (*MintJWTResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{82}
+	return file_ateapi_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *MintJWTResponse) GetActorJwt() string {
@@ -5583,7 +5760,7 @@ type MintCertRequest struct {
 
 func (x *MintCertRequest) Reset() {
 	*x = MintCertRequest{}
-	mi := &file_ateapi_proto_msgTypes[83]
+	mi := &file_ateapi_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5595,7 +5772,7 @@ func (x *MintCertRequest) String() string {
 func (*MintCertRequest) ProtoMessage() {}
 
 func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[83]
+	mi := &file_ateapi_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5608,7 +5785,7 @@ func (x *MintCertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertRequest.ProtoReflect.Descriptor instead.
 func (*MintCertRequest) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{83}
+	return file_ateapi_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *MintCertRequest) GetWorker() *ObjectRef {
@@ -5651,7 +5828,7 @@ type MintCertResponse struct {
 
 func (x *MintCertResponse) Reset() {
 	*x = MintCertResponse{}
-	mi := &file_ateapi_proto_msgTypes[84]
+	mi := &file_ateapi_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5663,7 +5840,7 @@ func (x *MintCertResponse) String() string {
 func (*MintCertResponse) ProtoMessage() {}
 
 func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ateapi_proto_msgTypes[84]
+	mi := &file_ateapi_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5676,7 +5853,7 @@ func (x *MintCertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MintCertResponse.ProtoReflect.Descriptor instead.
 func (*MintCertResponse) Descriptor() ([]byte, []int) {
-	return file_ateapi_proto_rawDescGZIP(), []int{84}
+	return file_ateapi_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *MintCertResponse) GetActorCertificates() [][]byte {
@@ -5810,7 +5987,7 @@ const file_ateapi_proto_rawDesc = "" +
 	"\ton_resume\x18\x03 \x01(\v2\x16.ateapi.OnResumeConfigR\bonResume\x12)\n" +
 	"\x10storage_location\x18\x04 \x01(\tR\x0fstorageLocation\"C\n" +
 	"\x0eOnResumeConfig\x121\n" +
-	"\tfrom_data\x18\x01 \x01(\x0e2\x14.ateapi.ResumeSourceR\bfromData\"\xf0\x01\n" +
+	"\tfrom_data\x18\x01 \x01(\x0e2\x14.ateapi.ResumeSourceR\bfromData\"\xe5\x02\n" +
 	"\tContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05image\x18\x02 \x01(\tR\x05image\x12\x18\n" +
@@ -5818,7 +5995,14 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x04args\x18\x04 \x03(\tR\x04args\x12 \n" +
 	"\x03env\x18\x05 \x03(\v2\x0e.ateapi.EnvVarR\x03env\x12/\n" +
 	"\x06readyz\x18\x06 \x01(\v2\x17.ateapi.ContainerReadyzR\x06readyz\x128\n" +
-	"\rvolume_mounts\x18\a \x03(\v2\x13.ateapi.VolumeMountR\fvolumeMounts\"2\n" +
+	"\rvolume_mounts\x18\a \x03(\v2\x13.ateapi.VolumeMountR\fvolumeMounts\x12B\n" +
+	"\x10security_context\x18\b \x01(\v2\x17.ateapi.SecurityContextR\x0fsecurityContext\x12/\n" +
+	"\tresources\x18\t \x01(\v2\x11.ateapi.ResourcesR\tresources\"K\n" +
+	"\x0fSecurityContext\x128\n" +
+	"\fcapabilities\x18\x01 \x01(\v2\x14.ateapi.CapabilitiesR\fcapabilities\"4\n" +
+	"\fCapabilities\x12\x10\n" +
+	"\x03add\x18\x01 \x03(\tR\x03add\x12\x12\n" +
+	"\x04drop\x18\x02 \x03(\tR\x04drop\"2\n" +
 	"\x06EnvVar\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\"l\n" +
@@ -5827,15 +6011,18 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x0ftimeout_seconds\x18\x02 \x01(\x05R\x0etimeoutSeconds\"7\n" +
 	"\rHTTPGetAction\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
-	"\x04port\x18\x02 \x01(\x05R\x04port\"\x8c\x02\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\"\xbd\x02\n" +
 	"\x06Volume\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12?\n" +
 	"\vdurable_dir\x18\x02 \x01(\v2\x1e.ateapi.DurableDirVolumeSourceR\n" +
 	"durableDir\x12X\n" +
 	"\x18external_volume_template\x18\x03 \x01(\v2\x1e.ateapi.ExternalVolumeTemplateR\x16externalVolumeTemplate\x12?\n" +
 	"\vsystem_info\x18\x05 \x01(\v2\x1e.ateapi.SystemInfoVolumeSourceR\n" +
-	"systemInfo\x12\x12\n" +
-	"\x04type\x18\x04 \x01(\tR\x04type\"\x18\n" +
+	"systemInfo\x12/\n" +
+	"\x05image\x18\x06 \x01(\v2\x19.ateapi.ImageVolumeSourceR\x05image\x12\x12\n" +
+	"\x04type\x18\x04 \x01(\tR\x04type\"1\n" +
+	"\x11ImageVolumeSource\x12\x1c\n" +
+	"\treference\x18\x01 \x01(\tR\treference\"\x18\n" +
 	"\x16DurableDirVolumeSource\"b\n" +
 	"\x16ExternalVolumeTemplate\x12\x1a\n" +
 	"\bcapacity\x18\x01 \x01(\tR\bcapacity\x12,\n" +
@@ -6112,7 +6299,7 @@ func file_ateapi_proto_rawDescGZIP() []byte {
 }
 
 var file_ateapi_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 90)
+var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
 var file_ateapi_proto_goTypes = []any{
 	(SnapshotContentScope)(0),             // 0: ateapi.SnapshotContentScope
 	(ActorSnapshotTagScope)(0),            // 1: ateapi.ActorSnapshotTagScope
@@ -6145,83 +6332,86 @@ var file_ateapi_proto_goTypes = []any{
 	(*SnapshotsConfig)(nil),               // 28: ateapi.SnapshotsConfig
 	(*OnResumeConfig)(nil),                // 29: ateapi.OnResumeConfig
 	(*Container)(nil),                     // 30: ateapi.Container
-	(*EnvVar)(nil),                        // 31: ateapi.EnvVar
-	(*ContainerReadyz)(nil),               // 32: ateapi.ContainerReadyz
-	(*HTTPGetAction)(nil),                 // 33: ateapi.HTTPGetAction
-	(*Volume)(nil),                        // 34: ateapi.Volume
-	(*DurableDirVolumeSource)(nil),        // 35: ateapi.DurableDirVolumeSource
-	(*ExternalVolumeTemplate)(nil),        // 36: ateapi.ExternalVolumeTemplate
-	(*SystemInfoVolumeSource)(nil),        // 37: ateapi.SystemInfoVolumeSource
-	(*SystemInfoDataSource)(nil),          // 38: ateapi.SystemInfoDataSource
-	(*ActorMetadataDataSource)(nil),       // 39: ateapi.ActorMetadataDataSource
-	(*ActorMetadataItem)(nil),             // 40: ateapi.ActorMetadataItem
-	(*TrustBundleDataSource)(nil),         // 41: ateapi.TrustBundleDataSource
-	(*VolumeMount)(nil),                   // 42: ateapi.VolumeMount
-	(*SandboxAssets)(nil),                 // 43: ateapi.SandboxAssets
-	(*ArchAssets)(nil),                    // 44: ateapi.ArchAssets
-	(*AssetFile)(nil),                     // 45: ateapi.AssetFile
-	(*CreateAtespaceRequest)(nil),         // 46: ateapi.CreateAtespaceRequest
-	(*GetAtespaceRequest)(nil),            // 47: ateapi.GetAtespaceRequest
-	(*ListAtespacesRequest)(nil),          // 48: ateapi.ListAtespacesRequest
-	(*ListAtespacesResponse)(nil),         // 49: ateapi.ListAtespacesResponse
-	(*DeleteAtespaceRequest)(nil),         // 50: ateapi.DeleteAtespaceRequest
-	(*CreateActorTemplateRequest)(nil),    // 51: ateapi.CreateActorTemplateRequest
-	(*GetActorTemplateRequest)(nil),       // 52: ateapi.GetActorTemplateRequest
-	(*ListActorTemplatesRequest)(nil),     // 53: ateapi.ListActorTemplatesRequest
-	(*ListActorTemplatesResponse)(nil),    // 54: ateapi.ListActorTemplatesResponse
-	(*DeleteActorTemplateRequest)(nil),    // 55: ateapi.DeleteActorTemplateRequest
-	(*GetActorRequest)(nil),               // 56: ateapi.GetActorRequest
-	(*CreateActorRequest)(nil),            // 57: ateapi.CreateActorRequest
-	(*UpdateActorRequest)(nil),            // 58: ateapi.UpdateActorRequest
-	(*SuspendActorRequest)(nil),           // 59: ateapi.SuspendActorRequest
-	(*SuspendActorResponse)(nil),          // 60: ateapi.SuspendActorResponse
-	(*PauseActorRequest)(nil),             // 61: ateapi.PauseActorRequest
-	(*PauseActorResponse)(nil),            // 62: ateapi.PauseActorResponse
-	(*ResumeActorRequest)(nil),            // 63: ateapi.ResumeActorRequest
-	(*ResumeActorResponse)(nil),           // 64: ateapi.ResumeActorResponse
-	(*DeleteActorRequest)(nil),            // 65: ateapi.DeleteActorRequest
-	(*GetActorSnapshotRequest)(nil),       // 66: ateapi.GetActorSnapshotRequest
-	(*GetActorSnapshotTagRequest)(nil),    // 67: ateapi.GetActorSnapshotTagRequest
-	(*ListActorSnapshotsRequest)(nil),     // 68: ateapi.ListActorSnapshotsRequest
-	(*ListActorSnapshotsResponse)(nil),    // 69: ateapi.ListActorSnapshotsResponse
-	(*CreateActorSnapshotTagRequest)(nil), // 70: ateapi.CreateActorSnapshotTagRequest
-	(*UpdateActorSnapshotTagRequest)(nil), // 71: ateapi.UpdateActorSnapshotTagRequest
-	(*DeleteActorSnapshotTagRequest)(nil), // 72: ateapi.DeleteActorSnapshotTagRequest
-	(*DeleteOptions)(nil),                 // 73: ateapi.DeleteOptions
-	(*ListWorkersRequest)(nil),            // 74: ateapi.ListWorkersRequest
-	(*ListWorkersResponse)(nil),           // 75: ateapi.ListWorkersResponse
-	(*GetWorkerRequest)(nil),              // 76: ateapi.GetWorkerRequest
-	(*CreateWorkerRequest)(nil),           // 77: ateapi.CreateWorkerRequest
-	(*UpdateWorkerRequest)(nil),           // 78: ateapi.UpdateWorkerRequest
-	(*DeleteWorkerRequest)(nil),           // 79: ateapi.DeleteWorkerRequest
-	(*DrainWorkerRequest)(nil),            // 80: ateapi.DrainWorkerRequest
-	(*ListActorsRequest)(nil),             // 81: ateapi.ListActorsRequest
-	(*ListActorsResponse)(nil),            // 82: ateapi.ListActorsResponse
-	(*Worker)(nil),                        // 83: ateapi.Worker
-	(*WorkerStatus)(nil),                  // 84: ateapi.WorkerStatus
-	(*WorkerCapacity)(nil),                // 85: ateapi.WorkerCapacity
-	(*ActorAssignment)(nil),               // 86: ateapi.ActorAssignment
-	(*KubeNamespacedObjectRef)(nil),       // 87: ateapi.KubeNamespacedObjectRef
-	(*DebugClearRequest)(nil),             // 88: ateapi.DebugClearRequest
-	(*DebugClearResponse)(nil),            // 89: ateapi.DebugClearResponse
-	(*MintJWTRequest)(nil),                // 90: ateapi.MintJWTRequest
-	(*MintJWTResponse)(nil),               // 91: ateapi.MintJWTResponse
-	(*MintCertRequest)(nil),               // 92: ateapi.MintCertRequest
-	(*MintCertResponse)(nil),              // 93: ateapi.MintCertResponse
-	nil,                                   // 94: ateapi.Selector.MatchLabelsEntry
-	nil,                                   // 95: ateapi.ExternalVolume.VolumeContextEntry
-	nil,                                   // 96: ateapi.SandboxAssets.AssetsEntry
-	nil,                                   // 97: ateapi.ArchAssets.FilesEntry
-	nil,                                   // 98: ateapi.Worker.LabelsEntry
-	(*timestamppb.Timestamp)(nil),         // 99: google.protobuf.Timestamp
+	(*SecurityContext)(nil),               // 31: ateapi.SecurityContext
+	(*Capabilities)(nil),                  // 32: ateapi.Capabilities
+	(*EnvVar)(nil),                        // 33: ateapi.EnvVar
+	(*ContainerReadyz)(nil),               // 34: ateapi.ContainerReadyz
+	(*HTTPGetAction)(nil),                 // 35: ateapi.HTTPGetAction
+	(*Volume)(nil),                        // 36: ateapi.Volume
+	(*ImageVolumeSource)(nil),             // 37: ateapi.ImageVolumeSource
+	(*DurableDirVolumeSource)(nil),        // 38: ateapi.DurableDirVolumeSource
+	(*ExternalVolumeTemplate)(nil),        // 39: ateapi.ExternalVolumeTemplate
+	(*SystemInfoVolumeSource)(nil),        // 40: ateapi.SystemInfoVolumeSource
+	(*SystemInfoDataSource)(nil),          // 41: ateapi.SystemInfoDataSource
+	(*ActorMetadataDataSource)(nil),       // 42: ateapi.ActorMetadataDataSource
+	(*ActorMetadataItem)(nil),             // 43: ateapi.ActorMetadataItem
+	(*TrustBundleDataSource)(nil),         // 44: ateapi.TrustBundleDataSource
+	(*VolumeMount)(nil),                   // 45: ateapi.VolumeMount
+	(*SandboxAssets)(nil),                 // 46: ateapi.SandboxAssets
+	(*ArchAssets)(nil),                    // 47: ateapi.ArchAssets
+	(*AssetFile)(nil),                     // 48: ateapi.AssetFile
+	(*CreateAtespaceRequest)(nil),         // 49: ateapi.CreateAtespaceRequest
+	(*GetAtespaceRequest)(nil),            // 50: ateapi.GetAtespaceRequest
+	(*ListAtespacesRequest)(nil),          // 51: ateapi.ListAtespacesRequest
+	(*ListAtespacesResponse)(nil),         // 52: ateapi.ListAtespacesResponse
+	(*DeleteAtespaceRequest)(nil),         // 53: ateapi.DeleteAtespaceRequest
+	(*CreateActorTemplateRequest)(nil),    // 54: ateapi.CreateActorTemplateRequest
+	(*GetActorTemplateRequest)(nil),       // 55: ateapi.GetActorTemplateRequest
+	(*ListActorTemplatesRequest)(nil),     // 56: ateapi.ListActorTemplatesRequest
+	(*ListActorTemplatesResponse)(nil),    // 57: ateapi.ListActorTemplatesResponse
+	(*DeleteActorTemplateRequest)(nil),    // 58: ateapi.DeleteActorTemplateRequest
+	(*GetActorRequest)(nil),               // 59: ateapi.GetActorRequest
+	(*CreateActorRequest)(nil),            // 60: ateapi.CreateActorRequest
+	(*UpdateActorRequest)(nil),            // 61: ateapi.UpdateActorRequest
+	(*SuspendActorRequest)(nil),           // 62: ateapi.SuspendActorRequest
+	(*SuspendActorResponse)(nil),          // 63: ateapi.SuspendActorResponse
+	(*PauseActorRequest)(nil),             // 64: ateapi.PauseActorRequest
+	(*PauseActorResponse)(nil),            // 65: ateapi.PauseActorResponse
+	(*ResumeActorRequest)(nil),            // 66: ateapi.ResumeActorRequest
+	(*ResumeActorResponse)(nil),           // 67: ateapi.ResumeActorResponse
+	(*DeleteActorRequest)(nil),            // 68: ateapi.DeleteActorRequest
+	(*GetActorSnapshotRequest)(nil),       // 69: ateapi.GetActorSnapshotRequest
+	(*GetActorSnapshotTagRequest)(nil),    // 70: ateapi.GetActorSnapshotTagRequest
+	(*ListActorSnapshotsRequest)(nil),     // 71: ateapi.ListActorSnapshotsRequest
+	(*ListActorSnapshotsResponse)(nil),    // 72: ateapi.ListActorSnapshotsResponse
+	(*CreateActorSnapshotTagRequest)(nil), // 73: ateapi.CreateActorSnapshotTagRequest
+	(*UpdateActorSnapshotTagRequest)(nil), // 74: ateapi.UpdateActorSnapshotTagRequest
+	(*DeleteActorSnapshotTagRequest)(nil), // 75: ateapi.DeleteActorSnapshotTagRequest
+	(*DeleteOptions)(nil),                 // 76: ateapi.DeleteOptions
+	(*ListWorkersRequest)(nil),            // 77: ateapi.ListWorkersRequest
+	(*ListWorkersResponse)(nil),           // 78: ateapi.ListWorkersResponse
+	(*GetWorkerRequest)(nil),              // 79: ateapi.GetWorkerRequest
+	(*CreateWorkerRequest)(nil),           // 80: ateapi.CreateWorkerRequest
+	(*UpdateWorkerRequest)(nil),           // 81: ateapi.UpdateWorkerRequest
+	(*DeleteWorkerRequest)(nil),           // 82: ateapi.DeleteWorkerRequest
+	(*DrainWorkerRequest)(nil),            // 83: ateapi.DrainWorkerRequest
+	(*ListActorsRequest)(nil),             // 84: ateapi.ListActorsRequest
+	(*ListActorsResponse)(nil),            // 85: ateapi.ListActorsResponse
+	(*Worker)(nil),                        // 86: ateapi.Worker
+	(*WorkerStatus)(nil),                  // 87: ateapi.WorkerStatus
+	(*WorkerCapacity)(nil),                // 88: ateapi.WorkerCapacity
+	(*ActorAssignment)(nil),               // 89: ateapi.ActorAssignment
+	(*KubeNamespacedObjectRef)(nil),       // 90: ateapi.KubeNamespacedObjectRef
+	(*DebugClearRequest)(nil),             // 91: ateapi.DebugClearRequest
+	(*DebugClearResponse)(nil),            // 92: ateapi.DebugClearResponse
+	(*MintJWTRequest)(nil),                // 93: ateapi.MintJWTRequest
+	(*MintJWTResponse)(nil),               // 94: ateapi.MintJWTResponse
+	(*MintCertRequest)(nil),               // 95: ateapi.MintCertRequest
+	(*MintCertResponse)(nil),              // 96: ateapi.MintCertResponse
+	nil,                                   // 97: ateapi.Selector.MatchLabelsEntry
+	nil,                                   // 98: ateapi.ExternalVolume.VolumeContextEntry
+	nil,                                   // 99: ateapi.SandboxAssets.AssetsEntry
+	nil,                                   // 100: ateapi.ArchAssets.FilesEntry
+	nil,                                   // 101: ateapi.Worker.LabelsEntry
+	(*timestamppb.Timestamp)(nil),         // 102: google.protobuf.Timestamp
 }
 var file_ateapi_proto_depIdxs = []int32{
 	0,   // 0: ateapi.LocalSnapshotInfo.content_scope:type_name -> ateapi.SnapshotContentScope
-	94,  // 1: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
-	99,  // 2: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
-	99,  // 3: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
+	97,  // 1: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
+	102, // 2: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
+	102, // 3: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
 	8,   // 4: ateapi.ExternalVolume.status:type_name -> ateapi.ExternalVolume.Status
-	95,  // 5: ateapi.ExternalVolume.volume_context:type_name -> ateapi.ExternalVolume.VolumeContextEntry
+	98,  // 5: ateapi.ExternalVolume.volume_context:type_name -> ateapi.ExternalVolume.VolumeContextEntry
 	11,  // 6: ateapi.Actor.metadata:type_name -> ateapi.ResourceMetadata
 	21,  // 7: ateapi.Actor.actor_template:type_name -> ateapi.ObjectRef
 	10,  // 8: ateapi.Actor.worker_selector:type_name -> ateapi.Selector
@@ -6247,147 +6437,151 @@ var file_ateapi_proto_depIdxs = []int32{
 	11,  // 28: ateapi.ActorTemplate.metadata:type_name -> ateapi.ResourceMetadata
 	10,  // 29: ateapi.ActorTemplate.worker_selector:type_name -> ateapi.Selector
 	30,  // 30: ateapi.ActorTemplate.containers:type_name -> ateapi.Container
-	34,  // 31: ateapi.ActorTemplate.volumes:type_name -> ateapi.Volume
+	36,  // 31: ateapi.ActorTemplate.volumes:type_name -> ateapi.Volume
 	28,  // 32: ateapi.ActorTemplate.snapshots_config:type_name -> ateapi.SnapshotsConfig
 	27,  // 33: ateapi.ActorTemplate.sandbox_config:type_name -> ateapi.SandboxConfig
 	23,  // 34: ateapi.ActorTemplate.resources:type_name -> ateapi.Resources
 	26,  // 35: ateapi.ActorTemplate.status:type_name -> ateapi.ActorTemplateStatus
 	24,  // 36: ateapi.Resources.limits:type_name -> ateapi.Limits
 	21,  // 37: ateapi.GoldenSnapshotStatus.golden_snapshot:type_name -> ateapi.ObjectRef
-	99,  // 38: ateapi.GoldenSnapshotStatus.take_golden_snapshot_at:type_name -> google.protobuf.Timestamp
+	102, // 38: ateapi.GoldenSnapshotStatus.take_golden_snapshot_at:type_name -> google.protobuf.Timestamp
 	25,  // 39: ateapi.ActorTemplateStatus.golden_snapshot_status:type_name -> ateapi.GoldenSnapshotStatus
-	43,  // 40: ateapi.ActorTemplateStatus.sandbox_assets:type_name -> ateapi.SandboxAssets
+	46,  // 40: ateapi.ActorTemplateStatus.sandbox_assets:type_name -> ateapi.SandboxAssets
 	3,   // 41: ateapi.SandboxConfig.sandbox_class:type_name -> ateapi.SandboxClass
 	0,   // 42: ateapi.SnapshotsConfig.on_pause:type_name -> ateapi.SnapshotContentScope
 	0,   // 43: ateapi.SnapshotsConfig.on_commit:type_name -> ateapi.SnapshotContentScope
 	29,  // 44: ateapi.SnapshotsConfig.on_resume:type_name -> ateapi.OnResumeConfig
 	4,   // 45: ateapi.OnResumeConfig.from_data:type_name -> ateapi.ResumeSource
-	31,  // 46: ateapi.Container.env:type_name -> ateapi.EnvVar
-	32,  // 47: ateapi.Container.readyz:type_name -> ateapi.ContainerReadyz
-	42,  // 48: ateapi.Container.volume_mounts:type_name -> ateapi.VolumeMount
-	33,  // 49: ateapi.ContainerReadyz.http_get:type_name -> ateapi.HTTPGetAction
-	35,  // 50: ateapi.Volume.durable_dir:type_name -> ateapi.DurableDirVolumeSource
-	36,  // 51: ateapi.Volume.external_volume_template:type_name -> ateapi.ExternalVolumeTemplate
-	37,  // 52: ateapi.Volume.system_info:type_name -> ateapi.SystemInfoVolumeSource
-	38,  // 53: ateapi.SystemInfoVolumeSource.data_sources:type_name -> ateapi.SystemInfoDataSource
-	39,  // 54: ateapi.SystemInfoDataSource.actor_metadata:type_name -> ateapi.ActorMetadataDataSource
-	41,  // 55: ateapi.SystemInfoDataSource.trust_bundle:type_name -> ateapi.TrustBundleDataSource
-	40,  // 56: ateapi.ActorMetadataDataSource.items:type_name -> ateapi.ActorMetadataItem
-	5,   // 57: ateapi.ActorMetadataItem.field:type_name -> ateapi.ActorMetadataField
-	3,   // 58: ateapi.SandboxAssets.sandbox_class:type_name -> ateapi.SandboxClass
-	96,  // 59: ateapi.SandboxAssets.assets:type_name -> ateapi.SandboxAssets.AssetsEntry
-	97,  // 60: ateapi.ArchAssets.files:type_name -> ateapi.ArchAssets.FilesEntry
-	20,  // 61: ateapi.CreateAtespaceRequest.atespace:type_name -> ateapi.Atespace
-	21,  // 62: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
-	20,  // 63: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
-	21,  // 64: ateapi.DeleteAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
-	22,  // 65: ateapi.CreateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
-	21,  // 66: ateapi.GetActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
-	22,  // 67: ateapi.ListActorTemplatesResponse.actor_templates:type_name -> ateapi.ActorTemplate
-	21,  // 68: ateapi.DeleteActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
-	21,  // 69: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
-	13,  // 70: ateapi.CreateActorRequest.actor:type_name -> ateapi.Actor
-	13,  // 71: ateapi.UpdateActorRequest.actor:type_name -> ateapi.Actor
-	21,  // 72: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
-	13,  // 73: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
-	21,  // 74: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
-	13,  // 75: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
-	21,  // 76: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
-	13,  // 77: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
-	21,  // 78: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
-	21,  // 79: ateapi.GetActorSnapshotRequest.actor_snapshot:type_name -> ateapi.ObjectRef
-	21,  // 80: ateapi.GetActorSnapshotTagRequest.actor_snapshot_tag:type_name -> ateapi.ObjectRef
-	17,  // 81: ateapi.ListActorSnapshotsResponse.actor_snapshots:type_name -> ateapi.ActorSnapshot
-	19,  // 82: ateapi.CreateActorSnapshotTagRequest.actor_snapshot_tag:type_name -> ateapi.ActorSnapshotTag
-	19,  // 83: ateapi.UpdateActorSnapshotTagRequest.actor_snapshot_tag:type_name -> ateapi.ActorSnapshotTag
-	21,  // 84: ateapi.DeleteActorSnapshotTagRequest.actor_snapshot_tag:type_name -> ateapi.ObjectRef
-	83,  // 85: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
-	21,  // 86: ateapi.GetWorkerRequest.worker:type_name -> ateapi.ObjectRef
-	83,  // 87: ateapi.CreateWorkerRequest.worker:type_name -> ateapi.Worker
-	83,  // 88: ateapi.UpdateWorkerRequest.worker:type_name -> ateapi.Worker
-	21,  // 89: ateapi.DeleteWorkerRequest.worker:type_name -> ateapi.ObjectRef
-	73,  // 90: ateapi.DeleteWorkerRequest.options:type_name -> ateapi.DeleteOptions
-	21,  // 91: ateapi.DrainWorkerRequest.worker:type_name -> ateapi.ObjectRef
-	13,  // 92: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
-	11,  // 93: ateapi.Worker.metadata:type_name -> ateapi.ResourceMetadata
-	98,  // 94: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
-	85,  // 95: ateapi.Worker.capacity:type_name -> ateapi.WorkerCapacity
-	84,  // 96: ateapi.Worker.status:type_name -> ateapi.WorkerStatus
-	6,   // 97: ateapi.WorkerStatus.state:type_name -> ateapi.WorkerState
-	86,  // 98: ateapi.WorkerStatus.assignment:type_name -> ateapi.ActorAssignment
-	87,  // 99: ateapi.ActorAssignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	21,  // 100: ateapi.ActorAssignment.actor:type_name -> ateapi.ObjectRef
-	21,  // 101: ateapi.MintCertRequest.worker:type_name -> ateapi.ObjectRef
-	7,   // 102: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
-	44,  // 103: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
-	45,  // 104: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
-	56,  // 105: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	57,  // 106: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	58,  // 107: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	59,  // 108: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	61,  // 109: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	63,  // 110: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	65,  // 111: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	66,  // 112: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
-	67,  // 113: ateapi.Control.GetActorSnapshotTag:input_type -> ateapi.GetActorSnapshotTagRequest
-	68,  // 114: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
-	70,  // 115: ateapi.Control.CreateActorSnapshotTag:input_type -> ateapi.CreateActorSnapshotTagRequest
-	71,  // 116: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
-	72,  // 117: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
-	74,  // 118: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	76,  // 119: ateapi.Control.GetWorker:input_type -> ateapi.GetWorkerRequest
-	77,  // 120: ateapi.Control.CreateWorker:input_type -> ateapi.CreateWorkerRequest
-	78,  // 121: ateapi.Control.UpdateWorker:input_type -> ateapi.UpdateWorkerRequest
-	79,  // 122: ateapi.Control.DeleteWorker:input_type -> ateapi.DeleteWorkerRequest
-	80,  // 123: ateapi.Control.DrainWorker:input_type -> ateapi.DrainWorkerRequest
-	81,  // 124: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	46,  // 125: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	47,  // 126: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	48,  // 127: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	50,  // 128: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	51,  // 129: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
-	52,  // 130: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
-	53,  // 131: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
-	55,  // 132: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
-	88,  // 133: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
-	90,  // 134: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	92,  // 135: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	13,  // 136: ateapi.Control.GetActor:output_type -> ateapi.Actor
-	13,  // 137: ateapi.Control.CreateActor:output_type -> ateapi.Actor
-	13,  // 138: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
-	60,  // 139: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	62,  // 140: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	64,  // 141: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	13,  // 142: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
-	17,  // 143: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
-	19,  // 144: ateapi.Control.GetActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	69,  // 145: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
-	19,  // 146: ateapi.Control.CreateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	19,  // 147: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	19,  // 148: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	75,  // 149: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	83,  // 150: ateapi.Control.GetWorker:output_type -> ateapi.Worker
-	83,  // 151: ateapi.Control.CreateWorker:output_type -> ateapi.Worker
-	83,  // 152: ateapi.Control.UpdateWorker:output_type -> ateapi.Worker
-	83,  // 153: ateapi.Control.DeleteWorker:output_type -> ateapi.Worker
-	83,  // 154: ateapi.Control.DrainWorker:output_type -> ateapi.Worker
-	82,  // 155: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	20,  // 156: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
-	20,  // 157: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
-	49,  // 158: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	20,  // 159: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
-	22,  // 160: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
-	22,  // 161: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
-	54,  // 162: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
-	22,  // 163: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
-	89,  // 164: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
-	91,  // 165: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	93,  // 166: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	136, // [136:167] is the sub-list for method output_type
-	105, // [105:136] is the sub-list for method input_type
-	105, // [105:105] is the sub-list for extension type_name
-	105, // [105:105] is the sub-list for extension extendee
-	0,   // [0:105] is the sub-list for field type_name
+	33,  // 46: ateapi.Container.env:type_name -> ateapi.EnvVar
+	34,  // 47: ateapi.Container.readyz:type_name -> ateapi.ContainerReadyz
+	45,  // 48: ateapi.Container.volume_mounts:type_name -> ateapi.VolumeMount
+	31,  // 49: ateapi.Container.security_context:type_name -> ateapi.SecurityContext
+	23,  // 50: ateapi.Container.resources:type_name -> ateapi.Resources
+	32,  // 51: ateapi.SecurityContext.capabilities:type_name -> ateapi.Capabilities
+	35,  // 52: ateapi.ContainerReadyz.http_get:type_name -> ateapi.HTTPGetAction
+	38,  // 53: ateapi.Volume.durable_dir:type_name -> ateapi.DurableDirVolumeSource
+	39,  // 54: ateapi.Volume.external_volume_template:type_name -> ateapi.ExternalVolumeTemplate
+	40,  // 55: ateapi.Volume.system_info:type_name -> ateapi.SystemInfoVolumeSource
+	37,  // 56: ateapi.Volume.image:type_name -> ateapi.ImageVolumeSource
+	41,  // 57: ateapi.SystemInfoVolumeSource.data_sources:type_name -> ateapi.SystemInfoDataSource
+	42,  // 58: ateapi.SystemInfoDataSource.actor_metadata:type_name -> ateapi.ActorMetadataDataSource
+	44,  // 59: ateapi.SystemInfoDataSource.trust_bundle:type_name -> ateapi.TrustBundleDataSource
+	43,  // 60: ateapi.ActorMetadataDataSource.items:type_name -> ateapi.ActorMetadataItem
+	5,   // 61: ateapi.ActorMetadataItem.field:type_name -> ateapi.ActorMetadataField
+	3,   // 62: ateapi.SandboxAssets.sandbox_class:type_name -> ateapi.SandboxClass
+	99,  // 63: ateapi.SandboxAssets.assets:type_name -> ateapi.SandboxAssets.AssetsEntry
+	100, // 64: ateapi.ArchAssets.files:type_name -> ateapi.ArchAssets.FilesEntry
+	20,  // 65: ateapi.CreateAtespaceRequest.atespace:type_name -> ateapi.Atespace
+	21,  // 66: ateapi.GetAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
+	20,  // 67: ateapi.ListAtespacesResponse.atespaces:type_name -> ateapi.Atespace
+	21,  // 68: ateapi.DeleteAtespaceRequest.atespace:type_name -> ateapi.ObjectRef
+	22,  // 69: ateapi.CreateActorTemplateRequest.actor_template:type_name -> ateapi.ActorTemplate
+	21,  // 70: ateapi.GetActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
+	22,  // 71: ateapi.ListActorTemplatesResponse.actor_templates:type_name -> ateapi.ActorTemplate
+	21,  // 72: ateapi.DeleteActorTemplateRequest.actor_template:type_name -> ateapi.ObjectRef
+	21,  // 73: ateapi.GetActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 74: ateapi.CreateActorRequest.actor:type_name -> ateapi.Actor
+	13,  // 75: ateapi.UpdateActorRequest.actor:type_name -> ateapi.Actor
+	21,  // 76: ateapi.SuspendActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 77: ateapi.SuspendActorResponse.actor:type_name -> ateapi.Actor
+	21,  // 78: ateapi.PauseActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 79: ateapi.PauseActorResponse.actor:type_name -> ateapi.Actor
+	21,  // 80: ateapi.ResumeActorRequest.actor:type_name -> ateapi.ObjectRef
+	13,  // 81: ateapi.ResumeActorResponse.actor:type_name -> ateapi.Actor
+	21,  // 82: ateapi.DeleteActorRequest.actor:type_name -> ateapi.ObjectRef
+	21,  // 83: ateapi.GetActorSnapshotRequest.actor_snapshot:type_name -> ateapi.ObjectRef
+	21,  // 84: ateapi.GetActorSnapshotTagRequest.actor_snapshot_tag:type_name -> ateapi.ObjectRef
+	17,  // 85: ateapi.ListActorSnapshotsResponse.actor_snapshots:type_name -> ateapi.ActorSnapshot
+	19,  // 86: ateapi.CreateActorSnapshotTagRequest.actor_snapshot_tag:type_name -> ateapi.ActorSnapshotTag
+	19,  // 87: ateapi.UpdateActorSnapshotTagRequest.actor_snapshot_tag:type_name -> ateapi.ActorSnapshotTag
+	21,  // 88: ateapi.DeleteActorSnapshotTagRequest.actor_snapshot_tag:type_name -> ateapi.ObjectRef
+	86,  // 89: ateapi.ListWorkersResponse.workers:type_name -> ateapi.Worker
+	21,  // 90: ateapi.GetWorkerRequest.worker:type_name -> ateapi.ObjectRef
+	86,  // 91: ateapi.CreateWorkerRequest.worker:type_name -> ateapi.Worker
+	86,  // 92: ateapi.UpdateWorkerRequest.worker:type_name -> ateapi.Worker
+	21,  // 93: ateapi.DeleteWorkerRequest.worker:type_name -> ateapi.ObjectRef
+	76,  // 94: ateapi.DeleteWorkerRequest.options:type_name -> ateapi.DeleteOptions
+	21,  // 95: ateapi.DrainWorkerRequest.worker:type_name -> ateapi.ObjectRef
+	13,  // 96: ateapi.ListActorsResponse.actors:type_name -> ateapi.Actor
+	11,  // 97: ateapi.Worker.metadata:type_name -> ateapi.ResourceMetadata
+	101, // 98: ateapi.Worker.labels:type_name -> ateapi.Worker.LabelsEntry
+	88,  // 99: ateapi.Worker.capacity:type_name -> ateapi.WorkerCapacity
+	87,  // 100: ateapi.Worker.status:type_name -> ateapi.WorkerStatus
+	6,   // 101: ateapi.WorkerStatus.state:type_name -> ateapi.WorkerState
+	89,  // 102: ateapi.WorkerStatus.assignment:type_name -> ateapi.ActorAssignment
+	90,  // 103: ateapi.ActorAssignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
+	21,  // 104: ateapi.ActorAssignment.actor:type_name -> ateapi.ObjectRef
+	21,  // 105: ateapi.MintCertRequest.worker:type_name -> ateapi.ObjectRef
+	7,   // 106: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
+	47,  // 107: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
+	48,  // 108: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
+	59,  // 109: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	60,  // 110: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	61,  // 111: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	62,  // 112: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	64,  // 113: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	66,  // 114: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	68,  // 115: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	69,  // 116: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
+	70,  // 117: ateapi.Control.GetActorSnapshotTag:input_type -> ateapi.GetActorSnapshotTagRequest
+	71,  // 118: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
+	73,  // 119: ateapi.Control.CreateActorSnapshotTag:input_type -> ateapi.CreateActorSnapshotTagRequest
+	74,  // 120: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
+	75,  // 121: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
+	77,  // 122: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	79,  // 123: ateapi.Control.GetWorker:input_type -> ateapi.GetWorkerRequest
+	80,  // 124: ateapi.Control.CreateWorker:input_type -> ateapi.CreateWorkerRequest
+	81,  // 125: ateapi.Control.UpdateWorker:input_type -> ateapi.UpdateWorkerRequest
+	82,  // 126: ateapi.Control.DeleteWorker:input_type -> ateapi.DeleteWorkerRequest
+	83,  // 127: ateapi.Control.DrainWorker:input_type -> ateapi.DrainWorkerRequest
+	84,  // 128: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	49,  // 129: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	50,  // 130: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	51,  // 131: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	53,  // 132: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	54,  // 133: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
+	55,  // 134: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
+	56,  // 135: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
+	58,  // 136: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
+	91,  // 137: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
+	93,  // 138: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	95,  // 139: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	13,  // 140: ateapi.Control.GetActor:output_type -> ateapi.Actor
+	13,  // 141: ateapi.Control.CreateActor:output_type -> ateapi.Actor
+	13,  // 142: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
+	63,  // 143: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	65,  // 144: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	67,  // 145: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	13,  // 146: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
+	17,  // 147: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
+	19,  // 148: ateapi.Control.GetActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	72,  // 149: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
+	19,  // 150: ateapi.Control.CreateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	19,  // 151: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	19,  // 152: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	78,  // 153: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	86,  // 154: ateapi.Control.GetWorker:output_type -> ateapi.Worker
+	86,  // 155: ateapi.Control.CreateWorker:output_type -> ateapi.Worker
+	86,  // 156: ateapi.Control.UpdateWorker:output_type -> ateapi.Worker
+	86,  // 157: ateapi.Control.DeleteWorker:output_type -> ateapi.Worker
+	86,  // 158: ateapi.Control.DrainWorker:output_type -> ateapi.Worker
+	85,  // 159: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	20,  // 160: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
+	20,  // 161: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
+	52,  // 162: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	20,  // 163: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
+	22,  // 164: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
+	22,  // 165: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
+	57,  // 166: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
+	22,  // 167: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
+	92,  // 168: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
+	94,  // 169: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	96,  // 170: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	140, // [140:171] is the sub-list for method output_type
+	109, // [109:140] is the sub-list for method input_type
+	109, // [109:109] is the sub-list for extension type_name
+	109, // [109:109] is the sub-list for extension extendee
+	0,   // [0:109] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }
@@ -6401,7 +6595,7 @@ func file_ateapi_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateapi_proto_rawDesc), len(file_ateapi_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   90,
+			NumMessages:   93,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -613,6 +613,29 @@ message Container {
   ContainerReadyz readyz = 6;
 
   repeated VolumeMount volume_mounts = 7;
+
+  // security_context adjusts the container's security settings. Unset leaves
+  // the default capability set.
+  SecurityContext security_context = 8;
+
+  // resources carries this container's compute limits, enforced inside the
+  // actor's sandbox. Only cpu and memory limits are supported.
+  Resources resources = 9;
+}
+
+// SecurityContext holds security settings for a container's process,
+// modeling a subset of the Kubernetes container securityContext.
+message SecurityContext {
+  Capabilities capabilities = 1;
+}
+
+// Capabilities adjusts a container's Linux capabilities relative to the
+// default set. Drop applies first, then add, so a capability in both is
+// granted. Capabilities are named without the "CAP_" prefix; "ALL" in drop
+// removes the whole default set.
+message Capabilities {
+  repeated string add = 1;
+  repeated string drop = 2;
 }
 
 // EnvVar supplies one environment variable to a container. Values are not
@@ -647,17 +670,26 @@ message Volume {
   // name of the volume. Must be a DNS label.
   string name = 1;
 
-  // Exactly one of durable_dir / external_volume_template / system_info
-  // must be set.
+  // Exactly one of durable_dir / external_volume_template / image /
+  // system_info must be set.
   DurableDirVolumeSource durable_dir = 2;
   ExternalVolumeTemplate external_volume_template = 3;
 
   // +k8s:optional
   SystemInfoVolumeSource system_info = 5;
 
+  ImageVolumeSource image = 6;
+
   // type discriminates the source union: "DurableDir",
-  // "ExternalVolumeTemplate" or "SystemInfo".
+  // "ExternalVolumeTemplate", "Image" or "SystemInfo".
   string type = 4;
+}
+
+// ImageVolumeSource mounts the contents of an OCI image, read-only. The
+// reference must be pinned by digest: changing the image invalidates
+// snapshots.
+message ImageVolumeSource {
+  string reference = 1;
 }
 
 // DurableDirVolumeSource is a durable directory on rootfs that persists


### PR DESCRIPTION
Adds a temporary converter that allows each Actor workflow to use the substrate resource rather than CRD, to prevent regression while we are in the parallel state.
* Allows each workflow to use the ActorTemplate substrate proto under the hood, in preparation for the full cut over, e2e tests start testing the new code path.
* Changes any functions that consumes the ActorTemplate CRD to use the substrate proto instead.
* The converter will be deleted once we fully cutover to the substrate resource.