### PR TITLE
ateapi: fail DB tests instead of skipping unless Docker is absent

### DIFF
--- a/cmd/ateapi/internal/store/atepg/atepg_test.go
+++ b/cmd/ateapi/internal/store/atepg/atepg_test.go
@@ -109,7 +109,7 @@ func requirePool(t *testing.T) *pgxpool.Pool {
 		containerPool = pool
 	})
 	if containerErr != nil {
-		t.Skipf("PostgreSQL testcontainer unavailable (requires Docker): %v", containerErr)
+		dockerenv.FailOrSkip(t, fmt.Errorf("PostgreSQL testcontainer: %w", containerErr))
 	}
 	return containerPool
 }

--- a/cmd/ateapi/internal/store/dockerenv/dockerenv.go
+++ b/cmd/ateapi/internal/store/dockerenv/dockerenv.go
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package dockerenv points testcontainers at the active Docker context.
+// Package dockerenv points testcontainers at the active Docker context and
+// owns the policy that decides whether a container that fails to start fails
+// the test or skips it (see [FailOrSkip]). Every container-backed test
+// fixture in this tree routes through both, so neither can drift.
 //
 // It lives apart from storetest because storetest imports atepg, so atepg
 // cannot import storetest back, and both need this before starting a

--- a/cmd/ateapi/internal/store/dockerenv/failorskip.go
+++ b/cmd/ateapi/internal/store/dockerenv/failorskip.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dockerenv
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// dialTimeout bounds a single endpoint probe. The probe only has to learn
+// whether something is listening, so it stays short.
+const dialTimeout = 2 * time.Second
+
+// testingTB is the part of [testing.TB] that [FailOrSkip] uses, so the policy
+// can be unit tested without a real test binary.
+type testingTB interface {
+	Helper()
+	Fatalf(format string, args ...any)
+	Skipf(format string, args ...any)
+}
+
+// FailOrSkip ends the test after a testcontainer failed to start.
+//
+// It fails rather than skips unless Docker is provably absent, so that a
+// container problem that is not a missing Docker (a reaper timeout, an image
+// pull failure, a daemon hiccup) is reported instead of silently removing the
+// tests that need a container from the run. In CI it always fails: the
+// runners have Docker, so any container error there is a real failure.
+//
+// Callers name their container in err, because the messages below are shared
+// by every fixture that routes through this policy.
+func FailOrSkip(t testing.TB, err error) {
+	t.Helper()
+	failOrSkip(t, err, inCI(), Unavailable)
+}
+
+// inCI reports whether the tests are running in continuous integration.
+// GitHub Actions sets both variables on every runner; accepting either keeps
+// the strict policy in place in a job that forwards only one of them.
+func inCI() bool {
+	return os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != ""
+}
+
+func failOrSkip(t testingTB, err error, ci bool, unavailable func() error) {
+	t.Helper()
+	// Each branch returns because the fake testing.TB the unit tests use
+	// records the call and keeps going, where a real *testing.T never returns
+	// from Fatalf or Skipf.
+	if ci {
+		t.Fatalf("container startup failed in CI, where Docker is expected: %v", err)
+		return
+	}
+	if reason := unavailable(); reason != nil {
+		t.Skipf("container startup failed and Docker is not reachable (%v): %v", reason, err)
+		return
+	}
+	t.Fatalf("container startup failed even though Docker is reachable: %v", err)
+}
+
+var (
+	unavailableOnce sync.Once
+	unavailableErr  error
+)
+
+// Unavailable reports why Docker is provably absent, or nil when it is not.
+//
+// It probes the endpoint [Configure] resolved into DOCKER_HOST and then the
+// default and rootless socket paths, because testcontainers does not stop at
+// DOCKER_HOST either: it walks its own list and uses the first endpoint that
+// answers, so an unset or dead DOCKER_HOST is not on its own proof that
+// Docker is missing. Probing means dialing rather than making an API call, so
+// it stays cheap, and anything it cannot decide (an endpoint scheme it cannot
+// dial, a daemon that accepts the connection but misbehaves) counts as
+// available, because only proven absence justifies skipping a test.
+//
+// The verdict is computed once: a Docker daemon does not appear or disappear
+// during a test binary's run, and the fixtures call this from every test that
+// hit the shared container error.
+func Unavailable() error {
+	unavailableOnce.Do(func() {
+		unavailableErr = unavailable(os.Getenv("DOCKER_HOST"), defaultSocketPaths(), dial)
+	})
+	return unavailableErr
+}
+
+func unavailable(host string, socketPaths []string, dial func(network, address string) error) error {
+	reason := errors.New("DOCKER_HOST is unset and no Docker context resolved one")
+	if host != "" {
+		reason = unreachable(host, dial)
+		if reason == nil {
+			return nil
+		}
+	}
+	for _, path := range socketPaths {
+		if unreachable("unix://"+path, dial) == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w, and no Docker socket answers at %s", reason, strings.Join(socketPaths, ", "))
+}
+
+// unreachable reports why nothing answers at a Docker endpoint, or nil when
+// something does or when this probe cannot tell.
+func unreachable(host string, dial func(network, address string) error) error {
+	scheme, address, ok := strings.Cut(host, "://")
+	if !ok {
+		return nil
+	}
+	var network string
+	switch scheme {
+	case "unix":
+		if _, err := os.Stat(address); err != nil {
+			return fmt.Errorf("no Docker socket at %s: %w", address, err)
+		}
+		network = "unix"
+	case "tcp", "http", "https":
+		network = "tcp"
+	default:
+		// npipe and anything else this probe cannot dial: not proven absent.
+		return nil
+	}
+	if err := dial(network, address); err != nil {
+		return fmt.Errorf("dialing Docker endpoint %s: %w", host, err)
+	}
+	return nil
+}
+
+// defaultSocketPaths returns the socket paths testcontainers falls back to
+// once DOCKER_HOST and the Docker context have not produced a working
+// endpoint, in its order: the default path, then the rootless ones (see
+// dockerSocketPath and rootlessDockerSocketPath in
+// testcontainers-go/internal/core).
+func defaultSocketPaths() []string {
+	paths := []string{"/var/run/docker.sock"}
+	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+		paths = append(paths, filepath.Join(dir, "docker.sock"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths,
+			filepath.Join(home, ".docker", "run", "docker.sock"),
+			filepath.Join(home, ".docker", "desktop", "docker.sock"),
+		)
+	}
+	return append(paths, filepath.Join("/run", "user", strconv.Itoa(os.Getuid()), "docker.sock"))
+}
+
+func dial(network, address string) error {
+	conn, err := net.DialTimeout(network, address, dialTimeout)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}

--- a/cmd/ateapi/internal/store/dockerenv/failorskip_test.go
+++ b/cmd/ateapi/internal/store/dockerenv/failorskip_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dockerenv
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// fakeTB records which of Fatalf and Skipf a policy decision reached.
+type fakeTB struct {
+	fatal   string
+	skipped string
+}
+
+func (f *fakeTB) Helper() {}
+
+func (f *fakeTB) Fatalf(format string, args ...any) {
+	f.fatal = fmt.Sprintf(format, args...)
+}
+
+func (f *fakeTB) Skipf(format string, args ...any) {
+	f.skipped = fmt.Sprintf(format, args...)
+}
+
+func TestFailOrSkip(t *testing.T) {
+	containerErr := errors.New("wait for reaper 7b77f493: context deadline exceeded")
+	dockerGone := errors.New("DOCKER_HOST is unset and no Docker context resolved one")
+
+	for _, tc := range []struct {
+		name        string
+		ci          bool
+		unavailable error
+		wantFatal   bool
+	}{{
+		name:        "CI set fails even without Docker",
+		ci:          true,
+		unavailable: dockerGone,
+		wantFatal:   true,
+	}, {
+		name:      "CI set fails with Docker present",
+		ci:        true,
+		wantFatal: true,
+	}, {
+		name:        "Docker absent locally skips",
+		unavailable: dockerGone,
+	}, {
+		name:      "any other error with Docker present fails",
+		wantFatal: true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeTB{}
+			failOrSkip(fake, containerErr, tc.ci, func() error { return tc.unavailable })
+
+			if tc.wantFatal {
+				if fake.fatal == "" {
+					t.Fatalf("failOrSkip() did not fail; skip = %q", fake.skipped)
+				}
+				if fake.skipped != "" {
+					t.Errorf("failOrSkip() also skipped: %q", fake.skipped)
+				}
+			} else {
+				if fake.skipped == "" {
+					t.Fatalf("failOrSkip() did not skip; fatal = %q", fake.fatal)
+				}
+				if fake.fatal != "" {
+					t.Errorf("failOrSkip() also failed: %q", fake.fatal)
+				}
+			}
+			message := fake.fatal + fake.skipped
+			if !strings.Contains(message, containerErr.Error()) {
+				t.Errorf("message %q does not report the underlying error", message)
+			}
+		})
+	}
+}
+
+func TestUnavailable(t *testing.T) {
+	listening := func(t *testing.T) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "docker.sock")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	socket := listening(t)
+	fallback := listening(t)
+	absent := filepath.Join(t.TempDir(), "absent.sock")
+	dialErr := errors.New("connection refused")
+
+	for _, tc := range []struct {
+		name string
+		host string
+		// socketPaths stands in for the default and rootless paths
+		// testcontainers probes after DOCKER_HOST.
+		socketPaths []string
+		// refuse names the endpoints whose dial fails; anything dialed and
+		// not named here answers.
+		refuse        []string
+		wantDialed    []string
+		wantAvailable bool
+	}{{
+		name: "no endpoint anywhere",
+	}, {
+		name:          "listening unix socket",
+		host:          "unix://" + socket,
+		wantDialed:    []string{"unix " + socket},
+		wantAvailable: true,
+	}, {
+		name:       "unix socket that refuses and no fallback",
+		host:       "unix://" + socket,
+		refuse:     []string{socket},
+		wantDialed: []string{"unix " + socket},
+	}, {
+		name:          "unix socket that refuses falls back to a default path",
+		host:          "unix://" + socket,
+		socketPaths:   []string{absent, fallback},
+		refuse:        []string{socket},
+		wantDialed:    []string{"unix " + socket, "unix " + fallback},
+		wantAvailable: true,
+	}, {
+		name:       "missing unix socket",
+		host:       "unix://" + absent,
+		wantDialed: nil,
+	}, {
+		name:          "listening tcp endpoint",
+		host:          "tcp://127.0.0.1:2375",
+		wantDialed:    []string{"tcp 127.0.0.1:2375"},
+		wantAvailable: true,
+	}, {
+		name:       "tcp endpoint that refuses and no fallback",
+		host:       "tcp://127.0.0.1:1",
+		refuse:     []string{"127.0.0.1:1"},
+		wantDialed: []string{"tcp 127.0.0.1:1"},
+	}, {
+		name:          "unreachable tcp endpoint falls back to a default path",
+		host:          "tcp://127.0.0.1:1",
+		socketPaths:   []string{fallback},
+		refuse:        []string{"127.0.0.1:1"},
+		wantDialed:    []string{"tcp 127.0.0.1:1", "unix " + fallback},
+		wantAvailable: true,
+	}, {
+		name:          "no DOCKER_HOST but a default path answers",
+		socketPaths:   []string{absent, fallback},
+		wantDialed:    []string{"unix " + fallback},
+		wantAvailable: true,
+	}, {
+		name:        "no DOCKER_HOST and every default path refuses",
+		socketPaths: []string{absent, fallback},
+		refuse:      []string{fallback},
+		wantDialed:  []string{"unix " + fallback},
+	}, {
+		name:          "scheme this probe cannot dial",
+		host:          "npipe:////./pipe/docker_engine",
+		wantAvailable: true,
+	}, {
+		name:          "endpoint without a scheme",
+		host:          "/var/run/docker.sock",
+		wantAvailable: true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			var dialed []string
+			err := unavailable(tc.host, tc.socketPaths, func(network, address string) error {
+				dialed = append(dialed, network+" "+address)
+				if slices.Contains(tc.refuse, address) {
+					return dialErr
+				}
+				return nil
+			})
+			if got := err == nil; got != tc.wantAvailable {
+				t.Errorf("unavailable(%q) = %v, want available = %v", tc.host, err, tc.wantAvailable)
+			}
+			if !slices.Equal(dialed, tc.wantDialed) {
+				t.Errorf("dialed %q, want %q", dialed, tc.wantDialed)
+			}
+		})
+	}
+}
+
+// TestDefaultSocketPaths checks that the fallback list names the default
+// socket, so an unset or dead DOCKER_HOST alone never counts as proof that
+// Docker is absent.
+func TestDefaultSocketPaths(t *testing.T) {
+	paths := defaultSocketPaths()
+	if !slices.Contains(paths, "/var/run/docker.sock") {
+		t.Errorf("defaultSocketPaths() = %q, want it to include the default socket", paths)
+	}
+}
+
+// TestUnavailableMemoizes checks that the exported verdict is computed once,
+// so a DOCKER_HOST that swallows connections costs one dial timeout for the
+// whole run rather than one per failing test.
+func TestUnavailableMemoizes(t *testing.T) {
+	first := Unavailable()
+	if second := Unavailable(); !errors.Is(second, first) && second != first {
+		t.Errorf("Unavailable() = %v then %v, want the same verdict", first, second)
+	}
+}

--- a/cmd/ateapi/internal/store/storetest/storetest.go
+++ b/cmd/ateapi/internal/store/storetest/storetest.go
@@ -183,7 +183,7 @@ func requireAdminPool(t *testing.T) *pgxpool.Pool {
 		containerErr = fmt.Errorf("pinging PostgreSQL testcontainer after retries: %w", pingErr)
 	})
 	if containerErr != nil {
-		t.Skipf("PostgreSQL testcontainer unavailable (requires Docker): %v", containerErr)
+		dockerenv.FailOrSkip(t, fmt.Errorf("PostgreSQL testcontainer: %w", containerErr))
 	}
 	return adminPool
 }


### PR DESCRIPTION
### What

`requireAdminPool` (`cmd/ateapi/internal/store/storetest/storetest.go`) and `requirePool`
(`cmd/ateapi/internal/store/atepg/atepg_test.go`) turned *any* PostgreSQL testcontainer startup
error into

    t.Skipf("PostgreSQL testcontainer unavailable (requires Docker): %v", containerErr)

without ever checking whether Docker was actually there. Both call sites now route through one
helper, `dockerenv.FailOrSkip`, that decides fail-versus-skip in a single place:

* **In CI** (`CI` or `GITHUB_ACTIONS` set) it always fails. The runners have Docker, so any
  container error there is a real failure.
* **Locally** it skips only when a cheap preflight proves Docker is absent, and fails on
  everything else.

The preflight (`dockerenv.Unavailable`) mirrors how testcontainers-go actually finds the daemon:
testcontainers walks its own list (`tc.host` property, `DOCKER_HOST`, the Docker context,
`/var/run/docker.sock`, the `docker.host` property, the rootless socket paths) and uses the first
endpoint that *answers*. So an unset or dead `DOCKER_HOST` is not on its own proof that Docker is
missing — the preflight also probes the default and rootless socket paths, and only reports
absence when none of them answers. Anything it cannot decide (a scheme it cannot dial, a daemon
that accepts the connection but misbehaves) counts as present, because only proven absence
justifies dropping a test. The verdict is memoized: a daemon does not come and go mid-binary, and
every failing test in a ~150-test package asks.

### Why

CI has already gone green with the controlapi DB suite skipped — 154 tests silently removed from
the run while the job reported success. A reaper timeout, an image pull failure or a daemon hiccup
was indistinguishable from "this developer has no Docker", and the message asserted the second
without checking. This is the fail-not-skip follow-up discussed on #1235 (see also #1230).

### Placement note for reviewers

The helper lives in `cmd/ateapi/internal/store/dockerenv`, not in `storetest`, because `storetest`
imports `atepg` (for `SetupPostgresPersistence`) and `atepg_test.go` is an in-package test — so
importing `storetest` back is a hard cycle. `dockerenv` is the leaf package both fixtures already
share, and it already owns the other half of the Docker story (`Configure`). Its package doc now
says it owns both.

### Files

    cmd/ateapi/internal/store/atepg/atepg_test.go      |   2 +-
    cmd/ateapi/internal/store/dockerenv/dockerenv.go   |   5 +-
    cmd/ateapi/internal/store/dockerenv/failorskip.go  | 173 +++++++++++++++++
    cmd/ateapi/internal/store/dockerenv/failorskip_test.go | 216 ++++++++++++++++++
    cmd/ateapi/internal/store/storetest/storetest.go   |   2 +-

No vendor changes, no dependency changes, no workflow changes, no other test semantics touched
(the 30x500ms ping loops, the `sync.Once` fixtures and the `TestMain` shutdown paths are
unchanged).

## Testing done

Unit tests: `failorskip_test.go` table-tests the policy against a fake `testing.TB`
(CI set -> fatal even without Docker; CI set with Docker -> fatal; Docker absent locally -> skip;
any other error with Docker present -> fatal), the preflight against an injectable dialer
(12 cases covering `DOCKER_HOST` unix/tcp/npipe/no-scheme, missing sockets, and the fallback to
the default socket paths), and the memoization.

    go build ./...                                                    exit=0
    go vet ./cmd/ateapi/...                                           exit=0
    gofmt -l <changed files>                                          exit=0 (no output)
    go test ./cmd/ateapi/internal/store/storetest/... -count=1         [no test files] exit=0
    go test -race ./cmd/ateapi/internal/store/dockerenv/... -count=1   ok 1.009s exit=0
    go test ./cmd/ateapi/internal/store/atepg/ -run TestContractSuite  ok 2.822s exit=0 (0 SKIP lines)
    CI=true go test .../atepg -run TestContractSuite -count=1          ok 2.618s exit=0
    go test ./cmd/ateapi/internal/store/... -count=1                   all ok exit=0
    go test ./cmd/ateapi/internal/controlapi/... ./cmd/ateapi/internal/actoridentity/... -count=1
                                                                      all ok (storetest importers)
    hack/verify/{gofmt,boilerplate,go-modules,golangci-lint}.sh        exit=0 each

All three policy branches were proved end-to-end on real test binaries at **both** call sites, not
just in the unit test. Note that the obvious command — `DOCKER_HOST=tcp://127.0.0.1:1 CI=true
go test ...` — **cannot** prove the fatal path: testcontainers ignores the unreachable
`DOCKER_HOST` and falls through to `/var/run/docker.sock`, so the container starts and the test
passes ("Resolved Docker Host: unix:///var/run/docker.sock", ok 1.979s). The real proofs used a
stripped environment (`env -i`, no `docker` CLI on `PATH`) and, for the no-Docker-at-all cases, an
unprivileged mount namespace (`unshare -rm` with a tmpfs over `/run`) so the default socket really
is gone:

| # | Environment | Result |
|---|---|---|
| A | atepg fixture, `CI=true`, no docker CLI, no socket | FAIL, exit 1: "container startup failed in CI, where Docker is expected: PostgreSQL testcontainer: inspecting Docker context: exec: \"docker\": executable file not found in $PATH" |
| B | atepg fixture, CI unset, no docker CLI, no socket anywhere | SKIP, exit 0 |
| C | atepg fixture, CI unset, reachable `DOCKER_HOST`, `DOCKER_API_VERSION=0.1` to force a container error | FAIL, exit 1: "container startup failed even though Docker is reachable: ... client version 0.1 is too old" |
| D | storetest fixture (controlapi), `CI=true`, no docker CLI | FAIL, exit 1 |
| E | storetest fixture (controlapi), CI unset, no Docker at all | SKIP, exit 0 |
| F | atepg fixture, CI unset, **no docker CLI but the daemon socket is live** | FAIL, exit 1 — under the old preflight this would have skipped |
| G | atepg fixture, CI unset, **dead `DOCKER_HOST` + live default socket + forced container error** | FAIL, exit 1 — under the old preflight this would have skipped |
| H | atepg fixture, `GITHUB_ACTIONS=true` with `CI` unset, no Docker | FAIL, exit 1 |

F and G are the review's two should-fix findings: before them, a machine with a working daemon but
no `docker` CLI (rootless, socket-mounted dev containers, a corrupt context store), or with a stale
`DOCKER_HOST` exported, would still have silently skipped every DB test — the same class of hole
this change exists to close, just narrower.

## Open questions for review

1. **No workflow assertion was added.** The optional "grep the `-v` output to prove
   `TestContractSuite` ran" step in `.github/workflows/pr-workflow.yaml` was left out. With every
   container error fatal under CI, "green with the DB suites skipped" is already unreachable, and a
   grep step would need either a second ~2-minute run of the DB packages or a `PIPESTATUS` pipeline
   that risks swallowing the `go test` exit code. Happy to add it if you want belt and braces.
2. **Retry budget is unchanged and now decides red/green.** The 30x500ms ping loop plus
   testcontainers' own waits used to decide skip-or-run; they now decide fail-or-pass. If CI starts
   flaking on slow container pulls, that budget is the knob — but widening it pre-emptively would
   be guessing. Out of scope here.
3. **Strictness is keyed on `CI` / `GITHUB_ACTIONS`.** `pr-workflow.yaml` runs `go test -race -v
   ./...` directly on `ubuntu-latest`, where the runner sets both, and `hack/run-root-tests.sh`
   uses `sudo -E env "PATH=${PATH}"` so they survive the privilege change. A future job that runs
   `go test` inside a container without forwarding either would silently degrade to the old
   skip-on-anything behavior. Accepting both variables is the cheap mitigation; a hard opt-out
   (fail unless explicitly told otherwise) would be the strict version if you want it.
4. **Fixture wording.** `FailOrSkip`'s messages are now generic ("container startup failed ...")
   and the two call sites wrap their own error with `fmt.Errorf("PostgreSQL testcontainer: %w",
   containerErr)`, so the next container fixture in the tree inherits the policy without inheriting
   a Postgres-specific message. Shout if you would rather keep the subject in the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYXeYhZaGKwgY57jvfMMYF
