### PR TITLE
benchmarking: follow go.mod's Go version in the benchmarking images

### DIFF
--- a/benchmarking/locust/Dockerfile
+++ b/benchmarking/locust/Dockerfile
@@ -25,6 +25,7 @@ RUN pip install --no-cache-dir --target=/app/deps -r requirements.txt
 # runner.py can spawn it as a subprocess during headless runs of glutton.
 # CGO_ENABLED=0 keeps us on boomer's pure-Go ZMQ (gomq), no libzmq needed.
 FROM golang:1.26-bookworm AS goboomer
+ENV GOTOOLCHAIN=auto
 WORKDIR /src
 COPY go.mod go.sum ./
 COPY vendor ./vendor


### PR DESCRIPTION
Fixes #1351

`Bump Go to 1.27` (69828945) raised the root `go.mod` and every
`hack/tools/*/go.mod` to `go 1.27.0`. `benchmarking/deploy_locust.sh --deploy`
now fails at the `boomer-glutton` build:

    go: go.mod requires go >= 1.27.0 (running go 1.26.7; GOTOOLCHAIN=local)

The `goboomer` stage builds `FROM golang:1.26-bookworm`, and the official
`golang` images set `GOTOOLCHAIN=local` in their image config. That disables
Go's toolchain resolution, so the base image tag becomes a second place where
the project's Go version is declared. It drifted out of sync with `go.mod` at
the 1.27 bump and would drift again at 1.28.

Simply bumping the tag would fix today's build and leave that second
declaration in place. This makes `go.mod` the only place the version is
declared instead.

## Changes

- **`benchmarking/locust/Dockerfile`**: set `GOTOOLCHAIN=auto` in the
  `goboomer` stage, undoing the base image's `local`. Go now reads the `go`
  directive from `go.mod` and fetches a matching toolchain when the base image
  falls behind, so a future minor bump needs no change here.


## Validation

No test covers this file. Verified by build.

- [x] `docker build --no-cache --platform linux/amd64 -f benchmarking/locust/Dockerfile .`
      compiles `boomer-glutton`, logging `go: downloading go1.27.0` where it
      previously failed.
- [x] Same build with `GOTOOLCHAIN` left at the image default still fails with
      the error above, confirming that variable is the cause rather than the
      base image version.

