### PR TITLE
atelet: cache pool resolutions so a list flap cannot split the CPU counter

### DIFF
--- a/cmd/atelet/statspoller.go
+++ b/cmd/atelet/statspoller.go
@@ -436,7 +436,7 @@ func newWorkerPoolFetcher(client kubernetes.Interface, nodeName string) func(ctx
 			LabelSelector: workerPoolLabel,
 		})
 		if err != nil {
-			slog.DebugContext(ctx, "Actor stats sweep: worker pool resolution failed; samples group without pool labels", slog.Any("err", err))
+			slog.DebugContext(ctx, "Actor stats sweep: worker pool list failed; answering from cached resolutions", slog.Any("err", err))
 			return nil
 		}
 		pools := make(map[string]workerPoolRef, len(pods.Items))

--- a/cmd/atelet/statspoller.go
+++ b/cmd/atelet/statspoller.go
@@ -68,9 +68,9 @@ const statsRPCTimeout = 55 * time.Second
 // ceil(n/statsSweepConcurrency) timeouts instead of n.
 const statsSweepConcurrency = 8
 
-// workerPoolListTimeout bounds the per-sweep pod list that resolves worker
-// pools. Pool labels are enrichment: better one unlabeled tick than a sweep
-// blocked on the apiserver.
+// workerPoolListTimeout bounds the per-sweep pod list that fetches worker
+// pools: pool labels are enrichment, so a slow apiserver must not stall the
+// sweep it is merely enriching.
 const workerPoolListTimeout = 10 * time.Second
 
 // clampActorStatsPollInterval enforces the floor on a nonzero configured
@@ -118,13 +118,13 @@ type statsPoller struct {
 	// connections the lifecycle RPCs are using.
 	dial func(ctx context.Context, podUID string) (activeStatsClient, io.Closer, error)
 
-	// workerPools resolves this node's worker pod UIDs to the pool that owns
-	// them, called once per sweep. Nil (or a nil map, or a missing entry)
-	// degrades to samples grouped without pool labels rather than dropped:
-	// the pool is enrichment, the sample is the point. The real resolver
-	// lists the node's pods by workerPoolLabel; the ateom directory name IS
-	// the worker pod UID, which is the join key.
-	workerPools func(ctx context.Context) map[string]workerPoolRef
+	// fetchWorkerPools is the raw fetch: one apiserver list mapping this
+	// node's worker pod UIDs to the pool that owns them, called once per
+	// sweep by resolveWorkerPools, which layers cachedPools over it. A nil
+	// return means the fetch failed. The real fetcher lists the node's pods
+	// by workerPoolLabel; the ateom directory name IS the worker pod UID,
+	// which is the join key.
+	fetchWorkerPools func(ctx context.Context) map[string]workerPoolRef
 
 	inst *statsInstruments
 
@@ -132,6 +132,15 @@ type statsPoller struct {
 	// per-actor channel the aggregates deliberately erase identity from.
 	// Nil disables emission; emit is nil-safe.
 	eventEmitter *statsEventEmitter
+
+	// cachedPools carries pool resolutions across sweeps, so one failed pod
+	// list cannot re-home a tick's samples -- and the CPU counter's
+	// increments, which can never be re-attributed -- onto a pool-less label
+	// set. Safe because a pod's pool is immutable for the pod's lifetime: an
+	// entry can be stale, never wrong. Only the sweep loop touches it;
+	// resolveWorkerPools prunes it to the pods whose ateom directories still
+	// exist, the same bound lastCPU keeps.
+	cachedPools map[string]workerPoolRef
 
 	// lastCPU is the previous sweep's cpu_usage_usec per actor uid, the
 	// baseline the next sweep's deltas are computed against. Only the sweep
@@ -175,9 +184,9 @@ type templateKey struct {
 	templateName      string
 	sandboxClass      string
 	source            string
-	// workerPool is zero-valued when the pod could not be resolved to a pool
-	// (resolver disabled, list failure, pod already gone): those samples group
-	// together without pool labels rather than vanish.
+	// workerPool is zero-valued when no fetch has resolved the pod yet (see
+	// resolveWorkerPools): those samples group together without pool labels
+	// rather than vanish.
 	workerPool workerPoolRef
 }
 
@@ -244,10 +253,13 @@ func (p *statsPoller) collect(ctx context.Context) map[templateKey]*templateAggr
 		return nil
 	}
 
-	var pools map[string]workerPoolRef
-	if p.workerPools != nil {
-		pools = p.workerPools(ctx)
+	podUIDs := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			podUIDs = append(podUIDs, e.Name())
+		}
 	}
+	pools := p.resolveWorkerPools(ctx, podUIDs)
 
 	var (
 		mu      sync.Mutex
@@ -256,11 +268,7 @@ func (p *statsPoller) collect(ctx context.Context) map[templateKey]*templateAggr
 		g       errgroup.Group
 	)
 	g.SetLimit(statsSweepConcurrency)
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		podUID := e.Name()
+	for _, podUID := range podUIDs {
 
 		g.Go(func() error {
 			// One deadline over the whole probe, dial included. The real dial
@@ -381,18 +389,46 @@ func statsSourceLabel(s ateompb.StatsSource) string {
 	}
 }
 
-// nodeWorkerPools returns a resolver that lists nodeName's worker pods once
-// per sweep and maps pod UID to the pool that owns it. One field-selected,
-// label-selected LIST per interval per node is deliberately chosen over a
-// standing informer: at the poll cadence the apiserver cost is negligible,
-// there is no cache to sync before the first sweep, and a failed list
-// degrades to unlabeled samples for one tick instead of blocking anything.
-func nodeWorkerPools(client kubernetes.Interface, nodeName string) func(ctx context.Context) map[string]workerPoolRef {
+// resolveWorkerPools returns this sweep's pod-UID-to-pool map: fresh
+// resolutions win, a failed or partial list falls back to cachedPools, and
+// the result -- rebuilt restricted to the pods whose ateom directories exist
+// -- becomes the new cache, pruning departed pods and bounding its size. The
+// residual unlabeled case is a pod no fetch has resolved yet, whether first
+// seen during an outage or omitted by a list racing the directory scan; it
+// groups without pool labels until a fetch returns it.
+func (p *statsPoller) resolveWorkerPools(ctx context.Context, podUIDs []string) map[string]workerPoolRef {
+	if p.fetchWorkerPools == nil {
+		return nil
+	}
+	if len(podUIDs) == 0 {
+		// Nothing to resolve: skip the fetch and prune the cache to the
+		// empty directory set, as a normal sweep would.
+		p.cachedPools = nil
+		return nil
+	}
+	fresh := p.fetchWorkerPools(ctx)
+	merged := make(map[string]workerPoolRef, len(podUIDs))
+	for _, uid := range podUIDs {
+		if ref, ok := fresh[uid]; ok {
+			merged[uid] = ref
+		} else if ref, ok := p.cachedPools[uid]; ok {
+			merged[uid] = ref
+		}
+	}
+	p.cachedPools = merged
+	return merged
+}
+
+// newWorkerPoolFetcher returns the fetch func behind fetchWorkerPools: one
+// field-selected, label-selected LIST of nodeName's worker pods per call.
+// Deliberately not a standing informer: at the poll cadence the apiserver
+// cost is negligible, there is no informer cache to sync before the first
+// sweep, and resolveWorkerPools already absorbs failed lists.
+func newWorkerPoolFetcher(client kubernetes.Interface, nodeName string) func(ctx context.Context) map[string]workerPoolRef {
 	return func(ctx context.Context) map[string]workerPoolRef {
-		// Bounded so a hung apiserver connection cannot stall the sweep it is
-		// merely enriching: past the deadline, this tick's samples group
-		// without pool labels, which is the same answer as any other failed
-		// list.
+		// Bounded so a hung apiserver cannot stall the sweep: past the
+		// deadline the fetch returns nil and resolveWorkerPools falls back
+		// to the cache.
 		listCtx, cancel := context.WithTimeout(ctx, workerPoolListTimeout)
 		defer cancel()
 		pods, err := client.CoreV1().Pods(metav1.NamespaceAll).List(listCtx, metav1.ListOptions{
@@ -567,7 +603,7 @@ func startStatsPoller(ctx context.Context, interval time.Duration, inst *statsIn
 	// NODE_NAME comes from the Downward API; without it the samples still
 	// flow, just grouped without pool labels.
 	if nodeName := os.Getenv("NODE_NAME"); nodeName != "" {
-		poller.workerPools = nodeWorkerPools(k8sClient, nodeName)
+		poller.fetchWorkerPools = newWorkerPoolFetcher(k8sClient, nodeName)
 	} else {
 		slog.WarnContext(ctx, "NODE_NAME not set; actor stats will carry no worker pool labels")
 	}

--- a/cmd/atelet/statspoller_test.go
+++ b/cmd/atelet/statspoller_test.go
@@ -347,7 +347,7 @@ func TestStatsPollerWorkerPoolLabels(t *testing.T) {
 		"uid-unpooled": {resp: executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 10, 8)},
 	}
 	p, _ := newPollerFixture(t, fakes)
-	p.workerPools = func(context.Context) map[string]workerPoolRef {
+	p.fetchWorkerPools = func(context.Context) map[string]workerPoolRef {
 		return map[string]workerPoolRef{"uid-pooled": {namespace: "pool-ns", name: "pool-a"}}
 	}
 
@@ -376,7 +376,7 @@ func TestStatsPollerPeriodicEvents(t *testing.T) {
 	p, _ := newPollerFixture(t, fakes)
 	var buf syncBuffer
 	p.eventEmitter = newBufferEmitter(&buf, false)
-	p.workerPools = func(context.Context) map[string]workerPoolRef {
+	p.fetchWorkerPools = func(context.Context) map[string]workerPoolRef {
 		return map[string]workerPoolRef{"uid-1": {namespace: "pool-ns", name: "pool-a"}}
 	}
 
@@ -470,12 +470,12 @@ func TestStatsPollerCPUDeltaSaturatesCorruptCounter(t *testing.T) {
 	}
 }
 
-// TestNodeWorkerPools pins the resolver's ingestion rules: a labeled worker
+// TestNewWorkerPoolFetcher pins the fetcher's ingestion rules: a labeled worker
 // maps by pod UID, an empty label value names no pool and never enters the
 // map (the presence-only selector matches it anyway), and unlabeled pods are
 // not workers at all. The fake clientset honors label selectors but not the
 // spec.nodeName field selector, so node scoping is not assertable here.
-func TestNodeWorkerPools(t *testing.T) {
+func TestNewWorkerPoolFetcher(t *testing.T) {
 	client := k8sfake.NewSimpleClientset(
 		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Name: "worker-a", Namespace: "pool-ns", UID: "uid-a",
@@ -490,10 +490,121 @@ func TestNodeWorkerPools(t *testing.T) {
 		}},
 	)
 
-	got := nodeWorkerPools(client, "node-1")(context.Background())
+	got := newWorkerPoolFetcher(client, "node-1")(context.Background())
 
 	want := map[string]workerPoolRef{"uid-a": {namespace: "pool-ns", name: "pool-a"}}
 	if diff := cmp.Diff(want, got, cmp.AllowUnexported(workerPoolRef{})); diff != "" {
-		t.Errorf("nodeWorkerPools mismatch (-want +got):\n%s", diff)
+		t.Errorf("newWorkerPoolFetcher mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestStatsPollerPoolCacheSurvivesListFlap pins the fix for the label-set
+// split: a failed list must answer from the cache and keep that tick's
+// samples on the pooled label set.
+func TestStatsPollerPoolCacheSurvivesListFlap(t *testing.T) {
+	fakes := map[string]*fakeStatsAteom{
+		"uid-1": {resp: executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 100, 80)},
+	}
+	p, _ := newPollerFixture(t, fakes)
+	listOK := true
+	p.fetchWorkerPools = func(context.Context) map[string]workerPoolRef {
+		if !listOK {
+			return nil // the apiserver list failed this sweep
+		}
+		return map[string]workerPoolRef{"uid-1": {namespace: "pool-ns", name: "pool-a"}}
+	}
+
+	pooled := templateKey{templateNamespace: "ns-a", templateName: "tmpl-a", sandboxClass: "gvisor", source: "cgroup",
+		workerPool: workerPoolRef{namespace: "pool-ns", name: "pool-a"}}
+
+	// Sweep 1 resolves and seeds the cache.
+	if got := p.collect(context.Background()); got[pooled] == nil {
+		t.Fatalf("sweep 1: no pooled aggregate; got %v", got)
+	}
+
+	// Sweep 2's list fails; the samples must STILL group under the pool.
+	listOK = false
+	got := p.collect(context.Background())
+	if got[pooled] == nil {
+		t.Errorf("sweep 2 (list flap): samples left the pooled label set; got %v", got)
+	}
+	if len(got) != 1 {
+		t.Errorf("sweep 2 (list flap): %d label sets, want 1 (no pool-less split)", len(got))
+	}
+}
+
+// TestStatsPollerPoolCachePrunes: the cache is rebuilt against the pods whose
+// ateom directories exist, so a departed pod's entry does not linger.
+func TestStatsPollerPoolCachePrunes(t *testing.T) {
+	fakes := map[string]*fakeStatsAteom{
+		"uid-1": {resp: noSampleResponse(ateompb.NoSampleReason_NO_SAMPLE_REASON_NO_WORKLOAD)},
+	}
+	p, _ := newPollerFixture(t, fakes)
+	p.fetchWorkerPools = func(context.Context) map[string]workerPoolRef {
+		return map[string]workerPoolRef{
+			"uid-1":    {namespace: "pool-ns", name: "pool-a"},
+			"uid-gone": {namespace: "pool-ns", name: "pool-a"}, // no ateom dir
+		}
+	}
+
+	p.collect(context.Background())
+
+	if _, ok := p.cachedPools["uid-1"]; !ok {
+		t.Errorf("cachedPools lost the live pod's entry: %v", p.cachedPools)
+	}
+	if _, ok := p.cachedPools["uid-gone"]; ok {
+		t.Errorf("cachedPools kept an entry with no ateom directory: %v", p.cachedPools)
+	}
+}
+
+// TestStatsPollerPoolCacheMissDuringOutage: a pod first seen while the list
+// is failing has no cache entry to fall back to -- it groups without pool
+// labels (the residual, documented case) and heals on the next good list.
+func TestStatsPollerPoolCacheMissDuringOutage(t *testing.T) {
+	fakes := map[string]*fakeStatsAteom{
+		"uid-new": {resp: executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 10, 8)},
+	}
+	p, _ := newPollerFixture(t, fakes)
+	p.fetchWorkerPools = func(context.Context) map[string]workerPoolRef { return nil }
+
+	got := p.collect(context.Background())
+
+	bare := templateKey{templateNamespace: "ns-a", templateName: "tmpl-a", sandboxClass: "gvisor", source: "cgroup"}
+	if got[bare] == nil || len(got) != 1 {
+		t.Errorf("collect() during outage = %v, want the one pool-less group", got)
+	}
+}
+
+// TestStatsPollerPoolCachePartialListFallsBack pins the per-pod half of the
+// promised fallback ("a failed OR PARTIAL list"): a fetch that succeeds but
+// omits a cached pod must not strand that pod's samples. Distinct from the
+// all-nil flap test above -- a whole-map fallback would pass that test and
+// fail this one.
+func TestStatsPollerPoolCachePartialListFallsBack(t *testing.T) {
+	fakes := map[string]*fakeStatsAteom{
+		"uid-1": {resp: executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 100, 80)},
+	}
+	p, _ := newPollerFixture(t, fakes)
+	full := true
+	p.fetchWorkerPools = func(context.Context) map[string]workerPoolRef {
+		if !full {
+			// A successful list that no longer contains uid-1 (races between
+			// the pod store and the dir scan look exactly like this).
+			return map[string]workerPoolRef{"uid-other": {namespace: "pool-ns", name: "pool-b"}}
+		}
+		return map[string]workerPoolRef{"uid-1": {namespace: "pool-ns", name: "pool-a"}}
+	}
+
+	pooled := templateKey{templateNamespace: "ns-a", templateName: "tmpl-a", sandboxClass: "gvisor", source: "cgroup",
+		workerPool: workerPoolRef{namespace: "pool-ns", name: "pool-a"}}
+
+	if got := p.collect(context.Background()); got[pooled] == nil {
+		t.Fatalf("sweep 1: no pooled aggregate; got %v", got)
+	}
+
+	full = false
+	got := p.collect(context.Background())
+	if got[pooled] == nil || len(got) != 1 {
+		t.Errorf("sweep 2 (partial list): samples left the pooled label set; got %v", got)
 	}
 }

--- a/cmd/atelet/statspoller_test.go
+++ b/cmd/atelet/statspoller_test.go
@@ -500,12 +500,15 @@ func TestNewWorkerPoolFetcher(t *testing.T) {
 
 // TestStatsPollerPoolCacheSurvivesListFlap pins the fix for the label-set
 // split: a failed list must answer from the cache and keep that tick's
-// samples on the pooled label set.
+// samples -- including the CPU increase computed during the flap, the value
+// that feeds the monotonic counter and can never be re-attributed -- on the
+// pooled label set.
 func TestStatsPollerPoolCacheSurvivesListFlap(t *testing.T) {
-	fakes := map[string]*fakeStatsAteom{
-		"uid-1": {resp: executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 100, 80)},
-	}
-	p, _ := newPollerFixture(t, fakes)
+	resp := executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 100, 80)
+	resp.GetSample().ActorUid = "uid-a"
+	resp.GetSample().CpuUsageUsec = 1000
+	fake := &fakeStatsAteom{resp: resp}
+	p, _ := newPollerFixture(t, map[string]*fakeStatsAteom{"uid-1": fake})
 	listOK := true
 	p.fetchWorkerPools = func(context.Context) map[string]workerPoolRef {
 		if !listOK {
@@ -517,19 +520,27 @@ func TestStatsPollerPoolCacheSurvivesListFlap(t *testing.T) {
 	pooled := templateKey{templateNamespace: "ns-a", templateName: "tmpl-a", sandboxClass: "gvisor", source: "cgroup",
 		workerPool: workerPoolRef{namespace: "pool-ns", name: "pool-a"}}
 
-	// Sweep 1 resolves and seeds the cache.
+	// Sweep 1 resolves, seeds the pool cache, and baselines the CPU counter.
 	if got := p.collect(context.Background()); got[pooled] == nil {
 		t.Fatalf("sweep 1: no pooled aggregate; got %v", got)
 	}
 
-	// Sweep 2's list fails; the samples must STILL group under the pool.
+	// Sweep 2: the list fails AND the actor consumed CPU. Both the sample and
+	// its delta must still group under the pool.
 	listOK = false
+	resp2 := executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 100, 80)
+	resp2.GetSample().ActorUid = "uid-a"
+	resp2.GetSample().CpuUsageUsec = 1600
+	fake.resp = resp2
 	got := p.collect(context.Background())
 	if got[pooled] == nil {
-		t.Errorf("sweep 2 (list flap): samples left the pooled label set; got %v", got)
+		t.Fatalf("sweep 2 (list flap): samples left the pooled label set; got %v", got)
 	}
 	if len(got) != 1 {
 		t.Errorf("sweep 2 (list flap): %d label sets, want 1 (no pool-less split)", len(got))
+	}
+	if got[pooled].cpuDeltaUsec != 600 {
+		t.Errorf("sweep 2 (list flap): pooled cpu delta = %d, want 600 -- the counter increment must land on the pooled series", got[pooled].cpuDeltaUsec)
 	}
 }
 
@@ -581,10 +592,11 @@ func TestStatsPollerPoolCacheMissDuringOutage(t *testing.T) {
 // all-nil flap test above -- a whole-map fallback would pass that test and
 // fail this one.
 func TestStatsPollerPoolCachePartialListFallsBack(t *testing.T) {
-	fakes := map[string]*fakeStatsAteom{
-		"uid-1": {resp: executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 100, 80)},
-	}
-	p, _ := newPollerFixture(t, fakes)
+	resp := executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 100, 80)
+	resp.GetSample().ActorUid = "uid-a"
+	resp.GetSample().CpuUsageUsec = 1000
+	fake := &fakeStatsAteom{resp: resp}
+	p, _ := newPollerFixture(t, map[string]*fakeStatsAteom{"uid-1": fake})
 	full := true
 	p.fetchWorkerPools = func(context.Context) map[string]workerPoolRef {
 		if !full {
@@ -603,8 +615,15 @@ func TestStatsPollerPoolCachePartialListFallsBack(t *testing.T) {
 	}
 
 	full = false
+	resp2 := executingResponse("ns-a", "tmpl-a", ateompb.SandboxClass_SANDBOX_CLASS_GVISOR, ateompb.StatsSource_STATS_SOURCE_CGROUP, 100, 80)
+	resp2.GetSample().ActorUid = "uid-a"
+	resp2.GetSample().CpuUsageUsec = 1250
+	fake.resp = resp2
 	got := p.collect(context.Background())
 	if got[pooled] == nil || len(got) != 1 {
 		t.Errorf("sweep 2 (partial list): samples left the pooled label set; got %v", got)
+	}
+	if got[pooled] != nil && got[pooled].cpuDeltaUsec != 250 {
+		t.Errorf("sweep 2 (partial list): pooled cpu delta = %d, want 250", got[pooled].cpuDeltaUsec)
 	}
 }


### PR DESCRIPTION
Fixes #1478.

One failed pod list per sweep grouped that tick's samples without `ate.workerpool.*` labels. Gauges blink and heal; the CPU counter does not: an OTel counter binds increments to their attribute set, so a single flap re-homes that sweep's CPU increase onto a newly-born pool-less series that coexists with the pooled one forever — pool-filtered `rate()` dips on every flap, a phantom unlabeled series bursts exactly during apiserver trouble, and cardinality doubles per flapped group for the process lifetime.

## Fix

A pod's pool is **immutable for the pod's lifetime** (the `ate.dev/worker-pool` label is stamped at creation; pods never move between pools), so caching resolutions per pod UID carries zero correctness risk. `resolveWorkerPools`:

* lets fresh resolutions win (harmless either way, given immutability),
* falls back to `cachedPools` when the list fails outright or misses one pod,
* rebuilds the cache restricted to the pods whose ateom directories exist this sweep — pruning departed pods and bounding memory with the same prune-to-the-living pattern `lastCPU` uses.

The residual unlabeled case shrinks to "pod first seen while the apiserver is unreachable", which heals on the next good list — and is pinned by a test as the documented behavior.

## Testing

* List flap: seed the cache, fail the next list, assert the samples stay on the pooled label set with no pool-less split.
* Prune: an entry whose ateom directory is gone leaves the cache; the live pod's entry stays.
* Residual case: a pod first seen during an outage groups without pool labels (one group, not an error).
* `hack/verify-all.sh` green.

Part of #896, toward #550.


## Note: cache lifetime is tied to ateom directories, which nothing cleans up

`cachedPools` evicts an entry on the first sweep after its ateom directory disappears — but today **nothing removes `ateoms/<podUID>/` when a worker pod is deleted** (the only cleanup anywhere is an ateom clearing its own stale socket at boot; directories accumulate until node replacement). Repo archaeology found no decision behind this: the directory set had no reader until the stats sweep (#961) promoted it into a discovery registry, so GC was never needed before.

Consequences for this PR, sized honestly:

* **Correctness is unaffected.** Pod UIDs are never reused, and a retained entry is only consulted when a sample arrives from that UID — a dead socket produces none.
* **Memory is a rounding error on a pre-existing cost.** The cache is bounded by the directory count (~150 bytes per departed pod, ~1.5 MB per ten thousand); each stale directory already costs more than its cache entry does — a dial attempt every sweep plus debug-log noise, on main today, independent of this PR.
* Eviction is deliberately **not** tied to the pod list — "the list stopped returning this pod" is exactly the flap signal this fix exists to distrust. The filesystem stays the retention authority, consistent with being the discovery authority.

The durable fix is directory GC (atelet holds both halves of the evidence each sweep: the dir set and the node's pod list; "absent from the pod list AND socket dead for N consecutive sweeps → remove" is safe against half-born ateoms and transient list failures). That pre-existing issue is now tracked as #1677; when it lands, cache eviction follows it automatically with zero changes here.


