### PR TITLE
benchmarking: re-dirty the glutton working set each cycle (--mem-churn)

### DIFF
--- a/benchmarking/automation/tests.yaml
+++ b/benchmarking/automation/tests.yaml
@@ -97,7 +97,9 @@ tests:
   # cycle is measured against a realistically-sized actor. actorMemory =
   # target + headroom (glutton itself, the guest, and on microvm the 128Mi
   # VMM reserve). The golden snapshot and cold boot stay small: the working
-  # set exists from the first fill onward.
+  # set exists from the first fill onward. --mem-churn re-randomizes 64Mi in
+  # place each cycle, so repeated suspends snapshot changing memory rather
+  # than a static set.
   - name: glutton_mem_1gi_gvisor
     type: locust
     description: "Large-memory: 1Gi resident working set, gvisor"
@@ -110,6 +112,8 @@ tests:
     flags:
       - "--mem-target"
       - "1Gi"
+      - "--mem-churn"
+      - "64Mi"
       - "--min-wait-time"
       - "1.0"
       - "--max-wait-time"
@@ -127,6 +131,8 @@ tests:
     flags:
       - "--mem-target"
       - "1Gi"
+      - "--mem-churn"
+      - "64Mi"
       - "--min-wait-time"
       - "1.0"
       - "--max-wait-time"
@@ -143,6 +149,8 @@ tests:
     flags:
       - "--mem-target"
       - "2Gi"
+      - "--mem-churn"
+      - "64Mi"
       - "--min-wait-time"
       - "1.0"
       - "--max-wait-time"
@@ -160,6 +168,8 @@ tests:
     flags:
       - "--mem-target"
       - "2Gi"
+      - "--mem-churn"
+      - "64Mi"
       - "--min-wait-time"
       - "1.0"
       - "--max-wait-time"

--- a/benchmarking/locust/common/boomer_config.py
+++ b/benchmarking/locust/common/boomer_config.py
@@ -19,7 +19,7 @@ Flag registration lives in the modules that own each flag:
   * --min-wait-time / --max-wait-time → common.wait_time.init_wait_time
   * --resume-mode                   → common.resume_mode.add_resume_mode_arguments
   * --durdir-*                      → common.durdir_config.add_durdir_arguments
-  * --mem-target                    → common.memload_config.add_memload_arguments
+  * --mem-target / --mem-churn      → common.memload_config.add_memload_arguments
 
 This module ties them together so boomer-Go workers can pick up the values
 the operator set in the web UI form:
@@ -54,6 +54,7 @@ _FLAGS = {
     "--durdir-read-mode": str,
     "--durdir-template": str,
     "--mem-target": str,
+    "--mem-churn": str,
 }
 
 

--- a/benchmarking/locust/common/memload_config.py
+++ b/benchmarking/locust/common/memload_config.py
@@ -31,3 +31,13 @@ def add_memload_arguments(parser: LocustArgumentParser) -> None:
         "realistically-sized memory (default: empty = disabled). Size the "
         "actorMemory limit above it for headroom.",
     )
+    group.add_argument(
+        "--mem-churn",
+        type=str,
+        default="",
+        help="How much of the working set each GluttonUser re-randomizes in "
+        "place every cycle (WriteRAM overwrite), with an optional unit "
+        "suffix (e.g. '64Mi'), so repeated suspends snapshot changing "
+        "memory like a live application's (default: empty = disabled). "
+        "Requires --mem-target.",
+    )

--- a/cmd/benchmarking/boomer-glutton/main.go
+++ b/cmd/benchmarking/boomer-glutton/main.go
@@ -42,7 +42,7 @@ func main() {
 		routerURL          = flag.String("router-url", "http://atenet-router.ate-system.svc.cluster.local", "atenet HTTP router base URL (no trailing slash).")
 		atespace           = flag.String("atespace", "benchmark", "Atespace every actor this worker creates lives in. Ensured (CreateAtespace, AlreadyExists is ok) at startup.")
 		promAddr           = flag.String("prometheus-addr", ":8001", "Address for the Prometheus /metrics endpoint.")
-		configJSON         = flag.String("config-json", "", "Initial dynconfig as a JSON object (keys: trace_probability, min_wait_time, max_wait_time in seconds, durdir_file_size_bytes, resume_mode, durdir_read_mode, durdir_template, mem_target). Unset fields keep their built-in defaults.")
+		configJSON         = flag.String("config-json", "", "Initial dynconfig as a JSON object (keys: trace_probability, min_wait_time, max_wait_time in seconds, durdir_file_size_bytes, resume_mode, durdir_read_mode, durdir_template, mem_target, mem_churn). Unset fields keep their built-in defaults.")
 		masterWebPort      = flag.Int("master-web-port", 0, "If non-zero, fetch dynconfig from http://{master-host}:{master-web-port}/boomer-config on each spawn message and fail fatally on error. {master-host} comes from boomer's existing --master-host flag.")
 		configPollInterval = flag.Duration("config-poll-interval", 10*time.Second, "With --master-web-port, also fetch dynconfig on this interval. A spawn message comes only when the number of users or the spawn rate changes, thus a load shape that changes the sample rate alone needs this. Zero stops the polling.")
 		userClass          = flag.String("user-class", "glutton", fmt.Sprintf("Locust user class to run, lowercase; one of %s.", strings.Join(userclass.Names(), "|")))

--- a/internal/benchmarking/boomer/dynconfig/dynconfig.go
+++ b/internal/benchmarking/boomer/dynconfig/dynconfig.go
@@ -55,6 +55,7 @@ type Config struct {
 	DurDirReadMode   string // ReadModeData | ReadModeDigest
 	DurDirTemplate   string // ActorTemplate name
 	MemTarget        string // resident RAM the GluttonUser fills via WriteRAM, suffixed (e.g. "2Gi"); "" disables
+	MemChurn         string // RAM re-randomized in place each cycle via WriteRAM overwrite, suffixed (e.g. "64Mi"); "" disables
 }
 
 // Holder lets readers Load() the current Config and writers Store() a new
@@ -93,6 +94,7 @@ type payload struct {
 	DurDirReadMode   *string  `json:"durdir_read_mode"`
 	DurDirTemplate   *string  `json:"durdir_template"`
 	MemTarget        *string  `json:"mem_target"`
+	MemChurn         *string  `json:"mem_churn"`
 }
 
 // Parse decodes a JSON blob (typically from a CLI flag) and merges its
@@ -165,8 +167,9 @@ func (c Config) Validate() error {
 	if c.DurDirReadMode != "" && c.DurDirReadMode != ReadModeData && c.DurDirReadMode != ReadModeDigest {
 		return fmt.Errorf("invalid durdir_read_mode %q: must be %q or %q", c.DurDirReadMode, ReadModeData, ReadModeDigest)
 	}
-	// MemTarget is passed to glutton verbatim, which owns the parse; an
-	// invalid value fails loudly there as a GluttonFillRAM error.
+	// MemTarget and MemChurn are passed to glutton verbatim, which owns the
+	// parse; invalid values fail loudly there as GluttonFillRAM /
+	// GluttonChurnRAM errors.
 	return nil
 }
 
@@ -198,6 +201,9 @@ func (p payload) merge(current Config) Config {
 	}
 	if p.MemTarget != nil {
 		out.MemTarget = *p.MemTarget
+	}
+	if p.MemChurn != nil {
+		out.MemChurn = *p.MemChurn
 	}
 	return out
 }
@@ -265,6 +271,7 @@ func StartPoll(
 					slog.String("durdir_read_mode", next.DurDirReadMode),
 					slog.String("durdir_template", next.DurDirTemplate),
 					slog.String("mem_target", next.MemTarget),
+					slog.String("mem_churn", next.MemChurn),
 				)
 			}
 		}
@@ -299,6 +306,7 @@ func SubscribeSpawn(url string, holder *Holder, sampler ProbabilityUpdater, fetc
 			slog.String("durdir_read_mode", next.DurDirReadMode),
 			slog.String("durdir_template", next.DurDirTemplate),
 			slog.String("mem_target", next.MemTarget),
+			slog.String("mem_churn", next.MemChurn),
 		)
 	})
 }

--- a/internal/benchmarking/boomer/glutton/lifecycle.go
+++ b/internal/benchmarking/boomer/glutton/lifecycle.go
@@ -111,6 +111,9 @@ func (r *taskRuntime) iterate() {
 	// carries the full working set; glutton keeps the allocations across
 	// suspend/resume, so this runs once per actor (retried if it fails).
 	user.ensureRAMFilled(ctx)
+	// Re-dirty part of the working set each cycle so repeated suspends
+	// snapshot an actor whose memory is changing, like a live application's.
+	user.churnRAM(ctx)
 	user.ping(ctx)
 	user.suspend(ctx)
 
@@ -354,7 +357,7 @@ func (u *gluttonUser) ensureRAMFilled(ctx context.Context) {
 	defer span.End()
 	start := time.Now()
 
-	err := u.writeRAM(ctx, "memload", target)
+	err := u.writeRAM(ctx, "memload", target, gluttonpb.WriteMode_WRITE_MODE_TRUNCATE)
 	clientLatency := time.Since(start)
 	logSampledTrace(span, "GluttonFillRAM", clientLatency, sourceClient, err)
 	if err != nil {
@@ -365,14 +368,41 @@ func (u *gluttonUser) ensureRAMFilled(ctx context.Context) {
 	bmetrics.RecordSuccess("http", "GluttonFillRAM", userClass, clientLatency, 0)
 }
 
-// writeRAM POSTs one WriteRAM allocation to the actor through the router,
+// churnRAM re-randomizes the first mem_churn bytes of the working set in
+// place (WriteRAM overwrite on the fill's key), so pages arrive dirty at
+// every suspend instead of only the first: a fill-once set is static, and
+// any future incremental snapshotting would make cycles two onward
+// unrepresentative of a live application. Runs once per iteration, only
+// after the fill has succeeded, and reports as its own GluttonChurnRAM
+// stats row.
+func (u *gluttonUser) churnRAM(ctx context.Context) {
+	churn := u.cfg.Dyn.Load().MemChurn
+	if churn == "" || !u.ramFilled {
+		return
+	}
+
+	ctx, span := u.cfg.Tracer.Start(ctx, "GluttonChurnRAM")
+	defer span.End()
+	start := time.Now()
+
+	err := u.writeRAM(ctx, "memload", churn, gluttonpb.WriteMode_WRITE_MODE_OVERWRITE)
+	clientLatency := time.Since(start)
+	logSampledTrace(span, "GluttonChurnRAM", clientLatency, sourceClient, err)
+	if err != nil {
+		bmetrics.RecordFailure("http", "GluttonChurnRAM", userClass, clientLatency, err.Error())
+		return
+	}
+	bmetrics.RecordSuccess("http", "GluttonChurnRAM", userClass, clientLatency, 0)
+}
+
+// writeRAM POSTs one WriteRAM request to the actor through the router,
 // mirroring ping's wire format (protobuf over HTTP). size is a suffixed
 // string (e.g. "2Gi") passed through verbatim; glutton parses it.
-func (u *gluttonUser) writeRAM(ctx context.Context, key, size string) error {
+func (u *gluttonUser) writeRAM(ctx context.Context, key, size string, mode gluttonpb.WriteMode) error {
 	body, err := proto.Marshal(&gluttonpb.WriteRAMRequest{
 		Key:       key,
 		Size:      size,
-		WriteMode: gluttonpb.WriteMode_WRITE_MODE_TRUNCATE,
+		WriteMode: mode,
 	})
 	if err != nil {
 		return err

--- a/internal/benchmarking/boomer/glutton/memfill_test.go
+++ b/internal/benchmarking/boomer/glutton/memfill_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/benchmarking/boomer/dynconfig"
 	"github.com/agent-substrate/substrate/internal/benchmarking/boomer/userclass"
 	"github.com/agent-substrate/substrate/internal/benchmarking/glutton/fake"
+	gluttonpb "github.com/agent-substrate/substrate/internal/proto/glutton"
 )
 
 func newTestGluttonUser(t *testing.T, srv *fake.Server, dyn dynconfig.Config) *gluttonUser {
@@ -65,6 +66,52 @@ func TestEnsureRAMFilledDisabledByDefault(t *testing.T) {
 	}
 	if got := len(srv.RecordedRAMWriteSizes()); got != 0 {
 		t.Errorf("WriteRAM calls with zero target = %d, want 0", got)
+	}
+}
+
+func TestChurnRAMOverwritesEachCycle(t *testing.T) {
+	srv := &fake.Server{}
+	u := newTestGluttonUser(t, srv, dynconfig.Config{MemTarget: "1Gi", MemChurn: "64Mi"})
+	ctx := context.Background()
+
+	// Churn before fill is a no-op: there is nothing to overwrite yet.
+	u.churnRAM(ctx)
+	if got := len(srv.RecordedRAMWriteSizes()); got != 0 {
+		t.Fatalf("WriteRAM calls from churn before fill = %d, want 0", got)
+	}
+
+	// Fill, then two cycles of churn.
+	u.ensureRAMFilled(ctx)
+	u.churnRAM(ctx)
+	u.churnRAM(ctx)
+
+	sizes := srv.RecordedRAMWriteSizes()
+	modes := srv.RecordedRAMWriteModes()
+	wantSizes := []string{"1Gi", "64Mi", "64Mi"}
+	wantModes := []gluttonpb.WriteMode{
+		gluttonpb.WriteMode_WRITE_MODE_TRUNCATE,
+		gluttonpb.WriteMode_WRITE_MODE_OVERWRITE,
+		gluttonpb.WriteMode_WRITE_MODE_OVERWRITE,
+	}
+	if len(sizes) != len(wantSizes) {
+		t.Fatalf("WriteRAM calls = %d (%v), want %d", len(sizes), sizes, len(wantSizes))
+	}
+	for i := range wantSizes {
+		if sizes[i] != wantSizes[i] || modes[i] != wantModes[i] {
+			t.Errorf("call %d = (%s, %v), want (%s, %v)", i, sizes[i], modes[i], wantSizes[i], wantModes[i])
+		}
+	}
+}
+
+func TestChurnRAMDisabledByDefault(t *testing.T) {
+	srv := &fake.Server{}
+	u := newTestGluttonUser(t, srv, dynconfig.Config{MemTarget: "1Gi"})
+	ctx := context.Background()
+
+	u.ensureRAMFilled(ctx)
+	u.churnRAM(ctx)
+	if got := len(srv.RecordedRAMWriteSizes()); got != 1 {
+		t.Errorf("WriteRAM calls with churn unset = %d, want 1 (fill only)", got)
 	}
 }
 

--- a/internal/benchmarking/glutton/fake/server.go
+++ b/internal/benchmarking/glutton/fake/server.go
@@ -61,6 +61,7 @@ type Server struct {
 	writeSizes    []int32
 	readModes     []gluttonpb.ReadMode
 	ramWriteSizes []string
+	ramWriteModes []gluttonpb.WriteMode
 }
 
 func (s *Server) reportedDigest() []byte {
@@ -108,6 +109,13 @@ func (s *Server) RecordedRAMWriteSizes() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.ramWriteSizes...)
+}
+
+// RecordedRAMWriteModes returns each /writeram request's write mode.
+func (s *Server) RecordedRAMWriteModes() []gluttonpb.WriteMode {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]gluttonpb.WriteMode(nil), s.ramWriteModes...)
 }
 
 func (s *Server) Start(t *testing.T) *httptest.Server {
@@ -189,6 +197,7 @@ func (s *Server) serve(w http.ResponseWriter, r *http.Request) {
 		}
 		s.mu.Lock()
 		s.ramWriteSizes = append(s.ramWriteSizes, req.GetSize())
+		s.ramWriteModes = append(s.ramWriteModes, req.GetWriteMode())
 		s.mu.Unlock()
 
 		resp, _ := proto.Marshal(&gluttonpb.WriteRAMResponse{})


### PR DESCRIPTION
#### What this pr do

Re-dirties part of the glutton working set on every benchmark cycle, so repeated suspends snapshot an actor whose memory is changing — like a live application's — instead of a set that was filled once and never touched again.

Each iteration (after the one-time fill), the GluttonUser sends one `WriteRAM` request with `WRITE_MODE_OVERWRITE`, re-randomizing the first `mem_churn` bytes of the working set in place. Overwrite mode already existed on the glutton API; this PR adds no proto changes and no glutton server changes — it is driver + config wiring only.

This is the follow-up from #1130's: the original self-driving memload continuously re-dirtied its pages, and that property was dropped in the move to API-driven fill. This restores it in the API-driven shape with a dialable amount instead of the old all-or-nothing full pass.

#### Why it matters

A fill-once working set is static: every suspend after the first packs up identical memory. If snapshotting ever gains incremental / dirty-page optimizations, a static benchmark would measure almost nothing from cycle two onward — and would score "upload nothing" as an infinite win. With churn, every cycle carries a known amount of freshly-dirtied pages, and the knob is sweepable (64Mi, 256Mi, …) so a future differential-snapshot optimization can be demonstrated as "upload cost scales with churn size, not total size."
