### PR TITLE
Update gVisor to the 2026-09-02 nightly and switch to zstd tarballs

### DIFF
--- a/cmd/atelet/sandbox_assets.go
+++ b/cmd/atelet/sandbox_assets.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	gzip "github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/zstd"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -53,7 +54,7 @@ const sandboxManifestName = "manifest.json"
 var maxAssetBytes int64 = 8 << 30
 
 const (
-	// gvisorAssetName is the gVisor release tarball asset (gvisor.tar.bz2). The
+	// gvisorAssetName is the gVisor release tarball asset (gvisor.tar.zstd). The
 	// tarball carries `runsc` together with the `gvisor-bin/` helper binaries,
 	// so it is extracted into a content-addressed directory rather than as a
 	// single file.
@@ -204,7 +205,7 @@ func (s *AteomHerder) fetchAsset(ctx context.Context, entry assetEntry) (string,
 	return localPath, nil
 }
 
-// fetchGVisorRelease downloads the gVisor release tarball (gvisor.tar.bz2,
+// fetchGVisorRelease downloads the gVisor release tarball (gvisor.tar.zstd,
 // verifying its sha256) and extracts it into a content-addressed directory in
 // the shared static-files cache, returning the local path of the extracted
 // `runsc` binary.
@@ -320,19 +321,21 @@ func (s *AteomHerder) downloadVerified(ctx context.Context, entry assetEntry, tm
 }
 
 // extractTarArchive decompresses and extracts the tarball file at tarPath into
-// destDir. It dynamically selects the decompression format (gzip, bzip2, or none)
-// based on the suffix of urlPath. If ctx is canceled, extraction will stop
-// early and return an error.
+// destDir. It dynamically selects the decompression format (gzip, bzip2, zstd,
+// or none) based on the suffix of urlPath. If ctx is canceled, extraction will
+// stop early and return an error.
 func extractTarArchive(ctx context.Context, tarPath, urlPath, destDir string) error {
-	var isGz, isBz, isTar bool
+	var isGz, isBz, isZst, isTar bool
 	if strings.HasSuffix(urlPath, ".tar.gz") || strings.HasSuffix(urlPath, ".tgz") {
 		isGz = true
 	} else if strings.HasSuffix(urlPath, ".tar.bz2") || strings.HasSuffix(urlPath, ".tbz2") {
 		isBz = true
+	} else if strings.HasSuffix(urlPath, ".tar.zst") || strings.HasSuffix(urlPath, ".tar.zstd") {
+		isZst = true
 	} else if strings.HasSuffix(urlPath, ".tar") {
 		isTar = true
 	} else {
-		return fmt.Errorf("%w: unsupported archive format for URL %s (must be .tar.gz, .tgz, .tar.bz2, .tbz2, or .tar)", ateerrors.ReasonInvalidSandboxAsset, urlPath)
+		return fmt.Errorf("%w: unsupported archive format for URL %s (must be .tar.gz, .tgz, .tar.bz2, .tbz2, .tar.zst, .tar.zstd, or .tar)", ateerrors.ReasonInvalidSandboxAsset, urlPath)
 	}
 
 	f, err := os.Open(tarPath)
@@ -353,6 +356,13 @@ func extractTarArchive(ctx context.Context, tarPath, urlPath, destDir string) er
 		r = gzr
 	} else if isBz {
 		r = bzip2.NewReader(buf)
+	} else if isZst {
+		zr, err := zstd.NewReader(buf)
+		if err != nil {
+			return fmt.Errorf("%w: failed to create zstd reader for %s: %w", ateerrors.ReasonInvalidSandboxAsset, urlPath, err)
+		}
+		defer zr.Close()
+		r = zr
 	} else if isTar {
 		r = buf
 	}

--- a/cmd/atelet/sandbox_assets_test.go
+++ b/cmd/atelet/sandbox_assets_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 func TestExtractTarArchive(t *testing.T) {
@@ -53,6 +55,24 @@ func TestExtractTarArchive(t *testing.T) {
 			name:      ".tar.bz2 format",
 			url:       "https://example.com/gvisor.tar.bz2",
 			compress:  nil,
+			wantError: false,
+		},
+		{
+			name: ".tar.zst format",
+			url:  "https://example.com/gvisor.tar.zst",
+			compress: func(w io.Writer) io.WriteCloser {
+				zw, _ := zstd.NewWriter(w) // no options, cannot fail
+				return zw
+			},
+			wantError: false,
+		},
+		{
+			name: ".tar.zstd format",
+			url:  "https://example.com/gvisor.tar.zstd",
+			compress: func(w io.Writer) io.WriteCloser {
+				zw, _ := zstd.NewWriter(w) // no options, cannot fail
+				return zw
+			},
 			wantError: false,
 		},
 		{

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -409,7 +409,7 @@ This means a single, cluster-managed config pins the sandbox runtime version for
 | `sandboxClass` | `string` | **Required.** Runtime family this config applies to: `gvisor` (default) or `microvm`. A `WorkerPool` only uses `SandboxConfig`s whose `sandboxClass` matches its own. |
 | `pauseImage` | `string` | **Required.** The image for the sandbox's root container (e.g. `registry.k8s.io/pause`, or `gcr.io/gke-release/pause` on GKE). Must be pinned by digest (`...@sha256:...`) — it is recorded in each snapshot's manifest so a restore rebuilds the sandbox from the same image. |
 | `default` | `bool` | Optional. Marks this as the cluster default for its `sandboxClass`. A `WorkerPool` with no `sandboxConfigName` resolves to the default for its class. At most one default per class. |
-| `assets` | `map[arch]map[name]AssetFile` | Optional. Content-addressed files atelet fetches, keyed by architecture (`amd64`, `arm64`) then asset name. gVisor expects a `gvisor` asset (the release's `gvisor.tar.bz2`), which atelet auto-extracts. A micro-VM backend expects several. Each `AssetFile` is a `{ url, sha256 }` pair. |
+| `assets` | `map[arch]map[name]AssetFile` | Optional. Content-addressed files atelet fetches, keyed by architecture (`amd64`, `arm64`) then asset name. gVisor expects a `gvisor` asset (the release's `gvisor.tar.zstd`), which atelet auto-extracts. A micro-VM backend expects several. Each `AssetFile` is a `{ url, sha256 }` pair. |
 
 A default cluster-wide gVisor `SandboxConfig` (`gvisor-default`) is installed with the platform, so gVisor pools work out of the box.
 
@@ -427,12 +427,12 @@ spec:
   assets:
     amd64:
       gvisor:
-        url: "gs://gvisor/releases/nightly/2026-08-28/x86_64/gvisor.tar.bz2"
-        sha256: "97f83fa5f352f2c6337d792b1c23c4e73a9c47529c08f6531029f8e0722cfe2c"
+        url: "gs://gvisor/releases/nightly/2026-09-02/x86_64/gvisor.tar.zstd"
+        sha256: "d547d81401461fd1c679c5c4fa0a6c2b8ef7dc3c22ce23c9e25dcc4c69cfd06f"
     arm64:
       gvisor:
-        url: "gs://gvisor/releases/nightly/2026-08-28/aarch64/gvisor.tar.bz2"
-        sha256: "561e281b7f8af95205b1df140c453a795a7fbc0db348c63b305e6521350734ef"
+        url: "gs://gvisor/releases/nightly/2026-09-02/aarch64/gvisor.tar.zstd"
+        sha256: "a64916f9813ce7e4841a30480a599337f7dda07b421c6bf0123db2212aa7d1df"
 ```
 
 ### Micro-VM SandboxConfig

--- a/manifests/ate-install/generated/ate.dev_sandboxconfigs.yaml
+++ b/manifests/ate-install/generated/ate.dev_sandboxconfigs.yaml
@@ -97,7 +97,7 @@ spec:
                   Assets is the set of files atelet fetches for this runtime, keyed first by
                   architecture (GOARCH, e.g. "amd64", "arm64") and then by asset name. The
                   asset names are interpreted by the sandbox backend: gVisor expects a
-                  "gvisor" asset (the release's gvisor.tar.bz2, which atelet extracts so
+                  "gvisor" asset (the release's gvisor.tar.zstd, which atelet extracts so
                   the gvisor-bin/ helpers sit next to runsc; a legacy bare-binary "runsc"
                   asset is still accepted); a micro-VM backend expects several (e.g.
                   "cloud-hypervisor", "kata-kernel", "kata-image"). The schema is

--- a/manifests/ate-install/sandboxconfig-gvisor.yaml
+++ b/manifests/ate-install/sandboxconfig-gvisor.yaml
@@ -15,7 +15,7 @@
 # Cluster-wide default SandboxConfig for the gVisor (runsc) sandbox class. A
 # WorkerPool with sandboxClass gvisor (the default) and no explicit
 # sandboxConfigName resolves to this. atelet fetches the gVisor release tarball
-# (gvisor.tar.bz2: runsc plus the gvisor-bin/ helpers runsc requires next to
+# (gvisor.tar.zstd: runsc plus the gvisor-bin/ helpers runsc requires next to
 # it) matching the worker node's architecture and extracts it locally. To pin a
 # different release, edit the assets below or create another SandboxConfig and
 # name it from the WorkerPool.
@@ -32,9 +32,9 @@ spec:
   assets:
     amd64:
       gvisor:
-        url: "gs://gvisor/releases/nightly/2026-08-28/x86_64/gvisor.tar.bz2"
-        sha256: "97f83fa5f352f2c6337d792b1c23c4e73a9c47529c08f6531029f8e0722cfe2c"
+        url: "gs://gvisor/releases/nightly/2026-09-02/x86_64/gvisor.tar.zstd"
+        sha256: "d547d81401461fd1c679c5c4fa0a6c2b8ef7dc3c22ce23c9e25dcc4c69cfd06f"
     arm64:
       gvisor:
-        url: "gs://gvisor/releases/nightly/2026-08-28/aarch64/gvisor.tar.bz2"
-        sha256: "561e281b7f8af95205b1df140c453a795a7fbc0db348c63b305e6521350734ef"
+        url: "gs://gvisor/releases/nightly/2026-09-02/aarch64/gvisor.tar.zstd"
+        sha256: "a64916f9813ce7e4841a30480a599337f7dda07b421c6bf0123db2212aa7d1df"

--- a/manifests/ate-install/sandboxconfig-validation.yaml
+++ b/manifests/ate-install/sandboxconfig-validation.yaml
@@ -29,7 +29,7 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["sandboxconfigs"]
   validations:
-  # gVisor needs a "gvisor" release-tarball asset (gvisor.tar.bz2: runsc plus
+  # gVisor needs a "gvisor" release-tarball asset (gvisor.tar.zstd: runsc plus
   # its gvisor-bin/ helpers) for every architecture it advertises. A legacy
   # bare-binary "runsc" asset is still accepted for releases that predate the
   # tarball.

--- a/pkg/api/v1alpha1/sandboxconfig_types.go
+++ b/pkg/api/v1alpha1/sandboxconfig_types.go
@@ -86,7 +86,7 @@ type SandboxConfigSpec struct {
 	// Assets is the set of files atelet fetches for this runtime, keyed first by
 	// architecture (GOARCH, e.g. "amd64", "arm64") and then by asset name. The
 	// asset names are interpreted by the sandbox backend: gVisor expects a
-	// "gvisor" asset (the release's gvisor.tar.bz2, which atelet extracts so
+	// "gvisor" asset (the release's gvisor.tar.zstd, which atelet extracts so
 	// the gvisor-bin/ helpers sit next to runsc; a legacy bare-binary "runsc"
 	// asset is still accepted); a micro-VM backend expects several (e.g.
 	// "cloud-hypervisor", "kata-kernel", "kata-image"). The schema is


### PR DESCRIPTION
## Summary

Improves the cold-node activation performance tracked in #811: the gVisor release extract on a cold node currently exceeds the router resume budget, so the first resume after a release bump always fails.

- Point the default gvisor SandboxConfig at the 2026-09-02 nightly, using the `gvisor.tar.zstd` tarballs the nightlies now publish alongside `gvisor.tar.bz2`. The win is decode speed, not just download size: stdlib bzip2 is a pure-Go, single-threaded decoder, and extracting the ~165 MB release costs a node roughly 20 seconds of CPU on the first actor operation it hosts — the dominant term of a cold-node activation. With zstd the same extraction takes ~2.9 s, measured on a GKE node running this change. The tarball is also ~22% smaller to download (129 MB vs 166 MB for x86_64).
- Teach `extractTarArchive` to decompress `.tar.zst` / `.tar.zstd` archives using `github.com/klauspost/compress/zstd` (already a dependency via ategcs), with test coverage for both suffixes.
- Update the `gvisor.tar.bz2` mentions in docs, manifests comments, and the SandboxConfig API comment (generated CRD refreshed via `hack/update/codegen.sh`).

The bucket only publishes sha512 checksums; the pinned sha256 sums were computed from downloads verified against the published sha512 sums.

## Test plan

- `go test ./cmd/atelet/` (includes new `.tar.zst` / `.tar.zstd` extraction cases)
- `go build ./cmd/atelet/...`, `go vet`, `gofmt` clean
- Verified the real x86_64 tarball lists `runsc` plus the `gvisor-bin/` helpers
- Deployed to a GKE cluster: atelet fetched and extracted the 2026-09-02 x86_64 zstd tarball in ~2.9 s (vs ~20 s for bz2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)