### PR TITLE
ateapi: Add min and max valiation to ActorMetadataItem.field

### DIFF
--- a/cmd/ateapi/internal/controlapi/validation_test.go
+++ b/cmd/ateapi/internal/controlapi/validation_test.go
@@ -712,6 +712,18 @@ func TestValidateSystemInfoVolumeSource(t *testing.T) {
 		}),
 		want: field.ErrorList{field.Required(itemsPath.Index(0).Child("field"), "")},
 	}, {
+		name: "item field outside the enum",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Field = ateapipb.ActorMetadataField(99)
+		}),
+		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("field"), nil, "").WithOrigin("maximum")},
+	}, {
+		name: "negative item field",
+		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
+			s.DataSources[0].ActorMetadata.Items[0].Field = ateapipb.ActorMetadataField(-1)
+		}),
+		want: field.ErrorList{field.Invalid(itemsPath.Index(0).Child("field"), nil, "").WithOrigin("minimum")},
+	}, {
 		name: "empty item path",
 		obj: valid(func(s *ateapipb.SystemInfoVolumeSource) {
 			s.DataSources[0].ActorMetadata.Items[0].Path = ""

--- a/cmd/ateapi/internal/controlapi/zz_generated.validation.go
+++ b/cmd/ateapi/internal/controlapi/zz_generated.validation.go
@@ -463,6 +463,12 @@ func Validate_ActorMetadataItem(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if e := validate.Maximum(ctx, op, fldPath, obj, oldObj, 3); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/pkg/proto/ateapipb/ateapi.pb.go
+++ b/pkg/proto/ateapipb/ateapi.pb.go
@@ -322,7 +322,7 @@ const (
 	ActorMetadataField_ACTOR_METADATA_FIELD_UNSPECIFIED ActorMetadataField = 0
 	ActorMetadataField_ACTOR_METADATA_FIELD_NAME        ActorMetadataField = 1
 	ActorMetadataField_ACTOR_METADATA_FIELD_ATESPACE    ActorMetadataField = 2
-	ActorMetadataField_ACTOR_METADATA_FIELD_UID         ActorMetadataField = 3
+	ActorMetadataField_ACTOR_METADATA_FIELD_UID         ActorMetadataField = 3 // Keep this in sync with ActorMetadataItem.field's maximum.
 )
 
 // Enum value maps for ActorMetadataField.
@@ -3545,6 +3545,8 @@ func (x *ActorMetadataDataSource) GetItems() []*ActorMetadataItem {
 type ActorMetadataItem struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// +k8s:required
+	// +k8s:minimum=1
+	// +k8s:maximum=3 # keep this in sync with the ActorMetadataField enum
 	Field ActorMetadataField `protobuf:"varint,1,opt,name=field,proto3,enum=ateapi.ActorMetadataField" json:"field,omitempty"`
 	// +k8s:required
 	// +k8s:minLength=1

--- a/pkg/proto/ateapipb/ateapi.proto
+++ b/pkg/proto/ateapipb/ateapi.proto
@@ -1139,6 +1139,8 @@ message ActorMetadataDataSource {
 // a clean relative Unix path from the root of the volume.
 message ActorMetadataItem {
   // +k8s:required
+  // +k8s:minimum=1
+  // +k8s:maximum=3 # keep this in sync with the ActorMetadataField enum
   ActorMetadataField field = 1;
 
   // +k8s:required
@@ -1153,6 +1155,7 @@ enum ActorMetadataField {
   ACTOR_METADATA_FIELD_NAME = 1;
   ACTOR_METADATA_FIELD_ATESPACE = 2;
   ACTOR_METADATA_FIELD_UID = 3;
+  // Keep this in sync with ActorMetadataItem.field's maximum.
 }
 
 // TrustBundleDataSource projects the trust anchors of the named trust bundle


### PR DESCRIPTION
Follow the style for all other enum validations.

Fix #1441 

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
