### PR TITLE
postgresql connect string might contains sensitive password

### DIFF
--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -307,7 +307,7 @@ func logFlagValues(ctx context.Context) {
 		slog.String("grpc-listen-addr", *listenAddr),
 		slog.String("grpc-server-cred-bundle", *grpcServerCredBundle),
 		slog.String("authentication-config", *authenticationConfigFile),
-		slog.String("postgres-connection-string", *postgresConnectionString),
+		slog.Bool("postgres-connection-string-set", *postgresConnectionString != ""),
 		slog.String("postgres-schema", *postgresSchema),
 		slog.String("actor-id-jwt-pool", *actorIDJWTPoolFile),
 		slog.String("actor-id-ca-pool", *actorIDCAPoolFile),


### PR DESCRIPTION
postgrel connect string might contains sensitive password, we should not print it in the log file

- [ x ] Tests pass
