### PR TITLE
manifests: wire OTLP exporter settings into the egress ext-proc

### DIFF
--- a/manifests/ate-install/ate-otel-config.yaml
+++ b/manifests/ate-install/ate-otel-config.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Single source of truth for the OTLP exporter settings shared by every control
-# plane component (ate-api-server, ate-controller, atelet, atenet-router), which
-# consume it via `envFrom`. ate-controller additionally propagates these values
+# plane component (ate-api-server, ate-controller, atelet, atenet-router,
+# atenet-egress), which consume it via `envFrom`. ate-controller additionally propagates these values
 # to the ateom worker pods it creates, which have no other way to receive them,
 # and atenet-router's --otlp-collector-address defaults to the endpoint below,
 # so Envoy's own spans follow it too.

--- a/manifests/ate-install/atenet-egress-with-sdsmint.yaml
+++ b/manifests/ate-install/atenet-egress-with-sdsmint.yaml
@@ -958,6 +958,9 @@ spec:
         # of it; without this flag the router has no actor-identity roots and
         # denies every egress CONNECT with a 503.
         - --actor-identity-ca-file=/run/actor-id-ca-certs/ca.crt
+        # Disables Envoy-side tracing only (a span per CONNECT tunnel is
+        # dataplane-volume noise). The ext-proc's own OTel SDK exports to
+        # $OTEL_EXPORTER_OTLP_ENDPOINT from ate-otel-config below.
         - --otlp-collector-address=
         # The egress Envoy's admin listener is on 15000, not the 9901 the flag
         # defaults to (that is the ingress gateway's port). Without this the
@@ -973,6 +976,19 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),service.instance.id=$(POD_UID)
+        # OTLP exporter settings shared by every control plane component; see
+        # manifests/ate-install/ate-otel-config.yaml. Without this the SDK
+        # falls back to localhost:4317, where nothing listens, and every
+        # egress metric and span is lost.
+        envFrom:
+        - configMapRef:
+            name: ate-otel-config
         ports:
         - name: extproc
           containerPort: 50051

--- a/manifests/ate-install/atenet-egress.yaml
+++ b/manifests/ate-install/atenet-egress.yaml
@@ -324,6 +324,9 @@ spec:
         # of it; without this flag the router has no actor-identity roots and
         # denies every egress CONNECT with a 503.
         - --actor-identity-ca-file=/run/actor-id-ca-certs/ca.crt
+        # Disables Envoy-side tracing only (a span per CONNECT tunnel is
+        # dataplane-volume noise). The ext-proc's own OTel SDK exports to
+        # $OTEL_EXPORTER_OTLP_ENDPOINT from ate-otel-config below.
         - --otlp-collector-address=
         # The egress Envoy's admin listener is on 15000, not the 9901 the flag
         # defaults to (that is the ingress gateway's port). Without this the
@@ -339,6 +342,19 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),service.instance.id=$(POD_UID)
+        # OTLP exporter settings shared by every control plane component; see
+        # manifests/ate-install/ate-otel-config.yaml. Without this the SDK
+        # falls back to localhost:4317, where nothing listens, and every
+        # egress metric and span is lost.
+        envFrom:
+        - configMapRef:
+            name: ate-otel-config
         ports:
         - name: extproc
           containerPort: 50051


### PR DESCRIPTION
The egress ext-proc container never received the shared OTLP exporter settings: unlike every other control plane component, its Deployment did not consume ate-otel-config via envFrom, so OTEL_EXPORTER_OTLP_ENDPOINT was unset and the OTel SDK fell back to localhost:4317, where nothing listens. Every egress metric and span was silently dropped, with the SDK logging an export-failure warning every ~20s — on a live GKE install this was the largest warn/error source in the cluster, and the registry-listed ext_proc instruments simply did not exist in GMP for the egress gateway.

Give the ext-proc the same envFrom, POD_UID, and OTEL_RESOURCE_ATTRIBUTES wiring the ingress router has, in both the plain and sdsmint egress manifests. --otlp-collector-address stays explicitly empty: that flag only controls Envoy-side tracing, and a span per CONNECT tunnel is dataplane-volume noise; the comment now says so instead of leaving the empty value looking accidental. Also add atenet-egress to the consumer list in the ate-otel-config header comment.

Verified on a live install: after applying the env change the SDK export-failure warnings stop and target_info for the egress deployment appears in Managed Prometheus.

Fixes #1459

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
