### PR TITLE
update the test to run against MicroVM environment

### DIFF
--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -423,10 +423,6 @@ func TestExternalVolumeLifecycle(t *testing.T) {
 }
 
 func TestDeleteActorAnyStateWithExternalVolume(t *testing.T) {
-	if e2e.IsMicroVM() {
-		t.Skip("Skipping TestDeleteActorAnyStateWithExternalVolume for microVM environment")
-	}
-
 	ctx := context.Background()
 	clients := e2e.GetClients()
 	nsObj := e2e.CreateNamespace(t)


### PR DESCRIPTION
Fixes #<issue_number_goes_here>
This test was introduced in PR #788 and initially skipped because external volumes lacked MicroVM support. That limitation was resolved during the PR's development, but the test wasn't updated to remove the skip during the final rebase

- [ x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
