### PR TITLE
CI: run only the egress tests in the MITM networking lanes

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -146,12 +146,12 @@ jobs:
     - name: Run E2E tests (networking, MITM egress)
       env:
         E2E_EGRESS_MITM: "1"
-      run: hack/run-e2e-kind.sh ./internal/e2e/suites/networking -v -args --no-color
+      run: hack/run-e2e-kind.sh ./internal/e2e/suites/networking -run '^TestActorEgress' -v -args --no-color
     - name: Run E2E tests (networking, MITM egress, micro-VM)
       env:
         E2E_EGRESS_MITM: "1"
         E2E_SANDBOX_CLASS: microvm
-      run: hack/run-e2e-kind.sh ./internal/e2e/suites/networking -v -args --no-color
+      run: hack/run-e2e-kind.sh ./internal/e2e/suites/networking -run '^TestActorEgress' -v -args --no-color
     - name: Dump diagnostics on failure
       if: failure()
       run: |


### PR DESCRIPTION
The networking suite's direct-access and arbitrary-port tests build their actors from the counter fixture and behave the same whichever egress gateway is deployed, so re-running them after the sdsmint swap adds CI time without adding coverage. Only egressFixture() reads E2E_EGRESS_MITM, so restrict both MITM lanes to the tests that use it.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
