### PR TITLE
e2e: rename the WebSocket fixture's ateomImage to workerImage

### DIFF
--- a/internal/e2e/fixtures/testserver/websocket.yaml.tmpl
+++ b/internal/e2e/fixtures/testserver/websocket.yaml.tmpl
@@ -28,7 +28,7 @@ metadata:
     workload: websocket${FIXTURE_SUFFIX}
 spec:
   replicas: 1
-  ateomImage: ${ATEOM_IMAGE}
+  workerImage: ${ATEOM_IMAGE}
 ${WORKERPOOL_RUNTIME}
 
 ---


### PR DESCRIPTION
The WorkerPool field was renamed while the WebSocket fixture was in flight, so the fixture kept the old name and the render tests rejected it as an unknown field. It was the last occurrence in the tree.
