### PR TITLE
demos/sandbox: use ateclient.NewClient for authenticated ate-api access

### DIFF
--- a/demos/sandbox/client/main.go
+++ b/demos/sandbox/client/main.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,12 +27,11 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/agent-substrate/substrate/internal/ateclient"
 	"github.com/agent-substrate/substrate/internal/atenet"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	"github.com/spf13/pflag"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 type ProcessRequest struct {
@@ -49,22 +47,14 @@ type ProcessResponse struct {
 	Error  string `json:"error,omitempty"`
 }
 
-func dialAteAPI(endpoint string) (ateapipb.ControlClient, *grpc.ClientConn, error) {
-	creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
-
-	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(creds))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return ateapipb.NewControlClient(conn), conn, nil
-}
-
 func main() {
 	actorName := pflag.String("name", "", "Name of the sandbox actor (required)")
 	atespace := pflag.String("atespace", "", "Atespace the actor lives in (required)")
-	ateapiAddr := pflag.String("ateapi", "localhost:8080", "Address of the ateapi gRPC server")
+	ateapiAddr := pflag.String("ateapi", "", "Address of the ateapi gRPC server (e.g. localhost:8080). If omitted, automatically port-forwards.")
 	atenetAddr := pflag.String("atenet", "localhost:8000", "Address of the atenet HTTP router")
+	tokenFile := pflag.String("token-file", "", "Path to a bearer token for ate-api authentication, or - to read it from stdin. Defaults to a Kubernetes ServiceAccount token.")
+	kubeconfig := pflag.String("kubeconfig", "", "Path to the kubeconfig file")
+	k8sContext := pflag.String("context", "", "The name of the kubeconfig context to use")
 	pflag.Parse()
 
 	if *actorName == "" {
@@ -89,11 +79,11 @@ func main() {
 
 	// 1. Connect to ateapi and Resume Actor
 	log.Printf("Connecting to ateapi at %s...", *ateapiAddr)
-	cli, conn, err := dialAteAPI(*ateapiAddr)
+	cli, err := ateclient.NewClient(ctx, *kubeconfig, *k8sContext, *ateapiAddr, *tokenFile, false)
 	if err != nil {
-		log.Fatalf("Failed to dial ateapi: %v", err)
+		log.Fatalf("Failed to connect to ateapi: %v", err)
 	}
-	defer conn.Close()
+	defer cli.Close()
 
 	log.Printf("Resuming actor %s...", actorRef.Name)
 	_, err = cli.ResumeActor(ctx, &ateapipb.ResumeActorRequest{Actor: actorRef.ToObjectRef()})


### PR DESCRIPTION
Fixes unauthenticated gRPC calls by replacing the custom dialAteAPI helper with internal/ateclient.NewClient, which automatically manages bearer tokens and ClusterTrustBundle TLS verification.

Fixes #1579

> It's a good idea to open an issue first for discussion.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
