### PR TITLE
Replace actor template namespace/name pair with ActorTemplate atespace and name pair in internal APIs

### DIFF
--- a/cmd/ateapi/internal/controlapi/workflow_delete.go
+++ b/cmd/ateapi/internal/controlapi/workflow_delete.go
@@ -184,13 +184,13 @@ func (w *ActorWorkflow) ensureAteletTerminated(ctx context.Context, actorRef res
 	}
 
 	req := &ateletpb.TerminateRequest{
-		TargetAteomUid:         assignment.GetWorkerPodUid(),
-		Atespace:               actor.GetMetadata().GetAtespace(),
-		ActorName:              actor.GetMetadata().GetName(),
-		ActorUid:               actor.GetMetadata().GetUid(),
-		ActorTemplateNamespace: actor.GetActorTemplateNamespace(),
-		ActorTemplateName:      actor.GetActorTemplateName(),
-		Spec:                   workloadSpec,
+		TargetAteomUid:        assignment.GetWorkerPodUid(),
+		Atespace:              actor.GetMetadata().GetAtespace(),
+		ActorName:             actor.GetMetadata().GetName(),
+		ActorUid:              actor.GetMetadata().GetUid(),
+		ActorTemplateAtespace: actorTemplate.GetMetadata().GetAtespace(),
+		ActorTemplateName:     actorTemplate.GetMetadata().GetName(),
+		Spec:                  workloadSpec,
 	}
 
 	if _, err := client.Terminate(ctx, req); err != nil {

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -187,13 +187,13 @@ func (w *ActorWorkflow) ensureAteletPaused(ctx context.Context, actorRef resourc
 	// actor is currently running (recorded on-node at Run/Restore) and pins it
 	// into the snapshot manifest.
 	req := &ateletpb.CheckpointRequest{
-		TargetAteomUid:         assignment.GetWorkerPodUid(),
-		Atespace:               actor.GetMetadata().GetAtespace(),
-		ActorName:              actor.GetMetadata().GetName(),
-		ActorTemplateNamespace: actor.GetActorTemplateNamespace(),
-		ActorTemplateName:      actor.GetActorTemplateName(),
-		Spec:                   workloadSpec,
-		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL,
+		TargetAteomUid:        assignment.GetWorkerPodUid(),
+		Atespace:              actor.GetMetadata().GetAtespace(),
+		ActorName:             actor.GetMetadata().GetName(),
+		ActorTemplateAtespace: actorTemplate.GetMetadata().GetAtespace(),
+		ActorTemplateName:     actorTemplate.GetMetadata().GetName(),
+		Spec:                  workloadSpec,
+		Type:                  ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL,
 		Config: &ateletpb.CheckpointRequest_LocalConfig{
 			LocalConfig: &ateletpb.LocalCheckpointConfiguration{
 				SnapshotName: actor.GetStatus().GetInProgressLocalSnapshotName(),

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -683,16 +683,16 @@ func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resou
 		tele.SnapshotKind = ateattr.SnapshotKindLocal
 
 		req := &ateletpb.RestoreRequest{
-			TargetAteomUid:         assignment.GetWorkerPodUid(),
-			Atespace:               actor.GetMetadata().GetAtespace(),
-			ActorName:              actor.GetMetadata().GetName(),
-			ActorTemplateNamespace: actor.GetActorTemplateNamespace(),
-			ActorTemplateName:      actor.GetActorTemplateName(),
-			Spec:                   workloadSpec,
-			ActorUid:               actor.GetMetadata().Uid,
-			EgressGateway:          egressGateway,
-			CpuMilli:               cpuMilli,
-			MemoryBytes:            memBytes,
+			TargetAteomUid:        assignment.GetWorkerPodUid(),
+			Atespace:              actor.GetMetadata().GetAtespace(),
+			ActorName:             actor.GetMetadata().GetName(),
+			ActorTemplateAtespace: actorTemplate.GetMetadata().GetAtespace(),
+			ActorTemplateName:     actorTemplate.GetMetadata().GetName(),
+			Spec:                  workloadSpec,
+			ActorUid:              actor.GetMetadata().Uid,
+			EgressGateway:         egressGateway,
+			CpuMilli:              cpuMilli,
+			MemoryBytes:           memBytes,
 		}
 		req.Type = ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL
 		req.Config = &ateletpb.RestoreRequest_LocalConfig{
@@ -731,13 +731,13 @@ func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resou
 		}
 		tele.WireSnapshotScope = ateattr.SnapshotScopeValue(scope)
 		req := &ateletpb.RestoreRequest{
-			TargetAteomUid:         assignment.GetWorkerPodUid(),
-			Atespace:               actor.GetMetadata().GetAtespace(),
-			ActorName:              actor.GetMetadata().GetName(),
-			ActorTemplateNamespace: actor.GetActorTemplateNamespace(),
-			ActorTemplateName:      actor.GetActorTemplateName(),
-			Spec:                   workloadSpec,
-			Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
+			TargetAteomUid:        assignment.GetWorkerPodUid(),
+			Atespace:              actor.GetMetadata().GetAtespace(),
+			ActorName:             actor.GetMetadata().GetName(),
+			ActorTemplateAtespace: actorTemplate.GetMetadata().GetAtespace(),
+			ActorTemplateName:     actorTemplate.GetMetadata().GetName(),
+			Spec:                  workloadSpec,
+			Type:                  ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
 			Config: &ateletpb.RestoreRequest_ExternalConfig{
 				ExternalConfig: &ateletpb.ExternalCheckpointConfiguration{
 					SnapshotUri: src.SnapshotURI.String(),
@@ -766,17 +766,17 @@ func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resou
 		}
 
 		req := &ateletpb.RunRequest{
-			TargetAteomUid:         assignment.GetWorkerPodUid(),
-			Atespace:               actor.GetMetadata().GetAtespace(),
-			ActorName:              actor.GetMetadata().GetName(),
-			ActorTemplateNamespace: actor.GetActorTemplateNamespace(),
-			ActorTemplateName:      actor.GetActorTemplateName(),
-			SandboxAssets:          sandboxAssets,
-			Spec:                   workloadSpec,
-			ActorUid:               actor.GetMetadata().Uid,
-			EgressGateway:          egressGateway,
-			CpuMilli:               cpuMilli,
-			MemoryBytes:            memBytes,
+			TargetAteomUid:        assignment.GetWorkerPodUid(),
+			Atespace:              actor.GetMetadata().GetAtespace(),
+			ActorName:             actor.GetMetadata().GetName(),
+			ActorTemplateAtespace: actorTemplate.GetMetadata().GetAtespace(),
+			ActorTemplateName:     actorTemplate.GetMetadata().GetName(),
+			SandboxAssets:         sandboxAssets,
+			Spec:                  workloadSpec,
+			ActorUid:              actor.GetMetadata().Uid,
+			EgressGateway:         egressGateway,
+			CpuMilli:              cpuMilli,
+			MemoryBytes:           memBytes,
 		}
 		_, err = client.Run(ctx, req)
 		return tele, maybeCrashActor(ctx, w.store, actorRef, err, "while creating workload from spec", ateattr.OperationResume)

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -244,13 +244,13 @@ func (w *ActorWorkflow) ensureAteletSuspended(ctx context.Context, actorRef reso
 	// actor is currently running (recorded on-node at Run/Restore) and pins it
 	// into the snapshot manifest.
 	req := &ateletpb.CheckpointRequest{
-		TargetAteomUid:         assignment.GetWorkerPodUid(),
-		Atespace:               actor.GetMetadata().GetAtespace(),
-		ActorName:              actor.GetMetadata().GetName(),
-		ActorTemplateNamespace: actor.GetActorTemplateNamespace(),
-		ActorTemplateName:      actor.GetActorTemplateName(),
-		Spec:                   workloadSpec,
-		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
+		TargetAteomUid:        assignment.GetWorkerPodUid(),
+		Atespace:              actor.GetMetadata().GetAtespace(),
+		ActorName:             actor.GetMetadata().GetName(),
+		ActorTemplateAtespace: actorTemplate.GetMetadata().GetAtespace(),
+		ActorTemplateName:     actorTemplate.GetMetadata().GetName(),
+		Spec:                  workloadSpec,
+		Type:                  ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
 		Config: &ateletpb.CheckpointRequest_ExternalConfig{
 			ExternalConfig: &ateletpb.ExternalCheckpointConfiguration{
 				SnapshotUri: snapshotURI.String(),
@@ -303,8 +303,8 @@ func (w *ActorWorkflow) ensurePausedSnapshotUploaded(ctx context.Context, actorR
 		Atespace:               actor.GetMetadata().GetAtespace(),
 		ActorName:              actor.GetMetadata().GetName(),
 		ActorUid:               actor.GetMetadata().GetUid(),
-		ActorTemplateNamespace: actor.GetActorTemplateNamespace(),
-		ActorTemplateName:      actor.GetActorTemplateName(),
+		ActorTemplateAtespace:  actorTemplate.GetMetadata().GetAtespace(),
+		ActorTemplateName:      actorTemplate.GetMetadata().GetName(),
 		LocalSnapshotName:      local.GetSnapshotName(),
 		DestinationSnapshotUri: snapshotURI.String(),
 		// The commit scope, like a running-origin suspend; atelet converts

--- a/cmd/atelet/lifecycle_test.go
+++ b/cmd/atelet/lifecycle_test.go
@@ -162,29 +162,29 @@ func TestLocalSnapshotGC(t *testing.T) {
 	}
 
 	if _, err := s.Run(ctx, &ateletpb.RunRequest{
-		Atespace:               atespace,
-		ActorName:              actorName,
-		ActorUid:               actorUID,
-		ActorTemplateNamespace: "default",
-		ActorTemplateName:      "counter",
-		TargetAteomUid:         ateomUID,
-		SandboxAssets:          sandboxAssets,
-		Spec:                   spec,
+		Atespace:              atespace,
+		ActorName:             actorName,
+		ActorUid:              actorUID,
+		ActorTemplateAtespace: "default",
+		ActorTemplateName:     "counter",
+		TargetAteomUid:        ateomUID,
+		SandboxAssets:         sandboxAssets,
+		Spec:                  spec,
 	}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
 	// Pause: a local checkpoint, which leaves the snapshot on this node.
 	if _, err := s.Checkpoint(ctx, &ateletpb.CheckpointRequest{
-		Atespace:               atespace,
-		ActorName:              actorName,
-		ActorUid:               actorUID,
-		ActorTemplateNamespace: "default",
-		ActorTemplateName:      "counter",
-		TargetAteomUid:         ateomUID,
-		Spec:                   spec,
-		Scope:                  ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL,
-		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL,
+		Atespace:              atespace,
+		ActorName:             actorName,
+		ActorUid:              actorUID,
+		ActorTemplateAtespace: "default",
+		ActorTemplateName:     "counter",
+		TargetAteomUid:        ateomUID,
+		Spec:                  spec,
+		Scope:                 ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL,
+		Type:                  ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL,
 		Config: &ateletpb.CheckpointRequest_LocalConfig{
 			LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotName: snapshotName},
 		},
@@ -198,15 +198,15 @@ func TestLocalSnapshotGC(t *testing.T) {
 
 	// Resume: restores from that local snapshot.
 	if _, err := s.Restore(ctx, &ateletpb.RestoreRequest{
-		Atespace:               atespace,
-		ActorName:              actorName,
-		ActorUid:               actorUID,
-		ActorTemplateNamespace: "default",
-		ActorTemplateName:      "counter",
-		TargetAteomUid:         ateomUID,
-		Spec:                   spec,
-		Scope:                  ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL,
-		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL,
+		Atespace:              atespace,
+		ActorName:             actorName,
+		ActorUid:              actorUID,
+		ActorTemplateAtespace: "default",
+		ActorTemplateName:     "counter",
+		TargetAteomUid:        ateomUID,
+		Spec:                  spec,
+		Scope:                 ateletpb.SnapshotScope_SNAPSHOT_SCOPE_FULL,
+		Type:                  ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL,
 		Config: &ateletpb.RestoreRequest_LocalConfig{
 			LocalConfig: &ateletpb.LocalCheckpointConfiguration{SnapshotName: snapshotName},
 		},
@@ -219,13 +219,13 @@ func TestLocalSnapshotGC(t *testing.T) {
 
 	// Terminate: the actor is gone, and so should its snapshot be.
 	if _, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
-		Atespace:               atespace,
-		ActorName:              actorName,
-		ActorUid:               actorUID,
-		ActorTemplateNamespace: "default",
-		ActorTemplateName:      "counter",
-		TargetAteomUid:         ateomUID,
-		Spec:                   spec,
+		Atespace:              atespace,
+		ActorName:             actorName,
+		ActorUid:              actorUID,
+		ActorTemplateAtespace: "default",
+		ActorTemplateName:     "counter",
+		TargetAteomUid:        ateomUID,
+		Spec:                  spec,
 	}); err != nil {
 		t.Fatalf("Terminate: %v", err)
 	}

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -511,17 +511,17 @@ func (s *AteomHerder) Run(ctx context.Context, req *ateletpb.RunRequest) (resp *
 	// Tell ateom to start the workload. gVisor uses RunscPath; the micro-VM
 	// runtime uses the full RuntimeAssetPaths set.
 	if _, err := client.RunWorkload(ctx, &ateompb.RunWorkloadRequest{
-		Atespace:               actorRef.Atespace,
-		ActorName:              actorRef.Name,
-		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
-		ActorTemplateName:      req.GetActorTemplateName(),
-		RunscPath:              runscPathFor(assetPaths),
-		RuntimeAssetPaths:      assetPaths,
-		Spec:                   spec,
-		ActorUid:               actorUID,
-		EgressGateway:          toAteomEgressGateway(req.GetEgressGateway()),
-		CpuMilli:               req.GetCpuMilli(),
-		MemoryBytes:            req.GetMemoryBytes(),
+		Atespace:              actorRef.Atespace,
+		ActorName:             actorRef.Name,
+		ActorTemplateAtespace: req.GetActorTemplateAtespace(),
+		ActorTemplateName:     req.GetActorTemplateName(),
+		RunscPath:             runscPathFor(assetPaths),
+		RuntimeAssetPaths:     assetPaths,
+		Spec:                  spec,
+		ActorUid:              actorUID,
+		EgressGateway:         toAteomEgressGateway(req.GetEgressGateway()),
+		CpuMilli:              req.GetCpuMilli(),
+		MemoryBytes:           req.GetMemoryBytes(),
 	}); err != nil {
 		return nil, fmt.Errorf("while calling ateom.RunWorkload: %w", err)
 	}
@@ -548,7 +548,7 @@ func initSnapshotSizeMetric() error {
 // recordSnapshotSize labels each image with the registry's file.name. That
 // label used to be spelled "kind", which means the snapshot's provenance
 // everywhere else in the ate.* namespace, not one of its files.
-func recordSnapshotSize(ctx context.Context, file, path, atNamespace, atName string) {
+func recordSnapshotSize(ctx context.Context, file, path, templateAtespace, templateName string) {
 	if snapshotSizeBytes == nil {
 		return
 	}
@@ -563,8 +563,8 @@ func recordSnapshotSize(ctx context.Context, file, path, atNamespace, atName str
 	}
 	snapshotSizeBytes.Record(ctx, fi.Size(), metric.WithAttributes(
 		semconv.FileNameKey.String(file),
-		ateattr.TemplateNamespaceKey.String(atNamespace),
-		ateattr.TemplateNameKey.String(atName),
+		ateattr.TemplateNamespaceKey.String(templateAtespace),
+		ateattr.TemplateNameKey.String(templateName),
 	))
 }
 
@@ -581,7 +581,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	tStart := time.Now()
 	var dAssets, dAteom, dPersist time.Duration
 	op := snapshotOp{
-		templateNamespace: req.GetActorTemplateNamespace(),
+		templateNamespace: req.GetActorTemplateAtespace(),
 		templateName:      req.GetActorTemplateName(),
 		kind:              checkpointSnapshotKind(req),
 		scope:             ateattr.SnapshotScopeValue(req.GetScope()),
@@ -629,15 +629,15 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 
 	tAteom := time.Now()
 	resp, err := client.CheckpointWorkload(ctx, &ateompb.CheckpointWorkloadRequest{
-		Atespace:               actorRef.Atespace,
-		ActorName:              actorRef.Name,
-		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
-		ActorTemplateName:      req.GetActorTemplateName(),
-		RunscPath:              runscPathFor(assetPaths),
-		RuntimeAssetPaths:      assetPaths,
-		Spec:                   spec,
-		Scope:                  toAteomSnapshotScope(req.GetScope()),
-		ActorUid:               actorUID,
+		Atespace:              actorRef.Atespace,
+		ActorName:             actorRef.Name,
+		ActorTemplateAtespace: req.GetActorTemplateAtespace(),
+		ActorTemplateName:     req.GetActorTemplateName(),
+		RunscPath:             runscPathFor(assetPaths),
+		RuntimeAssetPaths:     assetPaths,
+		Spec:                  spec,
+		Scope:                 toAteomSnapshotScope(req.GetScope()),
+		ActorUid:              actorUID,
 	})
 	dAteom = time.Since(tAteom)
 	if err != nil {
@@ -654,7 +654,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	sandboxRec.Atespace = req.GetAtespace()
 	sandboxRec.ActorName = req.GetActorName()
 	sandboxRec.ActorUID = req.GetActorUid()
-	sandboxRec.ActorTemplateNamespace = req.GetActorTemplateNamespace()
+	sandboxRec.ActorTemplateAtespace = req.GetActorTemplateAtespace()
 	sandboxRec.ActorTemplateName = req.GetActorTemplateName()
 	sandboxRec.Scope = ateattr.SnapshotScopeValue(req.GetScope())
 
@@ -725,7 +725,7 @@ func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.Che
 	for _, fileName := range rec.SnapshotFiles {
 		src := filepath.Join(checkpointDir, fileName)
 		dst := filepath.Join(localCheckpointPath, fileName)
-		recordSnapshotSize(ctx, fileName, src, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+		recordSnapshotSize(ctx, fileName, src, req.GetActorTemplateAtespace(), req.GetActorTemplateName())
 
 		if err := os.Rename(src, dst); err != nil {
 			return fmt.Errorf("failed to move %s to %s: %w", src, dst, err)
@@ -763,7 +763,7 @@ func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletp
 	if err != nil {
 		return err
 	}
-	return s.uploadSnapshot(ctx, uri, checkpointDir, rec, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+	return s.uploadSnapshot(ctx, uri, checkpointDir, rec, req.GetActorTemplateAtespace(), req.GetActorTemplateName())
 }
 
 // uploadSnapshot uploads rec's snapshot files from srcDir to uri (each
@@ -772,11 +772,11 @@ func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletp
 // assume every file it lists is already present. A crash mid-upload thus
 // leaves only orphaned files, never a manifest pointing at files that never
 // landed; retries overwrite the deterministic object names.
-func (s *AteomHerder) uploadSnapshot(ctx context.Context, uri resources.SnapshotURI, srcDir string, rec *sandboxAssetsRecord, templateNamespace, templateName string) error {
+func (s *AteomHerder) uploadSnapshot(ctx context.Context, uri resources.SnapshotURI, srcDir string, rec *sandboxAssetsRecord, templateAtespace, templateName string) error {
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, fileName := range rec.SnapshotFiles {
 		local := filepath.Join(srcDir, fileName)
-		recordSnapshotSize(ctx, fileName, local, templateNamespace, templateName)
+		recordSnapshotSize(ctx, fileName, local, templateAtespace, templateName)
 		g.Go(func() error {
 			objectURI, err := uri.ObjectURI(fileName + ".zstd")
 			if err != nil {
@@ -818,7 +818,7 @@ func (s *AteomHerder) UploadPausedCheckpoint(ctx context.Context, req *ateletpb.
 	tStart := time.Now()
 	var dPersist time.Duration
 	op := snapshotOp{
-		templateNamespace: req.GetActorTemplateNamespace(),
+		templateNamespace: req.GetActorTemplateAtespace(),
 		templateName:      req.GetActorTemplateName(),
 		// Always the actor's durable latest: golden actors are never paused
 		// (validation above rejects the golden atespace).
@@ -910,7 +910,7 @@ func (s *AteomHerder) uploadLocalCheckpointDir(ctx context.Context, req *ateletp
 		}
 	}
 
-	return rec.SandboxClass, s.uploadSnapshot(ctx, uri, localDir, rec, req.GetActorTemplateNamespace(), req.GetActorTemplateName())
+	return rec.SandboxClass, s.uploadSnapshot(ctx, uri, localDir, rec, req.GetActorTemplateAtespace(), req.GetActorTemplateName())
 }
 
 // narrowFullCaptureToData rewrites rec so a FULL capture uploads as a DATA
@@ -955,7 +955,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	tStart := time.Now()
 	var dMount, dManifest, dAssets, dDownload, dBundles, dAteom time.Duration
 	op := snapshotOp{
-		templateNamespace: req.GetActorTemplateNamespace(),
+		templateNamespace: req.GetActorTemplateAtespace(),
 		templateName:      req.GetActorTemplateName(),
 		scope:             ateattr.SnapshotScopeValue(req.GetScope()),
 	}
@@ -1179,18 +1179,18 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 
 	tAteom := time.Now()
 	_, err = client.RestoreWorkload(ctx, &ateompb.RestoreWorkloadRequest{
-		Atespace:               actorRef.Atespace,
-		ActorName:              actorRef.Name,
-		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
-		ActorTemplateName:      req.GetActorTemplateName(),
-		RunscPath:              runscPathFor(assetPaths),
-		RuntimeAssetPaths:      assetPaths,
-		Spec:                   spec,
-		Scope:                  toAteomSnapshotScope(req.GetScope()),
-		ActorUid:               req.GetActorUid(),
-		EgressGateway:          toAteomEgressGateway(req.GetEgressGateway()),
-		CpuMilli:               req.GetCpuMilli(),
-		MemoryBytes:            req.GetMemoryBytes(),
+		Atespace:              actorRef.Atespace,
+		ActorName:             actorRef.Name,
+		ActorTemplateAtespace: req.GetActorTemplateAtespace(),
+		ActorTemplateName:     req.GetActorTemplateName(),
+		RunscPath:             runscPathFor(assetPaths),
+		RuntimeAssetPaths:     assetPaths,
+		Spec:                  spec,
+		Scope:                 toAteomSnapshotScope(req.GetScope()),
+		ActorUid:              req.GetActorUid(),
+		EgressGateway:         toAteomEgressGateway(req.GetEgressGateway()),
+		CpuMilli:              req.GetCpuMilli(),
+		MemoryBytes:           req.GetMemoryBytes(),
 		// Informational: for DATA_ON_GOLDEN the golden snapshot's files are
 		// already staged into the restore dir by the combined download above;
 		// ateom restores from the shared dir and never fetches this URI.
@@ -1252,13 +1252,13 @@ func (s *AteomHerder) Terminate(ctx context.Context, req *ateletpb.TerminateRequ
 		return nil, status.Errorf(codes.InvalidArgument, "invalid workload spec: %v", err)
 	}
 	if _, err := client.TerminateWorkload(ctx, &ateompb.TerminateWorkloadRequest{
-		Atespace:               req.GetAtespace(),
-		ActorName:              req.GetActorName(),
-		ActorUid:               req.GetActorUid(),
-		ActorTemplateNamespace: req.GetActorTemplateNamespace(),
-		ActorTemplateName:      req.GetActorTemplateName(),
-		RunscPath:              runscPathFor(assetPaths),
-		Spec:                   spec,
+		Atespace:              req.GetAtespace(),
+		ActorName:             req.GetActorName(),
+		ActorUid:              req.GetActorUid(),
+		ActorTemplateAtespace: req.GetActorTemplateAtespace(),
+		ActorTemplateName:     req.GetActorTemplateName(),
+		RunscPath:             runscPathFor(assetPaths),
+		Spec:                  spec,
 	}); err != nil {
 		if status.Code(err) == codes.NotFound {
 			slog.InfoContext(ctx, "workload not found on ateom during terminate", slog.Any("actor", actorRef), slog.String("actorUID", actorUID))

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -69,18 +69,18 @@ func TestPortFlagDefault(t *testing.T) {
 
 func TestSnapshotManifestActorMetadata(t *testing.T) {
 	rec := sandboxAssetsRecord{
-		Atespace:               "team-a",
-		ActorName:              "actor-1",
-		ActorUID:               "actor-uid",
-		ActorTemplateNamespace: "templates",
-		ActorTemplateName:      "agent",
-		Scope:                  ateattr.SnapshotScopeFull,
+		Atespace:              "team-a",
+		ActorName:             "actor-1",
+		ActorUID:              "actor-uid",
+		ActorTemplateAtespace: "templates",
+		ActorTemplateName:     "agent",
+		Scope:                 ateattr.SnapshotScopeFull,
 	}
 	got, err := json.Marshal(rec)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{`"atespace":"team-a"`, `"actorName":"actor-1"`, `"actorUid":"actor-uid"`, `"actorTemplateNamespace":"templates"`, `"actorTemplateName":"agent"`, `"scope":"full"`} {
+	for _, want := range []string{`"atespace":"team-a"`, `"actorName":"actor-1"`, `"actorUid":"actor-uid"`, `"actorTemplateAtespace":"templates"`, `"actorTemplateName":"agent"`, `"scope":"full"`} {
 		if !bytes.Contains(got, []byte(want)) {
 			t.Errorf("manifest %s missing %s", got, want)
 		}
@@ -389,26 +389,26 @@ func TestCopyFile_CloseError(t *testing.T) {
 // break one field per case.
 func validRunRequest() *ateletpb.RunRequest {
 	return &ateletpb.RunRequest{
-		Atespace:               "ate-demo",
-		ActorName:              "counter-1",
-		ActorTemplateNamespace: "ate-demo",
-		ActorTemplateName:      "counter",
-		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
-		ActorUid:               "123e4567-e89b-12d3-a456-426614174000",
-		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
+		Atespace:              "ate-demo",
+		ActorName:             "counter-1",
+		ActorTemplateAtespace: "ate-demo",
+		ActorTemplateName:     "counter",
+		TargetAteomUid:        "422938ba-8860-4983-a25d-d6bcb0a69d4e",
+		ActorUid:              "123e4567-e89b-12d3-a456-426614174000",
+		Spec:                  &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
 	}
 }
 
 func validCheckpointRequest() *ateletpb.CheckpointRequest {
 	return &ateletpb.CheckpointRequest{
-		Atespace:               "ate-demo",
-		ActorName:              "counter-1",
-		ActorTemplateNamespace: "ate-demo",
-		ActorTemplateName:      "counter",
-		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
-		ActorUid:               "123e4567-e89b-12d3-a456-426614174000",
-		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
-		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
+		Atespace:              "ate-demo",
+		ActorName:             "counter-1",
+		ActorTemplateAtespace: "ate-demo",
+		ActorTemplateName:     "counter",
+		TargetAteomUid:        "422938ba-8860-4983-a25d-d6bcb0a69d4e",
+		ActorUid:              "123e4567-e89b-12d3-a456-426614174000",
+		Spec:                  &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
+		Type:                  ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
 		Config: &ateletpb.CheckpointRequest_ExternalConfig{
 			ExternalConfig: &ateletpb.ExternalCheckpointConfiguration{
 				SnapshotUri: "gs://bucket/root/snapshots/ate-demo/counter-1-snap",
@@ -420,14 +420,14 @@ func validCheckpointRequest() *ateletpb.CheckpointRequest {
 
 func validRestoreRequest() *ateletpb.RestoreRequest {
 	return &ateletpb.RestoreRequest{
-		Atespace:               "ate-demo",
-		ActorName:              "counter-1",
-		ActorTemplateNamespace: "ate-demo",
-		ActorTemplateName:      "counter",
-		TargetAteomUid:         "422938ba-8860-4983-a25d-d6bcb0a69d4e",
-		ActorUid:               "123e4567-e89b-12d3-a456-426614174000",
-		Spec:                   &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
-		Type:                   ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
+		Atespace:              "ate-demo",
+		ActorName:             "counter-1",
+		ActorTemplateAtespace: "ate-demo",
+		ActorTemplateName:     "counter",
+		TargetAteomUid:        "422938ba-8860-4983-a25d-d6bcb0a69d4e",
+		ActorUid:              "123e4567-e89b-12d3-a456-426614174000",
+		Spec:                  &ateletpb.WorkloadSpec{Containers: []*ateletpb.Container{{Name: "worker"}}},
+		Type:                  ateletpb.CheckpointType_CHECKPOINT_TYPE_EXTERNAL,
 		Config: &ateletpb.RestoreRequest_ExternalConfig{
 			ExternalConfig: &ateletpb.ExternalCheckpointConfiguration{
 				SnapshotUri: "gs://bucket/root/snapshots/ate-demo/counter-1-snap",
@@ -448,8 +448,8 @@ func TestValidateRunRequest(t *testing.T) {
 		{"invalid atespace", func(r *ateletpb.RunRequest) { r.Atespace = "../escape" }, true},
 		{"invalid actor name", func(r *ateletpb.RunRequest) { r.ActorName = "../escape" }, true},
 		{"invalid actor uid", func(r *ateletpb.RunRequest) { r.ActorUid = "../escape" }, true},
-		{"any actor template identity accepted", func(r *ateletpb.RunRequest) { r.ActorTemplateNamespace, r.ActorTemplateName = "Not_Valid", "Not_Valid" }, false},
-		{"empty actor template identity accepted", func(r *ateletpb.RunRequest) { r.ActorTemplateNamespace, r.ActorTemplateName = "", "" }, false},
+		{"any actor template identity accepted", func(r *ateletpb.RunRequest) { r.ActorTemplateAtespace, r.ActorTemplateName = "Not_Valid", "Not_Valid" }, false},
+		{"empty actor template identity accepted", func(r *ateletpb.RunRequest) { r.ActorTemplateAtespace, r.ActorTemplateName = "", "" }, false},
 		{"invalid container name", func(r *ateletpb.RunRequest) {
 			r.Spec.Containers = []*ateletpb.Container{{Name: "../escape"}}
 		}, true},
@@ -489,9 +489,9 @@ func TestValidateCheckpointRequest(t *testing.T) {
 		{"invalid actor name", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorName = "../escape" }), true},
 		{"invalid actor uid", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorUid = "../escape" }), true},
 		{"any actor template identity accepted", makeReq(func(r *ateletpb.CheckpointRequest) {
-			r.ActorTemplateNamespace, r.ActorTemplateName = "Not_Valid", "Not_Valid"
+			r.ActorTemplateAtespace, r.ActorTemplateName = "Not_Valid", "Not_Valid"
 		}), false},
-		{"empty actor template identity accepted", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorTemplateNamespace, r.ActorTemplateName = "", "" }), false},
+		{"empty actor template identity accepted", makeReq(func(r *ateletpb.CheckpointRequest) { r.ActorTemplateAtespace, r.ActorTemplateName = "", "" }), false},
 		{"invalid container name", makeReq(func(r *ateletpb.CheckpointRequest) {
 			r.Spec.Containers = []*ateletpb.Container{{Name: "../escape"}}
 		}), true},
@@ -549,9 +549,9 @@ func TestValidateRestoreRequest(t *testing.T) {
 		{"invalid actor name", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorName = "../escape" }), true},
 		{"invalid actor uid", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorUid = "../escape" }), true},
 		{"any actor template identity accepted", makeReq(func(r *ateletpb.RestoreRequest) {
-			r.ActorTemplateNamespace, r.ActorTemplateName = "Not_Valid", "Not_Valid"
+			r.ActorTemplateAtespace, r.ActorTemplateName = "Not_Valid", "Not_Valid"
 		}), false},
-		{"empty actor template identity accepted", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorTemplateNamespace, r.ActorTemplateName = "", "" }), false},
+		{"empty actor template identity accepted", makeReq(func(r *ateletpb.RestoreRequest) { r.ActorTemplateAtespace, r.ActorTemplateName = "", "" }), false},
 		{"invalid container name", makeReq(func(r *ateletpb.RestoreRequest) {
 			r.Spec.Containers = []*ateletpb.Container{{Name: "../escape"}}
 		}), true},
@@ -830,7 +830,7 @@ func TestRPCBoundariesReject(t *testing.T) {
 		t.Run("invalid ateom UID", func(t *testing.T) {
 			_, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
 				Atespace: okAtespace, ActorName: okID,
-				ActorUid: okActorUID, ActorTemplateNamespace: "default", ActorTemplateName: "template",
+				ActorUid: okActorUID, ActorTemplateAtespace: "default", ActorTemplateName: "template",
 				TargetAteomUid: badUID, Spec: okSpec,
 			})
 			wantInvalidArgument(t, "Terminate", err)
@@ -838,7 +838,7 @@ func TestRPCBoundariesReject(t *testing.T) {
 		t.Run("missing target ateom UID", func(t *testing.T) {
 			_, err := s.Terminate(ctx, &ateletpb.TerminateRequest{
 				Atespace: okAtespace, ActorName: okID,
-				ActorUid: okActorUID, ActorTemplateNamespace: "default", ActorTemplateName: "template",
+				ActorUid: okActorUID, ActorTemplateAtespace: "default", ActorTemplateName: "template",
 				Spec: okSpec,
 			})
 			wantInvalidArgument(t, "Terminate", err)
@@ -1623,7 +1623,7 @@ func validUploadPausedCheckpointRequest() *ateletpb.UploadPausedCheckpointReques
 		Atespace:               "ate-demo",
 		ActorName:              "counter-1",
 		ActorUid:               "123e4567-e89b-12d3-a456-426614174000",
-		ActorTemplateNamespace: "ate-demo",
+		ActorTemplateAtespace:  "ate-demo",
 		ActorTemplateName:      "counter",
 		LocalSnapshotName:      "pause-snap-1",
 		DestinationSnapshotUri: "gs://bucket/root/snapshots/ate-demo/snap-1",
@@ -1864,9 +1864,9 @@ func TestValidateUploadPausedCheckpointRequest(t *testing.T) {
 		{"golden atespace rejected", func(r *ateletpb.UploadPausedCheckpointRequest) { r.Atespace = resources.GoldenActorAtespace }, true},
 		{"invalid actor name", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorName = "UPPER" }, true},
 		{"invalid actor uid", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorUid = "" }, true},
-		{"any actor template identity accepted", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorTemplateNamespace = "no/slashes" }, false},
+		{"any actor template identity accepted", func(r *ateletpb.UploadPausedCheckpointRequest) { r.ActorTemplateAtespace = "no/slashes" }, false},
 		{"empty actor template identity accepted", func(r *ateletpb.UploadPausedCheckpointRequest) {
-			r.ActorTemplateNamespace, r.ActorTemplateName = "", ""
+			r.ActorTemplateAtespace, r.ActorTemplateName = "", ""
 		}, false},
 		{"invalid snapshot name", func(r *ateletpb.UploadPausedCheckpointRequest) { r.LocalSnapshotName = "../escape" }, true},
 		{"invalid snapshot uri", func(r *ateletpb.UploadPausedCheckpointRequest) { r.DestinationSnapshotUri = "not-a-uri" }, true},

--- a/cmd/atelet/sandbox_assets.go
+++ b/cmd/atelet/sandbox_assets.go
@@ -86,11 +86,11 @@ type sandboxAssetsRecord struct {
 	PauseImage string `json:"pauseImage"`
 	// Actor identity makes a flat snapshot self-identifying if control-plane
 	// persistence is unavailable.
-	Atespace               string `json:"atespace,omitempty"`
-	ActorName              string `json:"actorName,omitempty"`
-	ActorUID               string `json:"actorUid,omitempty"`
-	ActorTemplateNamespace string `json:"actorTemplateNamespace,omitempty"`
-	ActorTemplateName      string `json:"actorTemplateName,omitempty"`
+	Atespace              string `json:"atespace,omitempty"`
+	ActorName             string `json:"actorName,omitempty"`
+	ActorUID              string `json:"actorUid,omitempty"`
+	ActorTemplateAtespace string `json:"actorTemplateAtespace,omitempty"`
+	ActorTemplateName     string `json:"actorTemplateName,omitempty"`
 	// SnapshotFiles are the (relative) names of the files ateom wrote into the
 	// checkpoint directory, as reported by CheckpointWorkloadResponse. Recorded
 	// in the snapshot manifest so Restore ships/downloads exactly this set

--- a/cmd/atelet/statspoller.go
+++ b/cmd/atelet/statspoller.go
@@ -287,7 +287,7 @@ func (p *statsPoller) collect(ctx context.Context) map[templateKey]*templateAggr
 			}
 
 			key := templateKey{
-				templateNamespace: sample.GetActorTemplateNamespace(),
+				templateNamespace: sample.GetActorTemplateAtespace(),
 				templateName:      sample.GetActorTemplateName(),
 				sandboxClass:      sandboxClassLabel(sample.GetSandboxClass()),
 				source:            statsSourceLabel(sample.GetSource()),

--- a/cmd/atelet/statspoller_test.go
+++ b/cmd/atelet/statspoller_test.go
@@ -59,12 +59,12 @@ func (f *fakeStatsAteom) GetActiveWorkloadStats(ctx context.Context, req *ateomp
 func executingResponse(templateNS, templateName string, class ateompb.SandboxClass, source ateompb.StatsSource, current, workingSet uint64) *ateompb.GetActiveWorkloadStatsResponse {
 	return &ateompb.GetActiveWorkloadStatsResponse{
 		Result: &ateompb.GetActiveWorkloadStatsResponse_Sample{Sample: &ateompb.WorkloadStatsSample{
-			ActorTemplateNamespace: templateNS,
-			ActorTemplateName:      templateName,
-			SandboxClass:           class,
-			Source:                 source,
-			MemoryCurrentBytes:     current,
-			MemoryWorkingSetBytes:  workingSet,
+			ActorTemplateAtespace: templateNS,
+			ActorTemplateName:     templateName,
+			SandboxClass:          class,
+			Source:                source,
+			MemoryCurrentBytes:    current,
+			MemoryWorkingSetBytes: workingSet,
 		}},
 	}
 }
@@ -281,12 +281,12 @@ func gaugePointCount(t *testing.T, reader *sdkmetric.ManualReader, name string) 
 func cpuResponse(actorUID string, cpuUsec uint64) *ateompb.GetActiveWorkloadStatsResponse {
 	return &ateompb.GetActiveWorkloadStatsResponse{
 		Result: &ateompb.GetActiveWorkloadStatsResponse_Sample{Sample: &ateompb.WorkloadStatsSample{
-			ActorUid:               actorUID,
-			ActorTemplateNamespace: "ns-a",
-			ActorTemplateName:      "tmpl-a",
-			SandboxClass:           ateompb.SandboxClass_SANDBOX_CLASS_GVISOR,
-			Source:                 ateompb.StatsSource_STATS_SOURCE_CGROUP,
-			CpuUsageUsec:           cpuUsec,
+			ActorUid:              actorUID,
+			ActorTemplateAtespace: "ns-a",
+			ActorTemplateName:     "tmpl-a",
+			SandboxClass:          ateompb.SandboxClass_SANDBOX_CLASS_GVISOR,
+			Source:                ateompb.StatsSource_STATS_SOURCE_CGROUP,
+			CpuUsageUsec:          cpuUsec,
 		}},
 	}
 }

--- a/cmd/ateom-gvisor/stats.go
+++ b/cmd/ateom-gvisor/stats.go
@@ -213,11 +213,11 @@ func (s *AteomService) sampleSandbox(active *resources.ActorAttribution) (*ateom
 	}
 
 	return &ateompb.WorkloadStatsSample{
-		Atespace:               active.Ref.Atespace,
-		ActorName:              active.Ref.Name,
-		ActorUid:               active.UID,
-		ActorTemplateNamespace: active.TemplateNamespace,
-		ActorTemplateName:      active.TemplateName,
+		Atespace:              active.Ref.Atespace,
+		ActorName:             active.Ref.Name,
+		ActorUid:              active.UID,
+		ActorTemplateAtespace: active.TemplateAtespace,
+		ActorTemplateName:     active.TemplateName,
 
 		SandboxClass: ateompb.SandboxClass_SANDBOX_CLASS_GVISOR,
 		Source:       ateompb.StatsSource_STATS_SOURCE_CGROUP,

--- a/cmd/ateom-gvisor/stats_test.go
+++ b/cmd/ateom-gvisor/stats_test.go
@@ -42,10 +42,10 @@ import (
 // result, which is where the polling loop will actually live.
 
 var testActor = resources.ActorAttribution{
-	Ref:               resources.ActorRef{Atespace: "space-a", Name: "actor-a"},
-	UID:               "uid-a",
-	TemplateNamespace: "ns-a",
-	TemplateName:      "template-a",
+	Ref:              resources.ActorRef{Atespace: "space-a", Name: "actor-a"},
+	UID:              "uid-a",
+	TemplateAtespace: "ns-a",
+	TemplateName:     "template-a",
 }
 
 var healthyCgroup = map[string]string{
@@ -96,17 +96,17 @@ func TestGetWorkloadStats(t *testing.T) {
 	got.GetSample().ObservedAtUnixNano = 0
 
 	want := &ateompb.GetWorkloadStatsResponse{Sample: &ateompb.WorkloadStatsSample{
-		Atespace:               "space-a",
-		ActorName:              "actor-a",
-		ActorUid:               "uid-a",
-		ActorTemplateNamespace: "ns-a",
-		ActorTemplateName:      "template-a",
-		SandboxClass:           ateompb.SandboxClass_SANDBOX_CLASS_GVISOR,
-		Source:                 ateompb.StatsSource_STATS_SOURCE_CGROUP,
-		MemoryCurrentBytes:     157286400,
-		MemoryPeakBytes:        209715200,
-		MemoryWorkingSetBytes:  136314880,
-		CpuUsageUsec:           1234567,
+		Atespace:              "space-a",
+		ActorName:             "actor-a",
+		ActorUid:              "uid-a",
+		ActorTemplateAtespace: "ns-a",
+		ActorTemplateName:     "template-a",
+		SandboxClass:          ateompb.SandboxClass_SANDBOX_CLASS_GVISOR,
+		Source:                ateompb.StatsSource_STATS_SOURCE_CGROUP,
+		MemoryCurrentBytes:    157286400,
+		MemoryPeakBytes:       209715200,
+		MemoryWorkingSetBytes: 136314880,
+		CpuUsageUsec:          1234567,
 	}}
 	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 		t.Errorf("GetWorkloadStats() mismatch (-want +got):\n%s", diff)

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -98,14 +98,14 @@ func (s *AteomService) RestoreWorkload(ctx context.Context, req *ateompb.Restore
 	}
 
 	p := actorBootParams{
-		actorRef:      resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()},
-		actorUID:      req.GetActorUid(),
-		templateNS:    req.GetActorTemplateNamespace(),
-		templateName:  req.GetActorTemplateName(),
-		containers:    req.GetSpec().GetContainers(),
-		assetPaths:    req.GetRuntimeAssetPaths(),
-		egressGateway: req.GetEgressGateway(),
-		size:          sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
+		actorRef:         resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()},
+		actorUID:         req.GetActorUid(),
+		templateAtespace: req.GetActorTemplateAtespace(),
+		templateName:     req.GetActorTemplateName(),
+		containers:       req.GetSpec().GetContainers(),
+		assetPaths:       req.GetRuntimeAssetPaths(),
+		egressGateway:    req.GetEgressGateway(),
+		size:             sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
 	}
 	restoreDir := ateompath.RestoreStateDir(p.actorUID)
 	durableDir := ateompath.DurableDirVolumeMountsDir(p.actorUID)

--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -267,14 +267,14 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 	}
 
 	p := actorBootParams{
-		actorRef:      resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()},
-		actorUID:      req.GetActorUid(),
-		templateNS:    req.GetActorTemplateNamespace(),
-		templateName:  req.GetActorTemplateName(),
-		containers:    req.GetSpec().GetContainers(),
-		assetPaths:    req.GetRuntimeAssetPaths(),
-		egressGateway: req.GetEgressGateway(),
-		size:          sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
+		actorRef:         resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()},
+		actorUID:         req.GetActorUid(),
+		templateAtespace: req.GetActorTemplateAtespace(),
+		templateName:     req.GetActorTemplateName(),
+		containers:       req.GetSpec().GetContainers(),
+		assetPaths:       req.GetRuntimeAssetPaths(),
+		egressGateway:    req.GetEgressGateway(),
+		size:             sizing.FromLimits(req.GetCpuMilli(), req.GetMemoryBytes()),
 	}
 
 	attribution := p.actorAttribution()
@@ -305,12 +305,12 @@ func (s *AteomService) RunWorkload(ctx context.Context, req *ateompb.RunWorkload
 // request, or from a Restore request whose snapshot scope covers only the
 // durable-dir volumes (the workload itself cold-starts).
 type actorBootParams struct {
-	actorRef     resources.ActorRef
-	actorUID     string
-	templateNS   string
-	templateName string
-	containers   []*ateompb.Container
-	assetPaths   map[string]string
+	actorRef         resources.ActorRef
+	actorUID         string
+	templateAtespace string
+	templateName     string
+	containers       []*ateompb.Container
+	assetPaths       map[string]string
 	// egressGateway is nil unless actor TCP should be redirected through atunnel.
 	egressGateway *ateompb.EgressGateway
 	// size is the actor's declared limits (from the ActorTemplate), supplied on
@@ -324,10 +324,10 @@ type actorBootParams struct {
 // request, for retention in AteomService.activeActor.
 func (p actorBootParams) actorAttribution() resources.ActorAttribution {
 	return resources.ActorAttribution{
-		Ref:               p.actorRef,
-		UID:               p.actorUID,
-		TemplateNamespace: p.templateNS,
-		TemplateName:      p.templateName,
+		Ref:              p.actorRef,
+		UID:              p.actorUID,
+		TemplateAtespace: p.templateAtespace,
+		TemplateName:     p.templateName,
 	}
 }
 

--- a/cmd/ateom-microvm/stats.go
+++ b/cmd/ateom-microvm/stats.go
@@ -228,11 +228,11 @@ func (s *AteomService) sampleGuest(ctx context.Context, active *resources.ActorA
 	}
 
 	return &ateompb.WorkloadStatsSample{
-		Atespace:               active.Ref.Atespace,
-		ActorName:              active.Ref.Name,
-		ActorUid:               active.UID,
-		ActorTemplateNamespace: active.TemplateNamespace,
-		ActorTemplateName:      active.TemplateName,
+		Atespace:              active.Ref.Atespace,
+		ActorName:             active.Ref.Name,
+		ActorUid:              active.UID,
+		ActorTemplateAtespace: active.TemplateAtespace,
+		ActorTemplateName:     active.TemplateName,
 
 		SandboxClass: ateompb.SandboxClass_SANDBOX_CLASS_MICROVM,
 		Source:       ateompb.StatsSource_STATS_SOURCE_GUEST_AGENT,

--- a/cmd/ateom-microvm/stats_test.go
+++ b/cmd/ateom-microvm/stats_test.go
@@ -46,16 +46,16 @@ func TestActorBootParamsAttribution(t *testing.T) {
 		{
 			name: "fully populated",
 			p: actorBootParams{
-				actorRef:     resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
-				actorUID:     "uid-c",
-				templateNS:   "template-ns-d",
-				templateName: "template-name-e",
+				actorRef:         resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
+				actorUID:         "uid-c",
+				templateAtespace: "template-ns-d",
+				templateName:     "template-name-e",
 			},
 			want: resources.ActorAttribution{
-				Ref:               resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
-				UID:               "uid-c",
-				TemplateNamespace: "template-ns-d",
-				TemplateName:      "template-name-e",
+				Ref:              resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
+				UID:              "uid-c",
+				TemplateAtespace: "template-ns-d",
+				TemplateName:     "template-name-e",
 			},
 		},
 		{
@@ -81,19 +81,19 @@ func TestActorBootParamsAttribution(t *testing.T) {
 // the assertion that catches them drifting apart.
 func TestActorBootParamsAttributionMatchesRequest(t *testing.T) {
 	req := &ateompb.RunWorkloadRequest{
-		Atespace:               "atespace-a",
-		ActorName:              "actor-b",
-		ActorUid:               "uid-c",
-		ActorTemplateNamespace: "template-ns-d",
-		ActorTemplateName:      "template-name-e",
+		Atespace:              "atespace-a",
+		ActorName:             "actor-b",
+		ActorUid:              "uid-c",
+		ActorTemplateAtespace: "template-ns-d",
+		ActorTemplateName:     "template-name-e",
 	}
 
 	// Mirrors the actorBootParams literal in RunWorkload and RestoreWorkload.
 	p := actorBootParams{
-		actorRef:     resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()},
-		actorUID:     req.GetActorUid(),
-		templateNS:   req.GetActorTemplateNamespace(),
-		templateName: req.GetActorTemplateName(),
+		actorRef:         resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()},
+		actorUID:         req.GetActorUid(),
+		templateAtespace: req.GetActorTemplateAtespace(),
+		templateName:     req.GetActorTemplateName(),
 	}
 
 	if diff := cmp.Diff(ateomstats.ActorAttributionFromRequest(req), p.actorAttribution()); diff != "" {
@@ -111,10 +111,10 @@ func TestActorBootParamsAttributionMatchesRequest(t *testing.T) {
 // polling loop will actually live.
 
 var testActor = resources.ActorAttribution{
-	Ref:               resources.ActorRef{Atespace: "space-a", Name: "actor-a"},
-	UID:               "uid-a",
-	TemplateNamespace: "ns-a",
-	TemplateName:      "template-a",
+	Ref:              resources.ActorRef{Atespace: "space-a", Name: "actor-a"},
+	UID:              "uid-a",
+	TemplateAtespace: "ns-a",
+	TemplateName:     "template-a",
 }
 
 // fakeAgent stands in for the kata-agent client: a canned reply per container
@@ -193,17 +193,17 @@ func TestGetWorkloadStats(t *testing.T) {
 	got.GetSample().ObservedAtUnixNano = 0
 
 	want := &ateompb.GetWorkloadStatsResponse{Sample: &ateompb.WorkloadStatsSample{
-		Atespace:               "space-a",
-		ActorName:              "actor-a",
-		ActorUid:               "uid-a",
-		ActorTemplateNamespace: "ns-a",
-		ActorTemplateName:      "template-a",
-		SandboxClass:           ateompb.SandboxClass_SANDBOX_CLASS_MICROVM,
-		Source:                 ateompb.StatsSource_STATS_SOURCE_GUEST_AGENT,
-		MemoryCurrentBytes:     157286400,
-		MemoryPeakBytes:        209715200,
-		MemoryWorkingSetBytes:  136314880,
-		CpuUsageUsec:           1234567,
+		Atespace:              "space-a",
+		ActorName:             "actor-a",
+		ActorUid:              "uid-a",
+		ActorTemplateAtespace: "ns-a",
+		ActorTemplateName:     "template-a",
+		SandboxClass:          ateompb.SandboxClass_SANDBOX_CLASS_MICROVM,
+		Source:                ateompb.StatsSource_STATS_SOURCE_GUEST_AGENT,
+		MemoryCurrentBytes:    157286400,
+		MemoryPeakBytes:       209715200,
+		MemoryWorkingSetBytes: 136314880,
+		CpuUsageUsec:          1234567,
 	}}
 	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 		t.Errorf("GetWorkloadStats() mismatch (-want +got):\n%s", diff)

--- a/internal/actorlog/logger_test.go
+++ b/internal/actorlog/logger_test.go
@@ -38,10 +38,10 @@ const (
 )
 
 var testAttribution = resources.ActorAttribution{
-	Ref:               resources.ActorRef{Atespace: testAtespace, Name: testActorName},
-	UID:               testActorUID,
-	TemplateNamespace: testTemplateNS,
-	TemplateName:      testTemplateName,
+	Ref:              resources.ActorRef{Atespace: testAtespace, Name: testActorName},
+	UID:              testActorUID,
+	TemplateAtespace: testTemplateNS,
+	TemplateName:     testTemplateName,
 }
 
 // The registry owns the spellings (pinned by ateattr.TestKeySpellings), so the

--- a/internal/ateattr/ateattr.go
+++ b/internal/ateattr/ateattr.go
@@ -342,7 +342,7 @@ func ActorLogLabels(a resources.ActorAttribution, containerName string) map[stri
 		string(AtespaceKey):          a.Ref.Atespace,
 		string(ActorNameKey):         a.Ref.Name,
 		string(ActorUIDKey):          a.UID,
-		string(TemplateNamespaceKey): a.TemplateNamespace,
+		string(TemplateNamespaceKey): a.TemplateAtespace,
 		string(TemplateNameKey):      a.TemplateName,
 	}
 	if containerName != "" {

--- a/internal/ateattr/ateattr_test.go
+++ b/internal/ateattr/ateattr_test.go
@@ -206,10 +206,10 @@ func TestActorLogLabels(t *testing.T) {
 	const containerName = "counter"
 
 	attribution := resources.ActorAttribution{
-		Ref:               resources.ActorRef{Atespace: "team-a", Name: "support-agent-42"},
-		UID:               "uid-abc",
-		TemplateNamespace: "ate-agents",
-		TemplateName:      "support-agent",
+		Ref:              resources.ActorRef{Atespace: "team-a", Name: "support-agent-42"},
+		UID:              "uid-abc",
+		TemplateAtespace: "ate-agents",
+		TemplateName:     "support-agent",
 	}
 
 	tests := []struct {

--- a/internal/ateomstats/actorattribution.go
+++ b/internal/ateomstats/actorattribution.go
@@ -31,7 +31,7 @@ type attributionSource interface {
 	GetAtespace() string
 	GetActorName() string
 	GetActorUid() string
-	GetActorTemplateNamespace() string
+	GetActorTemplateAtespace() string
 	GetActorTemplateName() string
 }
 
@@ -51,8 +51,8 @@ func ActorAttributionFromRequest(req attributionSource) resources.ActorAttributi
 			Atespace: req.GetAtespace(),
 			Name:     req.GetActorName(),
 		},
-		UID:               req.GetActorUid(),
-		TemplateNamespace: req.GetActorTemplateNamespace(),
-		TemplateName:      req.GetActorTemplateName(),
+		UID:              req.GetActorUid(),
+		TemplateAtespace: req.GetActorTemplateAtespace(),
+		TemplateName:     req.GetActorTemplateName(),
 	}
 }

--- a/internal/ateomstats/actorattribution_test.go
+++ b/internal/ateomstats/actorattribution_test.go
@@ -28,10 +28,10 @@ import (
 // catch is a field being wired to the wrong source, which same-looking
 // placeholders would hide.
 var fullAttribution = resources.ActorAttribution{
-	Ref:               resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
-	UID:               "uid-c",
-	TemplateNamespace: "template-ns-d",
-	TemplateName:      "template-name-e",
+	Ref:              resources.ActorRef{Atespace: "atespace-a", Name: "actor-b"},
+	UID:              "uid-c",
+	TemplateAtespace: "template-ns-d",
+	TemplateName:     "template-name-e",
 }
 
 func TestActorAttributionFromRequest(t *testing.T) {
@@ -43,11 +43,11 @@ func TestActorAttributionFromRequest(t *testing.T) {
 		{
 			name: "run request",
 			req: &ateompb.RunWorkloadRequest{
-				Atespace:               "atespace-a",
-				ActorName:              "actor-b",
-				ActorUid:               "uid-c",
-				ActorTemplateNamespace: "template-ns-d",
-				ActorTemplateName:      "template-name-e",
+				Atespace:              "atespace-a",
+				ActorName:             "actor-b",
+				ActorUid:              "uid-c",
+				ActorTemplateAtespace: "template-ns-d",
+				ActorTemplateName:     "template-name-e",
 			},
 			want: fullAttribution,
 		},
@@ -57,33 +57,33 @@ func TestActorAttributionFromRequest(t *testing.T) {
 			// it was taken before the checkpoint.
 			name: "restore request",
 			req: &ateompb.RestoreWorkloadRequest{
-				Atespace:               "atespace-a",
-				ActorName:              "actor-b",
-				ActorUid:               "uid-c",
-				ActorTemplateNamespace: "template-ns-d",
-				ActorTemplateName:      "template-name-e",
+				Atespace:              "atespace-a",
+				ActorName:             "actor-b",
+				ActorUid:              "uid-c",
+				ActorTemplateAtespace: "template-ns-d",
+				ActorTemplateName:     "template-name-e",
 			},
 			want: fullAttribution,
 		},
 		{
 			name: "checkpoint request",
 			req: &ateompb.CheckpointWorkloadRequest{
-				Atespace:               "atespace-a",
-				ActorName:              "actor-b",
-				ActorUid:               "uid-c",
-				ActorTemplateNamespace: "template-ns-d",
-				ActorTemplateName:      "template-name-e",
+				Atespace:              "atespace-a",
+				ActorName:             "actor-b",
+				ActorUid:              "uid-c",
+				ActorTemplateAtespace: "template-ns-d",
+				ActorTemplateName:     "template-name-e",
 			},
 			want: fullAttribution,
 		},
 		{
 			name: "terminate request",
 			req: &ateompb.TerminateWorkloadRequest{
-				Atespace:               "atespace-a",
-				ActorName:              "actor-b",
-				ActorUid:               "uid-c",
-				ActorTemplateNamespace: "template-ns-d",
-				ActorTemplateName:      "template-name-e",
+				Atespace:              "atespace-a",
+				ActorName:             "actor-b",
+				ActorUid:              "uid-c",
+				ActorTemplateAtespace: "template-ns-d",
+				ActorTemplateName:     "template-name-e",
 			},
 			want: fullAttribution,
 		},

--- a/internal/proto/ateletpb/atelet.pb.go
+++ b/internal/proto/ateletpb/atelet.pb.go
@@ -306,16 +306,16 @@ func (x *MintActorCertificateResponse) GetActorCertificates() [][]byte {
 }
 
 type TerminateRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
-	Atespace               string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	ActorName              string                 `protobuf:"bytes,3,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
-	ActorUid               string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,5,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	TargetAteomUid        string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
+	Atespace              string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName             string                 `protobuf:"bytes,3,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid              string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateAtespace string                 `protobuf:"bytes,5,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	Spec                  *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *TerminateRequest) Reset() {
@@ -376,9 +376,9 @@ func (x *TerminateRequest) GetActorUid() string {
 	return ""
 }
 
-func (x *TerminateRequest) GetActorTemplateNamespace() string {
+func (x *TerminateRequest) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -434,14 +434,14 @@ func (*TerminateResponse) Descriptor() ([]byte, []int) {
 }
 
 type RunRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
-	Atespace               string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	ActorName              string                 `protobuf:"bytes,3,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
-	ActorUid               string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,5,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	TargetAteomUid        string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
+	Atespace              string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName             string                 `protobuf:"bytes,3,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid              string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateAtespace string                 `protobuf:"bytes,5,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	Spec                  *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
 	// The sandbox binaries to use for booting this actor from scratch. atelet
 	// fetches the relevant assets and records them with the actor's on-node state
 	// so a later Checkpoint can pin the same version into the snapshot manifest.
@@ -515,9 +515,9 @@ func (x *RunRequest) GetActorUid() string {
 	return ""
 }
 
-func (x *RunRequest) GetActorTemplateNamespace() string {
+func (x *RunRequest) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -1995,13 +1995,13 @@ func (x *ExternalCheckpointConfiguration) GetSnapshotUri() string {
 }
 
 type CheckpointRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
-	Atespace               string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	ActorName              string                 `protobuf:"bytes,3,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
-	ActorUid               string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,5,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	TargetAteomUid        string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
+	Atespace              string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName             string                 `protobuf:"bytes,3,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid              string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateAtespace string                 `protobuf:"bytes,5,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
 	// Sandbox binary config is not sent on checkpoint: atelet uses the version the
 	// actor is currently running (recorded with the actor's on-node state at
 	// Run/Restore) and records it into the snapshot manifest.
@@ -2078,9 +2078,9 @@ func (x *CheckpointRequest) GetActorUid() string {
 	return ""
 }
 
-func (x *CheckpointRequest) GetActorTemplateNamespace() string {
+func (x *CheckpointRequest) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -2196,8 +2196,8 @@ type UploadPausedCheckpointRequest struct {
 	ActorName string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
 	ActorUid  string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
 	// For metrics attribution, like on CheckpointRequest.
-	ActorTemplateNamespace string `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	ActorTemplateAtespace string `protobuf:"bytes,4,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
 	// The local checkpoint to upload: LocalSnapshotInfo.snapshot_name recorded
 	// at pause time.
 	LocalSnapshotName string `protobuf:"bytes,6,opt,name=local_snapshot_name,json=localSnapshotName,proto3" json:"local_snapshot_name,omitempty"`
@@ -2264,9 +2264,9 @@ func (x *UploadPausedCheckpointRequest) GetActorUid() string {
 	return ""
 }
 
-func (x *UploadPausedCheckpointRequest) GetActorTemplateNamespace() string {
+func (x *UploadPausedCheckpointRequest) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -2336,13 +2336,13 @@ func (*UploadPausedCheckpointResponse) Descriptor() ([]byte, []int) {
 }
 
 type RestoreRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	TargetAteomUid         string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
-	Atespace               string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	ActorName              string                 `protobuf:"bytes,3,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
-	ActorUid               string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,5,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	TargetAteomUid        string                 `protobuf:"bytes,1,opt,name=target_ateom_uid,json=targetAteomUid,proto3" json:"target_ateom_uid,omitempty"`
+	Atespace              string                 `protobuf:"bytes,2,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName             string                 `protobuf:"bytes,3,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid              string                 `protobuf:"bytes,4,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateAtespace string                 `protobuf:"bytes,5,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string                 `protobuf:"bytes,6,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
 	// Sandbox binary config is not sent on restore: the snapshot is
 	// self-describing. atelet reads the snapshot manifest to recover the pinned
 	// sandbox version that created it.
@@ -2434,9 +2434,9 @@ func (x *RestoreRequest) GetActorUid() string {
 	return ""
 }
 
-func (x *RestoreRequest) GetActorTemplateNamespace() string {
+func (x *RestoreRequest) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -2583,25 +2583,25 @@ const file_atelet_proto_rawDesc = "" +
 	"\x1bcertificate_signing_request\x18\x01 \x01(\fR\x19certificateSigningRequest\x12,\n" +
 	"\x12expected_actor_uid\x18\x02 \x01(\tR\x10expectedActorUid\"M\n" +
 	"\x1cMintActorCertificateResponse\x12-\n" +
-	"\x12actor_certificates\x18\x01 \x03(\fR\x11actorCertificates\"\xa8\x02\n" +
+	"\x12actor_certificates\x18\x01 \x03(\fR\x11actorCertificates\"\xa6\x02\n" +
 	"\x10TerminateRequest\x12(\n" +
 	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
 	"\batespace\x18\x02 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x03 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x04 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x05 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x04 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x05 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x06 \x01(\tR\x11actorTemplateName\x12(\n" +
 	"\x04spec\x18\a \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\"\x13\n" +
-	"\x11TerminateResponse\"\xf6\x03\n" +
+	"\x11TerminateResponse\"\xf4\x03\n" +
 	"\n" +
 	"RunRequest\x12(\n" +
 	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
 	"\batespace\x18\x02 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x03 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x04 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x05 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x04 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x05 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x06 \x01(\tR\x11actorTemplateName\x12(\n" +
 	"\x04spec\x18\a \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12<\n" +
 	"\x0esandbox_assets\x18\b \x01(\v2\x15.atelet.SandboxAssetsR\rsandboxAssets\x12A\n" +
@@ -2705,14 +2705,14 @@ const file_atelet_proto_rawDesc = "" +
 	"\x1cLocalCheckpointConfiguration\x12#\n" +
 	"\rsnapshot_name\x18\x01 \x01(\tR\fsnapshotName\"D\n" +
 	"\x1fExternalCheckpointConfiguration\x12!\n" +
-	"\fsnapshot_uri\x18\x01 \x01(\tR\vsnapshotUri\"\xab\x04\n" +
+	"\fsnapshot_uri\x18\x01 \x01(\tR\vsnapshotUri\"\xa9\x04\n" +
 	"\x11CheckpointRequest\x12(\n" +
 	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
 	"\batespace\x18\x02 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x03 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x04 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x05 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x04 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x05 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x06 \x01(\tR\x11actorTemplateName\x12(\n" +
 	"\x04spec\x18\a \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12*\n" +
 	"\x04type\x18\b \x01(\x0e2\x16.atelet.CheckpointTypeR\x04type\x12I\n" +
@@ -2721,25 +2721,25 @@ const file_atelet_proto_rawDesc = "" +
 	" \x01(\v2'.atelet.ExternalCheckpointConfigurationH\x00R\x0eexternalConfig\x12+\n" +
 	"\x05scope\x18\v \x01(\x0e2\x15.atelet.SnapshotScopeR\x05scopeB\b\n" +
 	"\x06config\"\x14\n" +
-	"\x12CheckpointResponse\"\x87\x03\n" +
+	"\x12CheckpointResponse\"\x85\x03\n" +
 	"\x1dUploadPausedCheckpointRequest\x12\x1a\n" +
 	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x02 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x04 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12.\n" +
 	"\x13local_snapshot_name\x18\x06 \x01(\tR\x11localSnapshotName\x128\n" +
 	"\x18destination_snapshot_uri\x18\a \x01(\tR\x16destinationSnapshotUri\x12:\n" +
 	"\rdesired_scope\x18\b \x01(\x0e2\x15.atelet.SnapshotScopeR\fdesiredScope\" \n" +
-	"\x1eUploadPausedCheckpointResponse\"\xee\x05\n" +
+	"\x1eUploadPausedCheckpointResponse\"\xec\x05\n" +
 	"\x0eRestoreRequest\x12(\n" +
 	"\x10target_ateom_uid\x18\x01 \x01(\tR\x0etargetAteomUid\x12\x1a\n" +
 	"\batespace\x18\x02 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x03 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x04 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x05 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x04 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x05 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x06 \x01(\tR\x11actorTemplateName\x12(\n" +
 	"\x04spec\x18\a \x01(\v2\x14.atelet.WorkloadSpecR\x04spec\x12*\n" +
 	"\x04type\x18\b \x01(\x0e2\x16.atelet.CheckpointTypeR\x04type\x12I\n" +

--- a/internal/proto/ateletpb/atelet.proto
+++ b/internal/proto/ateletpb/atelet.proto
@@ -69,7 +69,7 @@ message TerminateRequest {
   string actor_name = 3;
   string actor_uid = 4;
 
-  string actor_template_namespace = 5;
+  string actor_template_atespace = 5;
   string actor_template_name = 6;
 
   WorkloadSpec spec = 7;
@@ -85,7 +85,7 @@ message RunRequest {
   string actor_name = 3;
   string actor_uid = 4;
 
-  string actor_template_namespace = 5;
+  string actor_template_atespace = 5;
   string actor_template_name = 6;
 
   WorkloadSpec spec = 7;
@@ -337,7 +337,7 @@ message CheckpointRequest {
   string actor_name = 3;
   string actor_uid = 4;
 
-  string actor_template_namespace = 5;
+  string actor_template_atespace = 5;
   string actor_template_name = 6;
 
   // Sandbox binary config is not sent on checkpoint: atelet uses the version the
@@ -366,7 +366,7 @@ message UploadPausedCheckpointRequest {
   string actor_uid = 3;
 
   // For metrics attribution, like on CheckpointRequest.
-  string actor_template_namespace = 4;
+  string actor_template_atespace = 4;
   string actor_template_name = 5;
 
   // The local checkpoint to upload: LocalSnapshotInfo.snapshot_name recorded
@@ -394,7 +394,7 @@ message RestoreRequest {
   string actor_name = 3;
   string actor_uid = 4;
 
-  string actor_template_namespace = 5;
+  string actor_template_atespace = 5;
   string actor_template_name = 6;
 
   // Sandbox binary config is not sent on restore: the snapshot is

--- a/internal/proto/ateompb/ateom.pb.go
+++ b/internal/proto/ateompb/ateom.pb.go
@@ -269,16 +269,16 @@ func (NoSampleReason) EnumDescriptor() ([]byte, []int) {
 }
 
 type TerminateWorkloadRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	ActorName              string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
-	ActorUid               string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,6,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	Atespace              string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName             string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid              string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateAtespace string                 `protobuf:"bytes,4,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	RunscPath             string                 `protobuf:"bytes,6,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec                  *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *TerminateWorkloadRequest) Reset() {
@@ -332,9 +332,9 @@ func (x *TerminateWorkloadRequest) GetActorUid() string {
 	return ""
 }
 
-func (x *TerminateWorkloadRequest) GetActorTemplateNamespace() string {
+func (x *TerminateWorkloadRequest) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -397,14 +397,14 @@ func (*TerminateWorkloadResponse) Descriptor() ([]byte, []int) {
 }
 
 type RunWorkloadRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	ActorName              string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
-	ActorUid               string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,6,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	Atespace              string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName             string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid              string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateAtespace string                 `protobuf:"bytes,4,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	RunscPath             string                 `protobuf:"bytes,6,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec                  *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
 	// runtime_asset_paths maps a runtime asset name (e.g. "cloud-hypervisor",
 	// "virtiofsd", "kata-kernel", "kata-image", "kata-config")
 	// to the local on-disk path atelet fetched it to (content-addressed, like
@@ -473,9 +473,9 @@ func (x *RunWorkloadRequest) GetActorUid() string {
 	return ""
 }
 
-func (x *RunWorkloadRequest) GetActorTemplateNamespace() string {
+func (x *RunWorkloadRequest) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -1084,14 +1084,14 @@ func (*RunWorkloadResponse) Descriptor() ([]byte, []int) {
 }
 
 type CheckpointWorkloadRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	ActorName              string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
-	ActorUid               string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,6,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	Atespace              string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName             string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid              string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateAtespace string                 `protobuf:"bytes,4,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	RunscPath             string                 `protobuf:"bytes,6,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec                  *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
 	// The object storage URI of the snapshot to write. Object names are appended
 	// to it, so it addresses the snapshot as a whole rather than any one object.
 	//
@@ -1163,9 +1163,9 @@ func (x *CheckpointWorkloadRequest) GetActorUid() string {
 	return ""
 }
 
-func (x *CheckpointWorkloadRequest) GetActorTemplateNamespace() string {
+func (x *CheckpointWorkloadRequest) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -1260,14 +1260,14 @@ func (x *CheckpointWorkloadResponse) GetSnapshotFiles() []string {
 }
 
 type RestoreWorkloadRequest struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	Atespace               string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	ActorName              string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
-	ActorUid               string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	ActorTemplateNamespace string                 `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
-	RunscPath              string                 `protobuf:"bytes,6,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
-	Spec                   *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	Atespace              string                 `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName             string                 `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid              string                 `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateAtespace string                 `protobuf:"bytes,4,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string                 `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	RunscPath             string                 `protobuf:"bytes,6,opt,name=runsc_path,json=runscPath,proto3" json:"runsc_path,omitempty"`
+	Spec                  *WorkloadSpec          `protobuf:"bytes,7,opt,name=spec,proto3" json:"spec,omitempty"`
 	// The object storage URI of the snapshot to restore. Object names are
 	// appended to it; it addresses the snapshot, not any one object.
 	SnapshotUri string `protobuf:"bytes,8,opt,name=snapshot_uri,json=snapshotUri,proto3" json:"snapshot_uri,omitempty"`
@@ -1343,9 +1343,9 @@ func (x *RestoreWorkloadRequest) GetActorUid() string {
 	return ""
 }
 
-func (x *RestoreWorkloadRequest) GetActorTemplateNamespace() string {
+func (x *RestoreWorkloadRequest) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -1517,11 +1517,11 @@ type WorkloadStatsSample struct {
 	// RunWorkloadRequest / RestoreWorkloadRequest that started it. Echoed back so
 	// the caller can attribute the sample without holding its own mapping from
 	// worker to actor.
-	Atespace               string `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
-	ActorName              string `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
-	ActorUid               string `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
-	ActorTemplateNamespace string `protobuf:"bytes,4,opt,name=actor_template_namespace,json=actorTemplateNamespace,proto3" json:"actor_template_namespace,omitempty"`
-	ActorTemplateName      string `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
+	Atespace              string `protobuf:"bytes,1,opt,name=atespace,proto3" json:"atespace,omitempty"`
+	ActorName             string `protobuf:"bytes,2,opt,name=actor_name,json=actorName,proto3" json:"actor_name,omitempty"`
+	ActorUid              string `protobuf:"bytes,3,opt,name=actor_uid,json=actorUid,proto3" json:"actor_uid,omitempty"`
+	ActorTemplateAtespace string `protobuf:"bytes,4,opt,name=actor_template_atespace,json=actorTemplateAtespace,proto3" json:"actor_template_atespace,omitempty"`
+	ActorTemplateName     string `protobuf:"bytes,5,opt,name=actor_template_name,json=actorTemplateName,proto3" json:"actor_template_name,omitempty"`
 	// The sandbox runtime family that produced this sample.
 	SandboxClass SandboxClass `protobuf:"varint,6,opt,name=sandbox_class,json=sandboxClass,proto3,enum=ateom.SandboxClass" json:"sandbox_class,omitempty"`
 	// How the measurements below were obtained.
@@ -1607,9 +1607,9 @@ func (x *WorkloadStatsSample) GetActorUid() string {
 	return ""
 }
 
-func (x *WorkloadStatsSample) GetActorTemplateNamespace() string {
+func (x *WorkloadStatsSample) GetActorTemplateAtespace() string {
 	if x != nil {
-		return x.ActorTemplateNamespace
+		return x.ActorTemplateAtespace
 	}
 	return ""
 }
@@ -1842,24 +1842,24 @@ var File_ateom_proto protoreflect.FileDescriptor
 
 const file_ateom_proto_rawDesc = "" +
 	"\n" +
-	"\vateom.proto\x12\x05ateom\"\xa4\x02\n" +
+	"\vateom.proto\x12\x05ateom\"\xa2\x02\n" +
 	"\x18TerminateWorkloadRequest\x12\x1a\n" +
 	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x02 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x04 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12\x1d\n" +
 	"\n" +
 	"runsc_path\x18\x06 \x01(\tR\trunscPath\x12'\n" +
 	"\x04spec\x18\a \x01(\v2\x13.ateom.WorkloadSpecR\x04spec\"\x1b\n" +
-	"\x19TerminateWorkloadResponse\"\xdb\x04\n" +
+	"\x19TerminateWorkloadResponse\"\xd9\x04\n" +
 	"\x12RunWorkloadRequest\x12\x1a\n" +
 	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x02 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x04 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12\x1d\n" +
 	"\n" +
 	"runsc_path\x18\x06 \x01(\tR\trunscPath\x12'\n" +
@@ -1912,13 +1912,13 @@ const file_ateom_proto_rawDesc = "" +
 	"\rHTTPGetAction\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\"\x15\n" +
-	"\x13RunWorkloadResponse\"\xa3\x04\n" +
+	"\x13RunWorkloadResponse\"\xa1\x04\n" +
 	"\x19CheckpointWorkloadRequest\x12\x1a\n" +
 	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x02 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x04 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12\x1d\n" +
 	"\n" +
 	"runsc_path\x18\x06 \x01(\tR\trunscPath\x12'\n" +
@@ -1931,13 +1931,13 @@ const file_ateom_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"C\n" +
 	"\x1aCheckpointWorkloadResponse\x12%\n" +
-	"\x0esnapshot_files\x18\x01 \x03(\tR\rsnapshotFiles\"\xe2\x05\n" +
+	"\x0esnapshot_files\x18\x01 \x03(\tR\rsnapshotFiles\"\xe0\x05\n" +
 	"\x16RestoreWorkloadRequest\x12\x1a\n" +
 	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x02 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x04 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x12\x1d\n" +
 	"\n" +
 	"runsc_path\x18\x06 \x01(\tR\trunscPath\x12'\n" +
@@ -1956,13 +1956,13 @@ const file_ateom_proto_rawDesc = "" +
 	"\x0f_egress_gateway\"\x19\n" +
 	"\x17RestoreWorkloadResponse\"6\n" +
 	"\x17GetWorkloadStatsRequest\x12\x1b\n" +
-	"\tactor_uid\x18\x01 \x01(\tR\bactorUid\"\xad\x04\n" +
+	"\tactor_uid\x18\x01 \x01(\tR\bactorUid\"\xab\x04\n" +
 	"\x13WorkloadStatsSample\x12\x1a\n" +
 	"\batespace\x18\x01 \x01(\tR\batespace\x12\x1d\n" +
 	"\n" +
 	"actor_name\x18\x02 \x01(\tR\tactorName\x12\x1b\n" +
-	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x128\n" +
-	"\x18actor_template_namespace\x18\x04 \x01(\tR\x16actorTemplateNamespace\x12.\n" +
+	"\tactor_uid\x18\x03 \x01(\tR\bactorUid\x126\n" +
+	"\x17actor_template_atespace\x18\x04 \x01(\tR\x15actorTemplateAtespace\x12.\n" +
 	"\x13actor_template_name\x18\x05 \x01(\tR\x11actorTemplateName\x128\n" +
 	"\rsandbox_class\x18\x06 \x01(\x0e2\x13.ateom.SandboxClassR\fsandboxClass\x12*\n" +
 	"\x06source\x18\a \x01(\x0e2\x12.ateom.StatsSourceR\x06source\x120\n" +

--- a/internal/proto/ateompb/ateom.proto
+++ b/internal/proto/ateompb/ateom.proto
@@ -108,10 +108,8 @@ message TerminateWorkloadRequest {
   string atespace = 1;
   string actor_name = 2;
   string actor_uid = 3;
-
-  string actor_template_namespace = 4;
+  string actor_template_atespace = 4;
   string actor_template_name = 5;
-
   string runsc_path = 6;
   WorkloadSpec spec = 7;
 }
@@ -123,7 +121,7 @@ message RunWorkloadRequest {
   string atespace = 1;
   string actor_name = 2;
   string actor_uid = 3;
-  string actor_template_namespace = 4;
+  string actor_template_atespace = 4;
   string actor_template_name = 5;
 
   string runsc_path = 6;
@@ -262,8 +260,7 @@ message CheckpointWorkloadRequest {
   string atespace = 1;
   string actor_name = 2;
   string actor_uid = 3;
-
-  string actor_template_namespace = 4;
+  string actor_template_atespace = 4;
   string actor_template_name = 5;
 
   string runsc_path = 6;
@@ -301,7 +298,7 @@ message RestoreWorkloadRequest {
   string atespace = 1;
   string actor_name = 2;
   string actor_uid = 3;
-  string actor_template_namespace = 4;
+  string actor_template_atespace = 4;
   string actor_template_name = 5;
 
   string runsc_path = 6;
@@ -389,7 +386,7 @@ message WorkloadStatsSample {
   string atespace = 1;
   string actor_name = 2;
   string actor_uid = 3;
-  string actor_template_namespace = 4;
+  string actor_template_atespace = 4;
   string actor_template_name = 5;
 
   // The sandbox runtime family that produced this sample.

--- a/internal/resources/actorattribution.go
+++ b/internal/resources/actorattribution.go
@@ -23,8 +23,8 @@ package resources
 // (ateapi's ActorIdentity service, substratex509, ateompath.ActorIdentityDirPath)
 // — nothing here is a secret or is presented as proof of anything.
 type ActorAttribution struct {
-	Ref               ActorRef
-	UID               string
-	TemplateNamespace string
-	TemplateName      string
+	Ref              ActorRef
+	UID              string
+	TemplateAtespace string
+	TemplateName     string
 }


### PR DESCRIPTION
Both Atelet and Ateom internal APIs consume actor template namespace/name pair to telemetry. Updated them to use the new Substrate ActorTemplate proto instead of the legacy CRD one.