### PR TITLE
Simplify the langauge and clarify framework/harness section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Agent Substrate leverages Kubernetes for the infrastructure provisioning and wor
 
 This demo highlights the core developer experience and "Agentic Infrastructure" capabilities of Substrate:
 
-1.  **Instant Actor Teleport:** High-performance suspend and resume of actors onto any available worker in the pool with sub-second activation.
+1.  **Actor Teleport:** High-performance suspend and resume of actors onto any available worker in the pool with sub-second activation.
 2.  **State Persistence:** Persistent working memory (volatile RAM) and filesystem state preserved perfectly across hibernation cycles via full-state snapshots.
-3.  **Agent Swarm Multiplexing:** Demonstrates 30x+ oversubscription by "juggling" a large registry of stateful actors onto a small pool of shared physical pods.
+3.  **Agent Multiplexing:** Demonstrates 30x+ oversubscription by "juggling" a large registry of stateful actors onto a small pool of shared physical pods.
 
 To reproduce this demo in your own cluster, please refer to the detailed walkthrough in the **[Counter Demo](demos/counter/README.md)**.
 
@@ -36,10 +36,10 @@ For more videos and walkthroughs, visit our YouTube channel: **[agent-substrate]
 
 Agent Substrate is designed to be **framework and agent harness agnostic**. Because it manages standard OCI containers at the kernel level (via gVisor), it can host agents built on any stack.
 
-*   **Agent Development Kit (ADK):** Native support for ADK-compatible actor identity and persistent working memory.
-*   **LangChain:** Ideal execution environment for long-running, stateful LangChain agents and sandboxed tool-calling.
-*   **Claude Code & CodeX:** Support for high-density, stateful coding environments that preserve terminal and filesystem state across sessions.
-*   **Model Context Protocol (MCP):** Deploy secure, sandboxed MCP servers as Substrate Actors to provide durable tools for any LLM.
+*   **Agent Development Kit (ADK):** Support for ADK agents with session state preservation across invocations as actor state. Ideal for all types of agents and stateful tool or subagent calls.
+*   **LangChain:** Ideal execution environment for LangChain agents and tool calls.
+*   **Claude Code, CodeX, and Antigravity:** Support for high-density, stateful coding environments that preserve system state and filesystem state across sessions.
+*   **Model Context Protocol (MCP):** Support for deploying secure, sandboxed MCP servers as Substrate Actors to provide durable tools for any model.
 
 ## Ecosystem & Examples
 


### PR DESCRIPTION
Update the framework compatibility section to better describe how Agent Substrate preserves session and system state across invocations for ADK, LangChain, MCP, and coding agents (Claude Code, CodeX, and Antigravity). Also simplify the langauge in the demo highlights.
