### PR TITLE
Log the build version when each component starts

### DIFF
--- a/cmd/ateapi/main.go
+++ b/cmd/ateapi/main.go
@@ -99,6 +99,7 @@ func main() {
 	if err := serverboot.SetLogLevel(*logLevelFlag); err != nil {
 		serverboot.Fatal(ctx, "Invalid --log-level", err)
 	}
+	slog.InfoContext(ctx, "ateapi starting", slog.String("version", version.Version))
 
 	// Kept separate from ctx so that in-progress work (clients, informers) is
 	// not cancelled the moment SIGTERM arrives. The drainOnShutdown

--- a/cmd/atecontroller/main.go
+++ b/cmd/atecontroller/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/atecontroller/internal/workersync"
 	"github.com/agent-substrate/substrate/internal/ateapiauth"
 	"github.com/agent-substrate/substrate/internal/serverboot"
+	"github.com/agent-substrate/substrate/internal/version"
 	clientv1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/agent-substrate/substrate/pkg/client/clientset/versioned"
 	"github.com/agent-substrate/substrate/pkg/client/informers/externalversions"
@@ -53,6 +55,7 @@ var (
 
 	ateAPIConnSpec = pflag.String("ateapi-conn-spec", "k8s:///api.ate-system.svc:443", "")
 
+	showVersion  = pflag.Bool("version", false, "Print version and exit.")
 	logLevelFlag = pflag.String("log-level", "info", "Minimum log level: debug, info, warn, or error.")
 
 	otelEndpoint = pflag.String("otel-exporter-otlp-endpoint", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
@@ -90,11 +93,16 @@ func newControllerRuntimeLogger(h slog.Handler) logr.Logger {
 
 func main() {
 	pflag.Parse()
+	if *showVersion {
+		fmt.Println(version.String())
+		return
+	}
 	ctx := context.Background()
 	serverboot.InitLogger()
 	if err := serverboot.SetLogLevel(*logLevelFlag); err != nil {
 		serverboot.Fatal(ctx, "Invalid --log-level", err)
 	}
+	slog.InfoContext(ctx, "atecontroller starting", slog.String("version", version.Version))
 	ctrl.SetLogger(newControllerRuntimeLogger(slog.Default().Handler()))
 
 	// Both providers must be registered before the ateapi client below:

--- a/cmd/atelet/main.go
+++ b/cmd/atelet/main.go
@@ -129,6 +129,7 @@ func main() {
 	if err := serverboot.SetLogLevel(*logLevelFlag); err != nil {
 		serverboot.Fatal(ctx, "Invalid --log-level", err)
 	}
+	slog.InfoContext(ctx, "atelet starting", slog.String("version", version.Version))
 
 	// Kept separate from ctx so in-flight work (e.g. a Checkpoint/Restore
 	// streaming a multi-GiB snapshot) is not cancelled the moment SIGTERM

--- a/cmd/atenet/internal/router/router.go
+++ b/cmd/atenet/internal/router/router.go
@@ -40,6 +40,7 @@ import (
 	"github.com/agent-substrate/substrate/cmd/atenet/internal/router/ingress"
 	"github.com/agent-substrate/substrate/internal/ateapiauth"
 	"github.com/agent-substrate/substrate/internal/serverboot"
+	"github.com/agent-substrate/substrate/internal/version"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 )
 
@@ -129,6 +130,7 @@ func (s *RouterServer) Run(ctx context.Context) error {
 	if err := serverboot.SetLogLevel(s.cfg.LogLevel); err != nil {
 		return err
 	}
+	slog.InfoContext(ctx, "atenet router starting", slog.String("version", version.Version))
 
 	// Tracing must be initialized before constructing the ateapi gRPC client
 	// below, because otelgrpc.NewClientHandler captures the global

--- a/cmd/atenet/internal/sdsmint/run.go
+++ b/cmd/atenet/internal/sdsmint/run.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/agent-substrate/substrate/internal/localca"
+	"github.com/agent-substrate/substrate/internal/version"
 	secretservice "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
 	"google.golang.org/grpc"
 )
@@ -38,6 +39,7 @@ func run(ctx context.Context, cfg config) error {
 		return err
 	}
 	slog.SetDefault(logger)
+	slog.InfoContext(ctx, "atenet sdsmint starting", slog.String("version", version.Version))
 
 	if cfg.UDSPath == "" {
 		return errors.New("--uds-path is required")

--- a/cmd/ateom-gvisor/main.go
+++ b/cmd/ateom-gvisor/main.go
@@ -128,7 +128,7 @@ func do(ctx context.Context) error {
 		return err
 	}
 
-	slog.InfoContext(ctx, "ateom booting")
+	slog.InfoContext(ctx, "ateom booting", slog.String("version", version.Version))
 
 	const serviceName = "ateom-gvisor"
 	// Export through atelet's node-local relay when it is there, so telemetry

--- a/cmd/ateom-microvm/main.go
+++ b/cmd/ateom-microvm/main.go
@@ -114,7 +114,7 @@ func do(ctx context.Context) error {
 	if err := serverboot.SetLogLevel(*logLevelFlag); err != nil {
 		return err
 	}
-	slog.InfoContext(ctx, "ateom-microvm booting", slog.String("version", version.String()))
+	slog.InfoContext(ctx, "ateom-microvm booting", slog.String("version", version.Version))
 
 	const serviceName = "ateom-microvm"
 	// Export through atelet's node-local relay when it is there, so telemetry

--- a/cmd/podcertcontroller/main.go
+++ b/cmd/podcertcontroller/main.go
@@ -103,6 +103,7 @@ func main() {
 		return
 	}
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+	slog.InfoContext(ctx, "podcertcontroller starting", slog.String("version", version.Version))
 
 	var kconfig *rest.Config
 	var err error


### PR DESCRIPTION
Emit one "<component> starting" line right after the logger is up, carrying the stamped version.
atecontroller also gains the --version flag it was missing.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
