### PR TITLE
atepg: sweep expired leases on the maintenance tick

### DIFF
--- a/cmd/ateapi/internal/store/atepg/atepg.go
+++ b/cmd/ateapi/internal/store/atepg/atepg.go
@@ -50,8 +50,8 @@ const (
 
 type Persistence struct {
 	pool *pgxpool.Pool
-	// watchPool serves the outbox side only: the WatchWorkers pollers
-	// and the partition-maintenance loop.
+	// watchPool serves the background side: the WatchWorkers pollers and the
+	// maintenance loop (outbox partitions and the expired-lease sweep).
 	watchPool             *pgxpool.Pool
 	ownsWatchPool         bool
 	leaseTTL              time.Duration
@@ -164,12 +164,12 @@ func newPersistence(ctx context.Context, pool, watchPool *pgxpool.Pool) (*Persis
 	}
 	go func() {
 		defer close(p.maintenanceDone)
-		p.outboxMaintenance(maintenanceCtx)
+		p.backgroundMaintenance(maintenanceCtx)
 	}()
 	return p, nil
 }
 
-// Close stops the outbox maintenance loop and waits for it to exit,
+// Close stops the background maintenance loop and waits for it to exit,
 // then closes the watch pool if Connect created one. It does not close the
 // main pool, which the caller owns.
 func (p *Persistence) Close() {
@@ -1479,9 +1479,6 @@ const defaultLeaseTTL = 30 * time.Second
 func (p *Persistence) AcquireLease(ctx context.Context, key string) (*store.Lease, error) {
 	ttl := p.leaseTTL
 	token := uuid.NewString()
-	if err := p.cleanupExpiredLeases(ctx); err != nil {
-		slog.WarnContext(ctx, "failed to clean up expired PostgreSQL leases", "error", err)
-	}
 
 	acquired, err := p.acquireLease(ctx, key, token, ttl)
 	if err != nil {
@@ -1512,23 +1509,74 @@ func (p *Persistence) AcquireLease(ctx context.Context, key string) (*store.Leas
 	return store.NewLease(leaseCtx, closeFn), nil
 }
 
-func (p *Persistence) cleanupExpiredLeases(ctx context.Context) error {
-	if _, err := p.pool.Exec(ctx, `DELETE FROM leases WHERE expires_at <= clock_timestamp()`); err != nil {
-		return fmt.Errorf("deleting expired leases: %w", err)
+const (
+	// leaseSweepBatch bounds one DELETE so a single statement can never take
+	// an unbounded number of row locks. A pass repeats the statement until the
+	// table is drained, so this caps statement size, not how much one pass can
+	// reclaim after a burst of abandoned rows.
+	leaseSweepBatch = 1000
+
+	// leaseSweepPassTimeout bounds one sweep pass. It is far shorter than the
+	// outbox pass budget because the sweep issues only bounded DELETEs that
+	// never wait on a row lock; a pass still running this long is not making
+	// progress and is better retried on the next tick.
+	leaseSweepPassTimeout = 30 * time.Second
+)
+
+// sweepExpiredLeasesSQL collects one bounded batch of aged-out lease rows.
+//
+// Both expiry predicates are load-bearing. The outer one is what READ
+// COMMITTED re-checks against the updated tuple when the DELETE blocks on a
+// row lock: with the predicate only in the bounding subquery, a concurrent
+// takeover of that key would commit a live lease that this statement then
+// deleted, leaving two callers believing they hold the same key. FOR UPDATE
+// SKIP LOCKED keeps a pass from waiting on such rows at all -- another
+// transaction is already dealing with them -- and keeps replicas' sweeps from
+// serializing on each other.
+const sweepExpiredLeasesSQL = `
+	DELETE FROM leases
+	WHERE expires_at <= clock_timestamp()
+	  AND key IN (
+		SELECT key FROM leases
+		WHERE expires_at <= clock_timestamp()
+		LIMIT $1
+		FOR UPDATE SKIP LOCKED)`
+
+// sweepExpiredLeases deletes lease rows that have aged out, one bounded batch
+// at a time until a pass finds nothing more to collect. It is pure garbage
+// collection, never a correctness step: acquireLease treats an expired row as
+// absent and overwrites it, so a row a skipped or failed sweep leaves behind
+// costs a little storage and nothing else. That is why it runs unelected on
+// every replica, on the maintenance pool, off the pool that serves actor
+// resume requests.
+func (p *Persistence) sweepExpiredLeases(ctx context.Context) error {
+	for {
+		tag, err := p.watchPool.Exec(ctx, sweepExpiredLeasesSQL, leaseSweepBatch)
+		if err != nil {
+			return fmt.Errorf("deleting expired leases: %w", err)
+		}
+		if tag.RowsAffected() < leaseSweepBatch || ctx.Err() != nil {
+			return nil
+		}
 	}
-	return nil
 }
+
+// acquireLeaseSQL claims a key, taking over any row whose lease has already
+// expired. The ON CONFLICT ... WHERE clause is what makes an expired row
+// equivalent to a missing one, so acquisition never depends on an expired row
+// having been swept away first. It returns no row when the key is held.
+const acquireLeaseSQL = `
+	INSERT INTO leases (key, token, expires_at)
+	VALUES ($1, $2, clock_timestamp() + make_interval(secs => $3))
+	ON CONFLICT (key) DO UPDATE
+	SET token = EXCLUDED.token,
+	    expires_at = EXCLUDED.expires_at
+	WHERE leases.expires_at <= clock_timestamp()
+	RETURNING key`
 
 func (p *Persistence) acquireLease(ctx context.Context, key, token string, ttl time.Duration) (bool, error) {
 	var returnedKey string
-	err := p.pool.QueryRow(ctx, `
-		INSERT INTO leases (key, token, expires_at)
-		VALUES ($1, $2, clock_timestamp() + make_interval(secs => $3))
-		ON CONFLICT (key) DO UPDATE
-		SET token = EXCLUDED.token,
-		    expires_at = EXCLUDED.expires_at
-		WHERE leases.expires_at <= clock_timestamp()
-		RETURNING key`, key, token, ttl.Seconds()).Scan(&returnedKey)
+	err := p.pool.QueryRow(ctx, acquireLeaseSQL, key, token, ttl.Seconds()).Scan(&returnedKey)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return false, nil

--- a/cmd/ateapi/internal/store/atepg/atepg_test.go
+++ b/cmd/ateapi/internal/store/atepg/atepg_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -317,7 +318,11 @@ func TestCreateActorSnapshotTag_ForeignKeyErrors(t *testing.T) {
 	}
 }
 
-func TestAcquireLease_CleansExpiredLeases(t *testing.T) {
+// TestAcquireLease_DoesNotSweepOtherKeys keeps garbage collection off the
+// acquisition path: acquiring one key must touch only that key's row, never
+// scan or delete rows belonging to other keys. Reclaiming those is the
+// background maintenance sweep's job.
+func TestAcquireLease_DoesNotSweepOtherKeys(t *testing.T) {
 	s := setupPostgresPersistence(t)
 	ctx := context.Background()
 	if _, err := s.pool.Exec(ctx, `
@@ -332,15 +337,11 @@ func TestAcquireLease_CleansExpiredLeases(t *testing.T) {
 	}
 	defer lease.Close()
 
-	var expired, active int
-	if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM leases WHERE key = 'expired'`).Scan(&expired); err != nil {
-		t.Fatalf("counting expired lease: %v", err)
+	if _, ok := leaseToken(t, s, "expired"); !ok {
+		t.Error("AcquireLease deleted an unrelated expired lease; the sweep belongs on the maintenance tick")
 	}
-	if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM leases WHERE key = 'active'`).Scan(&active); err != nil {
-		t.Fatalf("counting active lease: %v", err)
-	}
-	if expired != 0 || active != 1 {
-		t.Errorf("lease counts = expired:%d active:%d, want 0 and 1", expired, active)
+	if _, ok := leaseToken(t, s, "active"); !ok {
+		t.Error("AcquireLease deleted an unrelated live lease")
 	}
 }
 
@@ -448,6 +449,177 @@ func TestAcquireLease_ExpiresAfterHolderStops(t *testing.T) {
 		t.Fatalf("AcquireLease after lease expiration failed: %v", err)
 	}
 	newLease.Close()
+}
+
+// TestAcquireLease_TakesOverExpiredRowWithoutSweep pins the property that lets
+// the expired-lease sweep live on the background maintenance tick instead of
+// on AcquireLease, and so on the actor resume path: an expired row that is
+// still present must be taken over by the acquire statement itself.
+func TestAcquireLease_TakesOverExpiredRowWithoutSweep(t *testing.T) {
+	s := setupPostgresPersistence(t)
+	ctx := context.Background()
+	s.leaseTTL = 200 * time.Millisecond
+
+	holderCtx, cancelHolder := context.WithCancel(ctx)
+	lease, err := s.AcquireLease(holderCtx, "stale-lease")
+	if err != nil {
+		t.Fatalf("AcquireLease failed: %v", err)
+	}
+	// Canceling without Close stops renewal and skips the release delete, so
+	// the row is left behind to expire, as a vanished process leaves it.
+	cancelHolder()
+	<-lease.Context().Done()
+	time.Sleep(s.leaseTTL + 300*time.Millisecond)
+
+	firstToken, ok := leaseToken(t, s, "stale-lease")
+	if !ok {
+		t.Fatal("expired lease row is gone; the test no longer exercises takeover of an existing row")
+	}
+
+	newLease, err := s.AcquireLease(ctx, "stale-lease")
+	if err != nil {
+		t.Fatalf("AcquireLease over an unswept expired row failed: %v", err)
+	}
+	defer newLease.Close()
+
+	secondToken, ok := leaseToken(t, s, "stale-lease")
+	if !ok {
+		t.Fatal("lease row missing after a successful acquisition")
+	}
+	if secondToken == firstToken {
+		t.Errorf("lease token after takeover = %q, want a new token (the expired row was not overwritten)", secondToken)
+	}
+}
+
+// TestSweepExpiredLeases checks the maintenance sweep discards expired rows
+// and leaves a live lease alone -- deleting a live row would let a second
+// holder acquire a key its owner still holds.
+func TestSweepExpiredLeases(t *testing.T) {
+	s := setupPostgresPersistence(t)
+	ctx := context.Background()
+
+	if _, err := s.pool.Exec(ctx, `
+		INSERT INTO leases (key, token, expires_at) VALUES
+			('expired-a', 'token-a', clock_timestamp() - interval '1 hour'),
+			('expired-b', 'token-b', clock_timestamp() - interval '1 second'),
+			('live',      'token-c', clock_timestamp() + interval '1 hour')`); err != nil {
+		t.Fatalf("seeding leases failed: %v", err)
+	}
+
+	if err := s.sweepExpiredLeases(ctx); err != nil {
+		t.Fatalf("sweepExpiredLeases failed: %v", err)
+	}
+
+	for _, key := range []string{"expired-a", "expired-b"} {
+		if _, ok := leaseToken(t, s, key); ok {
+			t.Errorf("lease %q survived the sweep, want it deleted", key)
+		}
+	}
+	token, ok := leaseToken(t, s, "live")
+	if !ok {
+		t.Error("the sweep deleted an unexpired lease")
+	} else if token != "token-c" {
+		t.Errorf("live lease token = %q, want %q", token, "token-c")
+	}
+
+	// A pass over a table with nothing left to collect is a no-op.
+	if err := s.sweepExpiredLeases(ctx); err != nil {
+		t.Fatalf("sweepExpiredLeases on an already-swept table failed: %v", err)
+	}
+	if _, ok := leaseToken(t, s, "live"); !ok {
+		t.Error("a second sweep deleted the unexpired lease")
+	}
+}
+
+// TestSweepExpiredLeases_DrainsPastOneBatch checks a backlog larger than
+// leaseSweepBatch -- what an ateapi replica dying mid-flight leaves behind --
+// is reclaimed by a single pass rather than one batch per tick.
+func TestSweepExpiredLeases_DrainsPastOneBatch(t *testing.T) {
+	s := setupPostgresPersistence(t)
+	ctx := context.Background()
+
+	backlog := leaseSweepBatch + leaseSweepBatch/2
+	if _, err := s.pool.Exec(ctx, `
+		INSERT INTO leases (key, token, expires_at)
+		SELECT 'expired-' || i, 'token-' || i, clock_timestamp() - interval '1 hour'
+		FROM generate_series(1, $1) AS i`, backlog); err != nil {
+		t.Fatalf("seeding expired leases failed: %v", err)
+	}
+
+	if err := s.sweepExpiredLeases(ctx); err != nil {
+		t.Fatalf("sweepExpiredLeases failed: %v", err)
+	}
+
+	var remaining int
+	if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM leases`).Scan(&remaining); err != nil {
+		t.Fatalf("counting leases failed: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("leases remaining after one sweep pass = %d, want 0", remaining)
+	}
+}
+
+// TestSweepExpiredLeases_ConcurrentTakeover pins why the sweep's DELETE keeps
+// its expiry predicate on the leases table itself and not only in the
+// bounding subquery: a sweep racing a takeover of the same expired key must
+// never remove the row that takeover commits. Deleting it would let a third
+// caller acquire a key whose new holder still believes it holds it.
+func TestSweepExpiredLeases_ConcurrentTakeover(t *testing.T) {
+	s := setupPostgresPersistence(t)
+	ctx := context.Background()
+
+	if _, err := s.pool.Exec(ctx, `
+		INSERT INTO leases (key, token, expires_at)
+		VALUES ('contended', 'stale', clock_timestamp() - interval '1 hour')`); err != nil {
+		t.Fatalf("seeding expired lease failed: %v", err)
+	}
+
+	// Take the row over in a transaction left open. Its row lock is what the
+	// sweep must either skip or, having blocked on it, re-check against the
+	// committed tuple.
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("beginning takeover transaction failed: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var takenKey string
+	if err := tx.QueryRow(ctx, acquireLeaseSQL, "contended", "fresh", 3600.0).Scan(&takenKey); err != nil {
+		t.Fatalf("taking over the expired lease failed: %v", err)
+	}
+
+	sweepDone := make(chan error, 1)
+	go func() { sweepDone <- s.sweepExpiredLeases(ctx) }()
+
+	// Give the sweep time to reach the row and skip or block on its lock.
+	time.Sleep(500 * time.Millisecond)
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("committing the takeover failed: %v", err)
+	}
+	if err := <-sweepDone; err != nil {
+		t.Fatalf("sweepExpiredLeases failed: %v", err)
+	}
+
+	token, ok := leaseToken(t, s, "contended")
+	if !ok {
+		t.Fatal("the sweep deleted a lease that was taken over while the sweep ran; two callers can now hold it")
+	}
+	if token != "fresh" {
+		t.Errorf("lease token = %q, want %q", token, "fresh")
+	}
+}
+
+// leaseToken reports the token stored for key, and whether the row exists.
+func leaseToken(t *testing.T, s *Persistence, key string) (string, bool) {
+	t.Helper()
+	var token string
+	err := s.pool.QueryRow(context.Background(), `SELECT token FROM leases WHERE key = $1`, key).Scan(&token)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false
+	}
+	if err != nil {
+		t.Fatalf("reading lease %q failed: %v", key, err)
+	}
+	return token, true
 }
 
 // TestAcquireLease_ConcurrentTakeover races many goroutines to acquire an

--- a/cmd/ateapi/internal/store/atepg/outbox.go
+++ b/cmd/ateapi/internal/store/atepg/outbox.go
@@ -17,7 +17,8 @@
 // (writeAndAppendEvent), per-replica watchers poll it with an xmin-fenced
 // xid cursor (WatchWorkers), and a background loop pre-creates partitions
 // and retires old ones by dropping them, recording a trim high-water mark
-// that lets lagging watchers detect loss and resync (outboxMaintenance).
+// that lets lagging watchers detect loss and resync (backgroundMaintenance,
+// which also sweeps expired lease rows on the same tick).
 
 package atepg
 
@@ -115,14 +116,15 @@ const (
 	// Minimum time retention keeps outbox rows.
 	outboxRetentionAge = 15 * time.Minute
 
-	// Paces partition maintenance.
-	outboxMaintenanceInterval = time.Minute
+	// Paces the background maintenance loop.
+	maintenanceInterval = time.Minute
 
 	// The outbox partition range width.
 	outboxPartitionInterval = 15 * time.Minute
 
-	// Bounds a maintenance pass to prevent indefinite hangs (e.g., from lock waits)
-	// which would permanently starve partition creation. Stalls abort and retry.
+	// Bounds the outbox step of a maintenance pass to prevent indefinite hangs
+	// (e.g., from lock waits) which would permanently starve partition
+	// creation. Stalls abort and retry.
 	outboxMaintenancePassTimeout = 5 * time.Minute
 
 	// How many intervals ahead partitions are pre-created: creation must stall past
@@ -146,9 +148,13 @@ func (p *Persistence) outboxNow(ctx context.Context) (time.Time, error) {
 	return now.UTC(), nil
 }
 
-// Maintains worker_outbox partitions on a fixed timer.
-func (p *Persistence) outboxMaintenance(ctx context.Context) {
-	ticker := time.NewTicker(outboxMaintenanceInterval)
+// backgroundMaintenance runs the store's periodic upkeep on a fixed timer:
+// worker_outbox partitions, and the expired-lease sweep. Both are garbage
+// collection that no request path waits on. Each step gets its own deadline,
+// so a step that spends its whole budget waiting on a lock cannot starve the
+// next one or make it report a timeout it never had.
+func (p *Persistence) backgroundMaintenance(ctx context.Context) {
+	ticker := time.NewTicker(maintenanceInterval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -156,11 +162,18 @@ func (p *Persistence) outboxMaintenance(ctx context.Context) {
 			return
 		case <-ticker.C:
 		}
-		passCtx, cancel := context.WithTimeout(ctx, outboxMaintenancePassTimeout)
-		if err := p.maintainWorkerOutboxPartitions(passCtx); err != nil && ctx.Err() == nil {
-			slog.WarnContext(ctx, "worker outbox maintenance failed", slog.Any("err", err))
-		}
-		cancel()
+		runMaintenanceStep(ctx, "worker outbox maintenance failed", outboxMaintenancePassTimeout, p.maintainWorkerOutboxPartitions)
+		runMaintenanceStep(ctx, "expired lease sweep failed", leaseSweepPassTimeout, p.sweepExpiredLeases)
+	}
+}
+
+// runMaintenanceStep runs one maintenance step under its own deadline, logging
+// failWarning unless the whole loop is shutting down.
+func runMaintenanceStep(ctx context.Context, failWarning string, timeout time.Duration, step func(context.Context) error) {
+	stepCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := step(stepCtx); err != nil && ctx.Err() == nil {
+		slog.WarnContext(ctx, failWarning, slog.Any("err", err))
 	}
 }
 

--- a/cmd/ateapi/internal/store/atepg/schema.go
+++ b/cmd/ateapi/internal/store/atepg/schema.go
@@ -106,7 +106,7 @@ CREATE TABLE IF NOT EXISTS workers (
 --
 -- 1. Ordering (xid): writeAndAppendEvent guarantees exactly one row per tx,
 --    ensuring distinct xids so polling batches never split a transaction.
--- 2. Retention (created_at partitions): outboxMaintenance drops expired
+-- 2. Retention (created_at partitions): backgroundMaintenance drops expired
 --    partitions to avoid VACUUM I/O debt. A DEFAULT partition catches overflow.
 -- 3. Durability (UNLOGGED): Skips WAL overhead. Crash recoveries trigger
 --    watchers to rebuild from the primary workers table. worker_outbox_trim


### PR DESCRIPTION
Fixes #1040.

### What

`AcquireLease` ran `DELETE FROM leases WHERE expires_at <= clock_timestamp()` —
a global, table-wide write — before every single acquisition. Since the actor
workflow lease (`lease:actor:<atespace>:<name>`) is taken on the ResumeActor
path, every resume paid for a scan and delete over rows belonging to unrelated
actors, and concurrent resumes contended with each other on those rows.

This moves the delete to the periodic loop that already maintains
`worker_outbox` partitions, and does nothing else to the lease protocol.

Changes, all in `cmd/ateapi/internal/store/atepg`:

- `AcquireLease` no longer calls `cleanupExpiredLeases`. `acquireLease` is
  untouched, only lifted into a named `acquireLeaseSQL` const so a test can run
  the same statement inside its own transaction.
- New `sweepExpiredLeases`, run from the maintenance loop on the watch pool
  (never the request pool), unelected on every replica.
- `outboxMaintenance` -> `backgroundMaintenance`, since it now covers more than
  the outbox; `outboxMaintenanceInterval` -> `maintenanceInterval` to match.
  `outboxMaintenancePassTimeout` keeps its outbox-specific name because it now
  bounds only the outbox step.
- Each maintenance step runs under its own deadline via a small
  `runMaintenanceStep` helper.
- Doc-comment fixes for the `watchPool` field and the `worker_outbox` schema
  comment, which both still named the old function/scope.

### Why this is safe

The sweep was never load-bearing for correctness, which is the whole reason it
can move:

- `acquireLease` upserts with `ON CONFLICT (key) DO UPDATE ... WHERE
  leases.expires_at <= clock_timestamp()`. An expired row is therefore already
  equivalent to a missing one: it is overwritten in place, with a fresh token
  and expiry. Nothing had to delete it first.
- `renewLease` and `releaseLease` both match on the holder's token, so a row
  the sweep removes can never strand a live holder or let a stale holder steal
  a lease back.

So deleting expired rows is pure garbage collection: skipping or failing a pass
costs a little storage and nothing else. That is what lets it run unelected on
every replica rather than needing the advisory-lock election the outbox
retention transaction uses.

### The one subtlety: the sweep's DELETE keeps its predicate on `leases`

The bounded statement is:

```sql
DELETE FROM leases
WHERE expires_at <= clock_timestamp()
  AND key IN (
    SELECT key FROM leases
    WHERE expires_at <= clock_timestamp()
    LIMIT $1
    FOR UPDATE SKIP LOCKED)
```

Both expiry predicates are load-bearing, and the outer one is easy to drop by
accident. Under READ COMMITTED, when the DELETE blocks on a row lock held by a
concurrent takeover of that same expired key, Postgres re-evaluates the DELETE's
`WHERE` against the committed tuple. Bounded by `key IN (...)` alone, that
re-check still matches (the key list was already materialized), and the sweep
deletes the *live* lease the takeover just wrote — after which a third caller
can acquire a key whose new holder still believes it holds it. Keeping
`expires_at <= clock_timestamp()` on the target relation makes the re-check
skip the row. `FOR UPDATE SKIP LOCKED` then avoids the block entirely and keeps
replicas' sweeps from serializing on one another.

`TestSweepExpiredLeases_ConcurrentTakeover` pins this: it fails deterministically
against the subquery-only form and passes against the committed one.

### Bounding and drain

`leaseSweepBatch = 1000` caps how many row locks one statement takes. The pass
loops until a batch comes back short, so a burst of abandoned rows — an ateapi
replica dying mid-flight leaves one row per in-flight actor — is reclaimed by a
single pass rather than 1000 rows per minute. The loop is bounded by
`leaseSweepPassTimeout` (30s), separate from the outbox pass's 5-minute budget.

### No metrics

Nothing in `docs/metrics/registry/metrics.yaml` is touched and no instrument is
added. A sweep-rows-collected counter is plausible follow-up but is not worth a
registry entry on its own here.

## Testing done

All in the worktree, against the package's real `postgres:18` testcontainer.

- `go build ./...` — exit 0, no output.
- `go vet ./cmd/ateapi/...` — exit 0, no output.
- `gofmt -l ./cmd ./internal ./pkg` — empty.
- `go test ./cmd/ateapi/internal/store/atepg/ -count=1` —
  `ok github.com/agent-substrate/substrate/cmd/ateapi/internal/store/atepg 8.755s`
- `go test ./cmd/ateapi/internal/store/atepg/ -count=1 -run 'Lease|Sweep' -v` —
  PASS `TestAcquireLease_DoesNotSweepOtherKeys`,
  `TestAcquireLease_ExpiresAfterHolderStops`,
  `TestAcquireLease_TakesOverExpiredRowWithoutSweep`,
  `TestSweepExpiredLeases`, `TestSweepExpiredLeases_DrainsPastOneBatch`,
  `TestSweepExpiredLeases_ConcurrentTakeover`,
  `TestAcquireLease_ConcurrentTakeover`.
- `go test ./cmd/ateapi/internal/controlapi/... -run 'Resume|Lease' -count=1` —
  `ok .../controlapi 3.720s`, `ok .../controlapi/functionaltest 11.465s`.
- `hack/verify/gofmt.sh`, `boilerplate.sh`, `go-modules.sh`, `golangci-lint.sh`
  — all exit 0, no output.
- `hack/verify/metrics.sh` not run: the diff touches no instrument, no label,
  and not `docs/metrics/registry/metrics.yaml`.

Negative check on the regression test: temporarily reverting only the sweep SQL
to the `key IN (...)`-only form makes `TestSweepExpiredLeases_ConcurrentTakeover`
fail with "the sweep deleted a lease that was taken over while the sweep ran;
two callers can now hold it". Reverted immediately after.

Test coverage added:

- `TestAcquireLease_CleansExpiredLeases` -> `TestAcquireLease_DoesNotSweepOtherKeys`,
  inverted: acquiring one key must leave other keys' rows, expired or live, alone.
- `TestAcquireLease_TakesOverExpiredRowWithoutSweep` — an expired row that is
  still present is taken over by the acquire statement itself.
- `TestSweepExpiredLeases` — expired rows go, the live row stays, a second pass
  is a no-op.
- `TestSweepExpiredLeases_DrainsPastOneBatch` — a 1500-row backlog clears in one
  pass.
- `TestSweepExpiredLeases_ConcurrentTakeover` — the mutual-exclusion regression
  test described above.

## Open questions for review

1. **Placement.** `backgroundMaintenance`, `maintenanceInterval`, and
   `runMaintenanceStep` still live in `outbox.go`, whose package comment is
   about the worker outbox. A follow-up could move them to a `maintenance.go`
   in the same package; kept out of this commit to keep the diff honest to its
   title.
2. **Unelected on every replica.** Deliberate — the sweep is idempotent GC and
   `SKIP LOCKED` keeps replicas out of each other's way — but if we would rather
   have exactly one sweeper, the `outboxMaintenanceLockKey` election pattern is
   right there.
3. **Sweep interval.** One minute is inherited from the outbox tick. Expired
   rows now live up to ~1 minute longer than before, which only matters for
   table size, not behavior.
4. **Metrics.** Deliberately none. Say the word if a rows-collected counter is
   wanted and it can go in with a registry entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYXeYhZaGKwgY57jvfMMYF
