### PR TITLE
imagecache: tune pull retry backoff per registry class

### DIFF
--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -96,6 +96,67 @@ const (
 	layerPullConcurrency = 4
 )
 
+// Pull retry backoffs, chosen per registry by retryBackoffFor. Both replace
+// go-containerregistry's default (3 attempts over ~4s, jitter 0.1), which is
+// tuned for a single flaky client, and both apply to every request of a pull,
+// including the /v2/ auth ping. The retryable status codes stay at the
+// library default, which already includes 429. Vars so tests can shrink the
+// waits.
+var (
+	// dedicatedRegistryBackoff covers registries where the deployment has
+	// its own quota (Artifact Registry, ECR, Harbor, self-hosted, …): the
+	// server absorbs retry bursts and nobody else competes for the limit,
+	// and pulls sit on the Run/Restore critical path, so retries start fast
+	// and come often — more attempts in less total wall clock, still quick
+	// enough to surface a real outage to the RPC-level retry.
+	dedicatedRegistryBackoff = remote.Backoff{
+		Duration: 200 * time.Millisecond,
+		Factor:   2.0,
+		Jitter:   1.0,
+		Steps:    4,
+		Cap:      2 * time.Second,
+	}
+	// sharedRegistryBackoff covers communal registries (registry.k8s.io,
+	// Docker Hub, …), where pulls are anonymous and rate limits are shared:
+	// a whole fleet can be throttled at once, so retries must outlast the
+	// throttling wave and full jitter must de-synchronize the herd rather
+	// than replay it.
+	sharedRegistryBackoff = remote.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Jitter:   1.0,
+		Steps:    4,
+		Cap:      10 * time.Second,
+	}
+)
+
+// sharedRegistries are the well-known communal registries whose rate limits
+// are shared across all anonymous clients. Everything not listed here is
+// assumed dedicated: fleet-scale pulls realistically hit either the pause
+// image (registry.k8s.io) or the customer's own registry, and enumerating
+// the small stable set of communal hosts beats guessing at every private
+// registry vendor.
+var sharedRegistries = map[string]bool{
+	"registry.k8s.io":      true,
+	"docker.io":            true,
+	"index.docker.io":      true, // name.ParseReference normalizes docker.io to this
+	"registry-1.docker.io": true,
+	"quay.io":              true,
+	"ghcr.io":              true,
+	"public.ecr.aws":       true,
+	"mcr.microsoft.com":    true,
+	"registry.gitlab.com":  true,
+	"cgr.dev":              true,
+}
+
+// retryBackoffFor picks the pull retry backoff for a registry host.
+func retryBackoffFor(registry string) remote.Backoff {
+	if sharedRegistries[registry] {
+		return sharedRegistryBackoff
+	}
+	return dedicatedRegistryBackoff
+}
+
 // Store is atelet's handle to the on-disk layer pool. It is safe for
 // concurrent use; concurrent pulls of the same image or layer are collapsed.
 // The store assumes it is the only writer on the node (one atelet per node).
@@ -672,14 +733,15 @@ func (s *Store) remoteOpts(ctx context.Context, parsedRef name.Reference) []remo
 	if s.platform != nil {
 		platform = *s.platform
 	}
+	registry := parsedRef.Context().Registry.RegistryStr()
 	opts := []remote.Option{
 		// Propagate caller ctx into go-containerregistry so cancellation tears
 		// down in-flight layer-blob HTTP requests instead of letting them run
 		// to completion in background goroutines.
 		remote.WithContext(ctx),
 		remote.WithPlatform(platform),
+		remote.WithRetryBackoff(retryBackoffFor(registry)),
 	}
-	registry := parsedRef.Context().Registry.RegistryStr()
 	if s.authenticator != nil && registryUsesGCPAuth(registry) {
 		opts = append(opts, remote.WithAuth(s.authenticator))
 	}

--- a/internal/imagecache/imagecache_test.go
+++ b/internal/imagecache/imagecache_test.go
@@ -20,12 +20,15 @@ import (
 	"context"
 	"io"
 	"log"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
@@ -89,6 +92,72 @@ func newTestStore(t *testing.T, opts ...Option) *Store {
 		t.Fatalf("New: %v", err)
 	}
 	return s
+}
+
+// TestRetryBackoffFor pins the per-registry split: well-known communal
+// registries get the patient fleet-throttling backoff, everything else —
+// registries the deployment has its own quota with, including local ones —
+// retries fast (their pulls sit on the Run/Restore critical path).
+func TestRetryBackoffFor(t *testing.T) {
+	for registry, want := range map[string]remote.Backoff{
+		"gcr.io":                              dedicatedRegistryBackoff,
+		"us.gcr.io":                           dedicatedRegistryBackoff,
+		"us-docker.pkg.dev":                   dedicatedRegistryBackoff,
+		"123.dkr.ecr.us-east-1.amazonaws.com": dedicatedRegistryBackoff,
+		"harbor.example.com":                  dedicatedRegistryBackoff,
+		"127.0.0.1:5000":                      dedicatedRegistryBackoff,
+		"registry.k8s.io":                     sharedRegistryBackoff,
+		"docker.io":                           sharedRegistryBackoff,
+		"index.docker.io":                     sharedRegistryBackoff,
+		"quay.io":                             sharedRegistryBackoff,
+		"ghcr.io":                             sharedRegistryBackoff,
+	} {
+		if got := retryBackoffFor(registry); got != want {
+			t.Errorf("retryBackoffFor(%q) = %+v, want %+v", registry, got, want)
+		}
+	}
+}
+
+// TestEnsureImage_RetriesRateLimit proves a pull survives transient 429s.
+// go-containerregistry's retry transport, configured with pullRetryBackoff,
+// covers every request including the /v2/ auth ping — the first request a
+// throttling registry rejects (as registry.k8s.io does per source IP).
+func TestEnsureImage_RetriesRateLimit(t *testing.T) {
+	origBackoff := dedicatedRegistryBackoff
+	dedicatedRegistryBackoff = remote.Backoff{Duration: time.Millisecond, Factor: 2.0, Jitter: 0.1, Steps: 4}
+	t.Cleanup(func() { dedicatedRegistryBackoff = origBackoff })
+
+	// throttle > 0 makes the registry reject the next request with a 429;
+	// it stays at zero until the test image is pushed.
+	var throttle, rejections atomic.Int32
+	inner := registry.New(registry.Logger(log.New(io.Discard, "", 0)))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if throttle.Add(-1) >= 0 {
+			rejections.Add(1)
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parsing registry URL: %v", err)
+	}
+
+	ref := u.Host + "/test/pause:1"
+	pushImage(t, ref, v1.Config{}, layerFromEntries(t, []tarEntry{
+		{name: "pause", typeflag: tar.TypeReg, body: "pause"},
+	}))
+	throttle.Store(2)
+
+	s := newTestStore(t)
+	if _, err := s.EnsureImage(context.Background(), ref); err != nil {
+		t.Fatalf("EnsureImage through a throttling registry: %v", err)
+	}
+	if got := rejections.Load(); got != 2 {
+		t.Errorf("registry rejected %d requests, want 2 (the throttling was not exercised)", got)
+	}
 }
 
 func TestEnsureImage_TagPullAndDigestHit(t *testing.T) {


### PR DESCRIPTION
## Summary

go-containerregistry retries 429s and 5xxs by default, but with a backoff tuned for a single flaky client: 3 attempts over ~4s with 0.1 jitter. When a whole fleet is throttled at once (registry.k8s.io rate-limited a 1000-node benchmark's pause-image pulls), every node retries nearly in lockstep and gives up before the limiter cools down, so the retries just replay the stampede.

This replaces the default with two profiles, split by **whose rate limit the pull is spending**:

- **Shared (communal) registries** — registry.k8s.io, Docker Hub, quay.io, ghcr.io, and other well-known anonymous-pull hosts. Their rate limits are shared across all clients, so a fleet retrying in lockstep just replays the stampede. These get a longer, fully-jittered backoff (4 attempts, up to ~14s) that outlasts a throttling wave and de-synchronizes the herd. The motivating case is registry.k8s.io, the CNCF-hosted registry that serves the pause image: it throttles aggressively, so a fleet retrying on the default schedule gives up before the rate limiter cools down.
- **Dedicated registries (the default)** — everything else: GCP Artifact Registry, AWS ECR, Harbor, self-hosted, local dev registries. The deployment owns the quota, the server absorbs retry bursts, and pulls sit on the Run/Restore critical path, so retries start at 200ms with 4 attempts capped at 2s — more attempts in less total wall clock, still failing fast enough to surface a real outage to the RPC-level retry.

Defaulting to the dedicated profile (rather than allowlisting private registries) is deliberate: Substrate is open source and customers run many registry vendors, but fleet-scale pulls realistically hit either the pause image or the customer's own registry. The small, stable set of communal hosts is enumerable; the set of private registry vendors is not.

## Test plan

- `TestRetryBackoffFor` pins the split across GCP, ECR, Harbor, local, and communal registry hosts.
- `TestEnsureImage_RetriesRateLimit` proves a pull survives transient 429s end to end through the retry transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
