### PR TITLE
ateapi: log timing breakdowns for suspend finalize and workflow leases

### DIFF
--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -347,19 +347,43 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 	ctx, done := stepSpan(ctx, "FinalizeSuspended")
 	defer func() { err = done(err) }()
 
+	// The step is a chain of store round-trips with no spans of its own, so
+	// log a per-call breakdown to attribute its latency. Deferred so a call
+	// that stalls and then fails still reports where the time went; steps not
+	// reached (or skipped) log zero.
+	start := time.Now()
+	var dGetActor, dReleaseWorker, dRefetchActor, dCreateSnapshot, dUpdateActor time.Duration
+	defer func() {
+		slog.InfoContext(ctx, "FinalizeSuspended store call durations",
+			slog.Any("actor", actorRef),
+			slog.Duration("total", time.Since(start)),
+			slog.Duration("get_actor", dGetActor),
+			slog.Duration("release_worker", dReleaseWorker),
+			slog.Duration("refetch_actor", dRefetchActor),
+			slog.Duration("create_snapshot", dCreateSnapshot),
+			slog.Duration("update_actor", dUpdateActor))
+	}()
+
+	t := time.Now()
 	latestActor, err := w.store.GetActor(ctx, actorRef)
+	dGetActor = time.Since(t)
 	if err != nil {
 		return nil, err
 	}
 
 	// 1. Free the worker (if it hasn't been freed yet)
 	if latestActor.GetStatus().GetWorkerAssignment() != nil {
-		if _, err := releaseWorker(ctx, w.store, latestActor); err != nil {
+		t = time.Now()
+		_, err := releaseWorker(ctx, w.store, latestActor)
+		dReleaseWorker = time.Since(t)
+		if err != nil {
 			return nil, err
 		}
 
 		// Re-fetch the actor now that the worker is freed.
+		t = time.Now()
 		latestActor, err = w.store.GetActor(ctx, actorRef)
+		dRefetchActor = time.Since(t)
 		if err != nil {
 			return nil, err
 		}
@@ -392,10 +416,14 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 		}
 		// ErrAlreadyExists means a previous attempt crashed after creating
 		// the snapshot record; the persisted record is authoritative.
-		if _, err := w.store.CreateActorSnapshot(ctx, snapshot); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
+		t = time.Now()
+		_, err = w.store.CreateActorSnapshot(ctx, snapshot)
+		dCreateSnapshot = time.Since(t)
+		if err != nil && !errors.Is(err, store.ErrAlreadyExists) {
 			return nil, err
 		}
 	}
+	t = time.Now()
 	storedActor, err := w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(latestActor), func(toUpdate *ateapipb.Actor) error {
 		toUpdate.Status.State = ateapipb.ActorState_ACTOR_STATE_SUSPENDED
 		if snapshotName != "" {
@@ -407,6 +435,7 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 		toUpdate.Status.LocalSnapshotInfo = nil
 		return nil
 	})
+	dUpdateActor = time.Since(t)
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")

--- a/cmd/ateapi/internal/store/atepg/atepg.go
+++ b/cmd/ateapi/internal/store/atepg/atepg.go
@@ -1479,11 +1479,23 @@ const defaultLeaseTTL = 30 * time.Second
 func (p *Persistence) AcquireLease(ctx context.Context, key string) (*store.Lease, error) {
 	ttl := p.leaseTTL
 	token := uuid.NewString()
+	// Acquisition runs before any workflow step span opens, so log the two
+	// queries' durations to make this window attributable: the cleanup DELETE
+	// scans the whole table and contends with concurrent acquires/releases.
+	t := time.Now()
 	if err := p.cleanupExpiredLeases(ctx); err != nil {
 		slog.WarnContext(ctx, "failed to clean up expired PostgreSQL leases", "error", err)
 	}
+	dCleanup := time.Since(t)
 
+	t = time.Now()
 	acquired, err := p.acquireLease(ctx, key, token, ttl)
+	dAcquire := time.Since(t)
+	slog.InfoContext(ctx, "PostgreSQL lease acquisition finished",
+		slog.String("key", key),
+		slog.Bool("acquired", acquired && err == nil),
+		slog.Duration("cleanup_expired", dCleanup),
+		slog.Duration("acquire", dAcquire))
 	if err != nil {
 		return nil, err
 	}
@@ -1500,14 +1512,25 @@ func (p *Persistence) AcquireLease(ctx context.Context, key string) (*store.Leas
 	}()
 
 	closeFn := func() {
+		// Close runs after the last workflow step span ends but inside the
+		// operation, so log its two waits: the renewal goroutine may be
+		// mid-query when cancelled, and the release DELETE contends with
+		// concurrent acquires' full-table cleanup DELETEs.
+		t := time.Now()
 		cancel()
 		<-renewalDone
+		dRenewalStop := time.Since(t)
 
 		releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer releaseCancel()
+		t = time.Now()
 		if err := p.releaseLease(releaseCtx, key, token); err != nil {
 			slog.WarnContext(releaseCtx, "failed to release PostgreSQL lease, relying on TTL to reclaim it", "key", key, "error", err)
 		}
+		slog.InfoContext(releaseCtx, "PostgreSQL lease released",
+			slog.String("key", key),
+			slog.Duration("renewal_stop", dRenewalStop),
+			slog.Duration("release", time.Since(t)))
 	}
 	return store.NewLease(leaseCtx, closeFn), nil
 }


### PR DESCRIPTION
## Summary

A 15s SuspendActor trace showed most of the time in three windows that tracing cannot attribute: the FinalizeSuspended step span wraps up to five store round-trips with no spans of their own, and the lease acquire/release around the workflow run entirely outside the step spans (2.1s before the first step, 1.15s after the last one in the observed trace).

This PR logs a per-call duration breakdown in each window:

- **FinalizeSuspended** logs the durations of its store calls (get, worker release, re-fetch, snapshot create, final update), emitted from a `defer` so a call that stalls and then fails still reports where the time went.
- **AcquireLease** logs the expired-lease cleanup and the acquire upsert separately; the cleanup DELETE scans the whole leases table and contends with concurrent acquires and releases.
- **Lease close** logs the renewal-goroutine stop and the release DELETE separately.

## Test plan

- Logging-only change; `make test` passes and existing suspend/lease tests cover the touched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)