### PR TITLE
(atelet): make the restore timing log a joinable per-actor latency record

### DIFF
--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -949,9 +949,9 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 	actorRef := resources.ActorRef{Atespace: req.GetAtespace(), Name: req.GetActorName()}
 
 	// Per-step timing so we can attribute resume latency between the rustfs
-	// download/decompress, the OCI image unpack, and ateom's own work. Logged at
-	// the end, and recorded per phase on the way out so a failed restore still
-	// reports the phases it completed. Phases left at zero never ran.
+	// download/decompress, the OCI image unpack, and ateom's own work. Reported on
+	// the way out, so a failed restore still accounts for the phases it completed.
+	// Phases left at zero never ran.
 	tStart := time.Now()
 	var dMount, dManifest, dAssets, dDownload, dBundles, dAteom time.Duration
 	op := snapshotOp{
@@ -959,15 +959,27 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		templateName:      req.GetActorTemplateName(),
 		scope:             ateattr.SnapshotScopeValue(req.GetScope()),
 	}
+	attribution := resources.ActorAttribution{
+		Ref:              actorRef,
+		UID:              actorUID,
+		TemplateAtespace: req.GetActorTemplateAtespace(),
+		TemplateName:     req.GetActorTemplateName(),
+	}
 	defer func() {
-		s.instruments.recordRestore(ctx, op, err,
-			phase{ateattr.SnapshotPhaseVolumeMount, dMount},
-			phase{ateattr.SnapshotPhaseManifestFetch, dManifest},
-			phase{ateattr.SnapshotPhaseSandboxAssets, dAssets},
-			phase{ateattr.SnapshotPhaseDownload, dDownload},
-			phase{ateattr.SnapshotPhaseOCIUnpack, dBundles},
-			phase{ateattr.SnapshotPhaseAteomRestore, dAteom},
-			phase{ateattr.SnapshotPhaseTotal, time.Since(tStart)})
+		// One slice feeds both signals, so the metric and the log cannot disagree
+		// about how long the restore took.
+		phases := []phase{
+			{ateattr.SnapshotPhaseVolumeMount, dMount},
+			{ateattr.SnapshotPhaseManifestFetch, dManifest},
+			{ateattr.SnapshotPhaseSandboxAssets, dAssets},
+			{ateattr.SnapshotPhaseDownload, dDownload},
+			{ateattr.SnapshotPhaseOCIUnpack, dBundles},
+			{ateattr.SnapshotPhaseAteomRestore, dAteom},
+			{ateattr.SnapshotPhaseTotal, time.Since(tStart)},
+		}
+		s.instruments.recordRestore(ctx, op, err, phases...)
+		slog.LogAttrs(ctx, slog.LevelInfo, "Restore timing breakdown",
+			snapshotLogAttrs(attribution, op, restoreDurationMetric, err, phases)...)
 	}()
 
 	// Not crashing the actor, because terminal errors here indicate problems with atelet,
@@ -1177,6 +1189,8 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		return nil, status.Errorf(codes.InvalidArgument, "invalid workload spec: %v", err)
 	}
 
+	// The ateom_restore phase is opaque from here; ateom logs its own breakdown of
+	// this call as "Actor restore phases".
 	tAteom := time.Now()
 	_, err = client.RestoreWorkload(ctx, &ateompb.RestoreWorkloadRequest{
 		Atespace:              actorRef.Atespace,
@@ -1213,11 +1227,6 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		return nil, ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonTerminalFileSystemError)
 	}
 
-	slog.InfoContext(ctx, "Restore timing breakdown", slog.Any("actor", actorRef),
-		slog.Duration("download", dDownload),   // rustfs/GCS fetch + decompress (or local copy)
-		slog.Duration("oci_unpack", dBundles),  // prepareOCIBundles: unpack the OCI image to the bundle
-		slog.Duration("ateom_restore", dAteom), // ateom.RestoreWorkload (see its own breakdown)
-		slog.Duration("total", time.Since(tStart)))
 	return &ateletpb.RestoreResponse{}, nil
 }
 

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -965,7 +965,14 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		TemplateAtespace: req.GetActorTemplateAtespace(),
 		TemplateName:     req.GetActorTemplateName(),
 	}
+	completed := false
 	defer func() {
+		// A panic unwinds through here with the named err still nil, so without
+		// this the last thing atelet reports before dying is a fast success.
+		outcome := err
+		if outcome == nil && !completed {
+			outcome = errRestoreUnwound
+		}
 		// One slice feeds both signals, so the metric and the log cannot disagree
 		// about how long the restore took.
 		phases := []phase{
@@ -977,9 +984,9 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			{ateattr.SnapshotPhaseAteomRestore, dAteom},
 			{ateattr.SnapshotPhaseTotal, time.Since(tStart)},
 		}
-		s.instruments.recordRestore(ctx, op, err, phases...)
+		s.instruments.recordRestore(ctx, op, outcome, phases...)
 		slog.LogAttrs(ctx, slog.LevelInfo, "Restore timing breakdown",
-			snapshotLogAttrs(attribution, op, restoreDurationMetric, err, phases)...)
+			snapshotLogAttrs(attribution, op, restoreDurationMetric, outcome, phases)...)
 	}()
 
 	// Not crashing the actor, because terminal errors here indicate problems with atelet,
@@ -1172,7 +1179,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			dDownload = 0
 		}
 		if isCollateral(err, prepErr) {
-			dAssets, dBundles = 0, 0
+			dAssets, dBundles = assetsAfterCollateral(prepFailedPhase, dAssets), 0
 		}
 		return nil, err
 	}
@@ -1227,6 +1234,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 		return nil, ateerrors.CrashIfReason(ctx, err, ateerrors.ReasonTerminalFileSystemError)
 	}
 
+	completed = true
 	return &ateletpb.RestoreResponse{}, nil
 }
 

--- a/cmd/atelet/metrics.go
+++ b/cmd/atelet/metrics.go
@@ -168,6 +168,16 @@ func isCollateral(groupErr, legErr error) bool {
 	return legErr != nil && groupErr != legErr
 }
 
+// assetsAfterCollateral keeps the sandbox-asset duration when the prep leg was
+// cancelled during the later OCI unpack: only the phase a leg stopped in is
+// truncated, and dropping a completed one reports a step that ran as never run.
+func assetsAfterCollateral(prepFailedPhase string, assets time.Duration) time.Duration {
+	if prepFailedPhase == ateattr.SnapshotPhaseSandboxAssets {
+		return 0
+	}
+	return assets
+}
+
 // restoreSnapshotKind classifies which snapshot a restore reads. A local
 // restore is evident from the wire; golden and latest both arrive as an external
 // URI prefix, so they are told apart by the identity the manifest records for

--- a/cmd/atelet/metrics_test.go
+++ b/cmd/atelet/metrics_test.go
@@ -351,6 +351,43 @@ func TestIsCollateral(t *testing.T) {
 	}
 }
 
+// TestAssetsAfterCollateral covers the other half of the collateral rule: a leg
+// cancelled during the unpack had already finished fetching its assets, and
+// since absence means "never ran", zeroing that reports a step that completed
+// as one that never started.
+func TestAssetsAfterCollateral(t *testing.T) {
+	const assets = 1200 * time.Millisecond
+
+	tests := []struct {
+		name            string
+		prepFailedPhase string
+		want            time.Duration
+	}{
+		{
+			name:            "cancelled during the asset fetch truncates it",
+			prepFailedPhase: ateattr.SnapshotPhaseSandboxAssets,
+			want:            0,
+		},
+		{
+			name:            "cancelled during the unpack keeps the completed asset fetch",
+			prepFailedPhase: ateattr.SnapshotPhaseOCIUnpack,
+			want:            assets,
+		},
+		{
+			name:            "an unattributed prep failure keeps it rather than guessing",
+			prepFailedPhase: "",
+			want:            assets,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := assetsAfterCollateral(tt.prepFailedPhase, assets); got != tt.want {
+				t.Errorf("assetsAfterCollateral() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRestoreSnapshotKind(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/atelet/snapshotlog.go
+++ b/cmd/atelet/snapshotlog.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log/slog"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/resources"
+)
+
+// snapshotLogAttrs renders what recordPhases measures as a per-actor record. The
+// histograms cannot be one: actor identity is barred from metric labels
+// (docs/metrics/substrate.yaml, cardinality_rules.no-actor-identity), so the
+// phase breakdown reaches a backend keyed by template only.
+//
+// durationKey is the name of the instrument these phases also feed, which is why
+// the values are seconds and not the nanoseconds slog.Duration writes: that
+// instrument declares unit s. Identity stays out of snapshotOp so no edit here
+// can route it into a datapoint.
+func snapshotLogAttrs(a resources.ActorAttribution, op snapshotOp, durationKey string, err error, phases []phase) []slog.Attr {
+	attrs := ateattr.ActorLogAttrs(a)
+
+	// Borrow the metric's dimensions rather than rebuild them: op.attrs already
+	// drops what is unknown and bounds the sandbox class. The template pair is
+	// identity here and a dimension there, and a key emitted twice leaves
+	// consumers to disagree about which copy wins.
+	seen := make(map[string]struct{}, len(attrs))
+	for _, attr := range attrs {
+		seen[attr.Key] = struct{}{}
+	}
+	for _, kv := range op.attrs() {
+		if _, dup := seen[string(kv.Key)]; dup {
+			continue
+		}
+		attrs = append(attrs, slog.String(string(kv.Key), kv.Value.Emit()))
+	}
+
+	// Absence means success, as on the instruments. There is no ate.snapshot.phase:
+	// on a datapoint it names the one step timed, and this record carries them all.
+	if err != nil {
+		attrs = append(attrs, slog.String(string(ateattr.FailureReasonKey), ateattr.FailureReason(err)))
+	}
+
+	for _, p := range phases {
+		if p.d == 0 {
+			continue
+		}
+		attrs = append(attrs, slog.Float64(durationKey+"."+p.name, p.d.Seconds()))
+	}
+	return attrs
+}

--- a/cmd/atelet/snapshotlog.go
+++ b/cmd/atelet/snapshotlog.go
@@ -15,11 +15,16 @@
 package main
 
 import (
+	"errors"
 	"log/slog"
 
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/resources"
 )
+
+// errRestoreUnwound stands in for a restore that left through a panic, where the
+// named error is still nil. Carries no reason, so it reports as UNKNOWN.
+var errRestoreUnwound = errors.New("restore did not run to completion")
 
 // snapshotLogAttrs renders what recordPhases measures as a per-actor record. The
 // histograms cannot be one: actor identity is barred from metric labels

--- a/cmd/atelet/snapshotlog.go
+++ b/cmd/atelet/snapshotlog.go
@@ -45,7 +45,7 @@ func snapshotLogAttrs(a resources.ActorAttribution, op snapshotOp, durationKey s
 		if _, dup := seen[string(kv.Key)]; dup {
 			continue
 		}
-		attrs = append(attrs, slog.String(string(kv.Key), kv.Value.Emit()))
+		attrs = append(attrs, slog.String(string(kv.Key), kv.Value.String()))
 	}
 
 	// Absence means success, as on the instruments. There is no ate.snapshot.phase:

--- a/cmd/atelet/snapshotlog_test.go
+++ b/cmd/atelet/snapshotlog_test.go
@@ -205,6 +205,21 @@ func TestSnapshotLogAttrs(t *testing.T) {
 			},
 		},
 		{
+			// A restore that panicked leaves the named err nil, so the defer
+			// substitutes this. Without a reason on the record it would read as a
+			// fast success right before atelet dies.
+			name:   "a restore that unwound reports as a failure, not a fast success",
+			op:     fullOp,
+			err:    errRestoreUnwound,
+			phases: []phase{{ateattr.SnapshotPhaseVolumeMount, 4 * time.Millisecond}, {ateattr.SnapshotPhaseTotal, 9 * time.Millisecond}},
+			wantStrings: map[string]string{
+				"ate.failure.reason": ateattr.ReasonUnknown,
+			},
+			wantNumbers: map[string]float64{
+				"ate.actor.restore.duration.total": 0.009,
+			},
+		},
+		{
 			name: "a sandbox class the manifest invented is bounded, not passed through",
 			op: snapshotOp{
 				templateNamespace: testTemplateNamespace,

--- a/cmd/atelet/snapshotlog_test.go
+++ b/cmd/atelet/snapshotlog_test.go
@@ -1,0 +1,248 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/ateerrors"
+	"github.com/agent-substrate/substrate/internal/resources"
+)
+
+const (
+	testActorAtespace = "team-a"
+	testActorName     = "support-agent-42"
+	testActorUID      = "uid-abc"
+)
+
+func testAttribution() resources.ActorAttribution {
+	return resources.ActorAttribution{
+		Ref:              resources.ActorRef{Atespace: testActorAtespace, Name: testActorName},
+		UID:              testActorUID,
+		TemplateAtespace: testTemplateNamespace,
+		TemplateName:     testTemplateName,
+	}
+}
+
+// renderRecord logs attrs through a local JSON handler, so the test sees the
+// record a collector would parse rather than the slice that built it. A local
+// logger keeps this parallel-safe: nothing touches slog.Default.
+func renderRecord(t *testing.T, attrs []slog.Attr) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	slog.New(slog.NewJSONHandler(&buf, nil)).LogAttrs(context.Background(), slog.LevelInfo, "Restore timing breakdown", attrs...)
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("unmarshal record %q: %v", buf.String(), err)
+	}
+	return rec
+}
+
+func wantNumber(t *testing.T, rec map[string]any, key string, want float64) {
+	t.Helper()
+	v, ok := rec[key]
+	if !ok {
+		t.Errorf("missing %s", key)
+		return
+	}
+	got, ok := v.(float64)
+	if !ok {
+		t.Errorf("%s is %T (%v), want a number", key, v, v)
+		return
+	}
+	if got != want {
+		t.Errorf("%s = %v, want %v", key, got, want)
+	}
+}
+
+func wantString(t *testing.T, rec map[string]any, key, want string) {
+	t.Helper()
+	if v, ok := rec[key]; !ok {
+		t.Errorf("missing %s", key)
+	} else if v != want {
+		t.Errorf("%s = %v, want %q", key, v, want)
+	}
+}
+
+func wantAbsent(t *testing.T, rec map[string]any, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		if v, ok := rec[k]; ok {
+			t.Errorf("%s is present with %v, want absent", k, v)
+		}
+	}
+}
+
+// TestSnapshotLogAttrsSeconds is the point of the record: the key is named after
+// an instrument that declares unit s, so the value has to be seconds. slog.Duration
+// would have written 2500000000 here, and a dashboard reading it as seconds would
+// be off by nine orders of magnitude.
+func TestSnapshotLogAttrsSeconds(t *testing.T) {
+	t.Parallel()
+
+	op := snapshotOp{
+		templateNamespace: testTemplateNamespace,
+		templateName:      testTemplateName,
+		kind:              ateattr.SnapshotKindLatest,
+		scope:             ateattr.SnapshotScopeFull,
+		sandboxClass:      "gvisor",
+	}
+	attrs := snapshotLogAttrs(testAttribution(), op, restoreDurationMetric, nil,
+		[]phase{
+			{ateattr.SnapshotPhaseDownload, 2500 * time.Millisecond},
+			{ateattr.SnapshotPhaseTotal, 3 * time.Second},
+		})
+
+	rec := renderRecord(t, attrs)
+	wantNumber(t, rec, "ate.actor.restore.duration.download", 2.5)
+	wantNumber(t, rec, "ate.actor.restore.duration.total", 3)
+}
+
+func TestSnapshotLogAttrs(t *testing.T) {
+	fullOp := snapshotOp{
+		templateNamespace: testTemplateNamespace,
+		templateName:      testTemplateName,
+		kind:              ateattr.SnapshotKindLatest,
+		scope:             ateattr.SnapshotScopeFull,
+		sandboxClass:      "gvisor",
+	}
+
+	tests := []struct {
+		name        string
+		op          snapshotOp
+		err         error
+		phases      []phase
+		wantStrings map[string]string
+		wantNumbers map[string]float64
+		wantAbsent  []string
+	}{
+		{
+			name: "a successful restore carries identity, the metric dimensions and every phase that ran",
+			op:   fullOp,
+			phases: []phase{
+				{ateattr.SnapshotPhaseVolumeMount, 4 * time.Millisecond},
+				{ateattr.SnapshotPhaseManifestFetch, 21 * time.Millisecond},
+				{ateattr.SnapshotPhaseSandboxAssets, 10 * time.Millisecond},
+				{ateattr.SnapshotPhaseDownload, 310 * time.Millisecond},
+				{ateattr.SnapshotPhaseOCIUnpack, 50 * time.Millisecond},
+				{ateattr.SnapshotPhaseAteomRestore, 60 * time.Millisecond},
+				{ateattr.SnapshotPhaseTotal, 420 * time.Millisecond},
+			},
+			wantStrings: map[string]string{
+				"ate.atespace":          testActorAtespace,
+				"ate.actor.name":        testActorName,
+				"ate.actor.uid":         testActorUID,
+				"ate.template.atespace": testTemplateNamespace,
+				"ate.template.name":     testTemplateName,
+				"ate.snapshot.kind":     ateattr.SnapshotKindLatest,
+				"ate.snapshot.scope":    ateattr.SnapshotScopeFull,
+				"ate.sandbox.class":     "gvisor",
+			},
+			wantNumbers: map[string]float64{
+				"ate.actor.restore.duration.volume_mount":   0.004,
+				"ate.actor.restore.duration.manifest_fetch": 0.021,
+				"ate.actor.restore.duration.download":       0.310,
+				"ate.actor.restore.duration.total":          0.420,
+			},
+			// The phase key names the one step a datapoint timed; this record has
+			// them all, so borrowing it here would give one key two meanings.
+			wantAbsent: []string{"ate.failure.reason", "ate.snapshot.phase", "actor", "total", "download"},
+		},
+		{
+			name:   "a phase that never ran is absent, not zero",
+			op:     fullOp,
+			phases: []phase{{ateattr.SnapshotPhaseDownload, 0}, {ateattr.SnapshotPhaseTotal, time.Second}},
+			wantNumbers: map[string]float64{
+				"ate.actor.restore.duration.total": 1,
+			},
+			wantAbsent: []string{"ate.actor.restore.duration.download"},
+		},
+		{
+			name: "a restore that died before the manifest omits the dimensions it never learned",
+			op: snapshotOp{
+				templateNamespace: testTemplateNamespace,
+				templateName:      testTemplateName,
+				scope:             ateattr.SnapshotScopeFull,
+			},
+			err:    fmt.Errorf("%w: while fetching snapshot manifest", ateerrors.ReasonFailedGetExternalObject),
+			phases: []phase{{ateattr.SnapshotPhaseTotal, 700 * time.Millisecond}},
+			wantStrings: map[string]string{
+				"ate.actor.uid":      testActorUID,
+				"ate.failure.reason": string(ateerrors.ReasonFailedGetExternalObject),
+			},
+			wantNumbers: map[string]float64{
+				"ate.actor.restore.duration.total": 0.7,
+			},
+			wantAbsent: []string{"ate.snapshot.kind", "ate.sandbox.class"},
+		},
+		{
+			name:   "an unclassified failure collapses onto UNKNOWN rather than leaking the message",
+			op:     fullOp,
+			err:    fmt.Errorf("dial tcp 10.96.192.187:9000: connect: connection refused"),
+			phases: []phase{{ateattr.SnapshotPhaseTotal, time.Second}},
+			wantStrings: map[string]string{
+				"ate.failure.reason": ateattr.ReasonUnknown,
+			},
+		},
+		{
+			name: "a sandbox class the manifest invented is bounded, not passed through",
+			op: snapshotOp{
+				templateNamespace: testTemplateNamespace,
+				templateName:      testTemplateName,
+				scope:             ateattr.SnapshotScopeFull,
+				sandboxClass:      "../../etc/passwd",
+			},
+			phases: []phase{{ateattr.SnapshotPhaseTotal, time.Second}},
+			wantStrings: map[string]string{
+				"ate.sandbox.class": ateattr.SandboxClassUnknown,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			attrs := snapshotLogAttrs(testAttribution(), tt.op, restoreDurationMetric, tt.err, tt.phases)
+
+			// json.Unmarshal keeps the last of a repeated key, so a duplicate is
+			// invisible in the rendered record and has to be caught on the slice.
+			seen := make(map[string]bool, len(attrs))
+			for _, attr := range attrs {
+				if seen[attr.Key] {
+					t.Errorf("key %s emitted twice", attr.Key)
+				}
+				seen[attr.Key] = true
+			}
+
+			rec := renderRecord(t, attrs)
+			for k, want := range tt.wantStrings {
+				wantString(t, rec, k, want)
+			}
+			for k, want := range tt.wantNumbers {
+				wantNumber(t, rec, k, want)
+			}
+			wantAbsent(t, rec, tt.wantAbsent...)
+		})
+	}
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -119,6 +119,30 @@ An actor's **own** lines carry trace context only if the actor emits these field
 
 ---
 
+### Actor-Attributed Component Logs
+
+A component's own `slog` output can also be about a specific actor. Those records take the identity keys from [`internal/ateattr`](../internal/ateattr) too, flat at the top level rather than inside a label group: a component writes no envelope, so a collector lifts the keys straight onto the log record's attributes. `ateattr.ActorLogAttrs` and `ateattr.ActorLogLabels` return the same five keys for this reason, and a test holds them together. Filtering on `ate.actor.uid` therefore finds a component record and an actor's own output alike.
+
+atelet's `Restore timing breakdown` is the first of these, and the only unsampled per-actor latency record Substrate produces. It is emitted once per restore, whether the restore succeeded or failed:
+
+```json
+{"time":"…","level":"INFO","msg":"Restore timing breakdown",
+ "ate.atespace":"ate-demo-counter","ate.actor.name":"counter-1","ate.actor.uid":"8f2a…",
+ "ate.template.atespace":"ate-demo-counter","ate.template.name":"counter",
+ "ate.snapshot.scope":"full","ate.snapshot.kind":"latest","ate.sandbox.class":"gvisor",
+ "ate.actor.restore.duration.download":0.310,
+ "ate.actor.restore.duration.oci_unpack":0.050,
+ "ate.actor.restore.duration.ateom_restore":0.060,
+ "ate.actor.restore.duration.total":0.420,
+ "trace_id":"4bf92f…","span_id":"00f067…","trace_flags":"01"}
+```
+
+The duration keys are the [`ate.actor.restore.duration`](#the-metric-registry) instrument's name with an `ate.snapshot.phase` value appended, and they hold **seconds**, matching that instrument's declared unit. The same rules apply as on the histogram: a phase that never ran is absent rather than zero, phases overlap and do not sum to the total, and `ate.failure.reason` is present only when the restore failed. There is no `ate.snapshot.phase` key on the record — on a datapoint it names the one step timed, and this record carries them all.
+
+This is the record to use for a per-actor wake-up distribution. The histogram cannot answer that question at all, because actor identity is barred from metric labels; traces can, but the data plane is head-sampled at 1%.
+
+---
+
 ## 2. Metrics
 
 Agent Substrate emits foundational OpenTelemetry system and server metrics to monitor the overall health and performance of the control plane services. Every metric below is emitted by a service binary over OTLP and is **independent of the deployment** — a Kind dev cluster gets the same instruments as production; only the backend differs (see [Where Telemetry Goes](#4-where-telemetry-goes)).

--- a/internal/ateattr/ateattr.go
+++ b/internal/ateattr/ateattr.go
@@ -19,6 +19,7 @@
 package ateattr
 
 import (
+	"log/slog"
 	"slices"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -345,6 +346,20 @@ func ActorLogLabels(a resources.ActorAttribution, containerName string) map[stri
 		labels[string(ActorContainerNameKey)] = containerName
 	}
 	return labels
+}
+
+// ActorLogAttrs is the same identity for a component's own slog record, which
+// needs no envelope: a collector lifts flat keys straight onto the record's OTLP
+// attributes. It must agree with ActorLogLabels key for key, or joining a
+// component record to the actor lifecycle stream takes two spellings.
+func ActorLogAttrs(a resources.ActorAttribution) []slog.Attr {
+	return []slog.Attr{
+		slog.String(string(AtespaceKey), a.Ref.Atespace),
+		slog.String(string(ActorNameKey), a.Ref.Name),
+		slog.String(string(ActorUIDKey), a.UID),
+		slog.String(string(TemplateAtespaceKey), a.TemplateAtespace),
+		slog.String(string(TemplateNameKey), a.TemplateName),
+	}
 }
 
 // ActorMetricAttributes returns the metric labels for an Actor.

--- a/internal/ateattr/ateattr_test.go
+++ b/internal/ateattr/ateattr_test.go
@@ -273,6 +273,97 @@ func TestActorLogLabels(t *testing.T) {
 	}
 }
 
+func TestActorLogAttrs(t *testing.T) {
+	tests := []struct {
+		name        string
+		attribution resources.ActorAttribution
+		want        map[string]string
+	}{
+		{
+			name: "identity reaches a component record under the same keys as the label envelope",
+			attribution: resources.ActorAttribution{
+				Ref:              resources.ActorRef{Atespace: "team-a", Name: "support-agent-42"},
+				UID:              "uid-abc",
+				TemplateAtespace: "ate-agents",
+				TemplateName:     "support-agent",
+			},
+			want: map[string]string{
+				"ate.atespace":          "team-a",
+				"ate.actor.name":        "support-agent-42",
+				"ate.actor.uid":         "uid-abc",
+				"ate.template.atespace": "ate-agents",
+				"ate.template.name":     "support-agent",
+			},
+		},
+		{
+			name:        "zero attribution still produces the five identity keys",
+			attribution: resources.ActorAttribution{},
+			want: map[string]string{
+				"ate.atespace":          "",
+				"ate.actor.name":        "",
+				"ate.actor.uid":         "",
+				"ate.template.atespace": "",
+				"ate.template.name":     "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ActorLogAttrs(tt.attribution)
+			if len(got) != len(tt.want) {
+				t.Errorf("got %d attrs, want %d: %v", len(got), len(tt.want), got)
+			}
+			for _, attr := range got {
+				want, ok := tt.want[attr.Key]
+				if !ok {
+					t.Errorf("unexpected attr %s", attr.Key)
+					continue
+				}
+				if v := attr.Value.String(); v != want {
+					t.Errorf("%s = %q, want %q", attr.Key, v, want)
+				}
+			}
+		})
+	}
+}
+
+// TestActorLogAttrsMatchesActorLogLabels is what keeps the two log shapes
+// joinable. A component record and an actor's own output describe the same actor,
+// so a consumer that filters on ate.actor.uid must find it in both; a key renamed
+// on one side only would otherwise split the stream in two silently.
+func TestActorLogAttrsMatchesActorLogLabels(t *testing.T) {
+	t.Parallel()
+
+	attribution := resources.ActorAttribution{
+		Ref:              resources.ActorRef{Atespace: "team-a", Name: "support-agent-42"},
+		UID:              "uid-abc",
+		TemplateAtespace: "ate-agents",
+		TemplateName:     "support-agent",
+	}
+
+	// The empty container name is the lifecycle-record form: ActorLogAttrs has no
+	// container to name, so that is the shape the two must match on.
+	labels := ActorLogLabels(attribution, "")
+	attrs := ActorLogAttrs(attribution)
+
+	if len(attrs) != len(labels) {
+		t.Fatalf("ActorLogAttrs has %d keys, ActorLogLabels has %d", len(attrs), len(labels))
+	}
+	for _, attr := range attrs {
+		want, ok := labels[attr.Key]
+		if !ok {
+			t.Errorf("key %s is in ActorLogAttrs and not in ActorLogLabels", attr.Key)
+			continue
+		}
+		if v := attr.Value.String(); v != want {
+			t.Errorf("%s = %q as an attr and %q as a label", attr.Key, v, want)
+		}
+	}
+}
+
 // TestMetricLabelValues pins the wire value of every bounded metric-label
 // constant. These are the exact strings dashboards and alerts group by, so a
 // typo or rename must fail here rather than silently fork a time series in

--- a/internal/imagecache/README.md
+++ b/internal/imagecache/README.md
@@ -19,8 +19,9 @@ What it buys, concretely:
 
 - Actor start/resume composes the rootfs with **one overlay mount
   (milliseconds)** instead of a full image extraction (tens of seconds for
-  GB-scale images). `Restore timing breakdown` logs show `oci_unpack`
-  dropping from ~15–20 s to single-digit milliseconds on warm nodes.
+  GB-scale images). `Restore timing breakdown` logs show
+  `ate.actor.restore.duration.oci_unpack` dropping from ~15–20 s to
+  single-digit milliseconds on warm nodes.
 - Layers shared between images are **downloaded and unpacked once per
   node**, not once per image; actors sharing layers also share page cache.
 - The cache is **on disk and survives atelet restarts and node reboots**


### PR DESCRIPTION
Restore timing breakdown is the only unsampled per-actor latency record we emit, and since traces are head-sampled at 1% on the data plane, and actor identity is not available from metric labels on purpose. 

This adds this to logs:

 Before:
```json
 {"msg":"Restore timing breakdown",
  "actor":{"type":"*ateapipb.Actor","atespace":"demo","name":"counter-1"},
  "download":310000000,"oci_unpack":50000000,"ateom_restore":60000000,"total":420000000}
```

 After:
```json
 {"msg":"Restore timing breakdown",
  "ate.atespace":"ate-demo-counter-substrate","ate.actor.name":"join-probe",
  "ate.actor.uid":"3a5b4e86-1a77-4da7-84c4-c0993d9c83ec",
  "ate.template.atespace":"ate-demo-counter-substrate","ate.template.name":"counter",
  "ate.snapshot.scope":"full","ate.snapshot.kind":"golden","ate.sandbox.class":"gvisor",
  "ate.actor.restore.duration.volume_mount":0.000004583,
  "ate.actor.restore.duration.manifest_fetch":0.006111636,
  "ate.actor.restore.duration.sandbox_assets":0.000098958,
  "ate.actor.restore.duration.download":0.025386544,
  "ate.actor.restore.duration.oci_unpack":0.000954919,
  "ate.actor.restore.duration.ateom_restore":0.147448298,
  "ate.actor.restore.duration.total":0.181189689,
  "trace_id":"c9d7ea9a5f90a5eb4399bfa0b966d5ac","span_id":"89280ba761137c8e"}
```

The duration keys are the `ate.actor.restore.duration` instrument's name plus an `ate.snapshot.phase` value, so a log key and the histogram it mirrors are literally the same identifier in source, which is also why they're seconds.

Also adds `ateattr.ActorLogAttrs`, the component-log twin of `ActorLogLabels`, held to the same key set by a test. 

 Verified on kind:
 - the ateom Actor restoring record for the same actor carries the identical `ate.actor.uid` and `trace_id`, this was impossible before
 - `ate_actor_restore_duration_seconds_sum{phase="total"} = 0.181189689`, matching the log to the nanosecond
 - induced a download failure by deleting a snapshot object: record sets `ate.failure.reason:` `FAILED_GET_EXTERNAL_OBJECT` and correctly omitted `ateom_restore`; the metric for the same restore shows the same six phases


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
