### PR TITLE
docs: warn that worker node pools must not auto-upgrade or use spot nodes

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -27,6 +27,12 @@ a version suffix, and the installed ate-api-server serves
 install instead, because its DaemonSet selector cannot be changed in
 place.
 
+Nothing drains worker nodes on its own: node auto-upgrade is off on
+every pool that runs workers and none of them is spot or preemptible,
+as the
+[Create Cluster warning](../tools/setup-gcp/README.md#2-create-cluster)
+requires.
+
 Actor snapshots are readable by both the old and the new build. An
 actor can therefore suspend on one version and resume on the other in
 either direction, which is what lets the two versions serve side by
@@ -48,7 +54,19 @@ Three things break an upgrade.
    same node, and old workers end up next to the new atelet: exactly
    the version skew the roll exists to prevent.
 2. **Do not edit a serving worker pool.** The controller would roll
-   the pool's Deployment straight through live actors.
+   the pool's Deployment straight through live actors. A deleted
+   worker pod does go through the eviction path: `SIGTERM` is
+   forwarded into the actor's containers and the control plane keeps
+   accepting a suspend for about 60 seconds, so an actor suspended
+   inside that window saves its state and stays resumable. Handling
+   `SIGTERM` by exiting cleanly is not enough on its own; the suspend
+   has to reach the control plane and finish. An actor still awake
+   when the window closes moves to `ACTOR_STATE_CRASHED`, which is
+   terminal: `resume` and `suspend` are both refused, there is no
+   recover verb, and the snapshot the actor still holds cannot be
+   used to start it. It has to be deleted and recreated, losing its
+   state. The same applies to scaling a serving pool down, which
+   removes pods without suspending the actors on them.
 3. **(If on GKE) Do not touch the node pool's label until every node
    is rolled.** A pool label update applies in place to every node in
    the pool, so the whole fleet flips at once, with no drain and no

--- a/tools/setup-gcp/README.md
+++ b/tools/setup-gcp/README.md
@@ -95,6 +95,34 @@ Filestore CSI driver disabled).
 > podcertificate ClusterTrustBundles to be ready" and `kubectl get
 > clustertrustbundles` reports the resource type is not served.
 
+> [!WARNING]
+> **Turn node auto-upgrade off on any node pool that runs workers, and do not
+> use spot or preemptible nodes for them.** When a worker pod is deleted,
+> `SIGTERM` is forwarded into the actor's containers and the control plane keeps
+> accepting a suspend for about 60 seconds. An actor suspended inside that
+> window keeps its state. One still awake when the window closes is moved to
+> `ACTOR_STATE_CRASHED` with its worker assignment cleared, and `CRASHED` is
+> terminal: `resume` and `suspend` are both refused, there is no recover verb,
+> and the snapshot the actor still holds cannot be used to start it. The only
+> way out is to delete the actor and create a new one, which loses its state.
+>
+> Auto-upgrade is the trigger to plan for, because GKE enables it by default and
+> it fires on Google's maintenance schedule rather than yours. `create cluster`
+> does not disable it, so do it yourself on every pool that runs workers:
+>
+> ```bash
+> gcloud container node-pools update "${NODE_POOL}" \
+>   --cluster "${CLUSTER_NAME}" --location "${CLUSTER_LOCATION}" \
+>   --no-enable-autoupgrade
+> ```
+>
+> This is a management setting, so it takes effect without recreating nodes and
+> is safe to apply to a serving cluster. Node auto-repair, preemption and OOM
+> kills reach the same path and cannot be configured away, so treat the setting
+> as removing the scheduled risk rather than all of it. Change versions through
+> the [rolling upgrade runbook](../../docs/upgrade.md), which has you suspend
+> every actor on a node at your own pace before the node moves.
+
 ```bash
 go run ./tools/setup-gcp create cluster [flags]
 ```


### PR DESCRIPTION
Docs-only backport of #1528 to `release-0.1`, ahead of the tag. Clean cherry-pick, no conflicts, no code.

`release-0.1` currently ships no warning that node auto-upgrade must be off on worker pools. An actor awake when its worker pod goes away reaches `ACTOR_STATE_CRASHED`, which is terminal, and the snapshot it still holds cannot be used to start it.

This matters for the tag specifically. #1526 is rated P1 on the grounds that the failure is only reachable outside the documented operations. Without these two paragraphs in the release there are no documented operations to be outside of, and auto-upgrade is on by default, so a cluster built exactly as the release documents it can lose actors on Google's maintenance schedule.

Same content as on `main`, reviewed and approved there.

## Testing

Docs only. `make test` passes on this branch.
