### PR TITLE
ate-setup: restore the build that publish and the image resolver broke

### DIFF
--- a/cmd/ate-setup/internal/steps/env.go
+++ b/cmd/ate-setup/internal/steps/env.go
@@ -104,6 +104,27 @@ func (e *Env) imageResolver() (imageResolver, error) {
 	return e.resolver, nil
 }
 
+// koRunner returns the resolver as the ko runner it is, for the steps that
+// build an image rather than only resolve a reference to one. Building is not
+// part of imageResolver because the pre-built resolver cannot do it:
+// --image-repo names images someone else published, and the tag it installs
+// need not correspond to anything in this checkout.
+func (e *Env) koRunner() (*ko.Runner, error) {
+	if e.Cfg.Images.IsPrebuilt() {
+		return nil, fmt.Errorf("publishing images builds them from source, which --image-repo does not do; " +
+			"drop it to build and push from this checkout")
+	}
+	resolver, err := e.imageResolver()
+	if err != nil {
+		return nil, err
+	}
+	runner, ok := resolver.(*ko.Runner)
+	if !ok {
+		return nil, fmt.Errorf("image resolver is %T, not a ko runner", resolver)
+	}
+	return runner, nil
+}
+
 // ResolveAndApply resolves the images in a manifest path and applies the
 // result. This is the run_ko apply of the shell scripts, split into its two
 // real steps.

--- a/cmd/ate-setup/internal/steps/publish.go
+++ b/cmd/ate-setup/internal/steps/publish.go
@@ -38,7 +38,7 @@ func (e *Env) PublishWorkerImages(ctx context.Context, w io.Writer) error {
 		return err
 	}
 	log.Stepf("publish_worker_images (%s)", version)
-	runner, err := e.Ko()
+	runner, err := e.koRunner()
 	if err != nil {
 		return err
 	}

--- a/cmd/ate-setup/internal/steps/publish_test.go
+++ b/cmd/ate-setup/internal/steps/publish_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agent-substrate/substrate/cmd/ate-setup/internal/config"
+	"github.com/agent-substrate/substrate/cmd/ate-setup/internal/images"
+)
+
+// TestKoRunnerPrebuilt covers the one resolver that cannot build. A pre-built
+// install has no ko runner behind imageResolver, so a step that needs to build
+// has to say so rather than dereference what is not there.
+func TestKoRunnerPrebuilt(t *testing.T) {
+	e := &Env{Cfg: &config.Config{
+		Root:   t.TempDir(),
+		Images: images.Source{Repo: "example.com/substrate", Tag: "v1.2.3"},
+	}}
+
+	runner, err := e.koRunner()
+	if err == nil {
+		t.Fatalf("koRunner() = %v, nil; want an error under --image-repo", runner)
+	}
+	// The message has to name the flag: it is the thing the caller passed and
+	// the thing they have to drop.
+	if !strings.Contains(err.Error(), "--image-repo") {
+		t.Errorf("koRunner() error = %q; want it to name --image-repo", err)
+	}
+}


### PR DESCRIPTION
`main` does not compile at `ea3bdc32`:

```
cmd/ate-setup/internal/steps/publish.go:41:19: e.Ko undefined (type *Env has no field or method Ko)
```

Postsubmit `run-tests` and `govulncheck` are both red, and every package under
`cmd/ate-setup/...` fails to build.

### How it happened

6101fe4 added `steps/publish.go`, which calls `Env.Ko()` to get a runner to
build with. ea3bdc3 replaced `Env.Ko()` with `Env.imageResolver()`, returning
an interface that the pre-built resolver can satisfy too. Both branched from
`8968cb09` and merged twenty minutes apart. The files do not overlap, so there
was no textual conflict, and neither branch ever contained the other's change —
both were legitimately green.

### The fix

`PublishWorkerImages` needs to *build*, which `imageResolver` deliberately
cannot do: `--image-repo` installs images someone else published, and its tag
need not correspond to anything in this checkout. So building gets its own
accessor, `koRunner`, which asserts the resolver back to `*ko.Runner` and
returns a clear error under `--image-repo` rather than a nil dereference.

### Worth a follow-up

`strict_required_status_checks_policy` is `false` on this repo, so a branch is
not required to be up to date with `main` before merging. Turning it on would
have caught this pre-merge, and will catch the next one.

Verified on Linux: `go build ./...` clean, `go test ./cmd/ate-setup/...` green.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
