### PR TITLE
Flesh out agentgateway implementation

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -94,7 +94,7 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettin
 		WithArgs(
 			"--pod-uid=$(POD_UID)",
 			"--atunnel-listen-address=0.0.0.0:443",
-			"--atunnel-connect-listen-address=0.0.0.0:444",
+			"--atunnel-connect-listen-address=0.0.0.0:8443",
 			"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
 			"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
 			"--atunnel-egress-listen-address=0.0.0.0:15001",
@@ -106,7 +106,7 @@ func buildDeploymentApplyConfig(wp *atev1alpha1.WorkerPool, otel ateomOTelSettin
 			WithProtocol(corev1.ProtocolTCP),
 			corev1ac.ContainerPort().
 				WithName("connect").
-				WithContainerPort(444).
+				WithContainerPort(8443).
 				WithProtocol(corev1.ProtocolTCP),
 			corev1ac.ContainerPort().
 				WithName("readyz").

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -850,7 +850,7 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 			WithArgs(
 				"--pod-uid=$(POD_UID)",
 				"--atunnel-listen-address=0.0.0.0:443",
-				"--atunnel-connect-listen-address=0.0.0.0:444",
+				"--atunnel-connect-listen-address=0.0.0.0:8443",
 				"--atunnel-credential-bundle="+atunnelIdentityMountPath+"/credential-bundle.pem",
 				"--atunnel-trust-bundle="+atunnelIdentityMountPath+"/trust-bundle.pem",
 				"--atunnel-egress-listen-address=0.0.0.0:15001",
@@ -862,7 +862,7 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 				WithProtocol(corev1.ProtocolTCP),
 				corev1ac.ContainerPort().
 					WithName("connect").
-					WithContainerPort(444).
+					WithContainerPort(8443).
 					WithProtocol(corev1.ProtocolTCP),
 				corev1ac.ContainerPort().
 					WithName("readyz").

--- a/cmd/atenet/internal/router/ingress/ingress.go
+++ b/cmd/atenet/internal/router/ingress/ingress.go
@@ -152,15 +152,14 @@ func (h *Handler) HandleRequestHeaders(ctx context.Context, md *extproc.RequestM
 			"actor %s routing failed", actorRef)
 	}
 
-	// atunnel's ingress server listens on :443 (mTLS) and forwards to
-	// targetPort on the actor; the router's client cert comes from the
-	// ORIGINAL_DST cluster's upstream TLS context (xds.go).
+	// atunnel's regular HTTPS ingress listens on :443 and forwards to the
+	// actor's targetPort.
 	targetAddr := net.JoinHostPort(workerIP, "443")
 
 	slog.InfoContext(ctx, "Route ok", slog.Any("actor", actorRef), slog.String("targetAddr", targetAddr))
 
-	// Envoy and agentgateway both pick the upstream from dynamic metadata,
-	// so the resolved address and port go there.
+	// ext_proc clients may use regular HTTPS on :443 or choose to CONNECT to
+	// atunnel instead.
 	dynamicMetadata, err := structpb.NewStruct(map[string]any{
 		OriginalDstMetadataKey: map[string]any{
 			OriginalDstAddressKey: targetAddr,

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -66,7 +66,7 @@ var (
 
 	// TODO(liorlieberman) have a sub package for all atunnel releated things like that
 	atunnelListenAddress        = pflag.String("atunnel-listen-address", "0.0.0.0:443", "Address for actor ingress HTTPS")
-	atunnelConnectListenAddress = pflag.String("atunnel-connect-listen-address", "0.0.0.0:444", "Address for actor ingress mTLS CONNECT")
+	atunnelConnectListenAddress = pflag.String("atunnel-connect-listen-address", "0.0.0.0:8443", "Address for actor ingress mTLS CONNECT")
 	workerCredentialBundle      = pflag.String("atunnel-credential-bundle", "/run/podidentity.podcert.ate.dev/credential-bundle.pem", "Worker Pod credential bundle used by atunnel for inbound serving and outbound mTLS")
 	podIdentityTrustBundle      = pflag.String("atunnel-trust-bundle", "/run/podidentity.podcert.ate.dev/trust-bundle.pem", "Pod identity trust bundle used for router clients and the node-local atelet")
 	atunnelClientIdentity       = pflag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -72,7 +72,7 @@ var (
 		"Unix socket of atelet's OTLP relay to export telemetry through, keeping it off the pod network. Empty, or absent at startup, exports directly to OTEL_EXPORTER_OTLP_ENDPOINT instead.")
 
 	atunnelListenAddress        = flag.String("atunnel-listen-address", "0.0.0.0:443", "Address for actor ingress HTTPS")
-	atunnelConnectListenAddress = flag.String("atunnel-connect-listen-address", "0.0.0.0:444", "Address for actor ingress mTLS CONNECT")
+	atunnelConnectListenAddress = flag.String("atunnel-connect-listen-address", "0.0.0.0:8443", "Address for actor ingress mTLS CONNECT")
 	workerCredentialBundle      = flag.String("atunnel-credential-bundle", "/run/podidentity.podcert.ate.dev/credential-bundle.pem", "Worker Pod credential bundle used by atunnel for inbound serving and outbound mTLS")
 	podIdentityTrustBundle      = flag.String("atunnel-trust-bundle", "/run/podidentity.podcert.ate.dev/trust-bundle.pem", "Pod identity trust bundle used for router clients and the node-local atelet")
 	atunnelClientIdentity       = flag.String("atunnel-client-identity", "spiffe://cluster.local/ns/ate-system/sa/atenet-router", "SPIFFE identity allowed to call actor ingress HTTPS")

--- a/cmd/kubectl-ate/internal/cmd/admin_make_ca_pool.go
+++ b/cmd/kubectl-ate/internal/cmd/admin_make_ca_pool.go
@@ -75,14 +75,25 @@ var makeCaPoolCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("while marshaling pool: %w", err)
 		}
+		certificateChain, err := ca.TLSCertificateChainPEM()
+		if err != nil {
+			return fmt.Errorf("while encoding CA certificate chain: %w", err)
+		}
+		privateKey, err := ca.TLSPrivateKeyPEM()
+		if err != nil {
+			return fmt.Errorf("while encoding CA private key: %w", err)
+		}
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: targetSecretNamespace,
 				Name:      targetSecretName,
 			},
+			Type: corev1.SecretTypeTLS,
 			Data: map[string][]byte{
-				"pool": poolBytes,
+				"pool":                  poolBytes,
+				corev1.TLSCertKey:       certificateChain,
+				corev1.TLSPrivateKeyKey: privateKey,
 			},
 		}
 

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -257,7 +257,11 @@ render_atenet_egress_manifest() {
       echo "Error: --experimental-additional-egress-extproc-service requires --atenet-router=envoy" >&2
       return 1
     fi
-    kubectl kustomize manifests/ate-install/agentgateway-egress \
+    local agentgateway_egress="manifests/ate-install/agentgateway-egress"
+    if [[ "${ATE_EXPERIMENTAL_USE_SDSMINT:-false}" == "true" ]]; then
+      agentgateway_egress="manifests/ate-install/agentgateway-egress-mitm"
+    fi
+    kubectl kustomize "${agentgateway_egress}" \
       --load-restrictor LoadRestrictionsNone | run_ko resolve -f -
   elif additional_egress_extproc_enabled; then
     patch_atenet_egress_manifest | run_ko resolve -f -
@@ -407,10 +411,13 @@ create_egress_mitm_ca_pool_secret() {
     --key-type=ECDSAP256
 }
 
-# Only the sdsmint egress variant mounts this pool.
+# Both egress implementations read this pool only in their opt-in MITM mode:
+# AgentGateway consumes its exported TLS chain and key, while Envoy's sdsmint
+# sidecar consumes the serialized pool.
 ensure_egress_mitm_ca_pool_secret() {
-  [[ "$(atenet_router)" != "agentgateway" ]] || return 0
-  [[ "${ATE_EXPERIMENTAL_USE_SDSMINT:-false}" == "true" ]] || return 0
+  if [[ "${ATE_EXPERIMENTAL_USE_SDSMINT:-false}" != "true" ]]; then
+    return 0
+  fi
   run_kubectl get secret -n ate-system egress-mitm-ca-pool >/dev/null 2>&1 \
     || create_egress_mitm_ca_pool_secret
 }

--- a/internal/atunnel/ingress.go
+++ b/internal/atunnel/ingress.go
@@ -39,7 +39,7 @@ import (
 const (
 	// DefaultConnectPort is the worker port on which atunnel accepts inbound
 	// mTLS CONNECT tunnels from the ingress router.
-	DefaultConnectPort = 444
+	DefaultConnectPort = 8443
 
 	// StaleAssignmentHeader distinguishes an atunnel routing rejection from a
 	// 421 returned by the actor application itself.

--- a/internal/e2e/suites/networking/networking_test.go
+++ b/internal/e2e/suites/networking/networking_test.go
@@ -87,10 +87,7 @@ func TestActorDirectAccess(t *testing.T) {
 // mTLS with the Actor's own actor-identity certificate plus an HTTP CONNECT to
 // atenet-egress, authorized there against that certificate, and only then
 // dialed out. A masqueraded (pre-gateway) egress would also return 200, so this
-// asserts the gateway is deployed and that it did not reject the Actor. The
-// response is also the request-level proof for AgentGateway: actor egress is
-// redirected to atunnel before it can leave the worker, so a successful origin
-// response necessarily crossed the egress gateway.
+// asserts the gateway is deployed and that it did not reject the Actor.
 func TestActorEgress(t *testing.T) {
 	ctx := context.Background()
 	actorName, _ := createAndResumeActor(t, ctx, "egress", egressFixture())
@@ -263,26 +260,6 @@ func waitForAccessLog(t *testing.T, ctx context.Context, since metav1.Time, want
 	}
 	if len(pods.Items) == 0 {
 		t.Fatalf("no %s pods in %s; the egress gateway is not deployed", gatewaySelector, gatewayNamespace)
-	}
-
-	// The Envoy implementation exposes the CONNECT authority and actor identity
-	// in its access log, so retain that stronger assertion where it is available.
-	// AgentGateway's substrateEgress API does not currently expose an equivalent
-	// request access-log contract. Its successful origin responses above still
-	// prove traversal because atunnel transparently redirects every actor socket
-	// to this gateway.
-	hasEnvoy := false
-	for _, pod := range pods.Items {
-		for _, container := range pod.Spec.Containers {
-			if container.Name == gatewayContainer {
-				hasEnvoy = true
-				break
-			}
-		}
-	}
-	if !hasEnvoy {
-		t.Logf("atenet-egress has no Envoy access-log container; request response proves %s through AgentGateway", want)
-		return
 	}
 
 	// Poll for the access log line (it may show up asynchronously from the actual traffic).

--- a/internal/e2e/suites/networking/networking_test.go
+++ b/internal/e2e/suites/networking/networking_test.go
@@ -87,7 +87,10 @@ func TestActorDirectAccess(t *testing.T) {
 // mTLS with the Actor's own actor-identity certificate plus an HTTP CONNECT to
 // atenet-egress, authorized there against that certificate, and only then
 // dialed out. A masqueraded (pre-gateway) egress would also return 200, so this
-// asserts the gateway is deployed and that it did not reject the Actor.
+// asserts the gateway is deployed and that it did not reject the Actor. The
+// response is also the request-level proof for AgentGateway: actor egress is
+// redirected to atunnel before it can leave the worker, so a successful origin
+// response necessarily crossed the egress gateway.
 func TestActorEgress(t *testing.T) {
 	ctx := context.Background()
 	actorName, _ := createAndResumeActor(t, ctx, "egress", egressFixture())
@@ -260,6 +263,26 @@ func waitForAccessLog(t *testing.T, ctx context.Context, since metav1.Time, want
 	}
 	if len(pods.Items) == 0 {
 		t.Fatalf("no %s pods in %s; the egress gateway is not deployed", gatewaySelector, gatewayNamespace)
+	}
+
+	// The Envoy implementation exposes the CONNECT authority and actor identity
+	// in its access log, so retain that stronger assertion where it is available.
+	// AgentGateway's substrateEgress API does not currently expose an equivalent
+	// request access-log contract. Its successful origin responses above still
+	// prove traversal because atunnel transparently redirects every actor socket
+	// to this gateway.
+	hasEnvoy := false
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			if container.Name == gatewayContainer {
+				hasEnvoy = true
+				break
+			}
+		}
+	}
+	if !hasEnvoy {
+		t.Logf("atenet-egress has no Envoy access-log container; request response proves %s through AgentGateway", want)
+		return
 	}
 
 	// Poll for the access log line (it may show up asynchronously from the actual traffic).

--- a/internal/e2e/trustbundle.go
+++ b/internal/e2e/trustbundle.go
@@ -94,9 +94,22 @@ func newEgressTrustPool(t *testing.T) (*corev1.Secret, string) {
 	if err != nil {
 		t.Fatalf("marshaling the egress pool: %v", err)
 	}
+	certificateChain, err := ca.TLSCertificateChainPEM()
+	if err != nil {
+		t.Fatalf("encoding the egress CA certificate chain: %v", err)
+	}
+	privateKey, err := ca.TLSPrivateKeyPEM()
+	if err != nil {
+		t.Fatalf("encoding the egress CA private key: %v", err)
+	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Namespace: egressCAPoolNamespace, Name: egressCAPoolSecretName},
-		Data:       map[string][]byte{egressCAPoolSecretKey: poolBytes},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			egressCAPoolSecretKey:   poolBytes,
+			corev1.TLSCertKey:       certificateChain,
+			corev1.TLSPrivateKeyKey: privateKey,
+		},
 	}, string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.RootCertificate.Raw}))
 }
 

--- a/internal/localca/localca.go
+++ b/internal/localca/localca.go
@@ -39,6 +39,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"sync"
@@ -213,6 +214,29 @@ type CA struct {
 
 	// The root certificate for this CA pool.
 	RootCertificate *x509.Certificate
+}
+
+// TLSCertificateChainPEM returns the CA certificate in the PEM encoding used
+// by TLS servers.
+func (ca *CA) TLSCertificateChainPEM() ([]byte, error) {
+	if ca == nil || ca.RootCertificate == nil {
+		return nil, fmt.Errorf("ca certificate: is nil")
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.RootCertificate.Raw}), nil
+}
+
+// TLSPrivateKeyPEM returns the CA signing key in the PKCS#8 PEM encoding used
+// by TLS servers.
+func (ca *CA) TLSPrivateKeyPEM() ([]byte, error) {
+	if ca == nil || ca.SigningKey == nil {
+		return nil, fmt.Errorf("ca key: is nil")
+	}
+
+	key, err := x509.MarshalPKCS8PrivateKey(ca.SigningKey)
+	if err != nil {
+		return nil, fmt.Errorf("ca key: serializing PKCS#8: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}), nil
 }
 
 type serializedPool struct {

--- a/internal/localca/localca.go
+++ b/internal/localca/localca.go
@@ -219,7 +219,7 @@ type CA struct {
 // TLSCertificateChainPEM returns the CA certificate in the PEM encoding used
 // by TLS servers.
 func (ca *CA) TLSCertificateChainPEM() ([]byte, error) {
-	if ca == nil || ca.RootCertificate == nil {
+	if ca.RootCertificate == nil {
 		return nil, fmt.Errorf("ca certificate: is nil")
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.RootCertificate.Raw}), nil
@@ -228,7 +228,7 @@ func (ca *CA) TLSCertificateChainPEM() ([]byte, error) {
 // TLSPrivateKeyPEM returns the CA signing key in the PKCS#8 PEM encoding used
 // by TLS servers.
 func (ca *CA) TLSPrivateKeyPEM() ([]byte, error) {
-	if ca == nil || ca.SigningKey == nil {
+	if ca.SigningKey == nil {
 		return nil, fmt.Errorf("ca key: is nil")
 	}
 

--- a/internal/localca/localca_test.go
+++ b/internal/localca/localca_test.go
@@ -15,8 +15,11 @@
 package localca
 
 import (
+	"bytes"
+	"crypto"
 	"crypto/ed25519"
 	"crypto/x509"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -72,6 +75,51 @@ func TestGenerateED25519CA(t *testing.T) {
 	roots.AddCert(cert)
 	if _, err := cert.Verify(x509.VerifyOptions{Roots: roots}); err != nil {
 		t.Errorf("self-signed verification failed: %v", err)
+	}
+}
+
+func TestTLSMaterialPEM(t *testing.T) {
+	ca, err := GenerateCA("test-ca", KeyTypeED25519, 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateED25519CA() error = %v", err)
+	}
+
+	chain, err := ca.TLSCertificateChainPEM()
+	if err != nil {
+		t.Fatalf("TLSCertificateChainPEM() error = %v", err)
+	}
+	block, rest := pem.Decode(chain)
+	if block == nil || block.Type != "CERTIFICATE" {
+		t.Fatalf("TLSCertificateChainPEM() first block = %#v, want CERTIFICATE", block)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("TLSCertificateChainPEM() has unexpected additional data: %q", rest)
+	}
+	if !bytes.Equal(block.Bytes, ca.RootCertificate.Raw) {
+		t.Error("TLSCertificateChainPEM() certificate differs from the issuing certificate")
+	}
+
+	keyPEM, err := ca.TLSPrivateKeyPEM()
+	if err != nil {
+		t.Fatalf("TLSPrivateKeyPEM() error = %v", err)
+	}
+	block, rest = pem.Decode(keyPEM)
+	if block == nil || block.Type != "PRIVATE KEY" {
+		t.Fatalf("TLSPrivateKeyPEM() block = %#v, want PRIVATE KEY", block)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("TLSPrivateKeyPEM() has unexpected additional data: %q", rest)
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("TLSPrivateKeyPEM() did not contain PKCS#8: %v", err)
+	}
+	publicKey, err := x509.MarshalPKIXPublicKey(key.(crypto.Signer).Public())
+	if err != nil {
+		t.Fatalf("marshaling private key's public key: %v", err)
+	}
+	if !bytes.Equal(ca.RootCertificate.RawSubjectPublicKeyInfo, publicKey) {
+		t.Error("TLSPrivateKeyPEM() key does not match the issuing certificate")
 	}
 }
 

--- a/manifests/ate-install/agentgateway-egress-mitm/kustomization.yaml
+++ b/manifests/ate-install/agentgateway-egress-mitm/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../atenet-egress.yaml
+
+components:
+  - ../components/agentgateway
+  - ../components/agentgateway-egress-mitm

--- a/manifests/ate-install/components/agentgateway-egress-mitm/kustomization.yaml
+++ b/manifests/ate-install/components/agentgateway-egress-mitm/kustomization.yaml
@@ -1,0 +1,109 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      version: v1
+      kind: ConfigMap
+      name: atenet-egress-agentgateway-substrate-config
+      namespace: ate-system
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: atenet-egress-agentgateway-substrate-config
+        namespace: ate-system
+      data:
+        config.yaml: |
+          frontendPolicies:
+            accessLog:
+              add:
+                substrate.connect.authority: source.connectHeaders["host"]
+
+          binds:
+          - port: 8443
+            tunnelProtocol: connect
+            listeners:
+            - protocol: HTTPS
+              tls:
+                cert: /run/servicedns.podcert.ate.dev/credential-bundle.pem
+                key: /run/servicedns.podcert.ate.dev/credential-bundle.pem
+                root: /run/actor-id-ca-certs/ca.crt
+              routes: []
+          - mode: internal
+            protocol: AUTO
+            listeners:
+            - protocol: HTTPS
+              tls:
+                mode: dynamicCa
+                cert: /run/egress-mitm/tls.crt
+                key: /run/egress-mitm/tls.key
+              routes:
+              - policies:
+                  substrateEgress:
+                    host: api.ate-system.svc:443
+                    policies:
+                      backendTLS:
+                        cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                        key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                        root: /run/servicedns-ca/trust-bundle.pem
+                backends:
+                - dynamic: {}
+                  policies:
+                    backendTLS: {}
+            - protocol: HTTP
+              routes:
+              - policies:
+                  substrateEgress:
+                    host: api.ate-system.svc:443
+                    policies:
+                      backendTLS:
+                        cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                        key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                        root: /run/servicedns-ca/trust-bundle.pem
+                backends:
+                - dynamic:
+                    target: source.connectHeaders["host"]
+            - protocol: TCP
+              tcpRoutes:
+              - backends:
+                - dynamic:
+                    target: source.connectHeaders["host"]
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: atenet-egress
+      namespace: ate-system
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          name: egress-mitm
+          mountPath: /run/egress-mitm
+          readOnly: true
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: egress-mitm
+          secret:
+            secretName: egress-mitm-ca-pool
+            items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key

--- a/manifests/ate-install/components/agentgateway/configmap.yaml
+++ b/manifests/ate-install/components/agentgateway/configmap.yaml
@@ -21,26 +21,16 @@ data:
   config.yaml: |
     # yaml-language-server: $schema=https://agentgateway.dev/schema/config
     config:
-      # Actor sandboxes behind a worker IP are replaced between requests. Do
-      # not retain an idle connection that may belong to the previous actor.
       backend:
-        poolMaxSize: 0
+        poolIdleTimeout: 5s
 
     frontendPolicies:
       tracing:
         host: $AGENTGATEWAY_OTLP_ADDRESS
         protocol: grpc
-        # Matches the router's dataPlaneTraceRatio; static config, so a router
-        # OTEL_TRACES_SAMPLER override must adjust it in step.
+        # Keep in sync with the router's dataPlaneTraceRatio.
         randomSampling: 0.01
 
-    # http/https serve direct (non-CONNECT) actor traffic only. connect.mode is
-    # a single global setting with no per-gateway override, and Tunnel mode's
-    # CONNECT interception happens below the per-request pipeline (at raw
-    # connection accept, before the method is even known) -- so a bind can't
-    # mix direct and CONNECT-tunnel traffic. CONNECT is served on its own
-    # dedicated binds below instead, mirroring Envoy's separate
-    # connect_terminate/connect_terminate_tls listeners.
     gateways:
       http:
         port: 8080
@@ -52,6 +42,22 @@ data:
           cert: /run/servicedns.podcert.ate.dev/credential-bundle.pem
           key: /run/servicedns.podcert.ate.dev/credential-bundle.pem
 
+    backends:
+    - name: dynamic
+      dynamic: {}
+      policies:
+        # All actor traffic reaches atunnel over mTLS CONNECT.
+        backendTunnel:
+          proxy:
+            backend: /dynamic
+          mode: connect
+          policies:
+            backendTLS:
+              cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+              key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+              root: /run/podidentity.podcert.ate.dev/trust-bundle.pem
+              insecureHost: true
+
     routes:
     - name: substrate-actors
       gateways:
@@ -61,68 +67,33 @@ data:
       - path:
           pathPrefix: /
       policies:
-        # AgentGateway calls ate-api directly to resume and resolve the actor.
         substrateIngress:
           host: api.ate-system.svc:443
+          # AgentGateway only uses atunnel's CONNECT listener.
+          connectTargetPort: 8443
           policies:
-            # ate-api presents a servicedns certificate and requires the
-            # gateway's podidentity client credential.
             backendTLS:
               cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
               key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
               root: /run/servicedns-ca/trust-bundle.pem
       backends:
-      - dynamic: {}
-        policies:
-          # atunnel serves HTTPS on each worker pod IP. Verify its certificate
-          # against the podidentity CA and present the router's podidentity
-          # credential. Worker SPIFFE IDs vary with their workload namespace,
-          # so skip DNS/IP hostname matching while retaining CA verification.
-          backendTLS:
-            cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
-            key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
-            root: /run/podidentity.podcert.ate.dev/trust-bundle.pem
-            insecureHost: true
+      - backend: /dynamic
 
-    # CONNECT ingress, on its own dedicated ports (matching Envoy's
-    # connect/connect-tls listeners) because tunnelProtocol only applies to a
-    # whole bind, and Tunnel mode's global connect.mode would otherwise turn
-    # http/https above into CONNECT-only too. Terminating the tunnel here
-    # (rather than Route mode's raw pass-through) means every request inside
-    # it -- not just the initial CONNECT -- is evaluated by substrateIngress
-    # and dynamic backend resolution below. That's what
-    # lets a client reach a port other than an actor's primary one: the
-    # CONNECT's own :authority carries the target port (e.g.
-    # "<actor-dns-name>:9090"), survives into source.connectHeaders across
-    # every re-entered request (see the wildcard bind below), and resolves
-    # the actor and port the same way request.host does for direct traffic.
+    # Terminate client CONNECT before internal HTTP routing.
     binds:
     - port: 8081
       tunnelProtocol: connect
       listeners:
-      # No routes: this listener only ever sees the CONNECT itself: the
-      # request that matters is re-entered into the wildcard bind below.
       - protocol: HTTP
         routes: []
     - port: 8444
       tunnelProtocol: connect
       listeners:
-      # Terminate the outer TLS before serving CONNECT, so the CONNECT
-      # request and its headers are encrypted on the wire -- otherwise this
-      # bind would ignore this listener's TLS config and serve CONNECT in
-      # plaintext on the raw socket.
       - protocol: HTTPS
         tls:
           cert: /run/servicedns.podcert.ate.dev/credential-bundle.pem
           key: /run/servicedns.podcert.ate.dev/credential-bundle.pem
         routes: []
-    # The wildcard internal bind: opens no socket, and is reached only by
-    # CONNECT re-entry from the binds above (regardless of the CONNECT's
-    # destination port, since an actor's exposed port is arbitrary and can't
-    # be enumerated ahead of time). This is where the actual actor route
-    # lives -- content-wise the same as substrate-actors above, except
-    # resolving the actor from the original CONNECT authority rather than
-    # this (re-entered) request's own, unrelated Host header.
     - mode: internal
       listeners:
       - protocol: HTTP
@@ -134,20 +105,15 @@ data:
           policies:
             substrateIngress:
               host: api.ate-system.svc:443
+              connectTargetPort: 8443
               policies:
                 backendTLS:
                   cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
                   key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
                   root: /run/servicedns-ca/trust-bundle.pem
           backends:
-          - dynamic:
-              target: source.connectHeaders["host"]
-            policies:
-              backendTLS:
-                cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
-                key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
-                root: /run/podidentity.podcert.ate.dev/trust-bundle.pem
-                insecureHost: true
+          - backend: /dynamic
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -158,12 +124,12 @@ data:
   config.yaml: |
     # yaml-language-server: $schema=https://agentgateway.dev/schema/config
     frontendPolicies:
-      connect:
-        mode: route
+      accessLog:
+        add:
+          substrate.connect.authority: source.connectHeaders["host"]
 
     binds:
-    # The actor tunnel is mutually authenticated with the actor identity SVID.
-    # CONNECT then re-enters one of the internal binds selected by :authority.
+    # Authenticate the actor before accepting CONNECT.
     - port: 8443
       tunnelProtocol: connect
       listeners:
@@ -172,22 +138,20 @@ data:
           cert: /run/servicedns.podcert.ate.dev/credential-bundle.pem
           key: /run/servicedns.podcert.ate.dev/credential-bundle.pem
           root: /run/actor-id-ca-certs/ca.crt
-        # CONNECT is handled by the tunnel frontend and re-enters the
-        # internal listeners below; an empty route list satisfies HTTPS
-        # listener validation without admitting direct traffic here.
+        # CONNECT re-enters the internal bind below.
         routes: []
 
-    # A single portless re-entry bind classifies the stream after CONNECT: TLS
-    # is intercepted with the dynamic MITM listener, while cleartext HTTP/1
-    # and h2c use the AUTO listener. The CONNECT authority remains only the
-    # destination, rather than encoding a protocol decision in its port.
+    # Route tunneled HTTP and pass through opaque streams.
     - mode: internal
+      protocol: AUTO
       listeners:
-      - protocol: HTTPS
-        tls:
-          mode: dynamicCa
-          substrateCaPool: /run/ca-state/mitm-pool.json
-          substrateCaId: mitm
+      - protocol: TLS
+        hostname: "*"
+        tcpRoutes:
+        - backends:
+          - dynamic:
+              target: source.connectHeaders["host"]
+      - protocol: HTTP
         routes:
         - policies:
             substrateEgress:
@@ -198,19 +162,10 @@ data:
                   key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
                   root: /run/servicedns-ca/trust-bundle.pem
           backends:
-          - dynamic: {}
-            policies:
-              backendTLS: {}
-      - protocol: AUTO
-        routes:
-        - policies:
-            substrateEgress:
-              host: api.ate-system.svc:443
-              policies:
-                backendTLS:
-                  cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
-                  key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
-                  root: /run/servicedns-ca/trust-bundle.pem
-          backends:
+          - dynamic:
+              target: source.connectHeaders["host"]
+      - protocol: TCP
+        tcpRoutes:
+        - backends:
           - dynamic:
               target: source.connectHeaders["host"]

--- a/manifests/ate-install/components/agentgateway/configmap.yaml
+++ b/manifests/ate-install/components/agentgateway/configmap.yaml
@@ -61,32 +61,18 @@ data:
       - path:
           pathPrefix: /
       policies:
-        extProc:
-          host: 127.0.0.1:50051
-          failureMode: failClosed
-          processingOptions:
-            requestHeaderMode: send
-            responseHeaderMode: skip
-            requestBodyMode: none
-            responseBodyMode: none
-            requestTrailerMode: skip
-            responseTrailerMode: skip
-          # The router's ext_proc server (cmd/atenet/internal/router/extproc.go)
-          # resolves the actor from
-          # attributes["envoy.filters.http.ext_proc"]["filter_state['dev.ate.authority']"].
-          # For direct (non-CONNECT) traffic on this route, request.host is the
-          # client's own :authority/Host -- there's no tunnel to look past.
-          requestAttributes:
-            "filter_state['dev.ate.authority']": request.host
+        # AgentGateway calls ate-api directly to resume and resolve the actor.
+        substrateIngress:
+          host: api.ate-system.svc:443
+          policies:
+            # ate-api presents a servicedns certificate and requires the
+            # gateway's podidentity client credential.
+            backendTLS:
+              cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+              key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+              root: /run/servicedns-ca/trust-bundle.pem
       backends:
-      - dynamic:
-          # The router reports the resolved worker atunnel address (host:443)
-          # as dynamic metadata rather than rewriting :authority -- see
-          # OriginalDstMetadataKey/OriginalDstAddressKey in xds.go. Reading it
-          # here means :authority/Host stays the actor's real DNS name the
-          # whole way through, so atunnel authorizes it directly with no
-          # restore-the-original-Host header needed.
-          target: extproc["envoy.filters.listener.original_dst"]["local"]
+      - dynamic: {}
         policies:
           # atunnel serves HTTPS on each worker pod IP. Verify its certificate
           # against the podidentity CA and present the router's podidentity
@@ -103,8 +89,8 @@ data:
     # whole bind, and Tunnel mode's global connect.mode would otherwise turn
     # http/https above into CONNECT-only too. Terminating the tunnel here
     # (rather than Route mode's raw pass-through) means every request inside
-    # it -- not just the initial CONNECT -- goes through ext_proc and dynamic
-    # backend resolution below, exactly like ordinary traffic. That's what
+    # it -- not just the initial CONNECT -- is evaluated by substrateIngress
+    # and dynamic backend resolution below. That's what
     # lets a client reach a port other than an actor's primary one: the
     # CONNECT's own :authority carries the target port (e.g.
     # "<actor-dns-name>:9090"), survives into source.connectHeaders across
@@ -146,22 +132,16 @@ data:
           - path:
               pathPrefix: /
           policies:
-            extProc:
-              host: 127.0.0.1:50051
-              failureMode: failClosed
-              processingOptions:
-                requestHeaderMode: send
-                responseHeaderMode: skip
-                requestBodyMode: none
-                responseBodyMode: none
-                requestTrailerMode: skip
-                responseTrailerMode: skip
-              requestAttributes:
-                "filter_state['dev.ate.authority']": source.connectHeaders["host"]
+            substrateIngress:
+              host: api.ate-system.svc:443
+              policies:
+                backendTLS:
+                  cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                  key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                  root: /run/servicedns-ca/trust-bundle.pem
           backends:
           - dynamic:
-              # See substrate-actors' backend above.
-              target: extproc["envoy.filters.listener.original_dst"]["local"]
+              target: source.connectHeaders["host"]
             policies:
               backendTLS:
                 cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
@@ -172,7 +152,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: atenet-egress-agentgateway-config
+  name: atenet-egress-agentgateway-substrate-config
   namespace: ate-system
 data:
   config.yaml: |
@@ -181,32 +161,56 @@ data:
       connect:
         mode: route
 
-    gateways:
-      egress:
-        port: 8443
-        protocol: HTTPS
+    binds:
+    # The actor tunnel is mutually authenticated with the actor identity SVID.
+    # CONNECT then re-enters one of the internal binds selected by :authority.
+    - port: 8443
+      tunnelProtocol: connect
+      listeners:
+      - protocol: HTTPS
         tls:
           cert: /run/servicedns.podcert.ate.dev/credential-bundle.pem
           key: /run/servicedns.podcert.ate.dev/credential-bundle.pem
           root: /run/actor-id-ca-certs/ca.crt
+        # CONNECT is handled by the tunnel frontend and re-enters the
+        # internal listeners below; an empty route list satisfies HTTPS
+        # listener validation without admitting direct traffic here.
+        routes: []
 
-    routes:
-    - name: substrate-egress
-      gateways:
-      - egress
-      policies:
-        extProc:
-          host: 127.0.0.1:50051
-          failureMode: failClosed
-          requestAttributes:
-            ate.extproc.direction: "'egress'"
-            source.certificate: source.certificate
-          processingOptions:
-            requestHeaderMode: send
-            responseHeaderMode: skip
-            requestBodyMode: none
-            responseBodyMode: none
-            requestTrailerMode: skip
-            responseTrailerMode: skip
-      backends:
-      - dynamic: {}
+    # A single portless re-entry bind classifies the stream after CONNECT: TLS
+    # is intercepted with the dynamic MITM listener, while cleartext HTTP/1
+    # and h2c use the AUTO listener. The CONNECT authority remains only the
+    # destination, rather than encoding a protocol decision in its port.
+    - mode: internal
+      listeners:
+      - protocol: HTTPS
+        tls:
+          mode: dynamicCa
+          substrateCaPool: /run/ca-state/mitm-pool.json
+          substrateCaId: mitm
+        routes:
+        - policies:
+            substrateEgress:
+              host: api.ate-system.svc:443
+              policies:
+                backendTLS:
+                  cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                  key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                  root: /run/servicedns-ca/trust-bundle.pem
+          backends:
+          - dynamic: {}
+            policies:
+              backendTLS: {}
+      - protocol: AUTO
+        routes:
+        - policies:
+            substrateEgress:
+              host: api.ate-system.svc:443
+              policies:
+                backendTLS:
+                  cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                  key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
+                  root: /run/servicedns-ca/trust-bundle.pem
+          backends:
+          - dynamic:
+              target: source.connectHeaders["host"]

--- a/manifests/ate-install/components/agentgateway/kustomization.yaml
+++ b/manifests/ate-install/components/agentgateway/kustomization.yaml
@@ -38,29 +38,11 @@ patches:
       name: atenet-router
       namespace: ate-system
     patch: |-
-      - op: test
-        path: /spec/template/spec/containers/0/args/4
-        value: --port-xds=18000
-      - op: remove
-        path: /spec/template/spec/containers/0/args/4
-      - op: test
-        path: /spec/template/spec/containers/0/args/8
-        value: --envoy-cert-path=/run/servicedns.podcert.ate.dev/credential-bundle.pem
-      - op: remove
-        path: /spec/template/spec/containers/0/args/8
-      - op: test
-        path: /spec/template/spec/containers/0/ports/0/name
-        value: xds
-      - op: remove
-        path: /spec/template/spec/containers/0/ports/0
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --atenet-router=agentgateway
       - op: replace
-        path: /spec/template/spec/containers/1
+        path: /spec/template/spec/containers/0
         value:
           name: agentgateway
-          image: cr.agentgateway.dev/agentgateway:v0.0.0-alpha.a6c0e366
+          image: cr.agentgateway.dev/agentgateway:v0.0.0-alpha.42dba5b
           args:
           - -f
           - /etc/agentgateway/config.yaml
@@ -87,6 +69,10 @@ patches:
             mountPath: /run/servicedns.podcert.ate.dev
           - name: podidentity
             mountPath: /run/podidentity.podcert.ate.dev
+          - name: servicedns-ca
+            mountPath: /run/servicedns-ca
+      - op: remove
+        path: /spec/template/spec/containers/1
   - target:
       group: apps
       version: v1
@@ -117,7 +103,7 @@ patches:
         path: /spec/template/spec/containers/0
         value:
           name: agentgateway
-          image: cr.agentgateway.dev/agentgateway:v1.4.1
+          image: cr.agentgateway.dev/agentgateway:v0.0.0-alpha.42dba5b
           args:
           - -f
           - /etc/agentgateway/config.yaml
@@ -149,9 +135,40 @@ patches:
           - name: actor-id-ca-certs
             mountPath: /run/actor-id-ca-certs
             readOnly: true
-      - op: add
-        path: /spec/template/spec/containers/1/args/-
-        value: --atenet-router=agentgateway
+          - name: podidentity
+            mountPath: /run/podidentity.podcert.ate.dev
+            readOnly: true
+          - name: servicedns-ca
+            mountPath: /run/servicedns-ca
+            readOnly: true
+          - name: ca-state
+            mountPath: /run/ca-state
+            readOnly: true
       - op: replace
         path: /spec/template/spec/volumes/0/configMap/name
-        value: atenet-egress-agentgateway-config
+        value: atenet-egress-agentgateway-substrate-config
+      - op: remove
+        path: /spec/template/spec/containers/1
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: servicedns-ca
+          projected:
+            sources:
+            - clusterTrustBundle:
+                signerName: servicedns.podcert.ate.dev/identity
+                labelSelector:
+                  matchLabels:
+                    podcert.ate.dev/canarying: live
+                path: trust-bundle.pem
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: ca-state
+          projected:
+            sources:
+            - secret:
+                name: egress-mitm-ca-pool
+                items:
+                - key: pool
+                  path: mitm-pool.json

--- a/manifests/ate-install/components/agentgateway/kustomization.yaml
+++ b/manifests/ate-install/components/agentgateway/kustomization.yaml
@@ -42,7 +42,7 @@ patches:
         path: /spec/template/spec/containers/0
         value:
           name: agentgateway
-          image: cr.agentgateway.dev/agentgateway:v0.0.0-alpha.42dba5b
+          image: cr.agentgateway.dev/agentgateway:v1.5.0
           args:
           - -f
           - /etc/agentgateway/config.yaml
@@ -73,6 +73,18 @@ patches:
             mountPath: /run/servicedns-ca
       - op: remove
         path: /spec/template/spec/containers/1
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: servicedns-ca
+          projected:
+            sources:
+            - clusterTrustBundle:
+                signerName: servicedns.podcert.ate.dev/identity
+                labelSelector:
+                  matchLabels:
+                    podcert.ate.dev/canarying: live
+                path: trust-bundle.pem
   - target:
       group: apps
       version: v1
@@ -103,7 +115,7 @@ patches:
         path: /spec/template/spec/containers/0
         value:
           name: agentgateway
-          image: cr.agentgateway.dev/agentgateway:v0.0.0-alpha.42dba5b
+          image: cr.agentgateway.dev/agentgateway:v1.5.0
           args:
           - -f
           - /etc/agentgateway/config.yaml
@@ -141,9 +153,6 @@ patches:
           - name: servicedns-ca
             mountPath: /run/servicedns-ca
             readOnly: true
-          - name: ca-state
-            mountPath: /run/ca-state
-            readOnly: true
       - op: replace
         path: /spec/template/spec/volumes/0/configMap/name
         value: atenet-egress-agentgateway-substrate-config
@@ -161,14 +170,3 @@ patches:
                   matchLabels:
                     podcert.ate.dev/canarying: live
                 path: trust-bundle.pem
-      - op: add
-        path: /spec/template/spec/volumes/-
-        value:
-          name: ca-state
-          projected:
-            sources:
-            - secret:
-                name: egress-mitm-ca-pool
-                items:
-                - key: pool
-                  path: mitm-pool.json


### PR DESCRIPTION
Flesh out the agentgateway implementation as a router and egress PEP. This also changes the atunnel CONNECT port to do 8443. Most of this is agentgateway contained, but the one other system we touch is localca; agentgateway's MITM support requires the TLS cert and key in the secret instead of the JSON pool (we don't rely on sdsmint).

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
