### PR TITLE
atelet: retry transient GCS errors on snapshot uploads

### DIFF
--- a/cmd/atelet/internal/ategcs/gcs.go
+++ b/cmd/atelet/internal/ategcs/gcs.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
 )
 
@@ -38,10 +40,35 @@ type gcsClient struct {
 	pool     []*storage.Client
 }
 
-// NewGCSClient wraps client. opts must be the options client was built with;
-// the pool of extra connections is built from them.
-func NewGCSClient(client *storage.Client, opts ...option.ClientOption) ObjectStorage {
-	return &gcsClient{client: client, opts: opts}
+// NewGCSClient returns a GCS-backed ObjectStorage. It builds its own
+// storage.Client from opts (and more from the same opts for the part-upload
+// pool, see uploadClient) rather than accepting one, because it installs a
+// RetryAlways policy (see setRetry) that is only safe for this package's own
+// operations and must not leak onto a client shared with other code.
+func NewGCSClient(ctx context.Context, opts ...option.ClientOption) (ObjectStorage, error) {
+	client, err := storage.NewClient(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	setRetry(client)
+	return &gcsClient{client: client, opts: opts}, nil
+}
+
+// setRetry makes every operation on c retry transient errors (408, 429, 5xx)
+// with backoff. The client's default RetryIdempotent policy never retries an
+// object write without a precondition, so a single 429 — routine while GCS
+// scales a cold bucket's key ranges up to a suspend burst — failed the whole
+// snapshot. RetryAlways is safe for this client because every write targets a
+// unique name (snapshot UUID directories, runID-suffixed part names) or is
+// idempotent (compose and copy from fixed sources, delete).
+func setRetry(c *storage.Client) {
+	c.SetRetry(
+		storage.WithPolicy(storage.RetryAlways),
+		// Suspend is latency-sensitive, so bound the worst case: at most 5
+		// attempts, under 5s of backoff sleep in total (250ms+500ms+1s+2s).
+		storage.WithBackoff(gax.Backoff{Initial: 250 * time.Millisecond, Max: 2 * time.Second, Multiplier: 2}),
+		storage.WithMaxAttempts(5),
+	)
 }
 
 // supportsStreamingPut is the streamingPutter marker: the GCS client's PutObject

--- a/cmd/atelet/internal/ategcs/gcs_retry_test.go
+++ b/cmd/atelet/internal/ategcs/gcs_retry_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ategcs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// A transient 429 on an upload must be retried, not surfaced: GCS sheds write
+// bursts with rateLimitExceeded while it scales a bucket's key ranges, and the
+// default client policy (RetryIdempotent) would fail the whole snapshot on the
+// first one because plain object writes carry no precondition.
+func TestPutObjectRetriesTransient429(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		attempts int
+		srvURL   string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/upload/"):
+			mu.Lock()
+			attempts++
+			n := attempts
+			mu.Unlock()
+			if n == 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				fmt.Fprint(w, `{"error":{"code":429,"message":"Your request distribution is too uneven across the key-ranges in your bucket.","errors":[{"reason":"rateLimitExceeded"}]}}`)
+				return
+			}
+			_, _ = io.Copy(io.Discard, r.Body)
+			if r.URL.Query().Get("uploadType") == "resumable" {
+				// Resumable initiation: hand back a session for the chunk PUTs.
+				w.Header().Set("Location", srvURL+"/upload-session")
+				return
+			}
+			// Single-shot multipart upload: done in one request.
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"name":"snap/pages.img.zstd","bucket":"snapshots"}`)
+		case r.URL.Path == "/upload-session":
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"name":"snap/pages.img.zstd","bucket":"snapshots"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	// The storage client routes everything, uploads included, at the emulator.
+	t.Setenv("STORAGE_EMULATOR_HOST", srv.URL)
+	ctx := context.Background()
+	store, err := NewGCSClient(ctx)
+	if err != nil {
+		t.Fatalf("storage client: %v", err)
+	}
+	defer store.(*gcsClient).client.Close()
+
+	if err := store.PutObject(ctx, "snapshots", "snap/pages.img.zstd", strings.NewReader("payload")); err != nil {
+		t.Fatalf("PutObject after a transient 429: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts != 2 {
+		t.Fatalf("upload attempts = %d, want 2 (one 429, one retry)", attempts)
+	}
+}

--- a/cmd/atelet/internal/ategcs/gcscompose.go
+++ b/cmd/atelet/internal/ategcs/gcscompose.go
@@ -45,6 +45,7 @@ func (g *gcsClient) uploadClient(ctx context.Context, i int) *storage.Client {
 				slog.WarnContext(ctx, "Falling back to one client for part uploads", slog.Any("err", err))
 				return
 			}
+			setRetry(c)
 			g.pool = append(g.pool, c)
 		}
 	})

--- a/cmd/atelet/internal/ategcs/gcspool_test.go
+++ b/cmd/atelet/internal/ategcs/gcspool_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"cloud.google.com/go/storage"
 	"google.golang.org/api/option"
 )
 
@@ -36,16 +35,16 @@ func TestPooledClientsAreBuiltLikeTheClientTheyStandIn(t *testing.T) {
 	t.Setenv("GCE_METADATA_HOST", "127.0.0.1:1")
 
 	ctx := context.Background()
-	anon, err := storage.NewClient(ctx, option.WithoutAuthentication())
+	store, err := NewGCSClient(ctx, option.WithoutAuthentication())
 	if err != nil {
 		t.Fatalf("an anonymous client must build without credentials: %v", err)
 	}
-	defer anon.Close()
 
-	g, ok := NewGCSClient(anon, option.WithoutAuthentication()).(*gcsClient)
+	g, ok := store.(*gcsClient)
 	if !ok {
 		t.Fatal("NewGCSClient did not return a *gcsClient")
 	}
+	defer g.client.Close()
 
 	pooled := g.uploadClient(ctx, 0)
 	if pooled == nil {

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -35,7 +35,6 @@ import (
 
 	"sync"
 
-	"cloud.google.com/go/storage"
 	"github.com/agent-substrate/substrate/cmd/atelet/internal/ategcs"
 	"github.com/agent-substrate/substrate/internal/ateapiauth"
 	"github.com/agent-substrate/substrate/internal/ateattr"
@@ -213,13 +212,12 @@ func main() {
 		go newImageCacheGC(imageCache, *imageCacheDir).Run(ctx)
 	}
 
-	anonGCSClient, err := storage.NewClient(ctx, option.WithoutAuthentication())
+	wrappedAnonGCS, err := ategcs.NewGCSClient(ctx, option.WithoutAuthentication())
 	if err != nil {
 		serverboot.Fatal(ctx, "Failed to create anonymous GCS client", err)
 	}
 
-	var gcsClient *storage.Client
-	var s3Client *s3.Client
+	var wrappedGCS ategcs.ObjectStorage
 	storageBackend := os.Getenv("ATE_STORAGE_BACKEND")
 	switch storageBackend {
 	case "s3":
@@ -230,29 +228,17 @@ func main() {
 		if err != nil {
 			serverboot.Fatal(ctx, "Failed to load S3 config", err)
 		}
-		s3Client = s3.NewFromConfig(cfg, func(o *s3.Options) {
+		wrappedGCS = ategcs.NewS3Client(s3.NewFromConfig(cfg, func(o *s3.Options) {
 			if usePathStyle := os.Getenv("AWS_S3_USE_PATH_STYLE"); usePathStyle == "true" {
 				o.UsePathStyle = true
 			}
-		})
+		}))
 	// GCS is currently the default, TODO: we assume workload identity / ADC
 	default:
-		gcsClient, err = storage.NewClient(ctx)
+		wrappedGCS, err = ategcs.NewGCSClient(ctx)
 		if err != nil {
 			serverboot.Fatal(ctx, "Failed to create GCS client", err)
 		}
-	}
-
-	var wrappedAnonGCS ategcs.ObjectStorage
-	if anonGCSClient != nil {
-		wrappedAnonGCS = ategcs.NewGCSClient(anonGCSClient, option.WithoutAuthentication())
-	}
-
-	var wrappedGCS ategcs.ObjectStorage
-	if s3Client != nil {
-		wrappedGCS = ategcs.NewS3Client(s3Client)
-	} else if gcsClient != nil {
-		wrappedGCS = ategcs.NewGCSClient(gcsClient)
 	}
 
 	volPlugins := make(map[string]volume.VolumePluginWorkerPlane)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/nftables v0.3.0
 	github.com/google/uuid v1.6.0
+	github.com/googleapis/gax-go/v2 v2.21.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/klauspost/compress v1.19.0
@@ -143,7 +144,6 @@ require (
 	github.com/google/pprof v0.0.0-20250602020802-c6617b811d0e // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
-	github.com/googleapis/gax-go/v2 v2.21.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect


### PR DESCRIPTION
Under a suspend load burst, GCS sheds writes with 429 rateLimitExceeded ("request distribution is too uneven across the key-ranges") while it scales a cold bucket's key ranges up to the offered rate. The storage client's default RetryIdempotent policy never retries an object write that carries no precondition, so a single transient 429 on pages.img propagated straight to FAILED_SAVE_SNAPSHOT and failed the suspend. In a load test this showed up as hundreds of failed checkpoints in the first minute of the run.

Set a RetryAlways policy on the wrapped client and on each client in the part-upload pool, so every operation retries 408/429/5xx with backoff. RetryAlways is safe for this client: every write targets a unique name (snapshot UUID directories, runID-suffixed part names) or is idempotent (compose and copy from fixed sources, delete). Suspend is latency-sensitive, so the worst case is bounded at 5 attempts with under 5s of backoff sleep in total.

Because RetryAlways is only safe for this package's own operations, NewGCSClient no longer accepts a caller-built *storage.Client it would have to mutate. It builds the client itself from ctx and opts, the same way it already builds the pool clients, so the policy cannot leak onto a client shared with other code, and the requirement that the pool's options match the client's holds by construction. atelet's main no longer touches the raw storage client at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)