### PR TITLE
ateapi: Fix various actor workflow races

### DIFF
--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -1853,6 +1853,40 @@ func TestResumeActor(t *testing.T) {
 	}
 }
 
+func TestResumeActor_WorkerDeletedAfterRestorePreservesCrash(t *testing.T) {
+	ns := namespaceForTest("ns-resume-worker-delete")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+	workerName := createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}
+	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: actorRef.GetAtespace(), Name: actorRef.GetName()},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	tc.fakeAtelet.AfterRestore = func(ctx context.Context) error {
+		_, err := tc.client.DeleteWorker(ctx, &ateapipb.DeleteWorkerRequest{Worker: &ateapipb.ObjectRef{Name: workerName}})
+		return err
+	}
+
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: actorRef}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("ResumeActor error = %v, want FailedPrecondition", err)
+	}
+	got, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: actorRef})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if got.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("state = %v, want CRASHED", got.GetStatus().GetState())
+	}
+	if got.GetStatus().GetWorkerAssignment() != nil {
+		t.Errorf("worker assignment = %v, want nil", got.GetStatus().GetWorkerAssignment())
+	}
+}
+
 func TestResumeActorPassesLiteralEnv(t *testing.T) {
 	ns := namespaceForTest("ns-resume-literal-env")
 	tc := setupTest(t, ns)
@@ -2472,6 +2506,80 @@ func TestResumeActor_RepointTemplateBeforeResume(t *testing.T) {
 				t.Errorf("restore request to atelet had golden snapshot uri = %q, want empty", got)
 			}
 		})
+	}
+}
+
+func TestSuspendActor_WorkerDeletedAfterCheckpointPreservesCrash(t *testing.T) {
+	ns := namespaceForTest("ns-suspend-worker-delete")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+	workerName := createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}
+	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: actorRef.GetAtespace(), Name: actorRef.GetName()},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+	tc.fakeAtelet.AfterCheckpoint = func(ctx context.Context) error {
+		_, err := tc.client.DeleteWorker(ctx, &ateapipb.DeleteWorkerRequest{Worker: &ateapipb.ObjectRef{Name: workerName}})
+		return err
+	}
+
+	if _, err := tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{Actor: actorRef}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("SuspendActor error = %v, want FailedPrecondition", err)
+	}
+	got, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: actorRef})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if got.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("state = %v, want CRASHED", got.GetStatus().GetState())
+	}
+	if got.GetStatus().GetExternalSnapshot() != nil {
+		t.Errorf("external snapshot = %v, want nil", got.GetStatus().GetExternalSnapshot())
+	}
+}
+
+func TestPauseActor_WorkerDeletedAfterCheckpointPreservesCrash(t *testing.T) {
+	ns := namespaceForTest("ns-pause-worker-delete")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+	workerName := createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: "id1"}
+	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: actorRef.GetAtespace(), Name: actorRef.GetName()},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+	tc.fakeAtelet.AfterCheckpoint = func(ctx context.Context) error {
+		_, err := tc.client.DeleteWorker(ctx, &ateapipb.DeleteWorkerRequest{Worker: &ateapipb.ObjectRef{Name: workerName}})
+		return err
+	}
+
+	if _, err := tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{Actor: actorRef}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("PauseActor error = %v, want FailedPrecondition", err)
+	}
+	got, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: actorRef})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if got.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("state = %v, want CRASHED", got.GetStatus().GetState())
+	}
+	if got.GetStatus().GetWorkerAssignment() != nil {
+		t.Errorf("worker assignment = %v, want nil", got.GetStatus().GetWorkerAssignment())
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/functionaltest/main_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/main_test.go
@@ -117,11 +117,13 @@ type FakeAteletServer struct {
 
 	CheckpointCalled  bool
 	CheckpointRequest *ateletpb.CheckpointRequest
+	AfterCheckpoint   func(context.Context) error
 
 	RestoreCalled  bool
 	RestoreRequest *ateletpb.RestoreRequest
 	FailRestore    error
 	RestoreDelay   time.Duration
+	AfterRestore   func(context.Context) error
 
 	UploadCalled  bool
 	UploadRequest *ateletpb.UploadPausedCheckpointRequest
@@ -169,6 +171,8 @@ func (f *FakeAteletServer) Reset() {
 	f.RestoreRequest = nil
 	f.FailRestore = nil
 	f.RestoreDelay = 0
+	f.AfterRestore = nil
+	f.AfterCheckpoint = nil
 
 	f.UploadCalled = false
 	f.UploadRequest = nil
@@ -211,6 +215,11 @@ func (f *FakeAteletServer) Checkpoint(ctx context.Context, req *ateletpb.Checkpo
 
 	f.CheckpointCalled = true
 	f.CheckpointRequest = proto.Clone(req).(*ateletpb.CheckpointRequest)
+	if f.AfterCheckpoint != nil {
+		if err := f.AfterCheckpoint(ctx); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := f.writeSnapshot(req.GetExternalConfig().GetSnapshotUri()); err != nil {
 		return nil, err
@@ -229,6 +238,11 @@ func (f *FakeAteletServer) Restore(ctx context.Context, req *ateletpb.RestoreReq
 	}
 	if f.FailRestore != nil {
 		return nil, f.FailRestore
+	}
+	if f.AfterRestore != nil {
+		if err := f.AfterRestore(ctx); err != nil {
+			return nil, err
+		}
 	}
 	return &ateletpb.RestoreResponse{}, nil
 }

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -212,9 +212,9 @@ func (w *ActorWorkflow) ensureAteletPaused(ctx context.Context, actorRef resourc
 // owned by this actor), records where the local snapshot lives, and commits
 // PAUSED with the assignment cleared in a single update — or CRASHED when the
 // worker's node name was lost, since a local snapshot on an unknown node can
-// never be resumed. It re-reads the actor first so an out-of-band transition
-// (e.g. the syncer crashing the actor after its worker died) is not
-// overwritten: with no assignment left there is nothing to finalize.
+// never be resumed. It re-reads the actor after releasing the worker and only
+// finalizes PAUSING, so an out-of-band transition (e.g. worker deletion
+// crashing the actor) is not overwritten.
 func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef resources.ActorRef, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "FinalizePaused")
 	defer func() { err = done(err) }()
@@ -222,6 +222,9 @@ func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef reso
 	latestActor, err := w.store.GetActor(ctx, actorRef)
 	if err != nil {
 		return nil, err
+	}
+	if got := latestActor.GetStatus().GetState(); got != ateapipb.ActorState_ACTOR_STATE_PAUSING {
+		return nil, status.Errorf(codes.FailedPrecondition, "FinalizePaused prerequisite not met for Actor: %s (got: %v, want %s)", actorRef, got, ateapipb.ActorState_ACTOR_STATE_PAUSING)
 	}
 
 	// 1. Free the worker (if it hasn't been freed yet)
@@ -251,7 +254,9 @@ func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef reso
 		if err != nil {
 			return nil, err
 		}
-		wasAlreadyCrashed := latestActor.GetStatus().GetState() == ateapipb.ActorState_ACTOR_STATE_CRASHED
+		if got := latestActor.GetStatus().GetState(); got != ateapipb.ActorState_ACTOR_STATE_PAUSING {
+			return nil, status.Errorf(codes.FailedPrecondition, "FinalizePaused prerequisite not met for Actor: %s (got: %v, want %s)", actorRef, got, ateapipb.ActorState_ACTOR_STATE_PAUSING)
+		}
 		newState := ateapipb.ActorState_ACTOR_STATE_PAUSED
 		if nodeName == "" {
 			// Without a node name we cannot record where the local snapshot lives,
@@ -288,7 +293,7 @@ func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef reso
 			toUpdate.Status.WorkerAssignment = nil
 			return nil
 		})
-		if err == nil && storedActor.GetStatus().GetState() == ateapipb.ActorState_ACTOR_STATE_CRASHED && !wasAlreadyCrashed {
+		if err == nil && storedActor.GetStatus().GetState() == ateapipb.ActorState_ACTOR_STATE_CRASHED {
 			logActorCrashed(ctx, latestActor, ateattr.OperationPause, ateattr.ReasonCorruptedAssignment)
 			recordActorCrash(ctx, crashAttrs)
 		}

--- a/cmd/ateapi/internal/controlapi/workflow_pause_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause_test.go
@@ -172,6 +172,48 @@ func TestEnsurePausedFinalized_RecordsContentScope(t *testing.T) {
 	}
 }
 
+func TestEnsurePausedFinalized_WorkerDeleteDuringReleasePreservesCrash(t *testing.T) {
+	ctx := context.Background()
+	st := newTestPersistence(t)
+	actorRef := resources.ActorRef{Atespace: "team-a", Name: "actor-1"}
+	workerName := testWorkerUID("worker-pod-1")
+	actor := storetest.MustCreateActor(t, ctx, st, &ateapipb.Actor{
+		Metadata: &ateapipb.ResourceMetadata{Atespace: actorRef.Atespace, Name: actorRef.Name},
+		Status: &ateapipb.ActorStatus{
+			State: ateapipb.ActorState_ACTOR_STATE_PAUSING,
+			WorkerAssignment: &ateapipb.WorkerAssignment{
+				Worker:       &ateapipb.ObjectRef{Name: workerName},
+				WorkerPodUid: workerName,
+			},
+			InProgressLocalSnapshotName: "local-snapshot-1",
+		},
+	})
+	if _, err := st.CreateWorker(ctx, &ateapipb.Worker{
+		Metadata:     &ateapipb.ResourceMetadata{Name: workerName},
+		SandboxClass: "gvisor",
+		NodeName:     "node-1",
+	}); err != nil {
+		t.Fatalf("CreateWorker: %v", err)
+	}
+	seedAssignment(t, st, workerName, &ateapipb.ActorAssignment{
+		Actor:    actorRef.ToObjectRef(),
+		ActorUid: actor.GetMetadata().GetUid(),
+	})
+
+	w := &ActorWorkflow{store: &crashAfterWorkerReleaseStore{Interface: st}}
+	_, err := w.ensurePausedFinalized(ctx, actorRef, &ateapipb.ActorTemplate{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("ensurePausedFinalized error = %v, want FailedPrecondition", err)
+	}
+	got, err := st.GetActor(ctx, actorRef)
+	if err != nil {
+		t.Fatalf("GetActor: %v", err)
+	}
+	if got.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("state = %v, want CRASHED", got.GetStatus().GetState())
+	}
+}
+
 // TestPauseActorWorkflow_RejectedAndIdempotentPaths covers the two
 // short-circuit paths of the pause workflow: rejection of the pause edge for
 // a non-RUNNING actor and the idempotent fast-forward for a PAUSED one.

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -787,8 +787,10 @@ func (w *ActorWorkflow) egressGateway() *ateletpb.EgressGateway {
 	return &ateletpb.EgressGateway{Address: w.egressGatewayAddress}
 }
 
-// finalizeRunning re-reads the actor for a fresh version and commits RUNNING,
-// recording the template the sprint booted with.
+// finalizeRunning re-reads the actor for a fresh version and commits RUNNING
+// only if it is still RESUMING. Worker deletion can crash the actor while the
+// restore RPC is in flight; that terminal state must not be overwritten. A
+// successful finalization also records the template the sprint booted with.
 func (w *ActorWorkflow) finalizeRunning(ctx context.Context, actorRef resources.ActorRef, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "FinalizeRunning")
 	defer func() { err = done(err) }()
@@ -796,6 +798,9 @@ func (w *ActorWorkflow) finalizeRunning(ctx context.Context, actorRef resources.
 	latestActor, err := w.store.GetActor(ctx, actorRef)
 	if err != nil {
 		return nil, err
+	}
+	if got := latestActor.GetStatus().GetState(); got != ateapipb.ActorState_ACTOR_STATE_RESUMING {
+		return nil, status.Errorf(codes.FailedPrecondition, "FinalizeRunning prerequisite not met for Actor: %s (got: %v, want %s)", actorRef, got, ateapipb.ActorState_ACTOR_STATE_RESUMING)
 	}
 
 	storedActor, err := w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(latestActor), func(toUpdate *ateapipb.Actor) error {

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/workercache"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -152,6 +153,62 @@ func TestAssignWorkerAttempt_MissingSelectedWorkerIsRetried(t *testing.T) {
 	}
 	if len(workers) != 0 {
 		t.Errorf("cached workers after missing claim = %d, want 0", len(workers))
+	}
+}
+
+func TestAssignWorkerAttempt_WorkerDeletedBeforeActorUpdate(t *testing.T) {
+	for _, state := range []ateapipb.ActorState{ateapipb.ActorState_ACTOR_STATE_SUSPENDED, ateapipb.ActorState_ACTOR_STATE_PAUSED} {
+		t.Run(state.String(), func(t *testing.T) {
+			ctx := t.Context()
+			reader := sdkmetric.NewManualReader()
+			if err := RegisterActorCrashes(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("ateapi")); err != nil {
+				t.Fatal(err)
+			}
+			persistence := newTestPersistence(t)
+			actor, wc := seedAssignFixture(t, ctx, persistence)
+			actorRef := resources.ActorRef{Atespace: "team-a", Name: "id1"}
+			actor, err := persistence.UpdateActor(ctx, actorRef, store.PreconditionFrom(actor), func(a *ateapipb.Actor) error {
+				a.Status.State = state
+				a.Status.ExternalSnapshot = &ateapipb.ExternalSnapshot{SnapshotUri: "gs://snapshots/committed"}
+				if state == ateapipb.ActorState_ACTOR_STATE_PAUSED {
+					a.Status.LocalSnapshotInfo = &ateapipb.LocalSnapshotInfo{SnapshotName: "pause-1"}
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			workerName := testWorkerUID("pod-1")
+			st := &conflictInjectingStore{Interface: persistence, inject: func() {
+				// The worker claim has committed, but the actor still has no backlink.
+				if _, err := NewWorkerWorkflow(persistence).DeleteWorker(ctx, workerName, store.DeletePreconditions{}); err != nil {
+					t.Fatalf("concurrent DeleteWorker: %v", err)
+				}
+			}}
+			w := &ActorWorkflow{store: st, workerCache: wc, scheduler: scheduling.New(wc)}
+			tmpl := &ateapipb.ActorTemplate{SandboxConfig: &ateapipb.SandboxConfig{SandboxClass: ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR}}
+			refreshed, _, err := w.assignWorkerAttempt(ctx, actorRef, actor, tmpl)
+			if !errors.Is(err, store.ErrVersionConflict) {
+				t.Fatalf("assignWorkerAttempt: %v, want retryable actor conflict", err)
+			}
+			if !proto.Equal(refreshed.GetStatus(), actor.GetStatus()) {
+				t.Errorf("actor status = %v, want unchanged %v", refreshed.GetStatus(), actor.GetStatus())
+			}
+			stored, err := persistence.GetActor(ctx, actorRef)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !proto.Equal(stored, refreshed) {
+				t.Errorf("stored actor = %v, want refreshed actor %v", stored, refreshed)
+			}
+			if _, err := persistence.GetWorker(ctx, workerName); !errors.Is(err, store.ErrNotFound) {
+				t.Errorf("GetWorker: %v, want worker deleted", err)
+			}
+			if _, err := persistence.FindWorkerHostingActor(ctx, actor.GetMetadata().GetUid()); !errors.Is(err, store.ErrNotFound) {
+				t.Errorf("FindWorkerHostingActor: %v, want pending claim removed", err)
+			}
+			assertNoCrashMetricDatapoint(t, reader)
+		})
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -344,9 +344,9 @@ func (w *ActorWorkflow) ensureVolumesDetached(ctx context.Context, actor *ateapi
 // ensureSuspendedFinalized releases the actor's worker (only when it is still
 // owned by this actor), records the in-progress snapshot as the actor's
 // external snapshot, and commits SUSPENDED with the assignment cleared in a
-// single update. It re-reads the actor first so an out-of-band transition
-// (e.g. the syncer crashing the actor after its worker died) is not
-// overwritten: with no assignment left there is nothing to finalize.
+// single update. It only finalizes SUSPENDING before and after releasing the
+// worker, so an out-of-band transition (e.g. worker deletion crashing the
+// actor) is not overwritten.
 func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef resources.ActorRef, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "FinalizeSuspended")
 	defer func() { err = done(err) }()
@@ -374,6 +374,9 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 	if err != nil {
 		return nil, err
 	}
+	if got := latestActor.GetStatus().GetState(); got != ateapipb.ActorState_ACTOR_STATE_SUSPENDING {
+		return nil, status.Errorf(codes.FailedPrecondition, "FinalizeSuspended prerequisite not met for Actor: %s (got: %v, want %s)", actorRef, got, ateapipb.ActorState_ACTOR_STATE_SUSPENDING)
+	}
 
 	// 1. Free the worker (if it hasn't been freed yet)
 	if latestActor.GetStatus().GetWorkerAssignment() != nil {
@@ -390,6 +393,9 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 		dRefetchActor = time.Since(t)
 		if err != nil {
 			return nil, err
+		}
+		if got := latestActor.GetStatus().GetState(); got != ateapipb.ActorState_ACTOR_STATE_SUSPENDING {
+			return nil, status.Errorf(codes.FailedPrecondition, "FinalizeSuspended prerequisite not met for Actor: %s (got: %v, want %s)", actorRef, got, ateapipb.ActorState_ACTOR_STATE_SUSPENDING)
 		}
 	}
 

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -457,6 +457,76 @@ func TestEnsureSuspendedFinalized_RetriesAfterObjectStoreFailure(t *testing.T) {
 	}
 }
 
+// crashAfterWorkerReleaseStore models DeleteWorker having loaded its Worker
+// before suspend releases it, then crashing the bound Actor immediately after
+// the release. The stale Worker is intentional: it is the snapshot the
+// concurrent delete workflow already holds.
+type crashAfterWorkerReleaseStore struct {
+	store.Interface
+}
+
+func (s *crashAfterWorkerReleaseStore) ReleaseActorFromWorker(ctx context.Context, workerName, actorUID string) (*ateapipb.Worker, error) {
+	staleWorker, err := s.Interface.GetWorker(ctx, workerName)
+	if err != nil {
+		return nil, err
+	}
+	staleAssignment, err := s.Interface.GetWorkerAssignment(ctx, workerName, actorUID)
+	if err != nil {
+		return nil, err
+	}
+	released, err := s.Interface.ReleaseActorFromWorker(ctx, workerName, actorUID)
+	if err != nil {
+		return nil, err
+	}
+	if err := NewWorkerWorkflow(s.Interface).releaseBoundActor(ctx, staleWorker, staleAssignment); err != nil {
+		return nil, err
+	}
+	return released, nil
+}
+
+func TestEnsureSuspendedFinalized_WorkerDeleteDuringReleasePreservesCrash(t *testing.T) {
+	ctx := context.Background()
+	persistence := newTestPersistence(t)
+	actorRef := resources.ActorRef{Atespace: "team-a", Name: "actor-1"}
+	workerName := testWorkerUID("pod-1")
+	actor := storetest.MustCreateActor(t, ctx, persistence, &ateapipb.Actor{
+		Metadata: &ateapipb.ResourceMetadata{Atespace: actorRef.Atespace, Name: actorRef.Name},
+		Status: &ateapipb.ActorStatus{
+			State: ateapipb.ActorState_ACTOR_STATE_SUSPENDING,
+			WorkerAssignment: &ateapipb.WorkerAssignment{
+				Worker:       &ateapipb.ObjectRef{Name: workerName},
+				WorkerPodUid: workerName,
+			},
+			InProgressSnapshotName: "snapshot-1",
+		},
+	})
+	if _, err := persistence.CreateWorker(ctx, &ateapipb.Worker{
+		Metadata:     &ateapipb.ResourceMetadata{Name: workerName},
+		SandboxClass: "gvisor",
+	}); err != nil {
+		t.Fatalf("CreateWorker: %v", err)
+	}
+	seedAssignment(t, persistence, workerName, &ateapipb.ActorAssignment{
+		Actor:    actorRef.ToObjectRef(),
+		ActorUid: actor.GetMetadata().GetUid(),
+	})
+
+	w := &ActorWorkflow{store: &crashAfterWorkerReleaseStore{Interface: persistence}}
+	_, err := w.ensureSuspendedFinalized(ctx, actorRef, &ateapipb.ActorTemplate{
+		SnapshotsConfig: &ateapipb.SnapshotsConfig{StorageLocation: "gs://snapshots"},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("ensureSuspendedFinalized error = %v, want FailedPrecondition", err)
+	}
+	got, err := persistence.GetActor(ctx, actorRef)
+	if err != nil {
+		t.Fatalf("GetActor: %v", err)
+	}
+	if got.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("state = %v, want CRASHED", got.GetStatus().GetState())
+	}
+}
+
 func TestEnsureSuspendedFinalized_ReleasesOnlyOwnWorker(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/cmd/ateapi/internal/controlapi/workflow_worker_delete.go
+++ b/cmd/ateapi/internal/controlapi/workflow_worker_delete.go
@@ -156,9 +156,9 @@ func (w *WorkerWorkflow) ensureBoundActorsReleased(ctx context.Context, worker *
 // still running when the pod disappeared is moved to ACTOR_STATE_CRASHED and its
 // pod pointers are cleared.
 //
-// Nothing to release is the common case and reports success: a superseded
-// assignment and an Actor that has since moved elsewhere both leave no Actor
-// pointing at this Worker, which is the state this is driving towards.
+// A superseded assignment or an Actor placed elsewhere needs no release. A
+// claim with no Actor backlink yet must invalidate the pending resume write
+// before deletion can remove the Worker.
 //
 // A concurrent SuspendActor or ResumeActor wins the optimistic version check;
 // this attempt fails as ABORTED so the caller retries against the newer state.
@@ -181,14 +181,14 @@ func (w *WorkerWorkflow) releaseBoundActor(ctx context.Context, worker *ateapipb
 		markSkipped(ctx, "assignment names a superseded actor incarnation")
 		return nil
 	}
-	// Skip if a concurrent SuspendActor already cleared the pointer, or if the
-	// actor has since been placed on a different worker.
-	if actor.GetStatus().GetWorkerAssignment().GetWorker().GetName() != name {
+	// An actor placed on a different worker is not ours to release.
+	actorWorker := actor.GetStatus().GetWorkerAssignment().GetWorker().GetName()
+	if actorWorker != "" && actorWorker != name {
 		markSkipped(ctx, "actor no longer points at this worker")
 		return nil
 	}
 	// If the actor is suspended, it's already been released.
-	if actor.GetStatus().GetState() == ateapipb.ActorState_ACTOR_STATE_SUSPENDED {
+	if actorWorker != "" && actor.GetStatus().GetState() == ateapipb.ActorState_ACTOR_STATE_SUSPENDED {
 		markSkipped(ctx, "actor suspended cleanly before the pod went away")
 		return nil
 	}
@@ -211,6 +211,13 @@ func (w *WorkerWorkflow) releaseBoundActor(ctx context.Context, worker *ateapipb
 		append(ateattr.ActorLogAttrs(resources.ActorAttributionFromActor(actor)),
 			slog.String("worker", name))...)
 	_, err = w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(actor), func(toUpdate *ateapipb.Actor) error {
+		if actorWorker == "" {
+			// A worker claim commits before resume writes the Actor backlink.
+			// Bump only the version so that pending write fails its CAS while
+			// preserving the Actor's resumable state and snapshots. Draining
+			// prevents a retry from binding to this Worker again.
+			return nil
+		}
 		toUpdate.Status.State = ateapipb.ActorState_ACTOR_STATE_CRASHED
 		toUpdate.Status.WorkerAssignment = nil
 		// Both in-progress checkpoints die with the worker: the durable one was
@@ -230,7 +237,7 @@ func (w *WorkerWorkflow) releaseBoundActor(ctx context.Context, worker *ateapipb
 		return fmt.Errorf("while releasing actor from worker %s: %w", name, err)
 	}
 
-	if !wasAlreadyCrashed {
+	if actorWorker != "" && !wasAlreadyCrashed {
 		logActorCrashed(ctx, actor, opName, ateattr.ReasonWorkerPodGone)
 		recordActorCrash(ctx, crashAttrs)
 	}

--- a/cmd/ateapi/internal/controlapi/workflow_worker_delete_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_worker_delete_test.go
@@ -102,6 +102,47 @@ func TestDeleteWorkerWorkflow_DrainsBeforeSweeping(t *testing.T) {
 	}
 }
 
+func TestDeleteWorkerWorkflow_PendingAssignmentWinsVersionCheck(t *testing.T) {
+	ctx := t.Context()
+	_, persistence := newWorkerDeleteWorkflow(t)
+	seedAPIWorker(t, ctx, persistence, validWorker(apiWorkerName))
+	actor := seedAPIActor(t, ctx, persistence, ateapipb.ActorState_ACTOR_STATE_SUSPENDED, func(a *ateapipb.Actor) {
+		a.Status.WorkerAssignment = nil
+	})
+	assignAPIWorker(t, ctx, persistence, apiWorkerName, actor.GetMetadata().GetUid())
+	st := &conflictInjectingStore{Interface: persistence, inject: func() {
+		// Resume writes its backlink after deletion reads the unassigned actor.
+		if _, err := persistence.UpdateActor(ctx, apiActorRef, store.PreconditionFrom(actor), func(a *ateapipb.Actor) error {
+			a.Status.State = ateapipb.ActorState_ACTOR_STATE_RESUMING
+			a.Status.WorkerAssignment = &ateapipb.WorkerAssignment{Worker: workerRef(apiWorkerName)}
+			return nil
+		}); err != nil {
+			t.Fatalf("concurrent actor assignment: %v", err)
+		}
+	}}
+	wf := NewWorkerWorkflow(st)
+	if _, err := wf.DeleteWorker(ctx, apiWorkerName, store.DeletePreconditions{}); status.Code(err) != codes.Aborted {
+		t.Fatalf("DeleteWorker: %v, want Aborted", err)
+	}
+	worker, err := persistence.GetWorker(ctx, apiWorkerName)
+	if err != nil {
+		t.Fatalf("GetWorker after conflict: %v", err)
+	}
+	if worker.GetStatus().GetState() != ateapipb.WorkerState_WORKER_STATE_DRAINING {
+		t.Errorf("worker state = %v, want DRAINING", worker.GetStatus().GetState())
+	}
+	if _, err := wf.DeleteWorker(ctx, apiWorkerName, store.DeletePreconditions{}); err != nil {
+		t.Fatalf("retry DeleteWorker: %v", err)
+	}
+	got, err := persistence.GetActor(ctx, apiActorRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED || got.GetStatus().GetWorkerAssignment() != nil {
+		t.Errorf("actor status after delete retry = %v, want CRASHED with no worker", got.GetStatus())
+	}
+}
+
 func TestDeleteWorkerWorkflow_ReleasesBoundActor(t *testing.T) {
 	ctx := context.Background()
 	wf, persistence := newWorkerDeleteWorkflow(t)


### PR DESCRIPTION
Worker deletion can race both lifecycle finalization and the gap between a worker claim and its actor backlink. Preserve `CRASHED` during resume and suspend finalization, returning `FailedPrecondition` instead of reporting an invalid successful transition.

When a drained worker still has a claim whose actor backlink is pending, advance the actor's version before deleting the worker. The pending resume write then loses its version check and retains the actor's suspended or paused state and snapshots for retry. If resume wins the version check, deletion returns `Aborted` and retries against the committed assignment.

Regression tests cover the lifecycle finalization races, both assignment/deletion orderings, snapshot preservation, and avoiding false crash metrics.

Fixes #1443

Validation:

- PostgreSQL regression tests for both assignment/deletion orderings passed with `-race`.
- `env -u NO_COLOR make verify` in a clean worktree (includes `go test -race ./...`).
