### PR TITLE
Report the actor template atespace in OTel tags

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor.go
+++ b/cmd/ateapi/internal/controlapi/actor.go
@@ -51,8 +51,8 @@ func (s *RPCService) CreateActor(ctx context.Context, req *ateapipb.CreateActorR
 	// validated request; malformed ones stay visible in rpc.server.call.duration.
 	defer func() {
 		s.instruments.recordLifecycleOp(ctx, ateattr.OperationCreate, start, err,
-			ateattr.TemplateNameKey.String(inActor.GetActorTemplateName()),
-			ateattr.TemplateNamespaceKey.String(inActor.GetActorTemplateNamespace()),
+			ateattr.TemplateNameKey.String(inActor.GetActorTemplate().GetName()),
+			ateattr.TemplateAtespaceKey.String(inActor.GetActorTemplate().GetAtespace()),
 		)
 	}()
 
@@ -343,8 +343,8 @@ func (s *RPCService) DeleteActor(ctx context.Context, req *ateapipb.DeleteActorR
 		var attrs []attribute.KeyValue
 		if deleted != nil {
 			attrs = append(attrs,
-				ateattr.TemplateNameKey.String(deleted.GetActorTemplateName()),
-				ateattr.TemplateNamespaceKey.String(deleted.GetActorTemplateNamespace()),
+				ateattr.TemplateNameKey.String(deleted.GetActorTemplate().GetName()),
+				ateattr.TemplateAtespaceKey.String(deleted.GetActorTemplate().GetAtespace()),
 			)
 		}
 		s.instruments.recordLifecycleOp(ctx, ateattr.OperationDelete, start, err, attrs...)

--- a/cmd/ateapi/internal/controlapi/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_test.go
@@ -48,10 +48,6 @@ func TestValidateCreateActorRequest(t *testing.T) {
 	withActorTemplate := withActorActorTemplate
 	withSourceSnapshotTag := withActorSourceSnapshotTag
 	withWorkerSelector := withActorWorkerSelector
-	// refOnly switches the fixture to the substrate reference form.
-	refOnly := func(a *ateapipb.Actor) {
-		a.ActorTemplateNamespace, a.ActorTemplateName = "", ""
-	}
 
 	tests := []struct {
 		name string
@@ -90,24 +86,24 @@ func TestValidateCreateActorRequest(t *testing.T) {
 		validReq(validActor(withMetadata(func(m *ateapipb.ResourceMetadata) { m.Name = "ID1" }))),
 		field.ErrorList{field.Invalid(field.NewPath("actor", "metadata", "name"), nil, "").WithOrigin("format=k8s-short-name")},
 	}, {
-		"valid actor.actor_template instead of legacy pair",
-		validReq(validActor(refOnly, withActorTemplate("as", "tmpl"))),
+		"valid actor.actor_template",
+		validReq(validActor(withActorTemplate("as", "tmpl"))),
 		nil,
 	}, {
 		"missing actor.actor_template.atespace",
-		validReq(validActor(refOnly, withActorTemplate("", "tmpl"))),
+		validReq(validActor(withActorTemplate("", "tmpl"))),
 		field.ErrorList{field.Required(field.NewPath("actor", "actor_template", "atespace"), "")},
 	}, {
 		"invalid actor.actor_template.atespace",
-		validReq(validActor(refOnly, withActorTemplate("invalid value", "tmpl"))),
+		validReq(validActor(withActorTemplate("invalid value", "tmpl"))),
 		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template", "atespace"), nil, "").WithOrigin("format=k8s-short-name")},
 	}, {
 		"missing actor.actor_template.name",
-		validReq(validActor(refOnly, withActorTemplate("as", ""))),
+		validReq(validActor(withActorTemplate("as", ""))),
 		field.ErrorList{field.Required(field.NewPath("actor", "actor_template", "name"), "")},
 	}, {
 		"invalid actor.actor_template.name",
-		validReq(validActor(refOnly, withActorTemplate("as", "invalid value"))),
+		validReq(validActor(withActorTemplate("as", "invalid value"))),
 		field.ErrorList{field.Invalid(field.NewPath("actor", "actor_template", "name"), nil, "").WithOrigin("format=k8s-short-name")},
 	}, {
 		"valid actor.source_snapshot_tag",
@@ -225,43 +221,14 @@ func TestValidateActorUpdate(t *testing.T) {
 		validOutput(withMetadata(func(m *ateapipb.ResourceMetadata) { m.Name = "invalid value" })),
 		field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), nil, "").WithOrigin("immutable")},
 	}, {
-		"missing actor.actor_template_namespace",
-		validInput(),
-		validOutput(func(a *ateapipb.Actor) { a.ActorTemplateNamespace = "" }),
-		field.ErrorList{
-			field.Invalid(field.NewPath("actor_template_namespace"), nil, "").WithOrigin("immutable"),
-		},
-	}, {
-		"invalid actor.actor_template_namespace",
-		validInput(),
-		validOutput(func(a *ateapipb.Actor) { a.ActorTemplateNamespace = "invalid value" }),
-		field.ErrorList{field.Invalid(field.NewPath("actor_template_namespace"), nil, "").WithOrigin("immutable")},
-	}, {
-		"missing actor.actor_template_name",
-		validInput(),
-		validOutput(func(a *ateapipb.Actor) { a.ActorTemplateName = "" }),
-		field.ErrorList{
-			field.Invalid(field.NewPath("actor_template_name"), nil, "").WithOrigin("immutable"),
-		},
-	}, {
-		"invalid actor.actor_template_name",
-		validInput(),
-		validOutput(func(a *ateapipb.Actor) { a.ActorTemplateName = "invalid value" }),
-		field.ErrorList{field.Invalid(field.NewPath("actor_template_name"), nil, "").WithOrigin("immutable")},
-	}, {
-		"add actor.actor_template",
-		validInput(),
-		validOutput(withActorTemplate("as", "nm")),
+		"change actor.actor_template",
+		validInput(withActorTemplate("as1", "nm1")),
+		validOutput(withActorTemplate("as2", "nm2")),
 		field.ErrorList{field.Invalid(field.NewPath("actor_template"), nil, "").WithOrigin("immutable")},
 	}, {
 		"clear actor.actor_template",
 		validInput(withActorTemplate("as", "nm")),
 		validOutput(func(a *ateapipb.Actor) { a.ActorTemplate = nil }),
-		field.ErrorList{field.Invalid(field.NewPath("actor_template"), nil, "").WithOrigin("immutable")},
-	}, {
-		"change actor.actor_template",
-		validInput(withActorTemplate("as1", "nm1")),
-		validOutput(withActorTemplate("as2", "nm2")),
 		field.ErrorList{field.Invalid(field.NewPath("actor_template"), nil, "").WithOrigin("immutable")},
 	}, {
 		"add actor.source_snapshot_tag",
@@ -599,9 +566,8 @@ func TestUpdateActor(t *testing.T) {
 			name:   "sets a worker_selector the stored actor does not have",
 			stored: &ateapipb.Actor{},
 			req: &ateapipb.Actor{
-				ActorTemplateNamespace: templateNS,
-				ActorTemplateName:      templateName,
-				WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
+				ActorTemplate:  &ateapipb.ObjectRef{Atespace: templateNS, Name: templateName},
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
 			},
 			want: &ateapipb.Actor{WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}}},
 		},
@@ -609,9 +575,8 @@ func TestUpdateActor(t *testing.T) {
 			name:   "overwrites an existing worker_selector",
 			stored: &ateapipb.Actor{WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}}},
 			req: &ateapipb.Actor{
-				ActorTemplateNamespace: templateNS,
-				ActorTemplateName:      templateName,
-				WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
+				ActorTemplate:  &ateapipb.ObjectRef{Atespace: templateNS, Name: templateName},
+				WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
 			},
 			want: &ateapipb.Actor{WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}}},
 		},
@@ -619,8 +584,7 @@ func TestUpdateActor(t *testing.T) {
 			name:   "an omitted worker_selector is cleared",
 			stored: &ateapipb.Actor{WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}}},
 			req: &ateapipb.Actor{
-				ActorTemplateNamespace: templateNS,
-				ActorTemplateName:      templateName,
+				ActorTemplate: &ateapipb.ObjectRef{Atespace: templateNS, Name: templateName},
 			},
 			want: &ateapipb.Actor{},
 		},
@@ -628,10 +592,9 @@ func TestUpdateActor(t *testing.T) {
 			name:   "SourceSnapshotTag immutable field is kept",
 			stored: &ateapipb.Actor{SourceSnapshotTag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag1"}},
 			req: &ateapipb.Actor{
-				ActorTemplateNamespace: templateNS,
-				ActorTemplateName:      templateName,
-				SourceSnapshotTag:      &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag1"},
-				WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
+				ActorTemplate:     &ateapipb.ObjectRef{Atespace: templateNS, Name: templateName},
+				SourceSnapshotTag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag1"},
+				WorkerSelector:    &ateapipb.Selector{MatchLabels: map[string]string{"tier": "paid"}},
 			},
 			want: &ateapipb.Actor{
 				SourceSnapshotTag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag1"},
@@ -642,9 +605,8 @@ func TestUpdateActor(t *testing.T) {
 			name:   "changes to status in the request are ignored",
 			stored: &ateapipb.Actor{},
 			req: &ateapipb.Actor{
-				ActorTemplateNamespace: templateNS,
-				ActorTemplateName:      templateName,
-				Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
+				ActorTemplate: &ateapipb.ObjectRef{Atespace: templateNS, Name: templateName},
+				Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
 			},
 			want: &ateapipb.Actor{},
 		},
@@ -652,8 +614,7 @@ func TestUpdateActor(t *testing.T) {
 			name:   "an omitted immutable field is rejected",
 			stored: &ateapipb.Actor{SourceSnapshotTag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag1"}},
 			req: &ateapipb.Actor{
-				ActorTemplateNamespace: templateNS,
-				ActorTemplateName:      templateName,
+				ActorTemplate: &ateapipb.ObjectRef{Atespace: templateNS, Name: templateName},
 				// Omitted SourceSnapshotTag
 			},
 			wantCode: codes.InvalidArgument,
@@ -662,9 +623,8 @@ func TestUpdateActor(t *testing.T) {
 			name:   "an immutable field the request rewrites is rejected",
 			stored: &ateapipb.Actor{SourceSnapshotTag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag1"}},
 			req: &ateapipb.Actor{
-				ActorTemplateNamespace: "attacker-ns",
-				ActorTemplateName:      "attacker-tmpl",
-				SourceSnapshotTag:      &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag2"},
+				ActorTemplate:     &ateapipb.ObjectRef{Atespace: "attacker-ns", Name: "attacker-tmpl"},
+				SourceSnapshotTag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tag2"},
 			},
 			wantCode: codes.InvalidArgument,
 		},
@@ -672,8 +632,7 @@ func TestUpdateActor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.stored.Metadata = &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID}
-			tt.stored.ActorTemplateNamespace = templateNS
-			tt.stored.ActorTemplateName = templateName
+			tt.stored.ActorTemplate = &ateapipb.ObjectRef{Atespace: templateNS, Name: templateName}
 			tt.stored.Status = &ateapipb.ActorStatus{
 				State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
 			}
@@ -694,8 +653,7 @@ func TestUpdateActor(t *testing.T) {
 			}
 
 			tt.want.Metadata = &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID, Version: 2}
-			tt.want.ActorTemplateNamespace = templateNS
-			tt.want.ActorTemplateName = templateName
+			tt.want.ActorTemplate = &ateapipb.ObjectRef{Atespace: templateNS, Name: templateName}
 			tt.want.Status = &ateapipb.ActorStatus{
 				State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
 			}
@@ -718,9 +676,8 @@ func TestUpdateActor_DeleteRecreateRace(t *testing.T) {
 	// Actor A: what the client reads, and what its uid precondition names.
 	// Freshly created, so it sits at version 1.
 	original := storetest.MustCreateActor(t, ctx, persistence, &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
-		ActorTemplateNamespace: "ns1",
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl1"},
 		Status: &ateapipb.ActorStatus{
 			State:            ateapipb.ActorState_ACTOR_STATE_RUNNING,
 			WorkerAssignment: &ateapipb.WorkerAssignment{WorkerPod: "pod-a"},
@@ -745,10 +702,9 @@ func TestUpdateActor_DeleteRecreateRace(t *testing.T) {
 				t.Fatalf("racing writer: DeleteActor: %v", err)
 			}
 			recreated, err = persistence.CreateActor(ctx, &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
-				ActorTemplateNamespace: "ns1",
-				ActorTemplateName:      "tmpl1",
-				Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
+				Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+				ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl1"},
+				Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
 			})
 			if err != nil {
 				t.Fatalf("racing writer: recreate CreateActor: %v", err)
@@ -798,10 +754,9 @@ func TestUpdateActor_ConcurrentDisjointUpdates(t *testing.T) {
 	actorRef := resources.ActorRef{Atespace: testAtespace, Name: testActorID}
 
 	original := storetest.MustCreateActor(t, ctx, persistence, &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
-		ActorTemplateNamespace: "ns1",
-		ActorTemplateName:      "tmpl1",
-		Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl1"},
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
 	})
 
 	// A suspend workflow bumps state (a field that a later update operation will not touch)
@@ -843,9 +798,8 @@ func TestUpdateActor_ConcurrentDisjointUpdates(t *testing.T) {
 // validActor returns a minimal Actor which should pass input validation.
 func validActor(mods ...func(*ateapipb.Actor)) *ateapipb.Actor {
 	a := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"},
-		ActorTemplateNamespace: "ns1",
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: "ns1", Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl1"},
 	}
 	for _, m := range mods {
 		m(a)

--- a/cmd/ateapi/internal/controlapi/crash_test.go
+++ b/cmd/ateapi/internal/controlapi/crash_test.go
@@ -442,8 +442,7 @@ func TestCrashActor_Metrics(t *testing.T) {
 			Name:     "counter-actor",
 			Uid:      "actor-uid-1",
 		},
-		ActorTemplateNamespace: "demo-ns",
-		ActorTemplateName:      "counter-template",
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "demo-ns", Name: "counter-template"},
 		Status: &ateapipb.ActorStatus{
 			State: ateapipb.ActorState_ACTOR_STATE_RUNNING,
 			WorkerAssignment: &ateapipb.WorkerAssignment{
@@ -483,7 +482,7 @@ func assertCrashMetricDatapoint(t *testing.T, reader *sdkmetric.ManualReader, wa
 			for _, dp := range sum.DataPoints {
 				op, _ := dp.Attributes.Value(ateattr.ActorOperationNameKey)
 				r, _ := dp.Attributes.Value(ateattr.FailureReasonKey)
-				tNS, _ := dp.Attributes.Value(ateattr.TemplateNamespaceKey)
+				tNS, _ := dp.Attributes.Value(ateattr.TemplateAtespaceKey)
 				tName, _ := dp.Attributes.Value(ateattr.TemplateNameKey)
 				wp, _ := dp.Attributes.Value(ateattr.WorkerPoolNameKey)
 				sc, _ := dp.Attributes.Value(ateattr.SandboxClassKey)

--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/internal/volume"
-	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -39,14 +38,12 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // TestCreateActor_Success tests the happy path for creating an actor.
 // Workflow:
-// 1. Creates a mock ActorTemplate in the test namespace.
+// 1. Creates a mock ActorTemplate in the test atespace.
 // 2. Calls CreateActor RPC.
 // 3. Verifies that the actor is successfully created and returned in the response with a generated ID.
 func TestCreateActor_Success(t *testing.T) {
@@ -61,21 +58,19 @@ func TestCreateActor_Success(t *testing.T) {
 			Atespace: testAtespace,
 			Name:     "id1",
 		},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
-		WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}},
-		Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
+		ActorTemplate:  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}},
+		Status:         &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
 
 	want := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Name: "id1", Atespace: testAtespace, Version: 1},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
-		Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
-		WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}},
+		Metadata:       &ateapipb.ResourceMetadata{Name: "id1", Atespace: testAtespace, Version: 1},
+		ActorTemplate:  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		Status:         &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
+		WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "free"}},
 	}
 
 	// The diff below ignores the server-assigned uid/timestamps (non-deterministic),
@@ -105,18 +100,17 @@ func TestCreateActor_WithExternalVolumes(t *testing.T) {
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
 
-	volumes := []atev1alpha1.Volume{
+	volumes := []*ateapipb.Volume{
 		{
 			Name: "ext-vol-1",
-			VolumeSource: atev1alpha1.VolumeSource{
-				ExternalVolumeTemplate: &atev1alpha1.ExternalVolumeTemplate{
-					StorageClassName: "standard",
-					Capacity:         resource.MustParse("10Gi"),
-				},
+			Type: "ExternalVolumeTemplate",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
 			},
 		},
 	}
-	mounts := []atev1alpha1.VolumeMount{
+	mounts := []*ateapipb.VolumeMount{
 		{
 			Name:      "ext-vol-1",
 			MountPath: "/data",
@@ -126,9 +120,8 @@ func TestCreateActor_WithExternalVolumes(t *testing.T) {
 
 	createResp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "vol-actor-1"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "vol-actor-1"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		},
 	})
 	if err != nil {
@@ -171,63 +164,17 @@ func TestCreateActor_TemplateNotFound(t *testing.T) {
 	defer tc.cleanup()
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "non-existent",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "non-existent"},
 	}})
 	if got := status.Code(err); got != codes.FailedPrecondition {
 		t.Fatalf("CreateActor with a missing template = %v, want FailedPrecondition (err: %v)", got, err)
 	}
 }
 
-// TestCreateActor_RejectsTemplateMatchExpressions pins the equality-only
-// selector contract: converting the template drops matchExpressions, which
-// would schedule the actor wider than the template declares, so CreateActor
-// must refuse instead.
-func TestCreateActor_RejectsTemplateMatchExpressions(t *testing.T) {
-	ns := namespaceForTest("ns-create-matchexpr")
-	tc := setupTest(t, ns)
-	defer tc.cleanup()
-
-	template := &atev1alpha1.ActorTemplate{
-		ObjectMeta: metav1.ObjectMeta{Name: "tmpl-expr", Namespace: ns},
-		Spec: atev1alpha1.ActorTemplateSpec{
-			SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://fake-fake-fake"},
-			Containers: []atev1alpha1.Container{{
-				Name:    "main",
-				Image:   "main@sha256:abc",
-				Command: []string{"/main"},
-			}},
-			WorkerSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{poolLabelKey: ns},
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{Key: "tier", Operator: metav1.LabelSelectorOpIn, Values: []string{"1"}},
-				},
-			},
-		},
-	}
-	if _, err := tc.substrateClient.ApiV1alpha1().ActorTemplates(ns).Create(context.Background(), template, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("failed to create actor template: %v", err)
-	}
-	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		_, err := tc.actorTemplateLister.ActorTemplates(ns).Get("tmpl-expr")
-		return err == nil, nil
-	}); err != nil {
-		t.Fatalf("template never appeared in the lister: %v", err)
-	}
-
-	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl-expr",
-	}})
-	assertGrpcError(t, err, codes.FailedPrecondition,
-		fmt.Sprintf("ActorTemplate %s/tmpl-expr workerSelector uses matchExpressions; only matchLabels is supported", ns))
-}
-
-// TestCreateActor_SubstrateTemplateRef covers the substrate reference form:
-// the actor names its template with an actor_template ObjectRef resolved from
-// the store instead of the legacy CRD namespace/name pair.
+// TestCreateActor_SubstrateTemplateRef covers creation against a template
+// with no golden snapshot yet: the actor names its template with an
+// actor_template ObjectRef resolved from the store at create time.
 func TestCreateActor_SubstrateTemplateRef(t *testing.T) {
 	ns := namespaceForTest("ns-create-sub-ref")
 	tc := setupTest(t, ns)
@@ -262,7 +209,7 @@ func TestCreateActor_SubstrateTemplateRef(t *testing.T) {
 		t.Errorf("CreateActor response mismatch (-want +got):\n%s", diff)
 	}
 
-	// A reference to a template that does not exist fails like the legacy pair.
+	// A reference to a template that does not exist fails.
 	_, err = tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
 		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "ref-actor-2"},
 		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "absent"},
@@ -281,18 +228,16 @@ func TestCreateActor_Duplicate(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("first CreateActor failed: %v", err)
 	}
 
 	_, err = tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	assertGrpcError(t, err, codes.AlreadyExists, "Actor id1 already exists")
 }
@@ -308,9 +253,8 @@ func TestCreateActor_StampsFullSpanIdentity(t *testing.T) {
 	attrs := recordRootSpanAttrs(t, func(ctx context.Context) {
 		if _, err := tc.service.CreateActor(ctx, &ateapipb.CreateActorRequest{
 			Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
-				ActorTemplateNamespace: ns,
-				ActorTemplateName:      "tmpl1",
+				Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+				ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 			},
 		}); err != nil {
 			t.Fatalf("CreateActor: %v", err)
@@ -320,7 +264,7 @@ func TestCreateActor_StampsFullSpanIdentity(t *testing.T) {
 	assertSpanStr(t, attrs, ateattr.AtespaceKey, testAtespace)
 	assertSpanStr(t, attrs, ateattr.ActorNameKey, testActorID)
 	assertSpanStr(t, attrs, ateattr.TemplateNameKey, "tmpl1")
-	assertSpanStr(t, attrs, ateattr.TemplateNamespaceKey, ns)
+	assertSpanStr(t, attrs, ateattr.TemplateAtespaceKey, testAtespace)
 	// uid is server-assigned on create, so assert it is present and non-empty
 	// rather than a fixed value.
 	if v, ok := attrs[ateattr.ActorUIDKey]; !ok || v.Type() != attribute.STRING || v.AsString() == "" {
@@ -335,18 +279,14 @@ func TestCreateActor_RejectsDifferentTemplateForDataSnapshot(t *testing.T) {
 	ns := namespaceForTest("ns-data-snapshot-template")
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
-	createTemplate(t, tc, ns)
-	createTemplateWithSelector(t, tc, ns, "tmpl2", nil)
+	tmpl := createTemplate(t, tc, ns)
+	createTemplateWithSelector(t, tc, "tmpl2", nil)
 
-	tmpl, err := tc.actorTemplateLister.ActorTemplates(ns).Get("tmpl1")
-	if err != nil {
-		t.Fatalf("Get source ActorTemplate: %v", err)
-	}
 	snapshot := storetest.MustCreateActorSnapshot(t, context.Background(), tc.persistence, &ateapipb.ActorSnapshot{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "data-snapshot"},
 		Status: &ateapipb.ActorSnapshotStatus{
 			SourceActor:      &ateapipb.ObjectRef{Atespace: testAtespace, Name: "source"},
-			ActorTemplateUid: string(tmpl.GetUID()),
+			ActorTemplateUid: tmpl.GetMetadata().GetUid(),
 			ContentScope:     ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA,
 			SnapshotUri:      "gs://snapshots/snapshots/" + testAtespace + "/data-snapshot",
 		},
@@ -358,12 +298,11 @@ func TestCreateActor_RejectsDifferentTemplateForDataSnapshot(t *testing.T) {
 		t.Fatalf("CreateActorSnapshotTag: %v", err)
 	}
 
-	_, err = tc.service.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+	_, err := tc.service.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "clone"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl2",
-			SourceSnapshotTag:      &ateapipb.ObjectRef{Atespace: testAtespace, Name: "data-snapshot"},
+			Metadata:          &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "clone"},
+			ActorTemplate:     &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl2"},
+			SourceSnapshotTag: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "data-snapshot"},
 		},
 	})
 	if status.Code(err) != codes.FailedPrecondition {
@@ -375,34 +314,33 @@ func TestCreateActor_RejectsSnapshotWithExternalVolumes(t *testing.T) {
 	ns := namespaceForTest("ns-snapshot-external-volume")
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
-	template, err := tc.substrateClient.ApiV1alpha1().ActorTemplates(ns).Create(context.Background(), &atev1alpha1.ActorTemplate{
-		ObjectMeta: metav1.ObjectMeta{Name: "tmpl1", Namespace: ns},
-		Spec: atev1alpha1.ActorTemplateSpec{
-			SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"},
-			Containers: []atev1alpha1.Container{{
-				Name: "main", Image: "main@sha256:abc", VolumeMounts: []atev1alpha1.VolumeMount{{Name: "data", MountPath: "/data"}},
+	template, err := tc.client.CreateActorTemplate(context.Background(), &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata:        &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "tmpl1"},
+			SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://snapshots"},
+			SandboxConfig: &ateapipb.SandboxConfig{
+				SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+				ConfigName:   "gvisor-default",
+			},
+			Containers: []*ateapipb.Container{{
+				Name: "main", Image: "main@sha256:abc", VolumeMounts: []*ateapipb.VolumeMount{{Name: "data", MountPath: "/data"}},
 			}},
-			Volumes: []atev1alpha1.Volume{{
+			Volumes: []*ateapipb.Volume{{
 				Name: "data",
-				VolumeSource: atev1alpha1.VolumeSource{ExternalVolumeTemplate: &atev1alpha1.ExternalVolumeTemplate{
-					Capacity: resource.MustParse("1Gi"), StorageClassName: "standard",
-				}},
+				Type: "ExternalVolumeTemplate",
+				ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+					Capacity: "1Gi", StorageClassName: "standard",
+				},
 			}},
 		},
-	}, metav1.CreateOptions{})
+	})
 	if err != nil {
 		t.Fatalf("Create ActorTemplate: %v", err)
-	}
-	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		got, err := tc.actorTemplateLister.ActorTemplates(ns).Get("tmpl1")
-		return err == nil && len(got.Spec.Volumes) == 1, nil
-	}); err != nil {
-		t.Fatalf("wait for ActorTemplate update: %v", err)
 	}
 	snapshot := storetest.MustCreateActorSnapshot(t, context.Background(), tc.persistence, &ateapipb.ActorSnapshot{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "external-volume-snapshot"},
 		Status: &ateapipb.ActorSnapshotStatus{
-			ActorTemplateUid: string(template.GetUID()),
+			ActorTemplateUid: template.GetMetadata().GetUid(),
 			SnapshotUri:      "gs://snapshots/snapshots/" + testAtespace + "/external-volume-snapshot",
 		},
 	})
@@ -416,10 +354,9 @@ func TestCreateActor_RejectsSnapshotWithExternalVolumes(t *testing.T) {
 
 	_, err = tc.service.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "clone"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
-			SourceSnapshotTag:      tagRef,
+			Metadata:          &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "clone"},
+			ActorTemplate:     &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+			SourceSnapshotTag: tagRef,
 		},
 	})
 	if status.Code(err) != codes.FailedPrecondition {
@@ -438,9 +375,8 @@ func TestGetActor_Found(t *testing.T) {
 	name := "id1"
 
 	createResp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -489,17 +425,15 @@ func TestListActors(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	resp1, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor 1 failed: %v", err)
 	}
 	resp2, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id2"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id2"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor 2 failed: %v", err)
@@ -545,9 +479,8 @@ func TestListActors_ByAtespace(t *testing.T) {
 
 	create := func(atespace, name string) *ateapipb.Actor {
 		resp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: atespace, Name: name},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: atespace, Name: name},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		}})
 		if err != nil {
 			t.Fatalf("CreateActor(%s, atespace=%q) failed: %v", name, atespace, err)
@@ -602,9 +535,8 @@ func TestListActors_AllAtespaces(t *testing.T) {
 
 	create := func(atespace, name string) {
 		if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: atespace, Name: name},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: atespace, Name: name},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		}}); err != nil {
 			t.Fatalf("CreateActor(%s, atespace=%q) failed: %v", name, atespace, err)
 		}
@@ -640,9 +572,8 @@ func TestListActors_Pagination(t *testing.T) {
 	var want []*ateapipb.Actor
 	for i := 0; i < 5; i++ {
 		resp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: fmt.Sprintf("name%d", i)},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: fmt.Sprintf("name%d", i)},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		}})
 		if err != nil {
 			t.Fatalf("CreateActor %d failed: %v", i, err)
@@ -696,9 +627,8 @@ func TestUpdateActor_Success(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	toUpdate, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		WorkerSelector: &ateapipb.Selector{
 			MatchLabels: map[string]string{"tier": "free"},
 		},
@@ -716,10 +646,9 @@ func TestUpdateActor_Success(t *testing.T) {
 	}
 
 	wantActor := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Name: "id1", Atespace: testAtespace, Version: 2},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
-		Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
+		Metadata:      &ateapipb.ResourceMetadata{Name: "id1", Atespace: testAtespace, Version: 2},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
 		WorkerSelector: &ateapipb.Selector{
 			MatchLabels: map[string]string{"tier": "paid"},
 		},
@@ -750,9 +679,8 @@ func TestUpdateActor(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	created, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		WorkerSelector: &ateapipb.Selector{
 			MatchLabels: map[string]string{"tier": "free"},
 		},
@@ -771,10 +699,9 @@ func TestUpdateActor(t *testing.T) {
 	}
 
 	wantActor := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Name: "id1", Atespace: testAtespace, Version: 2},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
-		Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
+		Metadata:      &ateapipb.ResourceMetadata{Name: "id1", Atespace: testAtespace, Version: 2},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
 		WorkerSelector: &ateapipb.Selector{
 			MatchLabels: map[string]string{"tier": "paid"},
 		},
@@ -804,9 +731,8 @@ func TestUpdateActor_Preconditions(t *testing.T) {
 	createActor := func() *ateapipb.Actor {
 		t.Helper()
 		actor, err := tc.client.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		}})
 		if err != nil {
 			t.Fatalf("CreateActor failed: %v", err)
@@ -909,9 +835,8 @@ func TestUpdateActor_StampsFullSpanIdentity(t *testing.T) {
 
 	toUpdate, err := tc.service.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		},
 	})
 	if err != nil {
@@ -930,7 +855,7 @@ func TestUpdateActor_StampsFullSpanIdentity(t *testing.T) {
 	assertSpanStr(t, attrs, ateattr.AtespaceKey, testAtespace)
 	assertSpanStr(t, attrs, ateattr.ActorNameKey, testActorID)
 	assertSpanStr(t, attrs, ateattr.TemplateNameKey, "tmpl1")
-	assertSpanStr(t, attrs, ateattr.TemplateNamespaceKey, ns)
+	assertSpanStr(t, attrs, ateattr.TemplateAtespaceKey, testAtespace)
 	if v, ok := attrs[ateattr.ActorUIDKey]; !ok || v.Type() != attribute.STRING || v.AsString() == "" {
 		t.Errorf("%s = %v, want non-empty server-assigned uid", ateattr.ActorUIDKey, v.String())
 	}
@@ -960,7 +885,7 @@ func TestUpdateActor_FailedLookupStampsRefIdentityOnly(t *testing.T) {
 
 	assertSpanStr(t, attrs, ateattr.AtespaceKey, testAtespace)
 	assertSpanStr(t, attrs, ateattr.ActorNameKey, testActorID)
-	for _, k := range []attribute.Key{ateattr.ActorUIDKey, ateattr.TemplateNameKey, ateattr.TemplateNamespaceKey, ateattr.ActorVersionKey} {
+	for _, k := range []attribute.Key{ateattr.ActorUIDKey, ateattr.TemplateNameKey, ateattr.TemplateAtespaceKey, ateattr.ActorVersionKey} {
 		if _, ok := attrs[k]; ok {
 			t.Errorf("unexpected %s on failed-update span", k)
 		}
@@ -975,9 +900,8 @@ func TestDeleteActor_Success(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -1012,9 +936,8 @@ func TestDeleteActor_NotSuspended(t *testing.T) {
 	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -1041,9 +964,8 @@ func TestDeleteActor_Crashed(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	created, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -1093,9 +1015,8 @@ func TestDeleteActor_StampsRefSpanIdentity(t *testing.T) {
 	createTemplate(t, tc, ns)
 	if _, err := tc.service.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: testActorID},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		},
 	}); err != nil {
 		t.Fatalf("seed CreateActor: %v", err)
@@ -1124,9 +1045,8 @@ func TestDeleteActor_StateDeleting(t *testing.T) {
 			Atespace: testAtespace,
 			Name:     "deleting-actor",
 		},
-		Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_DELETING},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_DELETING},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}
 	if _, err := tc.persistence.CreateActor(context.Background(), deletingActor); err != nil {
 		t.Fatalf("CreateActor: %v", err)
@@ -1154,9 +1074,8 @@ func TestDeleteActor_WrongState(t *testing.T) {
 			Atespace: testAtespace,
 			Name:     "running-actor",
 		},
-		Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}
 	if _, err := tc.persistence.CreateActor(context.Background(), runningActor); err != nil {
 		t.Fatalf("CreateActor: %v", err)
@@ -1194,8 +1113,7 @@ func TestDeleteActor_MultipleVolumeDeletionFailures(t *testing.T) {
 			Atespace: testAtespace,
 			Name:     "multi-vol-actor",
 		},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		Status: &ateapipb.ActorStatus{
 			State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
 			ActorVolumes: []*ateapipb.ExternalVolume{
@@ -1235,9 +1153,8 @@ func TestCreateActor_AtespaceNotFound(t *testing.T) {
 	// The template exists, but "missing-as" was never created. The template
 	// check fires first, so reaching this error proves the atespace check ran.
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: "missing-as", Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: "missing-as", Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	assertGrpcError(t, err, codes.FailedPrecondition, "Atespace missing-as not found")
 }
@@ -1303,18 +1220,17 @@ func TestActorLifecycle_WithExternalVolumes(t *testing.T) {
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
 
-	volumes := []atev1alpha1.Volume{
+	volumes := []*ateapipb.Volume{
 		{
 			Name: "data-vol",
-			VolumeSource: atev1alpha1.VolumeSource{
-				ExternalVolumeTemplate: &atev1alpha1.ExternalVolumeTemplate{
-					StorageClassName: "fast",
-					Capacity:         resource.MustParse("20Gi"),
-				},
+			Type: "ExternalVolumeTemplate",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "fast",
+				Capacity:         "20Gi",
 			},
 		},
 	}
-	mounts := []atev1alpha1.VolumeMount{
+	mounts := []*ateapipb.VolumeMount{
 		{
 			Name:      "data-vol",
 			MountPath: "/mnt/data",
@@ -1326,9 +1242,8 @@ func TestActorLifecycle_WithExternalVolumes(t *testing.T) {
 	// 1. CreateActor
 	createResp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "actor-vol-lc"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "actor-vol-lc"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		},
 	})
 	if err != nil {
@@ -1447,27 +1362,25 @@ func TestResumeActor_VolumeCreationFailure(t *testing.T) {
 	})
 	defer tc.cleanup()
 
-	volumes := []atev1alpha1.Volume{
+	volumes := []*ateapipb.Volume{
 		{
 			Name: "succ-vol1",
-			VolumeSource: atev1alpha1.VolumeSource{
-				ExternalVolumeTemplate: &atev1alpha1.ExternalVolumeTemplate{
-					StorageClassName: "standard",
-					Capacity:         resource.MustParse("10Gi"),
-				},
+			Type: "ExternalVolumeTemplate",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
 			},
 		},
 		{
 			Name: "fail-vol2",
-			VolumeSource: atev1alpha1.VolumeSource{
-				ExternalVolumeTemplate: &atev1alpha1.ExternalVolumeTemplate{
-					StorageClassName: "standard",
-					Capacity:         resource.MustParse("10Gi"),
-				},
+			Type: "ExternalVolumeTemplate",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
 			},
 		},
 	}
-	mounts := []atev1alpha1.VolumeMount{
+	mounts := []*ateapipb.VolumeMount{
 		{Name: "succ-vol1", MountPath: "/mnt/vol1"},
 		{Name: "fail-vol2", MountPath: "/mnt/vol2"},
 	}
@@ -1476,9 +1389,8 @@ func TestResumeActor_VolumeCreationFailure(t *testing.T) {
 	// Call CreateActor RPC directly
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "fail-actor"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "fail-actor"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		},
 	})
 	if err != nil {
@@ -1594,27 +1506,25 @@ func TestResumeActor_VolumeCreationRetrySuccess(t *testing.T) {
 	})
 	defer tc.cleanup()
 
-	volumes := []atev1alpha1.Volume{
+	volumes := []*ateapipb.Volume{
 		{
 			Name: "succ-vol1",
-			VolumeSource: atev1alpha1.VolumeSource{
-				ExternalVolumeTemplate: &atev1alpha1.ExternalVolumeTemplate{
-					StorageClassName: "standard",
-					Capacity:         resource.MustParse("10Gi"),
-				},
+			Type: "ExternalVolumeTemplate",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
 			},
 		},
 		{
 			Name: "retry-vol2",
-			VolumeSource: atev1alpha1.VolumeSource{
-				ExternalVolumeTemplate: &atev1alpha1.ExternalVolumeTemplate{
-					StorageClassName: "standard",
-					Capacity:         resource.MustParse("10Gi"),
-				},
+			Type: "ExternalVolumeTemplate",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
 			},
 		},
 	}
-	retryMounts := []atev1alpha1.VolumeMount{
+	retryMounts := []*ateapipb.VolumeMount{
 		{Name: "succ-vol1", MountPath: "/mnt/vol1"},
 		{Name: "retry-vol2", MountPath: "/mnt/vol2"},
 	}
@@ -1624,9 +1534,8 @@ func TestResumeActor_VolumeCreationRetrySuccess(t *testing.T) {
 	// Call CreateActor RPC directly
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "retry-actor"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "retry-actor"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		},
 	})
 	if err != nil {
@@ -1723,9 +1632,8 @@ func TestResumeActor(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -1749,9 +1657,8 @@ func TestResumeActor(t *testing.T) {
 		t.Fatalf("GetActor failed: %v", err)
 	}
 	want := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		Status: &ateapipb.ActorStatus{
 			State: ateapipb.ActorState_ACTOR_STATE_RUNNING,
 			WorkerAssignment: &ateapipb.WorkerAssignment{
@@ -1796,9 +1703,9 @@ func TestResumeActor(t *testing.T) {
 		Labels:          map[string]string{poolLabelKey: ns},
 		Status: &ateapipb.WorkerStatus{
 			Assignment: &ateapipb.ActorAssignment{
-				ActorTemplate: &ateapipb.KubeNamespacedObjectRef{
-					Namespace: ns,
-					Name:      "tmpl1",
+				ActorTemplateRef: &ateapipb.ObjectRef{
+					Atespace: testAtespace,
+					Name:     "tmpl1",
 				},
 				Actor: &ateapipb.ObjectRef{
 					Name:     name,
@@ -1821,12 +1728,12 @@ func TestResumeActorPassesLiteralEnv(t *testing.T) {
 	tc := setupTest(t, ns)
 	defer tc.cleanup()
 
-	createTemplateWithContainers(t, tc, ns, []atev1alpha1.Container{
+	createTemplateWithContainers(t, tc, ns, []*ateapipb.Container{
 		{
 			Name:    "main",
 			Image:   "main@sha256:abc",
 			Command: []string{"/main"},
-			Env: []atev1alpha1.EnvVar{
+			Env: []*ateapipb.EnvVar{
 				{
 					Name:  "LITERAL",
 					Value: "plain",
@@ -1837,9 +1744,8 @@ func TestResumeActorPassesLiteralEnv(t *testing.T) {
 	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -1890,9 +1796,8 @@ func TestResumeActor_NoWorkers(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	createResp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -1916,7 +1821,7 @@ func TestResumeActor_MultiPoolSelector(t *testing.T) {
 
 	createWorkerPool(t, tc, ns, "pool-a", map[string]string{"group": ns, "tier": "a"})
 	createWorkerPool(t, tc, ns, "pool-b", map[string]string{"group": ns, "tier": "b"})
-	createTemplateWithSelector(t, tc, ns, "tmpl1", &metav1.LabelSelector{
+	createTemplateWithSelector(t, tc, "tmpl1", &ateapipb.Selector{
 		MatchLabels: map[string]string{"group": ns},
 	})
 
@@ -1924,9 +1829,8 @@ func TestResumeActor_MultiPoolSelector(t *testing.T) {
 	createWorkerPod(t, tc, ns, "worker-b", "node1", "pool-b")
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		WorkerSelector: &ateapipb.Selector{
 			MatchLabels: map[string]string{"tier": "b"},
 		},
@@ -1966,7 +1870,7 @@ func TestResumeActor_RequiresBothSelectorsToMatch(t *testing.T) {
 	createWorkerPool(t, tc, ns, "pool-both", map[string]string{"group": ns, "tier": "b"})
 	createWorkerPool(t, tc, ns, "pool-template-only", map[string]string{"group": ns, "tier": "a"})
 	createWorkerPool(t, tc, ns, "pool-actor-only", map[string]string{"tier": "b"})
-	createTemplateWithSelector(t, tc, ns, "tmpl1", &metav1.LabelSelector{
+	createTemplateWithSelector(t, tc, "tmpl1", &ateapipb.Selector{
 		MatchLabels: map[string]string{"group": ns},
 	})
 
@@ -1975,9 +1879,8 @@ func TestResumeActor_RequiresBothSelectorsToMatch(t *testing.T) {
 	createWorkerPod(t, tc, ns, "worker-actor-only", "node1", "pool-actor-only")
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		WorkerSelector: &ateapipb.Selector{
 			MatchLabels: map[string]string{"tier": "b"},
 		},
@@ -2021,9 +1924,8 @@ func TestResumeActor_Reentrancy(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -2113,9 +2015,8 @@ func TestSuspendActor(t *testing.T) {
 	name := "id1"
 
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -2179,10 +2080,9 @@ func TestSuspendActor(t *testing.T) {
 	}
 	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: "other", Name: "cross-atespace"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
-			SourceSnapshotTag:      tagRef,
+			Metadata:          &ateapipb.ResourceMetadata{Atespace: "other", Name: "cross-atespace"},
+			ActorTemplate:     &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+			SourceSnapshotTag: tagRef,
 		},
 	}); status.Code(err) != codes.FailedPrecondition {
 		t.Fatalf("cross-atespace CreateActor status = %v, want FailedPrecondition", status.Code(err))
@@ -2200,10 +2100,9 @@ func TestSuspendActor(t *testing.T) {
 	createAtespace(t, tc, "other")
 	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: "other", Name: "cross-atespace"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
-			SourceSnapshotTag:      tagRef,
+			Metadata:          &ateapipb.ResourceMetadata{Atespace: "other", Name: "cross-atespace"},
+			ActorTemplate:     &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+			SourceSnapshotTag: tagRef,
 		},
 	}); err != nil {
 		t.Fatalf("CreateActor from published tag failed: %v", err)
@@ -2211,10 +2110,9 @@ func TestSuspendActor(t *testing.T) {
 
 	clone, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
 		Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "clone"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
-			SourceSnapshotTag:      tagRef,
+			Metadata:          &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "clone"},
+			ActorTemplate:     &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+			SourceSnapshotTag: tagRef,
 		},
 	})
 	if err != nil {
@@ -2254,10 +2152,9 @@ func TestSuspendActor(t *testing.T) {
 		t.Fatalf("GetActor failed: %v", err)
 	}
 	want := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
-		Status:                 &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
+		Metadata:      &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
 	}
 
 	if diff := cmp.Diff(want, getResp,
@@ -2307,9 +2204,8 @@ func TestPauseActor(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -2342,9 +2238,8 @@ func TestPauseActor(t *testing.T) {
 		t.Fatalf("GetActor failed: %v", err)
 	}
 	want := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Name: name, Atespace: testAtespace},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		Status: &ateapipb.ActorStatus{
 			State: ateapipb.ActorState_ACTOR_STATE_PAUSED,
 			LocalSnapshotInfo: &ateapipb.LocalSnapshotInfo{
@@ -2386,7 +2281,7 @@ func TestPauseActor_FailedLookupStampsRefIdentityOnly(t *testing.T) {
 
 	assertSpanStr(t, attrs, ateattr.AtespaceKey, testAtespace)
 	assertSpanStr(t, attrs, ateattr.ActorNameKey, testActorID)
-	for _, k := range []attribute.Key{ateattr.ActorUIDKey, ateattr.TemplateNameKey, ateattr.TemplateNamespaceKey, ateattr.ActorVersionKey} {
+	for _, k := range []attribute.Key{ateattr.ActorUIDKey, ateattr.TemplateNameKey, ateattr.TemplateAtespaceKey, ateattr.ActorVersionKey} {
 		if _, ok := attrs[k]; ok {
 			t.Errorf("unexpected %s on failed-pause span", k)
 		}
@@ -2416,7 +2311,7 @@ func TestResumeActor_ReleasesStaleWorkerWhenPoolBecomesIneligible(t *testing.T) 
 
 	createWorkerPool(t, tc, ns, "pool-a", map[string]string{"group": ns, "tier": "a"})
 	createWorkerPool(t, tc, ns, "pool-b", map[string]string{"group": ns, "tier": "b"})
-	createTemplateWithSelector(t, tc, ns, "tmpl1", &metav1.LabelSelector{
+	createTemplateWithSelector(t, tc, "tmpl1", &ateapipb.Selector{
 		MatchLabels: map[string]string{"group": ns},
 	})
 	createWorkerPod(t, tc, ns, "worker-a", "node1", "pool-a")
@@ -2424,10 +2319,9 @@ func TestResumeActor_ReleasesStaleWorkerWhenPoolBecomesIneligible(t *testing.T) 
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
-		WorkerSelector:         &ateapipb.Selector{MatchLabels: map[string]string{"tier": "a"}},
+		Metadata:       &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate:  &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		WorkerSelector: &ateapipb.Selector{MatchLabels: map[string]string{"tier": "a"}},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -2514,8 +2408,7 @@ func TestResumeActor_CrashesIfAssignedWorkerIsDraining(t *testing.T) {
 				Atespace: testAtespace,
 				Name:     id,
 			},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		},
 	}); err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -2625,7 +2518,7 @@ func TestUpdateActor_ReassignsPoolAcrossSuspendResume(t *testing.T) {
 
 	createWorkerPool(t, tc, ns, "pool-a", map[string]string{"group": ns, "tier": "a"})
 	createWorkerPool(t, tc, ns, "pool-b", map[string]string{"group": ns, "tier": "b"})
-	createTemplateWithSelector(t, tc, ns, "tmpl1", &metav1.LabelSelector{
+	createTemplateWithSelector(t, tc, "tmpl1", &ateapipb.Selector{
 		MatchLabels: map[string]string{"group": ns},
 	})
 
@@ -2634,9 +2527,8 @@ func TestUpdateActor_ReassignsPoolAcrossSuspendResume(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		WorkerSelector: &ateapipb.Selector{
 			MatchLabels: map[string]string{"tier": "a"},
 		},
@@ -2700,9 +2592,8 @@ func TestResumeActor_LeaseConflict(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -2747,9 +2638,8 @@ func TestResumeActor_DanglingWorker(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -2826,9 +2716,8 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -2884,9 +2773,8 @@ func TestSuspendActor_FromPaused(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -2974,9 +2862,8 @@ func TestSuspendActor_FromPaused_RetryAfterUploadFailure(t *testing.T) {
 
 	name := "id1"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}})
 	if err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
@@ -3047,9 +2934,8 @@ func TestResumeActor_RelocatesAfterSuspendFromPaused(t *testing.T) {
 	const pinned, relocated = "actor-pinned", "actor-squatter"
 	for _, name := range []string{pinned, relocated} {
 		if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-			Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		}}); err != nil {
 			t.Fatalf("CreateActor(%s) failed: %v", name, err)
 		}
@@ -3169,9 +3055,8 @@ func TestLifecycleOpPoolAttributesOnSuccess(t *testing.T) {
 
 			actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}
 			if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: actorRef.GetAtespace(), Name: actorRef.GetName()},
-				ActorTemplateNamespace: ns,
-				ActorTemplateName:      "tmpl1",
+				Metadata:      &ateapipb.ResourceMetadata{Atespace: actorRef.GetAtespace(), Name: actorRef.GetName()},
+				ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 			}}); err != nil {
 				t.Fatalf("CreateActor failed: %v", err)
 			}
@@ -3239,9 +3124,8 @@ func TestCreateActor_RejectsUnknownRequestFields(t *testing.T) {
 	createTemplate(t, tc, ns)
 
 	req := &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}}
 	unknown := protowire.AppendTag(nil, 9999, protowire.VarintType)
 	req.ProtoReflect().SetUnknown(protowire.AppendVarint(unknown, 42))

--- a/cmd/ateapi/internal/controlapi/functionaltest/atespace_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/atespace_test.go
@@ -65,8 +65,7 @@ func TestCreateAtespace_Success(t *testing.T) {
 			Metadata: &ateapipb.ResourceMetadata{
 				Atespace: "team-a",
 				Name:     "id1"},
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      "tmpl1",
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 		}}); err != nil {
 		t.Errorf("CreateActor into freshly created atespace failed: %v", err)
 	}
@@ -168,9 +167,8 @@ func TestDeleteAtespace_NonEmpty_Rejected(t *testing.T) {
 		t.Fatalf("CreateAtespace failed: %v", err)
 	}
 	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}}); err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
 	}
@@ -195,9 +193,8 @@ func TestDeleteAtespace_ScopedToTargetAtespace(t *testing.T) {
 
 	// Actor only in team-b.
 	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: "team-b", Name: "id1"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: "team-b", Name: "id1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}}); err != nil {
 		t.Fatalf("CreateActor failed: %v", err)
 	}

--- a/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
@@ -82,7 +82,6 @@ type testContext struct {
 	workerCache         *workercache.Cache
 	fakeAtelet          *FakeAteletServer
 	cleanup             func()
-	actorTemplateLister listersv1alpha1.ActorTemplateLister
 	workerPoolLister    listersv1alpha1.WorkerPoolLister
 	sandboxConfigLister listersv1alpha1.SandboxConfigLister
 	// ateletIndexer is the index DialForAteletOnNode looks up atelets in.
@@ -250,7 +249,6 @@ func setupTestWithVolumePlugins(t *testing.T, ns string, plugins map[string]volu
 		workerCache:         wc,
 		fakeAtelet:          fakeAtelet,
 		cleanup:             cleanup,
-		actorTemplateLister: actorTemplateLister,
 		workerPoolLister:    workerPoolLister,
 		sandboxConfigLister: sandboxConfigLister,
 		ateletIndexer:       ateletInformer.GetIndexer(),
@@ -262,9 +260,9 @@ func namespaceForTest(baseName string) string {
 	return fmt.Sprintf("%s-%d", baseName, time.Now().UnixNano())
 }
 
-func createTemplate(t *testing.T, tc *testContext, ns string) {
+func createTemplate(t *testing.T, tc *testContext, ns string) *ateapipb.ActorTemplate {
 	t.Helper()
-	createTemplateWithContainers(t, tc, ns, []atev1alpha1.Container{
+	return createTemplateWithContainers(t, tc, ns, []*ateapipb.Container{
 		{
 			Name:    "main",
 			Image:   "main@sha256:abc",
@@ -283,12 +281,14 @@ func createAtespace(t *testing.T, tc *testContext, name string) {
 
 const poolLabelKey = "pool"
 
-func createTemplateWithContainers(t *testing.T, tc *testContext, ns string, containers []atev1alpha1.Container) {
-	createTemplateWithContainersAndVolumes(t, tc, ns, containers, nil)
+func createTemplateWithContainers(t *testing.T, tc *testContext, ns string, containers []*ateapipb.Container) *ateapipb.ActorTemplate {
+	t.Helper()
+	return createTemplateWithContainersAndVolumes(t, tc, ns, containers, nil)
 }
 
-func createTemplateWithVolumes(t *testing.T, tc *testContext, ns string, volumes []atev1alpha1.Volume, mounts []atev1alpha1.VolumeMount) {
-	createTemplateWithContainersAndVolumes(t, tc, ns, []atev1alpha1.Container{
+func createTemplateWithVolumes(t *testing.T, tc *testContext, ns string, volumes []*ateapipb.Volume, mounts []*ateapipb.VolumeMount) *ateapipb.ActorTemplate {
+	t.Helper()
+	return createTemplateWithContainersAndVolumes(t, tc, ns, []*ateapipb.Container{
 		{
 			Name:         "main",
 			Image:        "main@sha256:abc",
@@ -298,32 +298,39 @@ func createTemplateWithVolumes(t *testing.T, tc *testContext, ns string, volumes
 	}, volumes)
 }
 
-func createTemplateWithContainersAndVolumes(t *testing.T, tc *testContext, ns string, containers []atev1alpha1.Container, volumes []atev1alpha1.Volume) {
+// createTemplateWithContainersAndVolumes creates the substrate ActorTemplate
+// "tmpl1" in testAtespace, backed by a WorkerPool in ns whose labels match the
+// template's worker selector, and seeds its golden snapshot. ns keys the pool
+// labels, so each test's template still selects only its own pool.
+func createTemplateWithContainersAndVolumes(t *testing.T, tc *testContext, ns string, containers []*ateapipb.Container, volumes []*ateapipb.Volume) *ateapipb.ActorTemplate {
 	t.Helper()
 
-	// Sandbox binaries now live on a (cluster-scoped) SandboxConfig resolved via
-	// the actor's WorkerPool, not on the ActorTemplate. Create a default gvisor
-	// SandboxConfig so a boot-from-spec Run can resolve its assets.
+	// Sandbox binaries live on a (cluster-scoped) SandboxConfig the template
+	// names. Create a default gvisor SandboxConfig so a boot-from-spec Run can
+	// resolve its assets.
 	ensureDefaultGvisorSandboxConfig(t, tc)
 	createWorkerPool(t, tc, ns, "pool1", map[string]string{poolLabelKey: ns})
 
-	actorTemplate := &atev1alpha1.ActorTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tmpl1",
-			Namespace: ns,
-		},
-		Spec: atev1alpha1.ActorTemplateSpec{
-			SnapshotsConfig: atev1alpha1.SnapshotsConfig{
-				Location: "gs://fake-fake-fake",
+	created, err := tc.client.CreateActorTemplate(context.Background(), &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{
+				Atespace: testAtespace,
+				Name:     "tmpl1",
+			},
+			SnapshotsConfig: &ateapipb.SnapshotsConfig{
+				StorageLocation: "gs://fake-fake-fake",
+			},
+			SandboxConfig: &ateapipb.SandboxConfig{
+				SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+				ConfigName:   "gvisor-default",
 			},
 			Containers: containers,
 			Volumes:    volumes,
-			WorkerSelector: &metav1.LabelSelector{
+			WorkerSelector: &ateapipb.Selector{
 				MatchLabels: map[string]string{poolLabelKey: ns},
 			},
 		},
-	}
-	createdTemplate, err := tc.substrateClient.ApiV1alpha1().ActorTemplates(ns).Create(context.Background(), actorTemplate, metav1.CreateOptions{})
+	})
 	if err != nil {
 		t.Fatalf("failed to create actor template: %v", err)
 	}
@@ -332,33 +339,29 @@ func createTemplateWithContainersAndVolumes(t *testing.T, tc *testContext, ns st
 	storetest.MustCreateActorSnapshot(t, context.Background(), tc.persistence, &ateapipb.ActorSnapshot{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: resources.GoldenActorAtespace, Name: goldenSnapshot},
 		Status: &ateapipb.ActorSnapshotStatus{
-			ActorTemplateNamespace: ns,
-			ActorTemplateName:      createdTemplate.GetName(),
-			ActorTemplateUid:       string(createdTemplate.GetUID()),
-			ContentScope:           ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
-			SnapshotUri:            "gs://fake-fake-fake/snapshots/" + resources.GoldenActorAtespace + "/" + goldenSnapshot,
+			ActorTemplateUid: created.GetMetadata().GetUid(),
+			ContentScope:     ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
+			SnapshotUri:      "gs://fake-fake-fake/snapshots/" + resources.GoldenActorAtespace + "/" + goldenSnapshot,
 		},
 	})
-	createdTemplate.Status = atev1alpha1.ActorTemplateStatus{
-		GoldenSnapshot: goldenSnapshot,
-	}
 
-	_, err = tc.substrateClient.ApiV1alpha1().ActorTemplates(ns).UpdateStatus(context.Background(), createdTemplate, metav1.UpdateOptions{})
+	// Record the golden snapshot on the template's status directly in the
+	// store, as the ActorTemplateReconciler's checkpoint would: there is no
+	// status RPC, and the reconciler does not run in this test environment.
+	updated, err := tc.persistence.UpdateActorTemplate(context.Background(),
+		resources.ActorTemplateRefFromActorTemplate(created), store.PreconditionFrom(created),
+		func(dbTemplate *ateapipb.ActorTemplate) error {
+			dbTemplate.Status = &ateapipb.ActorTemplateStatus{
+				GoldenSnapshotStatus: &ateapipb.GoldenSnapshotStatus{
+					GoldenSnapshot: &ateapipb.ObjectRef{Atespace: resources.GoldenActorAtespace, Name: goldenSnapshot},
+				},
+			}
+			return nil
+		})
 	if err != nil {
-		t.Fatalf("failed to update status: %v", err)
+		t.Fatalf("failed to record the template's golden snapshot: %v", err)
 	}
-
-	// Wait for Informer cache to sync
-	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		tmpl, err := tc.actorTemplateLister.ActorTemplates(ns).Get("tmpl1")
-		if err != nil {
-			return false, nil // Retry if not found in cache yet
-		}
-		return tmpl.Status.GoldenSnapshot != "", nil
-	})
-	if err != nil {
-		t.Fatalf("failed to wait for template status update in informer: %v", err)
-	}
+	return updated
 }
 
 // testPauseImage is the pause image the default test SandboxConfig carries;
@@ -426,36 +429,34 @@ func createWorkerPool(t *testing.T, tc *testContext, ns string, name string, lab
 	}
 }
 
-func createTemplateWithSelector(t *testing.T, tc *testContext, ns string, name string, selector *metav1.LabelSelector) {
+// createTemplateWithSelector creates a substrate ActorTemplate in
+// testAtespace with the given worker selector and no golden snapshot.
+func createTemplateWithSelector(t *testing.T, tc *testContext, name string, selector *ateapipb.Selector) *ateapipb.ActorTemplate {
 	t.Helper()
 	ensureDefaultGvisorSandboxConfig(t, tc)
-	actorTemplate := &atev1alpha1.ActorTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
-		},
-		Spec: atev1alpha1.ActorTemplateSpec{
-			SnapshotsConfig: atev1alpha1.SnapshotsConfig{
-				Location: "gs://fake-fake-fake",
+	created, err := tc.client.CreateActorTemplate(context.Background(), &ateapipb.CreateActorTemplateRequest{
+		ActorTemplate: &ateapipb.ActorTemplate{
+			Metadata: &ateapipb.ResourceMetadata{
+				Atespace: testAtespace,
+				Name:     name,
 			},
-			Containers: []atev1alpha1.Container{
+			SnapshotsConfig: &ateapipb.SnapshotsConfig{
+				StorageLocation: "gs://fake-fake-fake",
+			},
+			SandboxConfig: &ateapipb.SandboxConfig{
+				SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+				ConfigName:   "gvisor-default",
+			},
+			Containers: []*ateapipb.Container{
 				{Name: "main", Image: "main@sha256:abc", Command: []string{"/main"}},
 			},
 			WorkerSelector: selector,
 		},
-	}
-	_, err := tc.substrateClient.ApiV1alpha1().ActorTemplates(ns).Create(context.Background(), actorTemplate, metav1.CreateOptions{})
+	})
 	if err != nil {
 		t.Fatalf("failed to create actor template: %v", err)
 	}
-
-	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		_, err := tc.actorTemplateLister.ActorTemplates(ns).Get(name)
-		return err == nil, nil
-	})
-	if err != nil {
-		t.Fatalf("failed to wait for template %s/%s in informer: %v", ns, name, err)
-	}
+	return created
 }
 
 // createWorkerPod creates a worker pod, registers the matching Worker, and

--- a/cmd/ateapi/internal/controlapi/functionaltest/egress_policy_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/egress_policy_test.go
@@ -36,9 +36,8 @@ func setupEgressPolicyActor(t *testing.T, testName string) (*testContext, *ateap
 	createTemplate(t, tc, ns)
 
 	actor := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "egress-actor"},
-		ActorTemplateNamespace: ns,
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "egress-actor"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
 	}
 	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: actor}); err != nil {
 		t.Fatalf("CreateActor failed: %v", err)

--- a/cmd/ateapi/internal/controlapi/metrics.go
+++ b/cmd/ateapi/internal/controlapi/metrics.go
@@ -183,8 +183,8 @@ func (i *Instruments) recordLifecycleOp(ctx context.Context, op string, start ti
 // The pool keys are set together or not at all; see ateattr.WorkerPoolAttributes.
 func lifecycleOpAttrs(actor *ateapipb.Actor, template *ateapipb.ActorTemplate, snapshotKind, snapshotScope string) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
-		ateattr.TemplateNameKey.String(actor.GetActorTemplateName()),
-		ateattr.TemplateNamespaceKey.String(actor.GetActorTemplateNamespace()),
+		ateattr.TemplateNameKey.String(actor.GetActorTemplate().GetName()),
+		ateattr.TemplateAtespaceKey.String(actor.GetActorTemplate().GetAtespace()),
 	}
 	ass := actor.GetStatus().GetWorkerAssignment()
 	attrs = append(attrs, ateattr.WorkerPoolAttributes(ass.GetWorkerNamespace(), ass.GetWorkerPool())...)

--- a/cmd/ateapi/internal/controlapi/metrics_test.go
+++ b/cmd/ateapi/internal/controlapi/metrics_test.go
@@ -208,8 +208,7 @@ func TestLifecycleOpDurationShape(t *testing.T) {
 	inst, reader := newTestInstruments(t)
 
 	actor := &ateapipb.Actor{
-		ActorTemplateName:      "support-agent",
-		ActorTemplateNamespace: "ate-agents",
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "ate-agents", Name: "support-agent"},
 		Status: &ateapipb.ActorStatus{
 			WorkerAssignment: &ateapipb.WorkerAssignment{WorkerNamespace: "ate-workers", WorkerPool: "pool-a"},
 		},
@@ -224,7 +223,7 @@ func TestLifecycleOpDurationShape(t *testing.T) {
 	assertAttrKeys(t, dp,
 		ateattr.ActorOperationNameKey,
 		ateattr.TemplateNameKey,
-		ateattr.TemplateNamespaceKey,
+		ateattr.TemplateAtespaceKey,
 		ateattr.WorkerPoolNamespaceKey,
 		ateattr.WorkerPoolNameKey,
 		ateattr.SandboxClassKey,
@@ -254,7 +253,7 @@ func TestLifecycleOpDurationShape(t *testing.T) {
 // series would be indistinguishable from a real one. The unassigned actor also
 // pins the pool pair: a failure before the assign step emits neither key.
 func TestLifecycleOpAttrsOmitsUnknownScope(t *testing.T) {
-	actor := &ateapipb.Actor{ActorTemplateName: "support-agent", ActorTemplateNamespace: "ate-agents"}
+	actor := &ateapipb.Actor{ActorTemplate: &ateapipb.ObjectRef{Atespace: "ate-agents", Name: "support-agent"}}
 	for _, kv := range lifecycleOpAttrs(actor, nil, "", "") {
 		switch kv.Key {
 		case ateattr.SnapshotScopeKey, ateattr.SnapshotKindKey, ateattr.WorkerPoolNamespaceKey, ateattr.WorkerPoolNameKey:
@@ -283,7 +282,7 @@ func TestRecordLifecycleOp_OutcomeClassification(t *testing.T) {
 			inst, reader := newTestInstruments(t)
 			inst.recordLifecycleOp(context.Background(), tt.op, time.Now(), tt.err,
 				ateattr.TemplateNameKey.String("support-agent"),
-				ateattr.TemplateNamespaceKey.String("ate-agents"),
+				ateattr.TemplateAtespaceKey.String("ate-agents"),
 			)
 
 			dp := singleHistogramDP(t, reader, lifecycleOpDurationMetric)

--- a/cmd/ateapi/internal/controlapi/span_identity_test.go
+++ b/cmd/ateapi/internal/controlapi/span_identity_test.go
@@ -67,9 +67,8 @@ func assertSpanStr(t *testing.T, attrs map[attribute.Key]attribute.Value, key at
 func TestSetSpanActorAttributes(t *testing.T) {
 	t.Parallel()
 	actor := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "a1", Uid: "uid-a1", Version: 3},
-		ActorTemplateNamespace: "ns1",
-		ActorTemplateName:      "tmpl1",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "a1", Uid: "uid-a1", Version: 3},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "ns1", Name: "tmpl1"},
 	}
 
 	attrs := recordRootSpanAttrs(t, func(ctx context.Context) {
@@ -80,7 +79,7 @@ func TestSetSpanActorAttributes(t *testing.T) {
 	assertSpanStr(t, attrs, ateattr.ActorNameKey, "a1")
 	assertSpanStr(t, attrs, ateattr.ActorUIDKey, "uid-a1")
 	assertSpanStr(t, attrs, ateattr.TemplateNameKey, "tmpl1")
-	assertSpanStr(t, attrs, ateattr.TemplateNamespaceKey, "ns1")
+	assertSpanStr(t, attrs, ateattr.TemplateAtespaceKey, "ns1")
 	if v, ok := attrs[ateattr.ActorVersionKey]; !ok || v.Type() != attribute.INT64 || v.AsInt64() != 3 {
 		t.Errorf("%s = %v, want int64 3", ateattr.ActorVersionKey, v.String())
 	}
@@ -96,7 +95,7 @@ func TestSetSpanActorRefAttributes(t *testing.T) {
 	assertSpanStr(t, attrs, ateattr.AtespaceKey, "team-a")
 	assertSpanStr(t, attrs, ateattr.ActorNameKey, "a1")
 	// The ref-only stamp must not invent uid/template/version (not known pre-resolve).
-	for _, k := range []attribute.Key{ateattr.ActorUIDKey, ateattr.TemplateNameKey, ateattr.TemplateNamespaceKey, ateattr.ActorVersionKey} {
+	for _, k := range []attribute.Key{ateattr.ActorUIDKey, ateattr.TemplateNameKey, ateattr.TemplateAtespaceKey, ateattr.ActorVersionKey} {
 		if _, ok := attrs[k]; ok {
 			t.Errorf("unexpected %s on ref-only stamp", k)
 		}

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -29,13 +29,11 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/resources"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
-	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 )
 
 // TestSchedulerRecordable guards the retry-dedup rule: the assignment loop
@@ -1053,8 +1051,8 @@ func TestLoadActorForResume_OnGoldenDataResume(t *testing.T) {
 			}
 			seedWorkflowActor(t, ctx, persistence, actorRef, "ns", "tmpl1", actorState, seedOpts...)
 
-			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			if err := indexer.Add(&atev1alpha1.ActorTemplate{
+			storetest.MustCreateAtespace(t, ctx, persistence, "ns")
+			if _, err := persistence.CreateActorTemplate(ctx, mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "tmpl1"},
 				Spec: atev1alpha1.ActorTemplateSpec{
 					SnapshotsConfig: atev1alpha1.SnapshotsConfig{
@@ -1063,11 +1061,11 @@ func TestLoadActorForResume_OnGoldenDataResume(t *testing.T) {
 					},
 				},
 				Status: atev1alpha1.ActorTemplateStatus{GoldenSnapshot: tt.goldenSnapshot},
-			}); err != nil {
-				t.Fatalf("add template to indexer: %v", err)
+			})); err != nil {
+				t.Fatalf("create template: %v", err)
 			}
 
-			w := &ActorWorkflow{store: persistence, actorTemplateLister: listersv1alpha1.NewActorTemplateLister(indexer)}
+			w := &ActorWorkflow{store: persistence}
 			_, _, src, err := w.loadActorForResume(ctx, actorRef, false)
 			if got := status.Code(err); got != tt.wantCode {
 				t.Fatalf("status.Code(err) = %v, want %v (err: %v)", got, tt.wantCode, err)
@@ -1105,15 +1103,15 @@ func TestLoadActorForResume_GoldenFallbackRejectsNonFullGolden(t *testing.T) {
 	})
 	seedWorkflowActor(t, ctx, persistence, actorRef, "ns", "tmpl1", ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
 
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	if err := indexer.Add(&atev1alpha1.ActorTemplate{
+	storetest.MustCreateAtespace(t, ctx, persistence, "ns")
+	if _, err := persistence.CreateActorTemplate(ctx, mustTemplateFromCRD(&atev1alpha1.ActorTemplate{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "tmpl1"},
 		Status:     atev1alpha1.ActorTemplateStatus{GoldenSnapshot: "golden-1"},
-	}); err != nil {
-		t.Fatalf("add template to indexer: %v", err)
+	})); err != nil {
+		t.Fatalf("create template: %v", err)
 	}
 
-	w := &ActorWorkflow{store: persistence, actorTemplateLister: listersv1alpha1.NewActorTemplateLister(indexer)}
+	w := &ActorWorkflow{store: persistence}
 	_, _, _, err := w.loadActorForResume(ctx, actorRef, false)
 	if got := status.Code(err); got != codes.FailedPrecondition {
 		t.Fatalf("status.Code(err) = %v, want FailedPrecondition (err: %v)", got, err)
@@ -1129,12 +1127,11 @@ func TestLoadActorForResume_RunningActorShortCircuits(t *testing.T) {
 	actorRef := resources.ActorRef{Atespace: "team-a", Name: "id1"}
 
 	// Seed the actor as RUNNING. Note: No snapshot or template is seeded in the
-	// store or lister, proving that loadActorForResume short-circuits before
-	// attempting to fetch either.
+	// store, proving that loadActorForResume short-circuits before attempting
+	// to fetch either.
 	seedWorkflowActor(t, ctx, persistence, actorRef, "ns", "missing-tmpl", ateapipb.ActorState_ACTOR_STATE_RUNNING)
 
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	w := &ActorWorkflow{store: persistence, actorTemplateLister: listersv1alpha1.NewActorTemplateLister(indexer)}
+	w := &ActorWorkflow{store: persistence}
 
 	actor, tmpl, src, err := w.loadActorForResume(ctx, actorRef, false)
 	if err != nil {

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -23,11 +23,9 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
 	"github.com/agent-substrate/substrate/internal/resources"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
-	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -382,9 +380,6 @@ func TestEnsureSuspendedFinalized_StampsSubstrateTemplateRef(t *testing.T) {
 	if st.GetActorTemplateUid() != template.GetMetadata().GetUid() {
 		t.Errorf("snapshot ActorTemplateUid = %q, want %q", st.GetActorTemplateUid(), template.GetMetadata().GetUid())
 	}
-	if st.GetActorTemplateNamespace() != "" || st.GetActorTemplateName() != "" {
-		t.Errorf("legacy template fields = %q/%q, want empty for a ref-mode actor", st.GetActorTemplateNamespace(), st.GetActorTemplateName())
-	}
 }
 
 func TestEnsureSuspendedFinalized_ReleasesOnlyOwnWorker(t *testing.T) {
@@ -696,14 +691,8 @@ func TestSuspendActor_PausedWithoutLocalSnapshotCrashes(t *testing.T) {
 
 	// The template needs a snapshot location: MarkSuspending validates the
 	// destination URI before the workflow reaches the crash under test.
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	if err := indexer.Add(&atev1alpha1.ActorTemplate{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "tmpl1"},
-		Spec:       atev1alpha1.ActorTemplateSpec{SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://snapshots"}},
-	}); err != nil {
-		t.Fatalf("add template to indexer: %v", err)
-	}
-	w := NewActorWorkflow(st, nil, nil, listersv1alpha1.NewActorTemplateLister(indexer), nil, nil, nil, nil, "", nil)
+	// newTestActorWorkflow's stored template carries one.
+	w := newTestActorWorkflow(t, st, "ns", "tmpl1")
 
 	seedWorkflowActor(t, ctx, st, resources.ActorRef{Atespace: "team-a", Name: "id1"}, "ns", "tmpl1", ateapipb.ActorState_ACTOR_STATE_PAUSED)
 

--- a/cmd/ateapi/internal/controlapi/workflow_testutil_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_testutil_test.go
@@ -16,20 +16,17 @@ package controlapi
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"testing"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
 	"github.com/agent-substrate/substrate/internal/resources"
-	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
-	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 )
 
 // testWorkerUID derives a stable pod UID from a pod name, for Workers seeded
@@ -38,32 +35,38 @@ func testWorkerUID(podName string) string {
 	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(podName)).String()
 }
 
-// newTestActorWorkflow builds an ActorWorkflow backed by the given store and a
-// lister serving one minimal ActorTemplate. Dependencies the unit tests never
-// reach (worker cache, atelet dialer, k8s clients) are nil, so a step that
-// unexpectedly executes against them fails the test loudly.
-func newTestActorWorkflow(t *testing.T, st store.Interface, tmplNamespace, tmplName string) *ActorWorkflow {
+// newTestActorWorkflow builds an ActorWorkflow backed by the given store,
+// with one minimal ActorTemplate stored in tmplAtespace. Dependencies the
+// unit tests never reach (worker cache, atelet dialer, k8s clients) are nil,
+// so a step that unexpectedly executes against them fails the test loudly.
+func newTestActorWorkflow(t *testing.T, st store.Interface, tmplAtespace, tmplName string) *ActorWorkflow {
 	t.Helper()
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	if err := indexer.Add(&atev1alpha1.ActorTemplate{
-		ObjectMeta: metav1.ObjectMeta{Namespace: tmplNamespace, Name: tmplName},
-	}); err != nil {
-		t.Fatalf("add template to indexer: %v", err)
+	storetest.MustCreateAtespace(t, context.Background(), st, tmplAtespace)
+	if _, err := st.CreateActorTemplate(context.Background(), &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{Atespace: tmplAtespace, Name: tmplName},
+		SnapshotsConfig: &ateapipb.SnapshotsConfig{
+			StorageLocation: "gs://snapshots",
+		},
+		SandboxConfig: &ateapipb.SandboxConfig{
+			SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR,
+			ConfigName:   "gvisor",
+		},
+	}); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
+		t.Fatalf("create test ActorTemplate: %v", err)
 	}
-	return NewActorWorkflow(st, nil, nil, listersv1alpha1.NewActorTemplateLister(indexer), nil, nil, nil, nil, "", nil)
+	return NewActorWorkflow(st, nil, nil, nil, nil, nil, nil, nil, "", nil)
 }
 
 // seedWorkflowActor stores an actor with the given state, bound to the given
-// template (pass the same tmplNamespace/tmplName as newTestActorWorkflow).
+// template (pass the same tmplAtespace/tmplName as newTestActorWorkflow).
 // opts mutate the actor before it is stored.
-func seedWorkflowActor(t *testing.T, ctx context.Context, st store.Interface, actorRef resources.ActorRef, tmplNamespace, tmplName string, actorState ateapipb.ActorState, opts ...func(*ateapipb.Actor)) {
+func seedWorkflowActor(t *testing.T, ctx context.Context, st store.Interface, actorRef resources.ActorRef, tmplAtespace, tmplName string, actorState ateapipb.ActorState, opts ...func(*ateapipb.Actor)) {
 	t.Helper()
 
 	actor := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Name: actorRef.Name, Atespace: actorRef.Atespace},
-		Status:                 &ateapipb.ActorStatus{State: actorState},
-		ActorTemplateNamespace: tmplNamespace,
-		ActorTemplateName:      tmplName,
+		Metadata:      &ateapipb.ResourceMetadata{Name: actorRef.Name, Atespace: actorRef.Atespace},
+		Status:        &ateapipb.ActorStatus{State: actorState},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: tmplAtespace, Name: tmplName},
 	}
 	for _, opt := range opts {
 		opt(actor)

--- a/cmd/ateapi/internal/controlapi/workflow_worker_delete_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_worker_delete_test.go
@@ -50,9 +50,8 @@ var apiActorRef = resources.ActorRef{Atespace: "team-a", Name: "actor-1"}
 func seedAPIActor(t *testing.T, ctx context.Context, persistence store.Interface, state ateapipb.ActorState, opts ...func(*ateapipb.Actor)) *ateapipb.Actor {
 	t.Helper()
 	actor := &ateapipb.Actor{
-		Metadata:               &ateapipb.ResourceMetadata{Atespace: apiActorRef.Atespace, Name: apiActorRef.Name},
-		ActorTemplateNamespace: "ate-system",
-		ActorTemplateName:      "tmpl",
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: apiActorRef.Atespace, Name: apiActorRef.Name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "ate-system", Name: "tmpl"},
 		Status: &ateapipb.ActorStatus{
 			State: state,
 			WorkerAssignment: &ateapipb.WorkerAssignment{

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -563,7 +563,7 @@ func recordSnapshotSize(ctx context.Context, file, path, templateAtespace, templ
 	}
 	snapshotSizeBytes.Record(ctx, fi.Size(), metric.WithAttributes(
 		semconv.FileNameKey.String(file),
-		ateattr.TemplateNamespaceKey.String(templateAtespace),
+		ateattr.TemplateAtespaceKey.String(templateAtespace),
 		ateattr.TemplateNameKey.String(templateName),
 	))
 }

--- a/cmd/atelet/metrics.go
+++ b/cmd/atelet/metrics.go
@@ -90,7 +90,7 @@ type snapshotOp struct {
 func (o snapshotOp) attrs() []attribute.KeyValue {
 	attrs := make([]attribute.KeyValue, 0, 5)
 	attrs = append(attrs,
-		ateattr.TemplateNamespaceKey.String(o.templateNamespace),
+		ateattr.TemplateAtespaceKey.String(o.templateNamespace),
 		ateattr.TemplateNameKey.String(o.templateName),
 		ateattr.SnapshotScopeKey.String(o.scope),
 	)

--- a/cmd/atelet/metrics_test.go
+++ b/cmd/atelet/metrics_test.go
@@ -126,7 +126,7 @@ func TestRestoreDurationShape(t *testing.T) {
 		key  attribute.Key
 		want string
 	}{
-		{ateattr.TemplateNamespaceKey, testTemplateNamespace},
+		{ateattr.TemplateAtespaceKey, testTemplateNamespace},
 		{ateattr.TemplateNameKey, testTemplateName},
 		{ateattr.SnapshotKindKey, ateattr.SnapshotKindLatest},
 		{ateattr.SnapshotScopeKey, ateattr.SnapshotScopeDataOnGolden},

--- a/cmd/atelet/statspoller.go
+++ b/cmd/atelet/statspoller.go
@@ -183,7 +183,7 @@ type templateKey struct {
 func (k templateKey) attrs() metric.MeasurementOption {
 	attrs := make([]attribute.KeyValue, 0, 6)
 	attrs = append(attrs,
-		ateattr.TemplateNamespaceKey.String(k.templateNamespace),
+		ateattr.TemplateAtespaceKey.String(k.templateNamespace),
 		ateattr.TemplateNameKey.String(k.templateName),
 		ateattr.SandboxClassKey.String(k.sandboxClass),
 		ateattr.StatsSourceKey.String(k.source),

--- a/cmd/atenet/internal/router/extproc/metrics.go
+++ b/cmd/atenet/internal/router/extproc/metrics.go
@@ -65,7 +65,7 @@ func (s *Server) recordRouteDuration(ctx context.Context, d time.Duration, tmplN
 		return
 	}
 	s.routeDuration.Record(ctx, d.Seconds(), metric.WithAttributes(
-		ateattr.TemplateNamespaceKey.String(tmplNs),
+		ateattr.TemplateAtespaceKey.String(tmplNs),
 		ateattr.TemplateNameKey.String(tmplName),
 		ateattr.RouterOutcomeKey.String(outcome),
 		ateattr.RouterResumeKey.String(resume),

--- a/cmd/atenet/internal/router/extproc/metrics_test.go
+++ b/cmd/atenet/internal/router/extproc/metrics_test.go
@@ -125,10 +125,10 @@ func TestRecordRouteDuration_Attributes(t *testing.T) {
 
 	dp := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64]).DataPoints[0]
 	wantAttrs := map[string]string{
-		"ate.template.namespace": "team-a-ns",
-		"ate.template.name":      "tmpl-a",
-		"ate.router.outcome":     "ok",
-		"ate.router.resume":      "triggered",
+		"ate.template.atespace": "team-a-ns",
+		"ate.template.name":     "tmpl-a",
+		"ate.router.outcome":    "ok",
+		"ate.router.resume":     "triggered",
 	}
 
 	for k, want := range wantAttrs {

--- a/docs/metrics/registry/metrics.yaml
+++ b/docs/metrics/registry/metrics.yaml
@@ -72,10 +72,10 @@ groups:
       But an operator makes each template. No value comes from a request. Thus
       the number of values stays small.
     attributes:
-      - id: ate.template.namespace
+      - id: ate.template.atespace
         stability: development
         type: string
-        brief: The Kubernetes namespace of the ActorTemplate of the actor.
+        brief: The atespace of the ActorTemplate of the actor.
         examples: [ate-demo-counter]
       - id: ate.template.name
         stability: development
@@ -590,7 +590,7 @@ groups:
         requirement_level: required
       - ref: ate.failure.reason
         requirement_level: required
-      - ref: ate.template.namespace
+      - ref: ate.template.atespace
         requirement_level: required
       - ref: ate.template.name
         requirement_level: required
@@ -655,7 +655,7 @@ groups:
     attributes:
       - ref: ate.actor.operation.name
         requirement_level: required
-      - ref: ate.template.namespace
+      - ref: ate.template.atespace
         requirement_level: required
       - ref: ate.template.name
         requirement_level: required
@@ -773,7 +773,7 @@ groups:
         buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60]
         cuj: Cold starts are slow. Is the cause the download, the unpack, or ateom?
     attributes:
-      - ref: ate.template.namespace
+      - ref: ate.template.atespace
         requirement_level: required
       - ref: ate.template.name
         requirement_level: required
@@ -810,7 +810,7 @@ groups:
         buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60]
         cuj: Suspends are slow. Is the cause ateom or the upload?
     attributes:
-      - ref: ate.template.namespace
+      - ref: ate.template.atespace
         requirement_level: required
       - ref: ate.template.name
         requirement_level: required
@@ -849,7 +849,7 @@ groups:
     attributes:
       - ref: file.name
         requirement_level: required
-      - ref: ate.template.namespace
+      - ref: ate.template.atespace
         requirement_level: required
       - ref: ate.template.name
         requirement_level: required
@@ -874,7 +874,7 @@ groups:
         code_anchor: cmd/atelet/statspoller.go
         cuj: Which template uses the CPU of the node?
     attributes: &actor_stats_attributes
-      - ref: ate.template.namespace
+      - ref: ate.template.atespace
         requirement_level: required
       - ref: ate.template.name
         requirement_level: required
@@ -1052,7 +1052,7 @@ groups:
         buckets: [0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.25, 0.5, 1, 2.5, 5, 10, 15, 30]
         cuj: A request stopped or got a 503 error. Was the actor cold, was the fleet full, or has the router a defect?
     attributes:
-      - ref: ate.template.namespace
+      - ref: ate.template.atespace
         requirement_level: required
       - ref: ate.template.name
         requirement_level: required

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -11,7 +11,7 @@ To make underlying infrastructure transitions transparent, Agent Substrate estab
 * `ate.atespace`: The atespace the actor lives in (e.g., `ate-demo-counter`).
 * `ate.actor.uid`: Server-assigned UID of the actor, unique to the lifetime of an actor.
 * `ate.template.name`: The name of the actor's ActorTemplate (e.g., `counter`).
-* `ate.template.namespace`: The Kubernetes namespace of the actor's ActorTemplate (e.g., `ate-demo-counter`).
+* `ate.template.atespace`: The atespace of the actor's ActorTemplate (e.g., `ate-demo-counter`).
 * `ate.actor.container.name`: The name of the container within the actor that produced the log line (e.g., `counter`), so a multi-container actor's logs can be demultiplexed by container. Absent on the synthetic lifecycle records (`Actor starting`, `Actor restored`, …): those are about the actor, so no container produced them.
 
 Currently, Agent Substrate automatically wraps container output and injects these metadata labels into **container logs**. For metrics and distributed tracing, Agent Substrate provides foundational system telemetry and on-demand request tracing, with roadmap plans to fully integrate actor-level correlation.
@@ -128,10 +128,10 @@ Agent Substrate emits foundational OpenTelemetry system and server metrics to mo
 | Metric | Emitted by | Type | Measures |
 |--------|------------|------|----------|
 | `rpc.server.call.duration` | ateapi & atelet (gRPC servers, via `otelgrpc`) | histogram | per-method gRPC latency, request rate, and errors (labels `rpc.method`, `rpc.response.status_code`) |
-| `ate.actor.crashes` | ateapi | counter | Number of times actors transitioned to `ACTOR_STATE_CRASHED` with failure reasons (labels `ate.actor.operation.name`, `ate.failure.reason`, `ate.template.namespace`, `ate.template.name`, `ate.workerpool.namespace`, `ate.workerpool.name`, `ate.sandbox.class`) |
-| `atenet.router.route.duration` | atenet-router | histogram | Substrate E2E — Envoy receiving a request to Envoy forwarding it to the resolved worker, excluding actor compute and the response (labels `ate.template.namespace`, `ate.template.name`, `ate.router.outcome`, `ate.router.resume`) |
+| `ate.actor.crashes` | ateapi | counter | Number of times actors transitioned to `ACTOR_STATE_CRASHED` with failure reasons (labels `ate.actor.operation.name`, `ate.failure.reason`, `ate.template.atespace`, `ate.template.name`, `ate.workerpool.namespace`, `ate.workerpool.name`, `ate.sandbox.class`) |
+| `atenet.router.route.duration` | atenet-router | histogram | Substrate E2E — Envoy receiving a request to Envoy forwarding it to the resolved worker, excluding actor compute and the response (labels `ate.template.atespace`, `ate.template.name`, `ate.router.outcome`, `ate.router.resume`) |
 | `ate.scheduler.eligible_workers` | ateapi | histogram | number of eligible unassigned workers available during scheduling given the constraint filters (labels `ate.workerpool.namespace`, `ate.workerpool.name`, `ate.sandbox.class`, `ate.scheduling.constraint`) |
-| `atelet.snapshot.size` | atelet | histogram | uncompressed size in bytes of each gVisor snapshot image written during checkpoint (labels `file.name`, `ate.template.namespace`, `ate.template.name`) |
+| `atelet.snapshot.size` | atelet | histogram | uncompressed size in bytes of each gVisor snapshot image written during checkpoint (labels `file.name`, `ate.template.atespace`, `ate.template.name`) |
 | `ate.workerpool.desired_workers` | atecontroller | up/down counter | number of worker pods requested for a WorkerPool, from `spec.replicas` (labels
 `ate.workerpool.namespace`, `ate.workerpool.name`) |
 | `ate.workerpool.ready_workers` | atecontroller | up/down counter | number of worker pods currently ready for a WorkerPool, from `status.readyReplicas` (labels
@@ -139,7 +139,7 @@ Agent Substrate emits foundational OpenTelemetry system and server metrics to mo
 | `ate.workerpool.workers` | ateapi | up/down counter | live worker count per pool, split by state (`idle`/`assigned`) and sandbox class to provide fleet capacity and saturation at a glance |
 | `ate.actor.lifecycle.operation.duration` | ateapi | histogram | how long each actor operation (create/resume/suspend/pause/delete) takes and whether it failed (`error.type` present = failure, absent = success); labeled by operation, template, pool (`ate.workerpool.namespace` + `ate.workerpool.name`), sandbox class, and snapshot kind and scope on resume; already-running resume no-ops are not recorded so the histogram tracks actual activations, not router traffic |
 | `ate.scheduler.assignment.duration` | ateapi | histogram | time it takes for an actor to be assigned to a worker, per attempt (version-conflict retries record only the final attempt), with the outcome (`assigned` / `no_free_worker` / `error`), the assigned pool (`ate.workerpool.namespace` + `ate.workerpool.name`) and sandbox class to catch scheduling latency and capacity starvation problems |
-| `ate.actor.restore.duration` | atelet | histogram | how long each phase of a restore takes on the worker node, which is where cold-start latency actually goes once ateapi hands off (labels `ate.snapshot.phase`, `ate.snapshot.kind`, `ate.snapshot.scope`, `ate.template.namespace`, `ate.template.name`, `ate.sandbox.class`, plus `ate.failure.reason` on failure) |
+| `ate.actor.restore.duration` | atelet | histogram | how long each phase of a restore takes on the worker node, which is where cold-start latency actually goes once ateapi hands off (labels `ate.snapshot.phase`, `ate.snapshot.kind`, `ate.snapshot.scope`, `ate.template.atespace`, `ate.template.name`, `ate.sandbox.class`, plus `ate.failure.reason` on failure) |
 | `ate.actor.checkpoint.duration` | atelet | histogram | the same phase breakdown for writing a snapshot, so a slow suspend can be attributed to ateom or to the upload (same labels as the restore histogram) |
 | `ate.imagecache.requests` | atelet | counter | image lookups in the node-local image cache, by outcome (`ate.imagecache.outcome`), with `error.type` on the `error` outcome. A miss pays for the pull and the unpack, so the hit ratio per node is a leading indicator of resume latency |
 

--- a/internal/actorlog/logger_test.go
+++ b/internal/actorlog/logger_test.go
@@ -51,7 +51,7 @@ var (
 	actorNameLabel     = string(ateattr.ActorNameKey)
 	actorUIDLabel      = string(ateattr.ActorUIDKey)
 	containerNameLabel = string(ateattr.ActorContainerNameKey)
-	templateNSLabel    = string(ateattr.TemplateNamespaceKey)
+	templateNSLabel    = string(ateattr.TemplateAtespaceKey)
 	templateNameLabel  = string(ateattr.TemplateNameKey)
 )
 

--- a/internal/ateattr/ateattr.go
+++ b/internal/ateattr/ateattr.go
@@ -51,7 +51,7 @@ const (
 	ActorUIDKey           = attribute.Key("ate.actor.uid")
 	ActorContainerNameKey = attribute.Key("ate.actor.container.name")
 	TemplateNameKey       = attribute.Key("ate.template.name")
-	TemplateNamespaceKey  = attribute.Key("ate.template.namespace")
+	TemplateAtespaceKey   = attribute.Key("ate.template.atespace")
 	ActorVersionKey       = attribute.Key("ate.actor.version")
 )
 
@@ -178,10 +178,6 @@ const (
 	OperationDelete  = "delete"
 	OperationUnknown = "unknown"
 )
-
-// TemplateUnknown is the placeholder for the template labels when the Actor
-// record does not carry its template ref.
-const TemplateUnknown = "unknown"
 
 // AllOperations lists all registered bounded actor lifecycle operations.
 var AllOperations = []string{
@@ -327,8 +323,8 @@ func ActorAttributes(a *ateapipb.Actor) []attribute.KeyValue {
 		AtespaceKey.String(a.GetMetadata().GetAtespace()),
 		ActorNameKey.String(a.GetMetadata().GetName()),
 		ActorUIDKey.String(a.GetMetadata().GetUid()),
-		TemplateNameKey.String(a.GetActorTemplateName()),
-		TemplateNamespaceKey.String(a.GetActorTemplateNamespace()),
+		TemplateNameKey.String(a.GetActorTemplate().GetName()),
+		TemplateAtespaceKey.String(a.GetActorTemplate().GetAtespace()),
 		ActorVersionKey.Int64(a.GetMetadata().GetVersion()),
 	}
 }
@@ -339,11 +335,11 @@ func ActorAttributes(a *ateapipb.Actor) []attribute.KeyValue {
 // emitting it empty, so a consumer filtering on it gets container output only.
 func ActorLogLabels(a resources.ActorAttribution, containerName string) map[string]string {
 	labels := map[string]string{
-		string(AtespaceKey):          a.Ref.Atespace,
-		string(ActorNameKey):         a.Ref.Name,
-		string(ActorUIDKey):          a.UID,
-		string(TemplateNamespaceKey): a.TemplateAtespace,
-		string(TemplateNameKey):      a.TemplateName,
+		string(AtespaceKey):         a.Ref.Atespace,
+		string(ActorNameKey):        a.Ref.Name,
+		string(ActorUIDKey):         a.UID,
+		string(TemplateAtespaceKey): a.TemplateAtespace,
+		string(TemplateNameKey):     a.TemplateName,
 	}
 	if containerName != "" {
 		labels[string(ActorContainerNameKey)] = containerName
@@ -367,21 +363,10 @@ func ActorMetricAttributes(a *ateapipb.Actor, sandboxClass, operationName, reaso
 	}
 	operationName = NormalizeOperationName(operationName)
 
-	// TODO(zoez7): actors created via the ActorTemplate resource path do not carry
-	// the template ref yet, so report "unknown" rather than an empty label.
-	templateNamespace := a.GetActorTemplateNamespace()
-	if templateNamespace == "" {
-		templateNamespace = TemplateUnknown
-	}
-	templateName := a.GetActorTemplateName()
-	if templateName == "" {
-		templateName = TemplateUnknown
-	}
-
 	ass := a.GetStatus().GetWorkerAssignment()
 	attrs := []attribute.KeyValue{
-		TemplateNamespaceKey.String(templateNamespace),
-		TemplateNameKey.String(templateName),
+		TemplateAtespaceKey.String(a.GetActorTemplate().GetAtespace()),
+		TemplateNameKey.String(a.GetActorTemplate().GetName()),
 		SandboxClassKey.String(sandboxClass),
 		ActorOperationNameKey.String(operationName),
 		FailureReasonKey.String(reason),

--- a/internal/ateattr/ateattr_test.go
+++ b/internal/ateattr/ateattr_test.go
@@ -78,29 +78,28 @@ func TestActorAttributes(t *testing.T) {
 		{
 			name: "full actor",
 			actor: &ateapipb.Actor{
-				Metadata:               &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "support-agent-42", Uid: "uid-abc", Version: 7},
-				ActorTemplateNamespace: "ate-agents",
-				ActorTemplateName:      "support-agent",
+				Metadata:      &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "support-agent-42", Uid: "uid-abc", Version: 7},
+				ActorTemplate: &ateapipb.ObjectRef{Atespace: "ate-agents", Name: "support-agent"},
 			},
 			want: map[attribute.Key]any{
-				AtespaceKey:          "team-a",
-				ActorNameKey:         "support-agent-42",
-				ActorUIDKey:          "uid-abc",
-				TemplateNameKey:      "support-agent",
-				TemplateNamespaceKey: "ate-agents",
-				ActorVersionKey:      int64(7),
+				AtespaceKey:         "team-a",
+				ActorNameKey:        "support-agent-42",
+				ActorUIDKey:         "uid-abc",
+				TemplateNameKey:     "support-agent",
+				TemplateAtespaceKey: "ate-agents",
+				ActorVersionKey:     int64(7),
 			},
 		},
 		{
 			name:  "nil actor yields zero values, not a panic",
 			actor: nil,
 			want: map[attribute.Key]any{
-				AtespaceKey:          "",
-				ActorNameKey:         "",
-				ActorUIDKey:          "",
-				TemplateNameKey:      "",
-				TemplateNamespaceKey: "",
-				ActorVersionKey:      int64(0),
+				AtespaceKey:         "",
+				ActorNameKey:        "",
+				ActorUIDKey:         "",
+				TemplateNameKey:     "",
+				TemplateAtespaceKey: "",
+				ActorVersionKey:     int64(0),
 			},
 		},
 	}
@@ -156,7 +155,7 @@ func TestKeySpellings(t *testing.T) {
 		{ActorUIDKey, "ate.actor.uid"},
 		{ActorContainerNameKey, "ate.actor.container.name"},
 		{TemplateNameKey, "ate.template.name"},
-		{TemplateNamespaceKey, "ate.template.namespace"},
+		{TemplateAtespaceKey, "ate.template.atespace"},
 		{ActorVersionKey, "ate.actor.version"},
 		{ActorOperationNameKey, "ate.actor.operation.name"},
 		{WorkerPoolNamespaceKey, "ate.workerpool.namespace"},
@@ -227,7 +226,7 @@ func TestActorLogLabels(t *testing.T) {
 				"ate.actor.name":           "support-agent-42",
 				"ate.actor.uid":            "uid-abc",
 				"ate.actor.container.name": containerName,
-				"ate.template.namespace":   "ate-agents",
+				"ate.template.atespace":    "ate-agents",
 				"ate.template.name":        "support-agent",
 			},
 		},
@@ -236,11 +235,11 @@ func TestActorLogLabels(t *testing.T) {
 			attribution:   attribution,
 			containerName: "",
 			want: map[string]string{
-				"ate.atespace":           "team-a",
-				"ate.actor.name":         "support-agent-42",
-				"ate.actor.uid":          "uid-abc",
-				"ate.template.namespace": "ate-agents",
-				"ate.template.name":      "support-agent",
+				"ate.atespace":          "team-a",
+				"ate.actor.name":        "support-agent-42",
+				"ate.actor.uid":         "uid-abc",
+				"ate.template.atespace": "ate-agents",
+				"ate.template.name":     "support-agent",
 			},
 		},
 		{
@@ -248,11 +247,11 @@ func TestActorLogLabels(t *testing.T) {
 			attribution:   resources.ActorAttribution{},
 			containerName: "",
 			want: map[string]string{
-				"ate.atespace":           "",
-				"ate.actor.name":         "",
-				"ate.actor.uid":          "",
-				"ate.template.namespace": "",
-				"ate.template.name":      "",
+				"ate.atespace":          "",
+				"ate.actor.name":        "",
+				"ate.actor.uid":         "",
+				"ate.template.atespace": "",
+				"ate.template.name":     "",
 			},
 		},
 	}
@@ -336,8 +335,7 @@ func TestMetricLabelValues(t *testing.T) {
 
 func TestActorMetricAttributes(t *testing.T) {
 	actor := &ateapipb.Actor{
-		ActorTemplateNamespace: "default",
-		ActorTemplateName:      "counter-template",
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "default", Name: "counter-template"},
 		Status: &ateapipb.ActorStatus{
 			WorkerAssignment: &ateapipb.WorkerAssignment{
 				WorkerNamespace: "ate-workers",
@@ -349,7 +347,7 @@ func TestActorMetricAttributes(t *testing.T) {
 	t.Run("explicit operation and reason", func(t *testing.T) {
 		got := toMap(ActorMetricAttributes(actor, "gvisor", OperationResume, ReasonCorruptedAssignment))
 		want := map[attribute.Key]any{
-			TemplateNamespaceKey:   "default",
+			TemplateAtespaceKey:    "default",
 			TemplateNameKey:        "counter-template",
 			WorkerPoolNamespaceKey: "ate-workers",
 			WorkerPoolNameKey:      "default-pool",
@@ -364,7 +362,7 @@ func TestActorMetricAttributes(t *testing.T) {
 	t.Run("default unknown values", func(t *testing.T) {
 		got := toMap(ActorMetricAttributes(actor, "gvisor", "", ""))
 		want := map[attribute.Key]any{
-			TemplateNamespaceKey:   "default",
+			TemplateAtespaceKey:    "default",
 			TemplateNameKey:        "counter-template",
 			WorkerPoolNamespaceKey: "ate-workers",
 			WorkerPoolNameKey:      "default-pool",
@@ -379,7 +377,7 @@ func TestActorMetricAttributes(t *testing.T) {
 	t.Run("out of range operation name is normalized to unknown", func(t *testing.T) {
 		got := toMap(ActorMetricAttributes(actor, "gvisor", "invalid_op", ""))
 		want := map[attribute.Key]any{
-			TemplateNamespaceKey:   "default",
+			TemplateAtespaceKey:    "default",
 			TemplateNameKey:        "counter-template",
 			WorkerPoolNamespaceKey: "ate-workers",
 			WorkerPoolNameKey:      "default-pool",
@@ -391,7 +389,7 @@ func TestActorMetricAttributes(t *testing.T) {
 		assertAttrs(t, got, want)
 	})
 
-	t.Run("empty template ref reports unknown", func(t *testing.T) {
+	t.Run("empty template ref reports empty labels", func(t *testing.T) {
 		noTemplate := &ateapipb.Actor{
 			Status: &ateapipb.ActorStatus{
 				WorkerAssignment: &ateapipb.WorkerAssignment{
@@ -402,8 +400,8 @@ func TestActorMetricAttributes(t *testing.T) {
 		}
 		got := toMap(ActorMetricAttributes(noTemplate, "gvisor", OperationResume, ReasonUnknown))
 		want := map[attribute.Key]any{
-			TemplateNamespaceKey:   TemplateUnknown,
-			TemplateNameKey:        TemplateUnknown,
+			TemplateAtespaceKey:    "",
+			TemplateNameKey:        "",
 			WorkerPoolNamespaceKey: "ate-workers",
 			WorkerPoolNameKey:      "default-pool",
 			SandboxClassKey:        "gvisor",
@@ -419,12 +417,11 @@ func TestActorMetricAttributes(t *testing.T) {
 	// series that looks like a real pool.
 	t.Run("unassigned actor omits both pool keys", func(t *testing.T) {
 		unassigned := &ateapipb.Actor{
-			ActorTemplateNamespace: "default",
-			ActorTemplateName:      "counter-template",
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: "default", Name: "counter-template"},
 		}
 		got := toMap(ActorMetricAttributes(unassigned, "gvisor", OperationCreate, ReasonUnknown))
 		want := map[attribute.Key]any{
-			TemplateNamespaceKey:  "default",
+			TemplateAtespaceKey:   "default",
 			TemplateNameKey:       "counter-template",
 			SandboxClassKey:       "gvisor",
 			ActorOperationNameKey: OperationCreate,

--- a/internal/e2e/suites/metrics/metrics_test.go
+++ b/internal/e2e/suites/metrics/metrics_test.go
@@ -219,7 +219,7 @@ func TestPlatformMetricsEmitted(t *testing.T) {
 					foundCrashLine = true
 					opVal := extractLabelValue(line, "ate_actor_operation_name")
 					reasonVal := extractLabelValue(line, "ate_failure_reason")
-					tmplNSVal := extractLabelValue(line, "ate_template_namespace")
+					tmplAtespaceVal := extractLabelValue(line, "ate_template_atespace")
 					tmplNameVal := extractLabelValue(line, "ate_template_name")
 					workerPoolNSVal := extractLabelValue(line, "ate_workerpool_namespace")
 					workerPoolVal := extractLabelValue(line, "ate_workerpool_name")
@@ -238,8 +238,8 @@ func TestPlatformMetricsEmitted(t *testing.T) {
 						crashErrs = append(crashErrs, fmt.Sprintf("ate_failure_reason %q is invalid (must be a registered ateerrors reason enum like CORRUPTED_ASSIGNMENT, WORKER_POD_GONE, WORKER_REASSIGNED, UNKNOWN)", reasonVal))
 					}
 
-					if tmplNSVal == "" {
-						crashErrs = append(crashErrs, "ate_template_namespace label is missing or empty")
+					if tmplAtespaceVal == "" {
+						crashErrs = append(crashErrs, "ate_template_atespace label is missing or empty")
 					}
 					if tmplNameVal == "" {
 						crashErrs = append(crashErrs, "ate_template_name label is missing or empty")
@@ -258,8 +258,8 @@ func TestPlatformMetricsEmitted(t *testing.T) {
 					}
 
 					if len(crashErrs) > 0 {
-						errs = append(errs, fmt.Sprintf("ate_actor_crashes line %q failed label validation:\n  - %s\n  (Extracted labels: op=%q, reason=%q, tmplNS=%q, tmplName=%q, workerPoolNS=%q, workerPool=%q, sandboxClass=%q)",
-							line, strings.Join(crashErrs, "\n  - "), opVal, reasonVal, tmplNSVal, tmplNameVal, workerPoolNSVal, workerPoolVal, sandboxVal))
+						errs = append(errs, fmt.Sprintf("ate_actor_crashes line %q failed label validation:\n  - %s\n  (Extracted labels: op=%q, reason=%q, tmplAtespace=%q, tmplName=%q, workerPoolNS=%q, workerPool=%q, sandboxClass=%q)",
+							line, strings.Join(crashErrs, "\n  - "), opVal, reasonVal, tmplAtespaceVal, tmplNameVal, workerPoolNSVal, workerPoolVal, sandboxVal))
 					}
 				}
 			}


### PR DESCRIPTION
* Renames the`ate.template.namespace` attribute to `ate.template.atespace` and sources it from the actor's `actor_template` ObjectRef instead of the legacy CRD namespace/name pair.
* Updated functional tests now to use substrate ActorTemplates and bind actors through the `actor_template` ref.