### PR TITLE
A few improvements to `kubectl ate get workers`.

### DIFF
--- a/cmd/kubectl-ate/internal/cmd/get_test.go
+++ b/cmd/kubectl-ate/internal/cmd/get_test.go
@@ -38,7 +38,8 @@ func TestGetCommandArgs(t *testing.T) {
 		{name: "atespaces get", command: getAtespacesCmd, args: []string{"team-a"}},
 		{name: "atespaces get multiple", command: getAtespacesCmd, args: []string{"team-a", "team-b"}},
 		{name: "workers list", command: getWorkersCmd},
-		{name: "workers reject argument", command: getWorkersCmd, args: []string{"worker-1"}, wantErr: true},
+		{name: "workers get", command: getWorkersCmd, args: []string{"worker-1"}},
+		{name: "workers get multiple", command: getWorkersCmd, args: []string{"worker-1", "worker-2"}},
 		{name: "top workers list", command: topWorkersCmd},
 		{name: "top workers reject argument", command: topWorkersCmd, args: []string{"worker-1"}, wantErr: true},
 	}

--- a/cmd/kubectl-ate/internal/cmd/get_workers.go
+++ b/cmd/kubectl-ate/internal/cmd/get_workers.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/agent-substrate/substrate/cmd/kubectl-ate/internal/printer"
 	"github.com/agent-substrate/substrate/internal/ateclient"
+	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/spf13/cobra"
 )
 
@@ -33,10 +33,9 @@ var (
 )
 
 var getWorkersCmd = &cobra.Command{
-	Use:     "workers",
+	Use:     "workers <worker-name ...>",
 	Aliases: []string{"worker"},
-	Short:   "List all workers",
-	Args:    cobra.NoArgs,
+	Short:   "List all workers or get one or more workers",
 	RunE:    runGetWorkers,
 }
 
@@ -51,7 +50,9 @@ func init() {
 // GetWorkersRunner executes the get workers command logic.
 type GetWorkersRunner struct {
 	workerLister WorkerLister
+	workerGetter WorkerGetter
 	actorLister  ActorLister
+	names        []string
 	namespace    string
 	atespace     string
 	selector     string
@@ -61,6 +62,21 @@ type GetWorkersRunner struct {
 }
 
 func (r *GetWorkersRunner) Run(ctx context.Context) error {
+	if len(r.names) > 0 {
+		if r.namespace != "" || r.atespace != "" || r.selector != "" || r.sandboxClass != "" {
+			return fmt.Errorf("filter flags (--namespace, --atespace, --selector, --sandbox-class) cannot be used when getting workers by name")
+		}
+		workers := make([]*ateapipb.Worker, 0, len(r.names))
+		for _, name := range r.names {
+			worker, err := r.workerGetter.GetWorker(ctx, &ateapipb.GetWorkerRequest{Worker: &ateapipb.ObjectRef{Name: name}})
+			if err != nil {
+				return fmt.Errorf("failed to get worker %q: %w", name, err)
+			}
+			workers = append(workers, worker)
+		}
+		return printer.PrintWorkersTo(r.out, workers, r.outputFmt)
+	}
+
 	workers, err := listAllWorkers(ctx, r.workerLister)
 	if err != nil {
 		return err
@@ -69,12 +85,7 @@ func (r *GetWorkersRunner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	outWriter := r.out
-	if outWriter == nil {
-		outWriter = os.Stdout
-	}
-	return printer.PrintWorkersTo(outWriter, filtered, r.outputFmt)
+	return printer.PrintWorkersTo(r.out, filtered, r.outputFmt)
 }
 
 func runGetWorkers(cmd *cobra.Command, args []string) error {
@@ -87,13 +98,15 @@ func runGetWorkers(cmd *cobra.Command, args []string) error {
 
 	runner := &GetWorkersRunner{
 		workerLister: apiClient,
+		workerGetter: apiClient,
 		actorLister:  apiClient,
+		names:        args,
 		namespace:    getWorkerNamespaceFlag,
 		atespace:     getWorkerAtespaceFlag,
 		selector:     getWorkerSelectorFlag,
 		sandboxClass: getWorkerClassFlag,
 		outputFmt:    outputFmt,
-		out:          os.Stdout,
+		out:          cmd.OutOrStdout(),
 	}
 	return runner.Run(ctx)
 }

--- a/cmd/kubectl-ate/internal/cmd/get_workers_test.go
+++ b/cmd/kubectl-ate/internal/cmd/get_workers_test.go
@@ -17,39 +17,81 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/agent-substrate/substrate/cmd/kubectl-ate/internal/printer"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// mockWorkerGetter serves GetWorker calls from a name-keyed map, as the
+// GetWorkersRunner requires when getting workers by name.
+type mockWorkerGetter struct {
+	workers map[string]*ateapipb.Worker
+	err     error
+}
+
+func (m *mockWorkerGetter) GetWorker(ctx context.Context, req *ateapipb.GetWorkerRequest, opts ...grpc.CallOption) (*ateapipb.Worker, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	worker, ok := m.workers[req.GetWorker().GetName()]
+	if !ok {
+		return nil, errors.New("worker not found")
+	}
+	return worker, nil
+}
+
+func pinTime(t *testing.T, now time.Time) {
+	t.Helper()
+	prev := printer.TimeNow
+	printer.TimeNow = func() time.Time { return now }
+	t.Cleanup(func() { printer.TimeNow = prev })
+}
+
 func TestGetWorkersRunner_Filters(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinTime(t, now)
+
 	workers := []*ateapipb.Worker{
 		{
-			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-1"},
+			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-1", CreateTime: timestamppb.New(now.Add(-5 * time.Minute))},
 			WorkerNamespace: "ns-1",
 			WorkerPool:      "counter",
 			WorkerPod:       "pod-1",
 			SandboxClass:    "microvm",
 			Labels:          map[string]string{"ate.dev/worker-pool": "counter"},
-			Status:          &ateapipb.WorkerStatus{Capacity: &ateapipb.WorkerResources{Actors: 1}, Allocated: &ateapipb.WorkerResources{Actors: 1}},
+			Status: &ateapipb.WorkerStatus{
+				State:     ateapipb.WorkerState_WORKER_STATE_ACTIVE,
+				Capacity:  &ateapipb.WorkerResources{Actors: 1},
+				Allocated: &ateapipb.WorkerResources{Actors: 1},
+			},
 		},
 		{
-			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-2"},
+			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-2", CreateTime: timestamppb.New(now.Add(-3 * time.Hour))},
 			WorkerNamespace: "ns-1",
 			WorkerPool:      "other",
 			WorkerPod:       "pod-2",
 			SandboxClass:    "gvisor",
 			Labels:          map[string]string{"ate.dev/worker-pool": "other"},
+			Status:          &ateapipb.WorkerStatus{State: ateapipb.WorkerState_WORKER_STATE_ACTIVE},
 		},
 		{
-			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-3"},
+			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-3", CreateTime: timestamppb.New(now.Add(-72 * time.Hour))},
 			WorkerNamespace: "ns-2",
 			WorkerPool:      "counter",
 			WorkerPod:       "pod-3",
 			SandboxClass:    "gvisor",
 			Labels:          map[string]string{"ate.dev/worker-pool": "counter"},
-			Status:          &ateapipb.WorkerStatus{Capacity: &ateapipb.WorkerResources{Actors: 1}, Allocated: &ateapipb.WorkerResources{Actors: 1}},
+			Status: &ateapipb.WorkerStatus{
+				State:     ateapipb.WorkerState_WORKER_STATE_ACTIVE,
+				Capacity:  &ateapipb.WorkerResources{Actors: 1},
+				Allocated: &ateapipb.WorkerResources{Actors: 1},
+			},
 		},
 	}
 	actors := &mockActorLister{byAtespace: map[string][]*ateapipb.Actor{
@@ -57,10 +99,10 @@ func TestGetWorkersRunner_Filters(t *testing.T) {
 		"space-b": {actorOn("space-b", "actor-b", "worker-3")},
 	}}
 
-	header := "NAMESPACE   POOL      CLASS     POD     STATUS\n"
-	row1 := "ns-1        counter   microvm   pod-1   ASSIGNED(1/1)\n"
-	row2 := "ns-1        other     gvisor    pod-2   FREE\n"
-	row3 := "ns-2        counter   gvisor    pod-3   ASSIGNED(1/1)\n"
+	header := "NAME       POOL      STATE                 ACTORS   CPU   MEMORY   POD          AGE\n"
+	row1 := "worker-1   counter   WORKER_STATE_ACTIVE   1/1      -     -        ns-1/pod-1   5m\n"
+	row2 := "worker-2   other     WORKER_STATE_ACTIVE   0/0      -     -        ns-1/pod-2   3h\n"
+	row3 := "worker-3   counter   WORKER_STATE_ACTIVE   1/1      -     -        ns-2/pod-3   3d\n"
 
 	tests := []struct {
 		name         string
@@ -74,13 +116,10 @@ func TestGetWorkersRunner_Filters(t *testing.T) {
 		{name: "namespace", namespace: "ns-1", expected: header + row1 + row2},
 		{name: "atespace", atespace: "space-a", expected: header + row1},
 		// With no matching rows the tabwriter sizes columns to the header alone.
-		{name: "atespace excludes free workers", atespace: "no-such-space", expected: "NAMESPACE   POOL   CLASS   POD   STATUS\n"},
+		{name: "atespace excludes free workers", atespace: "no-such-space", expected: "NAME   POOL   STATE   ACTORS   CPU   MEMORY   POD   AGE\n"},
 		{name: "selector", selector: "ate.dev/worker-pool=counter", expected: header + row1 + row3},
 		{name: "sandbox class", sandboxClass: "microvm", expected: header + row1},
-		// gvisor-only rows shrink the CLASS column to the widest survivor.
-		{name: "sandbox class gvisor", sandboxClass: "gvisor", expected: "NAMESPACE   POOL      CLASS    POD     STATUS\n" +
-			"ns-1        other     gvisor   pod-2   FREE\n" +
-			"ns-2        counter   gvisor   pod-3   ASSIGNED(1/1)\n"},
+		{name: "sandbox class gvisor", sandboxClass: "gvisor", expected: header + row2 + row3},
 		{name: "combined", namespace: "ns-1", selector: "ate.dev/worker-pool=counter", expected: header + row1},
 	}
 
@@ -115,5 +154,84 @@ func TestGetWorkersRunner_InvalidSelector(t *testing.T) {
 
 	if err := runner.Run(context.Background()); err == nil {
 		t.Errorf("expected error for invalid label selector, got nil")
+	}
+}
+
+func TestGetWorkersRunner_GetByName(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinTime(t, now)
+
+	getter := &mockWorkerGetter{workers: map[string]*ateapipb.Worker{
+		"worker-1": {
+			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-1", CreateTime: timestamppb.New(now.Add(-5 * time.Minute))},
+			WorkerNamespace: "ns-1",
+			WorkerPool:      "counter",
+			WorkerPod:       "pod-1",
+			Status: &ateapipb.WorkerStatus{
+				State: ateapipb.WorkerState_WORKER_STATE_ACTIVE,
+				Capacity: &ateapipb.WorkerResources{Actors: 4, Resources: &ateapipb.Resources{Limits: []*ateapipb.Limits{
+					{Name: "cpu", Quantity: "2"}, {Name: "memory", Quantity: "4Gi"},
+				}}},
+				Allocated: &ateapipb.WorkerResources{Actors: 1, Resources: &ateapipb.Resources{Limits: []*ateapipb.Limits{
+					{Name: "cpu", Quantity: "500m"}, {Name: "memory", Quantity: "1Gi"},
+				}}},
+			},
+		},
+		"worker-2": {
+			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-2", CreateTime: timestamppb.New(now.Add(-72 * time.Hour))},
+			WorkerNamespace: "ns-1",
+			WorkerPool:      "counter",
+			WorkerPod:       "pod-2",
+			Status:          &ateapipb.WorkerStatus{State: ateapipb.WorkerState_WORKER_STATE_DRAINING},
+		},
+	}}
+
+	var buf bytes.Buffer
+	runner := &GetWorkersRunner{
+		workerGetter: getter,
+		names:        []string{"worker-1", "worker-2"},
+		outputFmt:    "table",
+		out:          &buf,
+	}
+	if err := runner.Run(context.Background()); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	expected := "NAME       POOL      STATE                   ACTORS   CPU      MEMORY    POD          AGE\n" +
+		"worker-1   counter   WORKER_STATE_ACTIVE     1/4      500m/2   1Gi/4Gi   ns-1/pod-1   5m\n" +
+		"worker-2   counter   WORKER_STATE_DRAINING   0/0      -        -         ns-1/pod-2   3d\n"
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetWorkersRunner_GetByName_Error(t *testing.T) {
+	runner := &GetWorkersRunner{
+		workerGetter: &mockWorkerGetter{err: errors.New("rpc failed")},
+		names:        []string{"missing-worker"},
+	}
+
+	if err := runner.Run(context.Background()); err == nil {
+		t.Errorf("expected error for failed GetWorker, got nil")
+	}
+}
+
+func TestGetWorkersRunner_GetByName_RejectsFilters(t *testing.T) {
+	tests := []struct {
+		name   string
+		runner GetWorkersRunner
+	}{
+		{name: "namespace", runner: GetWorkersRunner{names: []string{"worker-1"}, namespace: "ns-1"}},
+		{name: "atespace", runner: GetWorkersRunner{names: []string{"worker-1"}, atespace: "space-a"}},
+		{name: "selector", runner: GetWorkersRunner{names: []string{"worker-1"}, selector: "foo=bar"}},
+		{name: "sandbox class", runner: GetWorkersRunner{names: []string{"worker-1"}, sandboxClass: "gvisor"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.runner.Run(context.Background()); err == nil {
+				t.Errorf("expected error combining names with a filter flag, got nil")
+			}
+		})
 	}
 }

--- a/cmd/kubectl-ate/internal/cmd/workers.go
+++ b/cmd/kubectl-ate/internal/cmd/workers.go
@@ -34,6 +34,11 @@ type ActorLister interface {
 	ListActors(ctx context.Context, req *ateapipb.ListActorsRequest, opts ...grpc.CallOption) (*ateapipb.ListActorsResponse, error)
 }
 
+// WorkerGetter abstracts GetWorker RPC calls.
+type WorkerGetter interface {
+	GetWorker(ctx context.Context, req *ateapipb.GetWorkerRequest, opts ...grpc.CallOption) (*ateapipb.Worker, error)
+}
+
 // workersHostingAtespace names the Workers hosting an Actor in atespace. Asked
 // of the Actors, because a Worker listing reports how full each Worker is, not
 // which Actors it holds.

--- a/cmd/kubectl-ate/internal/printer/printer.go
+++ b/cmd/kubectl-ate/internal/printer/printer.go
@@ -32,14 +32,15 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// timeNow returns the current time. It is a package variable so tests can pin
-// it and make age rendering deterministic.
-var timeNow = time.Now
+// TimeNow returns the current time. It is a package variable, exported so
+// that tests in this package and in cmd can both pin it and make age
+// rendering deterministic.
+var TimeNow = time.Now
 
 // formatAge renders a resource's age from its creation timestamp, kubectl-style
 // (e.g. "5m", "3h", "2d").
 func formatAge(ts *timestamppb.Timestamp) string {
-	return duration.HumanDuration(timeNow().Sub(ts.AsTime()))
+	return duration.HumanDuration(TimeNow().Sub(ts.AsTime()))
 }
 
 // PrintActors prints a slice of actors to stdout in the requested format.
@@ -125,6 +126,38 @@ func sortWorkers(workers []*ateapipb.Worker) {
 	})
 }
 
+// workerActorsColumn renders a Worker's actor count as allocated/capacity
+// (e.g. "3/10").
+func workerActorsColumn(worker *ateapipb.Worker) string {
+	return fmt.Sprintf("%d/%d", worker.GetStatus().GetAllocated().GetActors(), worker.GetStatus().GetCapacity().GetActors())
+}
+
+// resourceLimit returns the quantity of the named limit (e.g. "cpu",
+// "memory"), or "" if it isn't set.
+func resourceLimit(res *ateapipb.Resources, name string) string {
+	for _, limit := range res.GetLimits() {
+		if limit.GetName() == name {
+			return limit.GetQuantity()
+		}
+	}
+	return ""
+}
+
+// workerResourceColumn renders a Worker's named resource limit as
+// allocated/capacity (e.g. "500m/2"). "-" if the Worker has no capacity
+// limit for that resource, since there is then nothing to compare against.
+func workerResourceColumn(worker *ateapipb.Worker, name string) string {
+	capacity := resourceLimit(worker.GetStatus().GetCapacity().GetResources(), name)
+	if capacity == "" {
+		return "-"
+	}
+	allocated := resourceLimit(worker.GetStatus().GetAllocated().GetResources(), name)
+	if allocated == "" {
+		allocated = "0"
+	}
+	return allocated + "/" + capacity
+}
+
 // PrintWorkersTo prints a slice of workers to the provided writer.
 func PrintWorkersTo(out io.Writer, workers []*ateapipb.Worker, format string) error {
 	sortWorkers(workers)
@@ -133,11 +166,17 @@ func PrintWorkersTo(out io.Writer, workers []*ateapipb.Worker, format string) er
 		return printProto(out, &ateapipb.ListWorkersResponse{Workers: workers}, format)
 	case "table":
 		w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
-		fmt.Fprintln(w, "NAMESPACE\tPOOL\tCLASS\tPOD\tSTATUS")
+		fmt.Fprintln(w, "NAME\tPOOL\tSTATE\tACTORS\tCPU\tMEMORY\tPOD\tAGE")
 		for _, worker := range workers {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-				worker.GetWorkerNamespace(), worker.GetWorkerPool(), worker.GetSandboxClass(),
-				worker.GetWorkerPod(), WorkerOccupancy(worker))
+			name := worker.GetMetadata().GetName()
+			pool := worker.GetWorkerPool()
+			state := worker.GetStatus().GetState().String()
+			pod := worker.GetWorkerNamespace() + "/" + worker.GetWorkerPod()
+			age := formatAge(worker.GetMetadata().GetCreateTime())
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				name, pool, state, workerActorsColumn(worker),
+				workerResourceColumn(worker, "cpu"), workerResourceColumn(worker, "memory"),
+				pod, age)
 		}
 		return w.Flush()
 	default:

--- a/cmd/kubectl-ate/internal/printer/printer_test.go
+++ b/cmd/kubectl-ate/internal/printer/printer_test.go
@@ -28,9 +28,9 @@ import (
 // age rendering is deterministic, restoring it on cleanup.
 func pinNow(t *testing.T, now time.Time) {
 	t.Helper()
-	prev := timeNow
-	timeNow = func() time.Time { return now }
-	t.Cleanup(func() { timeNow = prev })
+	prev := TimeNow
+	TimeNow = func() time.Time { return now }
+	t.Cleanup(func() { TimeNow = prev })
 }
 
 func TestFormatAge(t *testing.T) {
@@ -234,14 +234,26 @@ func TestPrintActorsTo_Invalid(t *testing.T) {
 }
 
 func TestPrintWorkersTo_Table(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
 	var buf bytes.Buffer
 	workers := []*ateapipb.Worker{
 		{
+			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-1", CreateTime: timestamppb.New(now.Add(-72 * time.Hour))},
 			WorkerNamespace: "default",
 			WorkerPool:      "pool-1",
 			WorkerPod:       "pod-1",
 			SandboxClass:    "gvisor",
-			Status:          &ateapipb.WorkerStatus{Capacity: &ateapipb.WorkerResources{Actors: 1}, Allocated: &ateapipb.WorkerResources{Actors: 1}},
+			Status: &ateapipb.WorkerStatus{
+				State: ateapipb.WorkerState_WORKER_STATE_ACTIVE,
+				Capacity: &ateapipb.WorkerResources{Actors: 4, Resources: &ateapipb.Resources{Limits: []*ateapipb.Limits{
+					{Name: "cpu", Quantity: "2"}, {Name: "memory", Quantity: "4Gi"},
+				}}},
+				Allocated: &ateapipb.WorkerResources{Actors: 1, Resources: &ateapipb.Resources{Limits: []*ateapipb.Limits{
+					{Name: "cpu", Quantity: "500m"}, {Name: "memory", Quantity: "1Gi"},
+				}}},
+			},
 		},
 	}
 
@@ -250,8 +262,8 @@ func TestPrintWorkersTo_Table(t *testing.T) {
 	}
 	output := buf.String()
 
-	expected := `NAMESPACE   POOL     CLASS    POD     STATUS
-default     pool-1   gvisor   pod-1   ASSIGNED(1/1)
+	expected := `NAME       POOL     STATE                 ACTORS   CPU      MEMORY    POD             AGE
+worker-1   pool-1   WORKER_STATE_ACTIVE   1/4      500m/2   1Gi/4Gi   default/pod-1   3d
 `
 	if diff := cmp.Diff(expected, output); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -260,8 +272,13 @@ default     pool-1   gvisor   pod-1   ASSIGNED(1/1)
 
 // A worker assigned to an actor created from a substrate ActorTemplate
 // carries only ActorTemplateRef; the printer must not dereference the legacy
-// CRD ref (regression test for a nil-pointer panic).
+// CRD ref (regression test for a nil-pointer panic). It also has no Status
+// or Metadata set at all, exercising the nil-capacity "-" fallback for
+// CPU/MEMORY and the zero-value ACTORS/STATE/AGE rendering.
 func TestPrintWorkersTo_Table_Free(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
 	var buf bytes.Buffer
 	workers := []*ateapipb.Worker{
 		{
@@ -276,8 +293,8 @@ func TestPrintWorkersTo_Table_Free(t *testing.T) {
 	}
 	output := buf.String()
 
-	expected := `NAMESPACE   POOL     CLASS   POD     STATUS
-default     pool-1           pod-1   FREE
+	expected := `NAME   POOL     STATE                      ACTORS   CPU   MEMORY   POD             AGE
+       pool-1   WORKER_STATE_UNSPECIFIED   0/0      -     -        default/pod-1   56y
 `
 	if diff := cmp.Diff(expected, output); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)
@@ -285,19 +302,25 @@ default     pool-1           pod-1   FREE
 }
 
 func TestPrintWorkersTo_Table_Sorted(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	pinNow(t, now)
+
 	var buf bytes.Buffer
 	workers := []*ateapipb.Worker{
 		{
+			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-z", CreateTime: timestamppb.New(now.Add(-5 * time.Minute))},
 			WorkerNamespace: "default",
 			WorkerPool:      "pool-1",
 			WorkerPod:       "pod-z",
 		},
 		{
+			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-a", CreateTime: timestamppb.New(now.Add(-5 * time.Minute))},
 			WorkerNamespace: "default",
 			WorkerPool:      "pool-1",
 			WorkerPod:       "pod-a",
 		},
 		{
+			Metadata:        &ateapipb.ResourceMetadata{Name: "worker-o", CreateTime: timestamppb.New(now.Add(-5 * time.Minute))},
 			WorkerNamespace: "other",
 			WorkerPool:      "pool-2",
 			WorkerPod:       "pod-1",
@@ -308,10 +331,10 @@ func TestPrintWorkersTo_Table_Sorted(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := `NAMESPACE   POOL     CLASS   POD     STATUS
-default     pool-1           pod-a   FREE
-default     pool-1           pod-z   FREE
-other       pool-2           pod-1   FREE
+	expected := `NAME       POOL     STATE                      ACTORS   CPU   MEMORY   POD             AGE
+worker-a   pool-1   WORKER_STATE_UNSPECIFIED   0/0      -     -        default/pod-a   5m
+worker-z   pool-1   WORKER_STATE_UNSPECIFIED   0/0      -     -        default/pod-z   5m
+worker-o   pool-2   WORKER_STATE_UNSPECIFIED   0/0      -     -        other/pod-1     5m
 `
 	if diff := cmp.Diff(expected, buf.String()); diff != "" {
 		t.Errorf("output mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Fixes #1570

Allow getting the state of a single worker, plus aligning the columns better to the fields in the resource.
