### PR TITLE
Update Actor Workflows to use substrate proto ActorTemplate

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -171,32 +171,7 @@ func (s *ServiceImpl) resolveSnapshotSource(ctx context.Context, actorAtespace s
 func validateCreateActorRequest(ctx context.Context, req *ateapipb.CreateActorRequest) field.ErrorList {
 	// Call the generated validation.
 	op := operation.Operation{Type: operation.Create}
-	errs := Validate_CreateActorRequest(ctx, op, nil, req, nil)
-
-	// The template is named by exactly one reference form: the substrate
-	// actor_template ref, or the legacy CRD namespace/name pair. The
-	// declarative annotations mark all three fields optional, so the union
-	// is enforced here.
-	if actor := req.GetActor(); actor != nil {
-		actorPath := field.NewPath("actor")
-		if actor.GetActorTemplate() != nil {
-			if actor.GetActorTemplateNamespace() != "" {
-				errs = append(errs, field.Forbidden(actorPath.Child("actor_template_namespace"), "may not be set together with actor_template"))
-			}
-			if actor.GetActorTemplateName() != "" {
-				errs = append(errs, field.Forbidden(actorPath.Child("actor_template_name"), "may not be set together with actor_template"))
-			}
-		} else {
-			if actor.GetActorTemplateNamespace() == "" {
-				errs = append(errs, field.Required(actorPath.Child("actor_template_namespace"), ""))
-			}
-			if actor.GetActorTemplateName() == "" {
-				errs = append(errs, field.Required(actorPath.Child("actor_template_name"), ""))
-			}
-		}
-	}
-
-	return errs
+	return Validate_CreateActorRequest(ctx, op, nil, req, nil)
 }
 
 func (s *RPCService) GetActor(ctx context.Context, req *ateapipb.GetActorRequest) (*ateapipb.Actor, error) {

--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/api/validate"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -72,16 +71,7 @@ func (s *ServiceImpl) CreateActor(ctx context.Context, inActor *ateapipb.Actor) 
 	// will still exist later.  Checking it here produces a nice error UX, but
 	// we still have to handle the template not existing later, which makes the
 	// UX inconsistent, at best.  Is it actually worth checking at all?
-	templateNamespace := inActor.GetActorTemplateNamespace()
-	templateName := inActor.GetActorTemplateName()
-	crdTemplate, err := s.actorTemplateLister.ActorTemplates(templateNamespace).Get(templateName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.FailedPrecondition, "ActorTemplate %s/%s not found", templateNamespace, templateName)
-		}
-		return nil, fmt.Errorf("while getting ActorTemplate: %w", err)
-	}
-	template, err := actorTemplateFromCRD(crdTemplate)
+	template, err := resolveActorTemplate(ctx, s.store, s.actorTemplateLister, inActor)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +171,32 @@ func (s *ServiceImpl) resolveSnapshotSource(ctx context.Context, actorAtespace s
 func validateCreateActorRequest(ctx context.Context, req *ateapipb.CreateActorRequest) field.ErrorList {
 	// Call the generated validation.
 	op := operation.Operation{Type: operation.Create}
-	return Validate_CreateActorRequest(ctx, op, nil, req, nil)
+	errs := Validate_CreateActorRequest(ctx, op, nil, req, nil)
+
+	// The template is named by exactly one reference form: the substrate
+	// actor_template ref, or the legacy CRD namespace/name pair. The
+	// declarative annotations mark all three fields optional, so the union
+	// is enforced here.
+	if actor := req.GetActor(); actor != nil {
+		actorPath := field.NewPath("actor")
+		if actor.GetActorTemplate() != nil {
+			if actor.GetActorTemplateNamespace() != "" {
+				errs = append(errs, field.Forbidden(actorPath.Child("actor_template_namespace"), "may not be set together with actor_template"))
+			}
+			if actor.GetActorTemplateName() != "" {
+				errs = append(errs, field.Forbidden(actorPath.Child("actor_template_name"), "may not be set together with actor_template"))
+			}
+		} else {
+			if actor.GetActorTemplateNamespace() == "" {
+				errs = append(errs, field.Required(actorPath.Child("actor_template_namespace"), ""))
+			}
+			if actor.GetActorTemplateName() == "" {
+				errs = append(errs, field.Required(actorPath.Child("actor_template_name"), ""))
+			}
+		}
+	}
+
+	return errs
 }
 
 func (s *RPCService) GetActor(ctx context.Context, req *ateapipb.GetActorRequest) (*ateapipb.Actor, error) {

--- a/cmd/ateapi/internal/controlapi/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_test.go
@@ -48,6 +48,11 @@ func TestValidateCreateActorRequest(t *testing.T) {
 	withActorTemplate := withActorActorTemplate
 	withSourceSnapshotTag := withActorSourceSnapshotTag
 	withWorkerSelector := withActorWorkerSelector
+	// refOnly switches the fixture to the substrate reference form; the two
+	// template reference forms are mutually exclusive on create.
+	refOnly := func(a *ateapipb.Actor) {
+		a.ActorTemplateNamespace, a.ActorTemplateName = "", ""
+	}
 
 	tests := []struct {
 		name string
@@ -102,24 +107,31 @@ func TestValidateCreateActorRequest(t *testing.T) {
 		validReq(validActor(func(a *ateapipb.Actor) { a.ActorTemplateName = "invalid value" })),
 		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template_name"), nil, "").WithOrigin("format=k8s-long-name")},
 	}, {
-		"valid actor.actor_template",
-		validReq(validActor(withActorTemplate("as", "tmpl"))),
+		"valid actor.actor_template instead of legacy pair",
+		validReq(validActor(refOnly, withActorTemplate("as", "tmpl"))),
 		nil,
 	}, {
+		"actor_template together with legacy pair",
+		validReq(validActor(withActorTemplate("as", "tmpl"))),
+		field.ErrorList{
+			field.Forbidden(field.NewPath("actor", "actor_template_namespace"), ""),
+			field.Forbidden(field.NewPath("actor", "actor_template_name"), ""),
+		},
+	}, {
 		"missing actor.actor_template.atespace",
-		validReq(validActor(withActorTemplate("", "tmpl"))),
+		validReq(validActor(refOnly, withActorTemplate("", "tmpl"))),
 		field.ErrorList{field.Required(field.NewPath("actor", "actor_template", "atespace"), "")},
 	}, {
 		"invalid actor.actor_template.atespace",
-		validReq(validActor(withActorTemplate("invalid value", "tmpl"))),
+		validReq(validActor(refOnly, withActorTemplate("invalid value", "tmpl"))),
 		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template", "atespace"), nil, "").WithOrigin("format=k8s-short-name")},
 	}, {
 		"missing actor.actor_template.name",
-		validReq(validActor(withActorTemplate("as", ""))),
+		validReq(validActor(refOnly, withActorTemplate("as", ""))),
 		field.ErrorList{field.Required(field.NewPath("actor", "actor_template", "name"), "")},
 	}, {
 		"invalid actor.actor_template.name",
-		validReq(validActor(withActorTemplate("as", "invalid value"))),
+		validReq(validActor(refOnly, withActorTemplate("as", "invalid value"))),
 		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template", "name"), nil, "").WithOrigin("format=k8s-short-name")},
 	}, {
 		"valid actor.source_snapshot_tag",
@@ -241,7 +253,6 @@ func TestValidateActorUpdate(t *testing.T) {
 		validInput(),
 		validOutput(func(a *ateapipb.Actor) { a.ActorTemplateNamespace = "" }),
 		field.ErrorList{
-			field.Required(field.NewPath("actor_template_namespace"), ""),
 			field.Invalid(field.NewPath("actor_template_namespace"), nil, "").WithOrigin("immutable"),
 		},
 	}, {
@@ -254,7 +265,6 @@ func TestValidateActorUpdate(t *testing.T) {
 		validInput(),
 		validOutput(func(a *ateapipb.Actor) { a.ActorTemplateName = "" }),
 		field.ErrorList{
-			field.Required(field.NewPath("actor_template_name"), ""),
 			field.Invalid(field.NewPath("actor_template_name"), nil, "").WithOrigin("immutable"),
 		},
 	}, {
@@ -858,7 +868,6 @@ func TestUpdateActor_ConcurrentDisjointUpdates(t *testing.T) {
 func validActor(mods ...func(*ateapipb.Actor)) *ateapipb.Actor {
 	a := &ateapipb.Actor{
 		Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"},
-		ActorTemplate:          &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl1"},
 		ActorTemplateNamespace: "ns1",
 		ActorTemplateName:      "tmpl1",
 	}

--- a/cmd/ateapi/internal/controlapi/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_test.go
@@ -48,8 +48,7 @@ func TestValidateCreateActorRequest(t *testing.T) {
 	withActorTemplate := withActorActorTemplate
 	withSourceSnapshotTag := withActorSourceSnapshotTag
 	withWorkerSelector := withActorWorkerSelector
-	// refOnly switches the fixture to the substrate reference form; the two
-	// template reference forms are mutually exclusive on create.
+	// refOnly switches the fixture to the substrate reference form.
 	refOnly := func(a *ateapipb.Actor) {
 		a.ActorTemplateNamespace, a.ActorTemplateName = "", ""
 	}
@@ -91,32 +90,9 @@ func TestValidateCreateActorRequest(t *testing.T) {
 		validReq(validActor(withMetadata(func(m *ateapipb.ResourceMetadata) { m.Name = "ID1" }))),
 		field.ErrorList{field.Invalid(field.NewPath("actor", "metadata", "name"), nil, "").WithOrigin("format=k8s-short-name")},
 	}, {
-		"missing actor.actor_template_namespace",
-		validReq(validActor(func(a *ateapipb.Actor) { a.ActorTemplateNamespace = "" })),
-		field.ErrorList{field.Required(field.NewPath("actor", "actor_template_namespace"), "")},
-	}, {
-		"invalid actor.actor_template_namespace",
-		validReq(validActor(func(a *ateapipb.Actor) { a.ActorTemplateNamespace = "invalid value" })),
-		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template_namespace"), nil, "").WithOrigin("format=k8s-short-name")},
-	}, {
-		"missing actor.actor_template_name",
-		validReq(validActor(func(a *ateapipb.Actor) { a.ActorTemplateName = "" })),
-		field.ErrorList{field.Required(field.NewPath("actor", "actor_template_name"), "")},
-	}, {
-		"invalid actor.actor_template_name",
-		validReq(validActor(func(a *ateapipb.Actor) { a.ActorTemplateName = "invalid value" })),
-		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template_name"), nil, "").WithOrigin("format=k8s-long-name")},
-	}, {
 		"valid actor.actor_template instead of legacy pair",
 		validReq(validActor(refOnly, withActorTemplate("as", "tmpl"))),
 		nil,
-	}, {
-		"actor_template together with legacy pair",
-		validReq(validActor(withActorTemplate("as", "tmpl"))),
-		field.ErrorList{
-			field.Forbidden(field.NewPath("actor", "actor_template_namespace"), ""),
-			field.Forbidden(field.NewPath("actor", "actor_template_name"), ""),
-		},
 	}, {
 		"missing actor.actor_template.atespace",
 		validReq(validActor(refOnly, withActorTemplate("", "tmpl"))),

--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -175,7 +175,9 @@ func TestCreateActor_TemplateNotFound(t *testing.T) {
 		ActorTemplateNamespace: ns,
 		ActorTemplateName:      "non-existent",
 	}})
-	assertGrpcError(t, err, codes.FailedPrecondition, fmt.Sprintf("ActorTemplate %s/non-existent not found", ns))
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Fatalf("CreateActor with a missing template = %v, want FailedPrecondition (err: %v)", got, err)
+	}
 }
 
 // TestCreateActor_RejectsTemplateMatchExpressions pins the equality-only
@@ -221,6 +223,64 @@ func TestCreateActor_RejectsTemplateMatchExpressions(t *testing.T) {
 	}})
 	assertGrpcError(t, err, codes.FailedPrecondition,
 		fmt.Sprintf("ActorTemplate %s/tmpl-expr workerSelector uses matchExpressions; only matchLabels is supported", ns))
+}
+
+// TestCreateActor_SubstrateTemplateRef covers the substrate reference form:
+// the actor names its template with an actor_template ObjectRef resolved from
+// the store instead of the legacy CRD namespace/name pair.
+func TestCreateActor_SubstrateTemplateRef(t *testing.T) {
+	ns := namespaceForTest("ns-create-sub-ref")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	ctx := context.Background()
+	if _, err := tc.client.CreateActorTemplate(ctx, &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata:        &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "sub-tmpl"},
+			Containers:      []*ateapipb.Container{{Name: "main", Image: "example.com/app:v1"}},
+			SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://my-bucket/snapshots"},
+			SandboxConfig:   &ateapipb.SandboxConfig{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR, ConfigName: "gvisor-default"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateActorTemplate failed: %v", err)
+	}
+
+	created, err := tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "ref-actor"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "sub-tmpl"},
+	}})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	want := &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "ref-actor", Version: 1},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "sub-tmpl"},
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
+	}
+	if diff := cmp.Diff(want, created, protocmp.Transform(), ignoreUID, ignoreTimestamps); diff != "" {
+		t.Errorf("CreateActor response mismatch (-want +got):\n%s", diff)
+	}
+
+	// A reference to a template that does not exist fails like the legacy pair.
+	_, err = tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "ref-actor-2"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "absent"},
+	}})
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Fatalf("CreateActor with an absent template ref = %v, want FailedPrecondition (err: %v)", got, err)
+	}
+
+	// The two reference forms are mutually exclusive.
+	_, err = tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "ref-actor-3"},
+		ActorTemplate:          &ateapipb.ObjectRef{Atespace: testAtespace, Name: "sub-tmpl"},
+		ActorTemplateNamespace: ns,
+		ActorTemplateName:      "tmpl1",
+	}})
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Fatalf("CreateActor with both reference forms = %v, want InvalidArgument (err: %v)", got, err)
+	}
 }
 
 // TestCreateActor_Duplicate tests that creating an actor with an existing ID fails.

--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -270,17 +270,6 @@ func TestCreateActor_SubstrateTemplateRef(t *testing.T) {
 	if got := status.Code(err); got != codes.FailedPrecondition {
 		t.Fatalf("CreateActor with an absent template ref = %v, want FailedPrecondition (err: %v)", got, err)
 	}
-
-	// The two reference forms are mutually exclusive.
-	_, err = tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "ref-actor-3"},
-		ActorTemplate:          &ateapipb.ObjectRef{Atespace: testAtespace, Name: "sub-tmpl"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
-	}})
-	if got := status.Code(err); got != codes.InvalidArgument {
-		t.Fatalf("CreateActor with both reference forms = %v, want InvalidArgument (err: %v)", got, err)
-	}
 }
 
 // TestCreateActor_Duplicate tests that creating an actor with an existing ID fails.

--- a/cmd/ateapi/internal/controlapi/template_convert.go
+++ b/cmd/ateapi/internal/controlapi/template_convert.go
@@ -61,6 +61,7 @@ func resolveActorTemplate(ctx context.Context, st actorTemplateGetter, lister li
 		}
 		return template, nil
 	}
+	// TODO: remove this fallback when we cut over to substrate resources.
 	crd, err := lister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/cmd/ateapi/internal/controlapi/template_convert.go
+++ b/cmd/ateapi/internal/controlapi/template_convert.go
@@ -15,18 +15,72 @@
 package controlapi
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"maps"
 	"sort"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/resources"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// actorTemplateGetter is the storage subset template resolution needs.
+type actorTemplateGetter interface {
+	GetActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef) (*ateapipb.ActorTemplate, error)
+}
+
+// errActorTemplateNotFound matches (via errors.Is) resolution failures where
+// the actor names a template that does not exist. Most callers return the
+// error as is — it already carries FailedPrecondition — while delete
+// tolerates it and cleans up without the template.
+var errActorTemplateNotFound = status.New(codes.FailedPrecondition, "actor template not found").Err()
+
+// resolveActorTemplate resolves an actor's template from whichever reference
+// form it carries: the substrate ActorTemplate resource when actor_template
+// is set, the ActorTemplate CRD otherwise. A missing template surfaces as a
+// templateNotFoundError either way.
+func resolveActorTemplate(ctx context.Context, st actorTemplateGetter, lister listersv1alpha1.ActorTemplateLister, actor *ateapipb.Actor) (*ateapipb.ActorTemplate, error) {
+	if ref := actor.GetActorTemplate(); ref != nil {
+		templateRef := resources.ActorTemplateRefFromObjectRef(ref)
+		template, err := st.GetActorTemplate(ctx, templateRef)
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("%w; ObjectRef: %s ", errActorTemplateNotFound, templateRef)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("while getting ActorTemplate: %w", err)
+		}
+		return template, nil
+	}
+	crd, err := lister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("%w; CRD %s/%s ", errActorTemplateNotFound, actor.GetActorTemplateNamespace(), actor.GetActorTemplateName())
+		}
+		return nil, fmt.Errorf("while getting ActorTemplate: %w", err)
+	}
+	return actorTemplateFromCRD(crd)
+}
+
+// actorTemplateObjectRef returns a fresh copy of the actor's substrate
+// template reference, or nil for CRD-backed actors — fresh so records built
+// from it never alias the actor message.
+func actorTemplateObjectRef(actor *ateapipb.Actor) *ateapipb.ObjectRef {
+	ref := actor.GetActorTemplate()
+	if ref == nil {
+		return nil
+	}
+	return &ateapipb.ObjectRef{Atespace: ref.GetAtespace(), Name: ref.GetName()}
+}
 
 // actorTemplateFromCRD projects an ActorTemplate CRD onto the substrate
 // ActorTemplate proto, so the workflows handle a single template type while

--- a/cmd/ateapi/internal/controlapi/template_convert_test.go
+++ b/cmd/ateapi/internal/controlapi/template_convert_test.go
@@ -15,10 +15,14 @@
 package controlapi
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/resources"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
+	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
@@ -28,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 )
 
 // TestActorTemplateFromCRD pins the full CRD-to-proto projection: every field
@@ -229,4 +234,128 @@ func mustTemplateFromCRD(crd *atev1alpha1.ActorTemplate) *ateapipb.ActorTemplate
 		panic(err)
 	}
 	return out
+}
+
+// seedSubstrateTemplate stores a minimal substrate ActorTemplate in team-a.
+func seedSubstrateTemplate(t *testing.T, ctx context.Context, persistence store.Interface, name string) *ateapipb.ActorTemplate {
+	t.Helper()
+	stored, err := persistence.CreateActorTemplate(ctx, &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: name},
+		SnapshotsConfig: &ateapipb.SnapshotsConfig{
+			StorageLocation: "gs://ate-snapshots/team-a/",
+		},
+		SandboxConfig: &ateapipb.SandboxConfig{
+			SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+			ConfigName:   "gvisor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActorTemplate: %v", err)
+	}
+	return stored
+}
+
+// TestResolveActorTemplate_PrefersSubstrateRef verifies the resolver reads
+// the substrate resource when the actor carries an actor_template reference,
+// and falls back to the converted CRD for legacy actors.
+func TestResolveActorTemplate_PrefersSubstrateRef(t *testing.T) {
+	ctx := context.Background()
+	persistence := newTestPersistence(t)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := indexer.Add(&atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "crd-tmpl", UID: types.UID("crd-uid-1")},
+	}); err != nil {
+		t.Fatalf("add template to indexer: %v", err)
+	}
+	lister := listersv1alpha1.NewActorTemplateLister(indexer)
+	stored := seedSubstrateTemplate(t, ctx, persistence, "sub-tmpl")
+
+	t.Run("ref mode reads the store", func(t *testing.T) {
+		actor := &ateapipb.Actor{ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "sub-tmpl"}}
+		got, err := resolveActorTemplate(ctx, persistence, lister, actor)
+		if err != nil {
+			t.Fatalf("resolveActorTemplate: %v", err)
+		}
+		if got.GetMetadata().GetUid() != stored.GetMetadata().GetUid() {
+			t.Errorf("template uid = %q, want the stored substrate template %q", got.GetMetadata().GetUid(), stored.GetMetadata().GetUid())
+		}
+	})
+
+	t.Run("ref to a missing template is FailedPrecondition", func(t *testing.T) {
+		actor := &ateapipb.Actor{ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "absent"}}
+		_, err := resolveActorTemplate(ctx, persistence, lister, actor)
+		if got := status.Code(err); got != codes.FailedPrecondition {
+			t.Fatalf("status.Code = %v, want FailedPrecondition (err: %v)", got, err)
+		}
+	})
+
+	t.Run("legacy mode converts the CRD", func(t *testing.T) {
+		actor := &ateapipb.Actor{ActorTemplateNamespace: "ns", ActorTemplateName: "crd-tmpl"}
+		got, err := resolveActorTemplate(ctx, persistence, lister, actor)
+		if err != nil {
+			t.Fatalf("resolveActorTemplate: %v", err)
+		}
+		if got.GetMetadata().GetUid() != "crd-uid-1" {
+			t.Errorf("template uid = %q, want the CRD uid", got.GetMetadata().GetUid())
+		}
+		if got.GetMetadata().GetAtespace() != "ns" || got.GetMetadata().GetName() != "crd-tmpl" {
+			t.Errorf("template identity = %s/%s, want ns/crd-tmpl", got.GetMetadata().GetAtespace(), got.GetMetadata().GetName())
+		}
+	})
+}
+
+// TestResolveActorTemplate_NotFound verifies a vanished template (either
+// form) and an actor naming no template at all surface
+// errActorTemplateNotFound, so callers like delete can tolerate them.
+func TestResolveActorTemplate_NotFound(t *testing.T) {
+	ctx := context.Background()
+	persistence := newTestPersistence(t)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	lister := listersv1alpha1.NewActorTemplateLister(indexer)
+	stored := seedSubstrateTemplate(t, ctx, persistence, "sub-tmpl")
+
+	tests := []struct {
+		name         string
+		actor        *ateapipb.Actor
+		wantNotFound bool
+	}{
+		{"ref mode resolves", &ateapipb.Actor{ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "sub-tmpl"}}, false},
+		{"ref to deleted template", &ateapipb.Actor{ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "gone"}}, true},
+		{"legacy CRD gone", &ateapipb.Actor{ActorTemplateNamespace: "ns", ActorTemplateName: "gone"}, true},
+		{"no template named at all", &ateapipb.Actor{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveActorTemplate(ctx, persistence, lister, tc.actor)
+			if tc.wantNotFound {
+				if !errors.Is(err, errActorTemplateNotFound) {
+					t.Fatalf("resolveActorTemplate err = %v, want errActorTemplateNotFound", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveActorTemplate: %v", err)
+			}
+			if got.GetMetadata().GetUid() != stored.GetMetadata().GetUid() {
+				t.Errorf("template uid = %q, want %q", got.GetMetadata().GetUid(), stored.GetMetadata().GetUid())
+			}
+		})
+	}
+}
+
+// TestActorTemplateObjectRef pins that snapshot and assignment records get a
+// fresh copy of the reference, never the actor's own message.
+func TestActorTemplateObjectRef(t *testing.T) {
+	if got := actorTemplateObjectRef(&ateapipb.Actor{}); got != nil {
+		t.Errorf("actorTemplateObjectRef(no ref) = %v, want nil", got)
+	}
+	actor := &ateapipb.Actor{ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "tmpl1"}}
+	got := actorTemplateObjectRef(actor)
+	if got == actor.GetActorTemplate() {
+		t.Error("actorTemplateObjectRef aliases the actor's reference")
+	}
+	if got.GetAtespace() != "team-a" || got.GetName() != "tmpl1" {
+		t.Errorf("actorTemplateObjectRef = %v, want team-a/tmpl1", got)
+	}
 }

--- a/cmd/ateapi/internal/controlapi/workflow.go
+++ b/cmd/ateapi/internal/controlapi/workflow.go
@@ -119,6 +119,7 @@ type actorWorkflowStore interface {
 	UpdateWorker(ctx context.Context, name string, precondition store.Precondition, mutate func(toUpdate *ateapipb.Worker) error) (*ateapipb.Worker, error)
 	GetActorSnapshot(ctx context.Context, snapshotRef resources.ActorSnapshotRef) (*ateapipb.ActorSnapshot, error)
 	CreateActorSnapshot(ctx context.Context, snapshot *ateapipb.ActorSnapshot) (*ateapipb.ActorSnapshot, error)
+	GetActorTemplate(ctx context.Context, templateRef resources.ActorTemplateRef) (*ateapipb.ActorTemplate, error)
 	AcquireLease(ctx context.Context, key string) (*store.Lease, error)
 }
 

--- a/cmd/ateapi/internal/controlapi/workflow_delete.go
+++ b/cmd/ateapi/internal/controlapi/workflow_delete.go
@@ -26,7 +26,6 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // DeleteActor executes the workflow to delete an actor. Idempotent.
@@ -51,19 +50,14 @@ func (w *ActorWorkflow) DeleteActor(ctx context.Context, actorRef resources.Acto
 	// is retained in the store in the DELETING state.
 	// TODO: Ensure GC collects all the remaining resources if the cleanup fails.
 	var errs []error
-	actorTemplate := (*ateapipb.ActorTemplate)(nil)
-	if actor.GetActorTemplateNamespace() != "" && actor.GetActorTemplateName() != "" {
-		tmpl, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
-		if err != nil && !k8serrors.IsNotFound(err) {
-			errs = append(errs, fmt.Errorf("while fetching actor template: %w", err))
-		}
-		// Cleanup stays best-effort: an unconvertible template is recorded and
-		// the remaining steps run without it, like a missing one.
-		if tmpl != nil {
-			if actorTemplate, err = actorTemplateFromCRD(tmpl); err != nil {
-				errs = append(errs, fmt.Errorf("while converting actor template: %w", err))
-			}
-		}
+	// Cleanup stays best-effort: an unresolvable template is recorded and
+	// the remaining steps run without it, like a missing one.
+	actorTemplate, err := resolveActorTemplate(ctx, w.store, w.actorTemplateLister, actor)
+	if errors.Is(err, errActorTemplateNotFound) {
+		actorTemplate, err = nil, nil
+	}
+	if err != nil {
+		errs = append(errs, fmt.Errorf("while fetching actor template: %w", err))
 	}
 
 	var atletTerminatedErr, volumesDetachedErr error

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -102,11 +102,7 @@ func (w *ActorWorkflow) loadActorForPause(ctx context.Context, actorRef resource
 	if err != nil {
 		return nil, nil, err
 	}
-	crdTemplate, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
-	if err != nil {
-		return nil, nil, fmt.Errorf("while getting ActorTemplate: %w", err)
-	}
-	actorTemplate, err := actorTemplateFromCRD(crdTemplate)
+	actorTemplate, err := resolveActorTemplate(ctx, w.store, w.actorTemplateLister, actor)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -172,11 +172,7 @@ func (w *ActorWorkflow) loadActorForResume(ctx context.Context, actorRef resourc
 		return actor, nil, src, nil
 	}
 
-	crdTemplate, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
-	if err != nil {
-		return nil, nil, src, fmt.Errorf("while getting ActorTemplate: %w", err)
-	}
-	actorTemplate, err := actorTemplateFromCRD(crdTemplate)
+	actorTemplate, err := resolveActorTemplate(ctx, w.store, w.actorTemplateLister, actor)
 	if err != nil {
 		return nil, nil, src, err
 	}
@@ -514,15 +510,19 @@ func (w *ActorWorkflow) assignWorkerAttempt(ctx context.Context, actorRef resour
 	}
 
 	assignment := &ateapipb.ActorAssignment{
-		ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
-			Namespace: actor.GetActorTemplateNamespace(),
-			Name:      actor.GetActorTemplateName(),
-		},
 		Actor: &ateapipb.ObjectRef{
 			Atespace: actor.GetMetadata().GetAtespace(),
 			Name:     actor.GetMetadata().GetName(),
 		},
 		ActorUid: actor.GetMetadata().GetUid(),
+	}
+	if ref := actorTemplateObjectRef(actor); ref != nil {
+		assignment.ActorTemplateRef = ref
+	} else {
+		assignment.ActorTemplate = &ateapipb.KubeNamespacedObjectRef{
+			Namespace: actor.GetActorTemplateNamespace(),
+			Name:      actor.GetActorTemplateName(),
+		}
 	}
 
 	// Workers() returns pointers directly from the cache, so the claim is written

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -141,6 +141,62 @@ func TestEnsureWorkerAssigned_ConflictExhaustionIsRetryable(t *testing.T) {
 	}
 }
 
+// TestAssignWorkerAttempt_StampsSubstrateTemplateRef verifies a ref-mode
+// actor's worker claim names the substrate template via actor_template_ref
+// and leaves the legacy kube reference unset.
+func TestAssignWorkerAttempt_StampsSubstrateTemplateRef(t *testing.T) {
+	ctx := context.Background()
+	persistence := newTestPersistence(t)
+
+	worker := &ateapipb.Worker{
+		Metadata:        &ateapipb.ResourceMetadata{Name: testWorkerUID("pod-free")},
+		WorkerNamespace: "worker-ns",
+		WorkerPool:      "pool",
+		WorkerPod:       "pod-free",
+		WorkerPodUid:    testWorkerUID("pod-free"),
+		SandboxClass:    "gvisor",
+		Status:          &ateapipb.WorkerStatus{State: ateapipb.WorkerState_WORKER_STATE_ACTIVE},
+	}
+	if _, err := persistence.CreateWorker(ctx, worker); err != nil {
+		t.Fatalf("CreateWorker: %v", err)
+	}
+
+	actor := storetest.MustCreateActor(t, ctx, persistence, &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "sub-tmpl"},
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
+	})
+
+	cacheCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	wc := workercache.New(persistence, time.Minute)
+	if err := wc.Start(cacheCtx); err != nil {
+		t.Fatalf("workercache.Start: %v", err)
+	}
+
+	w := &ActorWorkflow{store: persistence, workerCache: wc, scheduler: scheduling.New(wc)}
+	tmpl := &ateapipb.ActorTemplate{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "sub-tmpl"},
+		SandboxConfig: &ateapipb.SandboxConfig{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR},
+	}
+	_, assigned, err := w.assignWorkerAttempt(ctx, resources.ActorRef{Atespace: "team-a", Name: "id1"}, actor, tmpl)
+	if err != nil {
+		t.Fatalf("assignWorkerAttempt: %v", err)
+	}
+
+	stored, err := persistence.GetWorker(ctx, assigned.GetMetadata().GetName())
+	if err != nil {
+		t.Fatalf("GetWorker: %v", err)
+	}
+	assignment := stored.GetStatus().GetAssignment()
+	if assignment.GetActorTemplateRef().GetAtespace() != "team-a" || assignment.GetActorTemplateRef().GetName() != "sub-tmpl" {
+		t.Errorf("assignment ActorTemplateRef = %v, want team-a/sub-tmpl", assignment.GetActorTemplateRef())
+	}
+	if assignment.GetActorTemplate() != nil {
+		t.Errorf("assignment legacy ActorTemplate = %v, want nil for a ref-mode actor", assignment.GetActorTemplate())
+	}
+}
+
 func TestAssignWorkerAttempt_SkipsWorkerAssignedInOtherAtespace(t *testing.T) {
 	ctx := context.Background()
 	persistence := newTestPersistence(t)

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -109,11 +109,7 @@ func (w *ActorWorkflow) loadActorForSuspend(ctx context.Context, actorRef resour
 	if err != nil {
 		return nil, nil, err
 	}
-	crdTemplate, err := w.actorTemplateLister.ActorTemplates(actor.GetActorTemplateNamespace()).Get(actor.GetActorTemplateName())
-	if err != nil {
-		return nil, nil, fmt.Errorf("while getting ActorTemplate: %w", err)
-	}
-	actorTemplate, err := actorTemplateFromCRD(crdTemplate)
+	actorTemplate, err := resolveActorTemplate(ctx, w.store, w.actorTemplateLister, actor)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -388,6 +384,7 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 				SourceActorVersion:     latestActor.GetStatus().GetInProgressSnapshotSourceActorVersion(),
 				ActorTemplateNamespace: latestActor.GetActorTemplateNamespace(),
 				ActorTemplateName:      latestActor.GetActorTemplateName(),
+				ActorTemplate:          actorTemplateObjectRef(latestActor),
 				ActorTemplateUid:       actorTemplate.GetMetadata().GetUid(),
 				ContentScope:           commitSnapshotScope(actorRef.Atespace, actorTemplate),
 				SnapshotUri:            snapshotURI.String(),

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -347,6 +347,46 @@ func TestEnsureSuspendedFinalized_NoAssignment(t *testing.T) {
 	}
 }
 
+// TestEnsureSuspendedFinalized_StampsSubstrateTemplateRef verifies a
+// ref-mode actor's commit snapshot records the substrate template reference
+// alongside the template uid, with the legacy CRD fields left empty.
+func TestEnsureSuspendedFinalized_StampsSubstrateTemplateRef(t *testing.T) {
+	ctx := context.Background()
+	persistence := newTestPersistence(t)
+	template := seedSubstrateTemplate(t, ctx, persistence, "sub-tmpl")
+
+	const snapshotName = "2026-01-01t00-00-00z-ref"
+	storetest.MustCreateActor(t, ctx, persistence, &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "actor-1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "sub-tmpl"},
+		Status: &ateapipb.ActorStatus{
+			State:                                ateapipb.ActorState_ACTOR_STATE_SUSPENDING,
+			InProgressSnapshotName:               snapshotName,
+			InProgressSnapshotSourceActorVersion: 1,
+		},
+	})
+
+	w := &ActorWorkflow{store: persistence}
+	if _, err := w.ensureSuspendedFinalized(ctx, resources.ActorRef{Atespace: "team-a", Name: "actor-1"}, template); err != nil {
+		t.Fatalf("ensureSuspendedFinalized: %v", err)
+	}
+
+	snapshot, err := persistence.GetActorSnapshot(ctx, resources.ActorSnapshotRef{Atespace: "team-a", Name: snapshotName})
+	if err != nil {
+		t.Fatalf("GetActorSnapshot: %v", err)
+	}
+	st := snapshot.GetStatus()
+	if st.GetActorTemplate().GetAtespace() != "team-a" || st.GetActorTemplate().GetName() != "sub-tmpl" {
+		t.Errorf("snapshot ActorTemplate ref = %v, want team-a/sub-tmpl", st.GetActorTemplate())
+	}
+	if st.GetActorTemplateUid() != template.GetMetadata().GetUid() {
+		t.Errorf("snapshot ActorTemplateUid = %q, want %q", st.GetActorTemplateUid(), template.GetMetadata().GetUid())
+	}
+	if st.GetActorTemplateNamespace() != "" || st.GetActorTemplateName() != "" {
+		t.Errorf("legacy template fields = %q/%q, want empty for a ref-mode actor", st.GetActorTemplateNamespace(), st.GetActorTemplateName())
+	}
+}
+
 func TestEnsureSuspendedFinalized_ReleasesOnlyOwnWorker(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/cmd/ateapi/internal/controlapi/zz_generated.validation.go
+++ b/cmd/ateapi/internal/controlapi/zz_generated.validation.go
@@ -103,8 +103,7 @@ func Validate_Actor(
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -139,8 +138,7 @@ func Validate_Actor(
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -76,7 +76,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/api/validate/content"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -1869,12 +1868,6 @@ func validateRunRequest(req *ateletpb.RunRequest) error {
 	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
-	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
-	}
-	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
-	}
 	if len(errs) > 0 {
 		return errs.ToAggregate()
 	}
@@ -1894,12 +1887,6 @@ func validateCheckpointRequest(req *ateletpb.CheckpointRequest) error {
 	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
-	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
-	}
-	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
-	}
 	if len(errs) > 0 {
 		return errs.ToAggregate()
 	}
@@ -1946,12 +1933,6 @@ func validateRestoreRequest(req *ateletpb.RestoreRequest) error {
 	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
-	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
-	}
-	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
-	}
 	if len(errs) > 0 {
 		return errs.ToAggregate()
 	}
@@ -2002,12 +1983,6 @@ func validateTerminateRequest(req *ateletpb.TerminateRequest) error {
 	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
-	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
-	}
-	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
-	}
 	if len(errs) > 0 {
 		return errs.ToAggregate()
 	}
@@ -2039,12 +2014,6 @@ func validateUploadPausedCheckpointRequest(req *ateletpb.UploadPausedCheckpointR
 	errs = append(errs, resources.ValidateResourceName(req.GetAtespace(), field.NewPath("atespace"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorName(), field.NewPath("actor_name"))...)
 	errs = append(errs, resources.ValidateResourceName(req.GetActorUid(), field.NewPath("actor_uid"))...)
-	for _, msg := range content.IsDNS1123Label(req.GetActorTemplateNamespace()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_namespace"), req.GetActorTemplateNamespace(), msg))
-	}
-	for _, msg := range content.IsDNS1123Subdomain(req.GetActorTemplateName()) {
-		errs = append(errs, field.Invalid(field.NewPath("actor_template_name"), req.GetActorTemplateName(), msg))
-	}
 	errs = append(errs, resources.ValidateResourceName(req.GetLocalSnapshotName(), field.NewPath("local_snapshot_name"))...)
 	// Golden actors are never paused (the golden flow commits a running
 	// actor), so never promote a paused checkpoint to a golden snapshot.

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -448,8 +448,8 @@ func TestValidateRunRequest(t *testing.T) {
 		{"invalid atespace", func(r *ateletpb.RunRequest) { r.Atespace = "../escape" }, true},
 		{"invalid actor name", func(r *ateletpb.RunRequest) { r.ActorName = "../escape" }, true},
 		{"invalid actor uid", func(r *ateletpb.RunRequest) { r.ActorUid = "../escape" }, true},
-		{"invalid actor template namespace", func(r *ateletpb.RunRequest) { r.ActorTemplateNamespace = "Not_Valid" }, true},
-		{"invalid actor template name", func(r *ateletpb.RunRequest) { r.ActorTemplateName = "Not_Valid" }, true},
+		{"any actor template identity accepted", func(r *ateletpb.RunRequest) { r.ActorTemplateNamespace, r.ActorTemplateName = "Not_Valid", "Not_Valid" }, false},
+		{"empty actor template identity accepted", func(r *ateletpb.RunRequest) { r.ActorTemplateNamespace, r.ActorTemplateName = "", "" }, false},
 		{"invalid container name", func(r *ateletpb.RunRequest) {
 			r.Spec.Containers = []*ateletpb.Container{{Name: "../escape"}}
 		}, true},
@@ -488,8 +488,10 @@ func TestValidateCheckpointRequest(t *testing.T) {
 		{"invalid atespace", makeReq(func(r *ateletpb.CheckpointRequest) { r.Atespace = "../escape" }), true},
 		{"invalid actor name", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorName = "../escape" }), true},
 		{"invalid actor uid", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorUid = "../escape" }), true},
-		{"invalid actor template namespace", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorTemplateNamespace = "Not_Valid" }), true},
-		{"invalid actor template name", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorTemplateName = "Not_Valid" }), true},
+		{"any actor template identity accepted", makeReq(func(r *ateletpb.CheckpointRequest) {
+			r.ActorTemplateNamespace, r.ActorTemplateName = "Not_Valid", "Not_Valid"
+		}), false},
+		{"empty actor template identity accepted", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorTemplateNamespace, r.ActorTemplateName = "", "" }), false},
 		{"invalid container name", makeReq(func(r *ateletpb.CheckpointRequest) {
 			r.Spec.Containers = []*ateletpb.Container{{Name: "../escape"}}
 		}), true},
@@ -546,8 +548,10 @@ func TestValidateRestoreRequest(t *testing.T) {
 		{"invalid atespace", makeReq(func(r *ateletpb.RestoreRequest) { r.Atespace = "../escape" }), true},
 		{"invalid actor name", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorName = "../escape" }), true},
 		{"invalid actor uid", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorUid = "../escape" }), true},
-		{"invalid actor template namespace", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorTemplateNamespace = "Not_Valid" }), true},
-		{"invalid actor template name", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorTemplateName = "Not_Valid" }), true},
+		{"any actor template identity accepted", makeReq(func(r *ateletpb.RestoreRequest) {
+			r.ActorTemplateNamespace, r.ActorTemplateName = "Not_Valid", "Not_Valid"
+		}), false},
+		{"empty actor template identity accepted", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorTemplateNamespace, r.ActorTemplateName = "", "" }), false},
 		{"invalid container name", makeReq(func(r *ateletpb.RestoreRequest) {
 			r.Spec.Containers = []*ateletpb.Container{{Name: "../escape"}}
 		}), true},
@@ -829,22 +833,6 @@ func TestRPCBoundariesReject(t *testing.T) {
 				Atespace: okAtespace, ActorName: okID,
 				ActorUid: okActorUID, ActorTemplateNamespace: "default", ActorTemplateName: "template",
 				TargetAteomUid: badUID, Spec: okSpec,
-			})
-			wantInvalidArgument(t, "Terminate", err)
-		})
-		t.Run("missing template namespace", func(t *testing.T) {
-			_, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
-				Atespace: okAtespace, ActorName: okID,
-				ActorUid: okActorUID, ActorTemplateName: "template",
-				TargetAteomUid: okTargetAteomUID, Spec: okSpec,
-			})
-			wantInvalidArgument(t, "Terminate", err)
-		})
-		t.Run("missing template name", func(t *testing.T) {
-			_, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
-				Atespace: okAtespace, ActorName: okID,
-				ActorUid: okActorUID, ActorTemplateNamespace: "default",
-				TargetAteomUid: okTargetAteomUID, Spec: okSpec,
 			})
 			wantInvalidArgument(t, "Terminate", err)
 		})
@@ -1877,7 +1865,10 @@ func TestValidateUploadPausedCheckpointRequest(t *testing.T) {
 		{"golden atespace rejected", func(r *ateletpb.UploadPausedCheckpointRequest) { r.Atespace = resources.GoldenActorAtespace }, true},
 		{"invalid actor name", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorName = "UPPER" }, true},
 		{"invalid actor uid", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorUid = "" }, true},
-		{"invalid template namespace", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorTemplateNamespace = "no/slashes" }, true},
+		{"any actor template identity accepted", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorTemplateNamespace = "no/slashes" }, false},
+		{"empty actor template identity accepted", func(r *ateletpb.UploadPausedCheckpointRequest) {
+			r.ActorTemplateNamespace, r.ActorTemplateName = "", ""
+		}, false},
 		{"invalid snapshot name", func(r *ateletpb.UploadPausedCheckpointRequest) { r.LocalSnapshotName = "../escape" }, true},
 		{"invalid snapshot uri", func(r *ateletpb.UploadPausedCheckpointRequest) { r.DestinationSnapshotUri = "not-a-uri" }, true},
 		{"unspecified scope", func(r *ateletpb.UploadPausedCheckpointRequest) {

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -827,7 +827,6 @@ func TestRPCBoundariesReject(t *testing.T) {
 		wantInvalidArgument(t, "Restore", err)
 	})
 	t.Run("Terminate", func(t *testing.T) {
-		const okTargetAteomUID = "123e4567-e89b-12d3-a456-426614174001"
 		t.Run("invalid ateom UID", func(t *testing.T) {
 			_, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
 				Atespace: okAtespace, ActorName: okID,

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -858,10 +858,9 @@ type Actor struct {
 	// +k8s:required
 	// +k8s:subfield(atespace)=+k8s:required
 	Metadata *ResourceMetadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	// The template is named by exactly one reference form: the legacy CRD
-	// namespace/name pair below, or the substrate actor_template ref. All
-	// three fields are declaratively optional; validateCreateActorRequest
-	// enforces the union.
+	// The template is named by the legacy CRD namespace/name pair below or by
+	// the substrate actor_template ref; actor_template takes precedence when
+	// set.
 	//
 	// TODO: delete both fields once we start using actor_template below.
 	// +k8s:optional

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -858,12 +858,17 @@ type Actor struct {
 	// +k8s:required
 	// +k8s:subfield(atespace)=+k8s:required
 	Metadata *ResourceMetadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// The template is named by exactly one reference form: the legacy CRD
+	// namespace/name pair below, or the substrate actor_template ref. All
+	// three fields are declaratively optional; validateCreateActorRequest
+	// enforces the union.
+	//
 	// TODO: delete both fields once we start using actor_template below.
-	// +k8s:required
+	// +k8s:optional
 	// +k8s:format=k8s-short-name
 	// +k8s:immutable
 	ActorTemplateNamespace string `protobuf:"bytes,2,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	// +k8s:required
+	// +k8s:optional
 	// +k8s:format=k8s-long-name
 	// +k8s:immutable
 	ActorTemplateName string `protobuf:"bytes,3,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
@@ -5416,14 +5421,18 @@ func (x *WorkerCapacity) GetMemoryBytes() int64 {
 // WorkerAssignment.
 type ActorAssignment struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// ActorTemplates are Kubernetes CRDs rather than Substrate API resources, so
-	// this stays a kube reference.
+	// The KubeNamespacedObjectRef actor_template names the CRD-backed template
+	// of an actor created with the legacy CRD path
+	// actor_template_ref names the substrate ActorTemplate resource.
+	// Exactly one is set.
 	ActorTemplate *KubeNamespacedObjectRef `protobuf:"bytes,1,opt,name=actor_template,json=actorTemplate,proto3" json:"actor_template,omitempty"`
 	// +k8s:opaqueType
-	Actor         *ObjectRef `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
-	ActorUid      string     `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Actor    *ObjectRef `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
+	ActorUid string     `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	// +k8s:opaqueType
+	ActorTemplateRef *ObjectRef `protobuf:"bytes,4,opt,name=actor_template_ref,json=actorTemplateRef,proto3" json:"actor_template_ref,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ActorAssignment) Reset() {
@@ -5475,6 +5484,13 @@ func (x *ActorAssignment) GetActorUid() string {
 		return x.ActorUid
 	}
 	return ""
+}
+
+func (x *ActorAssignment) GetActorTemplateRef() *ObjectRef {
+	if x != nil {
+		return x.ActorTemplateRef
+	}
+	return nil
 }
 
 type KubeNamespacedObjectRef struct {
@@ -6184,11 +6200,12 @@ const file_ateapi_proto_rawDesc = "" +
 	"assignment\"P\n" +
 	"\x0eWorkerCapacity\x12\x1b\n" +
 	"\tcpu_milli\x18\x01 \x01(\x03R\bcpuMilli\x12!\n" +
-	"\fmemory_bytes\x18\x02 \x01(\x03R\vmemoryBytes\"\x9f\x01\n" +
+	"\fmemory_bytes\x18\x02 \x01(\x03R\vmemoryBytes\"\xe0\x01\n" +
 	"\x0fActorAssignment\x12F\n" +
 	"\x0eactor_template\x18\x01 \x01(\v2\x1f.ateapi.KubeNamespacedObjectRefR\ractorTemplate\x12'\n" +
 	"\x05actor\x18\x02 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\x12\x1b\n" +
-	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\"K\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x12?\n" +
+	"\x12actor_template_ref\x18\x04 \x01(\v2\x11.ateapi.ObjectRefR\x10actorTemplateRef\"K\n" +
 	"\x17KubeNamespacedObjectRef\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\"\x13\n" +
@@ -6511,77 +6528,78 @@ var file_ateapi_proto_depIdxs = []int32{
 	89,  // 102: ateapi.WorkerStatus.assignment:type_name -> ateapi.ActorAssignment
 	90,  // 103: ateapi.ActorAssignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
 	21,  // 104: ateapi.ActorAssignment.actor:type_name -> ateapi.ObjectRef
-	21,  // 105: ateapi.MintCertRequest.worker:type_name -> ateapi.ObjectRef
-	7,   // 106: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
-	47,  // 107: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
-	48,  // 108: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
-	59,  // 109: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	60,  // 110: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	61,  // 111: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	62,  // 112: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	64,  // 113: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	66,  // 114: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	68,  // 115: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	69,  // 116: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
-	70,  // 117: ateapi.Control.GetActorSnapshotTag:input_type -> ateapi.GetActorSnapshotTagRequest
-	71,  // 118: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
-	73,  // 119: ateapi.Control.CreateActorSnapshotTag:input_type -> ateapi.CreateActorSnapshotTagRequest
-	74,  // 120: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
-	75,  // 121: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
-	77,  // 122: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	79,  // 123: ateapi.Control.GetWorker:input_type -> ateapi.GetWorkerRequest
-	80,  // 124: ateapi.Control.CreateWorker:input_type -> ateapi.CreateWorkerRequest
-	81,  // 125: ateapi.Control.UpdateWorker:input_type -> ateapi.UpdateWorkerRequest
-	82,  // 126: ateapi.Control.DeleteWorker:input_type -> ateapi.DeleteWorkerRequest
-	83,  // 127: ateapi.Control.DrainWorker:input_type -> ateapi.DrainWorkerRequest
-	84,  // 128: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	49,  // 129: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	50,  // 130: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	51,  // 131: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	53,  // 132: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	54,  // 133: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
-	55,  // 134: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
-	56,  // 135: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
-	58,  // 136: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
-	91,  // 137: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
-	93,  // 138: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	95,  // 139: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	13,  // 140: ateapi.Control.GetActor:output_type -> ateapi.Actor
-	13,  // 141: ateapi.Control.CreateActor:output_type -> ateapi.Actor
-	13,  // 142: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
-	63,  // 143: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	65,  // 144: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	67,  // 145: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	13,  // 146: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
-	17,  // 147: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
-	19,  // 148: ateapi.Control.GetActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	72,  // 149: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
-	19,  // 150: ateapi.Control.CreateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	19,  // 151: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	19,  // 152: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	78,  // 153: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	86,  // 154: ateapi.Control.GetWorker:output_type -> ateapi.Worker
-	86,  // 155: ateapi.Control.CreateWorker:output_type -> ateapi.Worker
-	86,  // 156: ateapi.Control.UpdateWorker:output_type -> ateapi.Worker
-	86,  // 157: ateapi.Control.DeleteWorker:output_type -> ateapi.Worker
-	86,  // 158: ateapi.Control.DrainWorker:output_type -> ateapi.Worker
-	85,  // 159: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	20,  // 160: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
-	20,  // 161: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
-	52,  // 162: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	20,  // 163: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
-	22,  // 164: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
-	22,  // 165: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
-	57,  // 166: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
-	22,  // 167: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
-	92,  // 168: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
-	94,  // 169: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	96,  // 170: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	140, // [140:171] is the sub-list for method output_type
-	109, // [109:140] is the sub-list for method input_type
-	109, // [109:109] is the sub-list for extension type_name
-	109, // [109:109] is the sub-list for extension extendee
-	0,   // [0:109] is the sub-list for field type_name
+	21,  // 105: ateapi.ActorAssignment.actor_template_ref:type_name -> ateapi.ObjectRef
+	21,  // 106: ateapi.MintCertRequest.worker:type_name -> ateapi.ObjectRef
+	7,   // 107: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
+	47,  // 108: ateapi.SandboxAssets.AssetsEntry.value:type_name -> ateapi.ArchAssets
+	48,  // 109: ateapi.ArchAssets.FilesEntry.value:type_name -> ateapi.AssetFile
+	59,  // 110: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	60,  // 111: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	61,  // 112: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	62,  // 113: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	64,  // 114: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	66,  // 115: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	68,  // 116: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	69,  // 117: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
+	70,  // 118: ateapi.Control.GetActorSnapshotTag:input_type -> ateapi.GetActorSnapshotTagRequest
+	71,  // 119: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
+	73,  // 120: ateapi.Control.CreateActorSnapshotTag:input_type -> ateapi.CreateActorSnapshotTagRequest
+	74,  // 121: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
+	75,  // 122: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
+	77,  // 123: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	79,  // 124: ateapi.Control.GetWorker:input_type -> ateapi.GetWorkerRequest
+	80,  // 125: ateapi.Control.CreateWorker:input_type -> ateapi.CreateWorkerRequest
+	81,  // 126: ateapi.Control.UpdateWorker:input_type -> ateapi.UpdateWorkerRequest
+	82,  // 127: ateapi.Control.DeleteWorker:input_type -> ateapi.DeleteWorkerRequest
+	83,  // 128: ateapi.Control.DrainWorker:input_type -> ateapi.DrainWorkerRequest
+	84,  // 129: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	49,  // 130: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	50,  // 131: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	51,  // 132: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	53,  // 133: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	54,  // 134: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
+	55,  // 135: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
+	56,  // 136: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
+	58,  // 137: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
+	91,  // 138: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
+	93,  // 139: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	95,  // 140: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	13,  // 141: ateapi.Control.GetActor:output_type -> ateapi.Actor
+	13,  // 142: ateapi.Control.CreateActor:output_type -> ateapi.Actor
+	13,  // 143: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
+	63,  // 144: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	65,  // 145: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	67,  // 146: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	13,  // 147: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
+	17,  // 148: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
+	19,  // 149: ateapi.Control.GetActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	72,  // 150: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
+	19,  // 151: ateapi.Control.CreateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	19,  // 152: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	19,  // 153: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	78,  // 154: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	86,  // 155: ateapi.Control.GetWorker:output_type -> ateapi.Worker
+	86,  // 156: ateapi.Control.CreateWorker:output_type -> ateapi.Worker
+	86,  // 157: ateapi.Control.UpdateWorker:output_type -> ateapi.Worker
+	86,  // 158: ateapi.Control.DeleteWorker:output_type -> ateapi.Worker
+	86,  // 159: ateapi.Control.DrainWorker:output_type -> ateapi.Worker
+	85,  // 160: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	20,  // 161: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
+	20,  // 162: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
+	52,  // 163: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	20,  // 164: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
+	22,  // 165: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
+	22,  // 166: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
+	57,  // 167: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
+	22,  // 168: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
+	92,  // 169: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
+	94,  // 170: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	96,  // 171: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	141, // [141:172] is the sub-list for method output_type
+	110, // [110:141] is the sub-list for method input_type
+	110, // [110:110] is the sub-list for extension type_name
+	110, // [110:110] is the sub-list for extension extendee
+	0,   // [0:110] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -250,12 +250,17 @@ message Actor {
   // +k8s:subfield(atespace)=+k8s:required
   ResourceMetadata metadata = 1;
 
+  // The template is named by exactly one reference form: the legacy CRD
+  // namespace/name pair below, or the substrate actor_template ref. All
+  // three fields are declaratively optional; validateCreateActorRequest
+  // enforces the union.
+  //
   // TODO: delete both fields once we start using actor_template below.
-  // +k8s:required
+  // +k8s:optional
   // +k8s:format=k8s-short-name
   // +k8s:immutable
   string actor_template_namespace = 2;
-  // +k8s:required
+  // +k8s:optional
   // +k8s:format=k8s-long-name
   // +k8s:immutable
   string actor_template_name = 3;
@@ -1187,12 +1192,16 @@ message WorkerCapacity {
 // ActorAssignment names the Actor currently bound to a Worker — the inverse of
 // WorkerAssignment.
 message ActorAssignment {
-  // ActorTemplates are Kubernetes CRDs rather than Substrate API resources, so
-  // this stays a kube reference.
+  // The KubeNamespacedObjectRef actor_template names the CRD-backed template
+  // of an actor created with the legacy CRD path
+  // actor_template_ref names the substrate ActorTemplate resource.
+  // Exactly one is set.
   KubeNamespacedObjectRef actor_template = 1;
   // +k8s:opaqueType
   ObjectRef actor = 2;
   string actor_uid = 3;
+  // +k8s:opaqueType
+  ObjectRef actor_template_ref = 4;
 }
 
 message KubeNamespacedObjectRef {

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -250,10 +250,9 @@ message Actor {
   // +k8s:subfield(atespace)=+k8s:required
   ResourceMetadata metadata = 1;
 
-  // The template is named by exactly one reference form: the legacy CRD
-  // namespace/name pair below, or the substrate actor_template ref. All
-  // three fields are declaratively optional; validateCreateActorRequest
-  // enforces the union.
+  // The template is named by the legacy CRD namespace/name pair below or by
+  // the substrate actor_template ref; actor_template takes precedence when
+  // set.
   //
   // TODO: delete both fields once we start using actor_template below.
   // +k8s:optional

--- a/tools/apitool/exemptions.json
+++ b/tools/apitool/exemptions.json
@@ -116,6 +116,16 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.Capabilities.add",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.Capabilities.drop",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.Container.env",
     "message": "field has no doc comment"
   },
@@ -262,6 +272,11 @@
   {
     "rule": "documented",
     "subject": "ateapi.HTTPGetAction.port",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.ImageVolumeSource.reference",
     "message": "field has no doc comment"
   },
   {
@@ -416,6 +431,11 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.SecurityContext.capabilities",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.SnapshotContentScope",
     "message": "enum has no doc comment"
   },
@@ -457,6 +477,11 @@
   {
     "rule": "documented",
     "subject": "ateapi.Volume.external_volume_template",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.Volume.image",
     "message": "field has no doc comment"
   },
   {


### PR DESCRIPTION
Create/Suspend/Resume Actor workflows now uses the `Actor.actor_template` ObjectRef when specified, otherwise falls back to the CRD in cmd/ateapi/internal/controlapi/template_convert.go.
