### PR TITLE
Make 'documented' rule handle `validation-gen` tags.

### DIFF
--- a/tools/apitool/exemptions.json
+++ b/tools/apitool/exemptions.json
@@ -11,7 +11,37 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.Actor.actor_template_name",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.ActorAssignment.actor",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.ActorAssignment.actor_template_ref",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.ActorAssignment.actor_uid",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.ActorMetadataItem.field",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.ActorMetadataItem.path",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.ActorSnapshot.metadata",
     "message": "field has no doc comment"
   },
   {
@@ -51,6 +81,11 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.ActorSnapshotStatus.source_actor",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.ActorSnapshotStatus.source_actor_uid",
     "message": "field has no doc comment"
   },
@@ -62,6 +97,11 @@
   {
     "rule": "documented",
     "subject": "ateapi.ActorSnapshotTag.scope",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.ActorSnapshotTag.snapshot",
     "message": "field has no doc comment"
   },
   {
@@ -97,6 +137,11 @@
   {
     "rule": "documented",
     "subject": "ateapi.ActorTemplate.status",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.ActorTemplate.volumes",
     "message": "field has no doc comment"
   },
   {
@@ -176,6 +221,11 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.DeleteActorRequest.actor",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.DeleteActorRequest.any_state",
     "message": "field has no doc comment"
   },
@@ -186,13 +236,28 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.DeleteActorSnapshotTagRequest.actor_snapshot_tag",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.DeleteActorTemplateRequest",
     "message": "message has no doc comment"
   },
   {
     "rule": "documented",
+    "subject": "ateapi.DeleteActorTemplateRequest.actor_template",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.DeleteAtespaceRequest",
     "message": "message has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.DeleteAtespaceRequest.atespace",
+    "message": "field has no doc comment"
   },
   {
     "rule": "documented",
@@ -226,8 +291,18 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.GetActorRequest.actor",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.GetActorSnapshotRequest",
     "message": "message has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.GetActorSnapshotRequest.actor_snapshot",
+    "message": "field has no doc comment"
   },
   {
     "rule": "documented",
@@ -236,13 +311,28 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.GetActorSnapshotTagRequest.actor_snapshot_tag",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.GetActorTemplateRequest",
     "message": "message has no doc comment"
   },
   {
     "rule": "documented",
+    "subject": "ateapi.GetActorTemplateRequest.actor_template",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.GetAtespaceRequest",
     "message": "message has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.GetAtespaceRequest.atespace",
+    "message": "field has no doc comment"
   },
   {
     "rule": "documented",
@@ -376,6 +466,11 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.PauseActorRequest.actor",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.PauseActorResponse",
     "message": "message has no doc comment"
   },
@@ -398,6 +493,11 @@
     "rule": "documented",
     "subject": "ateapi.ResumeActorRequest",
     "message": "message has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.ResumeActorRequest.actor",
+    "message": "field has no doc comment"
   },
   {
     "rule": "documented",
@@ -431,6 +531,11 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.SuspendActorRequest.actor",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.SuspendActorResponse",
     "message": "message has no doc comment"
   },
@@ -446,6 +551,21 @@
   },
   {
     "rule": "documented",
+    "subject": "ateapi.SystemInfoDataSource.trust_bundle",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.TrustBundleDataSource.name",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.TrustBundleDataSource.path",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
     "subject": "ateapi.UpdateWorkerRequest",
     "message": "message has no doc comment"
   },
@@ -457,6 +577,11 @@
   {
     "rule": "documented",
     "subject": "ateapi.Volume.external_volume_template",
+    "message": "field has no doc comment"
+  },
+  {
+    "rule": "documented",
+    "subject": "ateapi.Volume.system_info",
     "message": "field has no doc comment"
   },
   {

--- a/tools/apitool/internal/lint/documented.go
+++ b/tools/apitool/internal/lint/documented.go
@@ -31,26 +31,43 @@ var Documented = Rule{
 func checkDocumented(api *model.API) ([]Finding, error) {
 	var findings []Finding
 	for _, m := range api.Messages {
-		if strings.TrimSpace(m.Comment) == "" {
+		if docText(m.Comment) == "" {
 			findings = append(findings, Finding{Subject: m.FullName, Message: "message has no doc comment"})
 		}
 		for _, f := range m.Fields {
-			if strings.TrimSpace(f.Comment) == "" {
+			if docText(f.Comment) == "" {
 				findings = append(findings, Finding{Subject: m.FullName + "." + f.Name, Message: "field has no doc comment"})
 			}
 		}
 	}
 	for _, e := range api.Enums {
-		if strings.TrimSpace(e.Comment) == "" {
+		if docText(e.Comment) == "" {
 			findings = append(findings, Finding{Subject: e.FullName, Message: "enum has no doc comment"})
 		}
 	}
 	for _, svc := range api.Services {
 		for _, method := range svc.Methods {
-			if strings.TrimSpace(method.Comment) == "" {
+			if docText(method.Comment) == "" {
 				findings = append(findings, Finding{Subject: method.ServiceFullName + "." + method.Name, Message: "method has no doc comment"})
 			}
 		}
 	}
 	return findings, nil
+}
+
+func docText(comment string) string {
+	var kept []string
+	for _, line := range strings.Split(comment, "\n") {
+		if isValidationGenTag(line) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+// isValidationGenTag reports whether line is a validation-gen Declarative
+// Validation tag, e.g. "+k8s:required" or "+k8s:format=k8s-short-name".
+func isValidationGenTag(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), "+k8s:")
 }

--- a/tools/apitool/internal/lint/documented_test.go
+++ b/tools/apitool/internal/lint/documented_test.go
@@ -37,6 +37,9 @@ func TestDocumented(t *testing.T) {
 		{"method undocumented", "a request", "a state", "does a thing", "", 1},
 		{"nothing documented", "", "", "", "", 4},
 		{"whitespace-only comment counts as undocumented", "\t", "\t", "   ", "\n", 4},
+		{"empty comment lines", "a request", "a state", "\n\n", "does another thing", 1},
+		{"tags only", "+k8s:required", "+k8s:optional", "+k8s:required\n+k8s:format=k8s-short-name", "does another thing", 3},
+		{"prose and tags", "a request\n\n+k8s:required", "a state", "does a thing\n\n+k8s:immutable", "does another thing", 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When checking documentation, remove `validation-gen` tags so we don't have false negative results if a field *only* has tags and no documentation.

