### PR TITLE
apitool: drop the exemptions for fields that are now documented

### DIFF
--- a/tools/apitool/exemptions.json
+++ b/tools/apitool/exemptions.json
@@ -116,16 +116,6 @@
   },
   {
     "rule": "documented",
-    "subject": "ateapi.Capabilities.add",
-    "message": "field has no doc comment"
-  },
-  {
-    "rule": "documented",
-    "subject": "ateapi.Capabilities.drop",
-    "message": "field has no doc comment"
-  },
-  {
-    "rule": "documented",
     "subject": "ateapi.Container.env",
     "message": "field has no doc comment"
   },
@@ -272,11 +262,6 @@
   {
     "rule": "documented",
     "subject": "ateapi.HTTPGetAction.port",
-    "message": "field has no doc comment"
-  },
-  {
-    "rule": "documented",
-    "subject": "ateapi.ImageVolumeSource.reference",
     "message": "field has no doc comment"
   },
   {
@@ -431,11 +416,6 @@
   },
   {
     "rule": "documented",
-    "subject": "ateapi.SecurityContext.capabilities",
-    "message": "field has no doc comment"
-  },
-  {
-    "rule": "documented",
     "subject": "ateapi.SnapshotContentScope",
     "message": "enum has no doc comment"
   },
@@ -477,11 +457,6 @@
   {
     "rule": "documented",
     "subject": "ateapi.Volume.external_volume_template",
-    "message": "field has no doc comment"
-  },
-  {
-    "rule": "documented",
-    "subject": "ateapi.Volume.image",
     "message": "field has no doc comment"
   },
   {


### PR DESCRIPTION
https://github.com/agent-substrate/substrate/commit/48090979dc56324a9985a52de4557243b287d964#diff-51a595730fdeea0b1efc0394d1b3e866426a9acb000b6f2110262867b9aaeae7 added exemptions unrelated to the PR

https://github.com/agent-substrate/substrate/pull/1276 removed the need for exemptions, which were currently failing on main

This PR cleans up the now failing defunct exemptions.
