### PR TITLE
imagecache: Re-unpack a layer retired while joining its flight

### DIFF
--- a/internal/imagecache/README.md
+++ b/internal/imagecache/README.md
@@ -244,13 +244,14 @@ skips the scan entirely, conservatively, if any record or bundle spec
 fails to read. There is no online whole-pool scan (ext4's split: bounded
 recovery at mount, fsck offline).
 
-**Deletion is two-phase.** A layer is atomically renamed to `.rm-*`
-inside the layer's singleflight (one `rename(2)` — eviction can never
-stall a pull), then removed asynchronously; a crash in between leaves
-the dir for the startup sweep. This matters because the kernel offers no
-protection here: deleting a directory that is a live overlay lowerdir in
-another mount namespace succeeds silently, leaves the overlay's behavior
-undefined, and doesn't even free the space until the mount goes away.
+**Deletion is two-phase.** A layer is atomically renamed to `.rm-*` under
+the layer's interlock (one `rename(2)`, taken only if uncontended — so
+eviction can never stall a pull), then removed asynchronously; a crash in
+between leaves the dir for the startup sweep. This matters because the
+kernel offers no protection here: deleting a directory that is a live
+overlay lowerdir in another mount namespace succeeds silently, leaves the
+overlay's behavior undefined, and doesn't even free the space until the
+mount goes away.
 
 Deleting the cache root by hand (while no actors are starting) remains
 safe — the store re-pulls whatever is missing.

--- a/internal/imagecache/gc.go
+++ b/internal/imagecache/gc.go
@@ -38,7 +38,7 @@ package imagecache
 //
 // Deletion is two-phase: the only steps that contend with the pull path
 // are one os.Remove of a record and one rename of a layer dir to a ".rm-*"
-// name inside the layer's singleflight (see retireLayer); the slow
+// name under the layer's interlock (see retireLayer); the slow
 // RemoveAll of multi-GB trees happens afterwards, on dirs nothing can
 // reach by diffID. A crash in between leaves a ".rm-*" dir for the
 // startup sweep.

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -215,6 +215,11 @@ type Store struct {
 	imageSF singleflight.Group
 	layerSF singleflight.Group
 
+	// layerLocks holds the retire/reuse interlock per layer (see layerLock).
+	// Entries are added on first use and never removed, so this is the one
+	// piece of per-layer bookkeeping eviction does not reclaim.
+	layerLocks sync.Map
+
 	// evictMu serializes EvictUnused passes (concurrent passes would fight
 	// over the same candidates for no benefit).
 	evictMu sync.Mutex
@@ -517,7 +522,7 @@ func (s *Store) cachedImage(digest v1.Hash) (*Image, error) {
 			return nil, fmt.Errorf("invalid diffID %q in image record for %s: %w", d, digest, err)
 		}
 		dir := s.layerDir(diffID)
-		if _, err := os.Stat(filepath.Join(dir, layerFSDirName)); err != nil {
+		if !layerFSPresent(dir) {
 			return nil, nil
 		}
 		layerDirs[i] = dir
@@ -635,6 +640,7 @@ func (s *Store) pull(ctx context.Context, parsedRef name.Reference, digest v1.Ha
 	// naming a missing lowerdir. Ordered after the rewrite so even this
 	// failure path leaves the surviving layers referenced.
 	for _, dir := range layerDirs {
+		// Not layerFSPresent: the errno is part of the report.
 		if _, err := os.Stat(filepath.Join(dir, layerFSDirName)); err != nil {
 			return nil, fmt.Errorf("layer dir vanished during pull (evicted?): %w", err)
 		}
@@ -648,21 +654,49 @@ func (s *Store) pull(ctx context.Context, parsedRef name.Reference, digest v1.Ha
 	return &Image{Digest: digest, Config: cfgFile.Config, LayerDirs: layerDirs}, nil
 }
 
+// layerFSPresent reports whether a layer's unpacked tree is in the pool.
+// Any stat failure counts as absent, so an unreadable layer is re-pulled
+// rather than handed to a caller that cannot use it.
+func layerFSPresent(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, layerFSDirName))
+	return err == nil
+}
+
 // ensureLayer makes the unpacked tree for diffID present in the pool,
 // collapsing concurrent requests for the same layer across images.
+//
+// A layer pull that joins the flight instead of leading it shares the
+// leader's outcome: one download per herd, failures and the leader's own
+// cancellation included.
 func (s *Store) ensureLayer(ctx context.Context, diffID v1.Hash, layer v1.Layer) (string, error) {
 	dir := s.layerDir(diffID)
-	_, err, _ := s.layerSF.Do(layerFlightKey(diffID.Hex), func() (any, error) {
-		if _, err := os.Stat(filepath.Join(dir, layerFSDirName)); err == nil {
-			// Refresh the dir mtime inside the flight: retireLayer re-checks
-			// the mtime in this same flight, so a layer reused here can
-			// never be renamed away between this stat and the image record
-			// that will re-reference it.
+	_, err, _ := s.layerSF.Do(diffID.String(), func() (any, error) {
+		// Acquire fails on a cancelled ctx even with the lock free, which
+		// would turn a cache hit into a failure shared with healthy
+		// joiners; a free lock still serves the cache hit below.
+		lock := s.layerLock(diffID.Hex)
+		ctxErr := lock.Acquire(ctx, 1)
+		if ctxErr != nil && !lock.TryAcquire(1) {
+			return nil, ctxErr
+		}
+		defer lock.Release(1)
+
+		if layerFSPresent(dir) {
+			// Refresh the mtime under the interlock: retireLayer re-checks it
+			// under the same lock, so a layer reused here can never be renamed
+			// away between this stat and the image record that will
+			// re-reference it.
 			now := time.Now()
 			if err := os.Chtimes(dir, now, now); err != nil {
 				slog.WarnContext(ctx, "Failed to refresh layer mtime on reuse", slog.String("diffid", diffID.String()), slog.Any("err", err))
 			}
 			return nil, nil
+		}
+		if ctxErr != nil {
+			// Only the hit: the layer streams are bound to the pull's parent
+			// ctx (remoteOpts), so unpacking here would run a whole download
+			// for a doomed pull.
+			return nil, ctxErr
 		}
 		return nil, s.unpackLayerToPool(ctx, diffID, layer)
 	})
@@ -731,7 +765,7 @@ func (s *Store) unpackLayerToPool(ctx context.Context, diffID v1.Hash, layer v1.
 	if err := os.Rename(tmp, s.layerDir(diffID)); err != nil {
 		// A concurrent unpack (another process sharing the pool) may have won;
 		// its layer is as good as ours.
-		if _, statErr := os.Stat(filepath.Join(s.layerDir(diffID), layerFSDirName)); statErr == nil {
+		if layerFSPresent(s.layerDir(diffID)) {
 			return nil
 		}
 		return fmt.Errorf("while moving layer into pool: %w", err)

--- a/internal/imagecache/retire.go
+++ b/internal/imagecache/retire.go
@@ -15,7 +15,7 @@
 package imagecache
 
 // Two-phase layer deletion: eviction renames a layer dir aside (one
-// rename(2) inside the layer singleflight — the only step that contends
+// rename(2) under the layer interlock — the only step that contends
 // with the pull path) and the slow RemoveAll of the renamed-aside tree
 // happens afterwards, outside all locks. A crash in between leaves a
 // ".rm-*" dir for the startup sweep. Nothing here needs privileges:
@@ -29,6 +29,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"golang.org/x/sync/semaphore"
 )
 
 // retiredPrefix marks a layer dir that eviction has renamed aside and that
@@ -56,9 +58,21 @@ const (
 	retireRetired
 )
 
-// layerFlightKey is the singleflight key shared by ensureLayer and
-// retireLayer; the retire/reuse interlock depends on both using it.
-func layerFlightKey(hex string) string { return "sha256:" + hex }
+// layerLock returns one layer's interlock, held by ensureLayer across its
+// stat and refresh-or-unpack and by retireLayer across its stat and rename,
+// so a reuse and a retirement never interleave. A lock rather than the
+// shared flight key, because a caller that joins a flight cannot tell
+// whether it joined a reuse or a retirement that renamed the dir away.
+// Never share one between layers: it is held for the length of an unpack,
+// so sharing would serialize unrelated downloads and let a retirement veto
+// a layer it could have taken.
+func (s *Store) layerLock(hex string) *semaphore.Weighted {
+	if lk, ok := s.layerLocks.Load(hex); ok {
+		return lk.(*semaphore.Weighted)
+	}
+	lk, _ := s.layerLocks.LoadOrStore(hex, semaphore.NewWeighted(1))
+	return lk.(*semaphore.Weighted)
+}
 
 // isLayerDirName reports whether name is a well-formed sha256 layer
 // directory name. Callers enumerate directories and read hexes out of
@@ -80,68 +94,52 @@ func isLayerDirName(name string) bool {
 // returns the renamed path; the caller deletes it afterwards. A layer
 // with an mtime after cutoff is vetoed and left in place.
 //
-// The mtime check and the rename run inside the layer singleflight — the
-// same flight in which ensureLayer refreshes the mtime — so a retirement
-// and a reuse cannot interleave: whichever runs second sees the first.
+// The mtime check and the rename run under the layer's interlock — the same
+// lock ensureLayer holds while it refreshes the mtime — so a retirement and
+// a reuse cannot interleave: whichever runs second sees the first.
 func (s *Store) retireLayer(hex string, cutoff time.Time) (string, retireStatus, error) {
 	if !isLayerDirName(hex) {
 		return "", retireVetoed, fmt.Errorf("not a layer dir name: %q", hex)
 	}
 	dir := filepath.Join(s.layersDir(), hex)
 
-	// Pre-flight, outside the singleflight: a missing dir or a fresh mtime
-	// means nothing to do, and no reason to enter the flight and block
-	// behind an in-progress download. Both checks are re-run inside the
-	// flight before the rename, so this is a fast path, not the
+	// Pre-flight, outside the interlock: a missing dir or a fresh mtime means
+	// nothing to do and no reason to contend with the pull path at all. Both
+	// checks are re-run under the lock, so this is a fast path, not the
 	// correctness path.
+	if fi, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+		return "", retireGone, nil
+	} else if err != nil {
+		return "", retireVetoed, err
+	} else if fi.ModTime().After(cutoff) {
+		slog.Info(logMsgLayerRetireVetoed, slog.String("diffid", hex), slog.Time("last_used", fi.ModTime()))
+		return "", retireVetoed, nil
+	}
+
+	// If we cannot acquire the lock it's being held by ensureLayer, which is
+	// using the layer.
+	lock := s.layerLock(hex)
+	if !lock.TryAcquire(1) {
+		return "", retireVetoed, nil
+	}
+	defer lock.Release(1)
+
 	fi, err := os.Stat(dir)
 	if errors.Is(err, os.ErrNotExist) {
 		return "", retireGone, nil
 	} else if err != nil {
 		return "", retireVetoed, err
 	}
+	// A concurrent ensureLayer touched the dir if it reused this layer since
+	// the pre-flight stat.
 	if fi.ModTime().After(cutoff) {
 		slog.Info(logMsgLayerRetireVetoed, slog.String("diffid", hex), slog.Time("last_used", fi.ModTime()))
 		return "", retireVetoed, nil
 	}
 
-	var retired string
-	status := retireGone
-	ran := false
-	_, err, _ = s.layerSF.Do(layerFlightKey(hex), func() (any, error) {
-		ran = true
-		fi, err := os.Stat(dir)
-		if errors.Is(err, os.ErrNotExist) {
-			status = retireGone
-			return nil, nil
-		} else if err != nil {
-			status = retireVetoed
-			return nil, err
-		}
-		// A concurrent ensureLayer touched the dir if it reused this layer
-		// since the pre-flight stat.
-		if fi.ModTime().After(cutoff) {
-			slog.Info(logMsgLayerRetireVetoed, slog.String("diffid", hex), slog.Time("last_used", fi.ModTime()))
-			status = retireVetoed
-			return nil, nil
-		}
-		dst := filepath.Join(s.layersDir(), fmt.Sprintf("%s%s-%d", retiredPrefix, hex[:12], time.Now().UnixNano()))
-		if err := os.Rename(dir, dst); err != nil {
-			status = retireVetoed
-			return nil, fmt.Errorf("while retiring layer %s: %w", hex, err)
-		}
-		retired = dst
-		status = retireRetired
-		return nil, nil
-	})
-	if !ran {
-		// Our closure never executed: Do joined a flight already in progress
-		// (an ensureLayer reuse or another retire), so status/retired are
-		// stale zero values. Concurrent activity on the layer is a veto.
-		return "", retireVetoed, nil
+	dst := filepath.Join(s.layersDir(), fmt.Sprintf("%s%s-%d", retiredPrefix, hex[:12], time.Now().UnixNano()))
+	if err := os.Rename(dir, dst); err != nil {
+		return "", retireVetoed, fmt.Errorf("while retiring layer %s: %w", hex, err)
 	}
-	if err != nil {
-		return "", status, err
-	}
-	return retired, status, nil
+	return dst, retireRetired, nil
 }

--- a/internal/imagecache/retire_test.go
+++ b/internal/imagecache/retire_test.go
@@ -17,8 +17,10 @@ package imagecache
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -26,16 +28,6 @@ import (
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
-
-// The retire/reuse interlock depends on retireLayer and ensureLayer using
-// the same singleflight key; pin the key format to diffID.String()'s.
-func TestLayerFlightKeyMatchesDiffIDString(t *testing.T) {
-	hex := strings.Repeat("ab", 32)
-	want := v1.Hash{Algorithm: "sha256", Hex: hex}.String()
-	if got := layerFlightKey(hex); got != want {
-		t.Errorf("layerFlightKey = %q, want %q", got, want)
-	}
-}
 
 func TestRetireLayerStatuses(t *testing.T) {
 	store := newTestStore(t)
@@ -143,8 +135,8 @@ func TestSweepLeavesNonPrefixedEntries(t *testing.T) {
 }
 
 // TestRetireLayerVsEnsureImageRace races retirement against pulls of an
-// image using the same layer. The singleflight serializes the retire
-// rename against unpack, and the in-flight mtime touch turns concurrent
+// image using the same layer. The layer interlock serializes the retire
+// rename against unpack, and the mtime touch it covers turns concurrent
 // reuse into a veto — so neither side may ever error. Run with -race.
 func TestRetireLayerVsEnsureImageRace(t *testing.T) {
 	_, host := newTestRegistry(t)
@@ -199,5 +191,252 @@ func TestRetireLayerVsEnsureImageRace(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(img.LayerDirs[0], layerFSDirName)); err != nil {
 		t.Errorf("final layer dir missing: %v", err)
+	}
+}
+
+// seedLayer pushes a one-layer image and pulls it, returning the layer, its
+// diffID and its dir in the pool.
+func seedLayer(t *testing.T, store *Store, ref string) (v1.Layer, v1.Hash, string) {
+	t.Helper()
+	layer := layerFromEntries(t, []tarEntry{
+		{name: "f", typeflag: tar.TypeReg, mode: 0o644, body: strings.Repeat("j", 512)},
+	})
+	pushImage(t, ref, v1.Config{}, layer)
+	if _, err := store.EnsureImage(context.Background(), ref); err != nil {
+		t.Fatalf("EnsureImage: %v", err)
+	}
+	diffID, err := layer.DiffID()
+	if err != nil {
+		t.Fatalf("layer diffID: %v", err)
+	}
+	return layer, diffID, layerDirOf(t, store, layer)
+}
+
+// waitForBlockedEnsure blocks until an ensureLayer goroutine is parked on
+// frame. Observing the block is what makes these tests deterministic:
+// releasing on a timer would let a loaded machine free the layer early, so
+// ensureLayer would sail through and the contended path would go untested
+// while the test still passed.
+func waitForBlockedEnsure(t *testing.T, frame string) {
+	t.Helper()
+	buf := make([]byte, 1<<20)
+	waitFor(t, "ensureLayer to block on "+frame, func() bool {
+		n := runtime.Stack(buf, true)
+		for n == len(buf) { // runtime.Stack truncates silently at cap
+			buf = make([]byte, 2*len(buf))
+			n = runtime.Stack(buf, true)
+		}
+		for _, g := range strings.Split(string(buf[:n]), "\n\ngoroutine ") {
+			if strings.Contains(g, "ensureLayer") && strings.Contains(g, frame) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// ensureLayerAsync runs ensureLayer on its own goroutine.
+func ensureLayerAsync(store *Store, diffID v1.Hash, layer v1.Layer) <-chan struct {
+	dir string
+	err error
+} {
+	done := make(chan struct {
+		dir string
+		err error
+	}, 1)
+	go func() {
+		dir, err := store.ensureLayer(context.Background(), diffID, layer)
+		done <- struct {
+			dir string
+			err error
+		}{dir, err}
+	}()
+	return done
+}
+
+// A GC pass must never block behind the pull path: a layer whose interlock
+// is held is reused or being unpacked right now, which is a veto.
+func TestRetireVetoedWhileLayerInterlockHeld(t *testing.T) {
+	_, host := newTestRegistry(t)
+	store := newTestStore(t)
+	_, diffID, dir := seedLayer(t, store, host+"/test/held:latest")
+	backdate(t, dir, 3*time.Hour)
+
+	lock := store.layerLock(diffID.Hex)
+	if err := lock.Acquire(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Release(1)
+
+	_, st, err := store.retireLayer(diffID.Hex, time.Now())
+	if err != nil || st != retireVetoed {
+		t.Fatalf("retireLayer while interlock held = %v, %v; want retireVetoed, nil", st, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, layerFSDirName)); err != nil {
+		t.Errorf("vetoed layer was disturbed: %v", err)
+	}
+}
+
+// ensureLayer must never hand back a dir a retirement renamed away. It waits
+// out the retirement on the interlock and then unpacks the layer again.
+func TestEnsureLayerWaitsOutRetirementThenRepacks(t *testing.T) {
+	_, host := newTestRegistry(t)
+	store := newTestStore(t)
+	layer, diffID, dir := seedLayer(t, store, host+"/test/retire-wait:latest")
+
+	// Hold the interlock across a rename, exactly as retireLayer does.
+	lock := store.layerLock(diffID.Hex)
+	if err := lock.Acquire(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(dir, dir+"-retired"); err != nil {
+		t.Fatal(err)
+	}
+
+	done := ensureLayerAsync(store, diffID, layer)
+	waitForBlockedEnsure(t, "semaphore.(*Weighted).Acquire")
+	lock.Release(1)
+
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("ensureLayer: %v", got.err)
+	}
+	if _, err := os.Stat(filepath.Join(got.dir, layerFSDirName)); err != nil {
+		t.Fatalf("ensureLayer returned a retired dir: %v", err)
+	}
+}
+
+// A retirement whose rename fails leaves the layer live and usable, so the
+// ensureLayer waiting behind it must reuse that layer, not fail the pull.
+func TestEnsureLayerWaitsOutFailedRetirementAndReusesLayer(t *testing.T) {
+	_, host := newTestRegistry(t)
+	store := newTestStore(t)
+	layer, diffID, dir := seedLayer(t, store, host+"/test/retire-failed:latest")
+
+	before, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rename "fails": the interlock is held but the dir is left in place.
+	lock := store.layerLock(diffID.Hex)
+	if err := lock.Acquire(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+
+	done := ensureLayerAsync(store, diffID, layer)
+	waitForBlockedEnsure(t, "semaphore.(*Weighted).Acquire")
+	lock.Release(1)
+
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("ensureLayer: %v", got.err)
+	}
+	// Same inode, not just same path: an unpack would have renamed a fresh
+	// tree into place, so SameFile is what tells reuse from re-download.
+	after, err := os.Stat(got.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Errorf("layer was re-downloaded instead of reused")
+	}
+}
+
+// holdEnsureFlight occupies the layer's dedup flight, finishing with err, so
+// an ensureLayer called meanwhile joins rather than leads.
+func holdEnsureFlight(t *testing.T, store *Store, diffID v1.Hash, body func() error) (release func()) {
+	t.Helper()
+	held, releaseCh := make(chan struct{}), make(chan struct{})
+	go func() {
+		_, _, _ = store.layerSF.Do(diffID.String(), func() (any, error) {
+			err := body()
+			close(held)
+			<-releaseCh
+			return nil, err
+		})
+	}()
+	<-held
+	var once sync.Once
+	release = func() { once.Do(func() { close(releaseCh) }) }
+	t.Cleanup(release)
+	return release
+}
+
+// Joining an ensure flight is the dedup working: one download shared by the
+// herd, failure included. Retrying per waiter would multiply full-size
+// downloads under a persistent failure.
+func TestEnsureLayerJoiningFailedEnsureSharesError(t *testing.T) {
+	_, host := newTestRegistry(t)
+	store := newTestStore(t)
+	layer, diffID, dir := seedLayer(t, store, host+"/test/join-pullfail:latest")
+	wantErr := errors.New("while unpacking layer: connection refused")
+
+	release := holdEnsureFlight(t, store, diffID, func() error {
+		return errors.Join(os.RemoveAll(dir), wantErr)
+	})
+	done := ensureLayerAsync(store, diffID, layer)
+	waitForBlockedEnsure(t, "sync.(*WaitGroup).Wait")
+	release()
+
+	if got := <-done; !errors.Is(got.err, wantErr) {
+		t.Fatalf("ensureLayer = %v, want the joined flight's error %v", got.err, wantErr)
+	}
+}
+
+// Distinct layers must never share an interlock. It is held across a whole
+// unpack, so sharing would serialize unrelated multi-GiB downloads and make
+// a retirement veto — and so re-date for a whole min-age window — a layer it
+// could have taken.
+func TestLayerLocksAreIndependentPerLayer(t *testing.T) {
+	store := newTestStore(t)
+	a, b := strings.Repeat("ab", 32), strings.Repeat("cd", 32)
+
+	lockA, lockAgain, lockB := store.layerLock(a), store.layerLock(a), store.layerLock(b)
+	if lockA != lockAgain {
+		t.Fatal("one layer resolved to two different interlocks")
+	}
+	if lockA == lockB {
+		t.Fatal("two distinct layers share one interlock")
+	}
+	if !store.layerLock(a).TryAcquire(1) {
+		t.Fatal("could not take the first layer's interlock")
+	}
+	defer store.layerLock(a).Release(1)
+	if !store.layerLock(b).TryAcquire(1) {
+		t.Fatal("holding one layer's interlock blocked an unrelated layer")
+	}
+	store.layerLock(b).Release(1)
+}
+
+// A cancelled context must not fail a lookup whose layer is already in the
+// pool: the semaphore fails a cancelled Acquire even when the lock is free,
+// and singleflight would hand that failure to healthy joiners. Reachable
+// when a sibling layer's failure cancels the pull's errgroup while queued
+// ensureLayer calls are still starting.
+func TestEnsureLayerCachedLayerSurvivesCancelledContext(t *testing.T) {
+	_, host := newTestRegistry(t)
+	store := newTestStore(t)
+	layer, diffID, dir := seedLayer(t, store, host+"/test/cancelled-ctx:latest")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := store.ensureLayer(ctx, diffID, layer)
+	if err != nil {
+		t.Fatalf("ensureLayer on a cached layer with a cancelled ctx: %v", err)
+	}
+	if got != dir {
+		t.Errorf("ensureLayer = %q, want %q", got, dir)
+	}
+
+	// Only the hit is served: with the layer absent, the cancelled ctx must
+	// fail the call rather than start a download — the layer streams are
+	// bound to the pull's parent ctx, so nothing would cancel it.
+	if err := RemoveAllWritable(dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ensureLayer(ctx, diffID, layer); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ensureLayer on an absent layer with a cancelled ctx = %v, want context.Canceled", err)
 	}
 }


### PR DESCRIPTION
Fixes #1076. Overlaps #1079 — both fix the same flake, only one should merge.

## The bug

`ensureLayer` and `retireLayer` shared one singleflight key per layer. That sharing *was* the retire/reuse interlock, but it made the pull path depend on something singleflight cannot express: a caller whose `Do` **joins** a flight rather than leading one learns nothing about what it joined. When the flight was a retirement, `ensureLayer` returned the layer path anyway — and the rename had just moved it aside. `pull` recorded a layer with nothing behind it, and its re-verify failed a healthy pull with `layer dir vanished during pull (evicted?)`.

#1076 attributes this to an eviction cutoff postdating `ensureLayer`'s mtime refresh. That can't fire at the default `minAge = 2m`: `cutoff = now - 2m` while a refreshed dir has mtime ≈ `now`, so `retireLayer` always vetoes. That window is real only at `minAge ≈ 0`.

## The fix

Use a lock for the interlock, and leave the singleflight to do only what it's good at.

- **Interlock**: a per-layer `semaphore.Weighted`, held by `ensureLayer` across its stat and refresh-or-unpack, and by `retireLayer` across its stat and rename. The two still can't interleave, but a waiter now *waits* and then re-reads the pool, instead of inheriting a verdict it can't interpret. Retirement uses `TryAcquire`, so a GC pass never blocks behind a download — same effect as the old join-is-a-veto rule.
- **Singleflight**: deduplication only, where joining is unambiguous. The leader's outcome is the joiner's — one download per herd, failure included, as it was before eviction existed.

The interlock is per layer, never shared between them: it is held for the length of an unpack, so two layers on one lock would serialize unrelated downloads and let a retirement veto — and so re-date for a whole min-age window — a layer it could have taken. `semaphore` (already a dep, same module as `singleflight`) rather than `sync.Mutex` because retirement needs `TryAcquire` and the pull path gets a context-aware `Acquire`; `k8s.io/utils/keymutex` has no try-variant. The `Acquire` falls back to `TryAcquire` on a context error, serving only the cache hit: the semaphore prefers the context error over a free slot, and a cancelled pull leading the flight for an already-cached layer must not fail the lookup for healthy joiners — but with the layer absent, the context error is returned rather than starting a download the layer streams (bound to the pull's parent context) would never cancel. Entries are created on first use and never removed — the one piece of per-layer bookkeeping eviction does not reclaim — because releasing one safely while a caller waits on it needs refcounting.

No behavior change outside the interlock: the layer-presence check keeps the semantics it always had (any stat failure counts the layer absent), now shared by its three call sites as `layerFSPresent`.

## Testing

The flake never reproduced naturally (~49,000 iterations, zero failures). With a throwaway instrumented build that widened the retire window and forced the evictor to win the race, joins-that-found-no-dir matched failures 1:1 in every run. Against this branch the same harness gives **0 failures at every head start**, versus 66/182/186 before.

Five committed tests pin the interlock:

- retirement vetoed while the interlock is held
- ensure waiting out a retirement, then repacking
- ensure waiting out a *failed* retirement, then reusing
- joined ensure sharing its leader's failure
- distinct layers never sharing an interlock
- a cancelled context not failing a lookup whose layer is already cached

The three that race release the held lock only once the call under test is observably blocked, so they cannot pass without exercising the contended path.

Full package `-race`: 74 pass, 0 fail. `TestConcurrentEnsureImageAndEvict` 300× race-clean, `TestRetireLayerVsEnsureImageRace` 200× race-clean. `make verify` clean except `metrics.sh` (needs Docker), `proto-fmt.sh` (needs `clang-format`), `shellcheck.sh` — the latter two fail identically on `main`, and this touches no metrics, protos, or shell scripts.

## Deliberately not fixed here

A joiner inherits a cancelled leader's `context.Canceled`, so pull B can fail on pull A's caller going away. That predates this PR — `ensureLayer` on `main` already returns the leader's error unconditionally — and the interlock neither causes nor worsens it. Undoing it means deciding whether shared work should follow any one caller's context at all, which is wider than this change; `ensureLayer`'s doc comment now records the decision.

One caveat on the usual justification: I could not find a server-side retry on the Run/Restore path that would absorb it. `EnsureImage` failures reach `maybeCrashActor`, are not crash-tagged, and come back as a plain error to the Resume RPC caller — there is no requeue. So the self-healing argument rests on the RPC client, which I have not traced.

## Follow-up (separate issue)

A pull whose last layer downloads for longer than `minAge` with no sibling completions stops touching its record, so eviction can legitimately remove its completed layers and the pull fails into a retry with the same `vanished during pull` string. That is the documented wedge-detection design, not the race this PR fixes; a time-based record heartbeat during long downloads would be its own change.

`TestConcurrentEnsureImageAndEvict` tests less than it appears: over 5,000 iterations it produced 33 eviction candidates and removed **zero** records, so the eviction-wins branch is almost never taken.



