### PR TITLE
atelet: validate guest-influenced stats samples by saturating aggregation

### DIFF
--- a/cmd/atelet/statspoller.go
+++ b/cmd/atelet/statspoller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -301,8 +302,8 @@ func (p *statsPoller) collect(ctx context.Context) map[templateKey]*templateAggr
 				aggs[key] = agg
 			}
 			agg.sampledActors++
-			agg.memoryCurrentBytes += int64(sample.GetMemoryCurrentBytes())
-			agg.memoryWorkingSetBytes += int64(sample.GetMemoryWorkingSetBytes())
+			agg.memoryCurrentBytes = addSat(agg.memoryCurrentBytes, sample.GetMemoryCurrentBytes())
+			agg.memoryWorkingSetBytes = addSat(agg.memoryWorkingSetBytes, sample.GetMemoryWorkingSetBytes())
 
 			// The counter increase this sample represents. A decrease means the
 			// epoch reset underneath us (the cgroup source restarts at zero on
@@ -317,9 +318,9 @@ func (p *statsPoller) collect(ctx context.Context) map[templateKey]*templateAggr
 			seenCPU[sample.GetActorUid()] = cpu
 			if last, ok := p.lastCPU[sample.GetActorUid()]; ok {
 				if last <= cpu {
-					agg.cpuDeltaUsec += int64(cpu - last)
+					agg.cpuDeltaUsec = addSat(agg.cpuDeltaUsec, cpu-last)
 				} else {
-					agg.cpuDeltaUsec += int64(cpu)
+					agg.cpuDeltaUsec = addSat(agg.cpuDeltaUsec, cpu)
 				}
 			}
 			return nil
@@ -332,6 +333,23 @@ func (p *statsPoller) collect(ctx context.Context) map[templateKey]*templateAggr
 	// see, so lastCPU cannot grow with actor churn.
 	p.lastCPU = seenCPU
 	return aggs
+}
+
+// addSat adds a sample's uint64 counter onto an int64 aggregate, saturating at
+// MaxInt64 at both hops: converting the wire value and adding it. The wire
+// carries whatever the guest kernel -- or, on the micro-VM runtime, the guest
+// agent -- reported, and a corrupt reading above 2^63 must degrade to a pinned
+// ceiling, not flip a gauge negative or feed a negative Add into the CPU
+// counter (which the OTel spec forbids). The same reasoning as
+// agentstats.Sample.Plus, one type boundary later.
+func addSat(agg int64, v uint64) int64 {
+	if v > math.MaxInt64 {
+		v = math.MaxInt64
+	}
+	if agg > math.MaxInt64-int64(v) {
+		return math.MaxInt64
+	}
+	return agg + int64(v)
 }
 
 // sandboxClassLabel maps the wire enum to the ate.sandbox.class label values

--- a/cmd/atelet/statspoller_test.go
+++ b/cmd/atelet/statspoller_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -355,5 +356,73 @@ func TestStatsPollerWorkerPoolLabels(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, got, cmp.AllowUnexported(templateAggregate{}, templateKey{}, workerPoolRef{})); diff != "" {
 		t.Errorf("collect() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAddSat(t *testing.T) {
+	tests := []struct {
+		name string
+		agg  int64
+		v    uint64
+		want int64
+	}{
+		{name: "normal add", agg: 100, v: 50, want: 150},
+		{name: "zero add", agg: 100, v: 0, want: 100},
+		// A wire value above MaxInt64 -- a corrupt or hostile guest reading --
+		// must pin at the ceiling, not wrap the aggregate negative.
+		{name: "value above MaxInt64 saturates", agg: 0, v: math.MaxUint64, want: math.MaxInt64},
+		// The addition itself can also overflow once inputs are clamped.
+		{name: "sum overflow saturates", agg: math.MaxInt64 - 10, v: 100, want: math.MaxInt64},
+		{name: "exactly at ceiling", agg: math.MaxInt64 - 5, v: 5, want: math.MaxInt64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := addSat(tc.agg, tc.v); got != tc.want {
+				t.Errorf("addSat(%d, %d) = %d, want %d", tc.agg, tc.v, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestStatsPollerCollectSaturatesCorruptSamples pins the end-to-end behavior:
+// one guest reporting absurd counters must not flip a template's aggregates
+// negative -- a negative gauge misreads as "no memory", and a negative CPU
+// delta is a spec-violating counter Add. Everything pins at MaxInt64 instead.
+func TestStatsPollerCollectSaturatesCorruptSamples(t *testing.T) {
+	key := templateKey{templateNamespace: "ns-a", templateName: "tmpl-a", sandboxClass: "gvisor", source: "cgroup"}
+	fakes := map[string]*fakeStatsAteom{
+		"uid-1": {resp: executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, math.MaxUint64, math.MaxUint64)},
+		"uid-2": {resp: executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 1000, 700)},
+	}
+	p, _ := newPollerFixture(t, fakes)
+
+	got := p.collect(context.Background())[key]
+	if got == nil {
+		t.Fatal("collect() returned no aggregate for the template")
+	}
+	if got.memoryCurrentBytes != math.MaxInt64 || got.memoryWorkingSetBytes != math.MaxInt64 {
+		t.Errorf("memory aggregates = %d/%d, want both pinned at MaxInt64",
+			got.memoryCurrentBytes, got.memoryWorkingSetBytes)
+	}
+	if got.memoryCurrentBytes < 0 || got.memoryWorkingSetBytes < 0 || got.cpuDeltaUsec < 0 {
+		t.Errorf("aggregate went negative: %+v", got)
+	}
+}
+
+// TestStatsPollerCPUDeltaSaturatesCorruptCounter: a baseline followed by an
+// absurd counter value is a huge "increase"; it must clamp, not go negative.
+func TestStatsPollerCPUDeltaSaturatesCorruptCounter(t *testing.T) {
+	key := templateKey{templateNamespace: "ns-a", templateName: "tmpl-a", sandboxClass: "gvisor", source: "cgroup"}
+	fake := &fakeStatsAteom{resp: cpuResponse("uid-a", 1000)}
+	p, _ := newPollerFixture(t, map[string]*fakeStatsAteom{"uid-1": fake})
+
+	if got := p.collect(context.Background())[key].cpuDeltaUsec; got != 0 {
+		t.Fatalf("first sweep delta = %d, want 0", got)
+	}
+
+	fake.resp = cpuResponse("uid-a", math.MaxUint64)
+	got := p.collect(context.Background())[key].cpuDeltaUsec
+	if got != math.MaxInt64 {
+		t.Errorf("corrupt-counter sweep delta = %d, want pinned at MaxInt64", got)
 	}
 }


### PR DESCRIPTION
Fixes #1476.

**What this is and is not:** not overflow protection for legitimate values — those cannot reach the limit (2^63 bytes ≈ 9.2 EB of RAM; 2^63 µs ≈ 292,000 years of CPU). It is **input validation at the guest→host trust boundary**. The micro-VM stats source is whatever the kata-agent inside the guest replies, and the guest kernel is exactly what untrusted actor code runs against — a compromised guest controls the reply, and kernel cgroup accounting bugs have produced underflowed counters that read as enormous u64s (cAdvisor clamps for the same reason). One such sample is enough.

## Damage pre-fix

* The corrupt CPU delta goes into `Float64Counter.Add` as a **negative value**. The Go SDK does not validate monotonicity, so the cumulative sum decreases; Prometheus reads a decreasing counter as a **counter reset**, and `rate()` fabricates a spike roughly the size of the entire counter — false alarms and garbage in the fleet-telemetry/chargeback pipeline #550 feeds.
* The template's node-local memory gauges flip negative, which dashboards read as "no memory in use".

Blast radius is the template's own series and operator dashboards/alerts — not cross-tenant — but it lands in exactly the data the platform bills and alerts from, and it is triggerable by the least-trusted component in the system.

## Fix

`addSat` clamps at MaxInt64 at both hops — converting the wire value, and the addition itself — applied at all four sites (two memory sums, both CPU-delta branches). A nonsensical reading degrades to a pinned ceiling that is *obviously* wrong on a dashboard, instead of a negative value that quietly breaks consumers. This extends the judgment `agentstats.Sample.Plus` already makes on the guest side of the same boundary to the host aggregation, where the spec-constrained sink actually lives. ~15 lines, two compares per sample.

## Testing

* `addSat` table: normal / zero / value-above-MaxInt64 / sum-overflow / exactly-at-ceiling.
* End-to-end through `collect()`: a corrupt-guest sample grouped with a healthy one pins the group's aggregates at MaxInt64 (never negative); a baseline-then-absurd CPU counter pins the delta rather than passing a negative value to the counter.
* Full `hack/verify-all.sh` green.

Part of #896, toward #550.
