### PR TITLE
ateom-microvm: promote checkpoint/restore phase timings to metrics

### DIFF
--- a/cmd/ateom-microvm/checkpoint.go
+++ b/cmd/ateom-microvm/checkpoint.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/ch"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
+	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/ateomstats"
 	"github.com/agent-substrate/substrate/internal/imagecache"
@@ -70,6 +71,7 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	s.setActiveRPC(rpcCheckpointWorkload, cancel)
 	defer s.clearActiveRPC()
 
+	tStart := time.Now()
 	if err := s.deactivateActorNetworking(ctx); err != nil {
 		return nil, err
 	}
@@ -145,12 +147,13 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	//   - Rootfs upper tar (Full only): host-backed like the durable volumes —
 	//     the memory snapshot does not carry rootfs writes. Under Data the
 	//     workload cold-starts on restore, discarding rootfs state.
-	var dSnapshot, dDurable, dUpper time.Duration
+	var snapStats vmSnapshotStats
+	var dDurable, dUpper time.Duration
 	g, gctx := errgroup.WithContext(ctx)
 	if scope == ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL {
 		g.Go(func() error {
 			var err error
-			dSnapshot, err = s.snapshotVMState(gctx, client, ra, actorUID, checkpointDir)
+			snapStats, err = s.snapshotVMState(gctx, client, ra, actorUID, checkpointDir)
 			return err
 		})
 	}
@@ -200,19 +203,48 @@ func (s *AteomService) CheckpointWorkload(ctx context.Context, req *ateompb.Chec
 	s.actorLogger.EmitLifecycleLog(ctx, "Actor checkpointed", attribution)
 	slog.InfoContext(ctx, "Actor checkpointed", slog.String("id", actorUID), slog.Any("snapshot_files", snapshotFiles),
 		slog.String("scope", scope.String()), slog.Duration("pause", dPause),
-		slog.Duration("snapshot", dSnapshot),
+		slog.Duration("snapshot", snapStats.snapshot),
 		// The tars run while the guest is paused, CONCURRENTLY with the CH
 		// snapshot: the paused window costs max(snapshot, durable_dir,
 		// rootfs_upper), and the tar durations scale with the actor's data.
 		slog.Duration("durable_dir", dDurable), slog.Duration("rootfs_upper", dUpper),
 		slog.Duration("teardown", dTeardown))
+
+	op := snapshotOp{
+		templateNamespace: attribution.TemplateNamespace,
+		templateName:      attribution.TemplateName,
+		scope:             scope,
+	}
+	s.instruments.recordCheckpoint(ctx, op,
+		phase{ateattr.SnapshotPhasePause, dPause},
+		phase{ateattr.SnapshotPhaseSnapshot, snapStats.snapshot},
+		phase{ateattr.SnapshotPhaseDurableDir, dDurable},
+		phase{ateattr.SnapshotPhaseRootfsUpper, dUpper},
+		phase{ateattr.SnapshotPhaseMerge, snapStats.merge},
+		phase{ateattr.SnapshotPhaseTeardown, dTeardown},
+		phase{ateattr.SnapshotPhaseTotal, time.Since(tStart)})
+	if snapStats.merged {
+		s.instruments.recordDeltaSize(ctx, op, snapStats.deltaBytes)
+	}
 	return &ateompb.CheckpointWorkloadResponse{SnapshotFiles: snapshotFiles}, nil
+}
+
+// vmSnapshotStats reports what snapshotVMState did: how long the CH snapshot
+// took, and — for an OnDemand-restored actor — how long the delta merge took
+// and how many populated delta bytes it overlaid onto the restore source.
+type vmSnapshotStats struct {
+	snapshot time.Duration
+	merge    time.Duration
+	// deltaBytes is meaningful only when merged is true: a cold-run or
+	// eager-restored actor merges nothing.
+	deltaBytes int64
+	merged     bool
 }
 
 // snapshotVMState captures the paused guest into checkpointDir: the CH snapshot
 // (config.json + state.json + memory-ranges) plus the base-id the restore side
-// needs, and returns how long the snapshot itself took.
-func (s *AteomService) snapshotVMState(ctx context.Context, client *ch.Client, ra *runningActor, actorUID, checkpointDir string) (time.Duration, error) {
+// needs, and returns how long the snapshot (and any delta merge) took.
+func (s *AteomService) snapshotVMState(ctx context.Context, client *ch.Client, ra *runningActor, actorUID, checkpointDir string) (vmSnapshotStats, error) {
 	// Record the FROZEN base id (the id the guest's virtio-fs find-paths are pinned
 	// to, <baseID>/rootfs). For a cold-run actor this is its own id; for a restored
 	// actor it is the golden id propagated via ra.baseID (set from the snapshot we
@@ -224,16 +256,17 @@ func (s *AteomService) snapshotVMState(ctx context.Context, client *ch.Client, r
 	if ra != nil && ra.baseID != "" {
 		baseID = ra.baseID
 	}
+	var stats vmSnapshotStats
 	if err := os.WriteFile(filepath.Join(checkpointDir, baseIDFile), []byte(baseID), 0o600); err != nil {
-		return 0, fmt.Errorf("while writing %s: %w", baseIDFile, err)
+		return stats, fmt.Errorf("while writing %s: %w", baseIDFile, err)
 	}
 
 	slog.InfoContext(ctx, "Snapshotting guest", slog.String("id", actorUID), slog.String("dir", checkpointDir))
 	tSnapshot := time.Now()
 	if err := client.Snapshot(ctx, checkpointDir); err != nil {
-		return 0, fmt.Errorf("while snapshotting guest: %w", err)
+		return stats, fmt.Errorf("while snapshotting guest: %w", err)
 	}
-	dSnapshot := time.Since(tSnapshot)
+	stats.snapshot = time.Since(tSnapshot)
 
 	// Diff-snapshot completion for an OnDemand-restored actor: CH's snapshot here is
 	// sparse — only the pages faulted in since the OnDemand restore — so on its own
@@ -254,16 +287,21 @@ func (s *AteomService) snapshotVMState(ctx context.Context, client *ch.Client, r
 		// Reuse base's on-disk working set (rename + overlay) instead of copying it —
 		// CH is paused and about to be torn down, and base is discarded after. See
 		// MergeDeltaIntoBase. (Falls back to the copying merge across filesystems.)
-		if err := ch.MergeDeltaIntoBase(ctx, base, delta); err != nil {
-			return 0, fmt.Errorf("while merging OnDemand delta into restore source: %w", err)
+		deltaBytes, err := ch.MergeDeltaIntoBase(ctx, base, delta)
+		if err != nil {
+			return stats, fmt.Errorf("while merging OnDemand delta into restore source: %w", err)
 		}
+		stats.merge = time.Since(tMerge)
+		stats.deltaBytes = deltaBytes
+		stats.merged = true
 		slog.InfoContext(ctx, "Merged OnDemand delta into base (complete snapshot)",
-			slog.String("id", actorUID), slog.Duration("merge", time.Since(tMerge)))
+			slog.String("id", actorUID), slog.Duration("merge", stats.merge),
+			slog.Int64("delta_bytes", deltaBytes))
 	}
 
 	// The RO lower never ships (reconstructed from the OCI image at restore).
 	// The disk-backed upper ships as its own tar from CheckpointWorkload; a
-	return dSnapshot, nil
+	return stats, nil
 }
 
 // listFiles returns the (relative) names of regular files directly under dir.

--- a/cmd/ateom-microvm/internal/ch/merge.go
+++ b/cmd/ateom-microvm/internal/ch/merge.go
@@ -42,47 +42,51 @@ import (
 // differential snapshot implemented on top of CH (which has no native diff
 // snapshot): it keeps OnDemand's fast, non-densifying restore while still producing
 // complete, re-restorable snapshots for the suspend/resume chain.
-func MergeSparseOverlay(ctx context.Context, baseFile, deltaFile, outFile string) error {
+//
+// Returns the populated bytes of deltaFile it overlaid — the size of the delta,
+// which is what a native differential snapshot would have uploaded.
+func MergeSparseOverlay(ctx context.Context, baseFile, deltaFile, outFile string) (int64, error) {
 	bi, err := os.Stat(baseFile)
 	if err != nil {
-		return fmt.Errorf("stat base %q: %w", baseFile, err)
+		return 0, fmt.Errorf("stat base %q: %w", baseFile, err)
 	}
 	// outFile := sparse copy of baseFile (preserves holes so it stays sparse).
 	tmp := outFile + ".merge.tmp"
 	_ = os.Remove(tmp)
 	if o, err := reaper.RunCombined(exec.CommandContext(ctx, "cp", "--sparse=always", baseFile, tmp)); err != nil {
-		return fmt.Errorf("cp base->tmp: %w: %s", err, o)
+		return 0, fmt.Errorf("cp base->tmp: %w: %s", err, o)
 	}
 
 	d, err := os.Open(deltaFile)
 	if err != nil {
-		return fmt.Errorf("open delta %q: %w", deltaFile, err)
+		return 0, fmt.Errorf("open delta %q: %w", deltaFile, err)
 	}
 	defer d.Close()
 	di, err := d.Stat()
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if di.Size() != bi.Size() {
 		// Same guest => identical memory-ranges length. A mismatch means the overlay
 		// offsets wouldn't line up, so refuse rather than corrupt.
-		return fmt.Errorf("MergeSparseOverlay: size mismatch base=%d delta=%d", bi.Size(), di.Size())
+		return 0, fmt.Errorf("MergeSparseOverlay: size mismatch base=%d delta=%d", bi.Size(), di.Size())
 	}
 
 	o, err := os.OpenFile(tmp, os.O_RDWR, 0o600)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer o.Close()
 
-	if _, err := copySparseRegions(d, o); err != nil {
-		return err
+	deltaBytes, err := copySparseRegions(d, o)
+	if err != nil {
+		return 0, err
 	}
 	// No fsync: atelet ships the merged image to GCS (the durability point), so a
 	// partial local file after a node crash is just discarded + the suspend retried;
 	// paying an ~150MiB fsync on the suspend critical path buys nothing.
 	if err := o.Close(); err != nil {
-		return err
+		return 0, err
 	}
 	// Put the merged image at outFile's name. Unlink the old one FIRST, then rename
 	// onto the now-free name, for the same reason as MergeDeltaIntoBase's final
@@ -93,9 +97,9 @@ func MergeSparseOverlay(ctx context.Context, baseFile, deltaFile, outFile string
 	// ~1140ms→~115ms. Unlike there, outFile need not exist: this is also called to
 	// write a merged image to a fresh path.
 	if err := os.Remove(outFile); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove old out: %w", err)
+		return 0, fmt.Errorf("remove old out: %w", err)
 	}
-	return os.Rename(tmp, outFile)
+	return deltaBytes, os.Rename(tmp, outFile)
 }
 
 // MergeDeltaIntoBase overlays deltaFile's populated pages onto baseFile in place
@@ -113,19 +117,21 @@ func MergeSparseOverlay(ctx context.Context, baseFile, deltaFile, outFile string
 // checkpoint-state/), so the renames are same-filesystem (metadata-only). If they
 // straddle a mount boundary (EXDEV) it falls back to the copying MergeSparseOverlay
 // (baseFile is untouched until the first rename succeeds).
-func MergeDeltaIntoBase(ctx context.Context, baseFile, deltaFile string) error {
+//
+// Like MergeSparseOverlay, returns the populated bytes of the delta it overlaid.
+func MergeDeltaIntoBase(ctx context.Context, baseFile, deltaFile string) (int64, error) {
 	bi, err := os.Stat(baseFile)
 	if err != nil {
-		return fmt.Errorf("stat base %q: %w", baseFile, err)
+		return 0, fmt.Errorf("stat base %q: %w", baseFile, err)
 	}
 	di, err := os.Stat(deltaFile)
 	if err != nil {
-		return fmt.Errorf("stat delta %q: %w", deltaFile, err)
+		return 0, fmt.Errorf("stat delta %q: %w", deltaFile, err)
 	}
 	if di.Size() != bi.Size() {
 		// Same guest => identical memory-ranges length; a mismatch would misalign the
 		// overlay offsets, so refuse rather than corrupt.
-		return fmt.Errorf("MergeDeltaIntoBase: size mismatch base=%d delta=%d", bi.Size(), di.Size())
+		return 0, fmt.Errorf("MergeDeltaIntoBase: size mismatch base=%d delta=%d", bi.Size(), di.Size())
 	}
 
 	// Move baseFile (with its already-on-disk working set) next to deltaFile. If this
@@ -137,26 +143,27 @@ func MergeDeltaIntoBase(ctx context.Context, baseFile, deltaFile string) error {
 		if errors.Is(err, unix.EXDEV) {
 			return MergeSparseOverlay(ctx, baseFile, deltaFile, deltaFile)
 		}
-		return fmt.Errorf("rename base->merged: %w", err)
+		return 0, fmt.Errorf("rename base->merged: %w", err)
 	}
 
 	d, err := os.Open(deltaFile)
 	if err != nil {
-		return fmt.Errorf("open delta %q: %w", deltaFile, err)
+		return 0, fmt.Errorf("open delta %q: %w", deltaFile, err)
 	}
 	defer d.Close()
 	m, err := os.OpenFile(merged, os.O_RDWR, 0o600)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer m.Close()
-	if _, err := copySparseRegions(d, m); err != nil {
-		return err
+	deltaBytes, err := copySparseRegions(d, m)
+	if err != nil {
+		return 0, err
 	}
 	// No fsync: atelet ships the merged image to GCS (the durability point), so a
 	// partial local file after a crash is just discarded + the suspend retried.
 	if err := m.Close(); err != nil {
-		return err
+		return 0, err
 	}
 	// Put the merged image at deltaFile's name. Unlink the old delta FIRST, then
 	// rename onto the now-free name: renaming OVER an existing file makes ext4
@@ -165,9 +172,9 @@ func MergeDeltaIntoBase(ctx context.Context, baseFile, deltaFile string) error {
 	// ~0.5-0.8s. Renaming to a non-existent name skips that flush (the dirty pages
 	// stay in page cache for atelet to ship), taking the merge ~840ms→~5ms.
 	if err := os.Remove(deltaFile); err != nil {
-		return fmt.Errorf("remove old delta: %w", err)
+		return 0, fmt.Errorf("remove old delta: %w", err)
 	}
-	return os.Rename(merged, deltaFile)
+	return deltaBytes, os.Rename(merged, deltaFile)
 }
 
 // copySparseRegions overwrites dst with every populated (non-hole) region of src

--- a/cmd/ateom-microvm/internal/ch/merge_test.go
+++ b/cmd/ateom-microvm/internal/ch/merge_test.go
@@ -108,8 +108,19 @@ func TestMergeDeltaIntoBase(t *testing.T) {
 	writeSparse(t, base, size, baseRegions)
 	writeSparse(t, delta, size, deltaRegions)
 
-	if err := MergeDeltaIntoBase(ctx, base, delta); err != nil {
+	deltaBytes, err := MergeDeltaIntoBase(ctx, base, delta)
+	if err != nil {
 		t.Fatalf("MergeDeltaIntoBase: %v", err)
+	}
+	// The reported delta size is what the overlay actually copied: at least the
+	// bytes written into the delta (the filesystem may round its data extents
+	// up to block granularity), and never the whole logical image.
+	deltaWritten := int64(0)
+	for _, r := range deltaRegions {
+		deltaWritten += int64(len(r.data))
+	}
+	if deltaBytes < deltaWritten || deltaBytes >= size {
+		t.Errorf("MergeDeltaIntoBase delta bytes = %d, want in [%d, %d)", deltaBytes, deltaWritten, int64(size))
 	}
 	got, err := os.ReadFile(delta)
 	if err != nil {
@@ -137,8 +148,12 @@ func TestMergeDeltaIntoBase(t *testing.T) {
 	rdelta := filepath.Join(rdir, "memory-ranges-delta")
 	writeSparse(t, rbase, size, baseRegions)
 	writeSparse(t, rdelta, size, deltaRegions)
-	if err := MergeSparseOverlay(ctx, rbase, rdelta, rdelta); err != nil {
+	refDeltaBytes, err := MergeSparseOverlay(ctx, rbase, rdelta, rdelta)
+	if err != nil {
 		t.Fatalf("MergeSparseOverlay: %v", err)
+	}
+	if refDeltaBytes != deltaBytes {
+		t.Errorf("MergeSparseOverlay delta bytes = %d, MergeDeltaIntoBase reported %d; the two merges read the same delta", refDeltaBytes, deltaBytes)
 	}
 	ref, err := os.ReadFile(rdelta)
 	if err != nil {
@@ -171,8 +186,12 @@ func TestMergeSparseOverlayNewOutFile(t *testing.T) {
 	writeSparse(t, base, size, baseRegions)
 	writeSparse(t, delta, size, deltaRegions)
 
-	if err := MergeSparseOverlay(context.Background(), base, delta, out); err != nil {
+	deltaBytes, err := MergeSparseOverlay(context.Background(), base, delta, out)
+	if err != nil {
 		t.Fatalf("MergeSparseOverlay: %v", err)
+	}
+	if deltaBytes < int64(len(deltaRegions[0].data)) || deltaBytes >= size {
+		t.Errorf("MergeSparseOverlay delta bytes = %d, want in [%d, %d)", deltaBytes, len(deltaRegions[0].data), int64(size))
 	}
 	got, err := os.ReadFile(out)
 	if err != nil {
@@ -192,7 +211,7 @@ func TestMergeDeltaIntoBaseSizeMismatch(t *testing.T) {
 	delta := filepath.Join(dir, "delta")
 	writeSparse(t, base, 1<<20, []region{{off: 0, data: fill(1, 4096)}})
 	writeSparse(t, delta, 2<<20, []region{{off: 0, data: fill(2, 4096)}})
-	if err := MergeDeltaIntoBase(context.Background(), base, delta); err == nil {
+	if _, err := MergeDeltaIntoBase(context.Background(), base, delta); err == nil {
 		t.Fatal("expected size-mismatch error, got nil")
 	}
 	// base must be untouched (no destructive rename happened before the check).

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -151,6 +151,11 @@ func do(ctx context.Context) error {
 	}
 	defer serverboot.ShutdownProvider("MeterProvider", mp.Shutdown)
 
+	instruments, err := NewInstruments(mp.Meter(serviceName))
+	if err != nil {
+		serverboot.Fatal(ctx, "Failed to create metric instruments", err)
+	}
+
 	// Create ateom dir.
 	ateomDir := ateompath.AteomPath(*podUID)
 	if err := os.MkdirAll(ateomDir, 0o700); err != nil {
@@ -253,7 +258,7 @@ func do(ctx context.Context) error {
 	}()
 	slog.InfoContext(ctx, "atunnel egress serving", slog.String("address", *atunnelEgressListenAddress))
 
-	ateomService := NewService(*podUID, *chBinary, *kataConfig, *kataDebug, *vmmMemReserve, interiorNetNS, actorLogger, atunnelIngress, atunnelEgress, atunnelEgressPort, *workerCredentialBundle, *podIdentityTrustBundle, *egressGatewayTrustBundle)
+	ateomService := NewService(*podUID, *chBinary, *kataConfig, *kataDebug, *vmmMemReserve, interiorNetNS, actorLogger, atunnelIngress, atunnelEgress, atunnelEgressPort, *workerCredentialBundle, *podIdentityTrustBundle, *egressGatewayTrustBundle, instruments)
 
 	svr := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
@@ -448,6 +453,11 @@ type AteomService struct {
 	// one happen — GetWorkloadStats must not take lock at all.
 	activeActor atomic.Pointer[resources.ActorAttribution]
 
+	// instruments holds the snapshot phase histograms. Nil is a valid no-op
+	// (see Instruments), so tests that build an AteomService by hand need no
+	// meter.
+	instruments *Instruments
+
 	// guestStats is what GetWorkloadStats measures with: the kata-agent client
 	// and the guest containers to sum. Nil whenever there is no guest to ask —
 	// before the containers are up, after teardownActor, and for the rest of an
@@ -469,7 +479,7 @@ type AteomService struct {
 var _ ateompb.AteomServer = (*AteomService)(nil)
 
 // NewService creates a new AteomService.
-func NewService(podUID, chBinary, kataConfig string, kataDebug bool, memReserveMiB int, interiorNetNS netns.NsHandle, actorLogger *actorlog.ActorLogger, atunnelIngress *atunnel.Server, atunnelEgress *atunnel.Egress, atunnelEgressPort uint16, workerCredentialBundlePath, podIdentityTrustBundlePath, egressGatewayTrustBundlePath string) *AteomService {
+func NewService(podUID, chBinary, kataConfig string, kataDebug bool, memReserveMiB int, interiorNetNS netns.NsHandle, actorLogger *actorlog.ActorLogger, atunnelIngress *atunnel.Server, atunnelEgress *atunnel.Egress, atunnelEgressPort uint16, workerCredentialBundlePath, podIdentityTrustBundlePath, egressGatewayTrustBundlePath string, instruments *Instruments) *AteomService {
 	return &AteomService{
 		lock:                         newCancelableMutex(),
 		podUID:                       podUID,
@@ -485,6 +495,7 @@ func NewService(podUID, chBinary, kataConfig string, kataDebug bool, memReserveM
 		workerCredentialBundlePath:   workerCredentialBundlePath,
 		podIdentityTrustBundlePath:   podIdentityTrustBundlePath,
 		egressGatewayTrustBundlePath: egressGatewayTrustBundlePath,
+		instruments:                  instruments,
 		running:                      map[string]*runningActor{},
 	}
 }

--- a/cmd/ateom-microvm/metrics.go
+++ b/cmd/ateom-microvm/metrics.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+)
+
+const (
+	restoreDurationMetric    = "ateom.actor.restore.duration"
+	checkpointDurationMetric = "ateom.actor.checkpoint.duration"
+	deltaSizeMetric          = "ateom.snapshot.delta.size"
+)
+
+// snapshotPhaseBuckets match atelet's ate.actor.*.duration buckets, so the
+// finer ateom phases recorded here line up under the ateom_restore /
+// ateom_checkpoint phases they decompose.
+var snapshotPhaseBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60}
+
+// deltaSizeBuckets cover an OnDemand delta: from a near-idle actor that
+// faulted a few hundred KiB back in, up to a guest that re-touched most of a
+// multi-GiB working set.
+var deltaSizeBuckets = []float64{1e5, 1e6, 5e6, 1e7, 2.5e7, 5e7, 1e8, 2.5e8, 5e8, 1e9, 2e9, 5e9}
+
+// Instruments holds ateom's snapshot histograms: the checkpoint/restore phase
+// breakdowns that previously existed only as structured log lines, and the
+// OnDemand delta size. A nil *Instruments is a valid no-op, so call sites
+// need no guard.
+type Instruments struct {
+	restoreDuration    metric.Float64Histogram
+	checkpointDuration metric.Float64Histogram
+	deltaSize          metric.Int64Histogram
+}
+
+func NewInstruments(meter metric.Meter) (*Instruments, error) {
+	restoreDuration, err := meter.Float64Histogram(
+		restoreDurationMetric,
+		metric.WithUnit("s"),
+		metric.WithDescription("Duration of one phase of an actor restore inside ateom-microvm. The phases are sequential and partition the total. Recorded on success."),
+		metric.WithExplicitBucketBoundaries(snapshotPhaseBuckets...),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s histogram: %w", restoreDurationMetric, err)
+	}
+
+	checkpointDuration, err := meter.Float64Histogram(
+		checkpointDurationMetric,
+		metric.WithUnit("s"),
+		metric.WithDescription("Duration of one phase of an actor checkpoint inside ateom-microvm. The snapshot, durable_dir and rootfs_upper captures run concurrently on the paused guest, so those phases are independent observations rather than a partition of the total. Recorded on success."),
+		metric.WithExplicitBucketBoundaries(snapshotPhaseBuckets...),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s histogram: %w", checkpointDurationMetric, err)
+	}
+
+	deltaSize, err := meter.Int64Histogram(
+		deltaSizeMetric,
+		metric.WithUnit("By"),
+		metric.WithDescription("Populated bytes of the OnDemand delta a checkpoint merged into its restore source: the pages the guest faulted in since the restore. Recorded only when a merge happened."),
+		metric.WithExplicitBucketBoundaries(deltaSizeBuckets...),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s histogram: %w", deltaSizeMetric, err)
+	}
+
+	return &Instruments{
+		restoreDuration:    restoreDuration,
+		checkpointDuration: checkpointDuration,
+		deltaSize:          deltaSize,
+	}, nil
+}
+
+// snapshotOp is the dimension set shared by every phase of one restore or
+// checkpoint. The sandbox class is not a dimension: everything this binary
+// emits is microvm, and the service resource already says so.
+type snapshotOp struct {
+	templateNamespace string
+	templateName      string
+	scope             ateompb.SnapshotScope
+}
+
+func (o snapshotOp) attrs() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		ateattr.TemplateNamespaceKey.String(o.templateNamespace),
+		ateattr.TemplateNameKey.String(o.templateName),
+		ateattr.SnapshotScopeKey.String(scopeValue(o.scope)),
+	}
+}
+
+// scopeValue maps the ateom wire enum onto the shared scope label values, the
+// same way ateattr.SnapshotScopeValue does for the atelet enum. An
+// unrecognized scope reports as unknown rather than stringified, so no wire
+// value can widen the label set.
+func scopeValue(scope ateompb.SnapshotScope) string {
+	switch scope {
+	case ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL:
+		return ateattr.SnapshotScopeFull
+	case ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA:
+		return ateattr.SnapshotScopeData
+	case ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN:
+		return ateattr.SnapshotScopeDataOnGolden
+	default:
+		return ateattr.SnapshotScopeUnknown
+	}
+}
+
+// phase is one timed step of a snapshot operation.
+type phase struct {
+	name string
+	d    time.Duration
+}
+
+func (i *Instruments) recordRestore(ctx context.Context, op snapshotOp, phases ...phase) {
+	if i == nil || i.restoreDuration == nil {
+		return
+	}
+	recordPhases(ctx, i.restoreDuration, op, phases)
+}
+
+func (i *Instruments) recordCheckpoint(ctx context.Context, op snapshotOp, phases ...phase) {
+	if i == nil || i.checkpointDuration == nil {
+		return
+	}
+	recordPhases(ctx, i.checkpointDuration, op, phases)
+}
+
+// recordDeltaSize reports the populated bytes of the OnDemand delta a
+// checkpoint overlaid onto its restore source. Zero is a real observation (an
+// idle actor faulted nothing back in); the caller skips the call entirely
+// when no merge happened.
+func (i *Instruments) recordDeltaSize(ctx context.Context, op snapshotOp, bytes int64) {
+	if i == nil || i.deltaSize == nil {
+		return
+	}
+	i.deltaSize.Record(ctx, bytes, metric.WithAttributes(
+		ateattr.TemplateNamespaceKey.String(op.templateNamespace),
+		ateattr.TemplateNameKey.String(op.templateName),
+	))
+}
+
+// recordPhases skips zero-valued phases: those never ran (a Data-scope
+// checkpoint captures no guest, a cold-run checkpoint merges nothing), and
+// reporting them as instantaneous would drag every percentile down.
+func recordPhases(ctx context.Context, h metric.Float64Histogram, op snapshotOp, phases []phase) {
+	base := op.attrs()
+	for _, p := range phases {
+		if p.d == 0 {
+			continue
+		}
+		attrs := make([]attribute.KeyValue, 0, len(base)+1)
+		attrs = append(attrs, base...)
+		attrs = append(attrs, ateattr.SnapshotPhaseKey.String(p.name))
+		h.Record(ctx, p.d.Seconds(), metric.WithAttributes(attrs...))
+	}
+}

--- a/cmd/ateom-microvm/metrics_test.go
+++ b/cmd/ateom-microvm/metrics_test.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+)
+
+const (
+	testTemplateNamespace = "ate-agents"
+	testTemplateName      = "support-agent"
+)
+
+// newTestInstruments builds the histograms against a local ManualReader so
+// tests stay parallel-safe and never touch the global meter provider.
+func newTestInstruments(t *testing.T) (*Instruments, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	inst, err := NewInstruments(mp.Meter("ateom-microvm"))
+	if err != nil {
+		t.Fatalf("NewInstruments: %v", err)
+	}
+	return inst, reader
+}
+
+func collectMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Metrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+	t.Fatalf("metric %q not collected", name)
+	return metricdata.Metrics{}
+}
+
+// phaseValues maps each recorded phase to the attribute set it carries.
+func phaseValues(t *testing.T, m metricdata.Metrics) map[string]attribute.Set {
+	t.Helper()
+	hist, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("%s is %T, want a float64 histogram", m.Name, m.Data)
+	}
+	byPhase := make(map[string]attribute.Set, len(hist.DataPoints))
+	for _, dp := range hist.DataPoints {
+		v, ok := dp.Attributes.Value(ateattr.SnapshotPhaseKey)
+		if !ok {
+			t.Errorf("datapoint without a phase attribute: %v", dp.Attributes.ToSlice())
+			continue
+		}
+		byPhase[v.AsString()] = dp.Attributes
+	}
+	return byPhase
+}
+
+func attrString(t *testing.T, set attribute.Set, k attribute.Key) string {
+	t.Helper()
+	v, ok := set.Value(k)
+	if !ok {
+		t.Errorf("missing attribute %s in %v", k, set.ToSlice())
+		return ""
+	}
+	return v.AsString()
+}
+
+func TestRecordRestoreShape(t *testing.T) {
+	inst, reader := newTestInstruments(t)
+
+	op := snapshotOp{
+		templateNamespace: testTemplateNamespace,
+		templateName:      testTemplateName,
+		scope:             ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN,
+	}
+	inst.recordRestore(context.Background(), op,
+		phase{ateattr.SnapshotPhaseVMRestore, 2 * time.Second},
+		phase{ateattr.SnapshotPhaseReadyz, 500 * time.Millisecond},
+		phase{ateattr.SnapshotPhaseTotal, 3 * time.Second})
+
+	m := collectMetric(t, reader, restoreDurationMetric)
+	if m.Unit != "s" {
+		t.Errorf("unit = %q, want %q", m.Unit, "s")
+	}
+	if m.Description == "" {
+		t.Error("description is empty")
+	}
+
+	byPhase := phaseValues(t, m)
+	if len(byPhase) != 3 {
+		t.Fatalf("recorded %d phases, want vm_restore, readyz and total", len(byPhase))
+	}
+	got := byPhase[ateattr.SnapshotPhaseVMRestore]
+	for _, tc := range []struct {
+		key  attribute.Key
+		want string
+	}{
+		{ateattr.TemplateNamespaceKey, testTemplateNamespace},
+		{ateattr.TemplateNameKey, testTemplateName},
+		{ateattr.SnapshotScopeKey, ateattr.SnapshotScopeDataOnGolden},
+	} {
+		if v := attrString(t, got, tc.key); v != tc.want {
+			t.Errorf("%s = %q, want %q", tc.key, v, tc.want)
+		}
+	}
+	if _, ok := got.Value(ateattr.ActorNameKey); ok {
+		t.Error("actor identity must never reach a metric datapoint")
+	}
+	if _, ok := got.Value(ateattr.ActorUIDKey); ok {
+		t.Error("actor identity must never reach a metric datapoint")
+	}
+}
+
+// TestRecordCheckpointSkipsAbsentPhases keeps phases that never ran out of the
+// percentiles: a Data-scope checkpoint captures no guest, a cold-run actor
+// merges nothing, and reporting either as instantaneous would drag every
+// percentile down.
+func TestRecordCheckpointSkipsAbsentPhases(t *testing.T) {
+	inst, reader := newTestInstruments(t)
+
+	inst.recordCheckpoint(context.Background(), snapshotOp{
+		templateNamespace: testTemplateNamespace,
+		templateName:      testTemplateName,
+		scope:             ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA,
+	},
+		phase{ateattr.SnapshotPhasePause, 5 * time.Millisecond},
+		phase{ateattr.SnapshotPhaseSnapshot, 0},
+		phase{ateattr.SnapshotPhaseRootfsUpper, 0},
+		phase{ateattr.SnapshotPhaseMerge, 0},
+		phase{ateattr.SnapshotPhaseDurableDir, 200 * time.Millisecond},
+		phase{ateattr.SnapshotPhaseTotal, time.Second})
+
+	byPhase := phaseValues(t, collectMetric(t, reader, checkpointDurationMetric))
+	for _, absent := range []string{ateattr.SnapshotPhaseSnapshot, ateattr.SnapshotPhaseRootfsUpper, ateattr.SnapshotPhaseMerge} {
+		if _, ok := byPhase[absent]; ok {
+			t.Errorf("phase %q never ran but was recorded as a zero observation", absent)
+		}
+	}
+	for _, present := range []string{ateattr.SnapshotPhasePause, ateattr.SnapshotPhaseDurableDir, ateattr.SnapshotPhaseTotal} {
+		if _, ok := byPhase[present]; !ok {
+			t.Errorf("phase %q missing", present)
+		}
+	}
+	if v := attrString(t, byPhase[ateattr.SnapshotPhasePause], ateattr.SnapshotScopeKey); v != ateattr.SnapshotScopeData {
+		t.Errorf("scope = %q, want %q", v, ateattr.SnapshotScopeData)
+	}
+}
+
+func TestRecordDeltaSize(t *testing.T) {
+	inst, reader := newTestInstruments(t)
+
+	inst.recordDeltaSize(context.Background(), snapshotOp{
+		templateNamespace: testTemplateNamespace,
+		templateName:      testTemplateName,
+		scope:             ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL,
+	}, 82345)
+
+	m := collectMetric(t, reader, deltaSizeMetric)
+	if m.Unit != "By" {
+		t.Errorf("unit = %q, want %q", m.Unit, "By")
+	}
+	hist, ok := m.Data.(metricdata.Histogram[int64])
+	if !ok {
+		t.Fatalf("%s is %T, want an int64 histogram", m.Name, m.Data)
+	}
+	if len(hist.DataPoints) != 1 {
+		t.Fatalf("recorded %d datapoints, want 1", len(hist.DataPoints))
+	}
+	dp := hist.DataPoints[0]
+	if dp.Sum != 82345 {
+		t.Errorf("sum = %d, want 82345", dp.Sum)
+	}
+	if v := attrString(t, dp.Attributes, ateattr.TemplateNamespaceKey); v != testTemplateNamespace {
+		t.Errorf("template namespace = %q, want %q", v, testTemplateNamespace)
+	}
+	if v := attrString(t, dp.Attributes, ateattr.TemplateNameKey); v != testTemplateName {
+		t.Errorf("template name = %q, want %q", v, testTemplateName)
+	}
+	// The delta is one file of one snapshot; the phase key names steps of an
+	// operation and does not belong here.
+	if _, ok := dp.Attributes.Value(ateattr.SnapshotPhaseKey); ok {
+		t.Error("delta size must not carry a phase attribute")
+	}
+}
+
+// TestScopeValue keeps the scope label bounded: every wire value maps onto the
+// shared label set, and an unrecognized one reports as unknown rather than
+// stringified.
+func TestScopeValue(t *testing.T) {
+	tests := []struct {
+		scope ateompb.SnapshotScope
+		want  string
+	}{
+		{ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL, ateattr.SnapshotScopeFull},
+		{ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA, ateattr.SnapshotScopeData},
+		{ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA_ON_GOLDEN, ateattr.SnapshotScopeDataOnGolden},
+		{ateompb.SnapshotScope_SNAPSHOT_SCOPE_UNSPECIFIED, ateattr.SnapshotScopeUnknown},
+		{ateompb.SnapshotScope(999), ateattr.SnapshotScopeUnknown},
+	}
+	for _, tt := range tests {
+		if got := scopeValue(tt.scope); got != tt.want {
+			t.Errorf("scopeValue(%v) = %q, want %q", tt.scope, got, tt.want)
+		}
+	}
+}
+
+// TestNilInstrumentsAreNoOps is the contract that lets AteomService run
+// without a meter (hand-built in tests): every record helper must tolerate a
+// nil receiver.
+func TestNilInstrumentsAreNoOps(t *testing.T) {
+	var inst *Instruments
+	op := snapshotOp{scope: ateompb.SnapshotScope_SNAPSHOT_SCOPE_FULL}
+	inst.recordRestore(context.Background(), op, phase{ateattr.SnapshotPhaseTotal, time.Second})
+	inst.recordCheckpoint(context.Background(), op, phase{ateattr.SnapshotPhaseTotal, time.Second})
+	inst.recordDeltaSize(context.Background(), op, 1)
+}

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/ch"
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
+	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/imagecache"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
@@ -142,7 +143,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		// files, and the untar above re-materialized the ACTOR's durable-dir
 		// data, so resuming the golden guest picks up the actor's data through
 		// the durable virtio-fs share.
-		if err := s.restoreFullScope(ctx, p, restoreDir, tStart); err != nil {
+		if err := s.restoreFullScope(ctx, p, scope, restoreDir, tStart); err != nil {
 			return nil, err
 		}
 	case ateompb.SnapshotScope_SNAPSHOT_SCOPE_DATA:
@@ -152,8 +153,14 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 		if err := s.coldBootActorRetrying(ctx, p); err != nil {
 			return nil, err
 		}
+		dTotal := time.Since(tStart)
 		slog.InfoContext(ctx, "Actor restored (durable-dir volumes, cold boot)",
-			slog.String("id", p.actorUID), slog.Duration("total", time.Since(tStart)))
+			slog.String("id", p.actorUID), slog.Duration("total", dTotal))
+		// A cold boot has none of the full-scope phases, so the total is the
+		// only observation.
+		s.instruments.recordRestore(ctx,
+			snapshotOp{templateNamespace: p.templateNS, templateName: p.templateName, scope: scope},
+			phase{ateattr.SnapshotPhaseTotal, dTotal})
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "unsupported snapshot scope: %v", scope)
 	}
@@ -174,7 +181,7 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 // and resume. Guest RAM — the actor's in-memory state and the frozen network config —
 // comes back from the memory snapshot; the durable-dir volumes were restored by the
 // caller from their tar.
-func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, restoreDir string, tStart time.Time) (retErr error) {
+func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, scope ateompb.SnapshotScope, restoreDir string, tStart time.Time) (retErr error) {
 	actorUID := p.actorUID
 
 	rr := s.resolveRuntime(p.assetPaths)
@@ -362,6 +369,8 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	// which hid that a first (cold) restore and a later (warm) one differ by more
 	// than 5x on the same actor. upper/lowers is the host reassembling the rootfs;
 	// vm_restore is cloud-hypervisor reading guest RAM back.
+	dReadyz := time.Since(tResume)
+	dTotal := time.Since(tStart)
 	slog.InfoContext(ctx, "Actor restore phases", slog.String("id", actorUID),
 		slog.Duration("prep", tPrep.Sub(tStart)),
 		slog.Duration("bundles", tBundles.Sub(tPrep)),
@@ -372,8 +381,22 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 		slog.Duration("vmm_launch", tLaunch.Sub(tTap)),
 		slog.Duration("vm_restore", tVMRestore.Sub(tLaunch)),
 		slog.Duration("resume", tResume.Sub(tVMRestore)),
-		slog.Duration("readyz", time.Since(tResume)),
-		slog.Duration("total", time.Since(tStart)))
+		slog.Duration("readyz", dReadyz),
+		slog.Duration("total", dTotal))
+	// The durable delta is not recorded: tDurable is pinned to tLowers today,
+	// so it would always be the zero recordPhases skips.
+	s.instruments.recordRestore(ctx,
+		snapshotOp{templateNamespace: p.templateNS, templateName: p.templateName, scope: scope},
+		phase{ateattr.SnapshotPhasePrep, tPrep.Sub(tStart)},
+		phase{ateattr.SnapshotPhaseBundles, tBundles.Sub(tPrep)},
+		phase{ateattr.SnapshotPhaseUpperJoin, tUpper.Sub(tBundles)},
+		phase{ateattr.SnapshotPhaseLowers, tLowers.Sub(tUpper)},
+		phase{ateattr.SnapshotPhaseTap, tTap.Sub(tDurable)},
+		phase{ateattr.SnapshotPhaseVMMLaunch, tLaunch.Sub(tTap)},
+		phase{ateattr.SnapshotPhaseVMRestore, tVMRestore.Sub(tLaunch)},
+		phase{ateattr.SnapshotPhaseResume, tResume.Sub(tVMRestore)},
+		phase{ateattr.SnapshotPhaseReadyz, dReadyz},
+		phase{ateattr.SnapshotPhaseTotal, dTotal})
 
 	// An eager restore has read the whole snapshot into guest memory, and nothing
 	// merges against it afterwards, so the staged copy is dead weight from here on —

--- a/docs/metrics/registry/metrics.yaml
+++ b/docs/metrics/registry/metrics.yaml
@@ -196,11 +196,14 @@ groups:
       - id: ate.snapshot.phase
         stability: development
         brief: >
-          The step of the operation that the component measured. The phases
-          occur at the same time. Thus they do not add up to the total. The
-          download occurs at the same time as the asset fetch and the OCI
-          unpack. Each phase is an independent measurement. A phase that did not
-          start is absent. It is not zero.
+          The step of the operation that the component measured. On the atelet
+          instruments the phases occur at the same time. Thus they do not add
+          up to the total. The download occurs at the same time as the asset
+          fetch and the OCI unpack. Each phase is an independent measurement.
+          A phase that did not start is absent. It is not zero. The
+          ateom-microvm instruments use their own values below. On those the
+          restore phases are sequential and do add up to the total; the note
+          of each instrument says which rule applies.
         type:
           members:
             - id: volume_mount
@@ -242,6 +245,82 @@ groups:
               stability: development
               value: total
               brief: The full operation. Use this value as the denominator. Do not add the phases together.
+            - id: pause
+              stability: development
+              value: pause
+              brief: Checkpoint on ateom-microvm. ateom pauses the guest.
+            - id: snapshot
+              stability: development
+              value: snapshot
+              brief: >
+                Checkpoint on ateom-microvm. cloud-hypervisor writes the VM
+                state and the memory image. This runs at the same time as
+                durable_dir and rootfs_upper.
+            - id: durable_dir
+              stability: development
+              value: durable_dir
+              brief: >
+                Checkpoint on ateom-microvm. ateom tars the durable-dir
+                volumes. This runs at the same time as snapshot and
+                rootfs_upper.
+            - id: rootfs_upper
+              stability: development
+              value: rootfs_upper
+              brief: >
+                Checkpoint on ateom-microvm. ateom tars the rootfs upper. This
+                runs at the same time as snapshot and durable_dir.
+            - id: merge
+              stability: development
+              value: merge
+              brief: >
+                Checkpoint on ateom-microvm. ateom overlays the OnDemand delta
+                onto the restore source. This occurs only for an actor that
+                was restored OnDemand.
+            - id: teardown
+              stability: development
+              value: teardown
+              brief: Checkpoint on ateom-microvm. ateom stops the VMM and cleans the sandbox up.
+            - id: prep
+              stability: development
+              value: prep
+              brief: >
+                Restore on ateom-microvm. The steps before the bundle build,
+                with the durable-dir untar and the snapshot path rewrite.
+            - id: bundles
+              stability: development
+              value: bundles
+              brief: Restore on ateom-microvm. ateom builds the container bundles.
+            - id: upper_join
+              stability: development
+              value: upper_join
+              brief: >
+                Restore on ateom-microvm. ateom waits for the rootfs upper
+                untar. The untar runs behind the bundle build, so this is only
+                the part that did not hide.
+            - id: lowers
+              stability: development
+              value: lowers
+              brief: Restore on ateom-microvm. ateom assembles the merged rootfs and starts virtiofsd.
+            - id: tap
+              stability: development
+              value: tap
+              brief: Restore on ateom-microvm. ateom rebuilds the actor network and the tap devices.
+            - id: vmm_launch
+              stability: development
+              value: vmm_launch
+              brief: Restore on ateom-microvm. ateom launches cloud-hypervisor.
+            - id: vm_restore
+              stability: development
+              value: vm_restore
+              brief: Restore on ateom-microvm. cloud-hypervisor reads the guest state back.
+            - id: resume
+              stability: development
+              value: resume
+              brief: Restore on ateom-microvm. cloud-hypervisor resumes the guest.
+            - id: readyz
+              stability: development
+              value: readyz
+              brief: Restore on ateom-microvm. ateom waits until each container reports ready.
 
   - id: registry.ate.failure
     type: attribute_group
@@ -974,6 +1053,97 @@ groups:
             The outcome is error. The key holds the HTTP status of the registry.
             The permitted values are 401, 403, 404, 429, 500, 502, 503 and 504.
             Each other status, and each failure with no status, reports _OTHER.
+
+  # ---------------------------------------------------------------------------
+  # Metrics. ateom-microvm
+  # ---------------------------------------------------------------------------
+
+  - id: metric.ateom.actor.restore.duration
+    type: metric
+    metric_name: ateom.actor.restore.duration
+    instrument: histogram
+    unit: s
+    stability: development
+    brief: The time of one phase of an actor restore inside ateom-microvm.
+    note: >
+      This instrument breaks the ateom_restore phase of
+      ate.actor.restore.duration down. The phases are sequential. They
+      partition the total, so here they do add up to the total. A Data scope
+      restore is a cold boot, and it records only the total. ateom records the
+      phases on success only. The failures are on the atelet histogram.
+    annotations:
+      substrate:
+        emitted_by: [ateom-microvm]
+        golden_signals: [latency]
+        code_anchor: cmd/ateom-microvm/metrics.go
+        buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60]
+        cuj: The ateom restore is slow. Is the cause the rootfs assembly, the VMM, or the readyz wait?
+    attributes:
+      - ref: ate.template.namespace
+        requirement_level: required
+      - ref: ate.template.name
+        requirement_level: required
+      - ref: ate.snapshot.scope
+        requirement_level: required
+      - ref: ate.snapshot.phase
+        requirement_level: required
+
+  - id: metric.ateom.actor.checkpoint.duration
+    type: metric
+    metric_name: ateom.actor.checkpoint.duration
+    instrument: histogram
+    unit: s
+    stability: development
+    brief: The time of one phase of an actor checkpoint inside ateom-microvm.
+    note: >
+      This instrument breaks the ateom_checkpoint phase of
+      ate.actor.checkpoint.duration down. The snapshot, durable_dir and
+      rootfs_upper captures run at the same time on the paused guest. Thus
+      those three do not add up to the total. The paused window costs the
+      slowest of them. ateom records the phases on success only.
+    annotations:
+      substrate:
+        emitted_by: [ateom-microvm]
+        golden_signals: [latency]
+        code_anchor: cmd/ateom-microvm/metrics.go
+        buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60]
+        cuj: The ateom checkpoint is slow. Is the cause the memory snapshot, a tar, or the merge?
+    attributes:
+      - ref: ate.template.namespace
+        requirement_level: required
+      - ref: ate.template.name
+        requirement_level: required
+      - ref: ate.snapshot.scope
+        requirement_level: required
+      - ref: ate.snapshot.phase
+        requirement_level: required
+
+  - id: metric.ateom.snapshot.delta.size
+    type: metric
+    metric_name: ateom.snapshot.delta.size
+    instrument: histogram
+    unit: By
+    stability: development
+    brief: The populated bytes of the OnDemand delta that a checkpoint merged into its restore source.
+    note: >
+      After an OnDemand restore, cloud-hypervisor writes only the pages that
+      the guest faulted in. ateom merges that delta into the restore source to
+      make the snapshot complete, and this instrument records the size of the
+      delta before the merge. Compare it with atelet.snapshot.size of the
+      memory image: the ratio says how much a delta upload would save. An
+      eager restore and a cold run merge nothing and record nothing.
+    annotations:
+      substrate:
+        emitted_by: [ateom-microvm]
+        golden_signals: [saturation]
+        code_anchor: cmd/ateom-microvm/metrics.go
+        buckets: [100000, 1000000, 5000000, 10000000, 25000000, 50000000, 100000000, 250000000, 500000000, 1000000000, 2000000000, 5000000000]
+        cuj: Would a differential snapshot upload be a small win or a large one?
+    attributes:
+      - ref: ate.template.namespace
+        requirement_level: required
+      - ref: ate.template.name
+        requirement_level: required
 
   # ---------------------------------------------------------------------------
   # Metrics. atecontroller

--- a/internal/ateattr/ateattr.go
+++ b/internal/ateattr/ateattr.go
@@ -262,6 +262,32 @@ const (
 	SnapshotPhaseTotal   = "total"
 )
 
+// Values for SnapshotPhaseKey emitted by ateom-microvm: the breakdown inside
+// the ateom_restore / ateom_checkpoint phases above, promoted from its
+// structured phase logs. Unlike the atelet phases, the restore phases here
+// are sequential and partition the total; the checkpoint captures (snapshot,
+// durable_dir, rootfs_upper) run concurrently on the paused guest, so those
+// three are independent observations.
+const (
+	// Checkpoint phases.
+	SnapshotPhasePause       = "pause"
+	SnapshotPhaseSnapshot    = "snapshot"
+	SnapshotPhaseDurableDir  = "durable_dir"
+	SnapshotPhaseRootfsUpper = "rootfs_upper"
+	SnapshotPhaseMerge       = "merge"
+	SnapshotPhaseTeardown    = "teardown"
+	// Restore phases.
+	SnapshotPhasePrep      = "prep"
+	SnapshotPhaseBundles   = "bundles"
+	SnapshotPhaseUpperJoin = "upper_join"
+	SnapshotPhaseLowers    = "lowers"
+	SnapshotPhaseTap       = "tap"
+	SnapshotPhaseVMMLaunch = "vmm_launch"
+	SnapshotPhaseVMRestore = "vm_restore"
+	SnapshotPhaseResume    = "resume"
+	SnapshotPhaseReadyz    = "readyz"
+)
+
 // FailureReason classifies err onto the bounded ateerrors taxonomy, reading the
 // wrapped Reason or the AIP-193 ErrorInfo detail. An error carrying neither
 // reports ReasonUnknown rather than anything derived from its message, which is


### PR DESCRIPTION
## What this pr do:

Exports ateom-microvm's checkpoint and restore phase breakdowns — until now visible only as structured log lines — as OTel histograms, and records the size of the OnDemand delta a checkpoint merges away.

New instruments (registered in `docs/metrics/registry/metrics.yaml`):

- `ateom.actor.checkpoint.duration` — phases `pause`, `snapshot`, `durable_dir`, `rootfs_upper`, `merge`, `teardown`, `total`. The three captures run concurrently on the paused guest, so they are independent observations, not a partition of the total.
- `ateom.actor.restore.duration` — phases `prep`, `bundles`, `upper_join`, `lowers`, `tap`, `vmm_launch`, `vm_restore`, `resume`, `readyz`, `total`. These are sequential and do partition the total. A Data-scope restore (cold boot) records only the total.
- `ateom.snapshot.delta.size` — populated bytes of the OnDemand delta before `MergeDeltaIntoBase` overlays it onto the restore source. The merge code already computed this and discarded it; both merge functions now return it.

All series carry the shared `ate.snapshot.phase` / `ate.snapshot.scope` / template attributes, so they decompose the existing `ateom_restore` / `ateom_checkpoint` phases of atelet's `ate.actor.*.duration` histograms. Everything rides the meter provider ateom already pushes through atelet's OTLP relay — no new export plumbing. Phases are recorded where the logs are (success path); failures remain visible on atelet's histograms. A nil `*Instruments` is a no-op, so hand-built test services need no meter.

## Why is it needed:

The suspend/resume benchmarking effort needs percentiles, not anecdotes, for where time goes *inside* the micro-VM lifecycle. Today the atelet-level phases end at opaque `ateom_restore` / `ateom_checkpoint` blocks, and the finer breakdown exists only in logs. With the large-memory benchmark workloads landing separately, these histograms are what splits a slow resume between rootfs assembly, the VMM memory restore, and the readyz wait — and `ateom.snapshot.delta.size` vs. the memory image size is the single number that says whether differential snapshot uploads are a 2x or a 10x win.

## Testing

- `GOOS=linux go build` / `go vet ./cmd/ateom-microvm/...` clean
- `go test ./cmd/ateom-microvm ./internal/ateattr` pass (new metrics tests run host-side against a ManualReader; merge tests assert the returned delta byte count)
- `gofmt` clean; registry validated with `hack/verify/metrics.sh`