### PR TITLE
(otel): split infra vs. workload faults

### DIFF
--- a/cmd/ateapi/internal/controlapi/crash.go
+++ b/cmd/ateapi/internal/controlapi/crash.go
@@ -37,9 +37,10 @@ func maybeCrashActor(ctx context.Context, st crashActorStore, actorRef resources
 	}
 
 	if ateerrors.ActorCrashRequested(err) {
-		// Extract AIP-193 ErrorInfo reason enum from the RPC error detail. If unclassified
-		// or unlisted, default to ateattr.ReasonUnknown to protect metric low-cardinality.
-		reason := ateerrors.ExtractReason(err)
+		// Extract AIP-193 ErrorInfo reason enum from the RPC error detail. Normalized
+		// here rather than in crashActor alone, so the log and the counter cannot
+		// report a different reason for the same crash.
+		reason := ateattr.FailureReason(err)
 
 		// Only the ref is knowable here; crashActor logs the authoritative record.
 		attrs := ateattr.ActorRefLogAttrs(actorRef)

--- a/cmd/ateapi/internal/controlapi/crash.go
+++ b/cmd/ateapi/internal/controlapi/crash.go
@@ -37,13 +37,21 @@ func maybeCrashActor(ctx context.Context, st crashActorStore, actorRef resources
 	}
 
 	if ateerrors.ActorCrashRequested(err) {
-		slog.ErrorContext(ctx, "Setting Actor to crashed due to error", slog.Any("error", err))
 		// Extract AIP-193 ErrorInfo reason enum from the RPC error detail. If unclassified
 		// or unlisted, default to ateattr.ReasonUnknown to protect metric low-cardinality.
 		reason := ateerrors.ExtractReason(err)
 
+		// Only the ref is knowable here; crashActor logs the authoritative record.
+		attrs := ateattr.ActorRefLogAttrs(actorRef)
+		attrs = append(attrs, ateattr.FailureLogAttrs(reason)...)
+		attrs = append(attrs,
+			slog.String(string(ateattr.ErrorTypeKey), status.Code(err).String()),
+			slog.Any("err", err),
+		)
+		slog.LogAttrs(ctx, slog.LevelError, "Setting Actor to crashed due to error", attrs...)
+
 		if cerr := crashActor(ctx, st, actorRef, opName, reason); cerr != nil {
-			slog.ErrorContext(ctx, "Failed to crash actor", slog.Any("cerr", cerr))
+			slog.ErrorContext(ctx, "Failed to crash actor", slog.Any("err", cerr))
 			return cerr
 		}
 		return status.Errorf(codes.DataLoss, "actor %s crashed", actorRef)
@@ -97,10 +105,21 @@ func crashActor(ctx context.Context, st crashActorStore, actorRef resources.Acto
 
 	// Increment metric only after a successful UpdateActor, and only if the actor was not already crashed.
 	if !wasAlreadyCrashed {
+		logActorCrashed(ctx, actor, opName, reason)
 		recordActorCrash(ctx, crashAttrs)
 	}
 
 	return nil
+}
+
+// logActorCrashed carries the identity ate.actor.crashes cannot: actor identity
+// is barred from metric labels, so this record is the only way to attribute a
+// crash to one agent. Call it beside recordActorCrash, under the same guard.
+func logActorCrashed(ctx context.Context, actor *ateapipb.Actor, opName, reason string) {
+	attrs := ateattr.ActorLogAttrs(resources.ActorAttributionFromActor(actor))
+	attrs = append(attrs, slog.String(string(ateattr.ActorOperationNameKey), opName))
+	attrs = append(attrs, ateattr.FailureLogAttrs(reason)...)
+	slog.LogAttrs(ctx, slog.LevelError, "Actor crashed", attrs...)
 }
 
 // crashActorStore encapsulates the subset of store operations needed to crash

--- a/cmd/ateapi/internal/controlapi/crash_test.go
+++ b/cmd/ateapi/internal/controlapi/crash_test.go
@@ -17,6 +17,8 @@ package controlapi
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"maps"
 	"strings"
 	"testing"
 
@@ -587,5 +589,97 @@ func TestCrashActorReleaseFailureLeavesWorkerReclaimable(t *testing.T) {
 	}
 	if worker.GetStatus().GetAssignment() == nil {
 		t.Error("worker assignment = nil, want still assigned (release failed, must remain retriable)")
+	}
+}
+
+// crashRecords captures the "Actor crashed" records a crash emits, so a test can
+// assert the identity that ate.actor.crashes is barred from carrying. crashActor
+// logs through the slog default, so this swaps it and the caller cannot be parallel.
+func crashRecords(t *testing.T) *[]map[string]string {
+	t.Helper()
+
+	var records []map[string]string
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slogHandlerFunc(func(r slog.Record) {
+		if r.Message != "Actor crashed" {
+			return
+		}
+		fields := map[string]string{}
+		r.Attrs(func(a slog.Attr) bool {
+			fields[a.Key] = a.Value.String()
+			return true
+		})
+		records = append(records, fields)
+	})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &records
+}
+
+type slogHandlerFunc func(slog.Record)
+
+func (f slogHandlerFunc) Enabled(context.Context, slog.Level) bool { return true }
+func (f slogHandlerFunc) Handle(_ context.Context, r slog.Record) error {
+	f(r)
+	return nil
+}
+func (f slogHandlerFunc) WithAttrs([]slog.Attr) slog.Handler { return f }
+func (f slogHandlerFunc) WithGroup(string) slog.Handler      { return f }
+
+// The crash record is the only signal carrying actor identity, so it must fire
+// exactly when the counter does. A crash counted but not logged is unattributable;
+// one logged but not counted double-counts on a retry.
+func TestCrashActor_RecordAndCounterAgree(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	if err := RegisterActorCrashes(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test")); err != nil {
+		t.Fatalf("RegisterActorCrashes: %v", err)
+	}
+	records := crashRecords(t)
+
+	ctx := context.Background()
+	st, cleanup := storetest.SetupTestStore(t)
+	defer cleanup()
+
+	actorRef := resources.ActorRef{Atespace: "demo-ns", Name: "counter-actor"}
+	storetest.MustCreateActor(t, ctx, st, &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: actorRef.Atespace, Name: actorRef.Name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "demo-ns", Name: "counter-template"},
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING},
+	})
+
+	if err := crashActor(ctx, st, actorRef, ateattr.OperationResume, ateattr.ReasonWorkerPodGone); err != nil {
+		t.Fatalf("crashActor: %v", err)
+	}
+	if len(*records) != 1 {
+		t.Fatalf("got %d crash records, want 1", len(*records))
+	}
+
+	got := (*records)[0]
+	stored, err := st.GetActor(ctx, actorRef)
+	if err != nil {
+		t.Fatalf("GetActor: %v", err)
+	}
+	want := map[string]string{
+		string(ateattr.AtespaceKey):           actorRef.Atespace,
+		string(ateattr.ActorNameKey):          actorRef.Name,
+		string(ateattr.ActorUIDKey):           stored.GetMetadata().GetUid(),
+		string(ateattr.TemplateAtespaceKey):   "demo-ns",
+		string(ateattr.TemplateNameKey):       "counter-template",
+		string(ateattr.ActorOperationNameKey): ateattr.OperationResume,
+		string(ateattr.FailureReasonKey):      ateattr.ReasonWorkerPodGone,
+		string(ateattr.FailureDomainKey):      ateattr.FailureDomainInfrastructure,
+	}
+	if !maps.Equal(got, want) {
+		t.Errorf("crash record = %v, want %v", got, want)
+	}
+	if got[string(ateattr.ActorUIDKey)] == "" {
+		t.Error("crash record carries no ate.actor.uid; it cannot survive a name reuse")
+	}
+
+	// Re-crashing an already-crashed actor must move neither signal.
+	if err := crashActor(ctx, st, actorRef, ateattr.OperationResume, ateattr.ReasonWorkerPodGone); err != nil {
+		t.Fatalf("second crashActor: %v", err)
+	}
+	if len(*records) != 1 {
+		t.Errorf("got %d crash records after re-crashing, want 1", len(*records))
 	}
 }

--- a/cmd/ateapi/internal/controlapi/workflow_pause.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause.go
@@ -265,7 +265,8 @@ func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef reso
 			// so the actor can never be resumed (the scheduler would search for a
 			// worker on an unknown node forever). Crash it instead of leaving it
 			// stuck in PAUSED.
-			slog.ErrorContext(ctx, "Node name not found during finalize pause, crashing actor", slog.Any("actor", actorRef))
+			slog.LogAttrs(ctx, slog.LevelError, "Node name not found during finalize pause, crashing actor",
+				ateattr.ActorRefLogAttrs(actorRef)...)
 			newState = ateapipb.ActorState_ACTOR_STATE_CRASHED
 		}
 		contentScope := effectiveContentScope(actorTemplate.GetSnapshotsConfig().GetOnPause())
@@ -295,6 +296,7 @@ func (w *ActorWorkflow) ensurePausedFinalized(ctx context.Context, actorRef reso
 			return nil
 		})
 		if err == nil && storedActor.GetStatus().GetState() == ateapipb.ActorState_ACTOR_STATE_CRASHED && !wasAlreadyCrashed {
+			logActorCrashed(ctx, latestActor, ateattr.OperationPause, ateattr.ReasonCorruptedAssignment)
 			recordActorCrash(ctx, crashAttrs)
 		}
 		if err != nil {

--- a/cmd/ateapi/internal/controlapi/workflow_pause_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_pause_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store/storetest"
+	"github.com/agent-substrate/substrate/internal/ateattr"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"google.golang.org/grpc/codes"
@@ -42,6 +43,7 @@ func TestEnsurePausedFinalized_WorkerGone(t *testing.T) {
 
 	ctx := context.Background()
 	actorRef := resources.ActorRef{Atespace: "team-a", Name: "actor-1"}
+	records := crashRecords(t)
 
 	actor := &ateapipb.Actor{
 		Metadata: &ateapipb.ResourceMetadata{Atespace: actorRef.Atespace, Name: actorRef.Name},
@@ -83,6 +85,18 @@ func TestEnsurePausedFinalized_WorkerGone(t *testing.T) {
 	}
 	if finalized.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
 		t.Errorf("returned state = %v, want CRASHED", finalized.GetStatus().GetState())
+	}
+
+	// This site records the crash counter, so it must write the record too, or
+	// a pause-finalize crash is the one kind nothing can attribute to an actor.
+	if len(*records) != 1 {
+		t.Fatalf("got %d crash records, want 1", len(*records))
+	}
+	if got := (*records)[0][string(ateattr.ActorUIDKey)]; got == "" {
+		t.Error("crash record carries no ate.actor.uid")
+	}
+	if got := (*records)[0][string(ateattr.FailureDomainKey)]; got != ateattr.FailureDomainInfrastructure {
+		t.Errorf("ate.failure.domain = %q, want %q", got, ateattr.FailureDomainInfrastructure)
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/workflow_worker_delete.go
+++ b/cmd/ateapi/internal/controlapi/workflow_worker_delete.go
@@ -129,8 +129,9 @@ func (w *WorkerWorkflow) ensureBoundActorReleased(ctx context.Context, worker *a
 	// Snapshot crash attributes before pod and pool pointers are cleared on actor.
 	crashAttrs := ateattr.ActorMetricAttributes(actor, worker.GetSandboxClass(), opName, ateattr.ReasonWorkerPodGone)
 
-	slog.InfoContext(ctx, "Releasing actor from a worker whose pod is gone",
-		slog.String("worker", name), slog.String("actor", actorRef.String()))
+	slog.LogAttrs(ctx, slog.LevelInfo, "Releasing actor from a worker whose pod is gone",
+		append(ateattr.ActorLogAttrs(resources.ActorAttributionFromActor(actor)),
+			slog.String("worker", name))...)
 	_, err = w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(actor), func(toUpdate *ateapipb.Actor) error {
 		toUpdate.Status.State = ateapipb.ActorState_ACTOR_STATE_CRASHED
 		toUpdate.Status.WorkerAssignment = nil
@@ -152,6 +153,7 @@ func (w *WorkerWorkflow) ensureBoundActorReleased(ctx context.Context, worker *a
 	}
 
 	if !wasAlreadyCrashed {
+		logActorCrashed(ctx, actor, opName, ateattr.ReasonWorkerPodGone)
 		recordActorCrash(ctx, crashAttrs)
 	}
 	return nil

--- a/cmd/atelet/metrics.go
+++ b/cmd/atelet/metrics.go
@@ -137,11 +137,11 @@ func recordPhases(ctx context.Context, h metric.Float64Histogram, op snapshotOp,
 		if p.d == 0 {
 			continue
 		}
-		attrs := make([]attribute.KeyValue, 0, len(base)+2)
+		attrs := make([]attribute.KeyValue, 0, len(base)+3)
 		attrs = append(attrs, base...)
 		attrs = append(attrs, ateattr.SnapshotPhaseKey.String(p.name))
 		if err != nil && (p.name == ateattr.SnapshotPhaseTotal || p.name == op.failedPhase) {
-			attrs = append(attrs, ateattr.FailureReasonKey.String(ateattr.FailureReason(err)))
+			attrs = append(attrs, ateattr.FailureAttributes(ateattr.FailureReason(err))...)
 		}
 		h.Record(ctx, p.d.Seconds(), metric.WithAttributes(attrs...))
 	}

--- a/cmd/atelet/snapshotlog.go
+++ b/cmd/atelet/snapshotlog.go
@@ -56,7 +56,7 @@ func snapshotLogAttrs(a resources.ActorAttribution, op snapshotOp, durationKey s
 	// Absence means success, as on the instruments. There is no ate.snapshot.phase:
 	// on a datapoint it names the one step timed, and this record carries them all.
 	if err != nil {
-		attrs = append(attrs, slog.String(string(ateattr.FailureReasonKey), ateattr.FailureReason(err)))
+		attrs = append(attrs, ateattr.FailureLogAttrs(ateattr.FailureReason(err))...)
 	}
 
 	for _, p := range phases {

--- a/docs/metrics/registry/metrics.yaml
+++ b/docs/metrics/registry/metrics.yaml
@@ -288,6 +288,14 @@ groups:
               stability: development
               value: LOCAL_SNAPSHOT_GONE
               brief: The local snapshot on the node no longer exists.
+            - id: workload_not_ready
+              stability: development
+              value: WORKLOAD_NOT_READY
+              brief: >
+                A container started but never passed its readyz probe before the
+                deadline of the probe. A slow node confounds this value: a cold
+                image or a throttled CPU also runs the probe out of time. The
+                phases of ate.actor.restore.duration separate the two.
             - id: corrupted_assignment
               stability: development
               value: CORRUPTED_ASSIGNMENT
@@ -304,9 +312,38 @@ groups:
               stability: development
               value: UNKNOWN
               brief: >
-                An infrastructure failure with no reason. Substrate does not
-                make a value from the error message. Thus the list of values
-                stays short.
+                A failure with no reason. Substrate does not make a value from
+                the error message. Thus the list of values stays short. This
+                value asserts no fault domain: read ate.failure.domain, which
+                reports unknown here and not infrastructure.
+
+      - id: ate.failure.domain
+        stability: development
+        brief: >
+          The side of the platform boundary the failure came from. A strict
+          function of ate.failure.reason, thus it adds no series. It exists
+          because an operator triages on the boundary and drills into the
+          reason, and because a consumer must not have to match on the names of
+          the reasons: a component ahead of the control plane can report a
+          reason that the control plane does not know, which becomes UNKNOWN,
+          and a name match would then count it as an infrastructure fault.
+        type:
+          members:
+            - id: infrastructure
+              stability: development
+              value: infrastructure
+              brief: Substrate failed. The node, the store, the object storage, the control plane.
+            - id: workload
+              stability: development
+              value: workload
+              brief: >
+                The actor failed. Substrate reports what the actor did; it does
+                not measure it. The actor chooses its own exit, thus this value
+                is a report and not a proof.
+            - id: unknown
+              stability: development
+              value: unknown
+              brief: The reason gives no domain. A gap in the taxonomy stays visible here and does not inflate one side.
 
   - id: registry.ate.scheduler
     type: attribute_group
@@ -590,6 +627,8 @@ groups:
         requirement_level: required
       - ref: ate.failure.reason
         requirement_level: required
+      - ref: ate.failure.domain
+        requirement_level: required
       - ref: ate.template.atespace
         requirement_level: required
       - ref: ate.template.name
@@ -790,6 +829,9 @@ groups:
       - ref: ate.failure.reason
         requirement_level:
           conditionally_required: The operation failed. The key occurs only on the phase that failed and on the total.
+      - ref: ate.failure.domain
+        requirement_level:
+          conditionally_required: ate.failure.reason occurs. The two keys always occur together.
 
   - id: metric.ate.actor.checkpoint.duration
     type: metric

--- a/docs/metrics/registry/metrics.yaml
+++ b/docs/metrics/registry/metrics.yaml
@@ -337,9 +337,13 @@ groups:
               stability: development
               value: workload
               brief: >
-                The actor failed. Substrate reports what the actor did; it does
-                not measure it. The actor chooses its own exit, thus this value
-                is a report and not a proof.
+                The owner of the actor fixes this, not the operator of the
+                platform. It covers a bad ActorTemplate as well as a process
+                that does not start. For the reasons that the actor reports
+                about itself, such as an exit or a probe that never passes,
+                this value is a report and not a proof: the actor chooses its
+                own exit. The reasons that Substrate measures, such as a
+                template that resolves to no runnable process, are not.
             - id: unknown
               stability: development
               value: unknown
@@ -869,6 +873,9 @@ groups:
       - ref: ate.failure.reason
         requirement_level:
           conditionally_required: The operation failed. The key occurs only on the phase that failed and on the total.
+      - ref: ate.failure.domain
+        requirement_level:
+          conditionally_required: ate.failure.reason occurs. The two keys always occur together.
 
   - id: metric.atelet.snapshot.size
     type: metric

--- a/docs/metrics/substrate.yaml
+++ b/docs/metrics/substrate.yaml
@@ -165,6 +165,33 @@ cardinality_rules:
     could_be_enforced_by: >
       A Weaver Rego policy can refuse a metric name that ends with errors_total
       and has a counterpart without the suffix.
+  - id: failure-keys-paired
+    brief: >
+      A component sets ate.failure.reason and ate.failure.domain together, or it
+      sets neither. ateattr.FailureAttributes and ateattr.FailureLogAttrs return
+      the pair, and a producer uses one of them rather than the keys.
+      The domain is a strict function of the reason, so it adds no series. It is
+      a key and not a rule in the consumer because the reasons of a component
+      ahead of the control plane can be unknown to the control plane, which
+      makes them UNKNOWN, and a consumer that matched on the names of the
+      reasons would count each of those as an infrastructure fault.
+    enforced: false
+    could_be_enforced_by: >
+      A Weaver Rego policy can make the two keys occur together in this
+      registry. Only live-check can see a component that sends one key.
+  - id: workload-domain-is-a-report
+    brief: >
+      A value of ate.failure.domain of workload says what the actor reported,
+      not what Substrate measured. The actor chooses its own exit code and can
+      hold memory until the kernel kills it, thus it decides this value. It can
+      raise the count of the failures of its own template and pool, and it can
+      exit 0 to hide a fault. A dashboard says "reported" and an alert on this
+      domain has a rate limit. One report for each activation is the bound.
+    enforced: false
+    could_be_enforced_by: >
+      Nothing. This is a property of a multi-tenant platform and not of the
+      registry. It is here so that a reader of the panel knows what the number
+      is.
   - id: pool-keys-paired
     brief: >
       A component sets ate.workerpool.namespace and ate.workerpool.name

--- a/docs/metrics/substrate.yaml
+++ b/docs/metrics/substrate.yaml
@@ -181,12 +181,14 @@ cardinality_rules:
       registry. Only live-check can see a component that sends one key.
   - id: workload-domain-is-a-report
     brief: >
-      A value of ate.failure.domain of workload says what the actor reported,
-      not what Substrate measured. The actor chooses its own exit code and can
-      hold memory until the kernel kills it, thus it decides this value. It can
-      raise the count of the failures of its own template and pool, and it can
-      exit 0 to hide a fault. A dashboard says "reported" and an alert on this
-      domain has a rate limit. One report for each activation is the bound.
+      Some of the reasons in the workload domain are what the actor reported
+      about itself: an exit code, or a probe that never passes. The actor
+      chooses those, thus it decides the value. It can raise the count of the
+      failures of its own template and pool, and it can exit 0 to hide a fault.
+      A dashboard says "reported" for those, and an alert on them has a rate
+      limit; one report for each activation is the bound. The reasons that
+      Substrate measures, such as a template that resolves to no runnable
+      process, carry no such caveat.
     enforced: false
     could_be_enforced_by: >
       Nothing. This is a property of a multi-tenant platform and not of the

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -141,6 +141,27 @@ The duration keys are the [`ate.actor.restore.duration`](#the-metric-registry) i
 
 This is the record to use for a per-actor wake-up distribution. The histogram cannot answer that question at all, because actor identity is barred from metric labels; traces can, but the data plane is head-sampled at 1%.
 
+ateapi's `Actor crashed` is the other one. It is written once per committed transition into `ACTOR_STATE_CRASHED`, beside the [`ate.actor.crashes`](#the-metric-registry) increment and under the same already-crashed guard, so the two can never disagree about how many crashes happened:
+
+```json
+{"time":"…","level":"ERROR","msg":"Actor crashed",
+ "ate.atespace":"ate-demo-counter","ate.actor.name":"counter-1","ate.actor.uid":"8f2a…",
+ "ate.template.atespace":"ate-demo-counter","ate.template.name":"counter",
+ "ate.actor.operation.name":"resume",
+ "ate.failure.reason":"WORKER_POD_GONE","ate.failure.domain":"infrastructure",
+ "trace_id":"4bf92f…","span_id":"00f067…","trace_flags":"01"}
+```
+
+The counter carries the same reason but no actor identity, so this record is the only way to attribute a crash to one agent. The decision-point line that precedes it (`Setting Actor to crashed due to error`) carries only `ate.atespace` and `ate.actor.name`: it is written before the Actor is loaded, so no uid exists yet.
+
+### Which side failed: `ate.failure.domain`
+
+`ate.failure.reason` names the cause; `ate.failure.domain` names the side of the platform boundary it came from, as `infrastructure`, `workload`, or `unknown`. It rides on every signal that carries a reason, and the two are always emitted together — producers call `ateattr.FailureAttributes` or `ateattr.FailureLogAttrs` rather than setting either key directly.
+
+The domain is a strict function of the reason, so it costs no series and no consumer needs it to disambiguate a value. It exists because the alternative is every consumer keeping its own map from reason to domain, and that map breaks silently: a component running ahead of the control plane can report a reason this build's `ateerrors.AllReasons` rejects, `ExtractReason` turns it into `UNKNOWN`, and a name-matching consumer would file every one of those as an infrastructure fault. `UNKNOWN` therefore reports `unknown` and not `infrastructure` — a gap in the taxonomy stays visible instead of inflating one side.
+
+One caveat belongs on any panel built from this. A `workload` domain says what the actor **reported**, not what substrate measured: the actor picks its own exit and can hold memory until the kernel kills it, so it can raise the failure count for its own template and pool, or exit cleanly to hide a fault. See `workload-domain-is-a-report` in [`docs/metrics/substrate.yaml`](metrics/substrate.yaml).
+
 ---
 
 ## 2. Metrics
@@ -152,7 +173,7 @@ Agent Substrate emits foundational OpenTelemetry system and server metrics to mo
 | Metric | Emitted by | Type | Measures |
 |--------|------------|------|----------|
 | `rpc.server.call.duration` | ateapi & atelet (gRPC servers, via `otelgrpc`) | histogram | per-method gRPC latency, request rate, and errors (labels `rpc.method`, `rpc.response.status_code`) |
-| `ate.actor.crashes` | ateapi | counter | Number of times actors transitioned to `ACTOR_STATE_CRASHED` with failure reasons (labels `ate.actor.operation.name`, `ate.failure.reason`, `ate.template.atespace`, `ate.template.name`, `ate.workerpool.namespace`, `ate.workerpool.name`, `ate.sandbox.class`) |
+| `ate.actor.crashes` | ateapi | counter | Number of times actors transitioned to `ACTOR_STATE_CRASHED` with failure reasons (labels `ate.actor.operation.name`, `ate.failure.reason`, `ate.failure.domain`, `ate.template.atespace`, `ate.template.name`, `ate.workerpool.namespace`, `ate.workerpool.name`, `ate.sandbox.class`) |
 | `atenet.router.route.duration` | atenet-router | histogram | Substrate E2E — Envoy receiving a request to Envoy forwarding it to the resolved worker, excluding actor compute and the response (labels `ate.template.atespace`, `ate.template.name`, `ate.router.outcome`, `ate.router.resume`) |
 | `ate.scheduler.eligible_workers` | ateapi | histogram | number of eligible unassigned workers available during scheduling given the constraint filters (labels `ate.workerpool.namespace`, `ate.workerpool.name`, `ate.sandbox.class`, `ate.scheduling.constraint`) |
 | `atelet.snapshot.size` | atelet | histogram | uncompressed size in bytes of each gVisor snapshot image written during checkpoint (labels `file.name`, `ate.template.atespace`, `ate.template.name`) |
@@ -163,7 +184,7 @@ Agent Substrate emits foundational OpenTelemetry system and server metrics to mo
 | `ate.workerpool.workers` | ateapi | up/down counter | live worker count per pool, split by state (`idle`/`assigned`) and sandbox class to provide fleet capacity and saturation at a glance |
 | `ate.actor.lifecycle.operation.duration` | ateapi | histogram | how long each actor operation (create/resume/suspend/pause/delete) takes and whether it failed (`error.type` present = failure, absent = success); labeled by operation, template, pool (`ate.workerpool.namespace` + `ate.workerpool.name`), sandbox class, and snapshot kind and scope on resume; already-running resume no-ops are not recorded so the histogram tracks actual activations, not router traffic |
 | `ate.scheduler.assignment.duration` | ateapi | histogram | time it takes for an actor to be assigned to a worker, per attempt (version-conflict retries record only the final attempt), with the outcome (`assigned` / `no_free_worker` / `error`), the assigned pool (`ate.workerpool.namespace` + `ate.workerpool.name`) and sandbox class to catch scheduling latency and capacity starvation problems |
-| `ate.actor.restore.duration` | atelet | histogram | how long each phase of a restore takes on the worker node, which is where cold-start latency actually goes once ateapi hands off (labels `ate.snapshot.phase`, `ate.snapshot.kind`, `ate.snapshot.scope`, `ate.template.atespace`, `ate.template.name`, `ate.sandbox.class`, plus `ate.failure.reason` on failure) |
+| `ate.actor.restore.duration` | atelet | histogram | how long each phase of a restore takes on the worker node, which is where cold-start latency actually goes once ateapi hands off (labels `ate.snapshot.phase`, `ate.snapshot.kind`, `ate.snapshot.scope`, `ate.template.atespace`, `ate.template.name`, `ate.sandbox.class`, plus `ate.failure.reason` and `ate.failure.domain` on failure) |
 | `ate.actor.checkpoint.duration` | atelet | histogram | the same phase breakdown for writing a snapshot, so a slow suspend can be attributed to ateom or to the upload (same labels as the restore histogram) |
 | `ate.imagecache.requests` | atelet | counter | image lookups in the node-local image cache, by outcome (`ate.imagecache.outcome`), with `error.type` on the `error` outcome. A miss pays for the pull and the unpack, so the hit ratio per node is a leading indicator of resume latency |
 
@@ -197,7 +218,7 @@ The three snapshot labels are orthogonal and mean the same thing on every histog
 
 **Phases overlap and do not sum to `total`.** The download runs concurrently with the asset fetch and OCI unpack, so each is an independent observation; use `total` as the denominator. A phase that never started is absent rather than zero.
 
-On a failure, `ate.failure.reason` marks the phase that died and the `total`, and nothing else, so `ate.actor.restore.duration{ate.snapshot.phase="download", ate.failure.reason!=""}` says how often the download is what breaks and why, while the phases that succeeded stay queryable as successes. The atelet histograms classify with substrate's own reason taxonomy (the same one `ate.actor.crashes` uses) rather than `error.type`, because these handlers return wrapped domain errors and the gRPC status is only assigned after the handler returns, so a status code would read `Unknown` for nearly every real failure. Infrastructure failures that carry no reason report `UNKNOWN`.
+On a failure, `ate.failure.reason` marks the phase that died and the `total`, and nothing else, so `ate.actor.restore.duration{ate.snapshot.phase="download", ate.failure.reason!=""}` says how often the download is what breaks and why, while the phases that succeeded stay queryable as successes. The atelet histograms classify with substrate's own reason taxonomy (the same one `ate.actor.crashes` uses) rather than `error.type`, because these handlers return wrapped domain errors and the gRPC status is only assigned after the handler returns, so a status code would read `Unknown` for nearly every real failure. A failure that carries no reason reports `UNKNOWN`. [`ate.failure.domain`](#which-side-failed-atefailuredomain) rides alongside wherever the reason is present, so a restore that failed because the actor never passed its readyz probe is separable from one the node broke.
 
 The `ate.*` control-plane metric labels are either fixed value sets (operation, outcome, state, class, kind, scope, phase) or scoped to the deployment catalog (template and pool names are operator-created, never derived from request payloads), and the label set varies per operation: resume carries the most dimensions, delete only the operation and error type. `ate.sandbox.class` is derived from the template (each template has exactly one class), so it adds no extra series next to the template labels; it exists so dashboards can aggregate by class without enumerating template names. High-cardinality actor identity (name/uid/atespace) stays off metrics entirely and lives on logs and traces instead.
 

--- a/internal/ateattr/ateattr.go
+++ b/internal/ateattr/ateattr.go
@@ -121,9 +121,15 @@ const (
 	FailureDomainUnknown        = "unknown"
 )
 
-// workloadReasons describe what the actor did rather than what substrate did.
-// Membership, not a name prefix, decides the domain.
+// workloadReasons are the failures the actor's owner fixes rather than the
+// platform operator: a misdeclared ActorTemplate as much as a process that will
+// not start. Membership, not a name prefix, decides the domain.
+//
+// ReasonInvalidSandboxAsset is deliberately absent: it reads a SandboxConfig,
+// which is cluster-scoped, so no actor can cause it or fix it.
 var workloadReasons = []ateerrors.Reason{
+	ateerrors.ReasonInvalidContainerConfig,
+	ateerrors.ReasonInvalidObjectURL,
 	ateerrors.ReasonWorkloadNotReady,
 }
 

--- a/internal/ateattr/ateattr.go
+++ b/internal/ateattr/ateattr.go
@@ -107,8 +107,55 @@ const (
 	RouterResumeKey         = attribute.Key("ate.router.resume")
 	RouterOutcomeKey        = attribute.Key("ate.router.outcome")
 	FailureReasonKey        = attribute.Key("ate.failure.reason")
+	FailureDomainKey        = attribute.Key("ate.failure.domain")
 	StatsSourceKey          = attribute.Key("ate.stats.source")
 )
+
+// Values for FailureDomainKey. A strict function of the reason, so it costs no
+// series. Emitted rather than derived downstream: a component ahead of ateapi
+// can report a reason this build rejects, which ExtractReason turns into
+// Unknown, and a consumer matching on the reason would file it as infrastructure.
+const (
+	FailureDomainInfrastructure = "infrastructure"
+	FailureDomainWorkload       = "workload"
+	FailureDomainUnknown        = "unknown"
+)
+
+// workloadReasons describe what the actor did rather than what substrate did.
+// Membership, not a name prefix, decides the domain.
+var workloadReasons = []ateerrors.Reason{
+	ateerrors.ReasonWorkloadNotReady,
+}
+
+// FailureAttributes returns the reason and its domain together, so no producer
+// can emit half the pair. Same rule as WorkerPoolAttributes.
+func FailureAttributes(reason string) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		FailureReasonKey.String(reason),
+		FailureDomainKey.String(FailureDomain(reason)),
+	}
+}
+
+// FailureLogAttrs is FailureAttributes for a slog record.
+func FailureLogAttrs(reason string) []slog.Attr {
+	return []slog.Attr{
+		slog.String(string(FailureReasonKey), reason),
+		slog.String(string(FailureDomainKey), FailureDomain(reason)),
+	}
+}
+
+// FailureDomain classifies a reason value. An unrecognized reason reports
+// FailureDomainUnknown rather than infrastructure, so a taxonomy gap stays
+// visible instead of inflating one side.
+func FailureDomain(reason string) string {
+	if slices.Contains(workloadReasons, ateerrors.Reason(reason)) {
+		return FailureDomainWorkload
+	}
+	if ateerrors.IsValidReason(reason) && reason != ReasonUnknown {
+		return FailureDomainInfrastructure
+	}
+	return FailureDomainUnknown
+}
 
 // Values for StatsSourceKey, mirroring ateompb.StatsSource. The two sources do
 // not measure the same thing (the cgroup source charges the sandbox runtime's
@@ -362,6 +409,16 @@ func ActorLogAttrs(a resources.ActorAttribution) []slog.Attr {
 	}
 }
 
+// ActorRefLogAttrs is ActorLogAttrs for a record written before the Actor
+// resolves, mirroring ActorRefAttributes on the span side. The uid is unknown
+// until the record loads, so it is omitted rather than emitted empty.
+func ActorRefLogAttrs(actorRef resources.ActorRef) []slog.Attr {
+	return []slog.Attr{
+		slog.String(string(AtespaceKey), actorRef.Atespace),
+		slog.String(string(ActorNameKey), actorRef.Name),
+	}
+}
+
 // ActorMetricAttributes returns the metric labels for an Actor.
 // High-cardinality attributes (atespace, actor name, actor uid) are omitted.
 // The worker-pool pair is omitted while the actor holds no assignment, so a
@@ -384,7 +441,7 @@ func ActorMetricAttributes(a *ateapipb.Actor, sandboxClass, operationName, reaso
 		TemplateNameKey.String(a.GetActorTemplate().GetName()),
 		SandboxClassKey.String(sandboxClass),
 		ActorOperationNameKey.String(operationName),
-		FailureReasonKey.String(reason),
 	}
+	attrs = append(attrs, FailureAttributes(reason)...)
 	return append(attrs, WorkerPoolAttributes(ass.GetWorkerNamespace(), ass.GetWorkerPool())...)
 }

--- a/internal/ateattr/ateattr_test.go
+++ b/internal/ateattr/ateattr_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"testing"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -169,6 +170,7 @@ func TestKeySpellings(t *testing.T) {
 		{SchedulerOutcomeKey, "ate.scheduler.outcome"},
 		{ErrorTypeKey, "error.type"},
 		{FailureReasonKey, "ate.failure.reason"},
+		{FailureDomainKey, "ate.failure.domain"},
 		{OTLPRelayKey, "ate.otlp.relay"},
 	}
 	for _, tt := range tests {
@@ -445,6 +447,7 @@ func TestActorMetricAttributes(t *testing.T) {
 			SandboxClassKey:        "gvisor",
 			ActorOperationNameKey:  OperationResume,
 			FailureReasonKey:       ReasonCorruptedAssignment,
+			FailureDomainKey:       FailureDomainInfrastructure,
 		}
 
 		assertAttrs(t, got, want)
@@ -460,6 +463,7 @@ func TestActorMetricAttributes(t *testing.T) {
 			SandboxClassKey:        "gvisor",
 			ActorOperationNameKey:  OperationUnknown,
 			FailureReasonKey:       ReasonUnknown,
+			FailureDomainKey:       FailureDomainUnknown,
 		}
 
 		assertAttrs(t, got, want)
@@ -475,6 +479,7 @@ func TestActorMetricAttributes(t *testing.T) {
 			SandboxClassKey:        "gvisor",
 			ActorOperationNameKey:  OperationUnknown,
 			FailureReasonKey:       ReasonUnknown,
+			FailureDomainKey:       FailureDomainUnknown,
 		}
 
 		assertAttrs(t, got, want)
@@ -498,6 +503,7 @@ func TestActorMetricAttributes(t *testing.T) {
 			SandboxClassKey:        "gvisor",
 			ActorOperationNameKey:  OperationResume,
 			FailureReasonKey:       ReasonUnknown,
+			FailureDomainKey:       FailureDomainUnknown,
 		}
 
 		assertAttrs(t, got, want)
@@ -517,6 +523,7 @@ func TestActorMetricAttributes(t *testing.T) {
 			SandboxClassKey:       "gvisor",
 			ActorOperationNameKey: OperationCreate,
 			FailureReasonKey:      ReasonUnknown,
+			FailureDomainKey:      FailureDomainUnknown,
 		}
 
 		assertAttrs(t, got, want)
@@ -674,5 +681,86 @@ func TestNormalizeOperationName(t *testing.T) {
 		if got := NormalizeOperationName(tt.op); got != tt.want {
 			t.Errorf("NormalizeOperationName(%q) = %q, want %q", tt.op, got, tt.want)
 		}
+	}
+}
+
+func TestFailureDomain(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		want   string
+	}{
+		{"workload reason", string(ateerrors.ReasonWorkloadNotReady), FailureDomainWorkload},
+		{"node infrastructure reason", string(ateerrors.ReasonTerminalFileSystemError), FailureDomainInfrastructure},
+		{"control-plane infrastructure reason", string(ateerrors.ReasonWorkerPodGone), FailureDomainInfrastructure},
+		{"unknown asserts no domain", ReasonUnknown, FailureDomainUnknown},
+		{"empty", "", FailureDomainUnknown},
+		{"unregistered reason", "SOMETHING_ELSE", FailureDomainUnknown},
+		{"workload prefix is not what decides", "WORKLOAD_NOT_A_REAL_REASON", FailureDomainUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FailureDomain(tt.reason); got != tt.want {
+				t.Errorf("FailureDomain(%q) = %q, want %q", tt.reason, got, tt.want)
+			}
+		})
+	}
+}
+
+// Every registered reason must classify, so adding one to AllReasons without
+// deciding its domain fails here rather than silently reporting unknown.
+func TestFailureDomainCoversAllReasons(t *testing.T) {
+	for _, r := range ateerrors.AllReasons {
+		got := FailureDomain(string(r))
+		if r == ateerrors.ReasonUnknown {
+			if got != FailureDomainUnknown {
+				t.Errorf("FailureDomain(%q) = %q, want %q", r, got, FailureDomainUnknown)
+			}
+			continue
+		}
+		if got == FailureDomainUnknown {
+			t.Errorf("FailureDomain(%q) = %q; add it to workloadReasons or confirm it is infrastructure", r, got)
+		}
+	}
+}
+
+func TestFailureAttributesAlwaysPaired(t *testing.T) {
+	reason := string(ateerrors.ReasonWorkloadNotReady)
+
+	kvs := FailureAttributes(reason)
+	if len(kvs) != 2 {
+		t.Fatalf("FailureAttributes() returned %d attributes, want 2", len(kvs))
+	}
+	if kvs[0].Key != FailureReasonKey || kvs[0].Value.AsString() != reason {
+		t.Errorf("FailureAttributes()[0] = %v, want %s=%s", kvs[0], FailureReasonKey, reason)
+	}
+	if kvs[1].Key != FailureDomainKey || kvs[1].Value.AsString() != FailureDomainWorkload {
+		t.Errorf("FailureAttributes()[1] = %v, want %s=%s", kvs[1], FailureDomainKey, FailureDomainWorkload)
+	}
+
+	attrs := FailureLogAttrs(reason)
+	if len(attrs) != len(kvs) {
+		t.Fatalf("FailureLogAttrs() returned %d attributes, FailureAttributes() returned %d; they must agree", len(attrs), len(kvs))
+	}
+	for i, a := range attrs {
+		if a.Key != string(kvs[i].Key) || a.Value.String() != kvs[i].Value.AsString() {
+			t.Errorf("FailureLogAttrs()[%d] = %s=%s, want %s=%s", i, a.Key, a.Value, kvs[i].Key, kvs[i].Value.AsString())
+		}
+	}
+}
+
+func TestActorRefLogAttrs(t *testing.T) {
+	attrs := ActorRefLogAttrs(resources.ActorRef{Atespace: "space-1", Name: "actor-1"})
+
+	got := make(map[string]string, len(attrs))
+	for _, a := range attrs {
+		got[a.Key] = a.Value.String()
+	}
+	want := map[string]string{
+		string(AtespaceKey):  "space-1",
+		string(ActorNameKey): "actor-1",
+	}
+	if !maps.Equal(got, want) {
+		t.Errorf("ActorRefLogAttrs() = %v, want %v", got, want)
 	}
 }

--- a/internal/ateattr/ateattr_test.go
+++ b/internal/ateattr/ateattr_test.go
@@ -690,7 +690,13 @@ func TestFailureDomain(t *testing.T) {
 		reason string
 		want   string
 	}{
-		{"workload reason", string(ateerrors.ReasonWorkloadNotReady), FailureDomainWorkload},
+		{"runtime workload reason", string(ateerrors.ReasonWorkloadNotReady), FailureDomainWorkload},
+		// A misdeclared template is the actor owner's to fix, so it is a
+		// workload fault even though substrate is what detects it.
+		{"template resolves to no runnable process", string(ateerrors.ReasonInvalidContainerConfig), FailureDomainWorkload},
+		{"template storage_location unparseable", string(ateerrors.ReasonInvalidObjectURL), FailureDomainWorkload},
+		// SandboxConfig is cluster-scoped, so no actor owner can cause or fix this.
+		{"bad sandbox asset stays infrastructure", string(ateerrors.ReasonInvalidSandboxAsset), FailureDomainInfrastructure},
 		{"node infrastructure reason", string(ateerrors.ReasonTerminalFileSystemError), FailureDomainInfrastructure},
 		{"control-plane infrastructure reason", string(ateerrors.ReasonWorkerPodGone), FailureDomainInfrastructure},
 		{"unknown asserts no domain", ReasonUnknown, FailureDomainUnknown},

--- a/internal/ateerrors/ateerrors.go
+++ b/internal/ateerrors/ateerrors.go
@@ -60,6 +60,16 @@ const (
 	// its state is unrecoverable.
 	ReasonLocalSnapshotGone Reason = "LOCAL_SNAPSHOT_GONE"
 
+	// ReasonWorkloadNotReady marks a container that started but never passed its
+	// readyz probe before the probe's deadline. First reason in the workload
+	// fault domain (ateattr.FailureDomain); the operation it failed under is
+	// ate.actor.operation.name, not part of this value.
+	//
+	// Confounded by a slow node: a cold image or a throttled CPU also runs the
+	// probe out of time. ate.actor.restore.duration.* on the same record
+	// separates the two.
+	ReasonWorkloadNotReady Reason = "WORKLOAD_NOT_READY"
+
 	// Control-plane failure reasons for ate.actor.crashes metric.
 	ReasonCorruptedAssignment Reason = "CORRUPTED_ASSIGNMENT"
 	ReasonWorkerReassigned    Reason = "WORKER_REASSIGNED"
@@ -77,6 +87,7 @@ var AllReasons = []Reason{
 	ReasonFailedGetExternalObject,
 	ReasonInvalidContainerConfig,
 	ReasonLocalSnapshotGone,
+	ReasonWorkloadNotReady,
 	ReasonCorruptedAssignment,
 	ReasonWorkerReassigned,
 	ReasonWorkerPodGone,

--- a/internal/e2e/suites/metrics/metrics_test.go
+++ b/internal/e2e/suites/metrics/metrics_test.go
@@ -238,6 +238,16 @@ func TestPlatformMetricsEmitted(t *testing.T) {
 						crashErrs = append(crashErrs, fmt.Sprintf("ate_failure_reason %q is invalid (must be a registered ateerrors reason enum like CORRUPTED_ASSIGNMENT, WORKER_POD_GONE, WORKER_REASSIGNED, UNKNOWN)", reasonVal))
 					}
 
+					// The pair travels together, and the domain must agree with the
+					// reason: a consumer splitting infrastructure from workload faults
+					// reads the domain and never matches on the names of the reasons.
+					domainVal := extractLabelValue(line, "ate_failure_domain")
+					if domainVal == "" {
+						crashErrs = append(crashErrs, "ate_failure_domain label is missing or empty")
+					} else if want := ateattr.FailureDomain(reasonVal); domainVal != want {
+						crashErrs = append(crashErrs, fmt.Sprintf("ate_failure_domain %q disagrees with ate_failure_reason %q, which classifies as %q", domainVal, reasonVal, want))
+					}
+
 					if tmplAtespaceVal == "" {
 						crashErrs = append(crashErrs, "ate_template_atespace label is missing or empty")
 					}

--- a/internal/readyz/readyz.go
+++ b/internal/readyz/readyz.go
@@ -23,6 +23,7 @@ package readyz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,8 +32,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/ateerrors"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
 )
 
 // Tuning knobs. Sized for actor cold-start where the HTTP server may take
@@ -65,6 +68,11 @@ var HTTPClient = func() *http.Client {
 // WaitAll blocks until every container with a readyz probe set reports 200,
 // or returns the first error. Containers without a probe are skipped (their
 // absence means "no readiness gate").
+//
+// Every caller is an ateom RPC handler, so a %w-wrapped Reason dies here:
+// errors.As cannot cross a process, and the interceptor would flatten it to a
+// bare codes.Internal, leaving atelet reading UNKNOWN. The ErrorInfo detail is
+// what carries it. Internal and no crash directive both match today's behavior.
 func WaitAll(ctx context.Context, containers []*ateompb.Container, actorIP string) error {
 	g, gctx := errgroup.WithContext(ctx)
 	for _, ac := range containers {
@@ -76,7 +84,11 @@ func WaitAll(ctx context.Context, containers []*ateompb.Container, actorIP strin
 			return Wait(gctx, ac.GetName(), ac.GetReadyz(), actorIP)
 		})
 	}
-	return g.Wait()
+	err := g.Wait()
+	if err != nil && errors.Is(err, ateerrors.ReasonWorkloadNotReady) {
+		return ateerrors.NewGRPCError(ctx, codes.Internal, ateerrors.ReasonWorkloadNotReady, nil, err)
+	}
+	return err
 }
 
 // Wait polls the configured HTTP endpoint until it returns 200, the context
@@ -101,8 +113,9 @@ func Wait(ctx context.Context, containerName string, probe *ateompb.Readyz, acto
 				containerName, time.Since(start), attempts, lastErr, err)
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("readyz for %q never returned 200 within %s (%d attempts, last error: %v)",
-				containerName, timeout, attempts, lastErr)
+			// Tagged only here: the cancellation above is ateom draining, not the actor failing.
+			return fmt.Errorf("%w: readyz for %q never returned 200 within %s (%d attempts, last error: %v)",
+				ateerrors.ReasonWorkloadNotReady, containerName, timeout, attempts, lastErr)
 		}
 
 		attempts++

--- a/internal/readyz/readyz_test.go
+++ b/internal/readyz/readyz_test.go
@@ -16,6 +16,8 @@ package readyz
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -25,7 +27,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/ateerrors"
 	"github.com/agent-substrate/substrate/internal/proto/ateompb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestURL(t *testing.T) {
@@ -157,6 +163,11 @@ func TestWait_ContextCancellation(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Wait returned nil, expected cancellation error")
 	}
+	// A cancelled probe is ateom draining, not the actor failing. Tagging it
+	// would attribute a node drain to the workload.
+	if errors.Is(err, ateerrors.ReasonWorkloadNotReady) {
+		t.Errorf("Wait tagged a cancellation with %v: %v", ateerrors.ReasonWorkloadNotReady, err)
+	}
 }
 
 func TestOverallTimeout(t *testing.T) {
@@ -208,6 +219,9 @@ func TestWait_GivesUpAtProbeTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Wait returned nil, expected a timeout error")
 	}
+	if !errors.Is(err, ateerrors.ReasonWorkloadNotReady) {
+		t.Errorf("Wait error = %v, want it to carry %v", err, ateerrors.ReasonWorkloadNotReady)
+	}
 	elapsed := time.Since(start)
 	if elapsed < time.Second {
 		t.Errorf("Wait gave up after %v, before the probe's 1s timeout", elapsed)
@@ -256,4 +270,39 @@ func pickFreePort(t *testing.T) int {
 	port := l.Addr().(*net.TCPAddr).Port
 	l.Close()
 	return port
+}
+
+// WaitAll is an ateom RPC boundary, so the reason has to reach atelet as an
+// ErrorInfo detail. A %w-wrapped Reason does not: errors.As cannot cross a
+// process, and the interceptor flattens a statusless error to a bare
+// codes.Internal, which reads back as UNKNOWN.
+func TestWaitAll_ReasonSurvivesTheRPCBoundary(t *testing.T) {
+	port := pickFreePort(t)
+	containers := []*ateompb.Container{{
+		Name:   "main",
+		Readyz: &ateompb.Readyz{HttpGet: &ateompb.HTTPGetAction{Port: int32(port)}, TimeoutSeconds: 1},
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := WaitAll(ctx, containers, "127.0.0.1")
+	if err == nil {
+		t.Fatal("WaitAll returned nil, expected a timeout error")
+	}
+
+	// What the interceptor does to a handler error, then what atelet reads.
+	overWire := fmt.Errorf("while calling ateom.RunWorkload: %w", asHandlerReturns(err))
+	if got := ateattr.FailureReason(overWire); got != string(ateerrors.ReasonWorkloadNotReady) {
+		t.Errorf("after the RPC hop FailureReason = %q, want %q", got, ateerrors.ReasonWorkloadNotReady)
+	}
+}
+
+// asHandlerReturns mimics ateinterceptors: a status error in the chain is
+// forwarded whole, anything else collapses to codes.Internal with only a message.
+func asHandlerReturns(err error) error {
+	var statusErr interface{ GRPCStatus() *status.Status }
+	if errors.As(err, &statusErr) {
+		return statusErr.GRPCStatus().Err()
+	}
+	return status.Error(codes.Internal, err.Error())
 }

--- a/internal/resources/actorattribution.go
+++ b/internal/resources/actorattribution.go
@@ -14,6 +14,8 @@
 
 package resources
 
+import "github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+
 // ActorAttribution is what telemetry about an actor is attributed to: an
 // ActorRef plus the two things a ref does not carry, the server-assigned uid and
 // the template the actor was built from. Shared by ateattr, actorlog, and
@@ -27,4 +29,15 @@ type ActorAttribution struct {
 	UID              string
 	TemplateAtespace string
 	TemplateName     string
+}
+
+// ActorAttributionFromActor builds the attribution for a loaded Actor. Nil-safe;
+// a nil Actor yields zero-valued fields.
+func ActorAttributionFromActor(a *ateapipb.Actor) ActorAttribution {
+	return ActorAttribution{
+		Ref:              ActorRefFromActor(a),
+		UID:              a.GetMetadata().GetUid(),
+		TemplateAtespace: a.GetActorTemplate().GetAtespace(),
+		TemplateName:     a.GetActorTemplate().GetName(),
+	}
 }


### PR DESCRIPTION
`ate.failure.reason` only ever named infrastructure faults, and the crash log didn't say which actor crashed. 

This PR adds the following:

- **`ate.failure.domain`** (`infrastructure` / `workload` / `unknown`) is available next to every `ate.failure.reason`. It's a strict function of the reason so it costs no series, but it's *emitted* rather than derived downstream, so a component ahead of ateapi can report a reason this build rejects, which collapses to `UNKNOWN`, and a consumer matching on reason names would file every one of those as infra. `UNKNOWN` now reports `unknown`, not `infrastructure`.
- **`Actor crashed`** record from ateapi, with full identity including the uid, via a helper both crash sites share. It sits under the same guard as the counter so the two can't disagree on how many crashes happened. The counter is barred from carrying actor identity, so this record is the only way to attribute a crash to one agent.
- **`WORKLOAD_NOT_READY`** on the readyz deadline, as the first workload-domain reason. Deadline branch only: a cancellation is ateom draining, not the actor failing.

Tested locally:
```
desc = WORKLOAD_NOT_READY: readyz for "counter" never returned 200 within 5s
```

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
