### PR TITLE
ate-setup: add subcommand for deploy the ate-controller

### DIFF
--- a/cmd/ate-setup/commands.md
+++ b/cmd/ate-setup/commands.md
@@ -40,6 +40,7 @@ a pre-scan pass, so they may appear anywhere on its command line.
 | `deploy ate-system --setup-csi` | `--deploy-ate-system --setup-csi` |
 | `deploy atelet` | `--deploy-atelet` |
 | `deploy apiserver` | `--deploy-ate-apiserver` |
+| `deploy ate-controller` | (no shell equivalent) |
 | `deploy atenet` | `--deploy-atenet` |
 | `deploy postgres` | `--deploy-postgres` |
 

--- a/cmd/ate-setup/internal/cmd/deploy.go
+++ b/cmd/ate-setup/internal/cmd/deploy.go
@@ -63,6 +63,16 @@ var deployAPIServerCmd = &cobra.Command{
 	},
 }
 
+var deployControllerCmd = &cobra.Command{
+	Use:     "ate-controller",
+	Aliases: []string{"controller"},
+	Short:   "Deploy ate-controller only, with the CRDs it serves",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return env.DeployAteController(cmd.Context())
+	},
+}
+
 var deployAtenetCmd = &cobra.Command{
 	Use:   "atenet",
 	Short: "Deploy the atenet dataplane only: router, egress, and DNS",
@@ -91,6 +101,7 @@ func init() {
 		deployAteSystemCmd,
 		deployAteletCmd,
 		deployAPIServerCmd,
+		deployControllerCmd,
 		deployAtenetCmd,
 		deployPostgresCmd,
 	)

--- a/cmd/ate-setup/internal/steps/deploy.go
+++ b/cmd/ate-setup/internal/steps/deploy.go
@@ -234,6 +234,25 @@ func (e *Env) DeployAteAPIServer(ctx context.Context) error {
 	return e.Kube.RolloutStatus(ctx, kube.KindDeployment, NamespaceAteSystem, "ate-api-server", e.Cfg.RolloutTimeout)
 }
 
+// DeployAteController redeploys only ate-controller.
+func (e *Env) DeployAteController(ctx context.Context) error {
+	log.Step("deploy_ate_controller")
+
+	if err := e.DeployCRDs(ctx); err != nil {
+		return err
+	}
+	if err := e.EnsureAteSystemNamespace(ctx); err != nil {
+		return err
+	}
+	if err := e.applyOtelConfig(ctx); err != nil {
+		return err
+	}
+	if err := e.KoApply(ctx, e.Cfg.Manifest("ate-controller.yaml")); err != nil {
+		return err
+	}
+	return e.Kube.RolloutStatus(ctx, kube.KindDeployment, NamespaceAteSystem, "ate-controller", e.Cfg.RolloutTimeout)
+}
+
 // DeployAtelet redeploys only the atelet DaemonSet.
 func (e *Env) DeployAtelet(ctx context.Context) error {
 	log.Step("deploy_atelet")


### PR DESCRIPTION
We should have a subcommand for ate-controller too, this is also useful for upgrade.

Part of #1272

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
