### PR TITLE
api: make WorkerPool workerImage required again

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -11,7 +11,7 @@ The `WorkerPool` defines the pool of physical "warm" compute capacity. It manage
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `replicas` | `int32` | **Required.** Number of physical standby pods to maintain in the cluster. |
-| `workerImage` | `string` | Optional. The container image for the `ateom` herder process (e.g. `ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor`). When unset, the controller injects a versioned default image for the pool's `sandboxClass`. |
+| `workerImage` | `string` | **Required.** The container image for the `ateom` herder process (e.g. `ko://github.com/agent-substrate/substrate/cmd/ateom-gvisor`). |
 | `sandboxClass` | `string` | Optional. The sandbox runtime family for the pool: `gvisor` (default) or `microvm`. Drives the worker pod shape (e.g. KVM device mounts, node placement) and which `SandboxConfig`s are eligible. |
 | `sandboxConfigName` | `string` | Optional. Name of a cluster-scoped [`SandboxConfig`](#3-sandboxconfig-the-sandbox-itself) providing the sandbox binaries and pause image. If empty, the cluster default `SandboxConfig` for the pool's `sandboxClass` is used. |
 | `template` | `WorkerPoolPodTemplate` | **Optional.** Metadata, scheduling, and resource settings for worker workloads. |

--- a/manifests/ate-install/generated/ate.dev_workerpools.yaml
+++ b/manifests/ate-install/generated/ate.dev_workerpools.yaml
@@ -443,13 +443,13 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
               workerImage:
-                description: |-
-                  WorkerImage is the ateom container image to deploy as workers. When
-                  unset, the controller injects a versioned default image for the pool's
-                  SandboxClass.
+                description: WorkerImage is the ateom container image to deploy as
+                  workers.
+                minLength: 1
                 type: string
             required:
             - replicas
+            - workerImage
             type: object
             x-kubernetes-validations:
             - message: nvidia.com/gpu is only supported when sandboxClass is 'gvisor'

--- a/pkg/api/v1alpha1/workerpool_types.go
+++ b/pkg/api/v1alpha1/workerpool_types.go
@@ -85,11 +85,10 @@ type WorkerPoolSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	Replicas int32 `json:"replicas"`
 
-	// WorkerImage is the ateom container image to deploy as workers. When
-	// unset, the controller injects a versioned default image for the pool's
-	// SandboxClass.
-	// +optional
-	WorkerImage string `json:"workerImage,omitempty"`
+	// WorkerImage is the ateom container image to deploy as workers.
+	// +kubebuilder:validation:MinLength=1
+	// +required
+	WorkerImage string `json:"workerImage"`
 
 	// Template holds optional metadata, scheduling, and resource settings for worker workloads.
 	//

--- a/pkg/api/v1alpha1/workerpool_validation_test.go
+++ b/pkg/api/v1alpha1/workerpool_validation_test.go
@@ -64,11 +64,12 @@ func TestWorkerPoolValidation(t *testing.T) {
 		wantErr: true,
 		errMsg:  "spec.replicas: Invalid value: -1: spec.replicas in body should be greater than or equal to 0",
 	}, {
-		name: "unset workerImage is allowed",
+		name: "missing workerImage",
 		mutate: func(wp *WorkerPool) {
 			wp.Spec.WorkerImage = ""
 		},
-		wantErr: false,
+		wantErr: true,
+		errMsg:  "spec.workerImage: Invalid value: \"\": spec.workerImage in body should be at least 1 chars long",
 	}, {
 		name: "valid template",
 		mutate: func(wp *WorkerPool) {


### PR DESCRIPTION
We should not make workerImage optional as it provide explicit information for what image workers use, removing it will need `atecontroller` to inject workerImage and leads to unnecessary control plane & dataplane wiring.



Fixes #861 

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
