### PR TITLE
test: drop the stale Volume.Type assertion from the counter demo test

### DIFF
--- a/cmd/ate-setup/internal/demos/counter/counter_test.go
+++ b/cmd/ate-setup/internal/demos/counter/counter_test.go
@@ -58,7 +58,6 @@ func TestExternalVolumeRenders(t *testing.T) {
 			for _, want := range []string{
 				"--validate-existing-file-path=/external-data/test.txt",
 				"mountPath: /external-data",
-				"type: ExternalVolumeTemplate",
 				"externalVolumeTemplate:",
 				tc.wantSC,
 			} {

--- a/docs/csi-volumes.md
+++ b/docs/csi-volumes.md
@@ -184,7 +184,6 @@ snapshotsConfig:
   storageLocation: gs://my-snapshots-bucket/stateful-agent
 volumes:
 - name: shared-storage
-  type: ExternalVolumeTemplate
   externalVolumeTemplate:
     capacity: 5Gi
     storageClassName: csi-nfs-sc


### PR DESCRIPTION
#1398 removed the Volume.Type union discriminator, but #1008's counter demo test still asserts the rendered manifest contains `type: ExternalVolumeTemplate`, so run-tests fails on every main push since both landed. Also drops the same stale line from the csi-volumes.md example.