### PR TITLE
apitool: extend the linter to understand Actor's EgressPolicy sub-resource

### DIFF
--- a/tools/apitool/internal/lint/create.go
+++ b/tools/apitool/internal/lint/create.go
@@ -40,6 +40,7 @@ func checkCreateRequestShape(api *model.API) ([]Finding, error) {
 
 	var findings []Finding
 	for _, rg := range resources {
+		parentName, isSubResource := model.ParentResourceName(rg.Message.Name)
 		for _, m := range rg.Methods {
 			verb, ok := standardVerbFor(m.Name, rg.Message.Name)
 			if !ok || verb != "Create" {
@@ -53,7 +54,7 @@ func checkCreateRequestShape(api *model.API) ([]Finding, error) {
 				continue
 			}
 
-			var resourceFields, optionsFields int
+			var resourceFields, optionsFields, parentFields int
 			for _, f := range req.Fields {
 				switch {
 				case f.TypeKind == "message" && f.TypeFullName == rg.Message.FullName:
@@ -64,12 +65,24 @@ func checkCreateRequestShape(api *model.API) ([]Finding, error) {
 							Message: fmt.Sprintf("resource field is named %q, want %q", f.Name, want),
 						})
 					}
+				case isSubResource && f.TypeKind == "message" && f.TypeFullName == objectRefTypeFullName:
+					parentFields++
+					if want := fieldNameForResource(parentName); f.Name != want {
+						findings = append(findings, Finding{
+							Subject: subject,
+							Message: fmt.Sprintf("parent field is named %q, want %q", f.Name, want),
+						})
+					}
 				case f.TypeKind == "message" && f.TypeFullName == createOptionsTypeFullName:
 					optionsFields++
 				default:
+					wantTypes := fmt.Sprintf("%s or %s", rg.Message.FullName, createOptionsTypeFullName)
+					if isSubResource {
+						wantTypes = fmt.Sprintf("%s, %s, or %s", rg.Message.FullName, objectRefTypeFullName, createOptionsTypeFullName)
+					}
 					findings = append(findings, Finding{
 						Subject: subject,
-						Message: fmt.Sprintf("field %q is %s, want %s or %s - non-resource control fields belong in %s", f.Name, fieldTypeDescription(f), rg.Message.FullName, createOptionsTypeFullName, createOptionsTypeFullName),
+						Message: fmt.Sprintf("field %q is %s, want %s - non-resource control fields belong in %s", f.Name, fieldTypeDescription(f), wantTypes, createOptionsTypeFullName),
 					})
 				}
 			}
@@ -83,6 +96,12 @@ func checkCreateRequestShape(api *model.API) ([]Finding, error) {
 				findings = append(findings, Finding{
 					Subject: subject,
 					Message: fmt.Sprintf("request has %d field(s) of type %s, want at most 1", optionsFields, createOptionsTypeFullName),
+				})
+			}
+			if isSubResource && parentFields != 1 {
+				findings = append(findings, Finding{
+					Subject: subject,
+					Message: fmt.Sprintf("request has %d field(s) of type %s identifying the parent %s, want exactly 1", parentFields, objectRefTypeFullName, parentName),
 				})
 			}
 		}

--- a/tools/apitool/internal/lint/create_test.go
+++ b/tools/apitool/internal/lint/create_test.go
@@ -65,3 +65,34 @@ func TestCreateRequestShape_IgnoresGetDelete(t *testing.T) {
 		t.Errorf("Check() = %+v, want no findings for a Delete method", findings)
 	}
 }
+
+// TestCreateRequestShape_SubResource confirms a sub-resource's Create
+// request must also embed an ObjectRef identifying the parent, named after
+// the parent resource.
+func TestCreateRequestShape_SubResource(t *testing.T) {
+	resourceField := model.Field{Name: "egress_policy", TypeKind: "message", TypeFullName: "test.EgressPolicy"}
+	parentField := model.Field{Name: "actor", TypeKind: "message", TypeFullName: "ateapi.ObjectRef"}
+	misnamedParentField := model.Field{Name: "parent", TypeKind: "message", TypeFullName: "ateapi.ObjectRef"}
+
+	tests := []struct {
+		name        string
+		reqFields   []model.Field
+		wantFinding bool
+	}{
+		{"resource plus parent field", []model.Field{resourceField, parentField}, false},
+		{"missing the parent field", []model.Field{resourceField}, true},
+		{"parent field, wrong name", []model.Field{resourceField, misnamedParentField}, true},
+		{"two parent fields", []model.Field{resourceField, parentField, parentField}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings, err := lint.CreateRequestShape.Check(subResourceMethodAPI("Create", tt.reqFields))
+			if err != nil {
+				t.Fatalf("Check() error = %v", err)
+			}
+			if got := len(findings) > 0; got != tt.wantFinding {
+				t.Errorf("Check() findings = %+v, want a finding: %v", findings, tt.wantFinding)
+			}
+		})
+	}
+}

--- a/tools/apitool/internal/lint/delete.go
+++ b/tools/apitool/internal/lint/delete.go
@@ -59,7 +59,7 @@ func checkDeleteRequestShape(api *model.API) ([]Finding, error) {
 				switch {
 				case f.TypeKind == "message" && f.TypeFullName == objectRefTypeFullName:
 					objectRefFields++
-					if want := fieldNameForResource(rg.Message.Name); f.Name != want {
+					if want := fieldNameForResource(locatorResourceName(rg.Message.Name)); f.Name != want {
 						findings = append(findings, Finding{
 							Subject: subject,
 							Message: fmt.Sprintf("resource field is named %q, want %q", f.Name, want),

--- a/tools/apitool/internal/lint/delete_test.go
+++ b/tools/apitool/internal/lint/delete_test.go
@@ -64,6 +64,30 @@ func TestDeleteRequestShape_IgnoresCreateUpdate(t *testing.T) {
 	}
 }
 
+// TestDeleteRequestShape_SubResource confirms a sub-resource's Delete
+// request identifies the parent, not the (fixed-name) sub-resource itself.
+func TestDeleteRequestShape_SubResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		reqFields   []model.Field
+		wantFinding bool
+	}{
+		{"named after the parent", []model.Field{{Name: "actor", TypeKind: "message", TypeFullName: "ateapi.ObjectRef"}}, false},
+		{"named after the sub-resource instead", []model.Field{{Name: "egress_policy", TypeKind: "message", TypeFullName: "ateapi.ObjectRef"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings, err := lint.DeleteRequestShape.Check(subResourceMethodAPI("Delete", tt.reqFields))
+			if err != nil {
+				t.Fatalf("Check() error = %v", err)
+			}
+			if got := len(findings) > 0; got != tt.wantFinding {
+				t.Errorf("Check() findings = %+v, want a finding: %v", findings, tt.wantFinding)
+			}
+		})
+	}
+}
+
 // deleteOptionsAPI builds a minimal API with just the shared
 // ateapi.DeleteOptions message, with the given fields.
 func deleteOptionsAPI(fields []model.Field) *model.API {

--- a/tools/apitool/internal/lint/fixtures_test.go
+++ b/tools/apitool/internal/lint/fixtures_test.go
@@ -101,3 +101,21 @@ func updateMethodAPI(reqFields []model.Field) *model.API {
 		},
 	}
 }
+
+// subResourceMethodAPI builds a minimal API with one
+// Control.{verb}ActorEgressPolicy method - "EgressPolicy" is a sub-resource
+// of "Actor" (see model.ParentResourceName) - with the given request fields.
+func subResourceMethodAPI(verb string, reqFields []model.Field) *model.API {
+	return &model.API{
+		Services: []model.Service{{
+			Name: "Control",
+			Methods: []model.Method{
+				{Name: verb + "ActorEgressPolicy", ServiceName: "Control", InputName: "test." + verb + "ActorEgressPolicyRequest", OutputName: "test.EgressPolicy"},
+			},
+		}},
+		Messages: []model.Message{
+			{FullName: "test.EgressPolicy", Name: "EgressPolicy"},
+			{FullName: "test." + verb + "ActorEgressPolicyRequest", Name: verb + "ActorEgressPolicyRequest", Fields: reqFields},
+		},
+	}
+}

--- a/tools/apitool/internal/lint/get.go
+++ b/tools/apitool/internal/lint/get.go
@@ -65,7 +65,7 @@ func checkGetRequestSingleObjectRef(api *model.API) ([]Finding, error) {
 				})
 				continue
 			}
-			if want := fieldNameForResource(rg.Message.Name); f.Name != want {
+			if want := fieldNameForResource(locatorResourceName(rg.Message.Name)); f.Name != want {
 				findings = append(findings, Finding{
 					Subject: subject,
 					Message: fmt.Sprintf("resource field is named %q, want %q", f.Name, want),

--- a/tools/apitool/internal/lint/get_test.go
+++ b/tools/apitool/internal/lint/get_test.go
@@ -62,3 +62,27 @@ func TestGetRequestSingleObjectRef_IgnoresCreateUpdate(t *testing.T) {
 		t.Errorf("Check() = %+v, want no findings for a Create method", findings)
 	}
 }
+
+// TestGetRequestSingleObjectRef_SubResource confirms a sub-resource's Get
+// request identifies the parent, not the (fixed-name) sub-resource itself.
+func TestGetRequestSingleObjectRef_SubResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		reqFields   []model.Field
+		wantFinding bool
+	}{
+		{"named after the parent", []model.Field{{Name: "actor", TypeKind: "message", TypeFullName: "ateapi.ObjectRef"}}, false},
+		{"named after the sub-resource instead", []model.Field{{Name: "egress_policy", TypeKind: "message", TypeFullName: "ateapi.ObjectRef"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings, err := lint.GetRequestSingleObjectRef.Check(subResourceMethodAPI("Get", tt.reqFields))
+			if err != nil {
+				t.Fatalf("Check() error = %v", err)
+			}
+			if got := len(findings) > 0; got != tt.wantFinding {
+				t.Errorf("Check() findings = %+v, want a finding: %v", findings, tt.wantFinding)
+			}
+		})
+	}
+}

--- a/tools/apitool/internal/lint/naming.go
+++ b/tools/apitool/internal/lint/naming.go
@@ -17,6 +17,8 @@ package lint
 import (
 	"regexp"
 	"strings"
+
+	"github.com/agent-substrate/substrate/tools/apitool/internal/model"
 )
 
 var pascalBoundary = regexp.MustCompile(`([a-z0-9])([A-Z])`)
@@ -31,4 +33,17 @@ func fieldNameForResource(resourceName string) string {
 
 func repeatedFieldNameForList(methodName string) string {
 	return snakeCase(strings.TrimPrefix(methodName, "List"))
+}
+
+// locatorResourceName returns the resource a Get/Delete request should
+// identify by ObjectRef: resourceName itself for a top-level resource, or
+// its parent for a sub-resource - a sub-resource's Get/Delete request
+// identifies the parent, since the sub-resource itself has a fixed, implied
+// name (for example, GetActorEgressPolicyRequest carries an "actor" field,
+// not an "egress_policy" one).
+func locatorResourceName(resourceName string) string {
+	if parent, ok := model.ParentResourceName(resourceName); ok {
+		return parent
+	}
+	return resourceName
 }

--- a/tools/apitool/internal/lint/standard_methods.go
+++ b/tools/apitool/internal/lint/standard_methods.go
@@ -55,8 +55,12 @@ func checkStandardMethodReturnsResource(api *model.API) ([]Finding, error) {
 }
 
 func standardVerbFor(methodName, resourceName string) (verb string, ok bool) {
+	name := resourceName
+	if parent, isSubResource := model.ParentResourceName(resourceName); isSubResource {
+		name = parent + resourceName
+	}
 	for _, v := range []string{"Get", "Create", "Update", "Delete"} {
-		if methodName == v+resourceName {
+		if methodName == v+name {
 			return v, true
 		}
 	}

--- a/tools/apitool/internal/lint/standard_methods_test.go
+++ b/tools/apitool/internal/lint/standard_methods_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/agent-substrate/substrate/tools/apitool/internal/lint"
+	"github.com/agent-substrate/substrate/tools/apitool/internal/model"
 )
 
 func TestStandardMethodReturnsResource(t *testing.T) {
@@ -32,6 +33,44 @@ func TestStandardMethodReturnsResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			findings, err := lint.StandardMethodReturnsResource.Check(standardMethodAPI(tt.outputName, nil))
+			if err != nil {
+				t.Fatalf("Check() error = %v", err)
+			}
+			if got := len(findings) > 0; got != tt.wantFinding {
+				t.Errorf("Check() findings = %+v, want a finding: %v", findings, tt.wantFinding)
+			}
+		})
+	}
+}
+
+// TestStandardMethodReturnsResource_SubResource confirms the rule
+// recognizes a sub-resource's standard methods (named
+// "{Verb}{Parent}{Resource}", e.g. GetActorEgressPolicy) as standard Get
+// methods, not as ignored custom ones.
+func TestStandardMethodReturnsResource_SubResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		outputName  string
+		wantFinding bool
+	}{
+		{"returns the sub-resource directly", "test.EgressPolicy", false},
+		{"returns a wrapper instead", "test.GetActorEgressPolicyResponse", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &model.API{
+				Services: []model.Service{{
+					Name: "Control",
+					Methods: []model.Method{
+						{Name: "GetActorEgressPolicy", ServiceName: "Control", InputName: "test.GetActorEgressPolicyRequest", OutputName: tt.outputName},
+					},
+				}},
+				Messages: []model.Message{
+					{FullName: "test.EgressPolicy", Name: "EgressPolicy"},
+					{FullName: "test.GetActorEgressPolicyRequest", Name: "GetActorEgressPolicyRequest"},
+				},
+			}
+			findings, err := lint.StandardMethodReturnsResource.Check(api)
 			if err != nil {
 				t.Fatalf("Check() error = %v", err)
 			}

--- a/tools/apitool/internal/lint/update.go
+++ b/tools/apitool/internal/lint/update.go
@@ -41,6 +41,7 @@ func checkUpdateRequestShape(api *model.API) ([]Finding, error) {
 
 	var findings []Finding
 	for _, rg := range resources {
+		parentName, isSubResource := model.ParentResourceName(rg.Message.Name)
 		for _, m := range rg.Methods {
 			verb, ok := standardVerbFor(m.Name, rg.Message.Name)
 			if !ok || verb != "Update" {
@@ -54,7 +55,7 @@ func checkUpdateRequestShape(api *model.API) ([]Finding, error) {
 				continue
 			}
 
-			var resourceFields int
+			var resourceFields, parentFields int
 			for _, f := range req.Fields {
 				switch {
 				case f.TypeKind == "message" && f.TypeFullName == rg.Message.FullName:
@@ -65,12 +66,24 @@ func checkUpdateRequestShape(api *model.API) ([]Finding, error) {
 							Message: fmt.Sprintf("resource field is named %q, want %q", f.Name, want),
 						})
 					}
+				case isSubResource && f.TypeKind == "message" && f.TypeFullName == objectRefTypeFullName:
+					parentFields++
+					if want := fieldNameForResource(parentName); f.Name != want {
+						findings = append(findings, Finding{
+							Subject: subject,
+							Message: fmt.Sprintf("parent field is named %q, want %q", f.Name, want),
+						})
+					}
 				case f.TypeKind == "message" && f.TypeFullName == fieldMaskTypeFullName:
 					// Field masks are being phased out; not policed by this rule.
 				default:
+					wantTypes := rg.Message.FullName
+					if isSubResource {
+						wantTypes = fmt.Sprintf("%s or %s", rg.Message.FullName, objectRefTypeFullName)
+					}
 					findings = append(findings, Finding{
 						Subject: subject,
-						Message: fmt.Sprintf("field %q is %s, want %s - non-resource control fields belong elsewhere", f.Name, fieldTypeDescription(f), rg.Message.FullName),
+						Message: fmt.Sprintf("field %q is %s, want %s - non-resource control fields belong elsewhere", f.Name, fieldTypeDescription(f), wantTypes),
 					})
 				}
 			}
@@ -78,6 +91,12 @@ func checkUpdateRequestShape(api *model.API) ([]Finding, error) {
 				findings = append(findings, Finding{
 					Subject: subject,
 					Message: fmt.Sprintf("request has %d field(s) of type %s, want exactly 1 embedding the resource", resourceFields, rg.Message.FullName),
+				})
+			}
+			if isSubResource && parentFields != 1 {
+				findings = append(findings, Finding{
+					Subject: subject,
+					Message: fmt.Sprintf("request has %d field(s) of type %s identifying the parent %s, want exactly 1", parentFields, objectRefTypeFullName, parentName),
 				})
 			}
 		}

--- a/tools/apitool/internal/lint/update_test.go
+++ b/tools/apitool/internal/lint/update_test.go
@@ -68,3 +68,34 @@ func TestUpdateRequestShape_IgnoresGetDelete(t *testing.T) {
 		t.Errorf("Check() = %+v, want no findings for a Delete method", findings)
 	}
 }
+
+// TestUpdateRequestShape_SubResource confirms a sub-resource's Update
+// request must also embed an ObjectRef identifying the parent, named after
+// the parent resource.
+func TestUpdateRequestShape_SubResource(t *testing.T) {
+	resourceField := model.Field{Name: "egress_policy", TypeKind: "message", TypeFullName: "test.EgressPolicy"}
+	parentField := model.Field{Name: "actor", TypeKind: "message", TypeFullName: "ateapi.ObjectRef"}
+	misnamedParentField := model.Field{Name: "parent", TypeKind: "message", TypeFullName: "ateapi.ObjectRef"}
+
+	tests := []struct {
+		name        string
+		reqFields   []model.Field
+		wantFinding bool
+	}{
+		{"resource plus parent field", []model.Field{resourceField, parentField}, false},
+		{"missing the parent field", []model.Field{resourceField}, true},
+		{"parent field, wrong name", []model.Field{resourceField, misnamedParentField}, true},
+		{"two parent fields", []model.Field{resourceField, parentField, parentField}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings, err := lint.UpdateRequestShape.Check(subResourceMethodAPI("Update", tt.reqFields))
+			if err != nil {
+				t.Fatalf("Check() error = %v", err)
+			}
+			if got := len(findings) > 0; got != tt.wantFinding {
+				t.Errorf("Check() findings = %+v, want a finding: %v", findings, tt.wantFinding)
+			}
+		})
+	}
+}

--- a/tools/apitool/internal/model/model.go
+++ b/tools/apitool/internal/model/model.go
@@ -550,7 +550,8 @@ func Resources(api *API) ([]Resource, error) {
 }
 
 // TODO: We should consider adding proto options to attach this (and other)
-// metadata in the proto service descriptor itself.
+// metadata, including subResourceParents below, in the proto service
+// descriptor itself.
 var resourceNames = []string{
 	"Actor",
 	"ActorSnapshot",
@@ -558,6 +559,26 @@ var resourceNames = []string{
 	"ActorTemplate",
 	"Atespace",
 	"Worker",
+	"EgressPolicy",
+}
+
+// subResourceParents maps a sub-resource's short name to the short name of
+// the resource it's nested directly under (one level - a sub-resource of a
+// sub-resource isn't represented here). For example, "EgressPolicy" is
+// nested under "Actor": its standard methods are named GetActorEgressPolicy,
+// not GetEgressPolicy, and its Get/Delete requests identify the parent
+// Actor rather than the (fixed-name) EgressPolicy itself. A name absent
+// from this map is a top-level resource.
+var subResourceParents = map[string]string{
+	"EgressPolicy": "Actor",
+}
+
+// ParentResourceName returns the short name of the resource resourceName is
+// nested under, and true - or "", false if resourceName is a top-level
+// resource.
+func ParentResourceName(resourceName string) (string, bool) {
+	parent, ok := subResourceParents[resourceName]
+	return parent, ok
 }
 
 func resourceForMethodName(methodName string) (string, error) {

--- a/tools/apitool/internal/model/model_test.go
+++ b/tools/apitool/internal/model/model_test.go
@@ -251,6 +251,52 @@ message Worker { string name = 1; }
 	}
 }
 
+// TestResources_SubResource confirms a sub-resource's methods (named
+// "{Verb}{Parent}{Resource}", e.g. GetActorEgressPolicy) group under the
+// sub-resource, not the parent, since "EgressPolicy" is a longer, more
+// specific match than "Actor" (see resourceNames/subResourceParents).
+func TestResources_SubResource(t *testing.T) {
+	api := buildAPI(t, `
+service FixtureService {
+  rpc GetActor(GetActorRequest) returns (Actor);
+  rpc GetActorEgressPolicy(GetActorEgressPolicyRequest) returns (EgressPolicy);
+}
+
+message GetActorRequest { string name = 1; }
+message GetActorEgressPolicyRequest { string name = 1; }
+
+message Actor { string name = 1; }
+message EgressPolicy { string name = 1; }
+`)
+
+	groups, err := model.Resources(api)
+	if err != nil {
+		t.Fatalf("Resources() error = %v", err)
+	}
+
+	var egressPolicyGroup *model.Resource
+	for i := range groups {
+		if groups[i].Message.Name == "EgressPolicy" {
+			egressPolicyGroup = &groups[i]
+		}
+	}
+	if egressPolicyGroup == nil {
+		t.Fatalf("no Resource for EgressPolicy; groups = %+v", groups)
+	}
+	if len(egressPolicyGroup.Methods) != 1 || egressPolicyGroup.Methods[0].Name != "GetActorEgressPolicy" {
+		t.Errorf("EgressPolicy group methods = %+v, want just [GetActorEgressPolicy]", egressPolicyGroup.Methods)
+	}
+}
+
+func TestParentResourceName(t *testing.T) {
+	if parent, ok := model.ParentResourceName("EgressPolicy"); !ok || parent != "Actor" {
+		t.Errorf(`ParentResourceName("EgressPolicy") = (%q, %v), want ("Actor", true)`, parent, ok)
+	}
+	if parent, ok := model.ParentResourceName("Actor"); ok {
+		t.Errorf(`ParentResourceName("Actor") = (%q, %v), want ok = false for a top-level resource`, parent, ok)
+	}
+}
+
 func TestResources_InvalidMethodName(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

Docs note: this change only affects `apitool`'s internal rule logic
(the rules' own `Description` strings and `tools/apitool/README.md`'s
description of the tool already cover this; no separate doc describes
the sub-resource shapes beyond the proto comments, which are unchanged).

Fixes #1427