### PR TITLE
ate-api-server: Tell the caller about issuer problems

### DIFF
--- a/internal/ateapiauth/server.go
+++ b/internal/ateapiauth/server.go
@@ -188,7 +188,7 @@ func (a jwtServerAuthenticator) authenticate(ctx context.Context) (context.Conte
 		}), nil
 	}
 	slog.DebugContext(ctx, "No JWT provider matched token issuer", slog.String("issuer", issuer))
-	return nil, status.Error(codes.Unauthenticated, "invalid bearer token")
+	return nil, status.Errorf(codes.Unauthenticated, "token issuer %q not trusted", issuer)
 }
 
 func unverifiedIssuer(token string) (string, error) {


### PR DESCRIPTION
If someone calls us with a JWT, and we don't trust it because the issuer is not configured in the authentication configuration file, it's fine (and very helpful for installers) if we tell them a little more detail.
