### PR TITLE
atelet(benchmarking): per-file snapshot transfer metrics with byte-layer breakdown

### DIFF
--- a/cmd/atelet/internal/ategcs/gcssparse.go
+++ b/cmd/atelet/internal/ategcs/gcssparse.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync/atomic"
 
 	"cloud.google.com/go/storage"
 	"golang.org/x/sync/errgroup"
@@ -42,28 +43,28 @@ const partWriterChunk = 16 << 20
 // The parts are consecutive byte ranges of the same sparse-extent stream — part 0
 // carries the header, the last carries the end sentinel — so the composed object is
 // exactly what the single-stream writer would have produced.
-func (g *gcsClient) PutSparseFile(ctx context.Context, bucket, object string, f *os.File) (res writeContentResult, err error) {
+func (g *gcsClient) PutSparseFile(ctx context.Context, bucket, object string, f *os.File) (stats UploadStats, err error) {
 	fi, err := f.Stat()
 	if err != nil {
-		return res, err
+		return stats, err
 	}
 	size := fi.Size()
 	exts, populated, err := sparseExtents(f, size)
 	if err != nil {
-		return res, err
+		return stats, err
 	}
-	res = writeContentResult{logicalBytes: size, populatedBytes: populated, sparse: true}
+	stats = UploadStats{LogicalBytes: size, PopulatedBytes: populated, Sparse: true}
 
 	n := sparsePartCount(populated)
 	if n < 2 {
 		// Too small to be worth splitting; the plain streaming path handles it.
-		return res, errSparseTooSmall
+		return stats, errSparseTooSmall
 	}
 	groups := planSparseParts(exts, populated, n)
 
 	var idBytes [8]byte
 	if _, err := rand.Read(idBytes[:]); err != nil {
-		return res, fmt.Errorf("while naming upload parts: %w", err)
+		return stats, fmt.Errorf("while naming upload parts: %w", err)
 	}
 	runID := hex.EncodeToString(idBytes[:])
 
@@ -81,6 +82,9 @@ func (g *gcsClient) PutSparseFile(ctx context.Context, bucket, object string, f 
 		}
 	}()
 
+	// The parts are consecutive ranges of one compressed stream, so the bytes
+	// handed to the part writers sum to the composed object's (wire) size.
+	var wire atomic.Int64
 	grp, gctx := errgroup.WithContext(ctx)
 	for i, ranges := range groups {
 		grp.Go(func() error {
@@ -88,7 +92,7 @@ func (g *gcsClient) PutSparseFile(ctx context.Context, bucket, object string, f 
 			obj := g.uploadClient(gctx, i).Bucket(bucket).Object(parts[i].ObjectName())
 			w := obj.NewWriter(gctx)
 			w.ChunkSize = partWriterChunk
-			if err := writeSparsePart(w, f, size, ranges, i == 0, i == len(groups)-1); err != nil {
+			if err := writeSparsePart(countingWriter{w: w, n: &wire}, f, size, ranges, i == 0, i == len(groups)-1); err != nil {
 				_ = w.Close()
 				return fmt.Errorf("while writing part %d of %q: %w", i, object, err)
 			}
@@ -96,9 +100,10 @@ func (g *gcsClient) PutSparseFile(ctx context.Context, bucket, object string, f 
 		})
 	}
 	if err := grp.Wait(); err != nil {
-		return res, err
+		return stats, err
 	}
-	return res, composeAll(ctx, bkt, object, parts, runID)
+	stats.WireBytes = wire.Load()
+	return stats, composeAll(ctx, bkt, object, parts, runID)
 }
 
 // errSparseTooSmall says the object is not worth splitting, so the caller should fall

--- a/cmd/atelet/internal/ategcs/objects.go
+++ b/cmd/atelet/internal/ategcs/objects.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/agent-substrate/substrate/internal/ateerrors"
@@ -93,13 +94,68 @@ func SendBytesToGCS(ctx context.Context, client ObjectStorage, gsURL string, con
 	return nil
 }
 
-func SendLocalFileToGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL string, localFilePath string) (err error) {
+// UploadStats reports the byte counts of one compressed upload, so a caller
+// can meter the transfer at each layer: the file as it appears on disk, the
+// bytes actually read, and the bytes that crossed the network.
+type UploadStats struct {
+	// LogicalBytes is the apparent size of the source, holes included.
+	LogicalBytes int64
+	// PopulatedBytes is the non-hole bytes actually read and compressed;
+	// equal to LogicalBytes for a dense source.
+	PopulatedBytes int64
+	// WireBytes is the compressed bytes handed to the object store.
+	WireBytes int64
+	// Sparse is true when the sparse-extent format was used.
+	Sparse bool
+}
+
+// DownloadStats mirrors UploadStats for a download: the logical size restored,
+// the non-hole bytes actually written, and the compressed bytes fetched.
+type DownloadStats struct {
+	// LogicalBytes is the logical size written locally (the original image size).
+	LogicalBytes int64
+	// PopulatedBytes is the non-hole bytes actually written locally.
+	PopulatedBytes int64
+	// WireBytes is the compressed bytes read from the object store.
+	WireBytes int64
+	// Sparse is true when the object used the sparse-extent format.
+	Sparse bool
+}
+
+// countingWriter counts the bytes written through it: the compressed (wire)
+// bytes handed to the object store. The count is atomic so the range-parallel
+// upload's part writers can share one counter.
+type countingWriter struct {
+	w io.Writer
+	n *atomic.Int64
+}
+
+func (cw countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	cw.n.Add(int64(n))
+	return n, err
+}
+
+// countingReader counts the bytes read through it: the compressed (wire)
+// bytes fetched from the object store.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (cr *countingReader) Read(p []byte) (int, error) {
+	n, err := cr.r.Read(p)
+	cr.n += int64(n)
+	return n, err
+}
+
+func SendLocalFileToGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL string, localFilePath string) (stats UploadStats, err error) {
 	ctx, span := tracer.Start(ctx, "sendLocalFileToGCSWithZstd")
 	defer span.End()
 
 	localFile, err := os.Open(localFilePath)
 	if err != nil {
-		return fmt.Errorf("while opening %q: %w", localFilePath, err)
+		return UploadStats{}, fmt.Errorf("while opening %q: %w", localFilePath, err)
 	}
 	defer func() {
 		if closeErr := localFile.Close(); closeErr != nil {
@@ -111,11 +167,12 @@ func SendLocalFileToGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL
 		}
 	}()
 
-	if err := sendZstd(ctx, client, gsURL, localFile); err != nil {
-		return fmt.Errorf("in sendZstd: %w", err)
+	stats, err = sendZstd(ctx, client, gsURL, localFile)
+	if err != nil {
+		return UploadStats{}, fmt.Errorf("in sendZstd: %w", err)
 	}
 
-	return nil
+	return stats, nil
 }
 
 // sparseFilePutter marks a backend that can upload a sparse FILE directly, splitting
@@ -123,7 +180,7 @@ func SendLocalFileToGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL
 // part splitter. Reports errSparseTooSmall when the file is not worth splitting, in
 // which case the caller falls back to the streaming path.
 type sparseFilePutter interface {
-	PutSparseFile(ctx context.Context, bucket, object string, f *os.File) (writeContentResult, error)
+	PutSparseFile(ctx context.Context, bucket, object string, f *os.File) (UploadStats, error)
 }
 
 // streamingPutter marks an ObjectStorage whose PutObject accepts a non-seekable
@@ -177,30 +234,31 @@ func writeContent(out io.Writer, content io.Reader) (writeContentResult, error) 
 //   - S3/rustfs PutObject hands the body to the AWS SDK, which needs a seekable body
 //     to sign + set Content-Length (a non-seekable pipe hangs there), so we compress
 //     to a SEEKABLE temp file first.
-func sendZstd(ctx context.Context, client ObjectStorage, gsURL string, content io.Reader) error {
+func sendZstd(ctx context.Context, client ObjectStorage, gsURL string, content io.Reader) (UploadStats, error) {
 	bucket, object, err := parseGCSURL(gsURL)
 	if err != nil {
-		return fmt.Errorf("while parsing URL: %w", err)
+		return UploadStats{}, fmt.Errorf("while parsing URL: %w", err)
 	}
 	tStart := time.Now()
 	if sp, ok := client.(sparseFilePutter); ok {
 		if f, isFile := content.(*os.File); isFile {
-			res, err := sp.PutSparseFile(ctx, bucket, object, f)
+			stats, err := sp.PutSparseFile(ctx, bucket, object, f)
 			switch {
 			case err == nil:
 				slog.InfoContext(ctx, "Compressed zstd upload",
 					slog.String("object", object), slog.Bool("sparse", true),
 					slog.Bool("ranged", true),
-					slog.Int64("logical_bytes", res.logicalBytes),
-					slog.Int64("populated_bytes", res.populatedBytes),
+					slog.Int64("logical_bytes", stats.LogicalBytes),
+					slog.Int64("populated_bytes", stats.PopulatedBytes),
+					slog.Int64("wire_bytes", stats.WireBytes),
 					slog.Duration("total", time.Since(tStart)))
-				return nil
+				return stats, nil
 			case !errors.Is(err, errSparseTooSmall):
-				return fmt.Errorf("while putting object %q: %w", object, err)
+				return UploadStats{}, fmt.Errorf("while putting object %q: %w", object, err)
 			}
 			// Too small to split: fall through to the streaming path.
 			if _, err := f.Seek(0, io.SeekStart); err != nil {
-				return err
+				return UploadStats{}, err
 			}
 		}
 	}
@@ -213,10 +271,10 @@ func sendZstd(ctx context.Context, client ObjectStorage, gsURL string, content i
 // sendBufferedZstd compresses content to a seekable temp file, then uploads it.
 // Used for backends (S3/rustfs) whose PutObject needs a seekable body to sign and
 // set Content-Length; the streaming counterpart is sendStreamingZstd.
-func sendBufferedZstd(ctx context.Context, client ObjectStorage, bucket, object string, content io.Reader, tStart time.Time) error {
+func sendBufferedZstd(ctx context.Context, client ObjectStorage, bucket, object string, content io.Reader, tStart time.Time) (UploadStats, error) {
 	tmpFile, err := os.CreateTemp("", "substrate-upload-compress-")
 	if err != nil {
-		return fmt.Errorf("while creating temp compress file: %w", err)
+		return UploadStats{}, fmt.Errorf("while creating temp compress file: %w", err)
 	}
 	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
@@ -224,21 +282,35 @@ func sendBufferedZstd(ctx context.Context, client ObjectStorage, bucket, object 
 	t0 := time.Now()
 	res, err := writeContent(tmpFile, content)
 	if err != nil {
-		return fmt.Errorf("while compressing %q: %w", object, err)
+		return UploadStats{}, fmt.Errorf("while compressing %q: %w", object, err)
 	}
 	dCompress := time.Since(t0)
 
+	// The temp file holds exactly the compressed payload, so its size is the
+	// wire byte count.
+	fi, err := tmpFile.Stat()
+	if err != nil {
+		return UploadStats{}, fmt.Errorf("while sizing temp file: %w", err)
+	}
+	stats := UploadStats{
+		LogicalBytes:   res.logicalBytes,
+		PopulatedBytes: res.populatedBytes,
+		WireBytes:      fi.Size(),
+		Sparse:         res.sparse,
+	}
+
 	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("while seeking temp file: %w", err)
+		return UploadStats{}, fmt.Errorf("while seeking temp file: %w", err)
 	}
 	if err := client.PutObject(ctx, bucket, object, tmpFile); err != nil {
-		return fmt.Errorf("while putting object %q: %w", object, err)
+		return UploadStats{}, fmt.Errorf("while putting object %q: %w", object, err)
 	}
 	slog.InfoContext(ctx, "Compressed zstd upload",
-		slog.String("object", object), slog.Bool("sparse", res.sparse),
-		slog.Int64("logical_bytes", res.logicalBytes), slog.Int64("populated_bytes", res.populatedBytes),
+		slog.String("object", object), slog.Bool("sparse", stats.Sparse),
+		slog.Int64("logical_bytes", stats.LogicalBytes), slog.Int64("populated_bytes", stats.PopulatedBytes),
+		slog.Int64("wire_bytes", stats.WireBytes),
 		slog.Duration("compress", dCompress), slog.Duration("total", time.Since(tStart)))
-	return nil
+	return stats, nil
 }
 
 // sendStreamingZstd compresses content and uploads it in one overlapped pass: a
@@ -246,15 +318,18 @@ func sendBufferedZstd(ctx context.Context, client ObjectStorage, bucket, object 
 // PutObject streams the read end to the object store. No seekable temp file, and
 // the compress runs concurrently with the network PUT. Used only for streaming
 // backends (GCS); see sendZstd.
-func sendStreamingZstd(ctx context.Context, client ObjectStorage, bucket, object string, content io.Reader, tStart time.Time) error {
+func sendStreamingZstd(ctx context.Context, client ObjectStorage, bucket, object string, content io.Reader, tStart time.Time) (UploadStats, error) {
 	type result struct {
 		res writeContentResult
 		err error
 	}
 	pr, pw := io.Pipe()
 	ch := make(chan result, 1)
+	// Everything the compressor feeds the pipe is what PutObject sends: count
+	// it on the write side, where the byte count survives a failed upload.
+	var wire atomic.Int64
 	go func() {
-		res, err := writeContent(pw, content)
+		res, err := writeContent(countingWriter{w: pw, n: &wire}, content)
 		// Closing the writer delivers EOF (or the compress error) to PutObject.
 		_ = pw.CloseWithError(err)
 		ch <- result{res: res, err: err}
@@ -268,16 +343,23 @@ func sendStreamingZstd(ctx context.Context, client ObjectStorage, bucket, object
 	}
 	r := <-ch
 	if putErr != nil {
-		return fmt.Errorf("while putting object %q: %w", object, putErr)
+		return UploadStats{}, fmt.Errorf("while putting object %q: %w", object, putErr)
 	}
 	if r.err != nil {
-		return fmt.Errorf("while compressing %q: %w", object, r.err)
+		return UploadStats{}, fmt.Errorf("while compressing %q: %w", object, r.err)
+	}
+	stats := UploadStats{
+		LogicalBytes:   r.res.logicalBytes,
+		PopulatedBytes: r.res.populatedBytes,
+		WireBytes:      wire.Load(),
+		Sparse:         r.res.sparse,
 	}
 	slog.InfoContext(ctx, "Compressed zstd upload",
-		slog.String("object", object), slog.Bool("sparse", r.res.sparse), slog.Bool("streaming", true),
-		slog.Int64("logical_bytes", r.res.logicalBytes), slog.Int64("populated_bytes", r.res.populatedBytes),
+		slog.String("object", object), slog.Bool("sparse", stats.Sparse), slog.Bool("streaming", true),
+		slog.Int64("logical_bytes", stats.LogicalBytes), slog.Int64("populated_bytes", stats.PopulatedBytes),
+		slog.Int64("wire_bytes", stats.WireBytes),
 		slog.Duration("total", time.Since(tStart)))
-	return nil
+	return stats, nil
 }
 
 // plainZstd writes src to w as a single plain zstd stream (SpeedFastest, all
@@ -297,13 +379,13 @@ func plainZstd(w io.Writer, src io.Reader) (int64, error) {
 	return n, zw.Close()
 }
 
-func FetchLocalFileFromGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL string, localFilePath string) (err error) {
+func FetchLocalFileFromGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL string, localFilePath string) (stats DownloadStats, err error) {
 	ctx, span := tracer.Start(ctx, "fetchLocalFileFromGCSWithZstd")
 	defer span.End()
 
 	localFile, err := os.Create(localFilePath)
 	if err != nil {
-		return fmt.Errorf("while opening %q: %w", localFilePath, err)
+		return DownloadStats{}, fmt.Errorf("while opening %q: %w", localFilePath, err)
 	}
 	defer func() {
 		if closeErr := localFile.Close(); closeErr != nil {
@@ -316,25 +398,26 @@ func FetchLocalFileFromGCSWithZstd(ctx context.Context, client ObjectStorage, gs
 	}()
 
 	if err := localFile.Chmod(0o600); err != nil {
-		return fmt.Errorf("in localFile.Chmod(0o600): %w", err)
+		return DownloadStats{}, fmt.Errorf("in localFile.Chmod(0o600): %w", err)
 	}
 
-	if err := fetchFromGCSWithZstd(ctx, client, gsURL, localFile); err != nil {
-		return fmt.Errorf("while fetching %q from GCS: %w", gsURL, err)
+	stats, err = fetchFromGCSWithZstd(ctx, client, gsURL, localFile)
+	if err != nil {
+		return DownloadStats{}, fmt.Errorf("while fetching %q from GCS: %w", gsURL, err)
 	}
 
-	return nil
+	return stats, nil
 }
 
-func fetchFromGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL string, out io.Writer) (err error) {
+func fetchFromGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL string, out io.Writer) (stats DownloadStats, err error) {
 	bucket, object, err := parseGCSURL(gsURL)
 	if err != nil {
-		return fmt.Errorf("%w:while parsing URL: %w", ateerrors.ReasonInvalidObjectURL, err)
+		return DownloadStats{}, fmt.Errorf("%w:while parsing URL: %w", ateerrors.ReasonInvalidObjectURL, err)
 	}
 
 	rc, err := client.GetObject(ctx, bucket, object)
 	if err != nil {
-		return fmt.Errorf("while getting object: %w", err)
+		return DownloadStats{}, fmt.Errorf("while getting object: %w", err)
 	}
 	defer func() {
 		if closeErr := rc.Close(); closeErr != nil {
@@ -347,22 +430,32 @@ func fetchFromGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL strin
 	}()
 
 	t0 := time.Now()
-	res, err := decodeContent(out, rc)
+	// The decoder consumes the whole object, so the bytes read off rc are the
+	// compressed (wire) byte count.
+	cr := &countingReader{r: rc}
+	res, err := decodeContent(out, cr)
 	if err != nil {
-		return err
+		return DownloadStats{}, err
+	}
+	stats = DownloadStats{
+		LogicalBytes:   res.logicalBytes,
+		PopulatedBytes: res.writtenBytes,
+		WireBytes:      cr.n,
+		Sparse:         res.sparse,
 	}
 	slog.InfoContext(ctx, "Decompressed zstd download",
-		slog.Bool("sparse", res.sparse), slog.Int64("logical_bytes", res.logicalBytes),
-		slog.Int64("written_bytes", res.writtenBytes), slog.Duration("took", time.Since(t0)))
-	return nil
+		slog.Bool("sparse", stats.Sparse), slog.Int64("logical_bytes", stats.LogicalBytes),
+		slog.Int64("written_bytes", stats.PopulatedBytes), slog.Int64("wire_bytes", stats.WireBytes),
+		slog.Duration("took", time.Since(t0)))
+	return stats, nil
 }
 
 // decodeContentResult reports what decodeContent decompressed.
 type decodeContentResult struct {
 	// logicalBytes is the logical size written to out (the original image size).
 	logicalBytes int64
-	// writtenBytes is the count of non-hole bytes actually written on the sparse
-	// file path; 0 on the io.Copy fallback (non-file destination).
+	// writtenBytes is the count of non-hole bytes actually written on the
+	// file-destination paths; 0 on the io.Copy fallback (non-file destination).
 	writtenBytes int64
 	// sparse is true when the input used the sparse-extent format.
 	sparse bool
@@ -382,11 +475,11 @@ func decodeContent(out io.Writer, src io.Reader) (decodeContentResult, error) {
 		if !ok {
 			return decodeContentResult{}, fmt.Errorf("sparse-extent snapshot requires a file destination, got %T", out)
 		}
-		size, derr := readSparseZstd(f, src) // src is positioned just after the magic
+		size, written, derr := readSparseZstd(f, src) // src is positioned just after the magic
 		if derr != nil {
 			return decodeContentResult{}, fmt.Errorf("in sparse-extent decode: %w", derr)
 		}
-		return decodeContentResult{logicalBytes: size, sparse: true}, nil
+		return decodeContentResult{logicalBytes: size, writtenBytes: written, sparse: true}, nil
 	}
 	if rerr != nil && rerr != io.EOF && rerr != io.ErrUnexpectedEOF {
 		return decodeContentResult{}, fmt.Errorf("while reading object header: %w", rerr)

--- a/cmd/atelet/internal/ategcs/objects_test.go
+++ b/cmd/atelet/internal/ategcs/objects_test.go
@@ -54,6 +54,44 @@ type streamingMemStore struct{ *memStore }
 
 func (s *streamingMemStore) supportsStreamingPut() {}
 
+// assertUploadStats checks the byte counts an upload reported: the logical
+// size exactly, the populated bytes between the data written into the sparse
+// source and the logical size (the filesystem may round extents up to block
+// granularity, or report no holes at all), and the wire bytes exactly the
+// stored object's size.
+func assertUploadStats(t *testing.T, s UploadStats, logical, minPopulated, wire int64, sparse bool) {
+	t.Helper()
+	if s.LogicalBytes != logical {
+		t.Errorf("upload LogicalBytes = %d, want %d", s.LogicalBytes, logical)
+	}
+	if s.PopulatedBytes < minPopulated || s.PopulatedBytes > logical {
+		t.Errorf("upload PopulatedBytes = %d, want in [%d, %d]", s.PopulatedBytes, minPopulated, logical)
+	}
+	if s.WireBytes != wire {
+		t.Errorf("upload WireBytes = %d, want %d (the stored object's size)", s.WireBytes, wire)
+	}
+	if s.Sparse != sparse {
+		t.Errorf("upload Sparse = %v, want %v", s.Sparse, sparse)
+	}
+}
+
+// assertDownloadStats mirrors assertUploadStats for the fetch side.
+func assertDownloadStats(t *testing.T, s DownloadStats, logical, minPopulated, wire int64, sparse bool) {
+	t.Helper()
+	if s.LogicalBytes != logical {
+		t.Errorf("download LogicalBytes = %d, want %d", s.LogicalBytes, logical)
+	}
+	if s.PopulatedBytes < minPopulated || s.PopulatedBytes > logical {
+		t.Errorf("download PopulatedBytes = %d, want in [%d, %d]", s.PopulatedBytes, minPopulated, logical)
+	}
+	if s.WireBytes != wire {
+		t.Errorf("download WireBytes = %d, want %d (the stored object's size)", s.WireBytes, wire)
+	}
+	if s.Sparse != sparse {
+		t.Errorf("download Sparse = %v, want %v", s.Sparse, sparse)
+	}
+}
+
 // TestSparseUploadStreamingRoundTrip drives the STREAMING upload path (GCS-like
 // backend) end-to-end through the real entry points: the object must still be the
 // sparse-extent format (magic) and download byte-exact. This guards the pipe path
@@ -86,7 +124,8 @@ func TestSparseUploadStreamingRoundTrip(t *testing.T) {
 	store := &streamingMemStore{newMemStore()}
 	ctx := context.Background()
 	const gsURL = "gs://bucket/snap/memory-ranges.zstd"
-	if err := SendLocalFileToGCSWithZstd(ctx, store, gsURL, srcPath); err != nil {
+	up, err := SendLocalFileToGCSWithZstd(ctx, store, gsURL, srcPath)
+	if err != nil {
 		t.Fatalf("streaming upload: %v", err)
 	}
 	stored := store.m["bucket/snap/memory-ranges.zstd"]
@@ -96,10 +135,13 @@ func TestSparseUploadStreamingRoundTrip(t *testing.T) {
 	if int64(len(stored)) >= size/2 {
 		t.Errorf("stored %d bytes; expected far less than logical %d (holes not skipped)", len(stored), size)
 	}
+	assertUploadStats(t, up, size, int64(4096+70000+5000), int64(len(stored)), true)
 	dstPath := filepath.Join(dir, "restored")
-	if err := FetchLocalFileFromGCSWithZstd(ctx, store, gsURL, dstPath); err != nil {
+	down, err := FetchLocalFileFromGCSWithZstd(ctx, store, gsURL, dstPath)
+	if err != nil {
 		t.Fatalf("download: %v", err)
 	}
+	assertDownloadStats(t, down, size, int64(4096+70000+5000), int64(len(stored)), true)
 	got, err := os.ReadFile(dstPath)
 	if err != nil {
 		t.Fatal(err)
@@ -148,7 +190,8 @@ func TestSparseUploadDownloadRoundTrip(t *testing.T) {
 	store := newMemStore()
 	ctx := context.Background()
 	const gsURL = "gs://bucket/snap/memory-ranges.zstd"
-	if err := SendLocalFileToGCSWithZstd(ctx, store, gsURL, srcPath); err != nil {
+	up, err := SendLocalFileToGCSWithZstd(ctx, store, gsURL, srcPath)
+	if err != nil {
 		t.Fatalf("upload: %v", err)
 	}
 	// The stored object must use the sparse-extent format (magic header).
@@ -160,11 +203,14 @@ func TestSparseUploadDownloadRoundTrip(t *testing.T) {
 	if int64(len(stored)) >= size/2 {
 		t.Errorf("stored %d bytes; expected far less than logical %d (holes not skipped)", len(stored), size)
 	}
+	assertUploadStats(t, up, size, int64(4096+70000+5000), int64(len(stored)), true)
 
 	dstPath := filepath.Join(dir, "restored")
-	if err := FetchLocalFileFromGCSWithZstd(ctx, store, gsURL, dstPath); err != nil {
+	down, err := FetchLocalFileFromGCSWithZstd(ctx, store, gsURL, dstPath)
+	if err != nil {
 		t.Fatalf("download: %v", err)
 	}
+	assertDownloadStats(t, down, size, int64(4096+70000+5000), int64(len(stored)), true)
 	got, err := os.ReadFile(dstPath)
 	if err != nil {
 		t.Fatal(err)
@@ -221,7 +267,7 @@ func TestSparseVersionRejected(t *testing.T) {
 	}
 	defer out.Close()
 	// readSparseZstd is called with the reader positioned just after the magic.
-	if _, err := readSparseZstd(out, bytes.NewReader(blob[len(sparseMagic):])); err == nil {
+	if _, _, err := readSparseZstd(out, bytes.NewReader(blob[len(sparseMagic):])); err == nil {
 		t.Fatal("expected an unsupported-version error, got nil")
 	}
 }
@@ -282,17 +328,33 @@ func TestPlainZstdBackwardCompatRoundTrip(t *testing.T) {
 	const gsURL = "gs://bucket/snap/config.json.zstd"
 	// SendBytesToGCS is uncompressed; use sendZstd with a non-file reader to
 	// hit the plain-zstd branch (no magic).
-	if err := sendZstd(ctx, store, gsURL, bytes.NewReader(want)); err != nil {
+	up, err := sendZstd(ctx, store, gsURL, bytes.NewReader(want))
+	if err != nil {
 		t.Fatalf("upload: %v", err)
 	}
 	stored := store.m["bucket/snap/config.json.zstd"]
 	if len(stored) >= len(sparseMagic) && string(stored[:len(sparseMagic)]) == sparseMagic {
 		t.Fatal("non-file upload unexpectedly used the sparse-extent format")
 	}
+	if up.Sparse {
+		t.Error("plain-zstd upload reported Sparse")
+	}
+	if up.WireBytes != int64(len(stored)) {
+		t.Errorf("upload WireBytes = %d, want %d (the stored object's size)", up.WireBytes, len(stored))
+	}
 	dir := t.TempDir()
 	dstPath := filepath.Join(dir, "config.json")
-	if err := FetchLocalFileFromGCSWithZstd(ctx, store, gsURL, dstPath); err != nil {
+	down, err := FetchLocalFileFromGCSWithZstd(ctx, store, gsURL, dstPath)
+	if err != nil {
 		t.Fatalf("download: %v", err)
+	}
+	// A dense payload: everything logical is populated.
+	if down.LogicalBytes != int64(len(want)) || down.PopulatedBytes != int64(len(want)) {
+		t.Errorf("download logical/populated = %d/%d, want %d/%d",
+			down.LogicalBytes, down.PopulatedBytes, len(want), len(want))
+	}
+	if down.WireBytes != int64(len(stored)) {
+		t.Errorf("download WireBytes = %d, want %d (the stored object's size)", down.WireBytes, len(stored))
 	}
 	got, err := os.ReadFile(dstPath)
 	if err != nil {

--- a/cmd/atelet/internal/ategcs/s3bench_test.go
+++ b/cmd/atelet/internal/ategcs/s3bench_test.go
@@ -68,7 +68,7 @@ func TestS3UploadAgainstRealServer(t *testing.T) {
 
 	start := time.Now()
 	url := fmt.Sprintf("gs://%s/bench/memory-ranges-%d.zstd", bucket, time.Now().UnixNano())
-	if err := SendLocalFileToGCSWithZstd(ctx, client, url, srcPath); err != nil {
+	if _, err := SendLocalFileToGCSWithZstd(ctx, client, url, srcPath); err != nil {
 		t.Fatalf("upload: %v", err)
 	}
 	d := time.Since(start)
@@ -78,7 +78,7 @@ func TestS3UploadAgainstRealServer(t *testing.T) {
 	// A multipart upload that reassembles wrong is worse than a slow one: pull the
 	// object back and compare it to the source byte for byte.
 	dst := filepath.Join(t.TempDir(), "restored")
-	if err := FetchLocalFileFromGCSWithZstd(ctx, client, url, dst); err != nil {
+	if _, err := FetchLocalFileFromGCSWithZstd(ctx, client, url, dst); err != nil {
 		t.Fatalf("download: %v", err)
 	}
 	if got, want := sha256File(t, dst), sha256File(t, srcPath); got != want {

--- a/cmd/atelet/internal/ategcs/sparseparts_test.go
+++ b/cmd/atelet/internal/ategcs/sparseparts_test.go
@@ -135,7 +135,7 @@ func decodeSparse(t *testing.T, r io.Reader) []byte {
 	}
 	defer os.Remove(out.Name())
 	defer out.Close()
-	if _, err := readSparseZstd(out, r); err != nil {
+	if _, _, err := readSparseZstd(out, r); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := out.Seek(0, io.SeekStart); err != nil {

--- a/cmd/atelet/internal/ategcs/sparsezstd.go
+++ b/cmd/atelet/internal/ategcs/sparsezstd.go
@@ -132,31 +132,32 @@ func writeSparseZstd(dst io.Writer, src *os.File) (logical, dataBytes int64, err
 // readSparseZstd decodes the sparse-extent format into dst, which becomes a sparse
 // file (the holes between extents are never written). src must be positioned just
 // AFTER the magic (the caller reads + dispatches on it). dst is truncated to the
-// logical size so trailing holes + the exact size are represented.
-func readSparseZstd(dst *os.File, src io.Reader) (logical int64, err error) {
+// logical size so trailing holes + the exact size are represented. Returns the
+// logical size and the extent (non-hole) bytes actually written.
+func readSparseZstd(dst *os.File, src io.Reader) (logical, written int64, err error) {
 	var ver uint32
 	if err := binary.Read(src, binary.LittleEndian, &ver); err != nil {
-		return 0, fmt.Errorf("reading sparse format version: %w", err)
+		return 0, 0, fmt.Errorf("reading sparse format version: %w", err)
 	}
 	if ver != sparseVersion {
-		return 0, fmt.Errorf("unsupported sparse snapshot format version %d (this build supports %d)", ver, sparseVersion)
+		return 0, 0, fmt.Errorf("unsupported sparse snapshot format version %d (this build supports %d)", ver, sparseVersion)
 	}
 
 	zr, err := zstd.NewReader(src, zstd.WithDecoderConcurrency(1))
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	defer zr.Close()
 
 	var size int64
 	if err := binary.Read(zr, binary.LittleEndian, &size); err != nil {
-		return 0, fmt.Errorf("reading totalSize: %w", err)
+		return 0, 0, fmt.Errorf("reading totalSize: %w", err)
 	}
 	if size < 0 {
-		return 0, fmt.Errorf("negative totalSize %d", size)
+		return 0, 0, fmt.Errorf("negative totalSize %d", size)
 	}
 	if err := dst.Truncate(size); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
 	// Replay the extent frames written by writeSparseZstd. Each frame is an offset
@@ -165,27 +166,29 @@ func readSparseZstd(dst *os.File, src io.Reader) (logical int64, err error) {
 	for {
 		var off int64
 		if err := binary.Read(zr, binary.LittleEndian, &off); err != nil {
-			return 0, fmt.Errorf("reading extent offset: %w", err)
+			return 0, 0, fmt.Errorf("reading extent offset: %w", err)
 		}
 		if off == sparseEndOffset {
 			break
 		}
 		var length int64
 		if err := binary.Read(zr, binary.LittleEndian, &length); err != nil {
-			return 0, fmt.Errorf("reading extent length: %w", err)
+			return 0, 0, fmt.Errorf("reading extent length: %w", err)
 		}
 		// Validate against the declared size (the stream is the downloaded snapshot):
 		// an out-of-range extent would seek/write past the file or wrap on the
 		// off+length arithmetic. size-off is safe because off <= size.
 		if off < 0 || length < 0 || off > size || length > size-off {
-			return 0, fmt.Errorf("sparse extent out of range (off=%d len=%d size=%d)", off, length, size)
+			return 0, 0, fmt.Errorf("sparse extent out of range (off=%d len=%d size=%d)", off, length, size)
 		}
 		if _, err := dst.Seek(off, io.SeekStart); err != nil {
-			return 0, err
+			return 0, 0, err
 		}
-		if _, err := io.CopyN(dst, zr, length); err != nil {
-			return 0, fmt.Errorf("writing extent @%d+%d: %w", off, length, err)
+		n, err := io.CopyN(dst, zr, length)
+		written += n
+		if err != nil {
+			return 0, 0, fmt.Errorf("writing extent @%d+%d: %w", off, length, err)
 		}
 	}
-	return size, nil
+	return size, written, nil
 }

--- a/cmd/atelet/internal/ategcs/sparsezstd_test.go
+++ b/cmd/atelet/internal/ategcs/sparsezstd_test.go
@@ -91,7 +91,7 @@ func TestSparseZstdRoundTrip(t *testing.T) {
 			defer src.Close()
 
 			var buf bytes.Buffer
-			logical, _, err := writeSparseZstd(&buf, src)
+			logical, dataBytes, err := writeSparseZstd(&buf, src)
 			if err != nil {
 				t.Fatalf("writeSparseZstd: %v", err)
 			}
@@ -108,12 +108,18 @@ func TestSparseZstdRoundTrip(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer dst.Close()
-			size, err := readSparseZstd(dst, bytes.NewReader(buf.Bytes()[len(sparseMagic):]))
+			size, written, err := readSparseZstd(dst, bytes.NewReader(buf.Bytes()[len(sparseMagic):]))
 			if err != nil {
 				t.Fatalf("readSparseZstd: %v", err)
 			}
 			if size != tc.size {
 				t.Errorf("readSparseZstd size=%d, want %d", size, tc.size)
+			}
+			// The reader replays exactly the extent bytes the writer fed in
+			// (fs-independent, unlike the declared regions, which the fs may
+			// round up to blocks or not make sparse at all).
+			if written != dataBytes {
+				t.Errorf("readSparseZstd written=%d, want %d (writeSparseZstd's dataBytes)", written, dataBytes)
 			}
 
 			want, err := os.ReadFile(srcPath)
@@ -204,7 +210,7 @@ func TestReadSparseZstdRejectsMalformed(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer dst.Close()
-			_, err = readSparseZstd(dst, bytes.NewReader(tc.stream))
+			_, _, err = readSparseZstd(dst, bytes.NewReader(tc.stream))
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tc.want)
 			}
@@ -226,7 +232,7 @@ func TestReadSparseZstdTruncated(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer dst.Close()
-	if _, err := readSparseZstd(dst, bytes.NewReader(stream)); err == nil {
+	if _, _, err := readSparseZstd(dst, bytes.NewReader(stream)); err == nil {
 		t.Fatal("expected an error for a stream missing its end sentinel, got nil")
 	}
 }

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -776,9 +776,14 @@ func (s *AteomHerder) uploadSnapshot(ctx context.Context, uri resources.Snapshot
 			if err != nil {
 				return fmt.Errorf("while addressing %s in GCS: %w", fileName, err)
 			}
-			if err := ategcs.SendLocalFileToGCSWithZstd(gCtx, s.gcsClient, objectURI, local); err != nil {
+			t := time.Now()
+			stats, err := ategcs.SendLocalFileToGCSWithZstd(gCtx, s.gcsClient, objectURI, local)
+			if err != nil {
 				return fmt.Errorf("while uploading %s to GCS: %w", fileName, err)
 			}
+			s.instruments.recordTransfer(gCtx, templateNamespace, templateName, fileName,
+				ateattr.SnapshotPhasePersist, time.Since(t),
+				stats.LogicalBytes, stats.PopulatedBytes, stats.WireBytes)
 			return nil
 		})
 	}
@@ -794,9 +799,14 @@ func (s *AteomHerder) uploadSnapshot(ctx context.Context, uri resources.Snapshot
 	if err != nil {
 		return fmt.Errorf("while addressing snapshot manifest in GCS: %w", err)
 	}
+	tManifest := time.Now()
 	if err := ategcs.SendBytesToGCS(ctx, s.gcsClient, manifestURI, manifest); err != nil {
 		return fmt.Errorf("while uploading snapshot manifest: %w", err)
 	}
+	// The manifest ships uncompressed, so all three byte kinds are its length.
+	s.instruments.recordTransfer(ctx, templateNamespace, templateName, sandboxManifestName,
+		ateattr.SnapshotPhasePersist, time.Since(tManifest),
+		int64(len(manifest)), int64(len(manifest)), int64(len(manifest)))
 	return nil
 }
 
@@ -1093,10 +1103,10 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 				if goldenRec == nil {
 					return fmt.Errorf("no golden snapshot record for a %s restore", req.GetScope())
 				}
-				if err := s.downloadCombinedCheckpoint(gctx, req.GetExternalConfig().GetSnapshotUri(), req.GetGoldenSnapshotUri(), checkpointDir, sandboxRec.SnapshotFiles, goldenRec.SnapshotFiles); err != nil {
+				if err := s.downloadCombinedCheckpoint(gctx, req.GetExternalConfig().GetSnapshotUri(), req.GetGoldenSnapshotUri(), checkpointDir, sandboxRec.SnapshotFiles, goldenRec.SnapshotFiles, req.GetActorTemplateNamespace(), req.GetActorTemplateName()); err != nil {
 					return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonFailedGetExternalObject, ateerrors.ReasonInvalidObjectURL, ateerrors.ReasonTerminalFileSystemError)
 				}
-			} else if err := s.downloadExternalCheckpoint(gctx, req.GetExternalConfig().GetSnapshotUri(), checkpointDir, sandboxRec.SnapshotFiles); err != nil {
+			} else if err := s.downloadExternalCheckpoint(gctx, req.GetExternalConfig().GetSnapshotUri(), checkpointDir, sandboxRec.SnapshotFiles, req.GetActorTemplateNamespace(), req.GetActorTemplateName()); err != nil {
 				return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonFailedGetExternalObject, ateerrors.ReasonInvalidObjectURL, ateerrors.ReasonTerminalFileSystemError)
 			}
 		case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
@@ -1116,7 +1126,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			})
 			if combineWithGolden {
 				gLocal.Go(func() error {
-					if err := s.downloadExternalCheckpoint(gLocalCtx, req.GetGoldenSnapshotUri(), checkpointDir, goldenOnlyFiles(sandboxRec.SnapshotFiles, goldenRec.SnapshotFiles)); err != nil {
+					if err := s.downloadExternalCheckpoint(gLocalCtx, req.GetGoldenSnapshotUri(), checkpointDir, goldenOnlyFiles(sandboxRec.SnapshotFiles, goldenRec.SnapshotFiles), req.GetActorTemplateNamespace(), req.GetActorTemplateName()); err != nil {
 						return ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonFailedGetExternalObject, ateerrors.ReasonInvalidObjectURL, ateerrors.ReasonTerminalFileSystemError)
 					}
 					return nil
@@ -1461,18 +1471,18 @@ func goldenOnlyFiles(actorFiles, goldenFiles []string) []string {
 // as a single folder: every file of the actor's own snapshot (the durable-dir
 // data) plus the golden snapshot's files the actor's set does not shadow, so
 // the result looks like a Full snapshot whose durable-dir data is the actor's.
-func (s *AteomHerder) downloadCombinedCheckpoint(ctx context.Context, actorURI, goldenURI, dstDir string, actorFiles, goldenFiles []string) error {
+func (s *AteomHerder) downloadCombinedCheckpoint(ctx context.Context, actorURI, goldenURI, dstDir string, actorFiles, goldenFiles []string, templateNamespace, templateName string) error {
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		return s.downloadExternalCheckpoint(gctx, actorURI, dstDir, actorFiles)
+		return s.downloadExternalCheckpoint(gctx, actorURI, dstDir, actorFiles, templateNamespace, templateName)
 	})
 	g.Go(func() error {
-		return s.downloadExternalCheckpoint(gctx, goldenURI, dstDir, goldenOnlyFiles(actorFiles, goldenFiles))
+		return s.downloadExternalCheckpoint(gctx, goldenURI, dstDir, goldenOnlyFiles(actorFiles, goldenFiles), templateNamespace, templateName)
 	})
 	return g.Wait()
 }
 
-func (s *AteomHerder) downloadExternalCheckpoint(ctx context.Context, snapshotURI string, dstDir string, files []string) error {
+func (s *AteomHerder) downloadExternalCheckpoint(ctx context.Context, snapshotURI string, dstDir string, files []string, templateNamespace, templateName string) error {
 	uri, err := resources.ParseSnapshotURI(snapshotURI)
 	if err != nil {
 		return err
@@ -1486,9 +1496,14 @@ func (s *AteomHerder) downloadExternalCheckpoint(ctx context.Context, snapshotUR
 			if err != nil {
 				return fmt.Errorf("while addressing %s in GCS: %w", fileName, err)
 			}
-			if err := ategcs.FetchLocalFileFromGCSWithZstd(gCtx, s.gcsClient, objectURI, local); err != nil {
+			t := time.Now()
+			stats, err := ategcs.FetchLocalFileFromGCSWithZstd(gCtx, s.gcsClient, objectURI, local)
+			if err != nil {
 				return fmt.Errorf("while downloading %s from GCS: %w", fileName, err)
 			}
+			s.instruments.recordTransfer(gCtx, templateNamespace, templateName, fileName,
+				ateattr.SnapshotPhaseDownload, time.Since(t),
+				stats.LogicalBytes, stats.PopulatedBytes, stats.WireBytes)
 			return nil
 		})
 	}

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -1189,7 +1189,8 @@ func TestDownloadCombinedCheckpoint(t *testing.T) {
 		"gs://bucket/golden-root/snapshots/ate-golden/golden-1",
 		dstDir,
 		[]string{"durable-dir.tar"},
-		[]string{"config.json", "memory-ranges", "durable-dir.tar"})
+		[]string{"config.json", "memory-ranges", "durable-dir.tar"},
+		"ate-demo", "counter")
 	if err != nil {
 		t.Fatalf("downloadCombinedCheckpoint: %v", err)
 	}

--- a/cmd/atelet/metrics.go
+++ b/cmd/atelet/metrics.go
@@ -21,6 +21,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
@@ -30,6 +31,8 @@ import (
 const (
 	restoreDurationMetric    = "ate.actor.restore.duration"
 	checkpointDurationMetric = "ate.actor.checkpoint.duration"
+	transferDurationMetric   = "atelet.snapshot.transfer.duration"
+	transferSizeMetric       = "atelet.snapshot.transfer.size"
 )
 
 // snapshotPhaseBuckets have to cover both ends of a phase breakdown: a warm OCI
@@ -37,11 +40,18 @@ const (
 // fetching a multi-GiB snapshot runs for tens of seconds.
 var snapshotPhaseBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60}
 
+// snapshotTransferSizeBuckets are the atelet.snapshot.size buckets extended
+// downward: one transfer observation can be a multi-GiB memory image's logical
+// size or a kilobyte manifest's wire size.
+var snapshotTransferSizeBuckets = []float64{1e4, 1e5, 1e6, 5e6, 1e7, 2.5e7, 5e7, 1e8, 2.5e8, 5e8, 1e9, 2e9, 5e9, 1e10}
+
 // Instruments holds atelet's cold-start histograms. A nil *Instruments is a
 // valid no-op, so call sites need no guard.
 type Instruments struct {
 	restoreDuration    metric.Float64Histogram
 	checkpointDuration metric.Float64Histogram
+	transferDuration   metric.Float64Histogram
+	transferSize       metric.Int64Histogram
 }
 
 func NewInstruments(meter metric.Meter) (*Instruments, error) {
@@ -65,9 +75,31 @@ func NewInstruments(meter metric.Meter) (*Instruments, error) {
 		return nil, fmt.Errorf("create %s histogram: %w", checkpointDurationMetric, err)
 	}
 
+	transferDuration, err := meter.Float64Histogram(
+		transferDurationMetric,
+		metric.WithUnit("s"),
+		metric.WithDescription("Duration of one snapshot file's transfer to or from object storage."),
+		metric.WithExplicitBucketBoundaries(snapshotPhaseBuckets...),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s histogram: %w", transferDurationMetric, err)
+	}
+
+	transferSize, err := meter.Int64Histogram(
+		transferSizeMetric,
+		metric.WithUnit("By"),
+		metric.WithDescription("Bytes of one snapshot file's transfer, one observation per ate.snapshot.bytes.kind value: logical (apparent size, holes included), populated (non-hole bytes read or written), and wire (compressed bytes on the wire)."),
+		metric.WithExplicitBucketBoundaries(snapshotTransferSizeBuckets...),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create %s histogram: %w", transferSizeMetric, err)
+	}
+
 	return &Instruments{
 		restoreDuration:    restoreDuration,
 		checkpointDuration: checkpointDuration,
+		transferDuration:   transferDuration,
+		transferSize:       transferSize,
 	}, nil
 }
 
@@ -121,6 +153,42 @@ func (i *Instruments) recordCheckpoint(ctx context.Context, op snapshotOp, err e
 		return
 	}
 	recordPhases(ctx, i.checkpointDuration, op, err, phases)
+}
+
+// recordTransfer records one snapshot file moving to (persist) or from
+// (download) object storage: the duration once, and the size once per byte
+// kind so a benchmark can tell which file dominates a phase and how much the
+// compression and the hole-skipping save. A negative size means the caller
+// does not know that count and is skipped; zero is a real observation. The
+// identity is the template's, like every atelet metric label — never the
+// actor's.
+func (i *Instruments) recordTransfer(ctx context.Context, templateNamespace, templateName, fileName, phaseName string, d time.Duration, logical, populated, wire int64) {
+	if i == nil || i.transferDuration == nil || i.transferSize == nil {
+		return
+	}
+	base := []attribute.KeyValue{
+		ateattr.TemplateNamespaceKey.String(templateNamespace),
+		ateattr.TemplateNameKey.String(templateName),
+		ateattr.SnapshotPhaseKey.String(phaseName),
+		semconv.FileNameKey.String(fileName),
+	}
+	i.transferDuration.Record(ctx, d.Seconds(), metric.WithAttributes(base...))
+	for _, kind := range []struct {
+		name string
+		n    int64
+	}{
+		{ateattr.SnapshotBytesKindLogical, logical},
+		{ateattr.SnapshotBytesKindPopulated, populated},
+		{ateattr.SnapshotBytesKindWire, wire},
+	} {
+		if kind.n < 0 {
+			continue
+		}
+		attrs := make([]attribute.KeyValue, 0, len(base)+1)
+		attrs = append(attrs, base...)
+		attrs = append(attrs, ateattr.SnapshotBytesKindKey.String(kind.name))
+		i.transferSize.Record(ctx, kind.n, metric.WithAttributes(attrs...))
+	}
 }
 
 // recordPhases skips zero-valued phases: those never started, because the

--- a/cmd/atelet/metrics_test.go
+++ b/cmd/atelet/metrics_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/ateerrors"
@@ -447,4 +448,119 @@ func TestCheckpointSnapshotKind(t *testing.T) {
 			}
 		})
 	}
+}
+
+// transferPoints returns the size datapoints of one collect keyed by bytes
+// kind, plus the duration datapoint count.
+func transferPoints(t *testing.T, reader *sdkmetric.ManualReader) (sizes map[string]metricdata.HistogramDataPoint[int64], durations int) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	sizes = map[string]metricdata.HistogramDataPoint[int64]{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case transferSizeMetric:
+				hist, ok := m.Data.(metricdata.Histogram[int64])
+				if !ok {
+					t.Fatalf("%s is %T, want an int64 histogram", m.Name, m.Data)
+				}
+				for _, dp := range hist.DataPoints {
+					v, ok := dp.Attributes.Value(ateattr.SnapshotBytesKindKey)
+					if !ok {
+						t.Errorf("size datapoint without a bytes kind: %v", dp.Attributes.ToSlice())
+						continue
+					}
+					sizes[v.AsString()] = dp
+				}
+			case transferDurationMetric:
+				hist, ok := m.Data.(metricdata.Histogram[float64])
+				if !ok {
+					t.Fatalf("%s is %T, want a float64 histogram", m.Name, m.Data)
+				}
+				durations = len(hist.DataPoints)
+			}
+		}
+	}
+	return sizes, durations
+}
+
+func TestRecordTransferShape(t *testing.T) {
+	inst, reader := newTestInstruments(t)
+
+	inst.recordTransfer(context.Background(), testTemplateNamespace, testTemplateName,
+		"memory-ranges", ateattr.SnapshotPhasePersist, 2*time.Second,
+		2<<30, 300<<20, 120<<20)
+
+	sizes, durations := transferPoints(t, reader)
+	if durations != 1 {
+		t.Errorf("recorded %d duration datapoints, want 1", durations)
+	}
+	wantSizes := map[string]int64{
+		ateattr.SnapshotBytesKindLogical:   2 << 30,
+		ateattr.SnapshotBytesKindPopulated: 300 << 20,
+		ateattr.SnapshotBytesKindWire:      120 << 20,
+	}
+	if len(sizes) != len(wantSizes) {
+		t.Fatalf("recorded %d size kinds, want %d: %v", len(sizes), len(wantSizes), sizes)
+	}
+	for kind, want := range wantSizes {
+		dp, ok := sizes[kind]
+		if !ok {
+			t.Errorf("bytes kind %q missing", kind)
+			continue
+		}
+		if dp.Sum != want {
+			t.Errorf("%s sum = %d, want %d", kind, dp.Sum, want)
+		}
+		for _, tc := range []struct {
+			key  attribute.Key
+			want string
+		}{
+			{ateattr.TemplateNamespaceKey, testTemplateNamespace},
+			{ateattr.TemplateNameKey, testTemplateName},
+			{ateattr.SnapshotPhaseKey, ateattr.SnapshotPhasePersist},
+			{semconv.FileNameKey, "memory-ranges"},
+		} {
+			if v := attrString(t, dp.Attributes, tc.key); v != tc.want {
+				t.Errorf("%s: %s = %q, want %q", kind, tc.key, v, tc.want)
+			}
+		}
+		if _, ok := dp.Attributes.Value(ateattr.ActorNameKey); ok {
+			t.Error("actor identity must never reach a metric datapoint")
+		}
+	}
+}
+
+// TestRecordTransferSkipsUnknownSizes keeps "the caller could not count this"
+// (negative) out of the histogram while keeping zero, which is a real
+// observation (an empty file transfers zero bytes).
+func TestRecordTransferSkipsUnknownSizes(t *testing.T) {
+	inst, reader := newTestInstruments(t)
+
+	inst.recordTransfer(context.Background(), testTemplateNamespace, testTemplateName,
+		"durable-dir.tar", ateattr.SnapshotPhaseDownload, time.Second,
+		4096, -1, 0)
+
+	sizes, _ := transferPoints(t, reader)
+	if _, ok := sizes[ateattr.SnapshotBytesKindPopulated]; ok {
+		t.Error("a negative (unknown) populated count was recorded")
+	}
+	wire, ok := sizes[ateattr.SnapshotBytesKindWire]
+	if !ok {
+		t.Fatal("a zero wire count is a real observation and must be recorded")
+	}
+	if wire.Sum != 0 {
+		t.Errorf("wire sum = %d, want 0", wire.Sum)
+	}
+}
+
+// TestRecordTransferNilInstruments is the no-op contract for hand-built
+// services with no meter.
+func TestRecordTransferNilInstruments(t *testing.T) {
+	var inst *Instruments
+	inst.recordTransfer(context.Background(), testTemplateNamespace, testTemplateName,
+		"memory-ranges", ateattr.SnapshotPhaseDownload, time.Second, 1, 1, 1)
 }

--- a/docs/metrics/registry/metrics.yaml
+++ b/docs/metrics/registry/metrics.yaml
@@ -242,6 +242,26 @@ groups:
               stability: development
               value: total
               brief: The full operation. Use this value as the denominator. Do not add the phases together.
+      - id: ate.snapshot.bytes.kind
+        stability: development
+        brief: >
+          The layer at which one snapshot-file transfer observation counts its
+          bytes. The three kinds measure the same transfer. Thus group by this
+          key. Do not sum across it.
+        type:
+          members:
+            - id: logical
+              stability: development
+              value: logical
+              brief: The apparent size of the file, holes included.
+            - id: populated
+              stability: development
+              value: populated
+              brief: The bytes that are not holes. These are the bytes the transfer read or wrote on disk.
+            - id: wire
+              stability: development
+              value: wire
+              brief: The compressed bytes on the wire.
 
   - id: registry.ate.failure
     type: attribute_group
@@ -852,6 +872,71 @@ groups:
       - ref: ate.template.namespace
         requirement_level: required
       - ref: ate.template.name
+        requirement_level: required
+
+  - id: metric.atelet.snapshot.transfer.duration
+    type: metric
+    metric_name: atelet.snapshot.transfer.duration
+    instrument: histogram
+    unit: s
+    stability: development
+    brief: The time of one snapshot file's transfer to or from object storage.
+    note: >
+      atelet records one measurement for each file of a snapshot, on the
+      upload of a checkpoint and on the download of a restore. The files of
+      one snapshot transfer at the same time, so the observations do not add
+      up to the download or persist phase of the ate.actor histograms. Pair
+      this instrument with the wire kind of atelet.snapshot.transfer.size to
+      compute the throughput of each file.
+    annotations:
+      substrate:
+        emitted_by: [atelet]
+        golden_signals: [latency]
+        code_anchor: cmd/atelet/metrics.go
+        buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60]
+        cuj: The download phase is slow. Is the cause the memory image or the durable-dir tar?
+    attributes:
+      - ref: file.name
+        requirement_level: required
+      - ref: ate.template.namespace
+        requirement_level: required
+      - ref: ate.template.name
+        requirement_level: required
+      - ref: ate.snapshot.phase
+        requirement_level: required
+        note: Only the download and persist values occur on this instrument.
+
+  - id: metric.atelet.snapshot.transfer.size
+    type: metric
+    metric_name: atelet.snapshot.transfer.size
+    instrument: histogram
+    unit: By
+    stability: development
+    brief: The bytes of one snapshot file's transfer, one observation for each byte kind.
+    note: >
+      For each transferred file atelet records the logical size, the populated
+      (non-hole) bytes, and the compressed wire bytes. Group by the
+      ate.snapshot.bytes.kind key. Do not sum across it. The ratio of
+      populated to logical shows how sparse the memory image is. The ratio of
+      wire to populated shows what the compression saves.
+    annotations:
+      substrate:
+        emitted_by: [atelet]
+        golden_signals: [saturation]
+        code_anchor: cmd/atelet/metrics.go
+        buckets: [10000, 100000, 1000000, 5000000, 10000000, 25000000, 50000000, 100000000, 250000000, 500000000, 1000000000, 2000000000, 5000000000, 10000000000]
+        cuj: How many bytes does each snapshot file put on the wire, and at which actor shape?
+    attributes:
+      - ref: file.name
+        requirement_level: required
+      - ref: ate.template.namespace
+        requirement_level: required
+      - ref: ate.template.name
+        requirement_level: required
+      - ref: ate.snapshot.phase
+        requirement_level: required
+        note: Only the download and persist values occur on this instrument.
+      - ref: ate.snapshot.bytes.kind
         requirement_level: required
 
   - id: metric.ate.actor.stats.cpu.time

--- a/internal/ateattr/ateattr.go
+++ b/internal/ateattr/ateattr.go
@@ -100,6 +100,7 @@ const (
 	SnapshotKindKey         = attribute.Key("ate.snapshot.kind")
 	SnapshotScopeKey        = attribute.Key("ate.snapshot.scope")
 	SnapshotPhaseKey        = attribute.Key("ate.snapshot.phase")
+	SnapshotBytesKindKey    = attribute.Key("ate.snapshot.bytes.kind")
 	ImageCacheOutcomeKey    = attribute.Key("ate.imagecache.outcome")
 	SchedulerOutcomeKey     = attribute.Key("ate.scheduler.outcome")
 	SchedulingConstraintKey = attribute.Key("ate.scheduling.constraint")
@@ -260,6 +261,18 @@ const (
 	// for local); SnapshotKindKey already says which.
 	SnapshotPhasePersist = "persist"
 	SnapshotPhaseTotal   = "total"
+)
+
+// Values for SnapshotBytesKindKey: the layer at which one snapshot-file
+// transfer observation counts its bytes. The three kinds measure the same
+// transfer, so rollups must group by this key rather than sum across it.
+const (
+	// SnapshotBytesKindLogical is the file's apparent size, holes included.
+	SnapshotBytesKindLogical = "logical"
+	// SnapshotBytesKindPopulated is the non-hole bytes actually read or written.
+	SnapshotBytesKindPopulated = "populated"
+	// SnapshotBytesKindWire is the compressed bytes on the wire.
+	SnapshotBytesKindWire = "wire"
 )
 
 // FailureReason classifies err onto the bounded ateerrors taxonomy, reading the


### PR DESCRIPTION
## What

Adds a per-file breakdown of snapshot transfers between atelet and object storage. Until now the `download` and `persist` phases were single observations, and `atelet.snapshot.size` recorded only a file's logical size on checkpoint — nothing said which file a slow phase spent its time on, or how many bytes actually crossed the network.

New instruments (registered in `docs/metrics/registry/metrics.yaml`), recorded once per snapshot file on both upload (`persist`) and download (`download`), including the manifest:

- `atelet.snapshot.transfer.duration` — one file's transfer time, labeled with `file.name` and `ate.snapshot.phase`. Files transfer concurrently, so observations don't sum to the phase total; compare them against each other.
- `atelet.snapshot.transfer.size` — the same file's bytes, one datapoint per `ate.snapshot.bytes.kind` value:
  - `logical` — apparent size, holes included;
  - `populated` — non-hole bytes actually read/written;
  - `wire` — compressed bytes on the network.

To feed this, `ategcs.SendLocalFileToGCSWithZstd` and `FetchLocalFileFromGCSWithZstd` now return `UploadStats` / `DownloadStats`. Logical and populated bytes were already computed internally and discarded; wire bytes are newly counted with a counting writer/reader on every route (range-parallel sparse upload, streaming upload, buffered S3 upload, and download). The sparse decoder also reports the extent bytes it writes, so populated bytes exist on the download side too. The existing per-transfer log lines gain a `wire_bytes` field.

## Why

The suspend/resume benchmarking effort needs to split transfer time and bytes between the memory image (`memory-ranges`), the durable-dir tar, and the rootfs upper at each actor shape — that split is the fork between the memory-image optimizations (delta uploads, lazy restore) and the durable-dir/tar optimizations. Duration × wire bytes gives per-file throughput; populated vs. logical shows how sparse the memory image really is; wire vs. populated shows what compression saves. None of that was observable before.

## Testing

- Sparse and plain round-trip tests now assert the returned stats: logical size exact, populated bounded (filesystems may round extents to blocks or report no holes), and wire bytes equal to the stored object's exact size.
- `readSparseZstd`'s written-bytes return is asserted equal to the encoder's fed data bytes (filesystem-independent invariant).
- New `recordTransfer` tests: attribute shape, one size datapoint per byte kind, negative (unknown) sizes skipped while zero is recorded, nil instruments are a no-op, actor identity never reaches a datapoint.
- `go build`, `go vet`, `gofmt` clean; `go test ./cmd/atelet/...` passes.
- Registry validated with `hack/verify/metrics.sh`.