### PR TITLE
ateom-microvm: reseed the guest CRNG on restore

### DIFF
--- a/cmd/ateom-microvm/internal/kata/agentclient.go
+++ b/cmd/ateom-microvm/internal/kata/agentclient.go
@@ -146,6 +146,18 @@ func (a *AgentClient) CreateContainer(ctx context.Context, req *agentpb.CreateCo
 	return nil
 }
 
+// ReseedRandomDev feeds fresh entropy into the guest's random device: the agent
+// writes data into /dev/random and reseeds the kernel CRNG. This is how a restored
+// or cloned guest diverges from the entropy state frozen in its snapshot. Mirrors
+// grpc.AgentService/ReseedRandomDev.
+func (a *AgentClient) ReseedRandomDev(ctx context.Context, data []byte) error {
+	req := &agentpb.ReseedRandomDevRequest{Data: data}
+	if err := a.client.Call(ctx, "grpc.AgentService", "ReseedRandomDev", req, &emptypb.Empty{}); err != nil {
+		return fmt.Errorf("agent ReseedRandomDev: %w", err)
+	}
+	return nil
+}
+
 // StartContainer execs the container's init process (pivots into the rootfs the
 // storages assembled). Mirrors grpc.AgentService/StartContainer.
 func (a *AgentClient) StartContainer(ctx context.Context, containerID string) error {

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -62,6 +63,37 @@ func restoreMemMode(ctx context.Context, info ch.VMMInfo) string {
 			slog.String("mode", ch.MemRestoreEager))
 	}
 	return ch.MemRestoreEager
+}
+
+// reseedGuestCRNG mixes fresh, per-restore entropy into the restored guest's kernel
+// CRNG through the kata-agent (see the call site in restoreFullScope for why a restore
+// needs this). The nonce is a throwaway; its only job is to differ between restores so
+// that clones of one snapshot diverge instead of producing identical randomness.
+func reseedGuestCRNG(ctx context.Context, actorUID string) error {
+	nonce, err := newReseedNonce()
+	if err != nil {
+		return err
+	}
+	dctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	ac, err := dialAgentRetry(dctx, kata.VsockSocketPath(actorUID), 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("dialing kata-agent for reseed: %w", err)
+	}
+	defer ac.Close()
+	if err := ac.ReseedRandomDev(dctx, nonce); err != nil {
+		return fmt.Errorf("reseeding guest CRNG: %w", err)
+	}
+	return nil
+}
+
+// newReseedNonce returns 32 bytes of fresh entropy to mix into the guest CRNG.
+func newReseedNonce() ([]byte, error) {
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generating reseed nonce: %w", err)
+	}
+	return nonce, nil
 }
 
 // RestoreWorkload brings the actor back from a snapshot, on a possibly different
@@ -352,6 +384,24 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 		return fmt.Errorf("while resuming restored guest: %w", err)
 	}
 	tResume := time.Now()
+
+	// Reseed the guest CRNG before the workload gets far. A restored guest resumes with
+	// the entropy pool frozen in the snapshot, so every actor restored from one snapshot
+	// (golden cold-start, tag clones) would share an identical CRNG state and emit the
+	// same "random" values. Cloud Hypervisor has no VmGenID device to signal the guest,
+	// so we feed fresh per-restore entropy through the kata-agent's ReseedRandomDev, which
+	// mixes it into /dev/random and reseeds. Best-effort: a failure leaves the actor
+	// running rather than failing the restore, but it is logged because the result is
+	// silently non-unique randomness.
+	// ponytail: this runs just after Resume, so a workload that reads randomness in the
+	// first instants after resume can outrun the reseed. Fully closing that needs a
+	// freeze/thaw around the reseed, or a VMM VmGenID that acts before the vCPUs resume.
+	if err := reseedGuestCRNG(ctx, actorUID); err != nil {
+		slog.WarnContext(ctx, "guest CRNG reseed on restore failed; actor may share entropy with clones of the same snapshot",
+			slog.String("id", actorUID), slog.Any("err", err))
+	} else {
+		slog.InfoContext(ctx, "reseeded guest CRNG on restore", slog.String("id", actorUID))
+	}
 
 	// Block until every readyz-enabled container reports 200.
 	if err := readyz.WaitAll(ctx, containers, ateomnet.ActorVethIP); err != nil {

--- a/cmd/ateom-microvm/restore.go
+++ b/cmd/ateom-microvm/restore.go
@@ -396,6 +396,12 @@ func (s *AteomService) restoreFullScope(ctx context.Context, p actorBootParams, 
 	// ponytail: this runs just after Resume, so a workload that reads randomness in the
 	// first instants after resume can outrun the reseed. Fully closing that needs a
 	// freeze/thaw around the reseed, or a VMM VmGenID that acts before the vCPUs resume.
+	//
+	// TODO: switch to a Cloud Hypervisor VmGenID device once it exists. clh has no such
+	// device today; Firecracker and QEMU do. With one, the VMM changes the generation id
+	// and notifies the guest before unpausing the vCPUs, so a >=5.18 kernel reseeds its
+	// CRNG on its own with no host round-trip, no per-restore RPC, and no post-Resume
+	// race. At that point this agent-driven reseed can be dropped.
 	if err := reseedGuestCRNG(ctx, actorUID); err != nil {
 		slog.WarnContext(ctx, "guest CRNG reseed on restore failed; actor may share entropy with clones of the same snapshot",
 			slog.String("id", actorUID), slog.Any("err", err))

--- a/cmd/ateom-microvm/restore_test.go
+++ b/cmd/ateom-microvm/restore_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -131,4 +132,23 @@ func TestRewriteSnapshotSocketPaths(t *testing.T) {
 			t.Errorf("serial file = %q, want %q", cfg.Serial.File, want)
 		}
 	})
+}
+
+func TestNewReseedNonce(t *testing.T) {
+	a, err := newReseedNonce()
+	if err != nil {
+		t.Fatalf("newReseedNonce: %v", err)
+	}
+	if len(a) != 32 {
+		t.Fatalf("nonce length = %d, want 32", len(a))
+	}
+	// The reseed only makes clones of one snapshot diverge if each restore mixes in
+	// distinct bytes, so two nonces must never be equal.
+	b, err := newReseedNonce()
+	if err != nil {
+		t.Fatalf("newReseedNonce (second call): %v", err)
+	}
+	if bytes.Equal(a, b) {
+		t.Fatal("two nonces are identical; reseed would not make clones diverge")
+	}
 }


### PR DESCRIPTION
## What

On the microVM restore path, ateom reseeds the guest kernel CRNG with fresh entropy through the kata-agent's ReseedRandomDev RPC, right after the guest resumes.

This implements the guest RNG reseed on restore that #1449 calls out as an unfiled gap (its Strategy 2, inject freshness at restore). Scoped to the kernel CRNG on the microVM runtime, so it does not close #1449.

## Why

Two actors restored from the same snapshot start with the same frozen CRNG state. The kernel reseeds from ambient entropy on its own, but not immediately. Measured on a live restore, two clones kept returning identical /proc/sys/kernel/random/uuid values for up to about 36ms after resume before that happened. A workload reading randomness in its first moments after resume can land in that window and get duplicate values across clones.

Cloud Hypervisor has no VmGenID device to signal the guest, so ateom reseeds it directly. On each restore it hands a fresh 32-byte nonce to the kata-agent, which mixes it into the guest CRNG. The nonce differs per restore, so clones diverge regardless of the kernel's own timing. The kata-agent already exposes this RPC, so the change is host-side in ateom.

## Behavior

Fires on every restore (golden cold-start and resume alike). Cold boot does not need it. Best-effort: a failure is logged, not fatal, so a transient agent error never fails an otherwise good restore.

## Scope and limits

- Covers the kernel CRNG only. A workload's own userspace PRNG seed lives in the checkpointed app memory and stays a workload concern (Strategy 5 in #1449).
- The reseed runs just after Resume, through the kata-agent, so it lands a few milliseconds after the vCPUs resume. In the live test the reseeded window shrank from about 36ms to about 6ms but did not reach zero. The first read or two after resume can still be frozen before the reseed lands. Fully closing it needs freezing the workload cgroup across the reseed, or a VMM VmGenID that acts before the vCPUs resume. A TODO in the code points at the VmGenID path once Cloud Hypervisor gains the device. Left as a follow-up.
- microVM runtime only. gVisor reads getrandom and urandom live from the host with no checkpointed RNG state, so restored gVisor sandboxes already get fresh entropy.

## Testing

- Unit test on the nonce generator (length, and that two nonces differ).
- Verified live on a GKE microVM cluster with a workload that continuously records /proc/sys/kernel/random/uuid, so the restore instant is observable. Two clones from one golden snapshot were compared. Stock ateom returned identical CRNG output for up to about 36ms (7 consecutive reads) after resume, varying run to run. With this change the shared window shrank to about 6ms (1 read), then diverged.
