### PR TITLE
ateapi: validate system-info projection paths at template creation

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor_template.go
+++ b/cmd/ateapi/internal/controlapi/actor_template.go
@@ -221,6 +221,82 @@ func ValidateCustom_VolumeMount_MountPath(_ context.Context, _ operation.Operati
 	return nil
 }
 
+// validateSystemInfoPath requires a clean relative Unix path for a file
+// projected into a system-info volume: no leading '/', no empty, '.' or
+// '..' segments, and no control characters. Mirrors the defensive check in
+// atelet's writeSystemInfoFile, which is otherwise only hit at actor start.
+func validateSystemInfoPath(fldPath *field.Path, p string) field.ErrorList {
+	bad := strings.HasPrefix(p, "/") || strings.HasSuffix(p, "/") ||
+		strings.Contains(p, "//") || mountPathBadSegmentRE.MatchString(p)
+	if !bad {
+		for _, r := range p {
+			if r < 0x20 || r == 0x7f {
+				bad = true
+				break
+			}
+		}
+	}
+	if bad {
+		return field.ErrorList{field.Invalid(fldPath, p, "must be a clean relative Unix path: must not start with '/', and contain no '..', '.', '//', trailing '/', or control characters")}
+	}
+	return nil
+}
+
+func ValidateCustom_ActorMetadataItem_Path(_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *string) field.ErrorList {
+	return validateSystemInfoPath(fldPath, *value)
+}
+
+func ValidateCustom_TrustBundleDataSource_Path(_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *string) field.ErrorList {
+	return validateSystemInfoPath(fldPath, *value)
+}
+
+// ValidateCustom_SystemInfoVolumeSource_DataSources requires every projected
+// file path to be unique across all data sources, and no path to name a
+// directory of another. atelet writes the files in order into one tree, so a
+// repeated path silently clobbers the earlier file and a file/directory
+// clash fails the actor start.
+func ValidateCustom_SystemInfoVolumeSource_DataSources(_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ []*ateapipb.SystemInfoDataSource) field.ErrorList {
+	var errs field.ErrorList
+	type projected struct {
+		path    string
+		fldPath *field.Path
+	}
+	var seen []projected
+	check := func(fldPath *field.Path, path string) {
+		if path == "" {
+			return // required is enforced by tags
+		}
+		for _, prev := range seen {
+			switch {
+			case prev.path == path:
+				errs = append(errs, field.Duplicate(fldPath, path))
+				return
+			case strings.HasPrefix(prev.path, path+"/"), strings.HasPrefix(path, prev.path+"/"):
+				errs = append(errs, field.Invalid(fldPath, path, fmt.Sprintf("must not be a directory of, or nested under, another projected path (%s)", prev.fldPath)))
+				return
+			}
+		}
+		seen = append(seen, projected{path: path, fldPath: fldPath})
+	}
+	for i, ds := range value {
+		if ds == nil {
+			continue
+		}
+		if tb := ds.TrustBundle; tb != nil {
+			check(fldPath.Index(i).Child("trust_bundle", "path"), tb.Path)
+		}
+		if am := ds.ActorMetadata; am != nil {
+			for j, item := range am.Items {
+				if item == nil {
+					continue
+				}
+				check(fldPath.Index(i).Child("actor_metadata", "items").Index(j).Child("path"), item.Path)
+			}
+		}
+	}
+	return errs
+}
+
 // ValidateCustom_ImageVolumeSource_Reference requires image references to
 // be pinned by digest, because changing the image content under a fixed
 // reference invalidates snapshots.

--- a/cmd/ateapi/internal/controlapi/actor_template.go
+++ b/cmd/ateapi/internal/controlapi/actor_template.go
@@ -23,12 +23,14 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/internal/volumepath"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -221,76 +223,46 @@ func ValidateCustom_VolumeMount_MountPath(_ context.Context, _ operation.Operati
 	return nil
 }
 
-// validateSystemInfoPath requires a clean relative Unix path for a file
-// projected into a system-info volume: no leading '/', no empty, '.' or
-// '..' segments, and no control characters. Mirrors the defensive check in
-// atelet's writeSystemInfoFile, which is otherwise only hit at actor start.
-func validateSystemInfoPath(fldPath *field.Path, p string) field.ErrorList {
-	bad := strings.HasPrefix(p, "/") || strings.HasSuffix(p, "/") ||
-		strings.Contains(p, "//") || mountPathBadSegmentRE.MatchString(p)
-	if !bad {
-		for _, r := range p {
-			if r < 0x20 || r == 0x7f {
-				bad = true
-				break
-			}
-		}
-	}
-	if bad {
-		return field.ErrorList{field.Invalid(fldPath, p, "must be a clean relative Unix path: must not start with '/', and contain no '..', '.', '//', trailing '/', or control characters")}
+// validateProjectedPath applies the projected-path rule shared with atelet,
+// which re-checks it before writing to the host.
+func validateProjectedPath(fldPath *field.Path, p string) field.ErrorList {
+	if err := volumepath.ValidateProjected(p); err != nil {
+		return field.ErrorList{field.Invalid(fldPath, p, err.Error())}
 	}
 	return nil
 }
 
 func ValidateCustom_ActorMetadataItem_Path(_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *string) field.ErrorList {
-	return validateSystemInfoPath(fldPath, *value)
+	return validateProjectedPath(fldPath, *value)
 }
 
 func ValidateCustom_TrustBundleDataSource_Path(_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *string) field.ErrorList {
-	return validateSystemInfoPath(fldPath, *value)
+	return validateProjectedPath(fldPath, *value)
 }
 
 // ValidateCustom_SystemInfoVolumeSource_DataSources requires every projected
-// file path to be unique across all data sources, and no path to name a
-// directory of another. atelet writes the files in order into one tree, so a
-// repeated path silently clobbers the earlier file and a file/directory
-// clash fails the actor start.
+// file path to be unique across all data sources: atelet writes them in
+// order into one tree, so a repeated path silently clobbers the earlier file.
 func ValidateCustom_SystemInfoVolumeSource_DataSources(_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ []*ateapipb.SystemInfoDataSource) field.ErrorList {
 	var errs field.ErrorList
-	type projected struct {
-		path    string
-		fldPath *field.Path
-	}
-	var seen []projected
-	check := func(fldPath *field.Path, path string) {
-		if path == "" {
-			return // required is enforced by tags
-		}
-		for _, prev := range seen {
-			switch {
-			case prev.path == path:
-				errs = append(errs, field.Duplicate(fldPath, path))
-				return
-			case strings.HasPrefix(prev.path, path+"/"), strings.HasPrefix(path, prev.path+"/"):
-				errs = append(errs, field.Invalid(fldPath, path, fmt.Sprintf("must not be a directory of, or nested under, another projected path (%s)", prev.fldPath)))
-				return
-			}
-		}
-		seen = append(seen, projected{path: path, fldPath: fldPath})
-	}
+	seen := sets.New[string]()
 	for i, ds := range value {
-		if ds == nil {
-			continue
-		}
-		if tb := ds.TrustBundle; tb != nil {
-			check(fldPath.Index(i).Child("trust_bundle", "path"), tb.Path)
-		}
-		if am := ds.ActorMetadata; am != nil {
-			for j, item := range am.Items {
+		switch {
+		case ds == nil:
+		case ds.TrustBundle != nil:
+			if seen.Has(ds.TrustBundle.Path) {
+				errs = append(errs, field.Duplicate(fldPath.Index(i).Child("trust_bundle", "path"), ds.TrustBundle.Path))
+			}
+			seen.Insert(ds.TrustBundle.Path)
+		case ds.ActorMetadata != nil:
+			for j, item := range ds.ActorMetadata.Items {
 				if item == nil {
 					continue
 				}
-				check(fldPath.Index(i).Child("actor_metadata", "items").Index(j).Child("path"), item.Path)
+				if seen.Has(item.Path) {
+					errs = append(errs, field.Duplicate(fldPath.Index(i).Child("actor_metadata", "items").Index(j).Child("path"), item.Path))
+				}
+				seen.Insert(item.Path)
 			}
 		}
 	}

--- a/cmd/ateapi/internal/controlapi/validation_test.go
+++ b/cmd/ateapi/internal/controlapi/validation_test.go
@@ -735,6 +735,78 @@ func TestValidateSystemInfoVolumeSource(t *testing.T) {
 			s.DataSources[0].ActorMetadata.Items[0].Path = strings.Repeat("p", 256)
 		}),
 		want: field.ErrorList{field.TooLong(itemsPath.Index(0).Child("path"), nil, 255).WithOrigin("maxLength")},
+	}, {
+		name: "valid: nested item path",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = "meta/actor-name"
+		}),
+	}, {
+		name: "item path traversal",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = "../../traversal-escape"
+		}),
+		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("path"), nil, "")},
+	}, {
+		name: "absolute item path",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = "/escaped"
+		}),
+		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("path"), nil, "")},
+	}, {
+		name: "item path with dot segment",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = "./actor-name"
+		}),
+		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("path"), nil, "")},
+	}, {
+		name: "item path with trailing slash",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = "actor-name/"
+		}),
+		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("path"), nil, "")},
+	}, {
+		name: "item path with empty segment",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = "meta//actor-name"
+		}),
+		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("path"), nil, "")},
+	}, {
+		name: "item path with control character",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = "actor\nname"
+		}),
+		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("path"), nil, "")},
+	}, {
+		name: "trust bundle path traversal",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[1].TrustBundle.Path = "../escape"
+		}),
+		want: field.ErrorList{field.Invalid(dsPath.Index(1).Child("trust_bundle", "path"), nil, "")},
+	}, {
+		name: "duplicate path within items",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[1].Path = "actor-name"
+		}),
+		want: field.ErrorList{field.Duplicate(itemsPath.Index(1).Child("path"), nil)},
+	}, {
+		name: "duplicate path across data sources",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[1].TrustBundle.Path = "actor-uid"
+		}),
+		want: field.ErrorList{field.Duplicate(dsPath.Index(1).Child("trust_bundle", "path"), nil)},
+	}, {
+		name: "path nested under another projected path",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[1].TrustBundle.Path = "actor-name/ca.pem"
+		}),
+		want: field.ErrorList{field.Invalid(dsPath.Index(1).Child("trust_bundle", "path"), nil, "")},
+	}, {
+		name: "path is a directory of another projected path",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = "certs/actor-name"
+			s.DataSources[1].TrustBundle.Path = "certs"
+		}),
+		want: field.ErrorList{field.Invalid(dsPath.Index(1).Child("trust_bundle", "path"), nil, "")},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -780,6 +852,17 @@ func TestValidateTrustBundleDataSource(t *testing.T) {
 		name: "path too long",
 		obj:  valid(func(tb *ateapipb.TrustBundleDataSource) { tb.Path = strings.Repeat("p", 256) }),
 		want: field.ErrorList{field.TooLong(field.NewPath("path"), nil, 255).WithOrigin("maxLength")},
+	}, {
+		name: "valid: nested path",
+		obj:  valid(func(tb *ateapipb.TrustBundleDataSource) { tb.Path = "certs/ca.pem" }),
+	}, {
+		name: "path traversal",
+		obj:  valid(func(tb *ateapipb.TrustBundleDataSource) { tb.Path = "../escape" }),
+		want: field.ErrorList{field.Invalid(field.NewPath("path"), nil, "")},
+	}, {
+		name: "absolute path",
+		obj:  valid(func(tb *ateapipb.TrustBundleDataSource) { tb.Path = "/escaped" }),
+		want: field.ErrorList{field.Invalid(field.NewPath("path"), nil, "")},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/ateapi/internal/controlapi/validation_test.go
+++ b/cmd/ateapi/internal/controlapi/validation_test.go
@@ -771,9 +771,20 @@ func TestValidateSystemInfoVolumeSource(t *testing.T) {
 		}),
 		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("path"), nil, "")},
 	}, {
-		name: "item path with control character",
+		name: "item path with NUL byte",
 		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
-			s.DataSources[0].ActorMetadata.Items[0].Path = "actor\nname"
+			s.DataSources[0].ActorMetadata.Items[0].Path = "actor\x00name"
+		}),
+		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("path"), nil, "")},
+	}, {
+		name: "valid: unicode item path",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = "méta/имя"
+		}),
+	}, {
+		name: "item path with too many segments",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Path = strings.Repeat("d/", 16) + "actor-name"
 		}),
 		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("path"), nil, "")},
 	}, {
@@ -794,19 +805,6 @@ func TestValidateSystemInfoVolumeSource(t *testing.T) {
 			s.DataSources[1].TrustBundle.Path = "actor-uid"
 		}),
 		want: field.ErrorList{field.Duplicate(dsPath.Index(1).Child("trust_bundle", "path"), nil)},
-	}, {
-		name: "path nested under another projected path",
-		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
-			s.DataSources[1].TrustBundle.Path = "actor-name/ca.pem"
-		}),
-		want: field.ErrorList{field.Invalid(dsPath.Index(1).Child("trust_bundle", "path"), nil, "")},
-	}, {
-		name: "path is a directory of another projected path",
-		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
-			s.DataSources[0].ActorMetadata.Items[0].Path = "certs/actor-name"
-			s.DataSources[1].TrustBundle.Path = "certs"
-		}),
-		want: field.ErrorList{field.Invalid(dsPath.Index(1).Child("trust_bundle", "path"), nil, "")},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/ateapi/internal/controlapi/zz_generated.validation.go
+++ b/cmd/ateapi/internal/controlapi/zz_generated.validation.go
@@ -365,6 +365,10 @@ func Validate_ActorMetadataItem(
 			if earlyReturn {
 				return // do not proceed
 			}
+			// custom validation
+			if e := ValidateCustom_ActorMetadataItem_Path(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 255); len(e) != 0 {
 				errs = append(errs, e...)
 			}
@@ -6017,6 +6021,10 @@ func Validate_SystemInfoVolumeSource(
 			if earlyReturn {
 				return // do not proceed
 			}
+			// custom validation
+			if e := ValidateCustom_SystemInfoVolumeSource_DataSources(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachPtrSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_SystemInfoDataSource); len(e) != 0 {
 				errs = append(errs, e...)
@@ -6309,6 +6317,10 @@ func Validate_TrustBundleDataSource(
 			}
 			if earlyReturn {
 				return // do not proceed
+			}
+			// custom validation
+			if e := ValidateCustom_TrustBundleDataSource_Path(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
 			}
 			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 255); len(e) != 0 {
 				errs = append(errs, e...)

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -29,7 +29,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -53,6 +52,7 @@ import (
 	"github.com/agent-substrate/substrate/internal/substratex509"
 	"github.com/agent-substrate/substrate/internal/version"
 	"github.com/agent-substrate/substrate/internal/volume"
+	"github.com/agent-substrate/substrate/internal/volumepath"
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/client/clientset/versioned"
 	"github.com/agent-substrate/substrate/pkg/client/informers/externalversions"
@@ -1685,17 +1685,11 @@ func writeSystemInfoVolume(ctx context.Context, rootPath string, actorRef resour
 
 // writeSystemInfoFile writes one projected file at relPath under rootPath via
 // write-to-temp-and-rename, creating parent directories as needed. relPath is
-// validated defensively even though ActorTemplate validation already rejects
-// non-clean paths: atelet is the last line before the value hits the host
-// filesystem.
+// re-checked against the rule ateapi applied at template creation: atelet is
+// the last line before the value hits the host filesystem.
 func writeSystemInfoFile(rootPath, relPath string, data []byte) error {
-	if relPath == "" || strings.HasPrefix(relPath, "/") {
-		return fmt.Errorf("invalid system-info path %q: must be a non-empty relative path", relPath)
-	}
-	for _, seg := range strings.Split(relPath, "/") {
-		if seg == ".." || seg == "." || seg == "" {
-			return fmt.Errorf("invalid system-info path %q: must not contain empty, '.', or '..' segments", relPath)
-		}
+	if err := volumepath.ValidateProjected(relPath); err != nil {
+		return fmt.Errorf("invalid system-info path %q: %w", relPath, err)
 	}
 	dst := filepath.Join(rootPath, filepath.FromSlash(relPath))
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -153,7 +153,7 @@ To deliver identity information, including credentials, to a running actor, you 
 Available information sources:
 
 #### actorMetadata
-The actorMetadata data source projects the actor's identity fields to files, one per item, analogous to the [Kubernetes downwardAPI volume](https://kubernetes.io/docs/concepts/storage/downward-api/). Each item selects a `field` — `name` (unique within an atespace), `atespace` (together with the name, the actor's full identity and DNS name), or `uid` (server-generated, distinguishes incarnations of the same name) — and the `path` the value is written to, raw with no trailing newline. `path` is a clean relative path from the root of the volume (no leading `/`, no `.` or `..` segments) and must not repeat or nest under another path projected into the same volume.
+The actorMetadata data source projects the actor's identity fields to files, one per item, analogous to the [Kubernetes downwardAPI volume](https://kubernetes.io/docs/concepts/storage/downward-api/). Each item selects a `field` — `name` (unique within an atespace), `atespace` (together with the name, the actor's full identity and DNS name), or `uid` (server-generated, distinguishes incarnations of the same name) — and the `path` the value is written to, raw with no trailing newline. `path` is a clean relative path from the root of the volume (no leading `/`, no `.` or `..` segments, at most 16 segments) and must not repeat another path projected into the same volume.
 
 ```yaml
 spec:

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -153,7 +153,7 @@ To deliver identity information, including credentials, to a running actor, you 
 Available information sources:
 
 #### actorMetadata
-The actorMetadata data source projects the actor's identity fields to files, one per item, analogous to the [Kubernetes downwardAPI volume](https://kubernetes.io/docs/concepts/storage/downward-api/). Each item selects a `field` — `name` (unique within an atespace), `atespace` (together with the name, the actor's full identity and DNS name), or `uid` (server-generated, distinguishes incarnations of the same name) — and the relative `path` the value is written to, raw with no trailing newline.
+The actorMetadata data source projects the actor's identity fields to files, one per item, analogous to the [Kubernetes downwardAPI volume](https://kubernetes.io/docs/concepts/storage/downward-api/). Each item selects a `field` — `name` (unique within an atespace), `atespace` (together with the name, the actor's full identity and DNS name), or `uid` (server-generated, distinguishes incarnations of the same name) — and the `path` the value is written to, raw with no trailing newline. `path` is a clean relative path from the root of the volume (no leading `/`, no `.` or `..` segments) and must not repeat or nest under another path projected into the same volume.
 
 ```yaml
 spec:

--- a/docs/egress-trust-bundle.md
+++ b/docs/egress-trust-bundle.md
@@ -53,8 +53,8 @@ spec:
 
 `trustBundle.path` is relative to the root of the volume, so the file's absolute path is
 `mountPath` + `path`. It must be a clean relative Unix path: no leading or
-trailing `/`, no `//`, `:`, `.`, or `..` segments. A `systemInfo` volume takes
-at most 8 data sources and their paths must not collide.
+trailing `/`, no `//`, `.`, or `..` segments, and at most 16 segments. A
+`systemInfo` volume takes at most 8 data sources and their paths must not repeat.
 
 The projected PEM contains `CERTIFICATE` blocks only, deduplicated and
 deliberately shuffled — order carries no meaning, so do not write anything that

--- a/internal/volumepath/volumepath.go
+++ b/internal/volumepath/volumepath.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package volumepath holds the rule for the relative paths at which substrate
+// projects files into an actor's volumes. ateapi applies it when an
+// ActorTemplate is created and atelet applies it again before writing to the
+// host filesystem; both call this one implementation so the two cannot drift.
+package volumepath
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// MaxSegments bounds the depth of a projected path.
+const MaxSegments = 16
+
+// ValidateProjected reports why p is not acceptable as the path of a file
+// projected into a volume, relative to the volume root. p must be non-empty,
+// contain no NUL byte, and split on '/' into at most MaxSegments segments,
+// none of which is "", "." or "..". Any other byte is allowed: Linux paths
+// are bytes, not text, so Unicode in any encoding passes.
+func ValidateProjected(p string) error {
+	if p == "" {
+		return errors.New("must not be empty")
+	}
+	if strings.IndexByte(p, 0) >= 0 {
+		return errors.New("must not contain a NUL byte")
+	}
+	segments := strings.Split(p, "/")
+	if len(segments) > MaxSegments {
+		return fmt.Errorf("must have at most %d path segments", MaxSegments)
+	}
+	for _, segment := range segments {
+		switch segment {
+		case "":
+			return errors.New("must be a relative path with no empty segments: no leading, trailing, or doubled '/'")
+		case ".", "..":
+			return fmt.Errorf("must not contain a %q path segment", segment)
+		}
+	}
+	return nil
+}

--- a/internal/volumepath/volumepath_test.go
+++ b/internal/volumepath/volumepath_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package volumepath
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestValidateProjected(t *testing.T) {
+	tests := []struct {
+		path string
+		ok   bool
+	}{
+		{"ca.pem", true},
+		{"certs/ca.pem", true},
+		{"méta/имя", true},
+		{"with space", true},
+		{".hidden", true},
+		{"..dots", true},
+		{strings.Repeat("d/", MaxSegments-1) + "f", true},
+		{"", false},
+		{"/etc/passwd", false},
+		{"a/", false},
+		{"a//b", false},
+		{".", false},
+		{"..", false},
+		{"./a", false},
+		{"a/../b", false},
+		{"a/./b", false},
+		{"a\x00b", false},
+		{strings.Repeat("d/", MaxSegments) + "f", false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q", tt.path), func(t *testing.T) {
+			err := ValidateProjected(tt.path)
+			if (err == nil) != tt.ok {
+				t.Errorf("ValidateProjected(%q) = %v, want ok=%v", tt.path, err, tt.ok)
+			}
+		})
+	}
+}

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -3304,12 +3304,12 @@ type SystemInfoVolumeSource struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// data_sources lists the projections to place within the volume. At most
 	// one actor_metadata entry may appear, and file paths must be unique
-	// across all entries: no path may repeat or name a directory of another.
+	// across all entries.
 	//
 	// +k8s:optional
 	// +k8s:maxItems=8
 	// +k8s:listType=atomic
-	// +k8s:customValidation # paths unique and non-nested across entries
+	// +k8s:customValidation # paths unique across entries
 	DataSources   []*SystemInfoDataSource `protobuf:"bytes,1,rep,name=data_sources,json=dataSources,proto3" json:"data_sources,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3473,13 +3473,13 @@ type ActorMetadataItem struct {
 	// +k8s:minimum=1
 	// +k8s:maximum=3 # keep this in sync with the ActorMetadataField enum
 	Field ActorMetadataField `protobuf:"varint,1,opt,name=field,proto3,enum=ateapi.ActorMetadataField" json:"field,omitempty"`
-	// path must be a clean relative Unix path: no leading '/', no empty, '.'
-	// or '..' segments, and no control characters.
+	// path must be a clean relative Unix path: at most 16 '/'-separated
+	// segments, none of them empty, '.' or '..', and no NUL byte.
 	//
 	// +k8s:required
 	// +k8s:minLength=1
 	// +k8s:maxLength=255
-	// +k8s:customValidation # clean relative path; no regex/pattern tag exists
+	// +k8s:customValidation # projected-path rule shared with atelet, see internal/volumepath
 	Path          string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3537,13 +3537,13 @@ type TrustBundleDataSource struct {
 	// +k8s:minLength=1
 	// +k8s:maxLength=253
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// path must be a clean relative Unix path: no leading '/', no empty, '.'
-	// or '..' segments, and no control characters.
+	// path must be a clean relative Unix path: at most 16 '/'-separated
+	// segments, none of them empty, '.' or '..', and no NUL byte.
 	//
 	// +k8s:required
 	// +k8s:minLength=1
 	// +k8s:maxLength=255
-	// +k8s:customValidation # clean relative path; no regex/pattern tag exists
+	// +k8s:customValidation # projected-path rule shared with atelet, see internal/volumepath
 	Path          string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -3304,11 +3304,12 @@ type SystemInfoVolumeSource struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// data_sources lists the projections to place within the volume. At most
 	// one actor_metadata entry may appear, and file paths must be unique
-	// across all entries.
+	// across all entries: no path may repeat or name a directory of another.
 	//
 	// +k8s:optional
 	// +k8s:maxItems=8
 	// +k8s:listType=atomic
+	// +k8s:customValidation # paths unique and non-nested across entries
 	DataSources   []*SystemInfoDataSource `protobuf:"bytes,1,rep,name=data_sources,json=dataSources,proto3" json:"data_sources,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3472,9 +3473,13 @@ type ActorMetadataItem struct {
 	// +k8s:minimum=1
 	// +k8s:maximum=3 # keep this in sync with the ActorMetadataField enum
 	Field ActorMetadataField `protobuf:"varint,1,opt,name=field,proto3,enum=ateapi.ActorMetadataField" json:"field,omitempty"`
+	// path must be a clean relative Unix path: no leading '/', no empty, '.'
+	// or '..' segments, and no control characters.
+	//
 	// +k8s:required
 	// +k8s:minLength=1
 	// +k8s:maxLength=255
+	// +k8s:customValidation # clean relative path; no regex/pattern tag exists
 	Path          string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3532,9 +3537,13 @@ type TrustBundleDataSource struct {
 	// +k8s:minLength=1
 	// +k8s:maxLength=253
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// path must be a clean relative Unix path: no leading '/', no empty, '.'
+	// or '..' segments, and no control characters.
+	//
 	// +k8s:required
 	// +k8s:minLength=1
 	// +k8s:maxLength=255
+	// +k8s:customValidation # clean relative path; no regex/pattern tag exists
 	Path          string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -1112,12 +1112,12 @@ message ExternalVolumeTemplate {
 message SystemInfoVolumeSource {
   // data_sources lists the projections to place within the volume. At most
   // one actor_metadata entry may appear, and file paths must be unique
-  // across all entries: no path may repeat or name a directory of another.
+  // across all entries.
   //
   // +k8s:optional
   // +k8s:maxItems=8
   // +k8s:listType=atomic
-  // +k8s:customValidation # paths unique and non-nested across entries
+  // +k8s:customValidation # paths unique across entries
   repeated SystemInfoDataSource data_sources = 1;
 }
 
@@ -1156,13 +1156,13 @@ message ActorMetadataItem {
   // +k8s:maximum=3 # keep this in sync with the ActorMetadataField enum
   ActorMetadataField field = 1;
 
-  // path must be a clean relative Unix path: no leading '/', no empty, '.'
-  // or '..' segments, and no control characters.
+  // path must be a clean relative Unix path: at most 16 '/'-separated
+  // segments, none of them empty, '.' or '..', and no NUL byte.
   //
   // +k8s:required
   // +k8s:minLength=1
   // +k8s:maxLength=255
-  // +k8s:customValidation # clean relative path; no regex/pattern tag exists
+  // +k8s:customValidation # projected-path rule shared with atelet, see internal/volumepath
   string path = 2;
 }
 
@@ -1183,13 +1183,13 @@ message TrustBundleDataSource {
   // +k8s:maxLength=253
   string name = 1;
 
-  // path must be a clean relative Unix path: no leading '/', no empty, '.'
-  // or '..' segments, and no control characters.
+  // path must be a clean relative Unix path: at most 16 '/'-separated
+  // segments, none of them empty, '.' or '..', and no NUL byte.
   //
   // +k8s:required
   // +k8s:minLength=1
   // +k8s:maxLength=255
-  // +k8s:customValidation # clean relative path; no regex/pattern tag exists
+  // +k8s:customValidation # projected-path rule shared with atelet, see internal/volumepath
   string path = 2;
 }
 

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -1112,11 +1112,12 @@ message ExternalVolumeTemplate {
 message SystemInfoVolumeSource {
   // data_sources lists the projections to place within the volume. At most
   // one actor_metadata entry may appear, and file paths must be unique
-  // across all entries.
+  // across all entries: no path may repeat or name a directory of another.
   //
   // +k8s:optional
   // +k8s:maxItems=8
   // +k8s:listType=atomic
+  // +k8s:customValidation # paths unique and non-nested across entries
   repeated SystemInfoDataSource data_sources = 1;
 }
 
@@ -1155,9 +1156,13 @@ message ActorMetadataItem {
   // +k8s:maximum=3 # keep this in sync with the ActorMetadataField enum
   ActorMetadataField field = 1;
 
+  // path must be a clean relative Unix path: no leading '/', no empty, '.'
+  // or '..' segments, and no control characters.
+  //
   // +k8s:required
   // +k8s:minLength=1
   // +k8s:maxLength=255
+  // +k8s:customValidation # clean relative path; no regex/pattern tag exists
   string path = 2;
 }
 
@@ -1178,9 +1183,13 @@ message TrustBundleDataSource {
   // +k8s:maxLength=253
   string name = 1;
 
+  // path must be a clean relative Unix path: no leading '/', no empty, '.'
+  // or '..' segments, and no control characters.
+  //
   // +k8s:required
   // +k8s:minLength=1
   // +k8s:maxLength=255
+  // +k8s:customValidation # clean relative path; no regex/pattern tag exists
   string path = 2;
 }
 

--- a/tools/apitool/exemptions.json
+++ b/tools/apitool/exemptions.json
@@ -21,11 +21,6 @@
   },
   {
     "rule": "documented",
-    "subject": "ateapi.ActorMetadataItem.path",
-    "message": "field has no doc comment"
-  },
-  {
-    "rule": "documented",
     "subject": "ateapi.TagScope",
     "message": "enum has no doc comment"
   },
@@ -392,11 +387,6 @@
   {
     "rule": "documented",
     "subject": "ateapi.TrustBundleDataSource.name",
-    "message": "field has no doc comment"
-  },
-  {
-    "rule": "documented",
-    "subject": "ateapi.TrustBundleDataSource.path",
     "message": "field has no doc comment"
   },
   {


### PR DESCRIPTION
`CreateActorTemplate` accepted `../escape` and `/escaped` in `ActorMetadataItem.path` and `TrustBundleDataSource.path`, and accepted several data sources projecting to the same path. atelet only rejects the traversal at actor start, so the template is created but the golden actor sits in `RESUMING`. atelet never rejects duplicate paths at all: it writes the files in order and the last one wins.

This PR moves both checks to template validation.

- The path rule lives in a new `internal/volumepath` package that both ateapi and atelet call, so the two cannot drift. It splits on `/` and rejects any segment that is empty, `.`, or `..`, caps depth at 16 segments, and rejects NUL bytes. Any other byte is allowed, so Unicode paths pass. `ActorMetadataItem.path` and `TrustBundleDataSource.path` apply it through a `+k8s:customValidation` hook, and atelet's `writeSystemInfoFile` applies it again before touching the host filesystem.
- `SystemInfoVolumeSource.data_sources` gets a hook that tracks projected paths in a set and reports a duplicate on repeats, in the same shape as the Kubernetes projected-volume validation.

The proto doc comment on `data_sources` also says at most one `actor_metadata` entry may appear. Nothing enforces that, and this PR leaves it alone.

New cases in `TestValidateSystemInfoVolumeSource` and `TestValidateTrustBundleDataSource` cover the rejected shapes, and `internal/volumepath` has its own table test. `hack/verify/codegen.sh` and `hack/verify/golangci-lint.sh` pass.

#1231 moves `writeSystemInfoFile` into `systeminfovolume.go` and onto `os.Root`. Whichever PR lands second points that copy at the shared rule.

Fixes #1436
Fixes #1438
