### PR TITLE
ateom: write the guest resolv.conf through os.Root

### DIFF
--- a/cmd/ateom-microvm/run.go
+++ b/cmd/ateom-microvm/run.go
@@ -217,6 +217,10 @@ func (s *AteomService) resolveRuntime(paths map[string]string) resolvedRuntime {
 // bundle rootfs (the overlay RO lower) so the guest gets cluster DNS: ateom drops
 // atelet's resolv.conf bind and sends no CreateSandbox.Dns, so the guest can
 // otherwise reach IPs but not resolve names.
+//
+// The rootfs is untrusted, so the write goes through os.Root and unlinks rather
+// than truncates: an image-planted /etc or /etc/resolv.conf symlink would
+// otherwise be followed and clobber that path on the worker pod as root.
 func writeGuestResolvConf(rootfs string) error {
 	content, err := os.ReadFile("/etc/resolv.conf")
 	if err != nil {
@@ -225,11 +229,26 @@ func writeGuestResolvConf(rootfs string) error {
 	if len(content) == 0 {
 		return fmt.Errorf("host /etc/resolv.conf is empty")
 	}
-	etc := filepath.Join(rootfs, "etc")
-	if err := os.MkdirAll(etc, 0o755); err != nil {
-		return fmt.Errorf("creating %q: %w", etc, err)
+	root, err := os.OpenRoot(rootfs)
+	if err != nil {
+		return fmt.Errorf("opening rootfs %q: %w", rootfs, err)
 	}
-	if err := os.WriteFile(filepath.Join(etc, "resolv.conf"), content, 0o644); err != nil {
+	defer root.Close()
+	if err := root.Mkdir("etc", 0o755); err != nil && !errors.Is(err, fs.ErrExist) {
+		return fmt.Errorf("creating %q: %w", filepath.Join(rootfs, "etc"), err)
+	}
+	if err := root.Remove("etc/resolv.conf"); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("removing existing guest resolv.conf: %w", err)
+	}
+	f, err := root.OpenFile("etc/resolv.conf", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("creating guest resolv.conf: %w", err)
+	}
+	_, err = f.Write(content)
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
 		return fmt.Errorf("writing guest resolv.conf: %w", err)
 	}
 	return nil

--- a/cmd/ateom-microvm/run_test.go
+++ b/cmd/ateom-microvm/run_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -28,6 +29,70 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateom-microvm/internal/kata"
 )
+
+// A symlink planted in the image at /etc or /etc/resolv.conf must not be followed
+// out of the rootfs, or the image picks what ateom overwrites as root.
+func TestWriteGuestResolvConfSymlinkEscape(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		link string // rootfs-relative path planted as a symlink to the canary
+		// A planted resolv.conf is just unlinked; only an escaping directory fails.
+		wantErr bool
+	}{
+		{name: "etc dir", link: "etc", wantErr: true},
+		{name: "resolv.conf", link: "etc/resolv.conf"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			canary := filepath.Join(dir, "canary")
+			if err := os.WriteFile(canary, []byte("INITIAL_STATE"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			rootfs := filepath.Join(dir, "rootfs")
+			if err := os.MkdirAll(filepath.Join(rootfs, filepath.Dir(tc.link)), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(canary, filepath.Join(rootfs, tc.link)); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := writeGuestResolvConf(rootfs); (err != nil) != tc.wantErr {
+				t.Errorf("writeGuestResolvConf(%q) error = %v, wantErr %v", rootfs, err, tc.wantErr)
+			}
+			got, err := os.ReadFile(canary)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != "INITIAL_STATE" {
+				t.Errorf("canary = %q, want it untouched: the symlink was followed out of the rootfs", got)
+			}
+		})
+	}
+}
+
+func TestWriteGuestResolvConf(t *testing.T) {
+	want, err := os.ReadFile("/etc/resolv.conf")
+	if err != nil || len(want) == 0 {
+		t.Skipf("no host /etc/resolv.conf to copy: %v", err)
+	}
+	rootfs := t.TempDir()
+
+	if err := writeGuestResolvConf(rootfs); err != nil {
+		t.Fatalf("writeGuestResolvConf(%q) = %v", rootfs, err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(rootfs, "etc", "resolv.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("guest resolv.conf = %q, want %q", got, want)
+	}
+	// A second boot of the same bundle must not fail on the file it just wrote.
+	if err := writeGuestResolvConf(rootfs); err != nil {
+		t.Errorf("writeGuestResolvConf(%q) second call = %v", rootfs, err)
+	}
+}
 
 // A vsock socket that has gone missing means cloud-hypervisor stopped the VM
 // (it unlinks the socket in the vsock device's shutdown), so the poll must give


### PR DESCRIPTION
The bundle rootfs comes from an untrusted actor image, and the plain os.MkdirAll/os.WriteFile pair followed symlinks out of it: an image with /etc or /etc/resolv.conf pointing at a worker pod path had ateom, running as root, truncate and overwrite that path. Confine the write to the rootfs with os.Root and unlink any existing entry instead of truncating through it.
