### PR TITLE
add JQ to automation dockerfile

### DIFF
--- a/benchmarking/automation/Dockerfile
+++ b/benchmarking/automation/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gettext-base \
         git \
         gnupg \
+        jq \
         make \
         python3 \
         python3-pip \


### PR DESCRIPTION
This adds JQ to the automation image because it is now a critical dependency for the installation scripts.
