### PR TITLE
Gate actor placement on worker device capacity

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor_sizing_test.go
+++ b/cmd/ateapi/internal/controlapi/actor_sizing_test.go
@@ -15,6 +15,7 @@
 package controlapi
 
 import (
+	"maps"
 	"testing"
 
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
@@ -22,14 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// TestActorResourceLimits covers the actor-side extraction: the CPU/memory limits
-// an ActorTemplate declares become the sandbox size and the scheduling floor.
+// TestActorResourceLimits covers the actor-side extraction: the CPU/memory/device
+// limits an ActorTemplate declares become the sandbox size and the scheduling floor.
 func TestActorResourceLimits(t *testing.T) {
 	tests := []struct {
-		name       string
-		res        *corev1.ResourceRequirements
-		wantCPU    int64
-		wantMemory int64
+		name        string
+		res         *corev1.ResourceRequirements
+		wantCPU     int64
+		wantMemory  int64
+		wantDevices map[string]int64
+		wantErr     bool
 	}{
 		{
 			name:       "nil resources yields zero",
@@ -67,16 +70,61 @@ func TestActorResourceLimits(t *testing.T) {
 			wantCPU:    0,
 			wantMemory: 0,
 		},
+		{
+			name: "device limits are read and do not vanish",
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:   resource.MustParse("2"),
+					"example.com/device": resource.MustParse("2"),
+				},
+			},
+			wantCPU:     2000,
+			wantDevices: map[string]int64{"example.com/device": 2},
+		},
+		{
+			name: "a whole device count in milli form is accepted",
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{"example.com/device": resource.MustParse("1000m")},
+			},
+			wantDevices: map[string]int64{"example.com/device": 1},
+		},
+		{
+			name: "fractional device quantity is an error",
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{"example.com/device": resource.MustParse("500m")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "native non-cpu/memory resources are not devices",
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("2"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+					"hugepages-2Mi":                 resource.MustParse("512Mi"),
+				},
+			},
+			wantCPU: 2000,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpl := mustTemplateFromCRD(&atev1alpha1.ActorTemplate{Spec: atev1alpha1.ActorTemplateSpec{Resources: tc.res}})
-			cpu, mem, err := actorResourceLimits(tmpl)
+			cpu, mem, devices, err := actorResourceLimits(tmpl)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("actorResourceLimits() = (%d, %d, %v), want error", cpu, mem, devices)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("actorResourceLimits() error: %v", err)
 			}
 			if cpu != tc.wantCPU || mem != tc.wantMemory {
 				t.Fatalf("actorResourceLimits() = (%d, %d), want (%d, %d)", cpu, mem, tc.wantCPU, tc.wantMemory)
+			}
+			if !maps.Equal(devices, tc.wantDevices) {
+				t.Fatalf("actorResourceLimits() devices = %v, want %v", devices, tc.wantDevices)
 			}
 		})
 	}

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -582,28 +582,41 @@ func workerAssignmentFrom(w *ateapipb.Worker) *ateapipb.WorkerAssignment {
 	}
 }
 
-// actorResourceLimits returns the actor's declared CPU (millicores) and memory
-// (bytes) limits from its ActorTemplate, or 0 for a dimension the template did
-// not set. These size the sandbox (supplied over the actor RPCs) and gate
-// scheduling (a worker must have >= capacity).
-func actorResourceLimits(tmpl *ateapipb.ActorTemplate) (cpuMilli, memBytes int64, err error) {
+// actorResourceLimits returns the actor's declared CPU (millicores), memory
+// (bytes), and extended-resource device limits from its ActorTemplate, or the
+// zero value for a dimension the template did not set. These size the sandbox
+// (supplied over the actor RPCs) and gate scheduling (a worker must have >=
+// capacity). Device counts must be whole numbers, so a fractional one is an
+// error rather than a silent round at placement time.
+func actorResourceLimits(tmpl *ateapipb.ActorTemplate) (cpuMilli, memBytes int64, devices map[string]int64, err error) {
 	for _, limit := range tmpl.GetResources().GetLimits() {
 		q, perr := resource.ParseQuantity(limit.GetQuantity())
 		if perr != nil {
-			return 0, 0, fmt.Errorf("invalid template resource limit %s=%q: %w", limit.GetName(), limit.GetQuantity(), perr)
+			return 0, 0, nil, fmt.Errorf("invalid template resource limit %s=%q: %w", limit.GetName(), limit.GetQuantity(), perr)
 		}
-		switch limit.GetName() {
-		case "cpu":
+		switch {
+		case limit.GetName() == "cpu":
 			cpuMilli = q.MilliValue()
-		case "memory":
+		case limit.GetName() == "memory":
 			memBytes = q.Value()
+		case resources.IsDeviceResource(limit.GetName()):
+			// MilliValue is the count times 1000, so a non-zero remainder is a
+			// fractional device count. "1000m" is one whole unit and passes;
+			// "500m" does not.
+			if q.MilliValue()%1000 != 0 {
+				return 0, 0, nil, fmt.Errorf("device %q limit %q is not a whole number", limit.GetName(), limit.GetQuantity())
+			}
+			if devices == nil {
+				devices = map[string]int64{}
+			}
+			devices[limit.GetName()] = q.Value()
 		}
 	}
-	return cpuMilli, memBytes, nil
+	return cpuMilli, memBytes, devices, nil
 }
 
 func schedulingConstraints(actor *ateapipb.Actor, tmpl *ateapipb.ActorTemplate) (scheduling.Constraints, error) {
-	cpuMilli, memBytes, err := actorResourceLimits(tmpl)
+	cpuMilli, memBytes, devices, err := actorResourceLimits(tmpl)
 	if err != nil {
 		return scheduling.Constraints{}, err
 	}
@@ -613,6 +626,7 @@ func schedulingConstraints(actor *ateapipb.Actor, tmpl *ateapipb.ActorTemplate) 
 		RequiredNodes: actor.GetStatus().GetLocalSnapshotInfo().GetNodeVmsWithLocalSnapshots(),
 		CPUMilli:      cpuMilli,
 		MemoryBytes:   memBytes,
+		Devices:       devices,
 	}
 	if sel := tmpl.GetWorkerSelector(); sel != nil {
 		c.TemplateSelector = labels.SelectorFromSet(labels.Set(sel.GetMatchLabels()))
@@ -672,8 +686,9 @@ func (w *ActorWorkflow) ensureAteletRestored(ctx context.Context, actorRef resou
 	egressGateway := w.egressGateway()
 
 	// The actor's declared limits ride the RPC down to the sandbox so it is sized
-	// to the actor (replacing the worker-pod downward-API approach).
-	cpuMilli, memBytes, err := actorResourceLimits(actorTemplate)
+	// to the actor (replacing the worker-pod downward-API approach). Devices do
+	// not ride the RPC yet; they only gate placement.
+	cpuMilli, memBytes, _, err := actorResourceLimits(actorTemplate)
 	if err != nil {
 		return tele, err
 	}

--- a/cmd/ateapi/internal/controlapi/zz_generated.validation.go
+++ b/cmd/ateapi/internal/controlapi/zz_generated.validation.go
@@ -4142,6 +4142,47 @@ func Validate_WorkerCapacity(
 		errs = append(errs, fn(fldPath.Child("memory_bytes"), &obj.MemoryBytes, oldVal, oldObj != nil)...)
 	}
 
+	{ // field ateapipb.WorkerCapacity.Devices
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj map[string]int64,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if ateDeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxProperties(ctx, op, fldPath, obj, oldObj, 32).MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.LabelKey); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if e := validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual,
+				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int64) field.ErrorList {
+					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
+				}); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *ateapipb.WorkerCapacity) map[string]int64 {
+				return oldObj.Devices
+			})
+		errs = append(errs, fn(fldPath.Child("devices"), obj.Devices, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }
 

--- a/cmd/ateapi/internal/scheduling/scheduling.go
+++ b/cmd/ateapi/internal/scheduling/scheduling.go
@@ -50,6 +50,13 @@ type Constraints struct {
 	// data (matching the pre-capacity behavior).
 	CPUMilli    int64
 	MemoryBytes int64
+
+	// Devices are the actor's declared extended-resource limits, keyed by
+	// resource name. Unlike CPUMilli and MemoryBytes, these are matched strictly
+	// (see Applies): absent worker capacity means zero, which cannot satisfy a
+	// non-zero requirement. Empty for every current template, since no actor
+	// device limit reaches the scheduler yet.
+	Devices map[string]int64
 }
 
 // ErrNoCapacity is returned by Schedule when no free worker satisfies the
@@ -155,6 +162,20 @@ func (s *scheduler) Applies(worker *ateapipb.Worker, constraints Constraints) bo
 	}
 	if constraints.MemoryBytes > 0 && capacity.GetMemoryBytes() > 0 && capacity.GetMemoryBytes() < constraints.MemoryBytes {
 		return false
+	}
+
+	// Devices are gated strictly, unlike CPU and memory above: a zero or absent
+	// device capacity means the worker has none of that device, not "unknown", so
+	// it cannot satisfy a non-zero requirement. Treating it as unconstrained would
+	// place device-requiring actors on workers without the device — the bug this
+	// dimension exists to prevent.
+	for name, need := range constraints.Devices {
+		if need <= 0 {
+			continue
+		}
+		if capacity.GetDevices()[name] < need {
+			return false
+		}
 	}
 
 	return len(constraints.RequiredNodes) == 0 || slices.Contains(constraints.RequiredNodes, worker.GetNodeName())

--- a/cmd/ateapi/internal/scheduling/scheduling_test.go
+++ b/cmd/ateapi/internal/scheduling/scheduling_test.go
@@ -162,6 +162,37 @@ func TestSchedule(t *testing.T) {
 			wantPod:     "w-tiny",
 		},
 		{
+			name: "only the worker with the device is picked",
+			fleet: fleet{
+				worker("w-plain", "gvisor", "node-a", tierTwo),
+				worker("w-device", "gvisor", "node-a", tierTwo, withDevices(map[string]int64{"example.com/device": 1})),
+			},
+			constraints: Constraints{SandboxClass: "gvisor", Devices: map[string]int64{"example.com/device": 1}},
+			wantPod:     "w-device",
+		},
+		{
+			name: "no worker has the device yields ErrNoCapacity",
+			fleet: fleet{
+				worker("w-plain", "gvisor", "node-a", tierTwo),
+			},
+			constraints: Constraints{SandboxClass: "gvisor", Devices: map[string]int64{"example.com/device": 1}},
+		},
+		{
+			name: "actor needs no device; device worker still eligible",
+			fleet: fleet{
+				worker("w-device", "gvisor", "node-a", tierTwo, withDevices(map[string]int64{"example.com/device": 1})),
+			},
+			constraints: Constraints{SandboxClass: "gvisor"},
+			wantPod:     "w-device",
+		},
+		{
+			name: "worker has fewer devices than needed yields ErrNoCapacity",
+			fleet: fleet{
+				worker("w-device", "gvisor", "node-a", tierTwo, withDevices(map[string]int64{"example.com/device": 2})),
+			},
+			constraints: Constraints{SandboxClass: "gvisor", Devices: map[string]int64{"example.com/device": 4}},
+		},
+		{
 			name:        "empty fleet",
 			fleet:       fleet{},
 			constraints: Constraints{SandboxClass: "gvisor"},
@@ -265,6 +296,18 @@ func TestApplies(t *testing.T) {
 			constraints: Constraints{SandboxClass: "gvisor"},
 			want:        false,
 		},
+		{
+			name:        "worker without the required device is excluded",
+			worker:      worker("w", "gvisor", "node-a", nil),
+			constraints: Constraints{SandboxClass: "gvisor", Devices: map[string]int64{"example.com/device": 1}},
+			want:        false,
+		},
+		{
+			name:        "worker with enough of the device is eligible",
+			worker:      worker("w", "gvisor", "node-a", nil, withDevices(map[string]int64{"example.com/device": 2})),
+			constraints: Constraints{SandboxClass: "gvisor", Devices: map[string]int64{"example.com/device": 1}},
+			want:        true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -315,6 +358,15 @@ func assigned(atespace, name string) func(*ateapipb.Worker) {
 func withCapacity(cpuMilli, memBytes int64) func(*ateapipb.Worker) {
 	return func(w *ateapipb.Worker) {
 		w.Capacity = &ateapipb.WorkerCapacity{CpuMilli: cpuMilli, MemoryBytes: memBytes}
+	}
+}
+
+func withDevices(devices map[string]int64) func(*ateapipb.Worker) {
+	return func(w *ateapipb.Worker) {
+		if w.Capacity == nil {
+			w.Capacity = &ateapipb.WorkerCapacity{}
+		}
+		w.Capacity.Devices = devices
 	}
 }
 

--- a/cmd/atecontroller/internal/workersync/capacity_test.go
+++ b/cmd/atecontroller/internal/workersync/capacity_test.go
@@ -15,6 +15,7 @@
 package workersync
 
 import (
+	"maps"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +28,7 @@ func TestWorkerCapacity(t *testing.T) {
 	pod := func(ctrs ...corev1.Container) *corev1.Pod {
 		return &corev1.Pod{Spec: corev1.PodSpec{Containers: ctrs}}
 	}
-	limited := func(name, cpu, mem string) corev1.Container {
+	limited := func(name, cpu, mem string, devices ...string) corev1.Container {
 		lim := corev1.ResourceList{}
 		if cpu != "" {
 			lim[corev1.ResourceCPU] = resource.MustParse(cpu)
@@ -35,20 +36,24 @@ func TestWorkerCapacity(t *testing.T) {
 		if mem != "" {
 			lim[corev1.ResourceMemory] = resource.MustParse(mem)
 		}
+		for i := 0; i+1 < len(devices); i += 2 {
+			lim[corev1.ResourceName(devices[i])] = resource.MustParse(devices[i+1])
+		}
 		return corev1.Container{Name: name, Resources: corev1.ResourceRequirements{Limits: lim}}
 	}
 
 	tests := []struct {
-		name       string
-		pod        *corev1.Pod
-		wantCPU    int64
-		wantMemory int64
+		name        string
+		pod         *corev1.Pod
+		wantCPU     int64
+		wantMemory  int64
+		wantDevices map[string]int64
+		wantNil     bool
 	}{
 		{
-			name:       "no ateom container yields zero",
-			pod:        pod(limited("sidecar", "1", "1Gi")),
-			wantCPU:    0,
-			wantMemory: 0,
+			name:    "no ateom container yields nil",
+			pod:     pod(limited("sidecar", "1", "1Gi")),
+			wantNil: true,
 		},
 		{
 			name:       "ateom container limits become capacity",
@@ -68,13 +73,45 @@ func TestWorkerCapacity(t *testing.T) {
 			wantCPU:    2000,
 			wantMemory: 0,
 		},
+		{
+			name:        "device limits become capacity",
+			pod:         pod(limited(ateomContainerName, "2", "2Gi", "example.com/device", "2")),
+			wantCPU:     2000,
+			wantMemory:  2 << 30,
+			wantDevices: map[string]int64{"example.com/device": 2},
+		},
+		{
+			name:        "a device-only worker is reported, not nil",
+			pod:         pod(limited(ateomContainerName, "", "", "example.com/device", "1")),
+			wantDevices: map[string]int64{"example.com/device": 1},
+		},
+		{
+			name:    "device on a non-ateom container is ignored",
+			pod:     pod(limited("sidecar", "", "", "example.com/device", "1")),
+			wantNil: true,
+		},
+		{
+			name:       "native non-cpu/memory resources are not devices",
+			pod:        pod(limited(ateomContainerName, "2", "2Gi", "ephemeral-storage", "10Gi", "hugepages-2Mi", "512Mi")),
+			wantCPU:    2000,
+			wantMemory: 2 << 30,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := workerCapacity(tc.pod)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("workerCapacity() = %+v, want nil", got)
+				}
+				return
+			}
 			if got.GetCpuMilli() != tc.wantCPU || got.GetMemoryBytes() != tc.wantMemory {
 				t.Fatalf("workerCapacity() = (%d, %d), want (%d, %d)",
 					got.GetCpuMilli(), got.GetMemoryBytes(), tc.wantCPU, tc.wantMemory)
+			}
+			if !maps.Equal(got.GetDevices(), tc.wantDevices) {
+				t.Fatalf("workerCapacity() devices = %v, want %v", got.GetDevices(), tc.wantDevices)
 			}
 		})
 	}

--- a/cmd/atecontroller/internal/workersync/syncer.go
+++ b/cmd/atecontroller/internal/workersync/syncer.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/resources"
 	listersv1alpha1 "github.com/agent-substrate/substrate/pkg/client/listers/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
@@ -332,12 +333,15 @@ func isWorkerEligible(pod *corev1.Pod) bool {
 const ateomContainerName = "ateom"
 
 // workerCapacity returns the worker pod's capacity for hosting an actor — CPU
-// in millicores and memory in bytes — taken from the ateom container's resource
-// limits. A dimension the pod does not limit reports 0, which the scheduler
-// treats as "unknown" (unconstrained); a pod that limits neither reports nil
-// rather than an all-zero message that says the same thing. The actor sandbox
-// runs nested in the ateom container's cgroup, so that container's limits — not
-// the pod total — are the relevant envelope.
+// in millicores, memory in bytes, and any extended-resource devices — taken from
+// the ateom container's resource limits. A CPU or memory dimension the pod does
+// not limit reports 0, which the scheduler treats as "unknown" (unconstrained);
+// a device the pod does not limit is simply absent from the map, which the
+// scheduler treats as zero-and-unsatisfiable. A pod that limits nothing reports
+// nil rather than an empty message that says the same thing. Every dimension,
+// devices included, comes from the ateom container's own limits, not the pod
+// total: the actor sandbox runs nested in that container's cgroup, and a device
+// the pool attaches to a different container is not visible to the sandbox.
 func workerCapacity(pod *corev1.Pod) *ateapipb.WorkerCapacity {
 	var capacity ateapipb.WorkerCapacity
 	for i := range pod.Spec.Containers {
@@ -351,9 +355,18 @@ func workerCapacity(pod *corev1.Pod) *ateapipb.WorkerCapacity {
 		if v := c.Resources.Limits.Memory(); v != nil {
 			capacity.MemoryBytes = v.Value()
 		}
+		for name, q := range c.Resources.Limits {
+			if !resources.IsDeviceResource(string(name)) {
+				continue
+			}
+			if capacity.Devices == nil {
+				capacity.Devices = map[string]int64{}
+			}
+			capacity.Devices[string(name)] = q.Value()
+		}
 		break
 	}
-	if capacity.CpuMilli == 0 && capacity.MemoryBytes == 0 {
+	if capacity.CpuMilli == 0 && capacity.MemoryBytes == 0 && len(capacity.Devices) == 0 {
 		return nil
 	}
 	return &capacity

--- a/internal/resources/devices.go
+++ b/internal/resources/devices.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import "strings"
+
+// IsDeviceResource reports whether a Kubernetes resource name denotes an
+// extended-resource device (for example nvidia.com/gpu) rather than a native
+// resource. The native resources that can appear on a container's limits (cpu,
+// memory, ephemeral-storage, hugepages-*) are unprefixed, while every extended
+// resource is domain-qualified, so a "/" in the name is what marks a device.
+//
+// Shared so the worker-capacity and actor-limit sides classify identically.
+func IsDeviceResource(name string) bool {
+	return strings.Contains(name, "/")
+}

--- a/internal/resources/devices_test.go
+++ b/internal/resources/devices_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import "testing"
+
+func TestIsDeviceResource(t *testing.T) {
+	tests := map[string]bool{
+		"nvidia.com/gpu":     true,
+		"example.com/device": true,
+		"amd.com/gpu":        true,
+		"cpu":                false,
+		"memory":             false,
+		"ephemeral-storage":  false,
+		"hugepages-2Mi":      false,
+		"hugepages-1Gi":      false,
+	}
+	for name, want := range tests {
+		if got := IsDeviceResource(name); got != want {
+			t.Errorf("IsDeviceResource(%q) = %v, want %v", name, got, want)
+		}
+	}
+}

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -5906,7 +5906,21 @@ type WorkerCapacity struct {
 	//
 	// +k8s:optional
 	// +k8s:minimum=1
-	MemoryBytes   int64 `protobuf:"varint,2,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"`
+	MemoryBytes int64 `protobuf:"varint,2,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"`
+	// Device capacity keyed by Kubernetes extended-resource name (e.g.
+	// "nvidia.com/gpu"), taken from the ateom container's limits. Unlike
+	// cpu_milli and memory_bytes, an absent or zero entry means the worker has
+	// none of that device and cannot host an actor that requires it: devices are
+	// discrete and cannot be treated as "unknown, therefore unconstrained".
+	//
+	// Field 3 is intentionally skipped so the pending multi-actor change can take
+	// it for an actor count without colliding.
+	//
+	// +k8s:optional
+	// +k8s:maxProperties=32
+	// +k8s:eachKey=+k8s:format=k8s-label-key
+	// +k8s:eachVal=+k8s:minimum=1
+	Devices       map[string]int64 `protobuf:"bytes,4,rep,name=devices,proto3" json:"devices,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5953,6 +5967,13 @@ func (x *WorkerCapacity) GetMemoryBytes() int64 {
 		return x.MemoryBytes
 	}
 	return 0
+}
+
+func (x *WorkerCapacity) GetDevices() map[string]int64 {
+	if x != nil {
+		return x.Devices
+	}
+	return nil
 }
 
 // ActorAssignment names the Actor currently bound to a Worker — the inverse of
@@ -6779,10 +6800,14 @@ const file_ateapi_proto_rawDesc = "" +
 	"\x05state\x18\x01 \x01(\x0e2\x13.ateapi.WorkerStateR\x05state\x127\n" +
 	"\n" +
 	"assignment\x18\x02 \x01(\v2\x17.ateapi.ActorAssignmentR\n" +
-	"assignment\"P\n" +
+	"assignment\"\xcb\x01\n" +
 	"\x0eWorkerCapacity\x12\x1b\n" +
 	"\tcpu_milli\x18\x01 \x01(\x03R\bcpuMilli\x12!\n" +
-	"\fmemory_bytes\x18\x02 \x01(\x03R\vmemoryBytes\"\xe0\x01\n" +
+	"\fmemory_bytes\x18\x02 \x01(\x03R\vmemoryBytes\x12=\n" +
+	"\adevices\x18\x04 \x03(\v2#.ateapi.WorkerCapacity.DevicesEntryR\adevices\x1a:\n" +
+	"\fDevicesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x01\"\xe0\x01\n" +
 	"\x0fActorAssignment\x12F\n" +
 	"\x0eactor_template\x18\x01 \x01(\v2\x1f.ateapi.KubeNamespacedObjectRefR\ractorTemplate\x12'\n" +
 	"\x05actor\x18\x02 \x01(\v2\x11.ateapi.ObjectRefR\x05actor\x12\x1b\n" +
@@ -6902,7 +6927,7 @@ func file_ateapi_proto_rawDescGZIP() []byte {
 }
 
 var file_ateapi_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 98)
+var file_ateapi_proto_msgTypes = make([]protoimpl.MessageInfo, 99)
 var file_ateapi_proto_goTypes = []any{
 	(SnapshotContentScope)(0),              // 0: ateapi.SnapshotContentScope
 	(ActorSnapshotTagScope)(0),             // 1: ateapi.ActorSnapshotTagScope
@@ -7011,14 +7036,15 @@ var file_ateapi_proto_goTypes = []any{
 	nil,                                    // 104: ateapi.Selector.MatchLabelsEntry
 	nil,                                    // 105: ateapi.ExternalVolume.VolumeContextEntry
 	nil,                                    // 106: ateapi.Worker.LabelsEntry
-	(*timestamppb.Timestamp)(nil),          // 107: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                  // 108: google.protobuf.Empty
+	nil,                                    // 107: ateapi.WorkerCapacity.DevicesEntry
+	(*timestamppb.Timestamp)(nil),          // 108: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                  // 109: google.protobuf.Empty
 }
 var file_ateapi_proto_depIdxs = []int32{
 	0,   // 0: ateapi.LocalSnapshotInfo.content_scope:type_name -> ateapi.SnapshotContentScope
 	104, // 1: ateapi.Selector.match_labels:type_name -> ateapi.Selector.MatchLabelsEntry
-	107, // 2: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
-	107, // 3: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
+	108, // 2: ateapi.ResourceMetadata.create_time:type_name -> google.protobuf.Timestamp
+	108, // 3: ateapi.ResourceMetadata.update_time:type_name -> google.protobuf.Timestamp
 	8,   // 4: ateapi.ExternalVolume.status:type_name -> ateapi.ExternalVolume.Status
 	105, // 5: ateapi.ExternalVolume.volume_context:type_name -> ateapi.ExternalVolume.VolumeContextEntry
 	11,  // 6: ateapi.Actor.metadata:type_name -> ateapi.ResourceMetadata
@@ -7030,7 +7056,7 @@ var file_ateapi_proto_depIdxs = []int32{
 	15,  // 12: ateapi.EgressPolicy.rules:type_name -> ateapi.EgressRule
 	16,  // 13: ateapi.EgressRule.hostnames:type_name -> ateapi.HostnameRule
 	17,  // 14: ateapi.EgressRule.ip_blocks:type_name -> ateapi.IPBlockRule
-	108, // 15: ateapi.EgressRule.all:type_name -> google.protobuf.Empty
+	109, // 15: ateapi.EgressRule.all:type_name -> google.protobuf.Empty
 	18,  // 16: ateapi.HostnameRule.effects:type_name -> ateapi.EgressRuleEffects
 	19,  // 17: ateapi.EgressRuleEffects.inject_static_headers:type_name -> ateapi.CredentialHeaderInjection
 	2,   // 18: ateapi.ActorStatus.state:type_name -> ateapi.ActorState
@@ -7060,7 +7086,7 @@ var file_ateapi_proto_depIdxs = []int32{
 	32,  // 42: ateapi.ActorTemplate.status:type_name -> ateapi.ActorTemplateStatus
 	30,  // 43: ateapi.Resources.limits:type_name -> ateapi.Limits
 	27,  // 44: ateapi.GoldenSnapshotStatus.golden_snapshot:type_name -> ateapi.ObjectRef
-	107, // 45: ateapi.GoldenSnapshotStatus.take_golden_snapshot_at:type_name -> google.protobuf.Timestamp
+	108, // 45: ateapi.GoldenSnapshotStatus.take_golden_snapshot_at:type_name -> google.protobuf.Timestamp
 	31,  // 46: ateapi.ActorTemplateStatus.golden_snapshot_status:type_name -> ateapi.GoldenSnapshotStatus
 	3,   // 47: ateapi.SandboxConfig.sandbox_class:type_name -> ateapi.SandboxClass
 	0,   // 48: ateapi.SnapshotsConfig.on_pause:type_name -> ateapi.SnapshotContentScope
@@ -7127,86 +7153,87 @@ var file_ateapi_proto_depIdxs = []int32{
 	94,  // 109: ateapi.Worker.status:type_name -> ateapi.WorkerStatus
 	6,   // 110: ateapi.WorkerStatus.state:type_name -> ateapi.WorkerState
 	96,  // 111: ateapi.WorkerStatus.assignment:type_name -> ateapi.ActorAssignment
-	97,  // 112: ateapi.ActorAssignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
-	27,  // 113: ateapi.ActorAssignment.actor:type_name -> ateapi.ObjectRef
-	27,  // 114: ateapi.ActorAssignment.actor_template_ref:type_name -> ateapi.ObjectRef
-	27,  // 115: ateapi.MintCertRequest.worker:type_name -> ateapi.ObjectRef
-	7,   // 116: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
-	62,  // 117: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
-	63,  // 118: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
-	64,  // 119: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
-	65,  // 120: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
-	67,  // 121: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
-	69,  // 122: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
-	71,  // 123: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
-	72,  // 124: ateapi.Control.GetActorEgressPolicy:input_type -> ateapi.GetActorEgressPolicyRequest
-	73,  // 125: ateapi.Control.CreateActorEgressPolicy:input_type -> ateapi.CreateActorEgressPolicyRequest
-	74,  // 126: ateapi.Control.UpdateActorEgressPolicy:input_type -> ateapi.UpdateActorEgressPolicyRequest
-	75,  // 127: ateapi.Control.DeleteActorEgressPolicy:input_type -> ateapi.DeleteActorEgressPolicyRequest
-	76,  // 128: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
-	77,  // 129: ateapi.Control.GetActorSnapshotTag:input_type -> ateapi.GetActorSnapshotTagRequest
-	78,  // 130: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
-	80,  // 131: ateapi.Control.CreateActorSnapshotTag:input_type -> ateapi.CreateActorSnapshotTagRequest
-	81,  // 132: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
-	82,  // 133: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
-	84,  // 134: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
-	86,  // 135: ateapi.Control.GetWorker:input_type -> ateapi.GetWorkerRequest
-	87,  // 136: ateapi.Control.CreateWorker:input_type -> ateapi.CreateWorkerRequest
-	88,  // 137: ateapi.Control.UpdateWorker:input_type -> ateapi.UpdateWorkerRequest
-	89,  // 138: ateapi.Control.DeleteWorker:input_type -> ateapi.DeleteWorkerRequest
-	90,  // 139: ateapi.Control.DrainWorker:input_type -> ateapi.DrainWorkerRequest
-	91,  // 140: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
-	52,  // 141: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
-	53,  // 142: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
-	54,  // 143: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
-	56,  // 144: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
-	57,  // 145: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
-	58,  // 146: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
-	59,  // 147: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
-	61,  // 148: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
-	98,  // 149: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
-	100, // 150: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
-	102, // 151: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
-	13,  // 152: ateapi.Control.GetActor:output_type -> ateapi.Actor
-	13,  // 153: ateapi.Control.CreateActor:output_type -> ateapi.Actor
-	13,  // 154: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
-	66,  // 155: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
-	68,  // 156: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
-	70,  // 157: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
-	13,  // 158: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
-	14,  // 159: ateapi.Control.GetActorEgressPolicy:output_type -> ateapi.EgressPolicy
-	14,  // 160: ateapi.Control.CreateActorEgressPolicy:output_type -> ateapi.EgressPolicy
-	14,  // 161: ateapi.Control.UpdateActorEgressPolicy:output_type -> ateapi.EgressPolicy
-	14,  // 162: ateapi.Control.DeleteActorEgressPolicy:output_type -> ateapi.EgressPolicy
-	23,  // 163: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
-	25,  // 164: ateapi.Control.GetActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	79,  // 165: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
-	25,  // 166: ateapi.Control.CreateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	25,  // 167: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	25,  // 168: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
-	85,  // 169: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
-	93,  // 170: ateapi.Control.GetWorker:output_type -> ateapi.Worker
-	93,  // 171: ateapi.Control.CreateWorker:output_type -> ateapi.Worker
-	93,  // 172: ateapi.Control.UpdateWorker:output_type -> ateapi.Worker
-	93,  // 173: ateapi.Control.DeleteWorker:output_type -> ateapi.Worker
-	93,  // 174: ateapi.Control.DrainWorker:output_type -> ateapi.Worker
-	92,  // 175: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
-	26,  // 176: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
-	26,  // 177: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
-	55,  // 178: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
-	26,  // 179: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
-	28,  // 180: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
-	28,  // 181: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
-	60,  // 182: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
-	28,  // 183: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
-	99,  // 184: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
-	101, // 185: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
-	103, // 186: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
-	152, // [152:187] is the sub-list for method output_type
-	117, // [117:152] is the sub-list for method input_type
-	117, // [117:117] is the sub-list for extension type_name
-	117, // [117:117] is the sub-list for extension extendee
-	0,   // [0:117] is the sub-list for field type_name
+	107, // 112: ateapi.WorkerCapacity.devices:type_name -> ateapi.WorkerCapacity.DevicesEntry
+	97,  // 113: ateapi.ActorAssignment.actor_template:type_name -> ateapi.KubeNamespacedObjectRef
+	27,  // 114: ateapi.ActorAssignment.actor:type_name -> ateapi.ObjectRef
+	27,  // 115: ateapi.ActorAssignment.actor_template_ref:type_name -> ateapi.ObjectRef
+	27,  // 116: ateapi.MintCertRequest.worker:type_name -> ateapi.ObjectRef
+	7,   // 117: ateapi.MintCertRequest.purpose:type_name -> ateapi.ActorCertificatePurpose
+	62,  // 118: ateapi.Control.GetActor:input_type -> ateapi.GetActorRequest
+	63,  // 119: ateapi.Control.CreateActor:input_type -> ateapi.CreateActorRequest
+	64,  // 120: ateapi.Control.UpdateActor:input_type -> ateapi.UpdateActorRequest
+	65,  // 121: ateapi.Control.SuspendActor:input_type -> ateapi.SuspendActorRequest
+	67,  // 122: ateapi.Control.PauseActor:input_type -> ateapi.PauseActorRequest
+	69,  // 123: ateapi.Control.ResumeActor:input_type -> ateapi.ResumeActorRequest
+	71,  // 124: ateapi.Control.DeleteActor:input_type -> ateapi.DeleteActorRequest
+	72,  // 125: ateapi.Control.GetActorEgressPolicy:input_type -> ateapi.GetActorEgressPolicyRequest
+	73,  // 126: ateapi.Control.CreateActorEgressPolicy:input_type -> ateapi.CreateActorEgressPolicyRequest
+	74,  // 127: ateapi.Control.UpdateActorEgressPolicy:input_type -> ateapi.UpdateActorEgressPolicyRequest
+	75,  // 128: ateapi.Control.DeleteActorEgressPolicy:input_type -> ateapi.DeleteActorEgressPolicyRequest
+	76,  // 129: ateapi.Control.GetActorSnapshot:input_type -> ateapi.GetActorSnapshotRequest
+	77,  // 130: ateapi.Control.GetActorSnapshotTag:input_type -> ateapi.GetActorSnapshotTagRequest
+	78,  // 131: ateapi.Control.ListActorSnapshots:input_type -> ateapi.ListActorSnapshotsRequest
+	80,  // 132: ateapi.Control.CreateActorSnapshotTag:input_type -> ateapi.CreateActorSnapshotTagRequest
+	81,  // 133: ateapi.Control.UpdateActorSnapshotTag:input_type -> ateapi.UpdateActorSnapshotTagRequest
+	82,  // 134: ateapi.Control.DeleteActorSnapshotTag:input_type -> ateapi.DeleteActorSnapshotTagRequest
+	84,  // 135: ateapi.Control.ListWorkers:input_type -> ateapi.ListWorkersRequest
+	86,  // 136: ateapi.Control.GetWorker:input_type -> ateapi.GetWorkerRequest
+	87,  // 137: ateapi.Control.CreateWorker:input_type -> ateapi.CreateWorkerRequest
+	88,  // 138: ateapi.Control.UpdateWorker:input_type -> ateapi.UpdateWorkerRequest
+	89,  // 139: ateapi.Control.DeleteWorker:input_type -> ateapi.DeleteWorkerRequest
+	90,  // 140: ateapi.Control.DrainWorker:input_type -> ateapi.DrainWorkerRequest
+	91,  // 141: ateapi.Control.ListActors:input_type -> ateapi.ListActorsRequest
+	52,  // 142: ateapi.Control.CreateAtespace:input_type -> ateapi.CreateAtespaceRequest
+	53,  // 143: ateapi.Control.GetAtespace:input_type -> ateapi.GetAtespaceRequest
+	54,  // 144: ateapi.Control.ListAtespaces:input_type -> ateapi.ListAtespacesRequest
+	56,  // 145: ateapi.Control.DeleteAtespace:input_type -> ateapi.DeleteAtespaceRequest
+	57,  // 146: ateapi.Control.CreateActorTemplate:input_type -> ateapi.CreateActorTemplateRequest
+	58,  // 147: ateapi.Control.GetActorTemplate:input_type -> ateapi.GetActorTemplateRequest
+	59,  // 148: ateapi.Control.ListActorTemplates:input_type -> ateapi.ListActorTemplatesRequest
+	61,  // 149: ateapi.Control.DeleteActorTemplate:input_type -> ateapi.DeleteActorTemplateRequest
+	98,  // 150: ateapi.Debug.DebugClear:input_type -> ateapi.DebugClearRequest
+	100, // 151: ateapi.ActorIdentity.MintJWT:input_type -> ateapi.MintJWTRequest
+	102, // 152: ateapi.ActorIdentity.MintCert:input_type -> ateapi.MintCertRequest
+	13,  // 153: ateapi.Control.GetActor:output_type -> ateapi.Actor
+	13,  // 154: ateapi.Control.CreateActor:output_type -> ateapi.Actor
+	13,  // 155: ateapi.Control.UpdateActor:output_type -> ateapi.Actor
+	66,  // 156: ateapi.Control.SuspendActor:output_type -> ateapi.SuspendActorResponse
+	68,  // 157: ateapi.Control.PauseActor:output_type -> ateapi.PauseActorResponse
+	70,  // 158: ateapi.Control.ResumeActor:output_type -> ateapi.ResumeActorResponse
+	13,  // 159: ateapi.Control.DeleteActor:output_type -> ateapi.Actor
+	14,  // 160: ateapi.Control.GetActorEgressPolicy:output_type -> ateapi.EgressPolicy
+	14,  // 161: ateapi.Control.CreateActorEgressPolicy:output_type -> ateapi.EgressPolicy
+	14,  // 162: ateapi.Control.UpdateActorEgressPolicy:output_type -> ateapi.EgressPolicy
+	14,  // 163: ateapi.Control.DeleteActorEgressPolicy:output_type -> ateapi.EgressPolicy
+	23,  // 164: ateapi.Control.GetActorSnapshot:output_type -> ateapi.ActorSnapshot
+	25,  // 165: ateapi.Control.GetActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	79,  // 166: ateapi.Control.ListActorSnapshots:output_type -> ateapi.ListActorSnapshotsResponse
+	25,  // 167: ateapi.Control.CreateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	25,  // 168: ateapi.Control.UpdateActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	25,  // 169: ateapi.Control.DeleteActorSnapshotTag:output_type -> ateapi.ActorSnapshotTag
+	85,  // 170: ateapi.Control.ListWorkers:output_type -> ateapi.ListWorkersResponse
+	93,  // 171: ateapi.Control.GetWorker:output_type -> ateapi.Worker
+	93,  // 172: ateapi.Control.CreateWorker:output_type -> ateapi.Worker
+	93,  // 173: ateapi.Control.UpdateWorker:output_type -> ateapi.Worker
+	93,  // 174: ateapi.Control.DeleteWorker:output_type -> ateapi.Worker
+	93,  // 175: ateapi.Control.DrainWorker:output_type -> ateapi.Worker
+	92,  // 176: ateapi.Control.ListActors:output_type -> ateapi.ListActorsResponse
+	26,  // 177: ateapi.Control.CreateAtespace:output_type -> ateapi.Atespace
+	26,  // 178: ateapi.Control.GetAtespace:output_type -> ateapi.Atespace
+	55,  // 179: ateapi.Control.ListAtespaces:output_type -> ateapi.ListAtespacesResponse
+	26,  // 180: ateapi.Control.DeleteAtespace:output_type -> ateapi.Atespace
+	28,  // 181: ateapi.Control.CreateActorTemplate:output_type -> ateapi.ActorTemplate
+	28,  // 182: ateapi.Control.GetActorTemplate:output_type -> ateapi.ActorTemplate
+	60,  // 183: ateapi.Control.ListActorTemplates:output_type -> ateapi.ListActorTemplatesResponse
+	28,  // 184: ateapi.Control.DeleteActorTemplate:output_type -> ateapi.ActorTemplate
+	99,  // 185: ateapi.Debug.DebugClear:output_type -> ateapi.DebugClearResponse
+	101, // 186: ateapi.ActorIdentity.MintJWT:output_type -> ateapi.MintJWTResponse
+	103, // 187: ateapi.ActorIdentity.MintCert:output_type -> ateapi.MintCertResponse
+	153, // [153:188] is the sub-list for method output_type
+	118, // [118:153] is the sub-list for method input_type
+	118, // [118:118] is the sub-list for extension type_name
+	118, // [118:118] is the sub-list for extension extendee
+	0,   // [0:118] is the sub-list for field type_name
 }
 
 func init() { file_ateapi_proto_init() }
@@ -7220,7 +7247,7 @@ func file_ateapi_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ateapi_proto_rawDesc), len(file_ateapi_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   98,
+			NumMessages:   99,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -1439,6 +1439,21 @@ message WorkerCapacity {
   // +k8s:optional
   // +k8s:minimum=1
   int64 memory_bytes = 2;
+
+  // Device capacity keyed by Kubernetes extended-resource name (e.g.
+  // "nvidia.com/gpu"), taken from the ateom container's limits. Unlike
+  // cpu_milli and memory_bytes, an absent or zero entry means the worker has
+  // none of that device and cannot host an actor that requires it: devices are
+  // discrete and cannot be treated as "unknown, therefore unconstrained".
+  //
+  // Field 3 is intentionally skipped so the pending multi-actor change can take
+  // it for an actor count without colliding.
+  //
+  // +k8s:optional
+  // +k8s:maxProperties=32
+  // +k8s:eachKey=+k8s:format=k8s-label-key
+  // +k8s:eachVal=+k8s:minimum=1
+  map<string, int64> devices = 4;
 }
 
 // ActorAssignment names the Actor currently bound to a Worker — the inverse of


### PR DESCRIPTION
Part of #752

## What and why

Worker capacity models only CPU and memory, so the scheduler is blind to devices even though a WorkerPool that requests `nvidia.com/gpu` already puts that key on the ateom container and an ActorTemplate can already declare it under `spec.resources.limits`. A GPU-requiring actor could therefore be placed on a pool with no GPU.

This adds a device dimension to `WorkerCapacity` (proto field 4; field 3 is left free for the pending multi-actor change), populates it from the ateom container's limits, extracts the actor side from the template, and gates placement in `scheduling.Applies`. Both sides classify devices through the shared `resources.IsDeviceResource`, so they cannot disagree on what counts as a device: a resource is a device when its name is domain-qualified (contains `/`). At the container-limits layer this cleanly separates extended resources (always domain-qualified, e.g. `nvidia.com/gpu`) from the native resources that can appear there (`cpu`, `memory`, `ephemeral-storage`, `hugepages-*`), none of which contain a slash. Actor-side device counts must be whole numbers (`"1000m"` is one unit, `"500m"` is rejected).

Devices are gated strictly, unlike CPU and memory. For CPU and memory a zero capacity means "unknown" and is treated as unconstrained, but an absent device means the worker has none of it and cannot host an actor that requires it. Treating a missing GPU as unconstrained would place GPU actors on GPU-less workers, which is the bug this prevents.

## Behavioral change

None today: no current template declares a device limit that reaches the scheduler, so `Applies` behaves exactly as before. `Worker.capacity` is immutable and set at creation, so existing workers report device capacity only after their pods are recreated.

## Scope

Scheduling only. This does not touch ateom, CDI injection, or runtime code, so it does not change whether a placed actor can use the GPU. Placement is gated on total device capacity, not remaining capacity, matching the existing stateless CPU/memory behavior. Per-container device selection and per-actor allocation remain open under #752; this change is a prerequisite for that work, not a substitute. The change is purely additive.

## Testing

Unit tests cover both extraction sides and the gate, including `ephemeral-storage`/`hugepages-*` not being treated as devices and the `"1000m"` vs `"500m"` cases.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
