### PR TITLE
atelet: constrain snapshot files to checkpoint directories

### DIFF
--- a/cmd/atelet/internal/ategcs/objects.go
+++ b/cmd/atelet/internal/ategcs/objects.go
@@ -118,6 +118,18 @@ func SendLocalFileToGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL
 	return nil
 }
 
+// SendFileToGCSWithZstd compresses and uploads an already-open file. The
+// caller retains ownership of localFile.
+func SendFileToGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL string, localFile *os.File) error {
+	ctx, span := tracer.Start(ctx, "sendFileToGCSWithZstd")
+	defer span.End()
+
+	if err := sendZstd(ctx, client, gsURL, localFile); err != nil {
+		return fmt.Errorf("in sendZstd: %w", err)
+	}
+	return nil
+}
+
 // sparseFilePutter marks a backend that can upload a sparse FILE directly, splitting
 // compression and upload by file range instead of piping one compressed stream into a
 // part splitter. Reports errSparseTooSmall when the file is not worth splitting, in
@@ -323,6 +335,21 @@ func FetchLocalFileFromGCSWithZstd(ctx context.Context, client ObjectStorage, gs
 		return fmt.Errorf("while fetching %q from GCS: %w", gsURL, err)
 	}
 
+	return nil
+}
+
+// FetchFileFromGCSWithZstd downloads and decompresses into an already-open
+// file. The caller retains ownership of localFile.
+func FetchFileFromGCSWithZstd(ctx context.Context, client ObjectStorage, gsURL string, localFile *os.File) error {
+	ctx, span := tracer.Start(ctx, "fetchFileFromGCSWithZstd")
+	defer span.End()
+
+	if err := localFile.Chmod(0o600); err != nil {
+		return fmt.Errorf("in localFile.Chmod(0o600): %w", err)
+	}
+	if err := fetchFromGCSWithZstd(ctx, client, gsURL, localFile); err != nil {
+		return fmt.Errorf("while fetching %q from GCS: %w", gsURL, err)
+	}
 	return nil
 }
 

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -654,9 +654,9 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 		return nil, fmt.Errorf("while calling ateom.CheckpointWorkload: %w", err)
 	}
 
-	sandboxRec.SnapshotFiles = resp.GetSnapshotFiles()
-	if len(sandboxRec.SnapshotFiles) == 0 && shouldHaveSnapshots(req) {
-		return nil, ateerrors.NewGRPCError(ctx, codes.DataLoss, ateerrors.ReasonInvalidCheckpointResult, ateerrors.ActorCrashedMetadata(), errors.New("ateom reported no snapshot files for checkpoint"))
+	sandboxRec.SnapshotFiles, err = checkpointSnapshotFiles(resp, shouldHaveSnapshots(req))
+	if err != nil {
+		return nil, ateerrors.NewGRPCError(ctx, codes.DataLoss, ateerrors.ReasonInvalidCheckpointResult, ateerrors.ActorCrashedMetadata(), err)
 	}
 	sandboxRec.Atespace = req.GetAtespace()
 	sandboxRec.ActorName = req.GetActorName()
@@ -708,6 +708,17 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 	}
 
 	return &ateletpb.CheckpointResponse{}, nil
+}
+
+func checkpointSnapshotFiles(resp *ateompb.CheckpointWorkloadResponse, required bool) ([]string, error) {
+	files := resp.GetSnapshotFiles()
+	if len(files) == 0 && required {
+		return nil, errors.New("ateom reported no snapshot files for checkpoint")
+	}
+	if err := validateSnapshotFiles(files); err != nil {
+		return nil, fmt.Errorf("ateom reported invalid snapshot files: %w", err)
+	}
+	return files, nil
 }
 
 func toAteomSnapshotScope(scope ateletpb.SnapshotScope) ateompb.SnapshotScope {

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -555,20 +555,11 @@ func initSnapshotSizeMetric() error {
 // recordSnapshotSize labels each image with the registry's file.name. That
 // label used to be spelled "kind", which means the snapshot's provenance
 // everywhere else in the ate.* namespace, not one of its files.
-func recordSnapshotSize(ctx context.Context, file, path, templateAtespace, templateName string) {
+func recordSnapshotSize(ctx context.Context, file string, size int64, templateAtespace, templateName string) {
 	if snapshotSizeBytes == nil {
 		return
 	}
-	fi, err := os.Stat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return
-	}
-	if err != nil {
-		slog.WarnContext(ctx, "Failed to stat snapshot image for size metric",
-			slog.String("file", file), slog.String("path", path), slog.Any("err", err))
-		return
-	}
-	snapshotSizeBytes.Record(ctx, fi.Size(), metric.WithAttributes(
+	snapshotSizeBytes.Record(ctx, size, metric.WithAttributes(
 		semconv.FileNameKey.String(file),
 		ateattr.TemplateAtespaceKey.String(templateAtespace),
 		ateattr.TemplateNameKey.String(templateName),
@@ -688,7 +679,7 @@ func (s *AteomHerder) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRe
 			return nil, ateerrors.NewGRPCError(ctx, codes.DataLoss, ateerrors.ReasonFaileSaveSnapshot, ateerrors.ActorCrashedMetadata(), fmt.Errorf("%w: while uploading external snapshot: %w", ateerrors.ReasonFaileSaveSnapshot, err))
 		}
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-		if err := s.moveLocalCheckpoint(ctx, req, checkpointDir, sandboxRec); err != nil {
+		if err := s.moveLocalCheckpoint(ctx, req, sandboxRec); err != nil {
 			dPersist = time.Since(tPersist)
 			op.failedPhase = ateattr.SnapshotPhasePersist
 			return nil, ateerrors.NewGRPCError(ctx, codes.DataLoss, ateerrors.ReasonFaileSaveSnapshot, ateerrors.ActorCrashedMetadata(), fmt.Errorf("%w: while moving to local snapshot: %w", ateerrors.ReasonFaileSaveSnapshot, err))
@@ -733,19 +724,32 @@ func toAteomSnapshotScope(scope ateletpb.SnapshotScope) ateompb.SnapshotScope {
 	}
 }
 
-func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, checkpointDir string, rec *sandboxAssetsRecord) error {
-	localCheckpointPath := ateompath.LocalSnapshotDir(req.GetActorUid(), req.GetLocalConfig().GetSnapshotName())
-	if err := os.MkdirAll(localCheckpointPath, 0o700); err != nil {
+func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.CheckpointRequest, rec *sandboxAssetsRecord) error {
+	root, err := os.OpenRoot(ateompath.ActorPath(req.GetActorUid()))
+	if err != nil {
+		return fmt.Errorf("while opening actor directory: %w", err)
+	}
+	defer root.Close()
+
+	localDir := filepath.Join("local-checkpoint", req.GetLocalConfig().GetSnapshotName())
+	if err := root.MkdirAll(localDir, 0o700); err != nil {
 		return fmt.Errorf("while creating local checkpoint directory: %w", err)
 	}
 
 	// Move exactly the files ateom reported.
 	for _, fileName := range rec.SnapshotFiles {
-		src := filepath.Join(checkpointDir, fileName)
-		dst := filepath.Join(localCheckpointPath, fileName)
-		recordSnapshotSize(ctx, fileName, src, req.GetActorTemplateAtespace(), req.GetActorTemplateName())
+		src := filepath.Join("checkpoint-state", fileName)
+		dst := filepath.Join(localDir, fileName)
+		info, err := root.Stat(src)
+		if err != nil {
+			return fmt.Errorf("while inspecting checkpoint file %s: %w", fileName, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("checkpoint file %s is not a regular file", fileName)
+		}
+		recordSnapshotSize(ctx, fileName, info.Size(), req.GetActorTemplateAtespace(), req.GetActorTemplateName())
 
-		if err := os.Rename(src, dst); err != nil {
+		if err := root.Rename(src, dst); err != nil {
 			return fmt.Errorf("failed to move %s to %s: %w", src, dst, err)
 		}
 	}
@@ -755,7 +759,7 @@ func (s *AteomHerder) moveLocalCheckpoint(ctx context.Context, req *ateletpb.Che
 	if err != nil {
 		return fmt.Errorf("while marshaling snapshot manifest: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(localCheckpointPath, sandboxManifestName), manifest, 0o600); err != nil {
+	if err := root.WriteFile(filepath.Join(localDir, sandboxManifestName), manifest, 0o600); err != nil {
 		return fmt.Errorf("while writing snapshot manifest: %w", err)
 	}
 
@@ -791,16 +795,34 @@ func (s *AteomHerder) uploadExternalCheckpoint(ctx context.Context, req *ateletp
 // leaves only orphaned files, never a manifest pointing at files that never
 // landed; retries overwrite the deterministic object names.
 func (s *AteomHerder) uploadSnapshot(ctx context.Context, uri resources.SnapshotURI, srcDir string, rec *sandboxAssetsRecord, templateAtespace, templateName string) error {
+	root, err := os.OpenRoot(srcDir)
+	if err != nil {
+		return fmt.Errorf("while opening snapshot directory: %w", err)
+	}
+	defer root.Close()
+
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, fileName := range rec.SnapshotFiles {
-		local := filepath.Join(srcDir, fileName)
-		recordSnapshotSize(ctx, fileName, local, templateAtespace, templateName)
 		g.Go(func() error {
+			local, err := root.Open(fileName)
+			if err != nil {
+				return fmt.Errorf("while opening %s in snapshot directory: %w", fileName, err)
+			}
+			defer local.Close()
+			info, err := local.Stat()
+			if err != nil {
+				return fmt.Errorf("while inspecting %s in snapshot directory: %w", fileName, err)
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("snapshot file %s is not a regular file", fileName)
+			}
+			recordSnapshotSize(ctx, fileName, info.Size(), templateAtespace, templateName)
+
 			objectURI, err := uri.ObjectURI(fileName + ".zstd")
 			if err != nil {
 				return fmt.Errorf("while addressing %s in GCS: %w", fileName, err)
 			}
-			if err := ategcs.SendLocalFileToGCSWithZstd(gCtx, s.gcsClient, objectURI, local); err != nil {
+			if err := ategcs.SendFileToGCSWithZstd(gCtx, s.gcsClient, objectURI, local); err != nil {
 				return fmt.Errorf("while uploading %s to GCS: %w", fileName, err)
 			}
 			return nil
@@ -883,7 +905,7 @@ func (s *AteomHerder) uploadLocalCheckpointDir(ctx context.Context, req *ateletp
 		return "", fmt.Errorf("while addressing snapshot manifest in GCS: %w", err)
 	}
 
-	manifest, err := os.ReadFile(filepath.Join(localDir, sandboxManifestName))
+	manifest, err := readSnapshotManifest(localDir)
 	if errors.Is(err, os.ErrNotExist) {
 		// The local snapshot is gone. A previous invocation may have uploaded
 		// and pruned it: the remote manifest is uploaded last, so its presence
@@ -929,6 +951,15 @@ func (s *AteomHerder) uploadLocalCheckpointDir(ctx context.Context, req *ateletp
 	}
 
 	return rec.SandboxClass, s.uploadSnapshot(ctx, uri, localDir, rec, req.GetActorTemplateAtespace(), req.GetActorTemplateName())
+}
+
+func readSnapshotManifest(dir string) ([]byte, error) {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	return root.ReadFile(sandboxManifestName)
 }
 
 // narrowFullCaptureToData rewrites rec so a FULL capture uploads as a DATA
@@ -1049,7 +1080,7 @@ func (s *AteomHerder) Restore(ctx context.Context, req *ateletpb.RestoreRequest)
 			return nil, ateerrors.CrashIfReason(ctx, fmt.Errorf("while unmarshalling sandbox record: %w", err), ateerrors.ReasonInvalidSandboxAsset)
 		}
 	case ateletpb.CheckpointType_CHECKPOINT_TYPE_LOCAL:
-		manifest, err := os.ReadFile(filepath.Join(ateompath.LocalSnapshotDir(actorUID, req.GetLocalConfig().GetSnapshotName()), sandboxManifestName))
+		manifest, err := readSnapshotManifest(ateompath.LocalSnapshotDir(actorUID, req.GetLocalConfig().GetSnapshotName()))
 		if err != nil {
 			if isTerminalFileSystemErr(err) {
 				return nil, ateerrors.NewGRPCError(ctx, codes.DataLoss, ateerrors.ReasonTerminalFileSystemError, ateerrors.ActorCrashedMetadata(), err)
@@ -1320,14 +1351,23 @@ func (s *AteomHerder) Terminate(ctx context.Context, req *ateletpb.TerminateRequ
 }
 
 func (s *AteomHerder) copyLocalCheckpoint(ctx context.Context, snapshotName string, srcDir, dstDir string, files []string) error {
+	sourceRoot, err := os.OpenRoot(filepath.Join(srcDir, snapshotName))
+	if err != nil {
+		return fmt.Errorf("while opening local checkpoint directory: %w", err)
+	}
+	defer sourceRoot.Close()
+	destinationRoot, err := os.OpenRoot(dstDir)
+	if err != nil {
+		return fmt.Errorf("while opening restore directory: %w", err)
+	}
+	defer destinationRoot.Close()
+
 	for _, fileName := range files {
 		if ctx.Err() != nil {
 			return fmt.Errorf("context cancelled: %w", ctx.Err())
 		}
-		src := filepath.Join(srcDir, snapshotName, fileName)
-		dst := filepath.Join(dstDir, fileName)
-		if _, err := copyFile(src, dst); err != nil {
-			return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+		if _, err := copyRootFile(sourceRoot, fileName, destinationRoot, fileName); err != nil {
+			return fmt.Errorf("failed to copy %s: %w", fileName, err)
 		}
 	}
 
@@ -1360,30 +1400,52 @@ var errKernelCopyUnsupported = errors.New("kernel range copy unsupported")
 // local checkpoint restore, and it destroys the sparseness that later stages rely on to
 // tell which parts of guest RAM actually hold anything.
 func copyFile(src, dst string) (int64, error) {
-	sourceFileStat, err := os.Stat(src)
-	if err != nil {
-		return 0, err
-	}
-
-	if !sourceFileStat.Mode().IsRegular() {
-		return 0, fmt.Errorf("%s is not a regular file", src)
-	}
-
 	source, err := os.Open(src)
 	if err != nil {
 		return 0, err
 	}
 	defer source.Close()
+	sourceFileStat, err := source.Stat()
+	if err != nil {
+		return 0, err
+	}
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
 
 	destination, err := createDestFile(dst)
 	if err != nil {
 		return 0, err
 	}
+	return copyOpenFile(source, destination, sourceFileStat.Size())
+}
 
+func copyRootFile(sourceRoot *os.Root, sourceName string, destinationRoot *os.Root, destinationName string) (int64, error) {
+	source, err := sourceRoot.Open(sourceName)
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
+	sourceFileStat, err := source.Stat()
+	if err != nil {
+		return 0, err
+	}
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", sourceName)
+	}
+
+	destination, err := destinationRoot.OpenFile(destinationName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
+	if err != nil {
+		return 0, err
+	}
+	return copyOpenFile(source, destination, sourceFileStat.Size())
+}
+
+func copyOpenFile(source *os.File, destination io.WriteCloser, sourceSize int64) (int64, error) {
 	if sd, ok := destination.(sparseDest); ok {
-		switch err := copySparse(source, sd, sourceFileStat.Size()); {
+		switch err := copySparse(source, sd, sourceSize); {
 		case err == nil:
-			return sourceFileStat.Size(), destination.Close()
+			return sourceSize, destination.Close()
 		case !errors.Is(err, errSparseUnsupported):
 			return 0, errors.Join(err, destination.Close())
 		}
@@ -1524,16 +1586,27 @@ func (s *AteomHerder) downloadExternalCheckpoint(ctx context.Context, snapshotUR
 	if err != nil {
 		return err
 	}
+	root, err := os.OpenRoot(dstDir)
+	if err != nil {
+		return fmt.Errorf("while opening restore directory: %w", err)
+	}
+	defer root.Close()
+
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, fileName := range files {
 		fileName := fileName
-		local := filepath.Join(dstDir, fileName)
 		g.Go(func() error {
 			objectURI, err := uri.ObjectURI(fileName + ".zstd")
 			if err != nil {
 				return fmt.Errorf("while addressing %s in GCS: %w", fileName, err)
 			}
-			if err := ategcs.FetchLocalFileFromGCSWithZstd(gCtx, s.gcsClient, objectURI, local); err != nil {
+			local, err := root.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+			if err != nil {
+				return fmt.Errorf("while opening %s in restore directory: %w", fileName, err)
+			}
+			fetchErr := ategcs.FetchFileFromGCSWithZstd(gCtx, s.gcsClient, objectURI, local)
+			closeErr := local.Close()
+			if err := errors.Join(fetchErr, closeErr); err != nil {
 				return fmt.Errorf("while downloading %s from GCS: %w", fileName, err)
 			}
 			return nil

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -292,6 +292,80 @@ func TestWriteSystemInfoVolume_TrustBundle(t *testing.T) {
 	})
 }
 
+func TestSnapshotManifestCannotEscapeRestoreDir(t *testing.T) {
+	parent := t.TempDir()
+	restoreDir := filepath.Join(parent, "restore-state")
+	if err := os.Mkdir(restoreDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(parent, "outside")
+	if err := os.WriteFile(outside, []byte("keep me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := json.Marshal(sandboxAssetsRecord{
+		SandboxClass:  "gvisor",
+		PauseImage:    testPauseImage,
+		SnapshotFiles: []string{"../outside"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := unmarshalSandboxRecord(manifest)
+	if err == nil {
+		// This is the next file-handling step in an external Restore. Before the
+		// manifest boundary rejected non-local paths, it truncated outside even
+		// when fetching the corresponding object subsequently failed.
+		s := &AteomHerder{gcsClient: fakeObjectStorage{err: errors.New("object not found")}}
+		_ = s.downloadExternalCheckpoint(context.Background(), "gs://bucket/root/snapshots/ate-demo/snap-1", restoreDir, rec.SnapshotFiles)
+	}
+	if !errors.Is(err, ateerrors.ReasonInvalidSandboxAsset) {
+		t.Fatalf("unmarshalSandboxRecord() error = %v, want ReasonInvalidSandboxAsset", err)
+	}
+	if got, readErr := os.ReadFile(outside); readErr != nil || string(got) != "keep me" {
+		t.Fatalf("file outside restore dir = %q, %v; want unchanged", got, readErr)
+	}
+}
+
+func TestCheckpointResponseCannotEscapeCheckpointDir(t *testing.T) {
+	parent := t.TempDir()
+	checkpointDir := filepath.Join(parent, "checkpoint-state")
+	if err := os.Mkdir(checkpointDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "outside"), []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	files, validationErr := checkpointSnapshotFiles(&ateompb.CheckpointWorkloadResponse{
+		SnapshotFiles: []string{"../outside"},
+	}, true)
+	store := &recordingObjectStorage{}
+	if validationErr == nil {
+		uri, err := resources.ParseSnapshotURI("gs://bucket/root/snapshots/ate-demo/snap-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := &AteomHerder{gcsClient: store}
+		if err := s.uploadSnapshot(context.Background(), uri, checkpointDir, &sandboxAssetsRecord{SnapshotFiles: files}, "test", "test"); err != nil {
+			t.Fatalf("uploadSnapshot() error = %v", err)
+		}
+	}
+	if validationErr == nil {
+		t.Fatal("checkpointSnapshotFiles() accepted a path outside the checkpoint directory")
+	}
+	if got := store.keys(); len(got) != 0 {
+		t.Fatalf("uploaded objects = %v, want none", got)
+	}
+}
+
+func TestCheckpointSnapshotFilesAllowsOptionalEmptyResult(t *testing.T) {
+	files, err := checkpointSnapshotFiles(&ateompb.CheckpointWorkloadResponse{}, false)
+	if err != nil || len(files) != 0 {
+		t.Fatalf("checkpointSnapshotFiles() = %v, %v; want empty result", files, err)
+	}
+}
+
 func TestWriteFileAtomic(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "actor-id")

--- a/cmd/atelet/main_test.go
+++ b/cmd/atelet/main_test.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/cmd/atelet/internal/ategcs"
 	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/ateerrors"
 	"github.com/agent-substrate/substrate/internal/atelet"
@@ -292,7 +293,66 @@ func TestWriteSystemInfoVolume_TrustBundle(t *testing.T) {
 	})
 }
 
-func TestSnapshotManifestCannotEscapeRestoreDir(t *testing.T) {
+func TestSnapshotManifestRejectsNonLocalFile(t *testing.T) {
+	manifest, err := json.Marshal(sandboxAssetsRecord{
+		SandboxClass:  "gvisor",
+		PauseImage:    testPauseImage,
+		SnapshotFiles: []string{"../outside"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = unmarshalSandboxRecord(manifest)
+	if !errors.Is(err, ateerrors.ReasonInvalidSandboxAsset) {
+		t.Fatalf("unmarshalSandboxRecord() error = %v, want ReasonInvalidSandboxAsset", err)
+	}
+}
+
+func TestCheckpointResponseRejectsNonLocalFile(t *testing.T) {
+	_, err := checkpointSnapshotFiles(&ateompb.CheckpointWorkloadResponse{
+		SnapshotFiles: []string{"../outside"},
+	}, true)
+	if err == nil {
+		t.Fatal("checkpointSnapshotFiles() accepted a path outside the checkpoint directory")
+	}
+}
+
+func TestCheckpointSnapshotFilesAllowsOptionalEmptyResult(t *testing.T) {
+	files, err := checkpointSnapshotFiles(&ateompb.CheckpointWorkloadResponse{}, false)
+	if err != nil || len(files) != 0 {
+		t.Fatalf("checkpointSnapshotFiles() = %v, %v; want empty result", files, err)
+	}
+}
+
+func TestUploadSnapshotRejectsSymlinkOutsideRoot(t *testing.T) {
+	parent := t.TempDir()
+	checkpointDir := filepath.Join(parent, "checkpoint-state")
+	if err := os.Mkdir(checkpointDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(parent, "outside")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(checkpointDir, "checkpoint.img")); err != nil {
+		t.Fatal(err)
+	}
+	uri, err := resources.ParseSnapshotURI(testSnapshotURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &recordingObjectStorage{}
+	err = (&AteomHerder{gcsClient: store}).uploadSnapshot(context.Background(), uri, checkpointDir,
+		&sandboxAssetsRecord{SnapshotFiles: []string{"checkpoint.img"}}, "test", "test")
+	if err == nil {
+		t.Fatal("uploadSnapshot() followed a symlink outside the checkpoint directory")
+	}
+	if got := store.keys(); len(got) != 0 {
+		t.Fatalf("uploaded objects = %v, want none", got)
+	}
+}
+
+func TestDownloadExternalCheckpointRejectsSymlinkOutsideRoot(t *testing.T) {
 	parent := t.TempDir()
 	restoreDir := filepath.Join(parent, "restore-state")
 	if err := os.Mkdir(restoreDir, 0o700); err != nil {
@@ -302,67 +362,54 @@ func TestSnapshotManifestCannotEscapeRestoreDir(t *testing.T) {
 	if err := os.WriteFile(outside, []byte("keep me"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-
-	manifest, err := json.Marshal(sandboxAssetsRecord{
-		SandboxClass:  "gvisor",
-		PauseImage:    testPauseImage,
-		SnapshotFiles: []string{"../outside"},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	rec, err := unmarshalSandboxRecord(manifest)
-	if err == nil {
-		// This is the next file-handling step in an external Restore. Before the
-		// manifest boundary rejected non-local paths, it truncated outside even
-		// when fetching the corresponding object subsequently failed.
-		s := &AteomHerder{gcsClient: fakeObjectStorage{err: errors.New("object not found")}}
-		_ = s.downloadExternalCheckpoint(context.Background(), "gs://bucket/root/snapshots/ate-demo/snap-1", restoreDir, rec.SnapshotFiles)
-	}
-	if !errors.Is(err, ateerrors.ReasonInvalidSandboxAsset) {
-		t.Fatalf("unmarshalSandboxRecord() error = %v, want ReasonInvalidSandboxAsset", err)
-	}
-	if got, readErr := os.ReadFile(outside); readErr != nil || string(got) != "keep me" {
-		t.Fatalf("file outside restore dir = %q, %v; want unchanged", got, readErr)
-	}
-}
-
-func TestCheckpointResponseCannotEscapeCheckpointDir(t *testing.T) {
-	parent := t.TempDir()
-	checkpointDir := filepath.Join(parent, "checkpoint-state")
-	if err := os.Mkdir(checkpointDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(parent, "outside"), []byte("private"), 0o600); err != nil {
+	if err := os.Symlink(outside, filepath.Join(restoreDir, "checkpoint.img")); err != nil {
 		t.Fatal(err)
 	}
 
-	files, validationErr := checkpointSnapshotFiles(&ateompb.CheckpointWorkloadResponse{
-		SnapshotFiles: []string{"../outside"},
-	}, true)
 	store := &recordingObjectStorage{}
-	if validationErr == nil {
-		uri, err := resources.ParseSnapshotURI("gs://bucket/root/snapshots/ate-demo/snap-1")
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := &AteomHerder{gcsClient: store}
-		if err := s.uploadSnapshot(context.Background(), uri, checkpointDir, &sandboxAssetsRecord{SnapshotFiles: files}, "test", "test"); err != nil {
-			t.Fatalf("uploadSnapshot() error = %v", err)
-		}
+	payload := filepath.Join(parent, "payload")
+	if err := os.WriteFile(payload, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
 	}
-	if validationErr == nil {
-		t.Fatal("checkpointSnapshotFiles() accepted a path outside the checkpoint directory")
+	if err := ategcs.SendLocalFileToGCSWithZstd(context.Background(), store, testSnapshotURI+"/checkpoint.img.zstd", payload); err != nil {
+		t.Fatal(err)
 	}
-	if got := store.keys(); len(got) != 0 {
-		t.Fatalf("uploaded objects = %v, want none", got)
+	err := (&AteomHerder{gcsClient: store}).downloadExternalCheckpoint(
+		context.Background(), testSnapshotURI, restoreDir, []string{"checkpoint.img"})
+	if err == nil {
+		t.Fatal("downloadExternalCheckpoint() followed a symlink outside the restore directory")
+	}
+	if got, err := os.ReadFile(outside); err != nil || string(got) != "keep me" {
+		t.Fatalf("outside file = %q, %v; want unchanged", got, err)
 	}
 }
 
-func TestCheckpointSnapshotFilesAllowsOptionalEmptyResult(t *testing.T) {
-	files, err := checkpointSnapshotFiles(&ateompb.CheckpointWorkloadResponse{}, false)
-	if err != nil || len(files) != 0 {
-		t.Fatalf("checkpointSnapshotFiles() = %v, %v; want empty result", files, err)
+func TestCopyLocalCheckpointRejectsSymlinkOutsideRoot(t *testing.T) {
+	parent := t.TempDir()
+	snapshotName := "pause-1"
+	snapshotDir := filepath.Join(parent, "local-checkpoint", snapshotName)
+	if err := os.MkdirAll(snapshotDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(parent, "outside")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(snapshotDir, "checkpoint.img")); err != nil {
+		t.Fatal(err)
+	}
+	restoreDir := filepath.Join(parent, "restore-state")
+	if err := os.Mkdir(restoreDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	err := (&AteomHerder{}).copyLocalCheckpoint(context.Background(), snapshotName,
+		filepath.Join(parent, "local-checkpoint"), restoreDir, []string{"checkpoint.img"})
+	if err == nil {
+		t.Fatal("copyLocalCheckpoint() followed a symlink outside the local checkpoint directory")
+	}
+	if _, err := os.Stat(filepath.Join(restoreDir, "checkpoint.img")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("restore file exists after rejected copy: %v", err)
 	}
 }
 

--- a/cmd/atelet/sandbox_assets.go
+++ b/cmd/atelet/sandbox_assets.go
@@ -493,7 +493,21 @@ func unmarshalSandboxRecord(data []byte) (*sandboxAssetsRecord, error) {
 	if rec.PauseImage == "" {
 		return nil, fmt.Errorf("%w: sandbox record/manifest has no pauseImage", ateerrors.ReasonInvalidSandboxAsset)
 	}
+	if err := validateSnapshotFiles(rec.SnapshotFiles); err != nil {
+		return nil, fmt.Errorf("%w: sandbox record/manifest has invalid snapshotFiles: %w", ateerrors.ReasonInvalidSandboxAsset, err)
+	}
 	return rec, nil
+}
+
+// validateSnapshotFiles ensures that joining a reported snapshot path to its
+// checkpoint directory cannot escape that directory.
+func validateSnapshotFiles(files []string) error {
+	for i, name := range files {
+		if !filepath.IsLocal(name) {
+			return fmt.Errorf("snapshotFiles[%d] %q is not local to the checkpoint directory", i, name)
+		}
+	}
+	return nil
 }
 
 func wrapFileSystemErr(msg string, err error) error {

--- a/cmd/atelet/sandbox_assets.go
+++ b/cmd/atelet/sandbox_assets.go
@@ -499,8 +499,9 @@ func unmarshalSandboxRecord(data []byte) (*sandboxAssetsRecord, error) {
 	return rec, nil
 }
 
-// validateSnapshotFiles ensures that joining a reported snapshot path to its
-// checkpoint directory cannot escape that directory.
+// validateSnapshotFiles rejects names that are not lexically local to a
+// checkpoint directory. Actual file access must still use os.Root so symlinks
+// cannot escape that directory.
 func validateSnapshotFiles(files []string) error {
 	for i, name := range files {
 		if !filepath.IsLocal(name) {


### PR DESCRIPTION
## Summary

- validate snapshot file names from manifests and ateom checkpoint responses before using them as relative paths
- confine checkpoint upload, local snapshot movement, local restore copies, and external restore writes with `os.Root`
- pass already-open files to the compression helpers so path validation cannot be bypassed by reopening a symlink
- preserve optional empty results for DATA checkpoints that do not contain runtime snapshot files

## Testing

- `go test -race ./cmd/atelet ./cmd/atelet/internal/ategcs -count=1`
- focused symlink confinement tests repeated with the race detector
- `hack/verify-all.sh`
