### PR TITLE
setup-gcp: fix atelet dashboard filters that match no deployment

### DIFF
--- a/tools/setup-gcp/dashboards/ate-e2e-latency-dashboard.json
+++ b/tools/setup-gcp/dashboards/ate-e2e-latency-dashboard.json
@@ -76,7 +76,7 @@
               },
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=\"atelet\", \"rpc.method\"=\"atelet.AteomHerder/Restore\"}[5m])))",
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=~\"atelet-.*\", \"rpc.method\"=\"atelet.AteomHerder/Restore\"}[5m])))",
                   "unitOverride": "s"
                 },
                 "plotType": "LINE",

--- a/tools/setup-gcp/dashboards/ate-grpc-dashboard.json
+++ b/tools/setup-gcp/dashboards/ate-grpc-dashboard.json
@@ -89,7 +89,7 @@
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "histogram_quantile(0.99, sum by (le, \"rpc.method\") (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=\"atelet\"}[5m])))",
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le, \"rpc.method\") (rate({\"rpc.server.call.duration_bucket\", top_level_controller_name=~\"atelet-.*\"}[5m])))",
                   "unitOverride": "s"
                 },
                 "plotType": "LINE",
@@ -114,7 +114,7 @@
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (\"rpc.method\") (rate({\"rpc.server.call.duration_count\", top_level_controller_name=\"atelet\"}[5m]))",
+                  "prometheusQuery": "sum by (\"rpc.method\") (rate({\"rpc.server.call.duration_count\", top_level_controller_name=~\"atelet-.*\"}[5m]))",
                   "unitOverride": "1/s"
                 },
                 "plotType": "LINE",
@@ -139,7 +139,7 @@
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (\"rpc.response.status_code\") (rate({\"rpc.server.call.duration_count\", top_level_controller_name=\"atelet\", \"rpc.response.status_code\"!=\"OK\"}[5m]))",
+                  "prometheusQuery": "sum by (\"rpc.response.status_code\") (rate({\"rpc.server.call.duration_count\", top_level_controller_name=~\"atelet-.*\", \"rpc.response.status_code\"!=\"OK\"}[5m]))",
                   "unitOverride": "1/s"
                 },
                 "plotType": "LINE",

--- a/tools/setup-gcp/dashboards/ate-snapshot-dashboard.json
+++ b/tools/setup-gcp/dashboards/ate-snapshot-dashboard.json
@@ -14,7 +14,7 @@
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "histogram_quantile(0.99, sum by (le, \"ate.template.name\") (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=\"atelet\", \"file.name\"=\"pages.img\"}[1h])))",
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le, \"ate.template.name\") (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=~\"atelet-.*\", \"file.name\"=\"pages.img\"}[1h])))",
                   "unitOverride": "By"
                 },
                 "plotType": "LINE",
@@ -39,7 +39,7 @@
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "histogram_quantile(0.50, sum by (le) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=\"atelet\"}[1h])))",
+                  "prometheusQuery": "histogram_quantile(0.50, sum by (le) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=~\"atelet-.*\"}[1h])))",
                   "unitOverride": "By"
                 },
                 "plotType": "LINE",
@@ -48,7 +48,7 @@
               },
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "histogram_quantile(0.95, sum by (le) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=\"atelet\"}[1h])))",
+                  "prometheusQuery": "histogram_quantile(0.95, sum by (le) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=~\"atelet-.*\"}[1h])))",
                   "unitOverride": "By"
                 },
                 "plotType": "LINE",
@@ -57,7 +57,7 @@
               },
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=\"atelet\"}[1h])))",
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le) (rate({\"atelet.snapshot.size_bucket\", top_level_controller_name=~\"atelet-.*\"}[1h])))",
                   "unitOverride": "By"
                 },
                 "plotType": "LINE",
@@ -83,7 +83,7 @@
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (\"ate.template.name\") (rate({\"atelet.snapshot.size_count\", top_level_controller_name=\"atelet\", \"file.name\"=\"pages.img\"}[1h]))",
+                  "prometheusQuery": "sum by (\"ate.template.name\") (rate({\"atelet.snapshot.size_count\", top_level_controller_name=~\"atelet-.*\", \"file.name\"=\"pages.img\"}[1h]))",
                   "unitOverride": "1/s"
                 },
                 "plotType": "LINE",


### PR DESCRIPTION
The atelet Deployment is always named "atelet-<suffix>" (see cmd/ate-setup/internal/steps/version.go), never plain "atelet", so every dashboard widget filtering on top_level_controller_name="atelet" renders empty even when the underlying metrics exist. The Snapshot Size & QPS dashboard was entirely blank on a fresh install because of this; the gRPC and E2E-latency dashboards had the same dead filter on their atelet panels.

Match the deployment name prefix with a regex instead. Verified against a live install (GMP PromQL): the equality filter returns 0 series while =~"atelet-.*" returns all 12 atelet.snapshot.size series.

Fixes #1453

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
