### PR TITLE
csi-hostpath: fix cert rotation in the testing Envoy config

### DIFF
--- a/cmd/ate-setup/internal/steps/overlay_test.go
+++ b/cmd/ate-setup/internal/steps/overlay_test.go
@@ -55,10 +55,16 @@ func TestEmitAdditionalEgressExtprocCluster(t *testing.T) {
 	if strings.Contains(out, "tls_certificates:") {
 		t.Error("emitted cluster block still carries an inline tls_certificates entry")
 	}
+	// watched_directory belongs in the SDS resource files, not here: on an
+	// inline entry Envoy silently ignores it.
+	if strings.Contains(out, "watched_directory") {
+		t.Error("emitted cluster block contains watched_directory")
+	}
 }
 
-// Splices the real sdsmint manifest and re-parses the result; this path has
-// no e2e coverage in CI.
+// Splices the real sdsmint manifest and re-parses the result. CI deploys the
+// sdsmint variant but never with the extproc flag, so this is the only
+// automated check on the injected cluster.
 func TestPatchAtenetEgressManifest(t *testing.T) {
 	root, err := config.RepoRoot()
 	if err != nil {
@@ -128,6 +134,19 @@ func TestPatchAtenetEgressManifest(t *testing.T) {
 	} {
 		if !strings.Contains(envoyYaml, want) {
 			t.Errorf("patched envoy.yaml is missing %q", want)
+		}
+	}
+	// watched_directory must live only in the SDS resource files; on an
+	// inline entry in the bootstrap Envoy silently ignores it. Comment
+	// lines may mention it.
+	for _, line := range strings.Split(envoyYaml, "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "#") && strings.Contains(line, "watched_directory") {
+			t.Errorf("patched envoy.yaml contains watched_directory outside the SDS resource files: %q", line)
+		}
+	}
+	for _, key := range []string{"sds-servicedns-cert.yaml", "sds-podidentity-cert.yaml", "sds-servicedns-validation.yaml"} {
+		if !strings.Contains(data[key], "watched_directory") {
+			t.Errorf("SDS resource %q is missing watched_directory; rotation would be silently broken", key)
 		}
 	}
 }

--- a/docs/csi-deployment.md
+++ b/docs/csi-deployment.md
@@ -70,6 +70,10 @@ metadata:
   namespace: kube-system
 data:
   envoy.yaml: |
+    # SDS (used for the TLS certs below) requires a node id and cluster.
+    node:
+      id: csi-nfs-envoy
+      cluster: csi-nfs-envoy
     static_resources:
       listeners:
       - name: grpc_listener

--- a/hack/third_party/csi-driver-host-path/deploy/csi-hostpath-testing.yaml
+++ b/hack/third_party/csi-driver-host-path/deploy/csi-hostpath-testing.yaml
@@ -19,6 +19,10 @@ metadata:
     app.kubernetes.io/component: envoy
 data:
   envoy.yaml: |
+    # SDS (used for the TLS certs below) requires a node id and cluster.
+    node:
+      id: csi-hostpath-envoy
+      cluster: csi-hostpath-envoy
     admin:
       address:
         socket_address: { address: 127.0.0.1, port_value: 15000 }
@@ -36,17 +40,27 @@ data:
               common_tls_context:
                 alpn_protocols:
                 - h2
-                tls_certificates:
-                - certificate_chain: { filename: /run/servicedns/credential-bundle.pem }
-                  private_key: { filename: /run/servicedns/credential-bundle.pem }
-                  watched_directory: { path: /run/servicedns }
-                validation_context:
-                  trusted_ca: { filename: /run/podidentity-ca/trust-bundle.pem }
-                  watched_directory: { path: /run/podidentity-ca }
-                  match_typed_subject_alt_names:
-                  - san_type: URI
-                    matcher:
-                      exact: "spiffe://cluster.local/ns/ate-system/sa/ate-api-server"
+                # Serving cert and trust bundle via filesystem SDS (the
+                # sds-*.yaml keys below): watched_directory only works on
+                # SDS-delivered secrets.
+                tls_certificate_sds_secret_configs:
+                - name: servicedns_serving_cert
+                  sds_config:
+                    resource_api_version: V3
+                    path_config_source:
+                      path: /etc/envoy/sds-servicedns-cert.yaml
+                combined_validation_context:
+                  default_validation_context:
+                    match_typed_subject_alt_names:
+                    - san_type: URI
+                      matcher:
+                        exact: "spiffe://cluster.local/ns/ate-system/sa/ate-api-server"
+                  validation_context_sds_secret_config:
+                    name: podidentity_validation_context
+                    sds_config:
+                      resource_api_version: V3
+                      path_config_source:
+                        path: /etc/envoy/sds-podidentity-validation.yaml
           filters:
           - name: envoy.filters.network.tcp_proxy
             typed_config:
@@ -65,6 +79,22 @@ data:
                 address:
                   pipe:
                     path: /csi/csi.sock
+  # SDS resources referenced by the listener above.
+  sds-servicedns-cert.yaml: |
+    resources:
+    - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+      name: servicedns_serving_cert
+      tls_certificate:
+        certificate_chain: { filename: /run/servicedns/credential-bundle.pem }
+        private_key: { filename: /run/servicedns/credential-bundle.pem }
+        watched_directory: { path: /run/servicedns }
+  sds-podidentity-validation.yaml: |
+    resources:
+    - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+      name: podidentity_validation_context
+      validation_context:
+        trusted_ca: { filename: /run/podidentity-ca/trust-bundle.pem }
+        watched_directory: { path: /run/podidentity-ca }
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Follow-up to the review comments on #1288 (merged before they could land there).

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

Changes:
- `hack/third_party/csi-driver-host-path/deploy/csi-hostpath-testing.yaml`: same fix as #1288 — the inline `watched_directory` was a no-op, so the serving cert and trust bundle move to filesystem SDS (SPIFFE SAN pin kept inline via `combined_validation_context`). SDS requires a node id and this sidecar passes no `--service-node`, so the bootstrap gains a `node:` stanza; the `docs/csi-deployment.md` example had the same gap and gets one too.
- `overlay_test.go` now asserts `watched_directory` appears nowhere in the emitted cluster block or the patched `envoy.yaml` (comments excluded) and is present in each SDS resource file, per review.
- Corrected the test comment claiming the sdsmint e2e suite is skipped in CI: the sdsmint variant is deployed in the MITM lanes; only the `--experimental-additional-egress-extproc-service` injection has no e2e coverage.

Verification: `go test ./cmd/ate-setup/...` passes; `envoy --mode validate` (v1.34) passes on the reworked csi-hostpath bootstrap with dummy PEMs mounted at the referenced paths.
