### PR TITLE
demos/counter: make suspend genuinely preserve the in-memory count

### DIFF
--- a/demos/counter/README.md
+++ b/demos/counter/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a demo of a stateful counter application running on Agent Substrate.
 
-It deploys a simple Go HTTP server (`counter.go`) that increments a counter on every request and preserves state across suspends and resumes.
+It deploys a simple Go HTTP server (`counter.go`) that increments two counters on every request — one in process memory, one in a file on a durable volume — and preserves both across suspends and resumes: the template's `onCommit: Full` snapshot captures process memory alongside the durable volumes, so the in-memory count continues from where it left off. (With a `Data`-scope snapshot policy, only the durable-volume counter would survive and the in-memory counter would restart from a cold boot.)
 
 ## Prerequisites
 
@@ -81,6 +81,11 @@ kubectl ate get actor my-counter-1 -a demo
 ```bash
 kubectl ate suspend actor my-counter-1 -a demo
 ```
+
+Repeat the `curl` from step 1 and the actor resumes from its snapshot —
+possibly on a different worker — with **both** counters continuing from where
+they left off: the memory count comes back from the `Full` snapshot's process
+memory, the file counter from the durable volume.
 
 4. To permanently delete the suspended actor, then the now-empty atespace:
 ```bash

--- a/demos/counter/counter-microvm.yaml.tmpl
+++ b/demos/counter/counter-microvm.yaml.tmpl
@@ -112,11 +112,13 @@ spec:
       workload: counter-microvm
   snapshotsConfig:
     onPause: Full
-    onCommit: Data
-    onResume:
-      # A Data snapshot resumes by combining the durable data with the golden
-      # snapshot's guest state (memory + fs delta) instead of cold-booting.
-      fromData: Golden
+    # Full, matching the gVisor variant: a suspend captures guest memory, so
+    # the in-RAM count continues from where it left off — the round-trip this
+    # demo's header comment promises. The golden-combining Data resume path
+    # (onResume.fromData: Golden) is exercised by the e2e demo suite's
+    # micro-VM cases; with Full on both triggers no Data snapshot is ever
+    # written here, so no onResume block is needed.
+    onCommit: Full
     location: gs://${BUCKET_NAME}/ate-demo-counter-microvm/
   volumes:
   - name: data

--- a/demos/counter/counter.yaml.tmpl
+++ b/demos/counter/counter.yaml.tmpl
@@ -91,7 +91,12 @@ ${EXTERNAL_VOLUME_MOUNTS}
       workload: counter
   snapshotsConfig:
     onPause: Full
-    onCommit: Data
+    # Full, so a suspend captures process memory as well as the durable
+    # volumes and the tutorial's in-memory counter really does continue
+    # across suspend/resume. Data-scope behavior (durable volumes only,
+    # memory cold-boots) is exercised by the e2e demo suite's own
+    # parameterized templates, not by this one.
+    onCommit: Full
     location: gs://${BUCKET_NAME}/ate-demo-counter/
   volumes:
   - name: data


### PR DESCRIPTION
The counter tutorial's headline claim — state preserved across suspend/resume — is false on the default path: with `onCommit: Data`, suspend excludes process memory, so the in-memory counter resets while only the durable file counter continues.

**Reproduced live** (GKE, template config identical to main): memory 5 → **1**,2,3 after suspend/resume; suspend manifest `scope:"data"`, `pages.img` 71 B (vs 2.2 MB golden Full). The micro-VM variant has the same broken promise via a different path: `fromData: Golden` restarts the count from the golden state — the e2e Golden case itself asserts memory=1 after suspend.

**Fix** (per maintainer decision — config *and* docs, both variants matching): `onCommit: Full` on both counter templates, drop the now-dead `onResume` block on the micro-VM one, and make the README precise about which scope preserves what.

**Verified live**: with `Full`, memory count runs 5 → **6**,7,8 across suspend/resume; snapshot manifest `scope:"full"`, `pages.img` 2.4 MB.

No coverage lost: `TestDurableDirLifecycle` exercises every `onCommit`/`onPause`/`fromData` combination (including Data and Golden) with its own parameterized templates, independent of the demo defaults — and its `Full/Full` case already asserts the memory count continues, in both sandbox classes.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
