### PR TITLE
podcertcontroller: add flags to raise client-go rate limits

### DIFF
--- a/cmd/podcertcontroller/main.go
+++ b/cmd/podcertcontroller/main.go
@@ -80,6 +80,17 @@ var (
 		"Number of concurrent worker goroutines per signer.",
 	)
 
+	kubeAPIQPS = pflag.Float32(
+		"kube-api-qps",
+		0,
+		"Sustained queries per second allowed against the Kubernetes API. 0 keeps the client-go default.",
+	)
+	kubeAPIBurst = pflag.Int(
+		"kube-api-burst",
+		0,
+		"Burst queries allowed against the Kubernetes API. 0 keeps the client-go default.",
+	)
+
 	showVersion = pflag.Bool("version", false, "Print version and exit.")
 )
 
@@ -108,6 +119,18 @@ func main() {
 			slog.ErrorContext(ctx, "Error reading kubeconfig", slog.Any("err", err))
 			os.Exit(1)
 		}
+	}
+
+	if *kubeAPIQPS < 0 || *kubeAPIBurst < 0 {
+		slog.ErrorContext(ctx, "Invalid rate limits: --kube-api-qps and --kube-api-burst must not be negative",
+			slog.Any("kube-api-qps", *kubeAPIQPS), slog.Int("kube-api-burst", *kubeAPIBurst))
+		os.Exit(1)
+	}
+	if *kubeAPIQPS > 0 {
+		kconfig.QPS = *kubeAPIQPS
+	}
+	if *kubeAPIBurst > 0 {
+		kconfig.Burst = *kubeAPIBurst
 	}
 
 	kc, err := kubernetes.NewForConfig(kconfig)


### PR DESCRIPTION
## Summary

The controller built its Kubernetes client from the default rest.Config, whose client-side limiter (QPS=5, Burst=10) is shared by every worker of both signers. Certificate issuance was therefore capped at roughly 5 PodCertificateRequests per second no matter the `--workers-per-signer` value, and pods in a large rollout sat in FailedMount ("credential bundle is not issued yet") for the duration: about 2000 seconds for a 10k-pod worker pool in the 1000-node load test.

This adds `--kube-api-qps` and `--kube-api-burst` and applies them to the config on both the in-cluster and kubeconfig paths. Both default to 0, which leaves client-go's own defaults untouched — behavior only changes where a deployment opts in. A follow-up PR will set values sized for large rollouts in `manifests/ate-install/pod-certificate-controller.yaml`.

## Test plan

- `go build` / `go vet` clean.
- Verified against the 1000-node load test (with raised limits set via the flags): bundle issuance keeps pace with pod creation instead of plateauing at ~4.5/sec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
