### PR TITLE
fix(ateom-gvisor): declare seccompProfile Unconfined so the worker survives RuntimeDefault

### DIFF
--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -312,10 +312,10 @@ func ateomSecurityContext(class atev1alpha1.SandboxClass) *corev1ac.SecurityCont
 				WithType(corev1.SeccompProfileTypeUnconfined))
 	}
 	// runsc's sandbox child also pivot_root()s, so it needs the same relaxation:
-	// a cluster that defaults seccomp to RuntimeDefault (an increasingly common
-	// baseline) denies the syscall whatever capabilities the worker holds, and the
-	// sandbox then dies during startup. Declare Unconfined explicitly so the
-	// worker does not depend on the cluster leaving the profile unset.
+	// a cluster that defaults seccomp to RuntimeDefault denies the syscall whatever
+	// capabilities the worker holds, and the sandbox then dies during startup.
+	// Declare Unconfined explicitly so the worker does not depend on the cluster
+	// leaving the profile unset.
 	return sc.
 		WithCapabilities(corev1ac.Capabilities().
 			WithDrop("ALL").

--- a/cmd/atecontroller/internal/controllers/workerpool_apply.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply.go
@@ -277,8 +277,9 @@ var ateomMicroVMCapabilities = slices.Concat(ateomGvisorCapabilities, []corev1.C
 })
 
 // ateomSecurityContext returns the ateom container security context for a sandbox
-// class. Neither class runs privileged; they differ in their capability set and
-// in seccomp. An empty class defaults to gVisor.
+// class. Neither class runs privileged; they differ in their capability set.
+// Both declare seccomp Unconfined because their sandbox child pivot_root()s,
+// which the default profile denies. An empty class defaults to gVisor.
 func ateomSecurityContext(class atev1alpha1.SandboxClass) *corev1ac.SecurityContextApplyConfiguration {
 	// Both runtimes mount inside the worker — runsc pivots root and the worker
 	// remounts /sys/fs/cgroup to nest per-actor cgroups; the micro-VM worker
@@ -310,11 +311,17 @@ func ateomSecurityContext(class atev1alpha1.SandboxClass) *corev1ac.SecurityCont
 			WithSeccompProfile(corev1ac.SeccompProfile().
 				WithType(corev1.SeccompProfileTypeUnconfined))
 	}
-	// gVisor needs no such relaxation and keeps the runtime default.
+	// runsc's sandbox child also pivot_root()s, so it needs the same relaxation:
+	// a cluster that defaults seccomp to RuntimeDefault (an increasingly common
+	// baseline) denies the syscall whatever capabilities the worker holds, and the
+	// sandbox then dies during startup. Declare Unconfined explicitly so the
+	// worker does not depend on the cluster leaving the profile unset.
 	return sc.
 		WithCapabilities(corev1ac.Capabilities().
 			WithDrop("ALL").
-			WithAdd(ateomGvisorCapabilities...))
+			WithAdd(ateomGvisorCapabilities...)).
+		WithSeccompProfile(corev1ac.SeccompProfile().
+			WithType(corev1.SeccompProfileTypeUnconfined))
 }
 
 // maybeApplyMicroVMPodShape adds the /dev/kvm device and node placement a

--- a/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
+++ b/cmd/atecontroller/internal/controllers/workerpool_apply_test.go
@@ -379,12 +379,12 @@ func TestAteomSecurityContextByClass(t *testing.T) {
 		name     string
 		class    atev1alpha1.SandboxClass
 		wantCaps []corev1.Capability
-		// wantSeccompUnconfined is micro-VM only: virtiofsd's sandbox pivot_root()s,
-		// which the default profile denies.
+		// wantSeccompUnconfined holds for every class: both runsc's and
+		// virtiofsd's sandbox pivot_root(), which the default profile denies.
 		wantSeccompUnconfined bool
 	}{
-		{"gvisor default", "", ateomGvisorCapabilities, false},
-		{"gvisor explicit", atev1alpha1.SandboxClassGvisor, ateomGvisorCapabilities, false},
+		{"gvisor default", "", ateomGvisorCapabilities, true},
+		{"gvisor explicit", atev1alpha1.SandboxClassGvisor, ateomGvisorCapabilities, true},
 		{"microvm", atev1alpha1.SandboxClassMicroVM, ateomMicroVMCapabilities, true},
 	}
 	for _, tt := range tests {
@@ -411,15 +411,12 @@ func TestAteomSecurityContextByClass(t *testing.T) {
 				*sc.AppArmorProfile.Type != corev1.AppArmorProfileTypeUnconfined {
 				t.Errorf("AppArmorProfile = %v, want Unconfined", sc.AppArmorProfile)
 			}
-			// gVisor must keep the runtime default (an unset profile), so the
-			// micro-VM relaxation cannot leak to it.
+			// Every class declares Unconfined explicitly so it does not depend on
+			// the cluster leaving the seccomp profile unset.
 			gotSeccompUnconfined := sc.SeccompProfile != nil && sc.SeccompProfile.Type != nil &&
 				*sc.SeccompProfile.Type == corev1.SeccompProfileTypeUnconfined
 			if gotSeccompUnconfined != tt.wantSeccompUnconfined {
 				t.Errorf("seccomp Unconfined = %v, want %v", gotSeccompUnconfined, tt.wantSeccompUnconfined)
-			}
-			if !tt.wantSeccompUnconfined && sc.SeccompProfile != nil {
-				t.Errorf("SeccompProfile = %v, want unset so the runtime default applies", sc.SeccompProfile)
 			}
 		})
 	}
@@ -916,7 +913,9 @@ func expectedDeploymentApplyConfig(mutatePodSpec func(*corev1ac.PodSpecApplyConf
 					WithDrop("ALL").
 					WithAdd(ateomGvisorCapabilities...)).
 				WithAppArmorProfile(corev1ac.AppArmorProfile().
-					WithType(corev1.AppArmorProfileTypeUnconfined))).
+					WithType(corev1.AppArmorProfileTypeUnconfined)).
+				WithSeccompProfile(corev1ac.SeccompProfile().
+					WithType(corev1.SeccompProfileTypeUnconfined))).
 			WithEnv(
 				corev1ac.EnvVar().
 					WithName("POD_UID").


### PR DESCRIPTION
Fixes #1368

The gVisor worker leaves `seccompProfile` unset and relies on the runtime default. `runsc`'s gofer/boot child processes `pivot_root()` while setting up the sandbox rootfs, and the default seccomp profile denies `pivot_root` whatever capabilities the worker holds — the same reason the microVM worker already declares `Unconfined`. On a cluster that defaults pod seccomp to `RuntimeDefault` (e.g. via an admission policy), the sandbox child dies during startup and `runsc create` fails with `cannot read client sync file: waiting for sandbox to start: EOF`.

This declares `Unconfined` explicitly for the gVisor worker too, mirroring the microVM branch. It relaxes the filter only on gVisor's own control processes; the actor workload inside the sandbox remains confined by the sentry's own seccomp.

> This change was prepared with AI assistance; I have reviewed and tested it.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
