### PR TITLE
Some fixes to kubectl-ate CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ hack/install-ate-kind.sh --deploy-demo-counter
 # install kubectl-ate
 go install ./cmd/kubectl-ate
 
-# create a counter actor in the demo's atespace (--template-ref names the
+# create a counter actor in the demo's atespace (--template names the
 # actor template, resolved in the actor's atespace)
-kubectl ate create actor my-counter-1 -a ate-demo-counter --template-ref counter
+kubectl ate create actor my-counter-1 -a ate-demo-counter --template counter
 
 # port-forward the network router to bind to local port `8000`
 kubectl port-forward -n ate-system svc/atenet-router 8000:80

--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -196,7 +196,7 @@ Manage the execution state of your workloads.
 # Create a new actor deriving from an ActorTemplate. The template name is
 # resolved in the actor's atespace. -a/--atespace is required and the
 # atespace must already exist (kubectl ate create atespace <atespace>).
-kubectl ate create actor my-actor --template-ref=<template-name> -a <atespace>
+kubectl ate create actor my-actor --template=<template-name> -a <atespace>
 
 # Resume an actor (assigns it to a free worker and restores its state)
 kubectl ate resume actor my-actor -a <atespace>
@@ -230,7 +230,7 @@ kubectl ate update tag <tag-name> -a <atespace> --scope published
 kubectl ate update tag <tag-name> -a <atespace> --scope atespace
 
 # Create an actor from a tag and remove the tag when it is no longer needed.
-kubectl ate create actor <actor-name> -a <atespace> --template-ref <template-name> --tag <tag-atespace/tag-name>
+kubectl ate create actor <actor-name> -a <atespace> --template <template-name> --tag <tag-atespace/tag-name>
 kubectl ate delete tag <tag-name> -a <atespace>
 ```
 

--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -110,8 +110,8 @@ kubectl ate get workers -l <label-selector>
 | `NAME` | The actor's name. User-provided for application actors; UUID for the golden actor that each template materialises during `ResumeGoldenActor`. |
 | `TEMPLATE` | The `ActorTemplate` the actor was created from, displayed as `<atespace>/<name>`. |
 | `STATE` | One of `ACTOR_STATE_RESUMING`, `ACTOR_STATE_RUNNING`, `ACTOR_STATE_SUSPENDING`, `ACTOR_STATE_SUSPENDED`. |
-| `ATEOM POD` | The worker pod (namespace/name) currently hosting the actor. Empty while suspended. |
-| `ATEOM IP` | The pod IP of that worker. Empty while suspended. |
+| `WORKER POD` | The worker pod (namespace/name) currently hosting the actor. Empty while suspended. |
+| `WORKER IP` | The pod IP of that worker. Empty while suspended. |
 | `VERSION` | Monotonic integer that increments on every state transition (resume / suspend / checkpoint). Useful for distinguishing snapshots. |
 | `AGE` | Time elapsed since the actor was created. |
 

--- a/cmd/kubectl-ate/README.md
+++ b/cmd/kubectl-ate/README.md
@@ -193,9 +193,7 @@ Manage the execution state of your workloads.
 *(Note: Actors are identified by a user-provided name, which must be a valid DNS-1123 label)*
 
 ```bash
-# Create a new actor deriving from an ActorTemplate. The template name is
-# resolved in the actor's atespace. -a/--atespace is required and the
-# atespace must already exist (kubectl ate create atespace <atespace>).
+# Create a new actor from an ActorTemplate.
 kubectl ate create actor my-actor --template=<template-name> -a <atespace>
 
 # Resume an actor (assigns it to a free worker and restores its state)
@@ -229,8 +227,8 @@ kubectl ate create tag <tag-name> -a <atespace> --actor <actor-name> [--scope pu
 kubectl ate update tag <tag-name> -a <atespace> --scope published
 kubectl ate update tag <tag-name> -a <atespace> --scope atespace
 
-# Create an actor from a tag and remove the tag when it is no longer needed.
-kubectl ate create actor <actor-name> -a <atespace> --template <template-name> --tag <tag-atespace/tag-name>
+# Create an actor from a tag.
+kubectl ate create actor <actor-name> -a <atespace> --template <template-name> --tag <tag-name>
 kubectl ate delete tag <tag-name> -a <atespace>
 ```
 

--- a/cmd/kubectl-ate/internal/cmd/create_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/create_actor.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var templateRefFlag string
+var templateFlag string
 var atespaceFlag string
 var sourceTagFlag string
 
@@ -32,7 +32,7 @@ var createActorCmd = &cobra.Command{
 	Short: "Create an actor",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		request, err := buildCreateActorRequest(args[0], atespaceFlag, templateRefFlag, sourceTagFlag)
+		request, err := buildCreateActorRequest(args[0], atespaceFlag, templateFlag, sourceTagFlag)
 		if err != nil {
 			return err
 		}
@@ -78,9 +78,8 @@ func buildCreateActorRequest(actorName, atespace, templateName, tag string) (*at
 }
 
 func init() {
-	// TODO: rename "template-ref" to "template" now that the legacy CRD flag is gone.
-	createActorCmd.Flags().StringVar(&templateRefFlag, "template-ref", "", "Name of the substrate ActorTemplate resource to derive the actor from, resolved in the actor's atespace (--atespace)")
-	_ = createActorCmd.MarkFlagRequired("template-ref")
+	createActorCmd.Flags().StringVar(&templateFlag, "template", "", "Name of the substrate ActorTemplate resource to derive the actor from, resolved in the actor's atespace (--atespace)")
+	_ = createActorCmd.MarkFlagRequired("template")
 	createActorCmd.Flags().StringVarP(&atespaceFlag, "atespace", "a", "", "Atespace to create the actor in (required)")
 	_ = createActorCmd.MarkFlagRequired("atespace")
 	createActorCmd.Flags().StringVar(&sourceTagFlag, "tag", "", "Initialize from a Tag in <atespace>/<name> format")

--- a/cmd/kubectl-ate/internal/cmd/create_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/create_actor.go
@@ -53,22 +53,21 @@ var createActorCmd = &cobra.Command{
 	},
 }
 
-// buildCreateActorRequest assembles the CreateActor request from the command
-// flags.
-func buildCreateActorRequest(actorName, atespace, templateName, tag string) (*ateapipb.CreateActorRequest, error) {
+func buildCreateActorRequest(actorName, atespace, template, tag string) (*ateapipb.CreateActorRequest, error) {
+	templateRef, err := parseAtespacedName(template, atespace)
+	if err != nil {
+		return nil, err
+	}
 	actor := &ateapipb.Actor{
 		Metadata: &ateapipb.ResourceMetadata{
 			Atespace: atespace,
 			Name:     actorName,
 		},
-		ActorTemplate: &ateapipb.ObjectRef{
-			Atespace: atespace,
-			Name:     templateName,
-		},
+		ActorTemplate: templateRef,
 	}
 
 	if tag != "" {
-		ref, err := parseNamespacedName(tag)
+		ref, err := parseAtespacedName(tag, atespace)
 		if err != nil {
 			return nil, err
 		}
@@ -78,10 +77,10 @@ func buildCreateActorRequest(actorName, atespace, templateName, tag string) (*at
 }
 
 func init() {
-	createActorCmd.Flags().StringVar(&templateFlag, "template", "", "Name of the substrate ActorTemplate resource to derive the actor from, resolved in the actor's atespace (--atespace)")
+	createActorCmd.Flags().StringVar(&templateFlag, "template", "", "The name of the ActorTemplate to derive the actor from, as <atespace>/<template-name>, or just <template-name> to use the actor's own atespace (--atespace)")
 	_ = createActorCmd.MarkFlagRequired("template")
-	createActorCmd.Flags().StringVarP(&atespaceFlag, "atespace", "a", "", "Atespace to create the actor in (required)")
+	createActorCmd.Flags().StringVarP(&atespaceFlag, "atespace", "a", "", "Atespace to create the actor in")
 	_ = createActorCmd.MarkFlagRequired("atespace")
-	createActorCmd.Flags().StringVar(&sourceTagFlag, "tag", "", "Initialize from a Tag in <atespace>/<name> format")
+	createActorCmd.Flags().StringVar(&sourceTagFlag, "tag", "", "The name of a Tag to initialize the actor from, as <atespace>/<tag-name>, or just <tag-name> to use the actor's own atespace (--atespace)")
 	createCmd.AddCommand(createActorCmd)
 }

--- a/cmd/kubectl-ate/internal/cmd/create_actor_test.go
+++ b/cmd/kubectl-ate/internal/cmd/create_actor_test.go
@@ -31,7 +31,7 @@ func TestBuildCreateActorRequest(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:        "template ref",
+			name:        "bare template name defaults to the actor's atespace",
 			templateRef: "counter",
 			want: &ateapipb.Actor{
 				Metadata:      &ateapipb.ResourceMetadata{Atespace: "demo", Name: "my-counter"},
@@ -39,16 +39,35 @@ func TestBuildCreateActorRequest(t *testing.T) {
 			},
 		},
 		{
-			name:        "template ref with tag",
+			name:        "bare tag name defaults to the actor's atespace",
 			templateRef: "counter",
-			tag:         "demo/before-upgrade",
+			tag:         "before-upgrade",
 			want: &ateapipb.Actor{
 				Metadata:      &ateapipb.ResourceMetadata{Atespace: "demo", Name: "my-counter"},
 				ActorTemplate: &ateapipb.ObjectRef{Atespace: "demo", Name: "counter"},
 				SourceTag:     &ateapipb.ObjectRef{Atespace: "demo", Name: "before-upgrade"},
 			},
 		},
-		{name: "malformed tag", templateRef: "counter", tag: "before-upgrade", wantErr: true},
+		{
+			name:        "qualified tag in a different atespace",
+			templateRef: "counter",
+			tag:         "other-atespace/before-upgrade",
+			want: &ateapipb.Actor{
+				Metadata:      &ateapipb.ResourceMetadata{Atespace: "demo", Name: "my-counter"},
+				ActorTemplate: &ateapipb.ObjectRef{Atespace: "demo", Name: "counter"},
+				SourceTag:     &ateapipb.ObjectRef{Atespace: "other-atespace", Name: "before-upgrade"},
+			},
+		},
+		{
+			name:        "qualified template in a different atespace",
+			templateRef: "shared-templates/counter",
+			want: &ateapipb.Actor{
+				Metadata:      &ateapipb.ResourceMetadata{Atespace: "demo", Name: "my-counter"},
+				ActorTemplate: &ateapipb.ObjectRef{Atespace: "shared-templates", Name: "counter"},
+			},
+		},
+		{name: "malformed template ref", templateRef: "a/b/c", wantErr: true},
+		{name: "malformed tag", templateRef: "counter", tag: "a/b/c", wantErr: true},
 	}
 
 	for _, test := range tests {

--- a/cmd/kubectl-ate/internal/cmd/get_test.go
+++ b/cmd/kubectl-ate/internal/cmd/get_test.go
@@ -56,18 +56,11 @@ func TestGetCommandArgs(t *testing.T) {
 	}
 }
 
-func TestParseActorSnapshotFlags(t *testing.T) {
+func TestParseTagScope(t *testing.T) {
 	if got, err := parseTagScope("published"); err != nil || got != ateapipb.TagScope_TAG_SCOPE_PUBLISHED {
 		t.Fatalf("parseTagScope(published) = (%v, %v)", got, err)
 	}
 	if _, err := parseTagScope("global"); err == nil {
 		t.Fatal("parseTagScope(global) succeeded")
-	}
-	ref, err := parseNamespacedName("team-a/before-upgrade")
-	if err != nil || ref.GetAtespace() != "team-a" || ref.GetName() != "before-upgrade" {
-		t.Fatalf("parseNamespacedName = (%v, %v)", ref, err)
-	}
-	if _, err := parseNamespacedName("before-upgrade"); err == nil {
-		t.Fatal("parseNamespacedName without atespace succeeded")
 	}
 }

--- a/cmd/kubectl-ate/internal/cmd/resourceref.go
+++ b/cmd/kubectl-ate/internal/cmd/resourceref.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/agent-substrate/substrate/internal/resources"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+)
+
+// parseAtespacedName parses a reference to an atespace-scoped resource,
+// either as <atespace>/<name> or as <name>, which defaults to defaultAtespace
+func parseAtespacedName(value, defaultAtespace string) (*ateapipb.ObjectRef, error) {
+	atespace, name, ok := strings.Cut(value, "/")
+	if !ok {
+		atespace, name = defaultAtespace, value
+	}
+	if !resources.IsValidResourceName(atespace) || !resources.IsValidResourceName(name) {
+		return nil, fmt.Errorf("malformed reference %q (expected <name> or <atespace>/<name>)", value)
+	}
+	return &ateapipb.ObjectRef{Atespace: atespace, Name: name}, nil
+}

--- a/cmd/kubectl-ate/internal/cmd/resourceref_test.go
+++ b/cmd/kubectl-ate/internal/cmd/resourceref_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestParseAtespacedName(t *testing.T) {
+	tests := []struct {
+		name            string
+		value           string
+		defaultAtespace string
+		want            *ateapipb.ObjectRef
+		wantErr         bool
+	}{
+		{
+			name:            "qualified reference",
+			value:           "team-a/before-upgrade",
+			defaultAtespace: "default-atespace",
+			want:            &ateapipb.ObjectRef{Atespace: "team-a", Name: "before-upgrade"},
+		},
+		{
+			name:            "bare name uses the default atespace",
+			value:           "before-upgrade",
+			defaultAtespace: "default-atespace",
+			want:            &ateapipb.ObjectRef{Atespace: "default-atespace", Name: "before-upgrade"},
+		},
+		{
+			name:            "bare name with no default atespace",
+			value:           "before-upgrade",
+			defaultAtespace: "",
+			wantErr:         true,
+		},
+		{
+			name:            "name contains an extra slash",
+			value:           "team-a/before/upgrade",
+			defaultAtespace: "default-atespace",
+			wantErr:         true,
+		},
+		{
+			name:            "empty atespace before the slash",
+			value:           "/before-upgrade",
+			defaultAtespace: "default-atespace",
+			wantErr:         true,
+		},
+		{
+			name:            "empty name after the slash",
+			value:           "team-a/",
+			defaultAtespace: "default-atespace",
+			wantErr:         true,
+		},
+		{
+			name:            "invalid atespace characters",
+			value:           "Team_A/before-upgrade",
+			defaultAtespace: "default-atespace",
+			wantErr:         true,
+		},
+		{
+			name:            "invalid name characters",
+			value:           "team-a/Before_Upgrade",
+			defaultAtespace: "default-atespace",
+			wantErr:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseAtespacedName(test.value, test.defaultAtespace)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("parseAtespacedName(%q, %q) error = %v, wantErr %t", test.value, test.defaultAtespace, err, test.wantErr)
+			}
+			if test.wantErr {
+				return
+			}
+			if diff := cmp.Diff(test.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("parseAtespacedName(%q, %q) mismatch (-want +got):\n%s", test.value, test.defaultAtespace, diff)
+			}
+		})
+	}
+}

--- a/cmd/kubectl-ate/internal/cmd/tag.go
+++ b/cmd/kubectl-ate/internal/cmd/tag.go
@@ -202,14 +202,6 @@ func parseTagScope(value string) (ateapipb.TagScope, error) {
 	}
 }
 
-func parseNamespacedName(value string) (*ateapipb.ObjectRef, error) {
-	atespace, name, ok := strings.Cut(value, "/")
-	if !ok || atespace == "" || name == "" || strings.Contains(name, "/") {
-		return nil, fmt.Errorf("malformed reference %q (expected <atespace>/<name>)", value)
-	}
-	return &ateapipb.ObjectRef{Atespace: atespace, Name: name}, nil
-}
-
 func init() {
 	getTagsCmd.Flags().StringVarP(&tagAtespaceFlag, "atespace", "a", "", "Atespace to list/get tags in")
 	getTagsCmd.Flags().BoolVarP(&tagAllAtespacesFlag, "all-atespaces", "A", false, "List tags across all atespaces")

--- a/cmd/kubectl-ate/internal/printer/printer.go
+++ b/cmd/kubectl-ate/internal/printer/printer.go
@@ -74,7 +74,7 @@ func PrintActorsTo(out io.Writer, actors []*ateapipb.Actor, format string) error
 		return printProto(out, &ateapipb.ListActorsResponse{Actors: actors}, format)
 	case "table":
 		w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
-		fmt.Fprintln(w, "ATESPACE\tNAME\tTEMPLATE\tSTATE\tATEOM POD\tATEOM IP\tVERSION\tAGE")
+		fmt.Fprintln(w, "ATESPACE\tNAME\tTEMPLATE\tSTATE\tWORKER POD\tWORKER IP\tVERSION\tAGE")
 		for _, actor := range actors {
 			atespace := actor.GetMetadata().GetAtespace()
 			name := actor.GetMetadata().GetName()

--- a/cmd/kubectl-ate/internal/printer/printer_test.go
+++ b/cmd/kubectl-ate/internal/printer/printer_test.go
@@ -83,8 +83,8 @@ func TestPrintActorsTo_Table(t *testing.T) {
 	}
 	output := buf.String()
 
-	expected := `ATESPACE   NAME   TEMPLATE             STATE                 ATEOM POD         ATEOM IP   VERSION   AGE
-team-a     id-1   default/template-1   ACTOR_STATE_RUNNING   worker-ns/pod-1   1.2.3.4    2         5m
+	expected := `ATESPACE   NAME   TEMPLATE             STATE                 WORKER POD        WORKER IP   VERSION   AGE
+team-a     id-1   default/template-1   ACTOR_STATE_RUNNING   worker-ns/pod-1   1.2.3.4     2         5m
 `
 	if diff := cmp.Diff(expected, output); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -183,10 +183,10 @@ func TestPrintActorsTo_Table_Sorted(t *testing.T) {
 	}
 
 	// Sorted by atespace first, then template namespace, template name, name.
-	expected := `ATESPACE   NAME    TEMPLATE             STATE                   ATEOM POD   ATEOM IP   VERSION   AGE
-team-a     alpha   default/template-1   ACTOR_STATE_RUNNING     <none>                 0         5m
-team-a     beta    other/template-2     ACTOR_STATE_SUSPENDED   <none>                 0         5h
-team-b     zebra   default/template-1   ACTOR_STATE_SUSPENDED   <none>                 0         3d
+	expected := `ATESPACE   NAME    TEMPLATE             STATE                   WORKER POD   WORKER IP   VERSION   AGE
+team-a     alpha   default/template-1   ACTOR_STATE_RUNNING     <none>                   0         5m
+team-a     beta    other/template-2     ACTOR_STATE_SUSPENDED   <none>                   0         5h
+team-b     zebra   default/template-1   ACTOR_STATE_SUSPENDED   <none>                   0         3d
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -217,8 +217,8 @@ func TestPrintActorsTo_Table_TemplateRef(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := `ATESPACE   NAME   TEMPLATE                             STATE                   ATEOM POD   ATEOM IP   VERSION   AGE
-team-a     id-1   ate-demo-counter-substrate/counter   ACTOR_STATE_SUSPENDED   <none>                 0         5m
+	expected := `ATESPACE   NAME   TEMPLATE                             STATE                   WORKER POD   WORKER IP   VERSION   AGE
+team-a     id-1   ate-demo-counter-substrate/counter   ACTOR_STATE_SUSPENDED   <none>                   0         5m
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)

--- a/demos/autoscaled-workerpool/README.md
+++ b/demos/autoscaled-workerpool/README.md
@@ -107,7 +107,7 @@ kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/ate-demo-aut
 
 ## How to Use
 
-We can trigger autoscaling by spawning multiple actors and sending traffic to assign workers in the pool. The actors go in the demo's atespace (`ate-demo-autoscaled-workerpool`) — `--template-ref` names the template, resolved in the actor's atespace:
+We can trigger autoscaling by spawning multiple actors and sending traffic to assign workers in the pool. The actors go in the demo's atespace (`ate-demo-autoscaled-workerpool`) — `--template` names the template, resolved in the actor's atespace:
 
 ### 1. Spawn load actors
 
@@ -117,7 +117,7 @@ go install ./cmd/kubectl-ate
 
 # Create 15 actors to generate load
 for i in {001..015}; do
-  kubectl ate create actor c$i -a ate-demo-autoscaled-workerpool --template-ref counter
+  kubectl ate create actor c$i -a ate-demo-autoscaled-workerpool --template counter
 done
 ```
 

--- a/demos/counter/README.md
+++ b/demos/counter/README.md
@@ -51,14 +51,14 @@ kubectl ate get actor-template counter -a ate-demo-counter -o yaml
 
 ### 2. Create a Counter Actor
 
-Create the counter actor with a chosen ID (e.g., `my-counter-1`) using `--template-ref` (the template's name, resolved in the actor's atespace — so the actor lives in the demo's atespace, which the deploy step already created):
+Create the counter actor with a chosen ID (e.g., `my-counter-1`) using `--template` (the template's name, resolved in the actor's atespace — so the actor lives in the demo's atespace, which the deploy step already created):
 
 ```bash
 # Install the CLI as a kubectl plugin if not already installed
 go install ./cmd/kubectl-ate
 
 # Create the actor from the counter template.
-kubectl ate create actor my-counter-1 -a ate-demo-counter --template-ref counter
+kubectl ate create actor my-counter-1 -a ate-demo-counter --template counter
 ```
 
 ### 3. Port-Forward Services
@@ -164,7 +164,7 @@ deploy directly instead:
 ./hack/install-ate.sh --deploy-demo-counter-microvm
 ```
 
-Then create an actor (`--template-ref counter-microvm`, in the
+Then create an actor (`--template counter-microvm`, in the
 `ate-demo-counter-microvm` atespace), increment the counter, suspend
 it, resume it (even on a different worker), and confirm the count continues —
 the actor's counter lives in guest RAM, so a continuing count proves the

--- a/demos/egress/README.md
+++ b/demos/egress/README.md
@@ -132,9 +132,9 @@ kubectl -n egress-target create deployment whoami --image=traefik/whoami
 kubectl -n egress-target expose deployment whoami --port=80
 TARGET_IP=$(kubectl -n egress-target get svc whoami -o jsonpath='{.spec.clusterIP}')
 
-# 2. Create and resume an Actor in the demo's atespace: --template-ref
+# 2. Create and resume an Actor in the demo's atespace: --template
 #    resolves the template by name within the actor's own atespace.
-kubectl ate create actor egress-demo -a ate-demo-egress --template-ref egress
+kubectl ate create actor egress-demo -a ate-demo-egress --template egress
 kubectl ate resume actor egress-demo -a ate-demo-egress   # wait for ACTOR_STATE_RUNNING
 
 # 3. Drive the Actor's egress through the ingress gateway.

--- a/demos/egress/test-egress.sh
+++ b/demos/egress/test-egress.sh
@@ -33,7 +33,7 @@
 set -o errexit -o nounset -o pipefail
 
 CTX="${KUBECTL_CONTEXT:-kind-kind}"
-# The actor lives in the demo's atespace: --template-ref resolves the
+# The actor lives in the demo's atespace: --template resolves the
 # template by name within the actor's own atespace.
 ATESPACE="${ATESPACE:-ate-demo-egress}"
 ACTOR="${ACTOR:-egress-demo}"
@@ -95,7 +95,7 @@ info "target = ${TARGET_IP}:${TARGET_PORT}"
 
 log "create + resume Actor ${ATESPACE}/${ACTOR}"
 ${KATE} create atespace "${ATESPACE}" >/dev/null 2>&1 || true
-${KATE} create actor "${ACTOR}" -a "${ATESPACE}" --template-ref "${TEMPLATE}" >/dev/null 2>&1 || true
+${KATE} create actor "${ACTOR}" -a "${ATESPACE}" --template "${TEMPLATE}" >/dev/null 2>&1 || true
 ${KATE} resume actor "${ACTOR}" -a "${ATESPACE}" >/dev/null 2>&1 || true
 for _ in $(seq 1 30); do
   ${KATE} get actors -a "${ATESPACE}" 2>/dev/null | grep -q "ACTOR_STATE_RUNNING" && break

--- a/demos/jupyter/README.md
+++ b/demos/jupyter/README.md
@@ -44,11 +44,11 @@ go install ./cmd/kubectl-ate
 ```
 
 The deploy created the `jupyter` actor template in the `ate-demo-jupyter`
-atespace. Create your `jupyter` actor there — `--template-ref` names the
+atespace. Create your `jupyter` actor there — `--template` names the
 template, resolved in the actor's atespace:
 
 ```bash
-kubectl ate create actor jupyter-notebook -a ate-demo-jupyter --template-ref jupyter
+kubectl ate create actor jupyter-notebook -a ate-demo-jupyter --template jupyter
 ```
 
 ### 2. Access Jupyter via the Proxy!

--- a/demos/multi-template/README.md
+++ b/demos/multi-template/README.md
@@ -39,7 +39,7 @@ This command will:
 
 ### 2. Create one actor per template
 
-Each actor goes in its template's atespace — `--template-ref` names the template,
+Each actor goes in its template's atespace — `--template` names the template,
 resolved in the actor's atespace — and their DNS names embed that atespace:
 
 ```bash
@@ -47,8 +47,8 @@ resolved in the actor's atespace — and their DNS names embed that atespace:
 go install ./cmd/kubectl-ate
 
 # Create two actors from different templates, one per atespace.
-kubectl ate create actor c1 -a ate-demo-multi-template-counter --template-ref counter
-kubectl ate create actor f1 -a ate-demo-multi-template-fspersist --template-ref fspersist
+kubectl ate create actor c1 -a ate-demo-multi-template-counter --template counter
+kubectl ate create actor f1 -a ate-demo-multi-template-fspersist --template fspersist
 ```
 
 ### 3. Port-forward the atenet router

--- a/demos/parking/README.md
+++ b/demos/parking/README.md
@@ -41,7 +41,7 @@ This command will:
 ### 2. Create more actors than workers
 
 Actors live in the demo's **atespace** (`ate-demo-parking`), and their DNS names
-embed it (`<id>.<atespace>.actors.resources.substrate.ate.dev`). `--template-ref`
+embed it (`<id>.<atespace>.actors.resources.substrate.ate.dev`). `--template`
 names the template, resolved in the actor's atespace:
 
 ```bash
@@ -50,7 +50,7 @@ go install ./cmd/kubectl-ate
 
 # 4 actors share a 2-worker pool -> oversubscribed.
 for id in p1 p2 p3 p4; do
-  kubectl ate create actor "$id" --atespace ate-demo-parking --template-ref parking
+  kubectl ate create actor "$id" --atespace ate-demo-parking --template parking
 done
 ```
 

--- a/demos/parking/load.sh
+++ b/demos/parking/load.sh
@@ -43,7 +43,7 @@ set -uo pipefail
 
 DURATION=30
 ROUTER="http://localhost:8000"
-# The template name, resolved in the actors' atespace (--template-ref).
+# The template name, resolved in the actors' atespace (--template).
 TEMPLATE="parking"
 ATESPACE="ate-demo-parking"
 SUFFIX="actors.resources.substrate.ate.dev"
@@ -97,7 +97,7 @@ echo
 echo "==> ensuring atespace ${ATESPACE} and actors exist (template ${TEMPLATE})"
 kubectl ate create atespace "${ATESPACE}" >/dev/null 2>&1 || true
 for a in "${ACTORS[@]}"; do
-  kubectl ate create actor "${a}" --atespace "${ATESPACE}" --template-ref "${TEMPLATE}" >/dev/null 2>&1 || true
+  kubectl ate create actor "${a}" --atespace "${ATESPACE}" --template "${TEMPLATE}" >/dev/null 2>&1 || true
 done
 
 # One worker per actor: hammer it with request->suspend until the deadline.

--- a/demos/sandbox/README.md
+++ b/demos/sandbox/README.md
@@ -47,13 +47,13 @@ kubectl ate get actor-template sandbox-template -a ate-demo-sandbox
 
 ### 2. Create a Sandbox Actor
 
-Create the sandbox actor in the demo's atespace with a chosen name (e.g., `my-sandbox-1`) — `--template-ref` names the template, resolved in the actor's atespace:
+Create the sandbox actor in the demo's atespace with a chosen name (e.g., `my-sandbox-1`) — `--template` names the template, resolved in the actor's atespace:
 
 ```bash
 # Install the CLI as a kubectl plugin if not already installed
 go install ./cmd/kubectl-ate
 
-kubectl ate create actor my-sandbox-1 -a ate-demo-sandbox --template-ref sandbox-template
+kubectl ate create actor my-sandbox-1 -a ate-demo-sandbox --template sandbox-template
 ```
 
 ### 3. Port-Forward Services

--- a/hack/run-microvm-demo.sh
+++ b/hack/run-microvm-demo.sh
@@ -115,7 +115,7 @@ cat <<EOF
 
   2. Create an actor in the template's atespace (kubectl-ate; install with: go install ./cmd/kubectl-ate):
        kubectl ate${KCTX_FLAG} create actor my-counter-1 -a ate-demo-counter-microvm \\
-         --template-ref counter-microvm
+         --template counter-microvm
 
   3. Port-forward the atenet-router and curl the in-RAM counter:
        kubectl${KCTX_FLAG} port-forward -n ate-system svc/atenet-router 8000:80 &

--- a/hack/verify-atenet-drain.sh
+++ b/hack/verify-atenet-drain.sh
@@ -116,8 +116,8 @@ run_kubectl patch workerpool -n "${DEMO_NS}" "${DEMO_POOL}" --type merge -p '{"s
 run_kubectl rollout status "deploy/${DEMO_POOL}" -n "${DEMO_NS}" --timeout=180s >/dev/null
 
 log_step "creating actors ${ACTOR_BUSY} + ${ACTOR_PARKED} in atespace ${ATESPACE}"
-run_kubectl_ate create actor "${ACTOR_BUSY}" -a "${ATESPACE}" --template-ref "${DEMO_POOL}" >/dev/null
-run_kubectl_ate create actor "${ACTOR_PARKED}" -a "${ATESPACE}" --template-ref "${DEMO_POOL}" >/dev/null
+run_kubectl_ate create actor "${ACTOR_BUSY}" -a "${ATESPACE}" --template "${DEMO_POOL}" >/dev/null
+run_kubectl_ate create actor "${ACTOR_PARKED}" -a "${ATESPACE}" --template "${DEMO_POOL}" >/dev/null
 
 log_step "occupying the only worker with ${ACTOR_BUSY}"
 for i in $(seq 1 20); do

--- a/hack/verify-egress-demo.sh
+++ b/hack/verify-egress-demo.sh
@@ -29,7 +29,7 @@ ROOT="$(git rev-parse --show-toplevel)"; cd "${ROOT}"
 
 CTX="${KUBECTL_CONTEXT:-kind-kind}"
 K="kubectl --context ${CTX}"
-# The actor lives in the demo's atespace: --template-ref resolves the
+# The actor lives in the demo's atespace: --template resolves the
 # template by name within the actor's own atespace.
 ATESPACE="${ATESPACE:-ate-demo-egress}"
 ACTOR="${ACTOR:-egress-demo}"
@@ -41,7 +41,7 @@ ${K} -n ate-system rollout status deployment/atenet-egress --timeout=120s
 echo "== create atespace + actor =="
 kubectl-ate --context "${CTX}" create atespace "${ATESPACE}" 2>/dev/null || true
 kubectl-ate --context "${CTX}" create actor "${ACTOR}" \
-  --atespace "${ATESPACE}" --template-ref egress 2>/dev/null || true
+  --atespace "${ATESPACE}" --template egress 2>/dev/null || true
 # The router resumes the actor on demand; give the control plane a beat to
 # register it before driving traffic.
 sleep 10


### PR DESCRIPTION
* Fix the column names to match the resource fields.
* Rename template flag name (fix TODO from CRD -> Substrate API refactor).
* Fix bug in `create actor` which conflated the atespace flag for both actor and actor template.