### PR TITLE
hack: let the kind node pull images in parallel [CI flake fix]

### DIFF
--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -112,6 +112,17 @@ runtimeConfig:
   "certificates.k8s.io/v1beta1": "true"
 networking:
   ipFamily: ${IP_FAMILY}
+# The install pulls ~570MB of third-party images (postgres, prometheus, the otel
+# collector, rustfs, envoy, jaeger) onto this one node. kubelet serializes image
+# pulls by default, so they queue behind one another and whichever workload draws
+# the back of the queue can miss its readiness deadline.
+# TODO: kind should probably default to parallel pulls for its single-node
+# clusters rather than leaving every user to patch it in.
+kubeadmConfigPatches:
+- |
+  kind: KubeletConfiguration
+  serializeImagePulls: false
+  maxParallelImagePulls: 4
 EOF
 
 echo "Deleting existing kind cluster '${KIND_CLUSTER_NAME}' if it exists..."


### PR DESCRIPTION
Installing the control plane pulls roughly 570MB of third-party images (postgres, prometheus, the otel collector, rustfs, envoy, jaeger) onto a single node. 

kubelet serializes image pulls by default, so they queue behind one another and whichever workload lands at the back of the queue can miss its readiness deadline.

e2e has failed repeatedly with postgres still in PodInitializing after 60s, its image not yet pulled, while everything else was already running.

Sample failure: https://github.com/agent-substrate/substrate/actions/runs/33258860897/job/99117220741

Note: This is after PR merge, and it's clearly unrelated to the PR.

AI-assisted.
