### PR TITLE
ci: stop the testcontainers reaper from deleting live test databases

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -29,6 +29,10 @@ permissions:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    # A lost reaper handshake gets a package's containers pruned mid-run
+    # (testcontainers-go#3827); a throwaway runner needs no reaping anyway.
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
     steps:
     - name: Checkout
       uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0


### PR DESCRIPTION
Fixes #1230

`cmd/ateapi/internal/controlapi` fails ~30 tests at once in `run-tests`, every one on `creating PostgreSQL test database: conn closed`. A package's PostgreSQL container is deleted while that package is still using it.

## Root cause

Every package binary under one `go test ./...` derives the same testcontainers session ID from the shared parent process, so all five packages that start a PostgreSQL container share one Ryuk reaper and one set of container labels. Ryuk deletes everything carrying that label once its connected-client count reaches zero.

The original failure had two upstream contributors:

- Reusing an existing reaper waited only for its Docker port mapping. Docker exposes the port before Ryuk is listening, so the handshake could fail with `read ack: EOF`. [testcontainers-go#3743](https://github.com/testcontainers/testcontainers-go/issues/3743) was fixed by [#3761](https://github.com/testcontainers/testcontainers-go/pull/3761); testcontainers-go v0.44.0 is now in main via #1237.
- `Reaper.connect` logs a failed handshake or startup and returns success anyway, so a package can run unregistered while its containers still carry the shared session label. [#3827](https://github.com/testcontainers/testcontainers-go/issues/3827) remains open upstream. Under v0.44.0 the observed failure moves to `wait for reaper <id>: context deadline exceeded` rather than eliminating the shared-reaper race.

One package then exits, Ryuk sees zero clients, and prunes the session, including a database another package is mid-suite on. `storetest`'s `sync.Once` blocks recreation, so every remaining test in that package fails on the same line.

The package count has since grown from four to five. That increases contention but does not change the defect.

## Fix

Disable the reaper for `run-tests`.

The reaper exists to clean up after a process that dies without doing so. `storetest` and `atepg` now terminate their own containers, and a GitHub runner is destroyed with the job, so CI does not need a shared reaper. Local development is untouched and keeps it.

No test accompanies this: the failure lives in CI job composition and a dependency, neither of which is reachable from a Go test. Evidence is below instead.

## Evidence

Ryuk's own log during a failing run; the container is removed, not crashed:

```
client disconnected  clients=0
prune check          clients=0
removed containers=1 networks=0 volumes=0 images=0
```

Forcing exactly one package to lose its reaper connection, with nothing else changed:

```
control   ok    cmd/ateapi/internal/store/atepg              10.229s
          ok    cmd/ateapi/internal/controlapi/functionaltest 30.673s

forced    ok    cmd/ateapi/internal/store/atepg              10.229s
          FAIL  cmd/ateapi/internal/controlapi/functionaltest 15.461s
                creating PostgreSQL test database: failed to connect to `user=postgres database=postgres`:
                  127.0.0.1:55110 (localhost): failed to receive message: read: connection reset by peer
```

30 of the 30 failing test names are among the 32 seen in run [32926359026](https://github.com/agent-substrate/substrate/actions/runs/32926359026).

## Related changes

- #1237 upgraded testcontainers-go to v0.44.0 and fixed the early handshake race for local runs, where the reaper stays enabled. It does not replace this CI change: on a 4-core Linux VM with cold build caches, database tests remained unavailable in 3/3 rounds as `wait for reaper <id>: context deadline exceeded`.
- #1345 proposed making CI container startup errors fail instead of skip, but closed without merging. It is separate from preventing a live container from being deleted.

---

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
