### PR TITLE
fix(tests): resolve flakiness in TestActorLifecycle_WithExternalVolumes

### DIFF
--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -1375,7 +1375,7 @@ func TestActorLifecycle_WithExternalVolumes(t *testing.T) {
 		},
 	}
 	createTemplateWithVolumes(t, tc, ns, volumes, mounts)
-	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+	workerName := createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
 
 	// 1. CreateActor
 	createResp, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
@@ -1421,6 +1421,7 @@ func TestActorLifecycle_WithExternalVolumes(t *testing.T) {
 	if pauseResp.GetActor().GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_PAUSED {
 		t.Fatalf("expected state ACTOR_STATE_PAUSED after pause, got %v", pauseResp.GetActor().GetStatus().GetState())
 	}
+	waitForWorkerAvailable(t, tc, workerName)
 
 	// 4. ResumeActor from paused
 	resumeResp2, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{


### PR DESCRIPTION
## Summary

Fixes the flaky test `TestActorLifecycle_WithExternalVolumes` in `cmd/ateapi/internal/controlapi/functionaltest` (`unit` lane).

**Root cause:** the test pauses and immediately resumes against a single 1-capacity worker; PauseActor commits the assignment release to the store, but AssignWorker reads the worker cache, which sees the release only after the PostgreSQL watch delivers it — losing that race fails the resume with `ResourceExhausted: no free workers available`.
**Fix:** wait for the release to reach the cache with the existing `waitForWorkerAvailable` helper (the same pattern sibling lifecycle tests use after suspend) before resuming.

Closes #1533

## Evidence

Flake rate over last 7 days: 5.7% (26 fail / 427 pass across 453 runs)
Failures span 14 branches incl. 9 on main; infra-failure runs excluded: 0

Failing runs: https://github.com/agent-substrate/substrate/actions/runs/33919495958, https://github.com/agent-substrate/substrate/actions/runs/33941175484
Passing runs: https://github.com/agent-substrate/substrate/actions/runs/33567474203, https://github.com/agent-substrate/substrate/actions/runs/33566785143

## Test plan

- [x] `go test -race -count=5 ./cmd/ateapi/internal/controlapi/functionaltest/ -run TestActorLifecycle_WithExternalVolumes` — passes (was intermittently failing before at ~6%)