### PR TITLE
docs: state the supported GKE versions for setup-gcp clusters

### DIFF
--- a/hack/ate-dev-env.sh.example
+++ b/hack/ate-dev-env.sh.example
@@ -25,9 +25,15 @@ export NETWORK=default
 export SUBNETWORK=default
 
 export CLUSTER_NAME=substrate-poc
-export CLUSTER_VERSION=1.35.5-gke.1163012
+# Supported: 1.36 (needs the beta APIs enabled at cluster creation, which
+# setup-gcp does) or 1.37+ (APIs served by default). Anything below 1.36 does
+# not work. GKE retires patch versions over time — if cluster creation rejects
+# this pin, pick a current one from:
+#   gcloud container get-server-config --zone ${CLUSTER_LOCATION} --format="value(defaultClusterVersion)"
+# See tools/setup-gcp/README.md ("Create Cluster") for the full constraint.
+export CLUSTER_VERSION=1.36.3-gke.1767000
 export NODE_POOL_NAME=gvisor-pool
-export NODE_POOL_VERSION=1.35.5-gke.1163012
+export NODE_POOL_VERSION=1.36.3-gke.1767000
 export GVISOR_NODE_MACHINE_TYPE=c3-standard-4
 
 # Set this if you are using an existing cluster with a different context name.

--- a/tools/setup-gcp/README.md
+++ b/tools/setup-gcp/README.md
@@ -68,20 +68,27 @@ Creates a GKE cluster configured for Agent Substrate.
 > [!WARNING]
 > Agent Substrate requires two Kubernetes beta APIs —
 > `certificates.k8s.io/v1beta1/podcertificaterequests` and
-> `certificates.k8s.io/v1beta1/clustertrustbundles` — and GKE only honors
-> `enableK8sBetaApis` **at cluster creation**. Enabling them later on an
-> existing cluster is not recoverable in place: the tool's reconcile path
-> issues the update, but the APIs do not become served — the cluster must be
-> **recreated** with them enabled. `create cluster` sets them for you; if you
-> bring your own cluster, create it with both APIs enabled from the start,
-> e.g.:
+> `certificates.k8s.io/v1beta1/clustertrustbundles` — which constrains the
+> supported GKE versions to exactly two configurations:
+>
+> * **GKE 1.36 with the beta APIs enabled at cluster creation.** GKE only
+>   honors `enableK8sBetaApis` **at creation time**. Enabling the APIs later
+>   on an existing cluster is not recoverable in place: the tool's reconcile
+>   path issues the update, but the APIs do not become served — the cluster
+>   must be **recreated** with them enabled.
+> * **GKE 1.37 or higher**, where the APIs are served by default and no beta
+>   enablement is needed.
+>
+> Versions below 1.36 are not supported. `create cluster` handles the
+> enablement for you; if you bring your own 1.36 cluster, create it with both
+> APIs enabled from the start, e.g.:
 >
 > ```bash
 > gcloud container clusters create "${CLUSTER_NAME}" ... \
 >   --enable-kubernetes-unstable-apis=certificates.k8s.io/v1beta1/podcertificaterequests,certificates.k8s.io/v1beta1/clustertrustbundles
 > ```
 >
-> The symptom of a cluster without them: the install hangs at "Waiting for
+> The symptom of a cluster without the APIs: the install hangs at "Waiting for
 > podcertificate ClusterTrustBundles to be ready" and `kubectl get
 > clustertrustbundles` reports the resource type is not served.
 


### PR DESCRIPTION
The Create Cluster warning explained the beta-API creation-time constraint but not which GKE versions work. Clarifies the two supported configurations: **GKE 1.36 with the beta APIs enabled at cluster creation**, or **GKE 1.37+** where `certificates.k8s.io/v1beta1` is served by default (no beta enablement needed). Versions below 1.36 are unsupported.

- [x] Tests pass (docs only)
- [x] Appropriate changes to documentation are included in the PR

---

Also updates `hack/ate-dev-env.sh.example`: it pinned `1.35.5-gke.1163012` — below the supported floor and no longer offered, so copying it verbatim failed cluster creation. Now pins the newest offered 1.36 patch (`1.36.3-gke.1767000`) with a comment on how to pick a fresh one when the pin ages out.

**Validated**: `setup-gcp create cluster` at `1.36.3-gke.1767000` (us-west1-c) succeeded, and both `certificates.k8s.io/v1beta1` APIs (`clustertrustbundles`, `podcertificaterequests`) are served on the resulting cluster — `kubectl get clustertrustbundles` returns the kube-apiserver-serving bundle. Throwaway cluster deleted after verification.
