### PR TITLE
imagecache: pass the request context to the requests counter as it is

### DIFF
--- a/internal/imagecache/metrics.go
+++ b/internal/imagecache/metrics.go
@@ -71,8 +71,10 @@ func (s *Store) recordRequest(ctx context.Context, outcome string, err error) {
 	if outcome == ateattr.ImageCacheOutcomeError {
 		attrs = append(attrs, ateattr.ErrorTypeKey.String(errorType(err)))
 	}
-	// A cancelled lookup still reports: its pull was started and paid for.
-	s.requests.Add(context.WithoutCancel(ctx), 1, metric.WithAttributes(attrs...))
+	// A cancelled lookup still reports: its pull was started and paid for. The
+	// request context is passed as it is; the SDK never checks its error, and
+	// reads only the span from it so an exemplar can point at the trace.
+	s.requests.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // failureOutcome separates a failed lookup from a caller that gave up.


### PR DESCRIPTION
The requests counter was recorded through `context.WithoutCancel` with a comment saying a cancelled lookup would otherwise not be reported. That is not how the SDK works. `Add` never checks `ctx.Err()`, and the only thing it reads from the context is the span, for exemplars. This passes the request context as it is and fixes the comment.

No behavior change. The existing cancelled-lookup test in `metrics_test.go` still passes.

Came out of the review on #1553, where the metrics guide repeated the same wrong reason.
