### PR TITLE
ateapi: close atelet conns evicted from the dialer cache

### DIFF
--- a/cmd/ateapi/internal/controlapi/dialer.go
+++ b/cmd/ateapi/internal/controlapi/dialer.go
@@ -80,7 +80,7 @@ func NewAteletDialer(workerIndexer cache.Indexer, ateletIndexer cache.Indexer, c
 	d := &AteletDialer{
 		workerIndexer: workerIndexer,
 		ateletIndexer: ateletIndexer,
-		ateletConns:   lru.New(1024),
+		ateletConns:   newAteletConnCache(1024),
 		dialCredentials: func(expectedPodUID string) (credentials.TransportCredentials, error) {
 			tlsConfig, err := buildTLSConfig(clientBundlePath, serverCAPath, expectedPodUID)
 			if err != nil {
@@ -93,6 +93,24 @@ func NewAteletDialer(workerIndexer cache.Indexer, ateletIndexer cache.Indexer, c
 		opt(d)
 	}
 	return d
+}
+
+// newAteletConnCache builds the atelet conn cache, which closes the
+// connections it evicts. A conn pushed out of the LRU without Close is not
+// reclaimed: grpc keeps most of its goroutines and buffers alive for the
+// life of the process. Closing on eviction can fail an RPC still in flight
+// on a conn that aged to the LRU tail, but that failure is visible and
+// retryable, unlike the leak.
+//
+// TODO: Consider pool semantics instead of a cache: a conn evicted for
+// capacity would drain — close only once its last in-flight RPC finishes
+// (e.g. refcounted checkout/release) — rather than being closed out from
+// under a caller. Worth revisiting if the retryable eviction failures show
+// up in practice.
+func newAteletConnCache(size int) *lru.Cache {
+	return lru.NewWithEvictionFunc(size, func(_ lru.Key, value interface{}) {
+		value.(*grpc.ClientConn).Close()
+	})
 }
 
 // DialForWorker returns a gRPC connection to the Atelet running on the same node as the specified worker pod.

--- a/cmd/ateapi/internal/controlapi/dialer_test.go
+++ b/cmd/ateapi/internal/controlapi/dialer_test.go
@@ -30,13 +30,13 @@ import (
 	"github.com/agent-substrate/substrate/internal/substratex509"
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/lru"
 )
 
 const testAteletSPIFFEID = "spiffe://cluster.local/ns/ate-system/sa/atelet"
@@ -161,7 +161,7 @@ func newDialerForPods(t *testing.T, workerPod, ateletPod *corev1.Pod) *AteletDia
 	return &AteletDialer{
 		workerIndexer: workerIndexer,
 		ateletIndexer: ateletIndexer,
-		ateletConns:   lru.New(16),
+		ateletConns:   newAteletConnCache(16),
 		dialCredentials: func(string) (credentials.TransportCredentials, error) {
 			return insecure.NewCredentials(), nil
 		},
@@ -403,6 +403,28 @@ func TestDialForAteletOnNode(t *testing.T) {
 		}
 		if again != conn {
 			t.Error("second DialForAteletOnNode returned a different connection, want the cached one")
+		}
+	})
+
+	t.Run("closes conns evicted from the cache", func(t *testing.T) {
+		d := NewAteletDialer(nil, newTestAteletIndexer(t,
+			ateletPod("atelet-1", "uid-1", "node1", "10.0.0.1"),
+			ateletPod("atelet-2", "uid-2", "node2", "10.0.0.2"),
+		), "", "", WithDialCredentials(func(string) (credentials.TransportCredentials, error) {
+			return insecure.NewCredentials(), nil
+		}))
+		d.ateletConns = newAteletConnCache(1)
+
+		first, err := d.DialForAteletOnNode("node1")
+		if err != nil {
+			t.Fatalf("DialForAteletOnNode(node1): %v", err)
+		}
+		if _, err := d.DialForAteletOnNode("node2"); err != nil {
+			t.Fatalf("DialForAteletOnNode(node2): %v", err)
+		}
+
+		if got := first.GetState(); got != connectivity.Shutdown {
+			t.Errorf("evicted conn state = %v, want %v (closed on eviction)", got, connectivity.Shutdown)
 		}
 	})
 }


### PR DESCRIPTION
AteletDialer caches one grpc.ClientConn per atelet pod UID in a 1024-entry LRU with no eviction function, so a conn pushed out to make room was forgotten, never closed. grpc does not reclaim an un-Closed conn: its goroutines and buffers stay alive for the life of the process. Close evicted conns via the cache's eviction hook, the same fix the atelet ateom dialer received.

Fixes #470

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [x] Appropriate changes to documentation are included in the PR
