### PR TITLE
Disable Filestore CSI when creating a GKE cluster. 

### DIFF
--- a/tools/setup-gcp/README.md
+++ b/tools/setup-gcp/README.md
@@ -64,7 +64,9 @@ go run ./tools/setup-gcp enable apis [flags]
 
 ### 2. Create Cluster
 
-Creates a GKE cluster configured for Agent Substrate.
+Creates a GKE cluster configured for Agent Substrate (with Workload Identity,
+required Kubernetes beta APIs, and Managed OpenTelemetry enabled, and the
+Filestore CSI driver disabled).
 
 > [!WARNING]
 > Agent Substrate requires two Kubernetes beta APIs —

--- a/tools/setup-gcp/cmd/cluster.go
+++ b/tools/setup-gcp/cmd/cluster.go
@@ -51,15 +51,14 @@ func deleteCluster(ctx context.Context, cfg *Config) error {
 	return waitContainerOperation(ctx, client, op.Name, cfg)
 }
 
-func createClusterInternal(ctx context.Context, cfg *Config, client *container.ClusterManagerClient, parent string) error {
-	slog.Info("Cluster does not exist. Creating...", slog.String("cluster", cfg.ClusterName))
+func buildCreateClusterRequest(parent string, cfg *Config) *containerpb.CreateClusterRequest {
 	var networkConfig *containerpb.NetworkConfig
 	if cfg.EnableDataplaneV2 {
 		networkConfig = &containerpb.NetworkConfig{
 			DatapathProvider: containerpb.DatapathProvider_ADVANCED_DATAPATH,
 		}
 	}
-	req := &containerpb.CreateClusterRequest{
+	return &containerpb.CreateClusterRequest{
 		Parent: parent,
 		Cluster: &containerpb.Cluster{
 			Name:                  cfg.ClusterName,
@@ -83,8 +82,22 @@ func createClusterInternal(ctx context.Context, cfg *Config, client *container.C
 			Subnetwork:                 cfg.Subnetwork,
 			NetworkConfig:              networkConfig,
 			ManagedOpentelemetryConfig: &containerpb.ManagedOpenTelemetryConfig{Scope: containerpb.ManagedOpenTelemetryConfig_COLLECTION_AND_INSTRUMENTATION_COMPONENTS.Enum()},
+			AddonsConfig: &containerpb.AddonsConfig{
+				GcpFilestoreCsiDriverConfig: &containerpb.GcpFilestoreCsiDriverConfig{
+					Enabled: false,
+				},
+			},
 		},
 	}
+}
+
+func filestoreCsiDriverEnabled(cluster *containerpb.Cluster) bool {
+	return cluster.GetAddonsConfig().GetGcpFilestoreCsiDriverConfig().GetEnabled()
+}
+
+func createClusterInternal(ctx context.Context, cfg *Config, client *container.ClusterManagerClient, parent string) error {
+	slog.Info("Cluster does not exist. Creating...", slog.String("cluster", cfg.ClusterName))
+	req := buildCreateClusterRequest(parent, cfg)
 	op, err := client.CreateCluster(ctx, req)
 	if err != nil {
 		return fmt.Errorf("create cluster: %w", err)
@@ -225,6 +238,31 @@ func createClusterIdempotent(ctx context.Context, cfg *Config) error {
 		}
 	} else {
 		slog.Info("Cluster ManagedOpentelemetryConfig match perfectly.", slog.String("cluster", cfg.ClusterName))
+	}
+
+	if filestoreCsiDriverEnabled(cluster) {
+		slog.Info("Mismatch in Filestore CSI driver config",
+			slog.Bool("current", true),
+			slog.Bool("expected", false))
+		slog.Info("Updating cluster to disable Filestore CSI driver...")
+		op, err := client.UpdateCluster(ctx, &containerpb.UpdateClusterRequest{
+			Name: clusterName,
+			Update: &containerpb.ClusterUpdate{
+				DesiredAddonsConfig: &containerpb.AddonsConfig{
+					GcpFilestoreCsiDriverConfig: &containerpb.GcpFilestoreCsiDriverConfig{
+						Enabled: false,
+					},
+				},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("update cluster filestore csi driver: %w", err)
+		}
+		if err := waitContainerOperation(ctx, client, op.Name, cfg); err != nil {
+			return err
+		}
+	} else {
+		slog.Info("Cluster Filestore CSI driver match perfectly.", slog.String("cluster", cfg.ClusterName))
 	}
 
 	return nil

--- a/tools/setup-gcp/cmd/cluster_test.go
+++ b/tools/setup-gcp/cmd/cluster_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+)
+
+func TestBuildCreateClusterRequest_FilestoreDisabled(t *testing.T) {
+	cfg := &Config{
+		ProjectID:       "test-project",
+		ClusterName:     "test-cluster",
+		ClusterLocation: "us-west1-c",
+		MachineType:     "c3-standard-4",
+	}
+	parent := "projects/test-project/locations/us-west1-c"
+
+	req := buildCreateClusterRequest(parent, cfg)
+	if req.Cluster == nil {
+		t.Fatal("expected req.Cluster to be non-nil")
+	}
+
+	addonsConfig := req.Cluster.AddonsConfig
+	if addonsConfig == nil {
+		t.Fatal("expected req.Cluster.AddonsConfig to be non-nil")
+	}
+
+	filestoreConfig := addonsConfig.GcpFilestoreCsiDriverConfig
+	if filestoreConfig == nil {
+		t.Fatal("expected GcpFilestoreCsiDriverConfig to be non-nil")
+	}
+
+	if filestoreConfig.Enabled {
+		t.Errorf("expected GcpFilestoreCsiDriverConfig.Enabled to be false, got true")
+	}
+}
+
+func TestFilestoreCsiDriverEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *containerpb.Cluster
+		want    bool
+	}{
+		{
+			name:    "nil cluster",
+			cluster: nil,
+			want:    false,
+		},
+		{
+			name:    "nil addons config",
+			cluster: &containerpb.Cluster{},
+			want:    false,
+		},
+		{
+			name: "nil filestore config",
+			cluster: &containerpb.Cluster{
+				AddonsConfig: &containerpb.AddonsConfig{},
+			},
+			want: false,
+		},
+		{
+			name: "filestore disabled",
+			cluster: &containerpb.Cluster{
+				AddonsConfig: &containerpb.AddonsConfig{
+					GcpFilestoreCsiDriverConfig: &containerpb.GcpFilestoreCsiDriverConfig{
+						Enabled: false,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "filestore enabled",
+			cluster: &containerpb.Cluster{
+				AddonsConfig: &containerpb.AddonsConfig{
+					GcpFilestoreCsiDriverConfig: &containerpb.GcpFilestoreCsiDriverConfig{
+						Enabled: true,
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filestoreCsiDriverEnabled(tt.cluster); got != tt.want {
+				t.Errorf("filestoreCsiDriverEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A custom version is required for now.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
