### PR TITLE
workersync: gate worker registration on ateom readiness

### DIFF
--- a/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
@@ -486,6 +486,10 @@ func createWorkerPod(t *testing.T, tc *testContext, ns string, name string, node
 	}
 	createdPod.Status.PodIPs = []corev1.PodIP{{IP: "127.0.0.1"}}
 	createdPod.Status.Phase = corev1.PodRunning
+	createdPod.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	}}
 	_, err = tc.k8sClient.CoreV1().Pods(ns).UpdateStatus(context.Background(), createdPod, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("failed to update worker pod status: %v", err)

--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	appsv1ac "k8s.io/client-go/applyconfigurations/apps/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -103,7 +104,15 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettin
 			corev1ac.ContainerPort().
 				WithName("connect").
 				WithContainerPort(444).
+				WithProtocol(corev1.ProtocolTCP),
+			corev1ac.ContainerPort().
+				WithName("readyz").
+				WithContainerPort(8080).
 				WithProtocol(corev1.ProtocolTCP)).
+		WithReadinessProbe(corev1ac.Probe().
+			WithHTTPGet(corev1ac.HTTPGetAction().
+				WithPath("/readyz").
+				WithPort(intstr.FromString("readyz")))).
 		WithSecurityContext(ateomSecurityContext(wp.Spec.SandboxClass)).
 		WithEnv(ateomContainerEnv(otel)...).
 		WithVolumeMounts(

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	appsv1ac "k8s.io/client-go/applyconfigurations/apps/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -784,7 +785,15 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 				corev1ac.ContainerPort().
 					WithName("connect").
 					WithContainerPort(444).
+					WithProtocol(corev1.ProtocolTCP),
+				corev1ac.ContainerPort().
+					WithName("readyz").
+					WithContainerPort(8080).
 					WithProtocol(corev1.ProtocolTCP)).
+			WithReadinessProbe(corev1ac.Probe().
+				WithHTTPGet(corev1ac.HTTPGetAction().
+					WithPath("/readyz").
+					WithPort(intstr.FromString("readyz")))).
 			WithSecurityContext(corev1ac.SecurityContext().
 				WithRunAsUser(0).
 				WithRunAsGroup(0).

--- a/cmd/atecontroller/internal/workersync/syncer.go
+++ b/cmd/atecontroller/internal/workersync/syncer.go
@@ -237,7 +237,7 @@ func (s *WorkerPoolSyncer) reconcile(ctx context.Context, key workerKey) error {
 		return s.markWorkerDraining(ctx, key)
 	}
 	if !isWorkerEligible(pod) {
-		// No IP yet; a later update event re-enqueues the pod.
+		// The pod has no IP or is not Ready yet; a later update event re-enqueues it.
 		return nil
 	}
 	return s.createOrUpdateWorker(ctx, key, pod)
@@ -316,7 +316,15 @@ func (s *WorkerPoolSyncer) createOrUpdateWorker(ctx context.Context, key workerK
 }
 
 func isWorkerEligible(pod *corev1.Pod) bool {
-	return pod.Status.PodIP != ""
+	if pod.Status.PodIP == "" {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // ateomContainerName is the name of the container in a worker pod that hosts the

--- a/cmd/atecontroller/internal/workersync/syncer_test.go
+++ b/cmd/atecontroller/internal/workersync/syncer_test.go
@@ -65,6 +65,13 @@ func workerPod(ns, name, poolName, uid, ip string) *corev1.Pod {
 			Phase:  corev1.PodRunning,
 			PodIP:  ip,
 			PodIPs: []corev1.PodIP{{IP: ip}},
+			// Eligibility requires Ready in addition to an IP: readiness is
+			// what says ateom is actually serving, not just that the sandbox
+			// got an address.
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
 		}
 	}
 	return pod
@@ -690,6 +697,75 @@ func TestSyncer_DeleteNeverEligiblePod(t *testing.T) {
 	mustReconcile(t, ctx, s, key)
 	if got := api.names(); len(got) != 0 {
 		t.Errorf("registry holds %v, want it empty", got)
+	}
+}
+
+// TestSyncer_PodWithIPButNotReadyIsNotRegistered pins the readiness half of
+// the eligibility gate: an IP alone no longer registers a worker, because the
+// sandbox having an address says nothing about ateom serving yet (#1106).
+// Both not-Ready shapes are covered — condition absent (kubelet hasn't probed
+// yet) and condition explicitly False (probe failing).
+func TestSyncer_PodWithIPButNotReadyIsNotRegistered(t *testing.T) {
+	ctx := context.Background()
+	ns, poolName := "ns-syncer-notready", "pool1"
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*corev1.Pod)
+	}{
+		{name: "no Ready condition", mutate: func(p *corev1.Pod) {
+			p.Status.Conditions = nil
+		}},
+		{name: "Ready=False", mutate: func(p *corev1.Pod) {
+			p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api := newFakeControl()
+			s, pods, _ := setupReconcileTest(t, api, workerPool(ns, poolName, "gvisor", nil))
+			pod := workerPod(ns, "worker-notready-1", poolName, testPodUID, "10.0.0.9")
+			tc.mutate(pod)
+			key := seedPod(t, pods, pod)
+
+			mustReconcile(t, ctx, s, key)
+			if got := api.names(); len(got) != 0 {
+				t.Errorf("registry holds %v for a not-Ready pod, want it empty", got)
+			}
+		})
+	}
+}
+
+// TestSyncer_ReadinessFlapDoesNotDeregister pins that eligibility only gates
+// registration: once a worker exists, a readiness blip must not remove it —
+// a bound actor keeps running through a failed probe, and deregistering would
+// strand it.
+func TestSyncer_ReadinessFlapDoesNotDeregister(t *testing.T) {
+	ctx := context.Background()
+	ns, podName, poolName := "ns-syncer-flap", "worker-flap-1", "pool1"
+
+	api := newFakeControl()
+	s, pods, _ := setupReconcileTest(t, api, workerPool(ns, poolName, "gvisor", nil))
+	pod := workerPod(ns, podName, poolName, testPodUID, "10.0.0.9")
+	key := seedPod(t, pods, pod)
+
+	mustReconcile(t, ctx, s, key)
+	if got := api.get(testPodUID); got == nil {
+		t.Fatalf("worker not registered for a Ready pod; registry holds %v", api.names())
+	}
+
+	notReady := pod.DeepCopy()
+	notReady.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}}
+	if err := pods.Update(notReady); err != nil {
+		t.Fatalf("updating pod: %v", err)
+	}
+
+	mustReconcile(t, ctx, s, key)
+	got := api.get(testPodUID)
+	if got == nil {
+		t.Fatalf("worker deregistered on a readiness flap; registry holds %v", api.names())
+	}
+	if got.GetStatus().GetState() == ateapipb.WorkerState_WORKER_STATE_DRAINING {
+		t.Errorf("worker marked DRAINING on a readiness flap, want it left ACTIVE")
 	}
 }
 

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -72,6 +72,7 @@ var (
 	atunnelClientIdentity       = pflag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")
 	atunnelEgressListenAddress  = pflag.String("atunnel-egress-listen-address", "0.0.0.0:15001", "Address for transparently intercepted actor egress TCP")
 	egressGatewayTrustBundle    = pflag.String("atunnel-egress-trust-bundle", "/run/servicedns.podcert.ate.dev/trust-bundle.pem", "Service DNS trust bundle for the remote egress gateway")
+	readinessListenAddress      = pflag.String("readiness-listen-address", "0.0.0.0:8080", "Address for HTTP readiness checks")
 
 	showVersion  = pflag.Bool("version", false, "Print version and exit.")
 	logLevelFlag = pflag.String("log-level", "info", "Minimum log level: debug, info, warn, or error.")
@@ -218,6 +219,7 @@ func do(ctx context.Context) error {
 	)
 	ateompb.RegisterAteomServer(svr, ateomService)
 	reflection.Register(svr)
+	readiness := &serverboot.Readiness{}
 
 	// Trap SIGTERM (sent by the kubelet at the start of the pod's termination
 	// grace period) and propagate it into the sandbox so the actor can save its
@@ -227,12 +229,15 @@ func do(ctx context.Context) error {
 	go func() {
 		sig := <-sigCh
 		slog.InfoContext(ctx, "Received signal; beginning graceful shutdown", slog.String("signal", sig.String()))
+		readiness.MarkNotReady()
 		// Use a fresh context: the do() context is torn down on return, but the
 		// shutdown must outlive it until the sandbox has stopped.
 		ateomService.gracefulShutdown(context.Background())
 		// Stop the server gracefully. This blocks until all in-flight RPCs have completed.
 		svr.GracefulStop()
 	}()
+
+	go serverboot.StartReadinessServer(ctx, *readinessListenAddress, readiness)
 
 	if err := svr.Serve(lis); err != nil {
 		slog.ErrorContext(ctx, "Failed to serve", slog.Any("err", err))

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -78,6 +78,7 @@ var (
 	atunnelClientIdentity       = flag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")
 	atunnelEgressListenAddress  = flag.String("atunnel-egress-listen-address", "0.0.0.0:15001", "Address for transparently intercepted actor egress TCP")
 	egressGatewayTrustBundle    = flag.String("atunnel-egress-trust-bundle", "/run/servicedns.podcert.ate.dev/trust-bundle.pem", "Service DNS trust bundle for the remote egress gateway")
+	readinessListenAddress      = flag.String("readiness-listen-address", "0.0.0.0:8080", "Address for HTTP readiness checks")
 )
 
 const (
@@ -261,6 +262,7 @@ func do(ctx context.Context) error {
 	)
 	ateompb.RegisterAteomServer(svr, ateomService)
 	reflection.Register(svr)
+	readiness := &serverboot.Readiness{}
 
 	// Trap SIGTERM (sent by the kubelet at the start of the pod's termination grace
 	// period) and propagate it into the guest so the actor can save its state and
@@ -273,6 +275,7 @@ func do(ctx context.Context) error {
 	go func() {
 		sig := <-sigCh
 		slog.InfoContext(ctx, "Received signal; beginning graceful shutdown", slog.String("signal", sig.String()))
+		readiness.MarkNotReady()
 		// Use a fresh context: the do() context is torn down on return, but the
 		// shutdown must outlive it until the guest has stopped and the VM is down.
 		ateomService.gracefulShutdown(context.Background())
@@ -280,6 +283,8 @@ func do(ctx context.Context) error {
 		// concurrent CheckpointWorkload) has completed, then unblocks svr.Serve below.
 		svr.GracefulStop()
 	}()
+
+	go serverboot.StartReadinessServer(ctx, *readinessListenAddress, readiness)
 
 	slog.InfoContext(ctx, "ateom-microvm serving", slog.String("socket", sockPath))
 	if err := svr.Serve(lis); err != nil {

--- a/internal/serverboot/serverboot.go
+++ b/internal/serverboot/serverboot.go
@@ -331,20 +331,26 @@ func StartMetricsServer(ctx context.Context, opts MetricsServerOptions) {
 	}
 }
 
+// StartReadinessServer runs an HTTP server exposing only /readyz. Blocks until
+// http.ListenAndServe returns; designed to be `go`-launched. A serve failure
+// exits the process: a worker whose readiness endpoint cannot come up never
+// turns Ready and never registers, so dying loudly lets the kubelet restart it
+// instead of leaving a pod that looks alive but can never receive work.
+func StartReadinessServer(ctx context.Context, addr string, readiness *Readiness) {
+	slog.InfoContext(ctx, "Starting readiness HTTP server", slog.String("addr", addr))
+	if err := http.ListenAndServe(addr, readinessMux(readiness)); err != nil {
+		slog.Error("Readiness HTTP server failed", slog.Any("err", err))
+		os.Exit(1)
+	}
+}
+
 // metricsMux builds the handler for StartMetricsServer; split out so
 // tests can exercise the endpoints without binding a port.
 func metricsMux(opts MetricsServerOptions) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	if opts.Readiness != nil {
-		mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
-			if !opts.Readiness.Ready() {
-				http.Error(w, "draining", http.StatusServiceUnavailable)
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ok"))
-		})
+		mux.Handle("/readyz", readinessHandler(opts.Readiness))
 	}
 	if opts.EnableHealthz {
 		mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -353,4 +359,22 @@ func metricsMux(opts MetricsServerOptions) *http.ServeMux {
 		})
 	}
 	return mux
+}
+
+// readinessMux builds the handler for StartReadinessServer.
+func readinessMux(readiness *Readiness) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/readyz", readinessHandler(readiness))
+	return mux
+}
+
+func readinessHandler(readiness *Readiness) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !readiness.Ready() {
+			http.Error(w, "draining", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
 }

--- a/internal/serverboot/serverboot_test.go
+++ b/internal/serverboot/serverboot_test.go
@@ -202,6 +202,23 @@ func TestReadyzStaticWithZeroValueReadiness(t *testing.T) {
 	}
 }
 
+func TestReadinessMux(t *testing.T) {
+	readiness := &Readiness{}
+	mux := readinessMux(readiness)
+
+	if got := getCode(t, mux, "/readyz"); got != http.StatusOK {
+		t.Errorf("/readyz before drain = %d, want %d", got, http.StatusOK)
+	}
+	if got := getCode(t, mux, "/metrics"); got != http.StatusNotFound {
+		t.Errorf("/metrics = %d, want %d", got, http.StatusNotFound)
+	}
+
+	readiness.MarkNotReady()
+	if got := getCode(t, mux, "/readyz"); got != http.StatusServiceUnavailable {
+		t.Errorf("/readyz during drain = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+}
+
 func TestReadyzAbsentWithoutReadiness(t *testing.T) {
 	mux := metricsMux(MetricsServerOptions{})
 	if got := getCode(t, mux, "/readyz"); got != http.StatusNotFound {


### PR DESCRIPTION
Fixes #1106. Takes over #1107 (adopting @Stevenjin8's approach and commits from that PR — credit to him for the design; trailer omitted only for CLA) and incorporates the review feedback it accumulated.

Workers were registered as schedulable the moment their pod had an IP — long before ateom's gRPC server was listening, which is the scheduling race in #1106 (actors dispatched to a cold ateom fail at dial time). Now:

- ateom (gvisor + microvm) serves HTTP `/readyz` on a dedicated port (8080) once its gRPC listener is up, flipping to 503 on SIGTERM so draining workers stop receiving work.
- The worker Deployment probes that endpoint (replaces the earlier TCP probe against the TLS port, which spammed handshake errors).
- `isWorkerEligible` requires `PodReady=True` in addition to an IP. Eligibility gates **registration only** — a readiness flap never deregisters a worker with a bound actor (pinned by `TestSyncer_ReadinessFlapDoesNotDeregister`).
- A readiness server that cannot come up exits the process rather than leaving a pod that looks alive but can never receive work.

Beyond #1107's head: dropped the pre-migration `controlapi/syncer_test.go` copy (didn't compile after #1203 moved the syncer), fixed the `workersync` fixtures for the new gate, and added `TestSyncer_PodWithIPButNotReadyIsNotRegistered` (+ the flap test above).

## Testing

- `go test ./...`: green, zero failures.
- `-race -count=10` on `workersync` + `serverboot`, `-race -count=5` on `controllers`, `-race` on all of `controlapi` incl. functional tests: green.
- Green under a hostile ambient env (`KUBECTL_CONTEXT`/`KO_DOCKER_REPO`/`PROJECT_ID` set to garbage).

## Scope notes

- The one post-#1160 failure with a *post-restore* signature (run 32891995583: restored actor's own container `/healthz` timing out, actor stuck RESUMING) is a different layer — ateom was demonstrably serving — and is **not** claimed as fixed here. If it recurs, it deserves its own issue. (The other suspected post-merge failure, run 32911674788, turned out to be that PR's own x509 regression, not this flake.)
- Mixed-version caveat: this controller pointed at pods running a pre-readyz ateom image leaves those workers unready/unregistered. The supported install flows build both from the same source, so this only matters for hand-rolled skew.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
