### PR TITLE
ateapi: regenerate validation code with the current generator

### DIFF
--- a/cmd/ateapi/internal/controlapi/zz_generated.validation.go
+++ b/cmd/ateapi/internal/controlapi/zz_generated.validation.go
@@ -6516,7 +6516,7 @@ func Validate_UpdateTagRequest(
 			func() { // cohort = "metadata"
 				earlyReturn := false
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "metadata",
-					func(o *ateapipb.Tag) *ateapipb.ResourceMetadata { return o.Metadata }, deepEqualImpl_, validate.RequiredPointer).MarkShortCircuit(); len(e) != 0 {
+					func(o *ateapipb.Tag) *ateapipb.ResourceMetadata { return o.Metadata }, ateDeepEqual, validate.RequiredPointer).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
 				}


### PR DESCRIPTION
`main` is red since #1480 merged: its regenerated `cmd/ateapi/internal/controlapi/zz_generated.validation.go` was produced by a stale generator build and references `deepEqualImpl_`, which doesn't exist — `cmd/ateapi` (and everything importing `controlapi`) fails to compile, and every open PR inherits the failure through CI's merge-with-main (see #1512's `run-tests` for an example, and `main`'s own post-merge `pr-workflow` runs for #1480/#1499).

Fix is a pure regeneration: `hack/update/codegen.sh` on current `main` changes exactly one line, `deepEqualImpl_` → `ateDeepEqual` (the helper the current generator actually emits). After it, `go build ./cmd/ateapi/...` succeeds and `go test ./cmd/ateapi/internal/controlapi/` passes.

No hand-written changes — the diff is generator output only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
