### PR TITLE
docs: point at the new names of the verify scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Agent Substrate uses a `Makefile` for its build and test tasks.
 
 `docs/metrics/registry/metrics.yaml` is an [OpenTelemetry Weaver](https://github.com/open-telemetry/weaver) registry. It defines every metric instrument the ate system components emit, and the permitted values of each label. Read it to find an instrument or its labels.
 
-If you add or rename an instrument, or add a metric label, update it and run `hack/verify/verify-metrics.sh`. `make verify` runs the same check.
+If you add or rename an instrument, or add a metric label, update it and run `hack/verify/metrics.sh`. `make verify` runs the same check.
 
 `docs/metrics/substrate.yaml` holds the rules Weaver cannot express: the cardinality rules, the known exceptions, and the subsystems that emit no metrics. Read `blind_spots` before you attribute a fault to a component.
 

--- a/docs/metrics/registry/metrics.yaml
+++ b/docs/metrics/registry/metrics.yaml
@@ -17,7 +17,7 @@
 # permitted values of each label. Use it as the only source of this data.
 #
 # `weaver registry check -r docs/metrics/registry` validates this file.
-# `hack/verify/verify-metrics.sh` runs that command in CI.
+# `hack/verify/metrics.sh` runs that command in CI.
 #
 # Weaver permits only `groups` and `imports` at the top level. Thus the rules
 # that Weaver cannot hold live in docs/metrics/substrate.yaml. That file is

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -184,7 +184,7 @@ The `ate.*` control-plane metric labels are either fixed value sets (operation, 
 It is an [OpenTelemetry Weaver](https://github.com/open-telemetry/weaver) registry. Weaver reads it, resolves each `ref`, and refuses a group or an attribute that is not correct:
 
 ```sh
-hack/verify/verify-metrics.sh              # the command that CI uses
+hack/verify/metrics.sh                           # the command that CI uses
 weaver registry check -r docs/metrics/registry   # the same command, direct
 ```
 


### PR DESCRIPTION
The rename of `hack/verify/verify-metrics.sh` to `hack/verify/metrics.sh` left three references to the old path behind. A reader who copies one of them gets a "No such file or directory" error.

Point `AGENTS.md`, `docs/observability.md`, and the header comment of `docs/metrics/registry/metrics.yaml` at the new name.

Docs only; no change to the script or to the registry data.

A follow-up of https://github.com/agent-substrate/substrate/pull/1221