### PR TITLE
atenet: enable the 5m route timeout in the router manifest

### DIFF
--- a/manifests/ate-install/atenet-router.yaml
+++ b/manifests/ate-install/atenet-router.yaml
@@ -180,7 +180,7 @@ spec:
         # deliberately does NOT scale with this; if you raise it and want long
         # turns to survive a shutdown, raise --drain-timeout and
         # terminationGracePeriodSeconds alongside it.
-        # - "--route-timeout=5m"
+        - "--route-timeout=5m"
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
release-0.1 ships the workload route at the 10s default, so any turn slower than about 15s (10s route plus the 5s parking budget in front of it) returns `504 upstream request timeout`. The caller cannot safely retry: the actor received the turn and is still working, so a retry runs it twice.

This uncomments the `--route-timeout=5m` line already present in the manifest, directly under the comment describing the trap.

**Not a cherry-pick of #1529.** That PR raises the constant on `main` and removes this line as redundant. Here the constant stays at 10s, so the manifest line is the fix.

**No other timing moves.** On this branch `drainTimeout()` derives from the constant and deliberately ignores `--route-timeout`, so the drain sequence and `terminationGracePeriodSeconds` are unchanged. The route idle timeout resolves to 5m either way.

**Does not close #1525.** The other half, where an abandoned answer can surface to the next caller, is unaffected by a longer ceiling.
