### PR TITLE
ate-setup: mirror the versioned substrate install of the shell installer

### DIFF
--- a/cmd/ate-setup/internal/demos/simple.go
+++ b/cmd/ate-setup/internal/demos/simple.go
@@ -48,9 +48,17 @@ var ExternalVolumePlaceholders = []string{
 	"EXTERNAL_VOLUMES",
 }
 
-// Render expands a demo template with the configured bucket name.
+// Render expands a demo template with the configured bucket name and the
+// build version (pool templates pin worker pods to version-labeled nodes).
 func Render(e *steps.Env, relPath string, extraValues map[string]string, drop []string) ([]byte, error) {
-	values := map[string]string{bucketNamePlaceholder: e.Cfg.BucketName}
+	version, _, err := e.SubstrateVersion()
+	if err != nil {
+		return nil, err
+	}
+	values := map[string]string{
+		bucketNamePlaceholder: e.Cfg.BucketName,
+		"SUBSTRATE_VERSION":   version,
+	}
 	for k, v := range extraValues {
 		values[k] = v
 	}

--- a/cmd/ate-setup/internal/ko/ko.go
+++ b/cmd/ate-setup/internal/ko/ko.go
@@ -122,17 +122,17 @@ func (r *Runner) ResolveBytes(ctx context.Context, manifest []byte) ([]byte, err
 // scripts shelled out to `make ldflags` for this; computing it here keeps the
 // value identical without depending on make.
 func (r *Runner) ldflags() []string {
-	return []string{fmt.Sprintf("-X=%s.Version=%s", versionPkg, r.version())}
+	return []string{fmt.Sprintf("-X=%s.Version=%s", versionPkg, BuildVersion(r.Root))}
 }
 
-// version mirrors the Makefile's VERSION: `git describe`, or "dev" when git
-// has nothing to say.
-func (r *Runner) version() string {
+// BuildVersion mirrors the Makefile's VERSION: `git describe`, or "dev" when
+// git has nothing to say. It is what ko stamps into the binaries.
+func BuildVersion(root string) string {
 	if v := os.Getenv("VERSION"); v != "" {
 		return v
 	}
 	cmd := exec.Command("git", "describe", "--tags", "--always", "--dirty")
-	cmd.Dir = r.Root
+	cmd.Dir = root
 	out, err := cmd.Output()
 	if err != nil {
 		return "dev"

--- a/cmd/ate-setup/internal/steps/csi.go
+++ b/cmd/ate-setup/internal/steps/csi.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -211,8 +210,8 @@ spec:
 
 	// The image cache directories under ateomHostDir were just wiped, so
 	// atelet has to recreate them.
-	log.Infof("Restarting the atelet DaemonSet (if present)...")
-	return e.Kube.RolloutRestart(ctx, NamespaceAteSystem, "atelet", time.Now())
+	log.Infof("Restarting the atelet DaemonSets (if present)...")
+	return e.RestartAteletDaemonSets(ctx)
 }
 
 func (e *Env) setupCSINFS(ctx context.Context) error {
@@ -366,8 +365,8 @@ spec:
 		return err
 	}
 
-	log.Infof("Restarting the atelet DaemonSet (if present)...")
-	return e.Kube.RolloutRestart(ctx, NamespaceAteSystem, "atelet", time.Now())
+	log.Infof("Restarting the atelet DaemonSets (if present)...")
+	return e.RestartAteletDaemonSets(ctx)
 }
 
 // checkNFSDSupport verifies the host kernel can serve NFS. The in-cluster NFS

--- a/cmd/ate-setup/internal/steps/delete.go
+++ b/cmd/ate-setup/internal/steps/delete.go
@@ -16,6 +16,9 @@ package steps
 
 import (
 	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/agent-substrate/substrate/cmd/ate-setup/internal/log"
 )
@@ -41,6 +44,12 @@ func (e *Env) DeleteAteSystem(ctx context.Context) error {
 		return err
 	}
 
+	// atelet DaemonSet names carry a version suffix.
+	if err := e.Kube.Typed.AppsV1().DaemonSets(NamespaceAteSystem).DeleteCollection(ctx,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "app=atelet"}); err != nil {
+		return fmt.Errorf("while deleting atelet daemonsets: %w", err)
+	}
+
 	for _, path := range [][]string{
 		{"components", "agentgateway", "configmap.yaml"},
 		{"postgres.yaml"},
@@ -50,7 +59,7 @@ func (e *Env) DeleteAteSystem(ctx context.Context) error {
 			return err
 		}
 	}
-	return nil
+	return e.UnlabelNodesSubstrateVersion(ctx)
 }
 
 // DeleteAtenet removes the atenet dataplane.

--- a/cmd/ate-setup/internal/steps/deploy.go
+++ b/cmd/ate-setup/internal/steps/deploy.go
@@ -56,8 +56,19 @@ type DeployOptions struct {
 func (e *Env) DeployAteSystem(ctx context.Context, opts DeployOptions) error {
 	log.Step("deploy_ate_system")
 
+	// Fail fast on an unusable build version before touching the cluster.
+	if _, _, err := e.SubstrateVersion(); err != nil {
+		return err
+	}
+
 	// The namespace has to exist before RBAC or CRDs are applied.
 	if err := e.EnsureAteSystemNamespace(ctx); err != nil {
+		return err
+	}
+
+	// Before the bundle: the atelet DaemonSet applied below and the demo
+	// WorkerPools' version-pinned pods schedule only to version-labeled nodes.
+	if err := e.LabelNodesSubstrateVersion(ctx); err != nil {
 		return err
 	}
 
@@ -120,6 +131,12 @@ func (e *Env) DeployAteSystem(ctx context.Context, opts DeployOptions) error {
 	if err != nil {
 		return err
 	}
+	// The atelet DaemonSet in the bundle is version-keyed; fill its
+	// placeholders after the render (kustomize and ko pass them through).
+	manifests, err = e.SubstituteVersion(manifests)
+	if err != nil {
+		return err
+	}
 	if err := e.Kube.ApplyBytes(ctx, manifests); err != nil {
 		return err
 	}
@@ -132,6 +149,10 @@ func (e *Env) DeployAteSystem(ctx context.Context, opts DeployOptions) error {
 		return err
 	}
 
+	ateletName, err := e.AteletDaemonSetName()
+	if err != nil {
+		return err
+	}
 	log.Step("Waiting for ATE system components to be ready...")
 	for _, w := range []struct{ kind, name string }{
 		{kube.KindStatefulSet, "postgres"},
@@ -139,7 +160,7 @@ func (e *Env) DeployAteSystem(ctx context.Context, opts DeployOptions) error {
 		{kube.KindDeployment, "ate-controller"},
 		{kube.KindDeployment, "atenet-router"},
 		{kube.KindDeployment, "atenet-egress"},
-		{kube.KindDaemonSet, "atelet"},
+		{kube.KindDaemonSet, ateletName},
 	} {
 		if err := e.Kube.RolloutStatus(ctx, w.kind, NamespaceAteSystem, w.name, e.Cfg.RolloutTimeout); err != nil {
 			return err
@@ -223,6 +244,9 @@ func (e *Env) DeployAtelet(ctx context.Context) error {
 	if err := e.EnsureAteSystemNamespace(ctx); err != nil {
 		return err
 	}
+	if err := e.LabelNodesSubstrateVersion(ctx); err != nil {
+		return err
+	}
 	if err := e.applyOtelConfig(ctx); err != nil {
 		return err
 	}
@@ -238,10 +262,18 @@ func (e *Env) DeployAtelet(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	manifest, err = e.SubstituteVersion(manifest)
+	if err != nil {
+		return err
+	}
 	if err := e.Kube.ApplyBytes(ctx, manifest); err != nil {
 		return err
 	}
-	return e.Kube.RolloutStatus(ctx, kube.KindDaemonSet, NamespaceAteSystem, "atelet", e.Cfg.RolloutTimeout)
+	ateletName, err := e.AteletDaemonSetName()
+	if err != nil {
+		return err
+	}
+	return e.Kube.RolloutStatus(ctx, kube.KindDaemonSet, NamespaceAteSystem, ateletName, e.Cfg.RolloutTimeout)
 }
 
 // DeployAtenet redeploys the atenet dataplane: router, egress, and DNS.

--- a/cmd/ate-setup/internal/steps/env.go
+++ b/cmd/ate-setup/internal/steps/env.go
@@ -57,6 +57,11 @@ type Env struct {
 	// ko is created lazily. Steps that only apply static manifests must work
 	// on a machine with no container registry credentials configured.
 	ko *ko.Runner
+
+	// substrateVersion caches the derived build version and its object-name
+	// suffix; see SubstrateVersion.
+	substrateVersion       string
+	substrateVersionSuffix string
 }
 
 // NewEnv connects to the cluster described by cfg.

--- a/cmd/ate-setup/internal/steps/version.go
+++ b/cmd/ate-setup/internal/steps/version.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/agent-substrate/substrate/cmd/ate-setup/internal/ko"
+	"github.com/agent-substrate/substrate/cmd/ate-setup/internal/log"
+	"github.com/agent-substrate/substrate/internal/versionlabel"
+)
+
+// SubstrateVersion returns the build version and the object-name suffix for atelet.
+// The version is the same one ko stamps into the binaries.
+func (e *Env) SubstrateVersion() (version, suffix string, err error) {
+	if e.substrateVersion != "" {
+		return e.substrateVersion, e.substrateVersionSuffix, nil
+	}
+	raw := ko.BuildVersion(e.Cfg.Root)
+	if v := versionlabel.Value(raw); v != raw {
+		return "", "", fmt.Errorf("build version %q is not a valid label value (it would sanitize to %q); pin a label-safe one with the VERSION env var", raw, v)
+	}
+	e.substrateVersion = raw
+	e.substrateVersionSuffix = versionlabel.NameSuffix(raw)
+	return e.substrateVersion, e.substrateVersionSuffix, nil
+}
+
+func (e *Env) AteletDaemonSetName() (string, error) {
+	_, suffix, err := e.SubstrateVersion()
+	if err != nil {
+		return "", err
+	}
+	return "atelet-" + suffix, nil
+}
+
+// unquotedVersionScalar matches a whole-scalar ${SUBSTRATE_VERSION} value
+// kustomize re-emitted unquoted. It is re-quoted before substitution so an
+// all-digit version lands as a YAML string, not an integer.
+var unquotedVersionScalar = regexp.MustCompile(`(?m)^(\s*[^:\n]+): \$\{SUBSTRATE_VERSION\}$`)
+
+// SubstituteVersion fills the ${SUBSTRATE_VERSION} and
+// ${SUBSTRATE_VERSION_SUFFIX} placeholders in a rendered manifest.
+func (e *Env) SubstituteVersion(manifest []byte) ([]byte, error) {
+	version, suffix, err := e.SubstrateVersion()
+	if err != nil {
+		return nil, err
+	}
+	s := unquotedVersionScalar.ReplaceAllString(string(manifest), `$1: "$${SUBSTRATE_VERSION}"`)
+	s = strings.ReplaceAll(s, "${SUBSTRATE_VERSION}", version)
+	s = strings.ReplaceAll(s, "${SUBSTRATE_VERSION_SUFFIX}", suffix)
+	return []byte(s), nil
+}
+
+// RestartAteletDaemonSets pod-restarts every atelet DaemonSet by label.
+func (e *Env) RestartAteletDaemonSets(ctx context.Context) error {
+	list, err := e.Kube.Typed.AppsV1().DaemonSets(NamespaceAteSystem).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=atelet",
+	})
+	if err != nil {
+		return fmt.Errorf("while listing atelet daemonsets: %w", err)
+	}
+	for _, ds := range list.Items {
+		if err := e.Kube.RolloutRestart(ctx, NamespaceAteSystem, ds.Name, time.Now()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// LabelNodesSubstrateVersion stamps ate.dev/substrate-version on every node
+// that does not carry it yet. Nodes that already carry the label keep their
+// value: during a rolling upgrade the operator owns the per-node value, and
+// an install must not yank nodes across versions behind its back.
+func (e *Env) LabelNodesSubstrateVersion(ctx context.Context) error {
+	version, _, err := e.SubstrateVersion()
+	if err != nil {
+		return err
+	}
+	log.Stepf("label_nodes_substrate_version (%s)", version)
+	nodes, err := e.Kube.Typed.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: "!" + versionlabel.Key,
+	})
+	if err != nil {
+		return fmt.Errorf("while listing unlabeled nodes: %w", err)
+	}
+	patch := fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, versionlabel.Key, version)
+	for _, node := range nodes.Items {
+		if _, err := e.Kube.Typed.CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
+			return fmt.Errorf("while labeling node %s: %w", node.Name, err)
+		}
+	}
+	return nil
+}
+
+// UnlabelNodesSubstrateVersion clears ate.dev/substrate-version from every
+// node that carries it. Uninstall removes the label with the system: the
+// install won't relabels a labeled node, so a leftover label would pin the
+// next install to the old version world.
+func (e *Env) UnlabelNodesSubstrateVersion(ctx context.Context) error {
+	log.Step("unlabel_nodes_substrate_version")
+	nodes, err := e.Kube.Typed.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: versionlabel.Key,
+	})
+	if err != nil {
+		return fmt.Errorf("while listing labeled nodes: %w", err)
+	}
+	patch := fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, versionlabel.Key)
+	for _, node := range nodes.Items {
+		if _, err := e.Kube.Typed.CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
+			return fmt.Errorf("while unlabeling node %s: %w", node.Name, err)
+		}
+	}
+	return nil
+}

--- a/cmd/ate-setup/internal/steps/version_test.go
+++ b/cmd/ate-setup/internal/steps/version_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import "testing"
+
+func TestSubstituteVersion(t *testing.T) {
+	e := &Env{substrateVersion: "v1.2.3", substrateVersionSuffix: "v1-2-3"}
+	in := "" +
+		"metadata:\n" +
+		"  name: atelet-${SUBSTRATE_VERSION_SUFFIX}\n" +
+		"  labels:\n" +
+		"    ate.dev/substrate-version: ${SUBSTRATE_VERSION}\n" +
+		"nodeSelector:\n" +
+		"  ate.dev/substrate-version: \"${SUBSTRATE_VERSION}\"\n"
+	// The unquoted scalar is re-quoted (an all-digit version must land as a
+	// YAML string); already-quoted values and name suffixes pass through.
+	want := "" +
+		"metadata:\n" +
+		"  name: atelet-v1-2-3\n" +
+		"  labels:\n" +
+		"    ate.dev/substrate-version: \"v1.2.3\"\n" +
+		"nodeSelector:\n" +
+		"  ate.dev/substrate-version: \"v1.2.3\"\n"
+
+	got, err := e.SubstituteVersion([]byte(in))
+	if err != nil {
+		t.Fatalf("SubstituteVersion: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("SubstituteVersion mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}


### PR DESCRIPTION
Same logic in #1357 but ported to the `ate-setup` go tool.


- [ ] Tests pass
- [x] Appropriate changes to documentation are included in the PR
