### PR TITLE
setup-gcp: validate iam flags before applying any binding

### DIFF
--- a/tools/setup-gcp/cmd/iam.go
+++ b/tools/setup-gcp/cmd/iam.go
@@ -132,20 +132,34 @@ func grantAteletPermissions(ctx context.Context, cfg *Config) error {
 	return nil
 }
 
+// validateIamFlags checks every flag the command needs before any of the
+// grants run. Each grant is a separate SetIamPolicy call, so a flag validated
+// partway through the sequence reports a usage error only after the earlier
+// grants have already been written to the project.
+func validateIamFlags(cfg *Config, bucketBindings bool) error {
+	if cfg.ProjectID == "" {
+		return errors.New("--project-id is required")
+	}
+	if cfg.ProjectNumber == "" {
+		return errors.New("--project-number is required")
+	}
+	if bucketBindings && cfg.BucketName == "" {
+		return errors.New("--bucket is required for bucket bindings")
+	}
+	return nil
+}
+
 var iamCmd = &cobra.Command{
 	Use:   "iam",
 	Short: "Create IAM bindings",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if cfg.ProjectID == "" {
-			return errors.New("--project-id is required")
-		}
-		if cfg.ProjectNumber == "" {
-			return errors.New("--project-number is required")
-		}
-
 		gkeNodes, _ := cmd.Flags().GetBool("gke-nodes")
 		atelet, _ := cmd.Flags().GetBool("atelet")
 		bucketBindings, _ := cmd.Flags().GetBool("bucket-bindings")
+
+		if err := validateIamFlags(&cfg, bucketBindings); err != nil {
+			return err
+		}
 
 		if gkeNodes {
 			if err := grantGkeNodePermissions(cmd.Context(), &cfg); err != nil {
@@ -158,9 +172,6 @@ var iamCmd = &cobra.Command{
 			}
 		}
 		if bucketBindings {
-			if cfg.BucketName == "" {
-				return errors.New("--bucket is required for bucket bindings")
-			}
 			if err := createIamPolicyBindings(cmd.Context(), &cfg); err != nil {
 				return err
 			}

--- a/tools/setup-gcp/cmd/iam_test.go
+++ b/tools/setup-gcp/cmd/iam_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "testing"
+
+func TestValidateIamFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            Config
+		bucketBindings bool
+		want           string
+	}{
+		{
+			name:           "missing project id",
+			cfg:            Config{},
+			bucketBindings: true,
+			want:           "--project-id is required",
+		},
+		{
+			name:           "missing project number",
+			cfg:            Config{ProjectID: "test-project"},
+			bucketBindings: true,
+			want:           "--project-number is required",
+		},
+		{
+			name:           "missing bucket while bucket bindings are requested",
+			cfg:            Config{ProjectID: "test-project", ProjectNumber: "123"},
+			bucketBindings: true,
+			want:           "--bucket is required for bucket bindings",
+		},
+		{
+			name:           "bucket not required when bucket bindings are disabled",
+			cfg:            Config{ProjectID: "test-project", ProjectNumber: "123"},
+			bucketBindings: false,
+		},
+		{
+			name:           "all required flags present",
+			cfg:            Config{ProjectID: "test-project", ProjectNumber: "123", BucketName: "test-bucket"},
+			bucketBindings: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateIamFlags(&tt.cfg, tt.bucketBindings)
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("validateIamFlags() = %v; want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateIamFlags() = nil; want %q", tt.want)
+			}
+			if err.Error() != tt.want {
+				t.Errorf("validateIamFlags() = %q; want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`create iam` checked --bucket from inside the bucket-bindings block, after the GKE node and atelet grants had already run. Invoking it without a bucket therefore wrote two project-level IAM bindings and only then failed with a usage error, leaving the project partly configured by a command that had rejected its own arguments.

Move the checks into validateIamFlags and call it before the first grant, so an argument error is reported without touching the project.

Reproduced with:

  setup-gcp create iam --project-id=P --project-number=N --bucket=

  before: two grants applied, then
          Error: --bucket is required for bucket bindings
  after:  Error: --bucket is required for bucket bindings, no grants applied

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [X] Appropriate changes to documentation are included in the PR
