### PR TITLE
storetest: terminate the shared PostgreSQL container, respect docker context

### DIFF
--- a/cmd/ateapi/internal/actoridentity/main_test.go
+++ b/cmd/ateapi/internal/actoridentity/main_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actoridentity
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
+)
+
+func TestMain(m *testing.M) {
+	storetest.RunTests(m)
+}

--- a/cmd/ateapi/internal/controlapi/functionaltest/main_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/main_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/testenv"
 	"google.golang.org/grpc"
@@ -97,6 +98,8 @@ func TestMain(m *testing.M) {
 	ateletGrpcServer.Stop()
 
 	stopEnv()
+
+	storetest.Shutdown()
 
 	os.Exit(code)
 }

--- a/cmd/ateapi/internal/controlapi/main_test.go
+++ b/cmd/ateapi/internal/controlapi/main_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlapi
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
+)
+
+func TestMain(m *testing.M) {
+	storetest.RunTests(m)
+}

--- a/cmd/ateapi/internal/store/atepg/atepg_test.go
+++ b/cmd/ateapi/internal/store/atepg/atepg_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/dockerenv"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 )
@@ -64,6 +65,10 @@ func requirePool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	containerOnce.Do(func() {
 		ctx := context.Background()
+		if err := dockerenv.Configure(ctx); err != nil {
+			containerErr = err
+			return
+		}
 		pgContainer, err := postgres.Run(ctx, "postgres:18-alpine",
 			postgres.WithDatabase("atepg"),
 			postgres.WithUsername("atepg"),

--- a/cmd/ateapi/internal/store/dockerenv/dockerenv.go
+++ b/cmd/ateapi/internal/store/dockerenv/dockerenv.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dockerenv points testcontainers at the active Docker context.
+//
+// It lives apart from storetest because storetest imports atepg, so atepg
+// cannot import storetest back, and both need this before starting a
+// container.
+package dockerenv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// Configure sets the environment testcontainers reads to find Docker, unless
+// it is already set. testcontainers-go resolves the daemon from DOCKER_HOST
+// and its own probe list; it never consults the Docker CLI context, so a
+// working `docker` command is not enough on its own.
+func Configure(ctx context.Context) error {
+	if os.Getenv("DOCKER_HOST") != "" {
+		return nil
+	}
+	output, err := exec.CommandContext(ctx, "docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}").Output()
+	if err != nil {
+		return fmt.Errorf("inspecting Docker context: %w", err)
+	}
+	host := strings.TrimSpace(string(output))
+	if host == "" {
+		return errors.New("active Docker context has no endpoint")
+	}
+	if err := os.Setenv("DOCKER_HOST", host); err != nil {
+		return fmt.Errorf("setting DOCKER_HOST: %w", err)
+	}
+	if os.Getenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE") == "" {
+		socket := host
+		if runtime.GOOS == "darwin" {
+			// The reaper runs inside the Docker VM and must mount its socket path.
+			socket = "/var/run/docker.sock"
+		}
+		if err := os.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", socket); err != nil {
+			return fmt.Errorf("setting TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/ateapi/internal/store/dockerenv/dockerenv_test.go
+++ b/cmd/ateapi/internal/store/dockerenv/dockerenv_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storetest
+package dockerenv
 
 import (
 	"context"
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func TestConfigureDockerHostFromContext(t *testing.T) {
+func TestConfigureFromContext(t *testing.T) {
 	t.Setenv("DOCKER_HOST", "")
 	t.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "")
 	dir := t.TempDir()
@@ -32,8 +32,8 @@ func TestConfigureDockerHostFromContext(t *testing.T) {
 	}
 	t.Setenv("PATH", dir)
 
-	if err := configureDockerHost(context.Background()); err != nil {
-		t.Fatalf("configureDockerHost() error = %v", err)
+	if err := Configure(context.Background()); err != nil {
+		t.Fatalf("Configure() error = %v", err)
 	}
 	if got, want := os.Getenv("DOCKER_HOST"), "unix:///custom/docker.sock"; got != want {
 		t.Errorf("DOCKER_HOST = %q, want %q", got, want)
@@ -47,12 +47,12 @@ func TestConfigureDockerHostFromContext(t *testing.T) {
 	}
 }
 
-func TestConfigureDockerHostPreservesEnvironment(t *testing.T) {
+func TestConfigurePreservesEnvironment(t *testing.T) {
 	t.Setenv("DOCKER_HOST", "tcp://docker.example:2376")
 	t.Setenv("PATH", t.TempDir())
 
-	if err := configureDockerHost(context.Background()); err != nil {
-		t.Fatalf("configureDockerHost() error = %v", err)
+	if err := Configure(context.Background()); err != nil {
+		t.Fatalf("Configure() error = %v", err)
 	}
 	if got, want := os.Getenv("DOCKER_HOST"), "tcp://docker.example:2376"; got != want {
 		t.Errorf("DOCKER_HOST = %q, want %q", got, want)

--- a/cmd/ateapi/internal/store/storetest/storetest.go
+++ b/cmd/ateapi/internal/store/storetest/storetest.go
@@ -24,9 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -34,6 +31,7 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/atepg"
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/dockerenv"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -151,7 +149,7 @@ func requireAdminPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	containerOnce.Do(func() {
 		ctx := context.Background()
-		if err := configureDockerHost(ctx); err != nil {
+		if err := dockerenv.Configure(ctx); err != nil {
 			containerErr = err
 			return
 		}
@@ -188,32 +186,4 @@ func requireAdminPool(t *testing.T) *pgxpool.Pool {
 		t.Skipf("PostgreSQL testcontainer unavailable (requires Docker): %v", containerErr)
 	}
 	return adminPool
-}
-
-func configureDockerHost(ctx context.Context) error {
-	if os.Getenv("DOCKER_HOST") != "" {
-		return nil
-	}
-	output, err := exec.CommandContext(ctx, "docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}").Output()
-	if err != nil {
-		return fmt.Errorf("inspecting Docker context: %w", err)
-	}
-	host := strings.TrimSpace(string(output))
-	if host == "" {
-		return errors.New("Docker context has no endpoint")
-	}
-	if err := os.Setenv("DOCKER_HOST", host); err != nil {
-		return fmt.Errorf("setting DOCKER_HOST: %w", err)
-	}
-	if os.Getenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE") == "" {
-		socket := host
-		if runtime.GOOS == "darwin" {
-			// The reaper runs inside the Docker VM and must mount its socket path.
-			socket = "/var/run/docker.sock"
-		}
-		if err := os.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", socket); err != nil {
-			return fmt.Errorf("setting TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: %w", err)
-		}
-	}
-	return nil
 }

--- a/cmd/ateapi/internal/store/storetest/storetest.go
+++ b/cmd/ateapi/internal/store/storetest/storetest.go
@@ -24,6 +24,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -148,6 +151,10 @@ func requireAdminPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	containerOnce.Do(func() {
 		ctx := context.Background()
+		if err := configureDockerHost(ctx); err != nil {
+			containerErr = err
+			return
+		}
 		containerPG, containerErr = postgres.Run(ctx, "postgres:18-alpine",
 			postgres.WithDatabase("postgres"),
 			postgres.WithUsername("postgres"),
@@ -181,4 +188,32 @@ func requireAdminPool(t *testing.T) *pgxpool.Pool {
 		t.Skipf("PostgreSQL testcontainer unavailable (requires Docker): %v", containerErr)
 	}
 	return adminPool
+}
+
+func configureDockerHost(ctx context.Context) error {
+	if os.Getenv("DOCKER_HOST") != "" {
+		return nil
+	}
+	output, err := exec.CommandContext(ctx, "docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}").Output()
+	if err != nil {
+		return fmt.Errorf("inspecting Docker context: %w", err)
+	}
+	host := strings.TrimSpace(string(output))
+	if host == "" {
+		return errors.New("Docker context has no endpoint")
+	}
+	if err := os.Setenv("DOCKER_HOST", host); err != nil {
+		return fmt.Errorf("setting DOCKER_HOST: %w", err)
+	}
+	if os.Getenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE") == "" {
+		socket := host
+		if runtime.GOOS == "darwin" {
+			// The reaper runs inside the Docker VM and must mount its socket path.
+			socket = "/var/run/docker.sock"
+		}
+		if err := os.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", socket); err != nil {
+			return fmt.Errorf("setting TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: %w", err)
+		}
+	}
+	return nil
 }

--- a/cmd/ateapi/internal/store/storetest/storetest.go
+++ b/cmd/ateapi/internal/store/storetest/storetest.go
@@ -13,12 +13,17 @@
 // limitations under the License.
 
 // Package storetest provides isolated PostgreSQL-backed stores for tests.
+//
+// One PostgreSQL container is shared by every test in a package; each test gets
+// its own database. Nothing stops that container when the test binary exits, so
+// packages using this package must call [Shutdown] from their TestMain.
 package storetest
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -114,6 +119,29 @@ func MustCreateActorSnapshot(t *testing.T, ctx context.Context, s store.Interfac
 		t.Fatalf("creating test actor snapshot %q/%q: %v", atespace, snapshot.GetMetadata().GetName(), err)
 	}
 	return created
+}
+
+// RunTests runs m and terminates the shared PostgreSQL container afterwards.
+// Packages with no other TestMain work should use it as their whole TestMain;
+// the rest must call [Shutdown] themselves.
+func RunTests(m *testing.M) {
+	code := m.Run()
+	Shutdown()
+	os.Exit(code)
+}
+
+// Shutdown terminates the shared PostgreSQL container, if one was started.
+func Shutdown() {
+	if adminPool != nil {
+		adminPool.Close()
+		adminPool = nil
+	}
+	if containerPG != nil {
+		if err := containerPG.Terminate(context.Background()); err != nil {
+			fmt.Fprintf(os.Stderr, "terminating PostgreSQL testcontainer: %v\n", err)
+		}
+		containerPG = nil
+	}
 }
 
 func requireAdminPool(t *testing.T) *pgxpool.Pool {

--- a/cmd/ateapi/internal/store/storetest/storetest_test.go
+++ b/cmd/ateapi/internal/store/storetest/storetest_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storetest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestConfigureDockerHostFromContext(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "")
+	dir := t.TempDir()
+	docker := filepath.Join(dir, "docker")
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nprintf 'unix:///custom/docker.sock\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	if err := configureDockerHost(context.Background()); err != nil {
+		t.Fatalf("configureDockerHost() error = %v", err)
+	}
+	if got, want := os.Getenv("DOCKER_HOST"), "unix:///custom/docker.sock"; got != want {
+		t.Errorf("DOCKER_HOST = %q, want %q", got, want)
+	}
+	wantSocket := "unix:///custom/docker.sock"
+	if runtime.GOOS == "darwin" {
+		wantSocket = "/var/run/docker.sock"
+	}
+	if got := os.Getenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE"); got != wantSocket {
+		t.Errorf("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE = %q, want %q", got, wantSocket)
+	}
+}
+
+func TestConfigureDockerHostPreservesEnvironment(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://docker.example:2376")
+	t.Setenv("PATH", t.TempDir())
+
+	if err := configureDockerHost(context.Background()); err != nil {
+		t.Fatalf("configureDockerHost() error = %v", err)
+	}
+	if got, want := os.Getenv("DOCKER_HOST"), "tcp://docker.example:2376"; got != want {
+		t.Errorf("DOCKER_HOST = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
I noticed my machine filling up with postgres containers ...

---

First:

storetest starts one PostgreSQL container per test binary in a sync.Once and never stops it, so every package that uses it leaks a container per run. Testcontainers' Ryuk reaper normally covers this, but it is not guaranteed to be running, and nothing else stops the container.

Add Shutdown, plus a RunTests wrapper for packages whose TestMain does nothing else, and call it from the three packages that use storetest. atepg already terminates its own container this way.

----

Second:

testcontainers does not respect docker contexts, making it difficult to use with [limactl](https://lima-vm.io/) etc.

See: https://github.com/testcontainers/testcontainers-go/issues/2607 

We automate the workaround to set the host env to point at the socket from the active docker context.

