### PR TITLE
ateom: create the OCI mountpoints through os.Root

### DIFF
--- a/cmd/ateom-microvm/internal/kata/overlay_linux.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux.go
@@ -28,8 +28,10 @@ package kata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -247,8 +249,28 @@ func StageMergedRootfs(ctx context.Context, bundleRootfs, upperBase, restoreID, 
 	// mounts /proc,/sys,/dev over them, and find-paths re-opens the tree by path on
 	// restore, so the layout must match on every node. Created in the MERGED tree, so
 	// they land in the upper (and ride the snapshot tar) rather than dirtying the image.
+	if err := ensureOCIMountpoints(dst); err != nil {
+		return fmt.Errorf("creating OCI mountpoints under %q: %w", dst, err)
+	}
+	return nil
+}
+
+// ensureOCIMountpoints creates the /proc, /sys and /dev mountpoints in a container
+// rootfs. Neither layer of that rootfs is trusted — the lower is the actor's image
+// and the upper is restored from the snapshot the guest wrote — so it goes through
+// os.Root: a plain MkdirAll would follow a symlink planted at one of those names and
+// create the directory wherever it points on the worker pod, as root. An entry that
+// already exists (including a symlink that stays inside the rootfs) is left alone.
+func ensureOCIMountpoints(rootfs string) error {
+	root, err := os.OpenRoot(rootfs)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
 	for _, d := range []string{"proc", "sys", "dev"} {
-		_ = os.MkdirAll(filepath.Join(dst, d), 0o755)
+		if err := root.Mkdir(d, 0o755); err != nil && !errors.Is(err, fs.ErrExist) {
+			return err
+		}
 	}
 	return nil
 }
@@ -334,9 +356,9 @@ func ReconstructSharedDirFromImage(ctx context.Context, bundleRootfs, restoreID,
 	}
 	// Ensure the standard OCI mountpoints exist even for minimal images: the container
 	// mounts /proc,/sys,/dev over them, and find-paths re-opens the lower by path on
-	// restore, so the layout must match on every node. (Bind still writable; ignore EEXIST.)
-	for _, d := range []string{"proc", "sys", "dev"} {
-		_ = os.MkdirAll(filepath.Join(dst, d), 0o755)
+	// restore, so the layout must match on every node. (Bind still writable.)
+	if err := ensureOCIMountpoints(dst); err != nil {
+		return fmt.Errorf("creating OCI mountpoints under %q: %w", dst, err)
 	}
 	// Remount read-only: the lower is immutable, so all writes go to the overlay upper
 	// and it stays byte-identical across reconstructions (required by find-paths migration).

--- a/cmd/ateom-microvm/internal/kata/overlay_linux_test.go
+++ b/cmd/ateom-microvm/internal/kata/overlay_linux_test.go
@@ -17,11 +17,45 @@
 package kata
 
 import (
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 )
+
+// The container rootfs is untrusted (the image below, the guest's own snapshot
+// upper above): a symlink planted at proc/sys/dev must not send the mountpoint
+// mkdir somewhere else on the worker pod.
+func TestEnsureOCIMountpoints(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "outside")
+	rootfs := filepath.Join(dir, "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootfs, "realsys"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// proc escapes, sys is an in-rootfs symlink to an existing dir, dev is absent.
+	if err := os.Symlink(filepath.Join(outside, "proc"), filepath.Join(rootfs, "proc")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("realsys", filepath.Join(rootfs, "sys")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureOCIMountpoints(rootfs); err != nil {
+		t.Fatalf("ensureOCIMountpoints(%q) = %v", rootfs, err)
+	}
+
+	if _, err := os.Lstat(outside); !os.IsNotExist(err) {
+		t.Errorf("Lstat(%q) = %v, want it never created: the symlink was followed out of the rootfs", outside, err)
+	}
+	if fi, err := os.Stat(filepath.Join(rootfs, "dev")); err != nil || !fi.IsDir() {
+		t.Errorf("dev: Stat = %v, %v; want a directory", fi, err)
+	}
+	if got, err := os.Readlink(filepath.Join(rootfs, "sys")); err != nil || got != "realsys" {
+		t.Errorf("sys: Readlink = %q, %v; want the in-rootfs symlink left alone", got, err)
+	}
+}
 
 // The kernel requires overlay upperdir and workdir on the same filesystem and
 // rejects a workdir nested inside (or equal to) upperdir — so they must be


### PR DESCRIPTION
The proc/sys/dev mountpoints were created with os.MkdirAll on paths inside the container rootfs, whose lower is the actor's image and whose upper is restored from the guest's own snapshot. A symlink planted at one of those names sent the mkdir wherever it pointed on the worker pod, created by ateom as root. Confine it to the rootfs with os.Root, in both the merged-overlay and the reconstructed-from-image staging paths.