### PR TITLE
atenet: run every Envoy on one digest-pinned v1.39

### DIFF
--- a/manifests/ate-install/atenet-egress-with-sdsmint.yaml
+++ b/manifests/ate-install/atenet-egress-with-sdsmint.yaml
@@ -146,8 +146,6 @@ data:
                   - object_key: ate.actor.identity
                     factory_key: envoy.string
                     shared_with_upstream: ONCE
-                    # Nothing downstream may overwrite an authenticated identity.
-                    read_only: true
                     skip_if_empty: true
                     format_string:
                       text_format_source:
@@ -863,7 +861,7 @@ spec:
           readOnly: true
       containers:
       - name: envoy
-        image: envoyproxy/envoy:v1.37-latest@sha256:1c2b79776c6e3b38e8b0113b825e6a599f9bfc08d680c199d80bf8964856c529
+        image: envoyproxy/envoy:v1.39-latest@sha256:57e14a549d7bd43c8d3f6d03e8cfa653e037d4b38e133acd9b54f38c524401b4
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ate-install/atenet-egress.yaml
+++ b/manifests/ate-install/atenet-egress.yaml
@@ -226,7 +226,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: envoy
-        image: envoyproxy/envoy:v1.34-latest
+        image: envoyproxy/envoy:v1.39-latest@sha256:57e14a549d7bd43c8d3f6d03e8cfa653e037d4b38e133acd9b54f38c524401b4
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/ate-install/atenet-router.yaml
+++ b/manifests/ate-install/atenet-router.yaml
@@ -267,7 +267,7 @@ spec:
         - name: "drain-signal"
           mountPath: "/var/run/atenet"
       - name: envoy
-        image: envoyproxy/envoy:v1.39-latest
+        image: envoyproxy/envoy:v1.39-latest@sha256:57e14a549d7bd43c8d3f6d03e8cfa653e037d4b38e133acd9b54f38c524401b4
         command:
         - "/usr/local/bin/envoy"
         - "-c"


### PR DESCRIPTION
    Three Envoy deployments, three different notions of what version they
    were on: the passthrough egress gateway floated at v1.34-latest, the
    MITM one was digest-pinned to v1.37, and the ingress router floated at
    v1.39-latest. A behavior difference between two of them was therefore
    ambiguous, since it could come from the proxy rather than from the
    configuration under test, and the floating tags let the gaps widen on
    their own with every upstream release.
    
    Put all three on v1.39-latest at the same multi-arch index digest.
    Pinning the digest rather than tracking the tag keeps arm64 resolvable
    while making a version change an explicit edit that shows up in review,
    which is the property the two floating references were missing.
    
    Drop read_only from the actor-identity filter state along the way, since
    v1.39 warns on it at every listener. Envoy removed the mutable versus
    read-only distinction entirely -- the checks caused subtle runtime bugs
    and bought little.
    
    The passthrough, MITM, and additional-ext_proc egress renderings all
    validate against v1.39 with no warnings or deprecations, as does the
    router bootstrap. The router's listeners and clusters arrive over ADS
    and are not covered by that check.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
