### PR TITLE
docs: add meeting notes and recordings links to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ We host a weekly community meeting every Thursday from 10:00am - 11:00am PST.
 - Video call link: https://meet.google.com/uhq-cxvn-dhy
 - Or dial: (US) +1 253-289-6971 PIN: 787 664 574 59#
 - More phone numbers: https://tel.meet/uhq-cxvn-dhy?pin=9044088223662
+- [Meeting notes](https://docs.google.com/document/d/1obSIvfcafLNniLYTQCcT2eCgxHqa2AQ3Ga7YTsju49s) for the weekly sync meeting
+- [Recordings and transcripts](https://drive.google.com/corp/drive/u/0/folders/1rX1S6vPxPrR8dA1lEBuBEXkGKjHtG-mL) of all community meetings
 
 We also have channels in the CNCF slack; [request an invite here](https://slack.cncf.io/)
 if you don't have access.


### PR DESCRIPTION
Extends the Community section of the README with:

- A link to the [meeting notes document](https://docs.google.com/document/d/1obSIvfcafLNniLYTQCcT2eCgxHqa2AQ3Ga7YTsju49s) for the weekly community sync meeting.
- A link to the [Drive folder](https://drive.google.com/corp/drive/u/0/folders/1rX1S6vPxPrR8dA1lEBuBEXkGKjHtG-mL) containing video recordings and transcripts of all community meetings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)