### PR TITLE
docs: add kagent to ecosystem examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Agent Substrate is designed to be **framework and agent harness agnostic**. Beca
 ## Ecosystem & Examples
 
 *   **[Agent Executor](https://github.com/google/ax):** A distributed agent runtime that demonstrates building a secure, hyper-scalable agent harness on Agent Substrate (see the [announcement blog](https://cloud.google.com/blog/products/ai-machine-learning/agent-executor-googles-distributed-agent-runtime) and [integration guide](https://github.com/google/ax/blob/main/manifests/README.md)).
-*   **[kagent](https://github.com/kagent-dev/kagent):** A Kubernetes-native framework for building, deploying, and managing AI agents that uses Agent Substrate to run sandboxed, stateful agent workloads (see the [announcement blog](https://kagent.dev/blog/the-future-of-kagent)).
+*   **[kagent](https://github.com/kagent-dev/kagent):** A CNCF Sandbox project and Kubernetes-native framework for building, deploying, and managing AI agents that uses Agent Substrate to run sandboxed, stateful agent workloads (see the [announcement blog](https://kagent.dev/blog/the-future-of-kagent)).
 
 ## Status and compatibility
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Agent Substrate is designed to be **framework and agent harness agnostic**. Beca
 ## Ecosystem & Examples
 
 *   **[Agent Executor](https://github.com/google/ax):** A distributed agent runtime that demonstrates building a secure, hyper-scalable agent harness on Agent Substrate (see the [announcement blog](https://cloud.google.com/blog/products/ai-machine-learning/agent-executor-googles-distributed-agent-runtime) and [integration guide](https://github.com/google/ax/blob/main/manifests/README.md)).
+*   **[kagent](https://github.com/kagent-dev/kagent):** A Kubernetes-native framework for building, deploying, and managing AI agents that uses Agent Substrate to run sandboxed, stateful agent workloads (see the [announcement blog](https://kagent.dev/blog/the-future-of-kagent)).
 
 ## Status and compatibility
 


### PR DESCRIPTION
## Summary

  Adds [kagent](https://github.com/kagent-dev/kagent) to our ecosystem examples, celebrating
  its adoption of Agent Substrate for sandboxed, stateful agent workloads.

  Read the [announcement](https://kagent.dev/blog/the-future-of-kagent) 🎉