### PR TITLE
Makefile: include all control-plane and demo images in build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ export KO_DOCKER_REPO := gcr.io/$(PROJECT_ID)/ate-images
 # Go commands
 GO := go
 KO := hack/run-tool.sh ko
+KO_FLAGS ?=
 
 # Binaries
 BINDIR := bin/
@@ -41,12 +42,14 @@ build: build-images build-atectl build-ate-setup
 
 .PHONY: build-images
 build-images:
-	$(KO) build \
+	$(KO) build $(KO_FLAGS) \
 	    --ldflags="$(LDFLAGS)" \
 	    ./cmd/ateapi \
+	    ./cmd/atecontroller \
 	    ./cmd/atelet \
-	    ./cmd/podcertcontroller \
-	    ./cmd/atenet
+	    ./cmd/atenet \
+	    ./cmd/ateom-gvisor \
+	    ./cmd/podcertcontroller
 
 .PHONY: build-atectl
 build-atectl:
@@ -64,7 +67,12 @@ build-atenet:
 
 .PHONY: build-demos
 build-demos:
-	$(KO) build --ldflags="$(LDFLAGS)" ./demos/counter ./demos/egress
+	$(KO) build $(KO_FLAGS) \
+	    --ldflags="$(LDFLAGS)" \
+	    ./demos/counter \
+	    ./demos/egress \
+	    ./demos/multi-template/fspersist \
+	    ./demos/sandbox
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ export KO_DOCKER_REPO := gcr.io/$(PROJECT_ID)/ate-images
 # Go commands
 GO := go
 KO := hack/run-tool.sh ko
+
+# Flags every ko image build gets, e.g. `make build-images KO_FLAGS=--push=false`.
+# Empty by default, so ko runs on its own defaults and whatever .ko.yaml configures.
 KO_FLAGS ?=
 
 # Binaries
@@ -34,6 +37,31 @@ VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo d
 VERSION_PKG := github.com/agent-substrate/substrate/internal/version
 LDFLAGS := -X=$(VERSION_PKG).Version=$(VERSION)
 
+# Every image the installer can deploy, defined once. These two sets together
+# have to cover images.Components in cmd/ate-setup/internal/images: a package
+# missing here has no image for a build from source, and one missing there has
+# none for an install from a release.
+CONTROL_PLANE_IMAGES := ./cmd/ateapi \
+                        ./cmd/atecontroller \
+                        ./cmd/atelet \
+                        ./cmd/atenet \
+                        ./cmd/podcertcontroller
+WORKER_IMAGES        := ./cmd/ateom-gvisor \
+                        ./cmd/ateom-microvm
+DEMO_IMAGES          := ./demos/counter \
+                        ./demos/egress \
+                        ./demos/multi-template/fspersist \
+                        ./demos/sandbox
+ALL_IMAGES           := $(CONTROL_PLANE_IMAGES) $(WORKER_IMAGES)
+
+# Developer builds may leave components out, e.g. the microvm image, the one
+# image built from a debian base rather than distroless static:
+#   make build-images SKIP_IMAGES=./cmd/ateom-microvm
+# Overriding IMAGES or DEMOS on the command line builds exactly that set.
+SKIP_IMAGES ?=
+IMAGES      := $(filter-out $(SKIP_IMAGES),$(ALL_IMAGES))
+DEMOS       := $(filter-out $(SKIP_IMAGES),$(DEMO_IMAGES))
+
 .PHONY: all
 all: build
 
@@ -44,13 +72,7 @@ build: build-images build-atectl build-ate-setup
 build-images:
 	$(KO) build $(KO_FLAGS) \
 	    --ldflags="$(LDFLAGS)" \
-	    ./cmd/ateapi \
-	    ./cmd/atecontroller \
-	    ./cmd/atelet \
-	    ./cmd/atenet \
-	    ./cmd/ateom-gvisor \
-	    ./cmd/ateom-microvm \
-	    ./cmd/podcertcontroller
+	    $(IMAGES)
 
 .PHONY: build-atectl
 build-atectl:
@@ -70,10 +92,7 @@ build-atenet:
 build-demos:
 	$(KO) build $(KO_FLAGS) \
 	    --ldflags="$(LDFLAGS)" \
-	    ./demos/counter \
-	    ./demos/egress \
-	    ./demos/multi-template/fspersist \
-	    ./demos/sandbox
+	    $(DEMOS)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ build-images:
 	    ./cmd/atelet \
 	    ./cmd/atenet \
 	    ./cmd/ateom-gvisor \
+	    ./cmd/ateom-microvm \
 	    ./cmd/podcertcontroller
 
 .PHONY: build-atectl


### PR DESCRIPTION
Fixes #1489

Ran local test of makefile to confirm previous and new images are built.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
