### PR TITLE
ateclient: spread RPCs over every ateapi replica

### DIFF
--- a/internal/ateclient/builder.go
+++ b/internal/ateclient/builder.go
@@ -63,6 +63,13 @@ type Client struct {
 }
 
 // Close closes the underlying gRPC connection and stops the port-forwarder.
+
+// roundRobinServiceConfig spreads RPCs over every address the resolver returns.
+// ateapi is a headless Service, so that is one address per replica, and gRPC's
+// default of pick_first would send an entire client's traffic to whichever one
+// it connected to first. internal/ateapiauth dials with the same policy.
+const roundRobinServiceConfig = `{"loadBalancingConfig": [{"round_robin":{}}]}`
+
 func (c *Client) Close() {
 	if c.tracerProvider != nil {
 		// Best practice to ensure clean provider shutdown, even though we skip exporters for clients.
@@ -118,6 +125,7 @@ func dialDirect(ctx context.Context, kubeconfigPath, k8sContext, endpoint, token
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
 	opts = append(opts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
+	opts = append(opts, grpc.WithDefaultServiceConfig(roundRobinServiceConfig))
 	tokenOpt, err := bearerTokenDialOption(ctx, clientset, tokenFile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
ateapi is a headless Service, so its DNS name resolves to one address per replica and the client picks. This one asked for no policy, which means gRPC's pick_first: it connects to whichever address answers first and sends everything there for the life of the connection.

So a client talks to one replica however many are running, and adding replicas moves no load. Measured with eight load generators against two replicas, one took 97% of the traffic.

internal/ateapiauth, which atelet and the controllers dial through, has asked for round_robin all along. This is the same policy for the clients that do not.

Pulled out from #1266, I ran into this while doing some custom benchmarking using ateclient, but this is already a bug for kubectl-ate, demos, ...

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

AI-assisted.