### PR TITLE
ate-setup: take the prebuilt version from the tag without its digest

### DIFF
--- a/cmd/ate-setup/internal/steps/version.go
+++ b/cmd/ate-setup/internal/steps/version.go
@@ -48,7 +48,9 @@ func (e *Env) SubstrateVersion() (version, suffix string, err error) {
 	if e.Cfg.Images.IsPrebuilt() {
 		raw = os.Getenv("VERSION")
 		if raw == "" {
-			raw = e.Cfg.Images.Tag
+			// The tag may carry its digest (v1@sha256:...); the version
+			// is the tag alone.
+			raw, _, _ = strings.Cut(e.Cfg.Images.Tag, "@")
 		}
 	} else {
 		// ko.BuildVersion consults VERSION itself before `git describe`.

--- a/cmd/ate-setup/internal/steps/version_test.go
+++ b/cmd/ate-setup/internal/steps/version_test.go
@@ -38,6 +38,11 @@ func TestSubstrateVersionPrebuilt(t *testing.T) {
 		want:       "v0.0.0-503-4b3423c0",
 		wantSuffix: "v0-0-0-503-4b3423c0",
 	}, {
+		name:       "a tag carrying its digest is the version without it",
+		source:     images.Source{Repo: "example.com/substrate", Tag: "v0.0.0@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+		want:       "v0.0.0",
+		wantSuffix: "v0-0-0",
+	}, {
 		name:       "built from source falls back to git",
 		source:     images.Source{},
 		want:       "dev",


### PR DESCRIPTION
With --image-repo the image tag becomes the substrate version, which names the atelet DaemonSet and the node label. A tag written with its digest, v1@sha256:..., is a valid image reference but not a valid label value, so the install failed at the atelet step unless VERSION was also set. The version is now the tag alone; the digest still pins the image.

Followup for #1391


- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
