### PR TITLE
atenet-egress: deliver TLS certs via filesystem SDS so rotation works

### DIFF
--- a/cmd/ate-setup/internal/steps/overlay.go
+++ b/cmd/ate-setup/internal/steps/overlay.go
@@ -200,18 +200,24 @@ func emitAdditionalEgressExtprocCluster(address, port, serverName string) string
         tls_params:
           tls_minimum_protocol_version: TLSv1_3
           tls_maximum_protocol_version: TLSv1_3
-        tls_certificates:
-        - certificate_chain: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
-          private_key: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
-          watched_directory: { path: /run/podidentity.podcert.ate.dev }
-        validation_context:
-          trusted_ca:
-            filename: /run/servicedns.podcert.ate.dev/trust-bundle.pem
-            watched_directory: { path: /run/servicedns.podcert.ate.dev }
-          match_typed_subject_alt_names:
-          - san_type: DNS
-            matcher:
-              exact: %s
+        tls_certificate_sds_secret_configs:
+        - name: podidentity_client_cert
+          sds_config:
+            resource_api_version: V3
+            path_config_source:
+              path: /etc/envoy/sds-podidentity-cert.yaml
+        combined_validation_context:
+          default_validation_context:
+            match_typed_subject_alt_names:
+            - san_type: DNS
+              matcher:
+                exact: %s
+          validation_context_sds_secret_config:
+            name: servicedns_validation_context
+            sds_config:
+              resource_api_version: V3
+              path_config_source:
+                path: /etc/envoy/sds-servicedns-validation.yaml
   load_assignment:
     cluster_name: %s
     endpoints:

--- a/cmd/ate-setup/internal/steps/overlay_test.go
+++ b/cmd/ate-setup/internal/steps/overlay_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/agent-substrate/substrate/cmd/ate-setup/internal/config"
+)
+
+// The emitted cluster must reference its TLS material through SDS: an inline
+// tls_certificates entry never picks up kubelet's certificate rotation.
+func TestEmitAdditionalEgressExtprocCluster(t *testing.T) {
+	out := emitAdditionalEgressExtprocCluster("foo.ate-system.svc.cluster.local", "50051", "foo.ate-system.svc")
+
+	var clusters []map[string]any
+	if err := yaml.Unmarshal([]byte(out), &clusters); err != nil {
+		t.Fatalf("emitted cluster block is not valid YAML: %v\n%s", err, out)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d", len(clusters))
+	}
+	if got := clusters[0]["name"]; got != additionalEgressExtprocCluster {
+		t.Errorf("cluster name = %v, want %s", got, additionalEgressExtprocCluster)
+	}
+
+	for _, want := range []string{
+		"tls_certificate_sds_secret_configs",
+		"path: /etc/envoy/sds-podidentity-cert.yaml",
+		"combined_validation_context",
+		"path: /etc/envoy/sds-servicedns-validation.yaml",
+		"exact: foo.ate-system.svc",
+		"port_value: 50051",
+		"address: foo.ate-system.svc.cluster.local",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("emitted cluster block is missing %q", want)
+		}
+	}
+	if strings.Contains(out, "tls_certificates:") {
+		t.Error("emitted cluster block still carries an inline tls_certificates entry")
+	}
+}
+
+// Splices the real sdsmint manifest and re-parses the result; this path has
+// no e2e coverage in CI.
+func TestPatchAtenetEgressManifest(t *testing.T) {
+	root, err := config.RepoRoot()
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+	env := &Env{Cfg: &config.Config{
+		Root:                           root,
+		ExperimentalUseSDSMint:         true,
+		AdditionalEgressExtprocService: "ate-system/foo:50051",
+	}}
+
+	patched, err := env.patchAtenetEgressManifest()
+	if err != nil {
+		t.Fatalf("patchAtenetEgressManifest failed: %v", err)
+	}
+	// Prose that merely mentions a marker survives on purpose; only lines
+	// that start with one are splice targets.
+	for _, line := range strings.Split(string(patched), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#ATE_MITM_EXTPROC") {
+			t.Errorf("patched manifest still contains an unreplaced marker line: %q", line)
+		}
+	}
+
+	// Find the atenet-egress ConfigMap among the manifest's documents.
+	var data map[string]string
+	for _, doc := range strings.Split(string(patched), "\n---\n") {
+		var obj struct {
+			Kind string            `json:"kind"`
+			Data map[string]string `json:"data"`
+		}
+		if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
+			t.Fatalf("patched manifest document is not valid YAML: %v", err)
+		}
+		if obj.Kind == "ConfigMap" {
+			data = obj.Data
+			break
+		}
+	}
+	if data == nil {
+		t.Fatal("no ConfigMap found in the patched manifest")
+	}
+
+	// Every file Envoy will read from /etc/envoy must be present and parse.
+	for _, key := range []string{
+		"envoy.yaml",
+		"sds-servicedns-cert.yaml",
+		"sds-podidentity-cert.yaml",
+		"sds-servicedns-validation.yaml",
+	} {
+		content, ok := data[key]
+		if !ok {
+			t.Errorf("ConfigMap is missing key %q", key)
+			continue
+		}
+		var parsed map[string]any
+		if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+			t.Errorf("ConfigMap key %q is not valid YAML: %v", key, err)
+		}
+	}
+
+	// The spliced cluster must reference the SDS files the ConfigMap ships.
+	envoyYaml := data["envoy.yaml"]
+	for _, want := range []string{
+		"path: /etc/envoy/sds-podidentity-cert.yaml",
+		"path: /etc/envoy/sds-servicedns-validation.yaml",
+		"cluster_name: " + additionalEgressExtprocCluster,
+	} {
+		if !strings.Contains(envoyYaml, want) {
+			t.Errorf("patched envoy.yaml is missing %q", want)
+		}
+	}
+}

--- a/docs/csi-deployment.md
+++ b/docs/csi-deployment.md
@@ -86,22 +86,27 @@ data:
               common_tls_context:
                 alpn_protocols:
                 - h2
-                tls_certificates:
-                - certificate_chain:
-                    filename: /run/servicedns/credential-bundle.pem
-                  private_key:
-                    filename: /run/servicedns/credential-bundle.pem
-                  watched_directory:
-                    path: /run/servicedns
-                validation_context:
-                  trusted_ca:
-                    filename: /run/podidentity-ca/trust-bundle.pem
-                  watched_directory:
-                    path: /run/podidentity-ca
-                  match_typed_subject_alt_names:
-                  - san_type: URI
-                    matcher:
-                      exact: "spiffe://cluster.local/ns/ate-system/sa/ate-api-server"
+                # Serving cert and trust bundle via filesystem SDS (the
+                # sds-*.yaml keys below): watched_directory only works on
+                # SDS-delivered secrets.
+                tls_certificate_sds_secret_configs:
+                - name: servicedns_serving_cert
+                  sds_config:
+                    resource_api_version: V3
+                    path_config_source:
+                      path: /etc/envoy/sds-servicedns-cert.yaml
+                combined_validation_context:
+                  default_validation_context:
+                    match_typed_subject_alt_names:
+                    - san_type: URI
+                      matcher:
+                        exact: "spiffe://cluster.local/ns/ate-system/sa/ate-api-server"
+                  validation_context_sds_secret_config:
+                    name: podidentity_validation_context
+                    sds_config:
+                      resource_api_version: V3
+                      path_config_source:
+                        path: /etc/envoy/sds-podidentity-validation.yaml
           filters:
           - name: envoy.filters.network.http_connection_manager
             typed_config:
@@ -138,7 +143,30 @@ data:
                 address:
                   pipe:
                     path: /csi/csi.sock
+  # SDS resources referenced by the listener above.
+  sds-servicedns-cert.yaml: |
+    resources:
+    - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+      name: servicedns_serving_cert
+      tls_certificate:
+        certificate_chain:
+          filename: /run/servicedns/credential-bundle.pem
+        private_key:
+          filename: /run/servicedns/credential-bundle.pem
+        watched_directory:
+          path: /run/servicedns
+  sds-podidentity-validation.yaml: |
+    resources:
+    - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+      name: podidentity_validation_context
+      validation_context:
+        trusted_ca:
+          filename: /run/podidentity-ca/trust-bundle.pem
+        watched_directory:
+          path: /run/podidentity-ca
 ```
+
+> **Note:** `watched_directory` takes effect only on SDS-delivered secrets. Attaching it to an inline `tls_certificates` or `validation_context` entry does nothing: Envoy reads those files once at config load, so a rotated certificate is never picked up and the proxy eventually serves (or trusts) expired material.
 
 #### 2. Envoy Sidecar in `csi-nfs-controller` Deployment
 

--- a/hack/experimental-additional-egress-extproc.sh
+++ b/hack/experimental-additional-egress-extproc.sh
@@ -131,22 +131,31 @@ emit_additional_egress_extproc_cluster() {
         tls_params:
           tls_minimum_protocol_version: TLSv1_3
           tls_maximum_protocol_version: TLSv1_3
-        # The gateway's own pod identity.
-        tls_certificates:
-        - certificate_chain: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
-          private_key: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
-          watched_directory: { path: /run/podidentity.podcert.ate.dev }
-        validation_context:
-          trusted_ca:
-            filename: /run/servicedns.podcert.ate.dev/trust-bundle.pem
-            watched_directory: { path: /run/servicedns.podcert.ate.dev }
-          # Chaining to the servicedns CA only proves the peer is some
-          # pod serving some Service. Pinning the name is what makes
-          # this the processor the operator asked for.
-          match_typed_subject_alt_names:
-          - san_type: DNS
-            matcher:
-              exact: ${server_name}
+        # The gateway's own pod identity, via filesystem SDS:
+        # watched_directory only works on SDS-delivered secrets, so an
+        # inline cert would never pick up kubelet's rotation.
+        tls_certificate_sds_secret_configs:
+        - name: podidentity_client_cert
+          sds_config:
+            resource_api_version: V3
+            path_config_source:
+              path: /etc/envoy/sds-podidentity-cert.yaml
+        combined_validation_context:
+          default_validation_context:
+            # Chaining to the servicedns CA only proves the peer is some
+            # pod serving some Service. Pinning the name is what makes
+            # this the processor the operator asked for. The flag-derived
+            # pin stays inline; the trust bundle rides SDS so it rotates.
+            match_typed_subject_alt_names:
+            - san_type: DNS
+              matcher:
+                exact: ${server_name}
+          validation_context_sds_secret_config:
+            name: servicedns_validation_context
+            sds_config:
+              resource_api_version: V3
+              path_config_source:
+                path: /etc/envoy/sds-servicedns-validation.yaml
   load_assignment:
     cluster_name: ${ADDITIONAL_EGRESS_EXTPROC_CLUSTER}
     endpoints:

--- a/manifests/ate-install/atenet-egress-with-sdsmint.yaml
+++ b/manifests/ate-install/atenet-egress-with-sdsmint.yaml
@@ -70,13 +70,15 @@ data:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               require_client_certificate: true
               common_tls_context:
-                tls_certificates:
-                # Gateway server identity (servicedns signer). credential-bundle.pem
-                # holds the leaf cert and key concatenated. watched_directory picks
-                # up kubelet's projected certificate rotation without a restart.
-                - certificate_chain: { filename: /run/servicedns.podcert.ate.dev/credential-bundle.pem }
-                  private_key: { filename: /run/servicedns.podcert.ate.dev/credential-bundle.pem }
-                  watched_directory: { path: /run/servicedns.podcert.ate.dev }
+                # Gateway server identity (servicedns signer), via filesystem
+                # SDS: watched_directory only works on SDS-delivered secrets,
+                # so an inline cert would never pick up kubelet's rotation.
+                tls_certificate_sds_secret_configs:
+                - name: servicedns_serving_cert
+                  sds_config:
+                    resource_api_version: V3
+                    path_config_source:
+                      path: /etc/envoy/sds-servicedns-cert.yaml
                 validation_context:
                   # Actors authenticate with an actor-identity client cert.
                   # Envoy enforces chain, signature, and validity period here, so
@@ -696,6 +698,36 @@ data:
         connect_timeout: 5s
 
       #ATE_MITM_EXTPROC_CLUSTER -- Don't modify this line.
+  # SDS resource for the gateway serving cert. kubelet rotates the projected
+  # volume by swapping its ..data symlink, which fires the watch and makes
+  # Envoy re-read the bundle (leaf cert and key concatenated in one file).
+  sds-servicedns-cert.yaml: |
+    resources:
+    - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+      name: servicedns_serving_cert
+      tls_certificate:
+        certificate_chain: { filename: /run/servicedns.podcert.ate.dev/credential-bundle.pem }
+        private_key: { filename: /run/servicedns.podcert.ate.dev/credential-bundle.pem }
+        watched_directory: { path: /run/servicedns.podcert.ate.dev }
+  # The next two keys are used only by the additional_egress_ext_proc cluster
+  # spliced over the #ATE_MITM_EXTPROC_CLUSTER marker. They ship
+  # unconditionally because the splice can only rewrite envoy.yaml, not add
+  # ConfigMap keys; with the flag off they are unreferenced files.
+  sds-podidentity-cert.yaml: |
+    resources:
+    - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+      name: podidentity_client_cert
+      tls_certificate:
+        certificate_chain: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
+        private_key: { filename: /run/podidentity.podcert.ate.dev/credential-bundle.pem }
+        watched_directory: { path: /run/podidentity.podcert.ate.dev }
+  sds-servicedns-validation.yaml: |
+    resources:
+    - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+      name: servicedns_validation_context
+      validation_context:
+        trusted_ca: { filename: /run/servicedns.podcert.ate.dev/trust-bundle.pem }
+        watched_directory: { path: /run/servicedns.podcert.ate.dev }
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/ate-install/atenet-egress.yaml
+++ b/manifests/ate-install/atenet-egress.yaml
@@ -58,13 +58,15 @@ data:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               require_client_certificate: true
               common_tls_context:
-                tls_certificates:
-                # Gateway server identity (servicedns signer). credential-bundle.pem
-                # holds the leaf cert and key concatenated. watched_directory picks
-                # up kubelet's projected certificate rotation without a restart.
-                - certificate_chain: { filename: /run/servicedns.podcert.ate.dev/credential-bundle.pem }
-                  private_key: { filename: /run/servicedns.podcert.ate.dev/credential-bundle.pem }
-                  watched_directory: { path: /run/servicedns.podcert.ate.dev }
+                # Gateway server identity (servicedns signer), via filesystem
+                # SDS: watched_directory only works on SDS-delivered secrets,
+                # so an inline cert would never pick up kubelet's rotation.
+                tls_certificate_sds_secret_configs:
+                - name: servicedns_serving_cert
+                  sds_config:
+                    resource_api_version: V3
+                    path_config_source:
+                      path: /etc/envoy/sds-servicedns-cert.yaml
                 validation_context:
                   # Actors authenticate with an actor-identity client cert.
                   # Envoy enforces chain, signature, and validity period here, so
@@ -186,6 +188,17 @@ data:
             dns_cache_config:
               name: egress_dns_cache
               dns_lookup_family: V4_ONLY
+  # SDS resource for the gateway serving cert. kubelet rotates the projected
+  # volume by swapping its ..data symlink, which fires the watch and makes
+  # Envoy re-read the bundle (leaf cert and key concatenated in one file).
+  sds-servicedns-cert.yaml: |
+    resources:
+    - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+      name: servicedns_serving_cert
+      tls_certificate:
+        certificate_chain: { filename: /run/servicedns.podcert.ate.dev/credential-bundle.pem }
+        private_key: { filename: /run/servicedns.podcert.ate.dev/credential-bundle.pem }
+        watched_directory: { path: /run/servicedns.podcert.ate.dev }
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Fixes https://github.com/agent-substrate/substrate/issues/1267

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

Envoy honors `watched_directory` only on SDS-delivered secrets; on the egress gateway's inline file-based certs it was silently ignored, so kubelet's projected-certificate rotation never reached Envoy and the gateway eventually served an expired certificate.

Changes:
- Both egress manifests: serving cert moves to filesystem SDS (`sds-servicedns-cert.yaml` ConfigMap key).
- The `additional_egress_ext_proc` cluster that the installers (Go `ate-setup` and `hack/install-ate.sh`) inject into the sdsmint manifest had the same defect: its client cert and trust bundle move to SDS, with the flag-derived SAN pin kept inline via `combined_validation_context`. The SDS files ship unconditionally in the ConfigMap since the injection can only rewrite `envoy.yaml`.
- `docs/csi-deployment.md`: example reworked to SDS; it showed the same broken pattern.
- New `overlay_test.go` covers the emitters — the only automated guard on this path, since the sdsmint e2e suite is skipped in CI.

Verification:
- `envoy --mode validate` passes on all three rendered bootstraps (plain on v1.34, sdsmint and injected-cluster variant on v1.37).
- Live rotation test on a GKE cluster: forced kubelet to re-request the projected podCertificate (kubelet restart; pod untouched), the signer issued a new leaf, and Envoy's admin `/certs` showed the new serial matching the on-disk bundle within seconds — same pod, zero restarts. Also reproduced locally in Docker with a kubelet-style atomic `..data` symlink swap.
- `go test ./cmd/ate-setup/...`, `go vet`, gofmt, shellcheck all clean; the networking e2e suite covers the plain manifest in CI.

Note: existing installs need a rollout restart of `atenet-egress` to pick up the new bootstrap.

