### PR TITLE
setup-gcp: enable artifactregistry.googleapis.com in bootstrap

### DIFF
--- a/tools/setup-gcp/cmd/api.go
+++ b/tools/setup-gcp/cmd/api.go
@@ -32,6 +32,7 @@ func enableRequiredAPIs(ctx context.Context, cfg *Config) error {
 	defer suClient.Close()
 
 	services := []string{
+		"artifactregistry.googleapis.com",
 		"cloudresourcemanager.googleapis.com",
 		"container.googleapis.com",
 		"networkconnectivity.googleapis.com",


### PR DESCRIPTION
Bootstrap grants `roles/artifactregistry.reader` to the GKE node service account and the atelet workload-identity principal, and ko pushes the control-plane images through gcr.io's Artifact Registry backing — but `enableRequiredAPIs` never enabled `artifactregistry.googleapis.com`, so a fresh project failed at image push/pull instead of step 1.