### PR TITLE
Don't run PR tests on docs-only changes

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -17,6 +17,9 @@ on:
   pull_request:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   schedule:
     # Weekly run on the default branch keeps the micro-VM asset cache warm (GitHub
     # evicts caches idle for 7 days). The push-to-main run populates the cache that


### PR DESCRIPTION
I've seen a few PRs which are just wasting CI time.

I don't know if this actually WORKS, of course...