### PR TITLE
ate-setup: widen digest-lookup auth and pass through pinned tags

### DIFF
--- a/cmd/ate-setup/commands.md
+++ b/cmd/ate-setup/commands.md
@@ -60,6 +60,16 @@ Each reference is then pinned to the digest its tag names, which takes one HEAD
 request per image, so the installer needs read access to `REPO` and not only the
 cluster does.
 
+That read is authenticated with the docker config file and the credential
+helpers it names, plus gcloud's own credentials for GCR and Artifact Registry:
+Application Default Credentials, falling back to the `gcloud` CLI. Installing a
+release onto GKE therefore needs no `~/.docker/config.json` entry. Amazon ECR
+and Azure Container Registry need credential-helper modules this repository does
+not depend on, so those registries need a `docker login` first.
+
+`TAG` may itself carry a digest, as in `--image-tag v0.0.0@sha256:...`. A tag
+that already names a manifest is used as written, and is not looked up.
+
 ## Deploy
 
 | `ate-setup` | `hack/install-ate.sh` |

--- a/cmd/ate-setup/internal/images/digest.go
+++ b/cmd/ate-setup/internal/images/digest.go
@@ -20,8 +20,20 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
+
+// keychain authenticates the digest lookups.
+//
+// The docker config file and the credential helpers it names, plus GCP. ko
+// resolves credentials through a multi-keychain of its own, and matching the
+// GCP half of it matters: a user whose Artifact Registry credentials are
+// gcloud's rather than a helper wired into ~/.docker/config.json would
+// otherwise get a working build from source and a 401 from --image-repo. ECR
+// and ACR need credential-helper modules this repository does not depend on,
+// so those registries need a docker login.
+var keychain = authn.NewMultiKeychain(authn.DefaultKeychain, google.Keychain)
 
 // Digester resolves a tagged image reference to the digest its tag currently
 // names, in "sha256:..." form. Prebuilt takes one so tests can rewrite
@@ -30,10 +42,8 @@ type Digester func(ctx context.Context, ref string) (string, error)
 
 // RemoteDigest asks ref's registry which manifest the tag names.
 //
-// One HEAD request per image, needing only read access, and authenticated the
-// way docker and ko are: from the docker config file and the credential helpers
-// it names. A localhost registry is contacted over plain HTTP, which is what
-// the Kind local registry serves.
+// One HEAD request per image, needing only read access. A localhost registry is
+// contacted over plain HTTP, which is what the Kind local registry serves.
 func RemoteDigest(ctx context.Context, ref string) (string, error) {
 	parsed, err := name.ParseReference(ref)
 	if err != nil {
@@ -41,7 +51,7 @@ func RemoteDigest(ctx context.Context, ref string) (string, error) {
 	}
 	desc, err := remote.Head(parsed,
 		remote.WithContext(ctx),
-		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+		remote.WithAuthFromKeychain(keychain),
 	)
 	if err != nil {
 		return "", fmt.Errorf("resolving %s to a digest: %w", ref, err)

--- a/cmd/ate-setup/internal/images/prebuilt.go
+++ b/cmd/ate-setup/internal/images/prebuilt.go
@@ -98,6 +98,12 @@ func (p *Prebuilt) ResolveBytes(ctx context.Context, manifest []byte) ([]byte, e
 // and leaves the reference legible in `kubectl get`.
 func (p *Prebuilt) pin(ctx context.Context, image string) (string, error) {
 	tagged := p.src.Repo + "/" + image + ":" + p.src.Tag
+	// A tag that already carries one is pinned as it stands. Looking it up
+	// would only append the same digest a second time, and the reference the
+	// caller wrote is the one they meant.
+	if strings.Contains(p.src.Tag, "@") {
+		return tagged, nil
+	}
 	if ref, ok := p.pinned[tagged]; ok {
 		return ref, nil
 	}

--- a/cmd/ate-setup/internal/images/prebuilt_test.go
+++ b/cmd/ate-setup/internal/images/prebuilt_test.go
@@ -94,6 +94,15 @@ func TestPrebuiltResolveBytes(t *testing.T) {
 			want: "spec:\n  workerImage: example.com/substrate/ateom-gvisor:v1.2.3" + digestSuffix + "\n",
 		},
 		{
+			// A tag can carry its own digest, and then there is nothing to look
+			// up. The stub would answer with testDigest a second time, so the
+			// expected output is also what catches a redundant lookup.
+			name: "tag already carries a digest",
+			src:  images.Source{Repo: "example.com/substrate", Tag: "v1.2.3" + digestSuffix},
+			in:   "image: ko://github.com/agent-substrate/substrate/cmd/ateapi\n",
+			want: "image: example.com/substrate/ateapi:v1.2.3" + digestSuffix + "\n",
+		},
+		{
 			name: "nested package maps to its image name",
 			in:   "image: ko://github.com/agent-substrate/substrate/demos/multi-template/fspersist\n",
 			want: "image: example.com/substrate/fspersist:v1.2.3" + digestSuffix + "\n",


### PR DESCRIPTION
Two follow-ups to the pre-built image install.

Digest lookups authenticated with the docker config file alone. Someone
installing a published release onto GKE, whose Artifact Registry credentials are
gcloud's rather than a credential helper wired into `~/.docker/config.json`, got
a working build from source and a 401 from `--image-repo`. The lookup keychain is
now `authn.NewMultiKeychain(authn.DefaultKeychain, google.Keychain)`, the same
relative order ko uses. `DefaultKeychain` stays first, so `~/.docker/config.json`
still wins wherever it has an entry, and `google.Keychain` returns `Anonymous`
immediately for any non-Google registry, so this is a no-op for Docker Hub, ghcr,
ECR, ACR and the Kind local registry. ECR and ACR would need credential-helper
modules this repository does not depend on, so those still need a `docker login`;
the doc comment no longer claims the lookup authenticates the way ko does.

Separately, `pin` appended the looked-up digest unconditionally, so
`--image-tag v1@sha256:...` produced `<repo>/<image>:v1@sha256:...@sha256:...`,
which no registry can parse. A tag that already carries a digest now passes
through as written.

No dependency change: `pkg/v1/google` was already vendored, and `atelet` already
uses the same package for its image pulls.

Verified against Artifact Registry with `DOCKER_CONFIG` pointed at an empty
directory, which reproduces the affected setup — without this change the lookup
fails with `DENIED: Unauthenticated request`, with it the tag resolves. Also
installed on a Kind cluster from a local registry, where all five control-plane
images came up pinned to the digests the registry published.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
