### PR TITLE
atepg: shorten the workflow lease TTL to 15s

### DIFF
--- a/cmd/ateapi/internal/store/atepg/atepg.go
+++ b/cmd/ateapi/internal/store/atepg/atepg.go
@@ -1473,8 +1473,39 @@ func (p *Persistence) ListWorkers(ctx context.Context, opts store.ListOptions) (
 // --- Workflow leases ---
 
 // defaultLeaseTTL is how long a lease may go unrenewed before another client
-// can reclaim it.
-const defaultLeaseTTL = 30 * time.Second
+// can reclaim it. The renew cadence and the renew grace window are derived
+// from it by leaseRenewInterval and leaseRenewDeadline, so the TTL is the only
+// number to tune. It is bounded from both sides:
+//
+//   - From above by the router: after a hard crash (SIGKILL, node loss) the
+//     dead replica's row stays valid for the rest of its TTL, and every cold
+//     workflow for that actor keeps failing with ErrLeaseConflict until it
+//     expires. The router parks and retries such a request for its
+//     parked-request budget (5s, DefaultParkedRequestBudget in the atenet
+//     router's ingress package) and then returns 503, so the TTL has to stay
+//     within a small number of those budgets.
+//   - From below by the router as well: the TTL must exceed that budget plus
+//     the slack a renewal can take, or a healthy holder that is merely slow
+//     to renew could be preempted inside a single parked request.
+//   - From below by Postgres: a renewal that is still failing when its
+//     deadline passes cancels the lease context, which is the context that
+//     wraps the atelet restore call, so an expiring lease aborts the cold
+//     operations in flight under it. A renewal is attempted one
+//     leaseRenewInterval after the last successful one, and its deadline sits
+//     leaseRenewDeadline after that same success, so the store outage a
+//     stalled renewal is guaranteed to ride out is the difference between
+//     them: ttl/3, i.e. 5s here. It rises to the full leaseRenewDeadline
+//     (10s) only when the outage happens to begin just after a renewal
+//     lands. An outage past that 5s floor is what costs in-flight cold work,
+//     and it is the reason the TTL is not cut further.
+//   - From below by fencing: a holder abandons its lease at
+//     leaseRenewDeadline after its last successful renewal, while the row
+//     only becomes acquirable at the full TTL, so ttl - leaseRenewDeadline
+//     == ttl/3 (5s here) is the margin in which an abandoned holder's
+//     already-issued atelet RPCs have to unwind before a second replica can
+//     start a restore of its own. Canceling the lease context reaches the
+//     caller at once, but not necessarily work already running on atelet.
+const defaultLeaseTTL = 15 * time.Second
 
 func (p *Persistence) AcquireLease(ctx context.Context, key string) (*store.Lease, error) {
 	ttl := p.leaseTTL
@@ -1544,9 +1575,27 @@ const (
 	renewDeadlineFraction   = 2.0 / 3.0
 )
 
+// leaseRenewInterval is how often a holder renews its lease, and
+// leaseRenewDeadline is how long after the last successful renewal a renewal
+// that keeps failing may go on retrying before the holder gives the lease up
+// and cancels its lease context. Both are anchored at the last success, so
+// renewDeadlineFraction has to exceed 1/renewIntervalDivisor for a stalled
+// renewal to get any window at all, and the two fractions are picked so that
+// both of the margins defaultLeaseTTL is chosen against come out at ttl/3:
+// leaseRenewDeadline - leaseRenewInterval is the outage a stalled renewal
+// rides out, and ttl - leaseRenewDeadline is the fencing margin before
+// another replica can take the lease over.
+func leaseRenewInterval(ttl time.Duration) time.Duration {
+	return ttl / renewIntervalDivisor
+}
+
+func leaseRenewDeadline(ttl time.Duration) time.Duration {
+	return time.Duration(float64(ttl) * renewDeadlineFraction)
+}
+
 func (p *Persistence) renewLeaseLoop(ctx context.Context, key, token string, ttl time.Duration) {
-	interval := ttl / renewIntervalDivisor
-	renewDeadline := time.Duration(float64(ttl) * renewDeadlineFraction)
+	interval := leaseRenewInterval(ttl)
+	renewDeadline := leaseRenewDeadline(ttl)
 
 	lastRenewed := time.Now()
 	timer := time.NewTimer(interval)

--- a/cmd/ateapi/internal/store/atepg/atepg_test.go
+++ b/cmd/ateapi/internal/store/atepg/atepg_test.go
@@ -498,3 +498,147 @@ func TestAcquireLease_ConcurrentTakeover(t *testing.T) {
 		lease.Close()
 	}
 }
+
+// routerParkedRequestBudget mirrors DefaultParkedRequestBudget in the atenet
+// router's ingress package, which lives under cmd/atenet/internal and so
+// cannot be imported here. It is how long the router parks and retries a
+// request whose actor is not routable yet before returning 503, and it is the
+// budget defaultLeaseTTL is chosen against.
+const routerParkedRequestBudget = 5 * time.Second
+
+// TestLeaseTimingConstraints pins the relationship between the lease TTL, the
+// renew cadence and the router's parked-request budget. These are not
+// independent knobs: see the comment on defaultLeaseTTL.
+func TestLeaseTimingConstraints(t *testing.T) {
+	if defaultLeaseTTL != 15*time.Second {
+		t.Errorf("defaultLeaseTTL = %v, want 15s", defaultLeaseTTL)
+	}
+	if got := leaseRenewInterval(defaultLeaseTTL); got != 5*time.Second {
+		t.Errorf("leaseRenewInterval(defaultLeaseTTL) = %v, want 5s", got)
+	}
+
+	// A crashed holder blocks cold workflows for its actor until the TTL
+	// runs out, and the router only parks a request for its budget, so the
+	// TTL must stay within a handful of budgets -- but it must also outlast
+	// one budget plus renewal slack, so a healthy but slow-renewing holder
+	// is never preempted inside a single parked request.
+	if defaultLeaseTTL <= routerParkedRequestBudget+leaseRenewInterval(defaultLeaseTTL) {
+		t.Errorf("defaultLeaseTTL = %v, want more than the router parked budget (%v) plus one renew interval (%v)",
+			defaultLeaseTTL, routerParkedRequestBudget, leaseRenewInterval(defaultLeaseTTL))
+	}
+	if defaultLeaseTTL > 3*routerParkedRequestBudget {
+		t.Errorf("defaultLeaseTTL = %v, want at most 3 router parked budgets (%v)", defaultLeaseTTL, 3*routerParkedRequestBudget)
+	}
+
+	// Losing the lease cancels the lease context, and with it the atelet
+	// restore running under it. A renewal fires one interval after the last
+	// success and its deadline is anchored at that same success, so the
+	// outage a stalled renewal is guaranteed to ride out is the difference
+	// between the two, and a holder that has given up is still fenced out of
+	// the row until the full TTL. Both margins are what a change to
+	// renewIntervalDivisor or renewDeadlineFraction would eat.
+	for _, ttl := range []time.Duration{defaultLeaseTTL, 6 * time.Second, time.Minute} {
+		if got, want := leaseRenewDeadline(ttl)-leaseRenewInterval(ttl), ttl/3; got < want {
+			t.Errorf("ttl %v: stalled-renew grace window = %v, want at least %v", ttl, got, want)
+		}
+		if got, want := ttl-leaseRenewDeadline(ttl), ttl/3; got < want {
+			t.Errorf("ttl %v: fencing margin = %v, want at least %v", ttl, got, want)
+		}
+	}
+	if got := leaseRenewDeadline(defaultLeaseTTL) - leaseRenewInterval(defaultLeaseTTL); got != 5*time.Second {
+		t.Errorf("stalled-renew grace window at the default TTL = %v, want 5s", got)
+	}
+}
+
+// holdLeaseRowLocked opens a transaction that holds an exclusive row lock on
+// the named lease until releaseAt, modeling a store blip that stalls the
+// holder's renewals for exactly that long.
+func holdLeaseRowLocked(t *testing.T, p *Persistence, key string, releaseAt time.Time) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Until(releaseAt)+30*time.Second)
+	defer cancel()
+
+	tx, err := p.pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("beginning blocking transaction: %v", err)
+	}
+	// A second Rollback after the explicit one below returns pgx.ErrTxClosed;
+	// this only matters on the t.Fatalf paths, where it hands the pooled
+	// connection and the row lock back instead of stranding both.
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `SELECT 1 FROM leases WHERE key = $1 FOR UPDATE`, key); err != nil {
+		t.Fatalf("locking lease row: %v", err)
+	}
+	time.Sleep(time.Until(releaseAt))
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatalf("releasing lease row lock: %v", err)
+	}
+}
+
+// TestLeaseRenewGraceWindow brackets the window a stalled renewal gets. At a
+// 6s TTL the renewal is due 2s after acquisition and its deadline lands at 4s,
+// so a blip clearing at 3.5s must be ridden out -- canceling the lease context
+// would abort the atelet restore running under it -- and one clearing at 4.5s
+// must cost the lease, which is what fences the row for the next replica.
+func TestLeaseRenewGraceWindow(t *testing.T) {
+	const ttl = 6 * time.Second
+
+	for _, tc := range []struct {
+		name     string
+		blip     time.Duration
+		wantLost bool
+	}{
+		{name: "inside the renew deadline", blip: 3500 * time.Millisecond},
+		{name: "past the renew deadline", blip: 4500 * time.Millisecond, wantLost: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := setupPostgresPersistence(t)
+			ctx := context.Background()
+			s.leaseTTL = ttl
+
+			key := "blipped-lease"
+			lease, err := s.AcquireLease(ctx, key)
+			if err != nil {
+				t.Fatalf("AcquireLease failed: %v", err)
+			}
+			defer lease.Close()
+			// The renew loop anchors its deadline at the moment the lease was
+			// acquired, so the blip is timed from here too.
+			acquired := time.Now()
+
+			var before time.Time
+			if err := s.pool.QueryRow(ctx, `SELECT expires_at FROM leases WHERE key = $1`, key).Scan(&before); err != nil {
+				t.Fatalf("reading initial expires_at: %v", err)
+			}
+
+			holdLeaseRowLocked(t, s, key, acquired.Add(tc.blip))
+
+			if tc.wantLost {
+				select {
+				case <-lease.Context().Done():
+				case <-time.After(leaseRenewInterval(ttl)):
+					t.Fatal("lease context still live after a renewal stalled past its deadline")
+				}
+				return
+			}
+
+			// Let the unblocked renewal land.
+			time.Sleep(500 * time.Millisecond)
+
+			select {
+			case <-lease.Context().Done():
+				t.Fatal("lease context was canceled by a renewal that stalled inside its deadline")
+			default:
+			}
+
+			var after time.Time
+			if err := s.pool.QueryRow(ctx, `SELECT expires_at FROM leases WHERE key = $1`, key).Scan(&after); err != nil {
+				t.Fatalf("reading renewed expires_at: %v", err)
+			}
+			if !after.After(before) {
+				t.Errorf("expires_at = %v, want it advanced past the pre-blip %v", after, before)
+			}
+		})
+	}
+}

--- a/cmd/atenet/internal/router/ingress/parking_test.go
+++ b/cmd/atenet/internal/router/ingress/parking_test.go
@@ -157,3 +157,17 @@ type simpleErr string
 func (e simpleErr) Error() string { return string(e) }
 
 const errOther simpleErr = "boom"
+
+// TestDefaultParkedRequestBudget_CoupledToLeaseTTL guards a constant that is
+// mirrored outside this package. atepg's defaultLeaseTTL is chosen as a small
+// multiple of this budget -- a crashed ateapi replica's lease keeps failing
+// cold workflows until it expires, and each park that outlives the budget is a
+// user-visible 503 -- but cmd/ateapi cannot import cmd/atenet, so the value is
+// hand-copied there. Changing it here means revisiting defaultLeaseTTL and the
+// mirror in atepg's TestLeaseTimingConstraints.
+func TestDefaultParkedRequestBudget_CoupledToLeaseTTL(t *testing.T) {
+	if DefaultParkedRequestBudget != 5*time.Second {
+		t.Errorf("DefaultParkedRequestBudget = %v, want 5s; see atepg defaultLeaseTTL before changing it",
+			DefaultParkedRequestBudget)
+	}
+}


### PR DESCRIPTION
### What

Cuts `defaultLeaseTTL` in the atepg store from 30s to 15s, and lifts the two
timings the renew loop derives from it (`ttl/3` renew interval, `2/3 ttl` renew
deadline) out of `renewLeaseLoop` into named `leaseRenewInterval` /
`leaseRenewDeadline` helpers so the TTL stays the only number to tune.

No behavior change beyond the constant. `renewIntervalDivisor` and
`renewDeadlineFraction` are untouched, so the renew cadence goes 10s -> 5s and
the renew deadline 20s -> 10s, both purely as a consequence of the TTL.

Diff is 3 files: `cmd/ateapi/internal/store/atepg/atepg.go`,
`cmd/ateapi/internal/store/atepg/atepg_test.go`, and a one-test drift guard in
`cmd/atenet/internal/router/ingress/parking_test.go`.

Addresses #606.

### Why

A lease left behind by a hard-crashed ateapi replica (SIGKILL, node loss) stays
valid for the remainder of its TTL, and every cold workflow for that actor keeps
failing with `ErrLeaseConflict` until it expires. That surfaces to users: the
conflict becomes `codes.Aborted` (`controlapi/workflow.go`), the router treats
Aborted as retryable while the request is parked (`ingress/resumer.go`), and
once `DefaultParkedRequestBudget` (5s, `ingress/parking.go`) runs out the
request gets a 503. At 30s that is up to six consecutive park budgets of
user-visible 503s per crash; at 15s it is three at worst, roughly 1.5 on
average.

The TTL is bounded from below by two margins that both scale with it, and the
PR makes both explicit in the doc comment because the choice of 15s rests on
them:

1. **Stalled-renew grace.** A renewal still failing when its deadline passes
   cancels the lease context, and that context wraps the atelet restore call
   (`acquireActorLease` returns `lease.Context()`, `workflow_resume.go` passes
   it to `ensureAteletRestored`), so an expiring lease aborts the cold
   operations in flight under it. The renewal fires one interval (`ttl/3`)
   after the last success while its deadline is anchored at that same success
   (`2/3 ttl`), so the **guaranteed** tolerated store outage is the difference,
   `ttl/3` = **5s** — rising to 10s only when the outage happens to begin just
   after a renewal lands.
2. **Fencing.** A holder abandons its lease at `2/3 ttl` while the row only
   becomes acquirable at the full TTL, leaving `ttl - renewDeadline` = `ttl/3`
   = **5s** for an abandoned holder's already-issued atelet RPCs to unwind
   before another replica can start a restore of its own. This change halves
   that margin from 10s to 5s.

A 10s TTL — the other candidate — would cut both margins to 3.3s, which is why
15s and not 10s.

### Note on the 5s vs 10s figure

An earlier draft of this change described the
grace window as the full renew deadline: 10s at a 15s TTL, 6.7s at a 10s TTL.
That is the best case, not the floor. Because the first renewal attempt does not
start until one interval after the last success, the guaranteed window is
`renewDeadline - interval` = `ttl/3`. The comment, the tests and the commit
message now all state the floor.

### Testing done

All run in the worktree at `/home/jpbetz/projects/substrate-worktrees/lease-ttl-15s`.

- `go build ./...` — exit 0
- `go vet ./cmd/ateapi/...` — exit 0
- `go test ./cmd/ateapi/internal/controlapi/... -count=1`
  - `ok github.com/agent-substrate/substrate/cmd/ateapi/internal/controlapi 10.181s`
  - `ok github.com/agent-substrate/substrate/cmd/ateapi/internal/controlapi/functionaltest 18.836s`
- `go test ./cmd/ateapi/internal/store/atepg/ -run Lease -count=1 -v` — all pass:
  `TestAcquireLease_CleansExpiredLeases`, `TestAcquireLease_ExpiresAfterHolderStops`,
  `TestAcquireLease_ConcurrentTakeover`, `TestLeaseTimingConstraints`,
  `TestLeaseRenewGraceWindow/inside_the_renew_deadline`,
  `TestLeaseRenewGraceWindow/past_the_renew_deadline`
- `go test ./cmd/ateapi/internal/store/atepg/ -count=1` (whole package) — `ok ... 14.999s`
- `go test ./cmd/atenet/internal/router/ingress/... -count=1` — `ok ... 0.248s`
- `gofmt -l cmd internal pkg` — empty; `hack/verify/gofmt.sh`, `hack/verify/boilerplate.sh`,
  `hack/verify/golangci-lint.sh` — all exit 0

**New tests.** `TestLeaseTimingConstraints` pins the TTL against the router's
park budget and asserts both margins (grace window and fencing) are at least
`ttl/3` across three TTLs. `TestLeaseRenewGraceWindow` brackets the window
behaviorally at a 6s TTL (2s interval, 4s deadline) by holding a `FOR UPDATE`
row lock on the lease: a blip clearing at 3.5s must **not** cost the lease, and
one clearing at 4.5s **must**.

**Mutation-checked**, so these are load-bearing rather than tautological:
- `renewDeadlineFraction = 0.55` -> `TestLeaseTimingConstraints` fails on the
  grace window at all three TTLs, and `.../inside_the_renew_deadline` fails
  with "lease context was canceled by a renewal that stalled inside its deadline".
- `renewDeadlineFraction = 0.85` -> `TestLeaseTimingConstraints` fails on the
  fencing margin, and `.../past_the_renew_deadline` fails with "lease context
  still live after a renewal stalled past its deadline".

**Coverage caveat for reviewers:** the behavioral lease tests are Docker-gated.
In a lane without Docker, `requirePool` skips them and the suite still reports
`ok`, leaving only `TestLeaseTimingConstraints` (pure constant arithmetic)
running. That is this package's pre-existing convention, not something this
branch changes.

### Open questions

1. **Is a 5s guaranteed grace window enough?** It covers a pgbouncer blip or a
   connection reset, but likely not a full restart of the single-replica
   in-cluster Postgres. If we want ~10s guaranteed, the cheap lever is raising
   `renewDeadlineFraction` (e.g. to 0.9), *not* raising the TTL — but that
   spends the fencing margin, taking it to `ttl/10` = 1.5s. Deliberately not
   done here: it is a separate tuning decision with its own risk, and this PR
   keeps the two margins symmetric at `ttl/3`. Flagging it because it is easy to assume the larger number.
2. **Fencing margin halves from 10s to 5s.** Called out explicitly since it is
   a real reduction in the time an abandoned holder's in-flight atelet work has
   to unwind. Context cancellation reaches the caller immediately but not
   necessarily work already running on atelet. I believe 5s is still ample for
   an RPC to unwind, but it is the part of this change I would most want a
   second opinion on.
3. **Cross-tree constant duplication.** `cmd/ateapi` and
   `cmd/atenet/internal/router/ingress` are mutually unimportable, so the 5s
   park budget is hand-copied into the atepg test. Mitigated with a guard test
   on the ingress side naming atepg as the coupled consumer, so changing either
   trips the other. The cleaner fix — hoisting the budget into a shared
   `internal/` package — felt out of scope for a constant change; say the word
   and I will do it instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYXeYhZaGKwgY57jvfMMYF
