### PR TITLE
router: keep the caller's trace context across the resume flight detach

### DIFF
--- a/cmd/atenet/internal/router/ingress/resumer.go
+++ b/cmd/atenet/internal/router/ingress/resumer.go
@@ -170,17 +170,26 @@ func (r *ActorResumer) ResumeActor(ctx context.Context, actorRef resources.Actor
 
 	reqID := atomic.AddUint64(&r.nextID, 1)
 
+	// The flight below detaches from the caller's lifecycle but must keep its
+	// trace identity: detaching with a bare background context makes the
+	// ateapi call start a fresh root trace, so the server-side resume spans
+	// (step.*, atelet, snapshot fetch) fragment away from the request that
+	// triggered them and sample independently of it. Joiners share the
+	// leader's flight, so the flight carries the leader's span context.
+	callerSpanCtx := trace.SpanContextFromContext(ctx)
+
 	ch := r.flight.DoChan(actorRef.String(), func() (interface{}, error) {
 		// We detach the context from the first caller using a fixed background budget.
 		// This guarantees that if Caller 1 disconnects or times out, the underlying
 		// resume operation continues running for Caller 2 and Caller 3 without failing.
+		// Only cancellation is detached; the trace context above is kept.
 		//
 		// The budget is therefore per-FLIGHT, not per-caller: its clock starts with
 		// the first caller, and later callers de-duplicated onto this flight share
 		// its remaining budget and outcome. A late joiner can see budget_exhausted
 		// after waiting far less than a full budget itself — the accepted cost of
 		// one control-plane RPC per hot actor (see docs/request-parking.md).
-		bgCtx, bgCancel := context.WithTimeout(context.Background(), r.budget)
+		bgCtx, bgCancel := context.WithTimeout(trace.ContextWithSpanContext(context.Background(), callerSpanCtx), r.budget)
 		defer bgCancel()
 		// The budget bounds the RETRY LOOP only — it never cancels an
 		// in-flight ResumeActor. ateapi durably claims the worker and marks

--- a/cmd/atenet/internal/router/ingress/resumer_test.go
+++ b/cmd/atenet/internal/router/ingress/resumer_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -583,5 +584,42 @@ func TestResumeBackoffHasNoCap(t *testing.T) {
 	}
 	if b.Steps < 1<<20 {
 		t.Errorf("resume backoff Steps must be high so the budget bounds the wait; got %d", b.Steps)
+	}
+}
+
+// The singleflight flight detaches from the caller's cancellation but must
+// keep the caller's trace identity, or the ateapi call starts a fresh root
+// trace and the server-side resume spans fragment away from the request that
+// triggered them.
+func TestActorResumer_FlightKeepsCallerTraceContext(t *testing.T) {
+	testActorRef := resources.ActorRef{Atespace: "team-a", Name: "actor-trace"}
+
+	want := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a},
+		SpanID:     trace.SpanID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	var got trace.SpanContext
+	mock := &resumerMockClient{
+		resumeFn: func(ctx context.Context, in *ateapipb.ResumeActorRequest, opts ...grpc.CallOption) (*ateapipb.ResumeActorResponse, error) {
+			got = trace.SpanContextFromContext(ctx)
+			return &ateapipb.ResumeActorResponse{
+				Actor: &ateapipb.Actor{Status: &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_RUNNING, WorkerAssignment: &ateapipb.WorkerAssignment{WorkerPodIp: "10.0.0.1"}}},
+			}, nil
+		},
+	}
+
+	resumer := NewActorResumer(mock)
+	ctx := trace.ContextWithSpanContext(context.Background(), want)
+	if _, _, err := resumer.ResumeActor(ctx, testActorRef); err != nil {
+		t.Fatalf("ResumeActor: %v", err)
+	}
+
+	if got.TraceID() != want.TraceID() {
+		t.Errorf("flight RPC trace ID = %s, want the caller's %s", got.TraceID(), want.TraceID())
+	}
+	if !got.IsSampled() {
+		t.Error("flight RPC lost the caller's sampled flag")
 	}
 }


### PR DESCRIPTION
The singleflight resume flight rebuilds its context from context.Background() so that a disconnecting caller cannot cancel the shared resume other parked requests are waiting on. That detach severed more than cancellation: it dropped the caller's span context, so the ateapi ResumeActor call started a fresh root trace, sampled independently of the ingress request. A sampled wake-on-request therefore produced a trace containing only the router's own spans, while the server-side resume work (step.*, atelet, snapshot fetch) landed in separate orphan traces — on a live install, a request that woke a suspended actor fragmented into three disconnected traces, and internal step spans showed up as trace roots.

Carry the leader's SpanContext into the flight's background context. Cancellation stays detached; only trace identity crosses the boundary. Joiners share the leader's flight, so the flight carries the leader's trace — the accepted corollary of deduplicating onto one control-plane RPC per hot actor.

Fixes #1486

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
