### PR TITLE
e2e: give TestActorEgress an in-cluster origin

### DIFF
--- a/internal/e2e/fixtures/serverpod.yaml.tmpl
+++ b/internal/e2e/fixtures/serverpod.yaml.tmpl
@@ -42,7 +42,7 @@ spec:
 ${ARGS}
     ports:
     - name: serve
-      containerPort: ${PORT}
+      containerPort: ${TARGET_PORT}
     # The suite starts dialing as soon as it has an address, so without a
     # readiness gate the first connection can land before the listener exists
     # and come back refused -- which reads as a failure of whatever sits between
@@ -82,4 +82,4 @@ spec:
   ports:
   - name: serve
     port: ${PORT}
-    targetPort: ${PORT}
+    targetPort: ${TARGET_PORT}

--- a/internal/e2e/serverpod.go
+++ b/internal/e2e/serverpod.go
@@ -51,10 +51,14 @@ type ServerPod struct {
 	// backs every server, so this is where a caller names the subcommand that
 	// picks its behavior -- []string{"grpc"}, say.
 	Args []string
-	// Port is what the binary listens on and what the Service publishes,
-	// unchanged, so an address a suite grafts into an assertion — a CONNECT
-	// authority in a gateway's access log, say — is this number.
+	// Port is what the Service publishes, so an address a suite grafts into an
+	// assertion — a CONNECT authority in a gateway's access log, say — is this
+	// number.
 	Port int
+	// TargetPort is what the binary listens on, defaulting to Port. Set it to
+	// publish a port the container -- uid 65532, every capability dropped --
+	// cannot bind, such as 80; the Service maps Port down to it.
+	TargetPort int
 	// Namespace deploys into an existing namespace instead of a fresh one, for
 	// a suite that has to populate that namespace first: credentials the pod
 	// mounts have to exist before it is scheduled, and DeployServerPod cannot
@@ -128,16 +132,21 @@ func DeployServerPod(t *testing.T, ctx context.Context, spec ServerPod) Server {
 // does not need a cluster.
 func renderServerPod(t *testing.T, spec ServerPod, namespace string) string {
 	t.Helper()
-	port := strconv.Itoa(spec.Port)
+	targetPort := spec.TargetPort
+	if targetPort == 0 {
+		targetPort = spec.Port
+	}
+	targetPortStr := strconv.Itoa(targetPort)
 	inline := map[string]string{
-		"${NAME}":      spec.Name,
-		"${NAMESPACE}": namespace,
-		"${IMAGE}":     "ko://" + spec.ImportPath,
-		"${PORT}":      port,
+		"${NAME}":        spec.Name,
+		"${NAMESPACE}":   namespace,
+		"${IMAGE}":       "ko://" + spec.ImportPath,
+		"${PORT}":        strconv.Itoa(spec.Port),
+		"${TARGET_PORT}": targetPortStr,
 	}
 	blocks := map[string]string{
-		"${ARGS}":            serverArgs(spec, port),
-		"${READINESS_PROBE}": serverReadinessProbe(spec, port),
+		"${ARGS}":            serverArgs(spec, targetPortStr),
+		"${READINESS_PROBE}": serverReadinessProbe(spec, targetPortStr),
 		// Indented to their parents: volumeMounts is a container field, volumes
 		// a pod one. An empty list takes its whole line, key included.
 		"${VOLUME_MOUNTS}": yamlListBlock(t, "volumeMounts", spec.VolumeMounts, 4),
@@ -149,25 +158,26 @@ func renderServerPod(t *testing.T, spec ServerPod, namespace string) string {
 // serverArgs renders the container's `args:` list -- spec.Args followed by the
 // --listen the template's contract always appends -- indented to replace the
 // template's `${ARGS}` line. It is never empty: every server takes --listen.
-func serverArgs(spec ServerPod, port string) string {
+func serverArgs(spec ServerPod, targetPort string) string {
 	const pad = "    "
 	out := []string{pad + "args:"}
 	for _, arg := range spec.Args {
 		out = append(out, fmt.Sprintf("%s- %q", pad, arg))
 	}
-	out = append(out, fmt.Sprintf("%s- %q", pad, "--listen=:"+port))
+	out = append(out, fmt.Sprintf("%s- %q", pad, "--listen=:"+targetPort))
 	return strings.Join(out, "\n")
 }
 
 // serverReadinessProbe renders the probe fragment for spec, indented to sit
-// under the template's `readinessProbe:` key.
-func serverReadinessProbe(spec ServerPod, port string) string {
+// under the template's `readinessProbe:` key. kubelet dials the container
+// directly, so the probe names the listen port rather than the published one.
+func serverReadinessProbe(spec ServerPod, targetPort string) string {
 	if spec.GRPCProbe {
-		return "      grpc:\n        port: " + port
+		return "      grpc:\n        port: " + targetPort
 	}
 	path := spec.HealthPath
 	if path == "" {
 		path = "/healthz"
 	}
-	return fmt.Sprintf("      httpGet:\n        path: %s\n        port: %s", path, port)
+	return fmt.Sprintf("      httpGet:\n        path: %s\n        port: %s", path, targetPort)
 }

--- a/internal/e2e/serverpod_test.go
+++ b/internal/e2e/serverpod_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -152,6 +153,66 @@ func TestRenderServerPod_HTTPProbe(t *testing.T) {
 	}
 	if probe.GRPC != nil {
 		t.Errorf("readinessProbe also carries a gRPC probe: %+v", probe.GRPC)
+	}
+}
+
+// TestRenderServerPod covers where each port lands: every field kubelet or
+// the binary reaches follows the listener, while the Service alone keeps the
+// published port.
+func TestRenderServerPod(t *testing.T) {
+	tests := []struct {
+		name          string
+		spec          ServerPod
+		wantPublished int32 // the Service's port
+		wantListen    int   // args, containerPort, probe and Service targetPort
+	}{{
+		name: "maps a privileged published port to an unprivileged listener",
+		spec: ServerPod{
+			Name:       "egresshttp",
+			ImportPath: "github.com/agent-substrate/substrate/internal/e2e/fixtures/testserver",
+			Args:       []string{"http"},
+			Port:       80,
+			TargetPort: 8080,
+		},
+		wantPublished: 80,
+		wantListen:    8080,
+	}, {
+		name: "defaults the listener to Port when TargetPort is unset",
+		spec: ServerPod{
+			Name:       "httporigin",
+			ImportPath: "github.com/agent-substrate/substrate/internal/e2e/fixtures/testserver",
+			Args:       []string{"http"},
+			Port:       8080,
+		},
+		wantPublished: 8080,
+		wantListen:    8080,
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pod, service := renderServerPodDocs(t, tc.spec)
+
+			container := pod.Spec.Containers[0]
+			if got, want := container.Args, []string{"http", "--listen=:" + strconv.Itoa(tc.wantListen)}; !slices.Equal(got, want) {
+				t.Errorf("container args = %v, want %v", got, want)
+			}
+			if got := container.Ports[0].ContainerPort; got != int32(tc.wantListen) {
+				t.Errorf("containerPort = %d, want the listen port %d", got, tc.wantListen)
+			}
+			probe := container.ReadinessProbe
+			if probe == nil || probe.HTTPGet == nil {
+				t.Fatalf("readinessProbe = %+v, want an httpGet probe", probe)
+			}
+			if got := probe.HTTPGet.Port.IntValue(); got != tc.wantListen {
+				t.Errorf("probe port = %d, want the listen port %d", got, tc.wantListen)
+			}
+
+			if got := service.Spec.Ports[0].Port; got != tc.wantPublished {
+				t.Errorf("service port = %d, want the published port %d", got, tc.wantPublished)
+			}
+			if got := service.Spec.Ports[0].TargetPort.IntValue(); got != tc.wantListen {
+				t.Errorf("service targetPort = %d, want the listen port %d", got, tc.wantListen)
+			}
+		})
 	}
 }
 

--- a/internal/e2e/suites/networking/networking_test.go
+++ b/internal/e2e/suites/networking/networking_test.go
@@ -82,24 +82,63 @@ func TestActorDirectAccess(t *testing.T) {
 	})
 }
 
+// egressHTTPTarget returns a copy of the origin TestActorEgress dials:
+// testserver's http subcommand, published on port 80, listening on 8080.
+func egressHTTPTarget() e2e.ServerPod {
+	return e2e.ServerPod{
+		Name:       "egresshttp",
+		ImportPath: "github.com/agent-substrate/substrate/internal/e2e/fixtures/testserver",
+		Args:       []string{"http"},
+		Port:       80,
+		TargetPort: 8080,
+	}
+}
+
 // TestActorEgress exercises the full egress path. The Actor's outbound TCP
 // connection is transparently redirected by nftables into atunnel, wrapped in
 // mTLS with the Actor's own actor-identity certificate plus an HTTP CONNECT to
 // atenet-egress, authorized there against that certificate, and only then
-// dialed out. A masqueraded (pre-gateway) egress would also return 200, so this
-// asserts the gateway is deployed and that it did not reject the Actor.
+// dialed out.
+//
+// The origin is deployed by the test, and a masqueraded, pre-gateway egress
+// would reach it just as well; the access-log assertion is what proves the
+// traffic went through the gateway.
 func TestActorEgress(t *testing.T) {
 	ctx := context.Background()
+
+	// Deploy the origin first so a fixture failure costs no Actor resume.
+	origin := egressHTTPTarget()
+	target := e2e.DeployServerPod(t, ctx, origin)
+
 	actorName, _ := createAndResumeActor(t, ctx, "egress", egressFixture())
 	router := mustRouterClient(t, ctx)
 	defer router.Close()
 
 	actorRef := resources.ActorRef{Atespace: networkingAtespace, Name: actorName}
-	status, body := fetchThroughEgressActor(t, ctx, router, actorRef, "http://example.com/")
+	url := fmt.Sprintf("http://%s/healthz", target.Address())
+
+	// Bound the access-log scan to lines this test produced: captured before
+	// the fetch, with slack for clock skew against the gateway's node.
+	since := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+	status, body := fetchThroughEgressActor(t, ctx, router, actorRef, url)
 	if status != http.StatusOK {
-		t.Fatalf("Actor egress fetch returned HTTP %d, want 200; body: %s", status, body)
+		t.Fatalf("Actor egress fetch of %s returned HTTP %d, want 200; body: %s", url, status, body)
 	}
-	t.Logf("Actor egress fetch succeeded; body: %s", body)
+	t.Logf("Actor egress fetch of %s succeeded; body: %s", url, body)
+
+	assertEgressGatewayConnect(t, ctx, since, actorName, strconv.Itoa(origin.Port))
+
+	// The Actor resolves the name itself -- DNS leaves over the UDP masquerade,
+	// not the tunnel, and atunnel forwards the resolved address, never the
+	// name -- so dialing by name covers a leg the by-address fetch above skips.
+	t.Run("by DNS name", func(t *testing.T) {
+		url := fmt.Sprintf("http://%s.%s.svc.cluster.local/healthz", origin.Name, target.Namespace)
+		status, body := fetchThroughEgressActor(t, ctx, router, actorRef, url)
+		if status != http.StatusOK {
+			t.Fatalf("Actor egress fetch of %s returned HTTP %d, want 200; body: %s", url, status, body)
+		}
+		t.Logf("Actor egress fetch of %s succeeded; body: %s", url, body)
+	})
 }
 
 // TestActorEgressHTTPS covers the same path as TestActorEgress with a TLS


### PR DESCRIPTION
Part of #246.

TestActorEgress fetched `http://example.com/`, so the test failed whenever that host was unreachable rather than when egress broke. GitHub-hosted runners also have no IPv6, so egress to an external domain needs extra setup on an IPv6-only cluster.

The test now deploys its own testserver origin and fetches that. Since an in-cluster origin would answer a pre-gateway masquerade just as readily, the test asserts the atenet-egress access log recorded the actor's CONNECT, and a subtest fetches by Service DNS name to keep actor-side resolution covered. ServerPod gains `TargetPort` (defaulting to `Port`) so the Service can publish 80 while the container binds an unprivileged listener; the rendering is unit-tested without a cluster.

First of a series retiring the remaining example.com fetches.

Tested: presubmits on the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
