### PR TITLE
docs: document the atelet Workload Identity grants setup-gcp creates

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" -i 
    go run ./tools/setup-gcp bootstrap
    ```
 
+   On a fresh project this step also creates the atelet Workload Identity IAM
+   grants that snapshots depend on — see
+   [what `create iam` actually grants](tools/setup-gcp/README.md#what-create-iam-actually-grants)
+   to audit them or apply them manually.
+
 4. Deploy the Agent Substrate system to your cluster:
    ```bash
    ./hack/install-ate.sh --deploy-ate-system

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" -i 
    On a fresh project this step also creates the atelet Workload Identity IAM
    grants that snapshots depend on — see
    [what `create iam` actually grants](tools/setup-gcp/README.md#what-create-iam-actually-grants)
-   to audit them or apply them manually.
+   to audit them or apply them manually. If you bring your own cluster instead,
+   note the required Kubernetes beta APIs can only be enabled **at cluster
+   creation** — see the [Create Cluster warning](tools/setup-gcp/README.md#2-create-cluster).
 
 4. Deploy the Agent Substrate system to your cluster:
    ```bash

--- a/tools/setup-gcp/README.md
+++ b/tools/setup-gcp/README.md
@@ -65,6 +65,26 @@ go run ./tools/setup-gcp enable apis [flags]
 
 Creates a GKE cluster configured for Agent Substrate.
 
+> [!WARNING]
+> Agent Substrate requires two Kubernetes beta APIs —
+> `certificates.k8s.io/v1beta1/podcertificaterequests` and
+> `certificates.k8s.io/v1beta1/clustertrustbundles` — and GKE only honors
+> `enableK8sBetaApis` **at cluster creation**. Enabling them later on an
+> existing cluster is not recoverable in place: the tool's reconcile path
+> issues the update, but the APIs do not become served — the cluster must be
+> **recreated** with them enabled. `create cluster` sets them for you; if you
+> bring your own cluster, create it with both APIs enabled from the start,
+> e.g.:
+>
+> ```bash
+> gcloud container clusters create "${CLUSTER_NAME}" ... \
+>   --enable-kubernetes-unstable-apis=certificates.k8s.io/v1beta1/podcertificaterequests,certificates.k8s.io/v1beta1/clustertrustbundles
+> ```
+>
+> The symptom of a cluster without them: the install hangs at "Waiting for
+> podcertificate ClusterTrustBundles to be ready" and `kubectl get
+> clustertrustbundles` reports the resource type is not served.
+
 ```bash
 go run ./tools/setup-gcp create cluster [flags]
 ```

--- a/tools/setup-gcp/README.md
+++ b/tools/setup-gcp/README.md
@@ -112,6 +112,52 @@ go run ./tools/setup-gcp create iam [flags]
 
 *\*Note: Required for bucket bindings unless the `BUCKET_NAME` environment variable is set.*
 
+#### What `create iam` actually grants
+
+On a fresh GCP project these bindings do not exist, and nothing else creates
+them — without them atelet cannot read or write snapshots (`403` from GCS on
+the first suspend/resume) and nodes cannot pull images. `bootstrap` and
+`create iam` apply them for you; the table below is the reference for auditing
+them, or for applying them by hand in projects where you cannot run the tool
+with project-level IAM permissions.
+
+atelet authenticates via [GKE Workload Identity
+Federation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity):
+its Kubernetes ServiceAccount (`ate-system/atelet`, created by
+`install-ate.sh`) is addressed directly as an IAM principal — no Google
+service account is created or impersonated. This only works on a cluster with
+Workload Identity enabled (`create cluster` enables the
+`PROJECT_ID.svc.id.goog` pool; a pre-existing cluster must have it enabled
+too, or atelet's GCS calls fail with `401`).
+
+| Member | Role | Resource | Why |
+| :--- | :--- | :--- | :--- |
+| atelet WI principal¹ | `roles/storage.objectAdmin` | project² | Read/write actor snapshots in GCS |
+| atelet WI principal¹ | `roles/artifactregistry.reader` | project² | Pull sandbox runtime assets |
+| atelet WI principal¹ | `roles/storage.objectAdmin` | snapshot bucket | Read/write snapshot objects |
+| atelet WI principal¹ | `roles/storage.bucketViewer` | snapshot bucket | List/stat the snapshot bucket |
+| default compute SA³ | `roles/storage.objectViewer` | project² | Nodes pull images from GCS-backed registries |
+| default compute SA³ | `roles/artifactregistry.reader` | project² | Nodes pull images from Artifact Registry |
+
+¹ `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/PROJECT_ID.svc.id.goog/subject/ns/ate-system/sa/atelet` — note it is keyed to the **project number**, not the ID.
+² Project-level today; scoping these down is tracked in the TODOs in `cmd/iam.go`.
+³ `PROJECT_NUMBER-compute@developer.gserviceaccount.com` (least-privileged node SA is #76).
+
+Manual equivalent:
+
+```bash
+ATELET="principal://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${PROJECT_ID}.svc.id.goog/subject/ns/ate-system/sa/atelet"
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="${ATELET}" --role=roles/storage.objectAdmin
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="${ATELET}" --role=roles/artifactregistry.reader
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET_NAME}" \
+  --member="${ATELET}" --role=roles/storage.objectAdmin
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET_NAME}" \
+  --member="${ATELET}" --role=roles/storage.bucketViewer
+```
+
 ### 5. Create Dashboards
 
 Creates or updates Cloud Monitoring dashboards.


### PR DESCRIPTION
Two fresh-project documentation gaps from install feedback, both in the setup-gcp docs:

1. **atelet Workload Identity grants**: created silently by `setup-gcp`, documented nowhere — anyone auditing them, or installing where they can't run the tool with project-level IAM permissions, has to reverse-engineer `cmd/iam.go`/`cmd/bucket.go`. Adds a "What `create iam` actually grants" reference — exact members/roles/resources (verified against the code), the Workload Identity prerequisite, the project-number-vs-ID footgun, and manual `gcloud` equivalents.

2. **`enableK8sBetaApis` is creation-time only**: the required `certificates.k8s.io/v1beta1` APIs (podcertificaterequests, clustertrustbundles) cannot be enabled in place on an existing cluster — the tool's reconcile path issues the update but the APIs never become served, and the install hangs at "Waiting for podcertificate ClusterTrustBundles". Adds a warning to the Create Cluster section with the bring-your-own-cluster `gcloud` flag and the symptom to recognize.

The main README quickstart now points at both.

- [x] Tests pass (docs only)
- [x] Appropriate changes to documentation are included in the PR
