### PR TITLE
[Upgrade] Version the install: node labels and a per-version atelet DaemonSet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ kubectl port-forward -n ate-system svc/atenet-router 8000:80
 curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" -i http://localhost:8000/
 ```
 
+Worker capacity is versioned: the dataplane (the atelet DaemonSet and the
+worker pods) schedules only on nodes that carry the
+`ate.dev/substrate-version` label, and the install stamps it on every node
+that exists when it runs. A node added later hosts no workers until you label
+it with the installed version
+(`kubectl label node <node> ate.dev/substrate-version=<build version>`).
+`kubectl get ds -n ate-system -l app=atelet -L ate.dev/substrate-version`
+prints the installed version, off the atelet DaemonSet the install created.
+
 ### GKE Quickstart (Development)
 
 1. Create and configure your environment file:
@@ -146,6 +155,11 @@ curl -X POST -H "Host: my-counter-1.demo.actors.resources.substrate.ate.dev" -i 
    ```bash
    ./hack/install-ate.sh --deploy-ate-system
    ```
+
+   Nodes that GKE adds later (autoscaling, auto-repair, node upgrades) are
+   born with the node pool's labels, so the pool needs
+   `ate.dev/substrate-version` too; see
+   [Node version labels](tools/setup-gcp/README.md).
 
 5. You can then deploy the sample applications. See [demos/counter/README.md](demos/counter/README.md) or [demos/sandbox/README.md](demos/sandbox/README.md) for detailed walkthroughs.
    ```bash

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -37,6 +37,29 @@ syntax.
 metadata; they do not affect actor scheduling. Actor selectors match
 `WorkerPool.metadata.labels`, not `WorkerPool.spec.template.labels`.
 
+#### Pin pools to the installed substrate version (`template.nodeSelector`)
+
+The installation labels every node with the substrate build version it deployed.
+Set the same label as a `nodeSelector` on every pool, so its workers only run
+on nodes of that version:
+
+```yaml
+spec:
+  template:
+    nodeSelector:
+      ate.dev/substrate-version: "<installed version>"
+```
+
+Read the installed version off the atelet DaemonSet:
+
+```bash
+kubectl get ds -n ate-system -l app=atelet -L ate.dev/substrate-version
+```
+
+The pin is critical to make a rolling upgrade possible. An upgrade moves nodes to
+the new version one at a time, deleting each node's old worker pods once it
+moves. A pinned pool cannot put those pods back on a moved node, so the old
+version drains away node by node. An unpinned pool breaks this constraints.
 #### Worker Capacity (`spec.template.resources`)
 
 Setting `resources.limits` (CPU and Memory) on a `WorkerPool` establishes each worker pod's **capacity** — the envelope available to host an actor sandbox, taken from the `ateom` container's limits. The scheduler only places an actor on a worker whose capacity is `>=` the actor's declared resource limits (see [Sandbox Right-Sizing](#sandbox-right-sizing-specresources) on the `ActorTemplate`).

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -223,6 +223,58 @@ default_postgres_connection_string() {
   echo "postgresql://postgres@postgres.ate-system.svc:5432/atepg?sslmode=verify-full&sslrootcert=/run/servicedns.podcert.ate.dev/trust-bundle.pem&sslcert=/run/podidentity.podcert.ate.dev/credential-bundle.pem&sslkey=/run/podidentity.podcert.ate.dev/credential-bundle.pem"
 }
 
+# --- Versioned dataplane rendering ---
+#
+# The atelet DaemonSet is keyed by substrate version (name suffix + nodeSelector on
+# the ate.dev/substrate-version node label) so a rolling upgrade can run two
+# daemonset on disjoint node sets.
+
+SUBSTRATE_VERSION=""
+SUBSTRATE_VERSION_SUFFIX=""
+
+ensure_substrate_version() {
+  if [[ -n "${SUBSTRATE_VERSION}" ]]; then
+    return 0
+  fi
+  local version_flag=""
+  version_flag="$(make -s ldflags | grep 'internal/version\.Version=' | head -n 1 || true)"
+  local version_raw="${version_flag#*internal/version.Version=}"
+  if [[ -z "${version_raw}" ]]; then
+    echo "error: could not read the build version from 'make ldflags'" >&2
+    return 1
+  fi
+  # Verify the build label is valid format and derive the version string and object suffix.
+  local derived=""
+  derived="$(go run ./internal/versionlabel/cmd "${version_raw}")" || return 1
+  SUBSTRATE_VERSION="${derived%% *}"
+  SUBSTRATE_VERSION_SUFFIX="${derived##* }"
+}
+
+atelet_daemonset_name() {
+  echo "atelet-${SUBSTRATE_VERSION_SUFFIX}"
+}
+
+# substitute_version fills the ${SUBSTRATE_VERSION}/${SUBSTRATE_VERSION_SUFFIX}
+# placeholders in a rendered manifest stream. It runs after kustomize and ko to replace.
+substitute_version() {
+  ensure_substrate_version
+  sed -e "s/: \${SUBSTRATE_VERSION}\$/: \"${SUBSTRATE_VERSION}\"/" \
+      -e "s/\${SUBSTRATE_VERSION}/${SUBSTRATE_VERSION}/g" \
+      -e "s/\${SUBSTRATE_VERSION_SUFFIX}/${SUBSTRATE_VERSION_SUFFIX}/g"
+}
+
+# label_nodes_substrate_version stamps ate.dev/substrate-version on every node
+# that does not carry it yet. The versioned atelet DaemonSet and worker pods
+# schedule only to nodes labeled with their substrate version.
+label_nodes_substrate_version() {
+  ensure_substrate_version
+  log_step "label_nodes_substrate_version (${SUBSTRATE_VERSION})"
+  local node=""
+  for node in $(run_kubectl get nodes -l '!ate.dev/substrate-version' -o name); do
+    run_kubectl label "${node}" "ate.dev/substrate-version=${SUBSTRATE_VERSION}"
+  done
+}
+
 render_ate_system_manifests() {
   local router=""
   router="$(atenet_router)"
@@ -232,16 +284,16 @@ render_ate_system_manifests() {
     if [[ "${ATE_INSTALL_KIND:-false}" == "true" ]]; then
       overlay="manifests/ate-install/kind-agentgateway"
     fi
-    kubectl kustomize "${overlay}" --load-restrictor LoadRestrictionsNone | run_ko resolve -f -
+    kubectl kustomize "${overlay}" --load-restrictor LoadRestrictionsNone | run_ko resolve -f - | substitute_version
     return
   fi
 
   if [[ "${ATE_INSTALL_KIND:-false}" == "true" ]]; then
     # Build everything resolved with Kustomize for Kind
-    kubectl kustomize manifests/ate-install/kind --load-restrictor LoadRestrictionsNone | run_ko resolve -f -
+    kubectl kustomize manifests/ate-install/kind --load-restrictor LoadRestrictionsNone | run_ko resolve -f - | substitute_version
   else
     # Build everything resolved with base manifests for GKE
-    run_ko resolve -f manifests/ate-install
+    run_ko resolve -f manifests/ate-install | substitute_version
   fi
 }
 
@@ -359,10 +411,16 @@ apply_otel_endpoint_override() {
 
   local workload
   for workload in deployment/ate-api-server deployment/ate-controller \
-                  deployment/atenet-router daemonset/atelet; do
+                  deployment/atenet-router; do
     if run_kubectl -n ate-system get "${workload}" >/dev/null 2>&1; then
       run_kubectl -n ate-system rollout restart "${workload}"
     fi
+  done
+  # atelet DaemonSet names carry a version suffix; restart whichever versions
+  # are installed.
+  local ds=""
+  for ds in $(run_kubectl -n ate-system get daemonset -l app=atelet -o name 2>/dev/null); do
+    run_kubectl -n ate-system rollout restart "${ds}"
   done
 }
 
@@ -555,9 +613,16 @@ setup_csi() {
 
 deploy_ate_system() {
   log_step "deploy_ate_system"
+  # Fail fast on an unusable build version before touching the cluster.
+  ensure_substrate_version
+
   # Ensure namespace exists before applying RBAC or CRDs
   run_kubectl apply -f manifests/ate-install/ate-system-namespace.yaml \
     && run_kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/ate-system --timeout=60s
+
+  # The atelet DaemonSet applied below and the demo WorkerPools' worker pods
+  # schedule only to version-labeled nodes.
+  label_nodes_substrate_version
 
   # Not ensure_crds: its existence check skips upgrades, stranding stale CRD
   # schemas and RBAC (role.yaml has no other apply path).
@@ -618,7 +683,7 @@ deploy_ate_system() {
   run_kubectl rollout status deployment/ate-controller -n ate-system --timeout="$(rollout_timeout)"
   run_kubectl rollout status deployment/atenet-router -n ate-system --timeout="$(rollout_timeout)"
   run_kubectl rollout status deployment/atenet-egress -n ate-system --timeout="$(rollout_timeout)"
-  run_kubectl rollout status daemonset/atelet -n ate-system --timeout="$(rollout_timeout)"
+  run_kubectl rollout status "daemonset/$(atelet_daemonset_name)" -n ate-system --timeout="$(rollout_timeout)"
 
   # After the bundle, which carries its own copy of ate-otel-config.
   apply_otel_endpoint_override
@@ -661,25 +726,27 @@ deploy_ate_apiserver() {
 
 deploy_atelet() {
   log_step "deploy_atelet"
+  ensure_substrate_version
   ensure_crds
 
   # Ensure namespace exists
   run_kubectl apply -f manifests/ate-install/ate-system-namespace.yaml \
     && run_kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/ate-system --timeout=60s
 
+  label_nodes_substrate_version
   apply_otel_config
   apply_otel_endpoint_override
 
   local manifest=""
   if [[ "${ATE_INSTALL_KIND:-false}" == "true" ]]; then
     # Use Kustomize to build and resolve the atelet DaemonSet patch
-    manifest=$(kubectl kustomize manifests/ate-install/kind/atelet --load-restrictor LoadRestrictionsNone | run_ko resolve -f -)
+    manifest=$(kubectl kustomize manifests/ate-install/kind/atelet --load-restrictor LoadRestrictionsNone | run_ko resolve -f - | substitute_version)
   else
     # Use base manifest for GKE
-    manifest=$(run_ko resolve -f manifests/ate-install/atelet.yaml)
+    manifest=$(run_ko resolve -f manifests/ate-install/atelet.yaml | substitute_version)
   fi
   echo "${manifest}" | run_kubectl apply -f -
-  run_kubectl rollout status daemonset/atelet -n ate-system --timeout="$(rollout_timeout)"
+  run_kubectl rollout status "daemonset/$(atelet_daemonset_name)" -n ate-system --timeout="$(rollout_timeout)"
 }
 
 deploy_atenet() {
@@ -886,10 +953,13 @@ delete_ate_system() {
   else
     run_kubectl delete --ignore-not-found -f manifests/ate-install
   fi
+
+  run_kubectl delete --ignore-not-found -n ate-system daemonset -l app=atelet
   run_kubectl delete --ignore-not-found \
     -f manifests/ate-install/components/agentgateway/configmap.yaml
   run_kubectl delete --ignore-not-found -f manifests/ate-install/postgres.yaml
   run_kubectl delete --ignore-not-found -f manifests/ate-install/generated
+  run_kubectl label nodes -l ate.dev/substrate-version ate.dev/substrate-version-
 }
 
 delete_atenet() {

--- a/hack/setup-csi-hostpath-kind.sh
+++ b/hack/setup-csi-hostpath-kind.sh
@@ -133,8 +133,9 @@ spec:
     serverName: csi-hostpath-controller.default.svc
 EOF
 
-# 9. Restart atelet to recreate image cache directories if they were wiped
+# 9. Restart atelet to recreate image cache directories if they were wiped.
+# atelet DaemonSet names carry a build-version suffix, so select by label.
 echo "Restarting atelet DaemonSet (if present)..."
-kubectl rollout restart daemonset/atelet -n ate-system >/dev/null 2>&1 || true
+kubectl rollout restart daemonset -l app=atelet -n ate-system >/dev/null 2>&1 || true
 
 echo "CSI Hostpath setup complete!"

--- a/hack/setup-csi-nfs-kind.sh
+++ b/hack/setup-csi-nfs-kind.sh
@@ -134,8 +134,9 @@ spec:
   nodeSocketOverride: unix:///var/lib/kubelet/plugins/csi-nfsplugin/csi.sock
 EOF
 
-# 9. Restart atelet to ensure it reconnects to the new CSI socket
+# 9. Restart atelet to ensure it reconnects to the new CSI socket.
+# atelet DaemonSet names carry a build-version suffix, so select by label.
 echo "Restarting atelet DaemonSet (if present)..."
-kubectl rollout restart daemonset/atelet -n ate-system >/dev/null 2>&1 || true
+kubectl rollout restart daemonset -l app=atelet -n ate-system >/dev/null 2>&1 || true
 
 echo "CSI NFS setup complete!"

--- a/internal/versionlabel/cmd/main.go
+++ b/internal/versionlabel/cmd/main.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command cmd prints "<label value> <object-name suffix>" for a build
+// version, so shell installers and upgrade tooling use the same derivation
+// instead of mirroring it. Versions the label sanitizer would rewrite are
+// rejected: the cluster labels must match the version string stamped into
+// the binaries byte for byte.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/agent-substrate/substrate/internal/versionlabel"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: versionlabel <build version>")
+		os.Exit(2)
+	}
+	raw := os.Args[1]
+	if v := versionlabel.Value(raw); v != raw {
+		fmt.Fprintf(os.Stderr, "error: build version %q is not a valid label value (it would sanitize to %q); pin a label-safe one with VERSION=...\n", raw, v)
+		os.Exit(1)
+	}
+	fmt.Printf("%s %s\n", raw, versionlabel.NameSuffix(raw))
+}

--- a/internal/versionlabel/versionlabel.go
+++ b/internal/versionlabel/versionlabel.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package versionlabel derives the ate.dev/substrate-version label that keys
+// versioned dataplane objects to a substrate build version. The install script
+// stamps it on nodes and on the versioned atelet DaemonSet; upgrade tooling
+// pins WorkerPool pod templates to it. Every writer must derive names and
+// values through this package so they agree.
+package versionlabel
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// Key is the label key used consistently on nodes, Deployments, pod templates,
+// and pod nodeSelectors.
+const Key = "ate.dev/substrate-version"
+
+// unknown stands in for a version that sanitizes to nothing.
+const unknown = "unknown"
+
+const nameSuffixMaxLength = 30
+
+// Value normalizes a build version into a valid label value. The version is
+// free-form via -ldflags, so invalid bytes map to '-' deterministically
+// instead of being rejected.
+func Value(version string) string {
+	if version != "" && len(validation.IsValidLabelValue(version)) == 0 {
+		return version
+	}
+	b := []byte(version)
+	for i := range b {
+		if c := b[i]; !isAlphanumerics(c) && c != '-' && c != '_' && c != '.' {
+			b[i] = '-'
+		}
+	}
+	if len(b) > validation.LabelValueMaxLength {
+		b = b[:validation.LabelValueMaxLength]
+	}
+	// Label value boundaries must be alphanumeric.
+	start, end := 0, len(b)
+	for start < end && !isAlphanumerics(b[start]) {
+		start++
+	}
+	for end > start && !isAlphanumerics(b[end-1]) {
+		end--
+	}
+	if start == end {
+		return unknown
+	}
+	return string(b[start:end])
+}
+
+// NameSuffix normalizes a build version into a DNS-1123-label-safe object
+// name suffix that can be appended to an object name. Currently it's only
+// used by the atelet DaemonSet during upgrade.
+func NameSuffix(version string) string {
+	if version == "" {
+		return unknown
+	}
+	b := []byte(strings.ToLower(version))
+	for i := range b {
+		if c := b[i]; !('a' <= c && c <= 'z' || '0' <= c && c <= '9') {
+			b[i] = '-'
+		}
+	}
+	start, end := 0, len(b)
+	for start < end && b[start] == '-' {
+		start++
+	}
+	for end > start && b[end-1] == '-' {
+		end--
+	}
+	s := string(b[start:end])
+	if s == "" || len(s) > nameSuffixMaxLength {
+		sum := sha256.Sum256([]byte(version))
+		return "v" + hex.EncodeToString(sum[:])[:10]
+	}
+	return s
+}
+
+func isAlphanumerics(c byte) bool {
+	return '0' <= c && c <= '9' || 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z'
+}

--- a/internal/versionlabel/versionlabel_test.go
+++ b/internal/versionlabel/versionlabel_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versionlabel
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestValue(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"dev", "dev"},
+		{"v1.2.3", "v1.2.3"},
+		{"v0.1.0-3-gabc1234-dirty", "v0.1.0-3-gabc1234-dirty"},
+		{"1.2.3+build.4", "1.2.3-build.4"},
+		{"-leading-dash", "leading-dash"},
+		{"trailing-dot.", "trailing-dot"},
+		{"", "unknown"},
+		{"+++", "unknown"},
+		{strings.Repeat("a", 100), strings.Repeat("a", 63)},
+	}
+	for _, tt := range tests {
+		got := Value(tt.in)
+		if got != tt.want {
+			t.Errorf("Value(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+		if errs := validation.IsValidLabelValue(got); len(errs) != 0 {
+			t.Errorf("Value(%q) = %q is not a valid label value: %v", tt.in, got, errs)
+		}
+	}
+}
+
+func TestNameSuffix(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"dev", "dev"},
+		{"v1.2.3", "v1-2-3"},
+		{"v0.1.0-3-gabc1234-dirty", "v0-1-0-3-gabc1234-dirty"},
+		{"1.2.3+build.4", "1-2-3-build-4"},
+		{"UPPER.Case", "upper-case"},
+		{"-v1-", "v1"},
+		{"", "unknown"},
+	}
+	for _, tt := range tests {
+		got := NameSuffix(tt.in)
+		if got != tt.want {
+			t.Errorf("NameSuffix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+		if errs := validation.IsDNS1123Label(got); len(errs) != 0 {
+			t.Errorf("NameSuffix(%q) = %q is not DNS-1123-label-safe: %v", tt.in, got, errs)
+		}
+	}
+}
+
+// NameSuffix is lossy: distinct versions can share a suffix, so writers must
+// compare the version label under Key before mutating an object found at a
+// derived name.
+func TestNameSuffixCollides(t *testing.T) {
+	if a, b := NameSuffix("1.2.3"), NameSuffix("1-2-3"); a != b {
+		t.Errorf("expected %q and %q to collide, got %q vs %q", "1.2.3", "1-2-3", a, b)
+	}
+}
+
+// TestNameSuffixFallsBackToHash covers versions that sanitize to nothing or
+// exceed the length cap: both must yield a short, deterministic, DNS-safe
+// suffix that still differs across versions.
+func TestNameSuffixFallsBackToHash(t *testing.T) {
+	long := "v" + strings.Repeat("1.0.", 20)
+	for _, in := range []string{"+++", long, long + "x"} {
+		got := NameSuffix(in)
+		if len(got) != 11 || !strings.HasPrefix(got, "v") {
+			t.Errorf("NameSuffix(%q) = %q, want an 11-char hash suffix starting with 'v'", in, got)
+		}
+		if again := NameSuffix(in); again != got {
+			t.Errorf("NameSuffix(%q) not deterministic: %q vs %q", in, got, again)
+		}
+		if errs := validation.IsDNS1123Label(got); len(errs) != 0 {
+			t.Errorf("NameSuffix(%q) = %q is not DNS-1123-label-safe: %v", in, got, errs)
+		}
+	}
+	if NameSuffix(long) == NameSuffix(long+"x") {
+		t.Errorf("hash suffixes for distinct versions collided: %q", NameSuffix(long))
+	}
+}

--- a/manifests/ate-install/atelet.yaml
+++ b/manifests/ate-install/atelet.yaml
@@ -78,26 +78,40 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 # 4. Create DaemonSet
+#
+# ${SUBSTRATE_VERSION} and ${SUBSTRATE_VERSION_SUFFIX} are placeholders that
+# hack/install-ate.sh fills in after kustomize/ko.
+#
+# During a rolling upgrade both old/new version DaemonSets coexist, each pinned 
+# to nodes carrying a version label while the operator flip nodes from old version
+# label to new versio label one at a time.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: atelet
+  name: atelet-${SUBSTRATE_VERSION_SUFFIX}
   namespace: ate-system
   labels:
     app: atelet
+    ate.dev/substrate-version: "${SUBSTRATE_VERSION}"
 spec:
   selector:
     matchLabels:
       app: atelet
+      ate.dev/substrate-version: "${SUBSTRATE_VERSION}"
   template:
     metadata:
       labels:
         app: atelet
+        ate.dev/substrate-version: "${SUBSTRATE_VERSION}"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: atelet
+      # Pin to nodes labelled with this substrate version. install-ate.sh labels unlabeled
+      # nodes at install time; the operator owns the label afterwards.
+      nodeSelector:
+        ate.dev/substrate-version: "${SUBSTRATE_VERSION}"
       # Budget for the full shutdown sequence: --drain-delay (0 for atelet) +
       # --drain-timeout (5m). Sized long because Checkpoint/Restore stream
       # multi-GiB snapshots and must not be force-cancelled mid-upload. The sum

--- a/manifests/ate-install/kind/atelet/kustomization.yaml
+++ b/manifests/ate-install/kind/atelet/kustomization.yaml
@@ -23,7 +23,7 @@ patches:
       apiVersion: apps/v1
       kind: DaemonSet
       metadata:
-        name: atelet
+        name: atelet-${SUBSTRATE_VERSION_SUFFIX}
         namespace: ate-system
       spec:
         template:

--- a/tools/setup-gcp/README.md
+++ b/tools/setup-gcp/README.md
@@ -99,6 +99,16 @@ go run ./tools/setup-gcp create cluster [flags]
 | `--subnetwork` | VPC subnetwork name. | `SUBNETWORK` | `default` |
 | `--machine-type` | Machine type for the gVisor node pool. | `GVISOR_NODE_MACHINE_TYPE` | `c3-standard-4` |
 
+**Node version labels:** pool labels are the birth default for every node GKE
+creates later (autoscaling, auto-repair, node upgrades), and `setup-gcp` does
+not set `ate.dev/substrate-version` on the pool, so those nodes arrive
+unlabeled and run no dataplane pods (see the README's note on node version
+labels). Stamp the pool with
+`gcloud container node-pools update ... --node-labels=...` (list the existing
+labels first and carry them all over; the flag replaces the full set), and
+create additional pools with
+`--node-labels=ate.dev/substrate-version=<build version>`.
+
 ### 3. Create Bucket
 
 Creates a GCS bucket for storing snapshots.


### PR DESCRIPTION
A rolling upgrade needs two substrate versions running in one cluster, split by node: `atelet` and `ateom` speak a node-local protocol with no cross-version guarantees, so everything on a node has to come from one build. Today nothing records which build a node runs, and the `atelet` DaemonSet is a single fixed-name object, so a second version can only replace the first in place, instead of our porposed node by node rolling ([design](https://docs.google.com/document/d/1JduAyGZFyqdNp4UhKiv0EN-is3iW5tf5BwGTWbt2ouI/edit?usp=sharing&resourcekey=0-MXG12QCkleIxhY7cOB7g6A)).

This PR is the basis for upgrade. Nodes and the `atelet` DaemonSet get keyed by an `ate.dev/substrate-version` label whose value is the build version stamped into the binaries.

### One derivation for the version label

`internal/versionlabel` turns the build version into its two forms in one place:

| form | grammar | used for |
|---|---|---|
| label value | k8s label value | node labels, DaemonSet labels, nodeSelectors |
| name suffix | DNS-1123 | the DaemonSet name `atelet-<suffix>` |

A version that is not a valid label value is rejected, because the label has to match what the `ldflags` stamp put into the binaries through MAKEFILE and `ko`. It's also exposed shell, so the install script can use it.

### A DaemonSet per version

`atelet-<suffix>` as the name, the version label on metadata, selector, and pod template, and a pod nodeSelector on the same label. Two versions run side by side on disjoint old/new node sets.

### The install becomes version-aware

- `install-ate.sh` reads the version from the same `make ldflags` output it stamps the binaries with, then fills the manifest placeholders.
- It labels the nodes that exist at install time, nodes come after it carry no version label yet (so add notes in README). Re-running the install is idempotent, this is the basis for upgrade runbook later.
- The `README` documents the invariant, how to read the installed version off the DaemonSet, and that a node added later hosts no workers until it carries the label. On GKE the node pool label is the birth default for new nodes - added in `tools/setup-gcp/README.md`.

### Follow-ups
- `ate-setup` need same modification
- minimize the affect for daily developer (pin the `VERSION` as `{USER}-dev` instead of from git
- the manual rolling-upgrade runbook.

Fix #1270
Ref [design doc](https://docs.google.com/document/d/1JduAyGZFyqdNp4UhKiv0EN-is3iW5tf5BwGTWbt2ouI/edit?usp=sharing&resourcekey=0-MXG12QCkleIxhY7cOB7g6A)