### PR TITLE
ateom-gvisor: drop -direct from runsc restore

### DIFF
--- a/cmd/ateom-gvisor/runsc.go
+++ b/cmd/ateom-gvisor/runsc.go
@@ -284,7 +284,6 @@ func (r *runsc) cmdRestore(ctx context.Context, out io.Writer, containerName, ch
 		"-image-path", checkpointPath,
 		"-pid-file", ateompath.PIDFilePath(r.actorUID, containerName),
 		"-background",
-		"-direct",
 		"-detach",
 		containerName,
 	)


### PR DESCRIPTION
Fixes https://github.com/agent-substrate/substrate/issues/1530

O_DIRECT bypasses the page cache and disables readahead, so concurrent
restores on a node serialize on disk latency (about 130 MB/s per node).
The atelet has just written the pages file, so it is already cached;
reading it from there lets 88 concurrent restores finish in 15 s
instead of 190 s. 

