### PR TITLE
hack: wait for a pool's Deployment to exist before its rollout [CI flake fix]

### DIFF
--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -140,6 +140,26 @@ run_kubectl_fatal() {
   fi
 }
 
+# wait_for_pool_rollout waits for a WorkerPool's Deployment to roll out.
+# ate-controller creates that Deployment, so it does not exist yet when the
+# apply returns, and `kubectl rollout status` errors on a missing object rather
+# than waiting for it. Gate on creation first.
+wait_for_pool_rollout() {
+  local pool="$1" namespace="$2" timeout="${3:-300s}"
+  run_kubectl wait --for=create "deployment/${pool}" -n "${namespace}" \
+    --timeout="${timeout}" \
+    && run_kubectl rollout status "deployment/${pool}" -n "${namespace}" \
+      --timeout="${timeout}"
+}
+
+# wait_for_pool_rollout_fatal aborts the install on failure, like run_kubectl_fatal.
+wait_for_pool_rollout_fatal() {
+  if ! wait_for_pool_rollout "$@"; then
+    echo "error: worker pool $1 did not roll out" >&2
+    exit 1
+  fi
+}
+
 run_kubectl_ate() {
   go run ./cmd/kubectl-ate \
     ${KUBECTL_CONTEXT:+--context=${KUBECTL_CONTEXT}} \

--- a/hack/install-demo-autoscaled-workerpool.sh
+++ b/hack/install-demo-autoscaled-workerpool.sh
@@ -59,7 +59,7 @@ demo-autoscaled-workerpool_deploy() {
   run_kubectl apply -f demos/autoscaled-workerpool/hpa-kind.yaml
 
   log_step "Waiting for autoscaled-workerpool demo to be ready..."
-  run_kubectl rollout status deployment/counter -n ate-demo-autoscaled-workerpool --timeout=300s
+  wait_for_pool_rollout counter ate-demo-autoscaled-workerpool
   run_kubectl wait --for=condition=Ready actortemplate/counter -n ate-demo-autoscaled-workerpool --timeout=300s
 }
 

--- a/hack/install-demo-counter-substrate.sh
+++ b/hack/install-demo-counter-substrate.sh
@@ -90,7 +90,7 @@ demo-counter-substrate_deploy_variant() {
     | run_ko apply -f -
 
   log_step "Waiting for the ${pool} worker pool rollout..."
-  run_kubectl_fatal rollout status "deployment/${pool}" -n "${atespace}" --timeout=300s
+  wait_for_pool_rollout_fatal "${pool}" "${atespace}"
 
   # The store enforces that the template's atespace exists at create time.
   if ! run_kubectl_ate create atespace "${atespace}" >/dev/null 2>&1 \

--- a/hack/install-demo-counter.sh
+++ b/hack/install-demo-counter.sh
@@ -69,7 +69,7 @@ demo-counter_deploy() {
   # with a tight readiness deadline -- run against an already-warm node instead
   # of racing that cold-start work.
   log_step "Waiting for counter demo to be ready..."
-  run_kubectl_fatal rollout status deployment/counter -n ate-demo-counter --timeout=300s
+  wait_for_pool_rollout_fatal counter ate-demo-counter
   run_kubectl_fatal wait --for=condition=Ready actortemplate/counter -n ate-demo-counter --timeout=300s
 }
 

--- a/hack/install-demo-egress.sh
+++ b/hack/install-demo-egress.sh
@@ -83,7 +83,7 @@ demo-egress_deploy() {
   # The WorkerPool controller names the Deployment after the WorkerPool
   # ("egress"), the same way demo-counter gets "deployment/counter". The old
   # "egress-deployment" name was NotFound on every successful deploy.
-  run_kubectl rollout status deployment/egress -n ate-demo-egress --timeout=300s
+  wait_for_pool_rollout egress ate-demo-egress
   run_kubectl wait --for=condition=Ready actortemplate/egress -n ate-demo-egress --timeout=300s
 }
 
@@ -105,7 +105,7 @@ demo-egress-microvm_deploy() {
     | run_ko apply -f -
 
   log_step "Waiting for micro-VM egress demo to be ready..."
-  run_kubectl rollout status deployment/egress-microvm -n ate-demo-egress-microvm --timeout=300s
+  wait_for_pool_rollout egress-microvm ate-demo-egress-microvm
   # A micro-VM golden is a cloud-hypervisor cold boot plus a checkpoint, on
   # nested KVM in CI, so it needs a longer budget than the gVisor one above.
   run_kubectl wait --for=condition=Ready actortemplate/egress-microvm \
@@ -131,7 +131,7 @@ demo-egress-mitm_deploy() {
     | run_ko apply -f -
 
   log_step "Waiting for MITM egress demo to be ready..."
-  run_kubectl rollout status deployment/egress-mitm -n ate-demo-egress-mitm --timeout=300s
+  wait_for_pool_rollout egress-mitm ate-demo-egress-mitm
   # The golden snapshot only becomes Ready once an actor starts, and an actor
   # whose trust bundle does not resolve never does — so a timeout here is the
   # symptom of a missing sdsmint install (see demo-egress-mitm_usage).
@@ -158,8 +158,7 @@ demo-egress-microvm-mitm_deploy() {
     | run_ko apply -f -
 
   log_step "Waiting for micro-VM MITM egress demo to be ready..."
-  run_kubectl rollout status deployment/egress-microvm-mitm \
-    -n ate-demo-egress-microvm-mitm --timeout=300s
+  wait_for_pool_rollout egress-microvm-mitm ate-demo-egress-microvm-mitm
   # A micro-VM golden is a cloud-hypervisor cold boot plus a checkpoint, on
   # nested KVM in CI, so it needs a longer budget than the gVisor one above.
   run_kubectl wait --for=condition=Ready actortemplate/egress-microvm-mitm \

--- a/hack/install-demo-multi-template.sh
+++ b/hack/install-demo-multi-template.sh
@@ -37,7 +37,7 @@ demo-multi-template_deploy() {
 
   # Wait for both ActorTemplates to be ready before returning.
   log_step "Waiting for multi-template demo to be ready..."
-  run_kubectl rollout status deployment/shared-pool -n ate-demo-multi-template-pool --timeout=300s
+  wait_for_pool_rollout shared-pool ate-demo-multi-template-pool
   run_kubectl wait --for=condition=Ready actortemplate/counter -n ate-demo-multi-template-counter --timeout=300s
   run_kubectl wait --for=condition=Ready actortemplate/fspersist -n ate-demo-multi-template-fspersist --timeout=300s
 }

--- a/hack/install-demo-parking.sh
+++ b/hack/install-demo-parking.sh
@@ -38,7 +38,7 @@ demo-parking_deploy() {
   # Wait for the demo to be fully ready before returning: the small WorkerPool
   # must be rolled out and the ActorTemplate's golden snapshot built.
   log_step "Waiting for parking demo to be ready..."
-  run_kubectl rollout status deployment/parking -n ate-demo-parking --timeout=300s
+  wait_for_pool_rollout parking ate-demo-parking
   run_kubectl wait --for=condition=Ready actortemplate/parking -n ate-demo-parking --timeout=300s
 }
 


### PR DESCRIPTION
ate-controller creates a WorkerPool's Deployment, so it does not exist yet when the apply returns. 

`kubectl rollout status` reads the object before it starts watching and errors on a missing one instead of waiting, so whether these waits worked at all came down to beating the controller by a round trip. 

e2e lost that race by 178ms, failing the deploy with NotFound while the pool's pods were already being created.

Fixes yet another flake I observed here: https://github.com/agent-substrate/substrate/actions/runs/33275880827/job/99162382080?pr=1283
