### PR TITLE
docs: add a store policy for the ateapi persistence layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ We provide several sample applications demonstrating Agent Substrate's capabilit
 * [Glossary](docs/glossary.md): Core terms (Actor, Atespace, ActorTemplate, WorkerPool, Worker, ate-api-server, atenet, atelet, ateom) and how they relate.
 * [Integration Repositories](docs/integration-repos.md): Where integrations live, how their repositories are named, and how fixes flow back to core.
 * [Observability Guide](docs/observability.md): Guide to actor logging, metrics, and distributed tracing.
+* [Store Policy](docs/dev/store.md): Rules for the `ateapi` persistence layer — data model, write path, schema evolution, and the review checklist for store changes.
 * [Authentication Guide](docs/authentication.md): Configure trusted JWT providers and human credentials.
 * [Request Parking](docs/request-parking.md): How the router parks requests through transient worker-pool saturation.
 * [Threat Model](docs/threat-model.md): Trust boundaries, assumptions, and known risks.

--- a/docs/dev/store.md
+++ b/docs/dev/store.md
@@ -1,0 +1,262 @@
+# Store Policy
+
+Rules for `ateapi`'s persistence layer: the backend-neutral contract in
+`cmd/ateapi/internal/store` and its PostgreSQL implementation in
+`cmd/ateapi/internal/store/atepg`.
+
+Nothing here is new. It is the contract in `store.go`, the schema header comment
+in `atepg/schema.go`, and a run of store-PR review positions, collected so that a
+store change is reviewed against a written standard rather than reviewer memory.
+Read it before adding a table, a column, a `store.Interface` method, or a
+transaction.
+
+**Non-goals.** Not a design document, a tuning guide, or an operations runbook.
+The proto surface is governed by the [API style guide](../api-style-guide.md) —
+sections [6.3/6.4](../api-style-guide.md#63-uid) and
+[7](../api-style-guide.md#7-resource-freshness-and-optimistic-concurrency) are
+load-bearing here and are not repeated. Go conventions:
+[code style guide](../code-style-guide.md). Layout: [code layout](code-layout.md).
+There is no watch over actors and no global revision; sections 1 and 4 are what
+keep the option of adding one open.
+
+## 1. Data model
+
+**Proto is the source of truth.** Each resource row stores one marshaled proto in
+a `bytea proto` column. A field is projected into its own column only where
+PostgreSQL itself needs the value — identity, foreign keys, ordering, paging, or
+an atomic concurrency check. Everything else stays in the proto.
+
+**Every proto-bearing table carries `uid` and `version`.** They are projections
+of the proto's `ResourceMetadata` and must agree with it: a read that finds them
+out of step fails loudly instead of repairing itself
+(`validateProtoMetadataMatchesColumns`).
+
+**`version` is a per-object counter.** The writer that read the row increments it
+(`setUpdateMetadata`). It is not a global revision, a commit order, or a watch
+cursor. Do not add a sequence, an `xmin` projection, or a "global version" column
+to make it one: that funnels every write through one hot row, and it is the
+hardest decision here to walk back.
+
+**`atespace` leads every actor-family primary key.** `actors`,
+`actor_egress_policies`, `actor_templates`, `actor_snapshots`, and
+`actor_snapshot_tags` all key on `(atespace, …)`. Atespace is the only viable
+shard key this data model has, and a new actor-family table that does not lead
+with it forecloses partitioning before we get to choose. Workers are the
+deliberate exception: global-scoped, keyed by Kubernetes pod UID.
+
+**Page tokens stay topology-free.** A token carries a format version, the list
+method it was issued for, its scope, and the last row's ordering values — enough
+to resume a keyset scan, nothing more (`atepg/pagetoken.go`). No offsets,
+snapshot identifiers, replica identity, xids, or LSNs. A token must stay valid
+against any replica and across a failover, and it is a public API string with a
+size budget.
+
+## 2. Write path
+
+**Optimistic uid+version compare-and-set only.** Every update takes a
+`store.Precondition` carrying both guards; both are required, and a missing one
+is `ErrPreconditionRequired` rather than a blind write. Two shapes give that
+guarantee. A lock-free path checks the guards against the row it read and
+re-asserts both in the `WHERE` clause of the `UPDATE`, so zero rows affected is
+`ErrVersionConflict` (`UpdateActor` in `atepg/atepg.go`). A path that reads
+`SELECT … FOR UPDATE` checks the precondition against the locked row and gets the
+same guarantee from the lock (`UpdateWorker`). Either is acceptable; an update
+that does neither is a blind write. `version` guards the lost update; `uid`
+guards name reuse across lifecycles; neither substitutes for the other. No update
+path may be last-writer-wins.
+
+**Deletes guard differently, on purpose.** `store.DeletePreconditions` guards are
+independently waivable — the zero value pins nothing, which is what an unguarded
+delete wants. A delete that must act on one incarnation passes `UID`; one that
+must act on one revision passes `Version`. A delete still reads `FOR UPDATE` so
+the incarnation the guard was checked against is the one removed
+(`DeleteWorker`), and a delete that touches a second row is still one
+transaction.
+
+**Auto-retry only on an explicit precondition failure.** The store runs `mutate`
+once per attempt and surfaces the conflict. A caller that retries must re-read
+and rebuild *all* of its intent from the state it lost to, not just the row that
+conflicted: the assignment loop in `controlapi/workflow_resume.go` refreshes the
+actor but rescans a stale worker cache, so it can claim a second worker and
+strand the first. That is a known defect, not the pattern to copy. Never retry
+`ErrUIDConflict` — the name now addresses a different incarnation, so no retry
+can resolve it. Never retry a `mutate`'s own error; it is returned verbatim so
+the caller can tell the cases apart.
+
+`store.Interface` still reserves internal retry for backends: its update comments
+say `mutate` may run more than once and that `ErrVersionConflict` can mean an
+exhausted retry budget. No `atepg` path implements such a retry, and no caller
+may depend on one. The interface comment should be narrowed to match the
+backend, not the backend widened to match the comment.
+
+**Cross-row invariants live in one store transaction.** An operation that must
+leave two rows consistent — binding a worker to an actor is the canonical case —
+belongs in a single `store.Interface` method with one transaction. Two calls from
+the workflow layer leave a window in which a crash, a deadline, or a lost CAS
+strands the first row; the claim-then-transition sequence in `workflow_resume.go`
+is the known instance, tracked rather than endorsed. **Reviewers reject new
+two-call claim/release patterns on sight.** A store primitive is also testable by
+the contract suite, where the atomicity can actually be asserted.
+
+**The actor lease guards atelet side effects, not store consistency.**
+`AcquireLease` is a TTL row in `leases` that stops two replicas driving the same
+sandbox through a resume or suspend. It is not what makes a multi-row write
+correct and must not become that: TTL leases lapse under load, clock skew, and a
+slow database; a CAS does not. An invariant that holds only while a lease is held
+is not an invariant.
+
+**No Go work under a row lock.** `UpdateWorker` holds `SELECT … FOR UPDATE`
+across unmarshal, `mutate`, marshal, and the outbox insert, because the
+assignment predicate lives inside the opaque proto and cannot be pushed into a
+`WHERE` clause. That is what makes an occupancy test inside `mutate` a
+compare-and-set, and it is the ceiling on worker write throughput. The lock scope
+must not grow: no RPC, no cache lookup, no second table's read-modify-write, no
+extra caller-supplied closure. New code should prefer the lock-free actor shape —
+read, mutate, CAS `UPDATE`.
+
+## 3. Projected-column checklist
+
+A new column beside `proto` is the change most often regretted. Each one must:
+
+1. **Name the query it serves** — a `WHERE`, `ORDER BY`, `JOIN`, or constraint
+   the store issues today. "We will probably need it" is not a query.
+2. **Be written in the same statement as `proto`, under the same CAS guard.** No
+   second `UPDATE`, trigger, or backfill job that can lag. The projection and the
+   proto may only ever be wrong together.
+3. **Carry no index without a HOT/WAL benchmark.** The workload is whole-row
+   replace; an index on a projected column can turn a HOT update into a non-HOT
+   one and adds WAL on every write to that row.
+4. **Not exist for observability.** Reporting, debugging, and metrics are served
+   from the proto, the outbox, or an offline query — never a write-path tax for
+   something no writer reads.
+5. **Survive an N-1 binary** (section 5).
+
+The same test applies to a column duplicating a value already in the proto: the
+store treats disagreement as a hard failure, so each one is a new way to fail.
+
+## 4. Outbox
+
+**The outbox is a cache, never a source of truth.** `worker_outbox` is UNLOGGED
+and range-partitioned by `created_at`; maintenance drops expired partitions and
+records a trim high-water mark. It exists so watchers can avoid polling
+`workers`, which stays authoritative: a watcher that falls behind the trim mark,
+or sees the postmaster restart, closes its channel to force a resync. No data may
+live only in the outbox, and no consumer may treat it as a durable log.
+
+The poll is fenced behind `pg_snapshot_xmin(pg_current_snapshot())` so no
+in-flight transaction's row can appear after the cursor has passed its xid. That
+fence is also why any long-running transaction — an operator's `psql` session, a
+migration — stalls delivery on every replica. Run DDL outside the serving window.
+
+The payload is one event-type byte plus the marshaled proto, and that byte is
+read by other replicas mid-rolling-deploy, so the values are append-only stable
+like any persisted enum (section 6).
+
+**Any future watch defines its own `xid8` cursor** over its own outbox. Do not
+reuse per-object `version` as a cursor, and do not add a global revision to serve
+one.
+
+## 5. Schema evolution
+
+- **Forward-only in production.** No automatic down migration; a bad migration is
+  fixed by rolling forward.
+- **Additive and expand-only.** Add a nullable or defaulted column, a table, an
+  index. Do not rename, retype, or drop in place. Contract only once every binary
+  that reads the old shape is gone.
+- **The old binary must read the new schema.** N-1 and N serve simultaneously
+  during a rolling upgrade, so N-1 has to keep working against the schema N
+  installed. This is the rule that makes `SELECT proto` plus a few pinned columns
+  preferable to a wide projected row.
+- **The N-1 round-trip must be lossless.** A read-modify-write by an N-1 binary
+  must not destroy state written by N. Proto unknown-field preservation gives
+  this for free inside `proto` — the strongest reason to keep state there rather
+  than in columns. Never round-trip a stored proto through JSON: `protojson`
+  cannot represent unknown fields and drops them silently.
+- **Migrations own the schema once the migration baseline lands.** Until then
+  `atepg/schema.go` is idempotent DDL applied at startup. Either way, the rules
+  above are what a schema change is reviewed against.
+
+## 6. Proto compatibility is a storage rule
+
+`proto` is stored verbatim, so every proto change is a storage migration.
+
+- **Never reuse a field tag.** Removed tags are `reserved`, permanently; a reused
+  tag decodes stored bytes into the wrong field.
+- **Retyping or removing a field requires rewriting every stored row**, not just
+  a proto edit. Budget it as a migration.
+- **Enums are add-only.** A value that has ever been persisted can never be
+  renumbered or removed, and readers must tolerate values they do not know.
+- **Unknown fields must survive a read-modify-write** on every path that reads
+  and rewrites a stored proto.
+
+There is no `docs/api_changes.md` yet. Until there is, this section plus
+[section 7 of the API style guide](../api-style-guide.md#7-resource-freshness-and-optimistic-concurrency)
+is the rule.
+
+## 7. Testing bar
+
+- **`storecontract` is the contract.**
+  `cmd/ateapi/internal/store/storecontract/contract.go` holds backend-neutral
+  assertions, run against `atepg` from `atepg/contract_test.go`. Behavior callers
+  rely on but the suite does not assert is not part of the contract: add the
+  assertion in the same PR as the behavior.
+- **Backend tests test the backend.** `atepg/atepg_test.go` covers what is
+  specific to PostgreSQL: foreign-key error mapping, page-token shape, lease
+  expiry and takeover.
+- **Concurrency is tested by mutate injection, not sleeps.** The
+  read-modify-write closure is the injection point: the test issues the competing
+  write from inside `mutate`, making the interleaving deterministic. See
+  `TestUpdateActor_ConcurrentWriteReturnsConflict`,
+  `TestUpdateActorTemplate_ConcurrentWriteReturnsConflict`, and
+  `TestUpdateActorSnapshotTag_CASPreventsDeleteRecreateABA` in
+  `atepg/atepg_test.go`. Every new CAS path gets one.
+- **The N-1 round-trip is asserted, not assumed.** A `storecontract` case must
+  show that a stored proto carrying fields the running binary does not know
+  survives a read-modify-write intact. No such case exists today; the first
+  change that leans on the guarantee writes it.
+- **Database tests must run in CI, not skip.** The fixtures skip when the
+  PostgreSQL testcontainer is unavailable — right on a laptop without Docker,
+  wrong in CI, where a green run with zero store tests has already happened. A
+  skip in CI is a failure; do not add a fixture that can skip silently.
+
+## 8. Operational limits
+
+The honest v1 envelope. A description of what has been built, not a target:
+
+- One tuned primary (8-16 vCPU), 2-4 `ateapi` replicas.
+- Order 10^4-10^5 workers, 10^6 actor rows, 10^3 lifecycle operations per second.
+- A cold resume is about five writes over four or five transactions. Isolated
+  `UpdateWorker` throughput is a microbenchmark, not a system number.
+- **The first ceiling is not PostgreSQL.** It is the O(fleet) scan in ateapi
+  scheduling: each resume walks the whole worker cache. Scheduling cost should be
+  O(candidates); a change that adds another full-fleet pass is a regression.
+- **In-cluster PostgreSQL is for development and evaluation.** Production means
+  managed PostgreSQL with backups and point-in-time recovery. There is no backup
+  path for the StatefulSet today, and an empty database comes back reporting
+  healthy.
+
+## PR checklist for store changes
+
+- [ ] New table stores its proto in `bytea` and carries `uid` + `version`; an
+      actor-family primary key leads with `atespace`.
+- [ ] Each new projected column names the query it serves, is written in the same
+      statement under the same CAS guard, and any index has a benchmark.
+- [ ] Every update requires a uid+version precondition and enforces it, either by
+      re-asserting both guards in the `WHERE` clause or by checking them against
+      a row read `FOR UPDATE`. No blind writes.
+- [ ] A new delete states which guards it pins and which it waives, and reads the
+      row it deletes `FOR UPDATE`.
+- [ ] Retries happen only on an explicit precondition failure, after re-reading
+      everything the attempt was built from. No retry on `ErrUIDConflict`.
+- [ ] Any invariant spanning two rows is one store method and one transaction —
+      not two calls from `controlapi`, and not a lease.
+- [ ] No RPC, cache read, or extra closure runs inside a `FOR UPDATE`
+      transaction.
+- [ ] Schema change is additive, forward-only, and readable by the N-1 binary.
+- [ ] A change relying on N-1 round-trip losslessness ships the `storecontract`
+      case that asserts it.
+- [ ] No field tag reused, no enum value removed or renumbered; a retype or
+      removal ships with a row rewrite.
+- [ ] New contract behavior asserted in `storecontract`; new CAS paths have a
+      mutate-injection test; no new fixture that can skip silently.
+- [ ] Page tokens carry no topology.


### PR DESCRIPTION
### What

Adds `docs/dev/store.md` (~2 pages) and links it from the README documentation
index. No code, proto, generated, manifest, or vendor file is touched.

The doc covers, in eight short sections plus a closing per-PR checklist:

1. **Data model** — proto is the source of truth; every proto-bearing table
   carries `uid` + `version`; `version` is a per-object counter and never a
   global revision or watch cursor; `atespace` leads every actor-family primary
   key; page tokens stay topology-free.
2. **Write path** — optimistic uid+version CAS only, in either of the two shapes
   the code uses (guards re-asserted in the `WHERE` clause, or checked against a
   row read `FOR UPDATE`); deletes guard differently on purpose; retry only on an
   explicit precondition failure and only after re-reading everything the attempt
   was built from; cross-row invariants live in one store transaction; the actor
   lease guards atelet side effects, not store consistency; no Go work under a
   row lock.
3. **Projected-column checklist** — name the query, write it under the same CAS
   guard, no index without a HOT/WAL benchmark, no write-path tax for
   observability.
4. **Outbox** — a cache, never a source of truth; the `pg_snapshot_xmin` fence
   and what stalls it; any future watch defines its own `xid8` cursor.
5. **Schema evolution** — forward-only, additive/expand-only, N-1 reads the new
   schema, the N-1 round-trip is lossless.
6. **Proto compatibility as a storage rule** — `bytea` is stored verbatim, so
   never reuse a tag, enums are add-only, a retype or removal ships with a row
   rewrite.
7. **Testing bar** — `storecontract` is the contract; concurrency is tested by
   mutate injection, not sleeps; database tests must run in CI rather than skip.
8. **Operational limits** — the honest v1 envelope, and the note that the first
   ceiling is the O(fleet) scheduling scan in ateapi, not PostgreSQL.

### Why

The rules governing the store are real but scattered across `store.go` contract
comments, the `atepg/schema.go` header, and a run of review positions on store
PRs. A reviewer had to remember them and a contributor had no way to read them
before writing a change. Nothing in the doc is a new rule: every claim is
grounded in the code as it stands on `main`, and the citations name the function
or test rather than a line number so they survive edits.

Three places where the doc records a gap rather than papering over it:

- `store.Interface`'s update comments reserve internal retry for backends
  ("mutate may run more than once", "if the retry budget is exhausted"). No
  `atepg` path implements one. The doc says the comment should be narrowed to
  match the backend, and that no caller may depend on a retry.
- The assignment retry loop in `controlapi/workflow_resume.go` refreshes the
  actor but rescans a stale worker cache, so it can claim a second worker and
  strand the first. The doc cites it as the known defect, not as the pattern to
  copy.
- Nothing asserts that unknown proto fields survive an N-1 read-modify-write.
  The doc makes that a `storecontract` case the first change relying on the
  guarantee has to write.

### Testing done

Docs-only change, so no test suite bears on it; nothing was regressed and no
suite was run green as evidence.

- `hack/verify/boilerplate.sh`, `gofmt.sh`, `licenses.sh`, `go-modules.sh`,
  `metrics.sh`, `shellcheck.sh`: all exit 0.
- `hack/verify/proto-fmt.sh`: exits 1 with "Failed to find clang-format: please
  make sure it is in your PATH". Environmental — the tool is not installed here
  and the diff touches no `.proto` file.
- `go vet ./cmd/ateapi/internal/store/...`: exit 0, no output.
  `gofmt -l cmd/ateapi/internal/store/`: no output.
- All five relative links and both anchors resolve
  (`../api-style-guide.md#63-uid`, `#7-resource-freshness-and-optimistic-concurrency`,
  `../code-style-guide.md`, `code-layout.md`), and the README entry's target
  exists.
- Every cited symbol, file, and test name verified present on `main`.
- No British spellings (misspell runs `locale: US`); no trailing whitespace; no
  issue or PR numbers in the doc or the commit message.

### Open questions for review

- **Home for the link.** It is in the README "Documentation & Guides" index, but
  it is a contributor doc and `docs/dev/code-layout.md` is not in that index at
  all. CONTRIBUTING.md or an `AGENTS.md` line under Repository Layout ("changes
  under `cmd/ateapi/internal/store` are reviewed against `docs/dev/store.md`")
  may be the better home. Happy to move it.
- **Overlap with the ops posture.** Section 8's last bullet (in-cluster
  PostgreSQL is dev/eval only, no StatefulSet backup path, an empty database
  reports healthy) belongs to a store-ops doc that does not exist yet. When one
  lands, this should reduce to a one-line pointer so the two do not drift.
- **`docs/api_changes.md`.** Section 6 states the proto-as-storage rules and says
  there is no `docs/api_changes.md` yet. If that doc is being written elsewhere,
  section 6 should shrink to a pointer.
- **Follow-ups the doc implies but does not do:** narrow the `store.Interface`
  retry comments to match `atepg`, and add the N-1 unknown-field round-trip case
  to `storecontract`. Both are small and can be separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYXeYhZaGKwgY57jvfMMYF
