### PR TITLE
enhance tests to validate volume lifecycle for actor state changes

### DIFF
--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -2551,7 +2551,7 @@ func TestPauseActor_VolumeLifecycle_DetachAndResumeAttach(t *testing.T) {
 		{Name: "vol1", MountPath: "/mnt/vol1"},
 	}
 	createTemplateWithVolumes(t, tc, ns, volumes, mounts)
-	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+	workerName := createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
 
 	// 2. Create actor and resume to RUNNING; volume is attached to node1.
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
@@ -2598,6 +2598,7 @@ func TestPauseActor_VolumeLifecycle_DetachAndResumeAttach(t *testing.T) {
 		t.Errorf("detached nodes after pause mismatch (-want +got):\n%s", diff)
 	}
 	plugin.mu.Unlock()
+	waitForWorkerAvailable(t, tc, workerName)
 
 	// 4. ResumeActor from PAUSED: volume is re-attached to node1 and actor transitions to ACTOR_STATE_RUNNING.
 	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
@@ -3565,7 +3566,7 @@ func TestResumeActor_PausedLocalSnapshotMissing_Crashes(t *testing.T) {
 	defer tc.cleanup()
 
 	createTemplate(t, tc, ns)
-	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+	workerName := createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
 
 	name := "paused-missing-actor"
 	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
@@ -3602,6 +3603,7 @@ func TestResumeActor_PausedLocalSnapshotMissing_Crashes(t *testing.T) {
 	if getResp.GetStatus().GetLocalSnapshotInfo() == nil {
 		t.Fatal("expected LocalSnapshotInfo to be present on paused actor")
 	}
+	waitForWorkerAvailable(t, tc, workerName)
 
 	// Simulate node-local files missing by configuring fakeAtelet.FailRestore
 	// with a terminal file system error and the ActorCrashRequested directive.

--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/ateattr"
+	"github.com/agent-substrate/substrate/internal/ateerrors"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/resources"
 	"github.com/agent-substrate/substrate/internal/volume"
@@ -1749,6 +1750,238 @@ func TestResumeActor_VolumeCreationRetrySuccess(t *testing.T) {
 	}
 }
 
+type attachFailVolumePlugin struct {
+	volume.VolumePluginControlPlane
+	mu             sync.Mutex
+	attachAttempts int
+	failUntil      int
+	attachedNodes  []string
+	detachedNodes  []string
+	deleted        []string
+}
+
+func (a *attachFailVolumePlugin) CreateVolume(ctx context.Context, name, capacity, driverName string, parameters map[string]string) (string, map[string]string, error) {
+	return "storage-" + name, parameters, nil
+}
+
+func (a *attachFailVolumePlugin) AttachVolume(ctx context.Context, volumeID, node string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.attachAttempts++
+	if a.attachAttempts <= a.failUntil {
+		return fmt.Errorf("simulated volume attach failure on attempt %d", a.attachAttempts)
+	}
+	a.attachedNodes = append(a.attachedNodes, node)
+	return nil
+}
+
+func (a *attachFailVolumePlugin) DetachVolume(ctx context.Context, volumeID, node string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.detachedNodes = append(a.detachedNodes, node)
+	return nil
+}
+
+func (a *attachFailVolumePlugin) DeleteVolume(ctx context.Context, volumeID string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.deleted = append(a.deleted, volumeID)
+	return nil
+}
+
+// TestResumeActor_VolumeAttachFailureAndRetry tests that when volume attachment to a worker node
+// fails during ResumeActor, the actor is left in ACTOR_STATE_RESUMING with its worker assignment
+// and provisioned volumes intact, and that a subsequent call to ResumeActor re-attempts volume attachment
+// and successfully transitions the actor to ACTOR_STATE_RUNNING.
+func TestResumeActor_VolumeAttachFailureAndRetry(t *testing.T) {
+	ns := namespaceForTest("ns-resume-vol-attach-retry")
+	plugin := &attachFailVolumePlugin{failUntil: 1}
+	tc := setupTestWithVolumePlugins(t, ns, map[string]volume.VolumePluginControlPlane{
+		"substrate.io/mock": plugin,
+	})
+	defer tc.cleanup()
+
+	volumes := []*ateapipb.Volume{
+		{
+			Name: "vol1",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
+			},
+		},
+	}
+	mounts := []*ateapipb.VolumeMount{
+		{Name: "vol1", MountPath: "/mnt/vol1"},
+	}
+	createTemplateWithVolumes(t, tc, ns, volumes, mounts)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	// Call CreateActor RPC directly
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "attach-retry-actor"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected CreateActor to succeed, got: %v", err)
+	}
+
+	// First call to ResumeActor: provisioning succeeds, worker is assigned, but AttachVolume fails (attempt 1)
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-retry-actor"},
+	})
+	if err == nil {
+		t.Fatalf("expected first ResumeActor to fail due to attach failure, but it succeeded")
+	}
+	if !strings.Contains(err.Error(), "simulated volume attach failure on attempt 1") {
+		t.Errorf("expected error containing simulated volume attach failure, got: %v", err)
+	}
+
+	// Verify actor status after failed attach: in ACTOR_STATE_RESUMING, worker assigned, volume CREATED
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after failed attach: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_RESUMING {
+		t.Errorf("actor state after failed attach = %v, want ACTOR_STATE_RESUMING", getResp.GetStatus().GetState())
+	}
+	if getResp.GetStatus().GetWorkerAssignment() == nil || getResp.GetStatus().GetWorkerAssignment().GetWorkerPod() != "worker-1" {
+		t.Errorf("worker assignment = %v, want worker-1", getResp.GetStatus().GetWorkerAssignment())
+	}
+	if len(getResp.GetStatus().GetActorVolumes()) != 1 {
+		t.Fatalf("expected 1 volume on actor, got %d", len(getResp.GetStatus().GetActorVolumes()))
+	}
+	vol := getResp.GetStatus().GetActorVolumes()[0]
+	if vol.GetStatus() != ateapipb.ExternalVolume_STATUS_CREATED || vol.GetStorageVolumeId() == "" {
+		t.Errorf("vol1 unexpected state after failed attach: %v", vol)
+	}
+
+	// Second call to ResumeActor: reuses assigned worker, re-attempts volume attach, succeeds (attempt 2), transitions to RUNNING
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("expected second ResumeActor to succeed, got: %v", err)
+	}
+
+	getResp, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after successful retry: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_RUNNING {
+		t.Errorf("actor state after retry = %v, want ACTOR_STATE_RUNNING", getResp.GetStatus().GetState())
+	}
+
+	// Clean up by suspending and deleting the actor
+	_, err = tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteActor failed: %v", err)
+	}
+}
+
+// TestResumeActor_VolumeAttachFailure_DeleteActor tests that when volume attachment fails during ResumeActor,
+// calling DeleteActor without any_state is rejected because the actor is in ACTOR_STATE_RESUMING,
+// but calling DeleteActor with any_state=true succeeds, cleaning up worker assignment and volumes.
+func TestResumeActor_VolumeAttachFailure_DeleteActor(t *testing.T) {
+	ns := namespaceForTest("ns-resume-vol-attach-del")
+	plugin := &attachFailVolumePlugin{failUntil: 100}
+	tc := setupTestWithVolumePlugins(t, ns, map[string]volume.VolumePluginControlPlane{
+		"substrate.io/mock": plugin,
+	})
+	defer tc.cleanup()
+
+	volumes := []*ateapipb.Volume{
+		{
+			Name: "vol1",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
+			},
+		},
+	}
+	mounts := []*ateapipb.VolumeMount{
+		{Name: "vol1", MountPath: "/mnt/vol1"},
+	}
+	createTemplateWithVolumes(t, tc, ns, volumes, mounts)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	// Call CreateActor RPC
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "attach-fail-actor"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected CreateActor to succeed, got: %v", err)
+	}
+
+	// Call ResumeActor RPC, which assigns worker-1 and fails on AttachVolume
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-fail-actor"},
+	})
+	if err == nil {
+		t.Fatalf("expected ResumeActor to fail due to attach failure, but it succeeded")
+	}
+
+	// Verify actor is in ACTOR_STATE_RESUMING
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-fail-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_RESUMING {
+		t.Fatalf("actor state = %v, want ACTOR_STATE_RESUMING", getResp.GetStatus().GetState())
+	}
+	actorUID := getResp.GetMetadata().GetUid()
+
+	// Calling DeleteActor without any_state should fail because RESUMING is not a deletable state
+	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-fail-actor"},
+	})
+	assertGrpcErrorRegex(t, err, codes.FailedPrecondition, "is not in a deletable state")
+
+	// Calling DeleteActor with any_state=true should succeed and cleanly tear down
+	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor:    &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-fail-actor"},
+		AnyState: true,
+	})
+	if err != nil {
+		t.Fatalf("DeleteActor with AnyState failed: %v", err)
+	}
+
+	// Verify volume was detached and deleted
+	expectedVolumeID := "storage-substrate-" + actorUID + "-vol1"
+	if diff := cmp.Diff([]string{"node1"}, plugin.detachedNodes); diff != "" {
+		t.Errorf("detached nodes mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{expectedVolumeID}, plugin.deleted); diff != "" {
+		t.Errorf("deleted volume IDs mismatch (-want +got):\n%s", diff)
+	}
+
+	// Confirm GetActor returns NotFound after deletion
+	_, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "attach-fail-actor"},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("GetActor after DeleteActor err = %v, want NotFound", err)
+	}
+}
+
 // TestResumeActor tests the full workflow of resuming a suspended actor.
 // Workflow:
 // 1. Creates a mock ActorTemplate.
@@ -2559,6 +2792,99 @@ func TestPauseActor(t *testing.T) {
 	if getResp.GetStatus().GetLocalSnapshotInfo().GetSnapshotName() == "" {
 		t.Error("LocalSnapshotInfo.SnapshotName is empty, want the name the pause checkpointed under")
 	}
+}
+
+// TestResumeActor_PausedLocalSnapshotMissing_Crashes tests that if the local checkpoint
+// files on the worker node are missing (e.g. node reboot, /tmp wipe) when resuming a PAUSED actor,
+// atelet returns a terminal file system error and ateapi marks the actor ACTOR_STATE_CRASHED
+// while releasing the assigned worker pod.
+func TestResumeActor_PausedLocalSnapshotMissing_Crashes(t *testing.T) {
+	ns := namespaceForTest("ns-resume-paused-missing")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	name := "paused-missing-actor"
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+
+	if _, err := tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	}); err != nil {
+		t.Fatalf("PauseActor failed: %v", err)
+	}
+
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_PAUSED {
+		t.Fatalf("actor state = %v, want ACTOR_STATE_PAUSED", getResp.GetStatus().GetState())
+	}
+	if getResp.GetStatus().GetLocalSnapshotInfo() == nil {
+		t.Fatal("expected LocalSnapshotInfo to be present on paused actor")
+	}
+
+	// Simulate node-local files missing by configuring fakeAtelet.FailRestore
+	// with a terminal file system error and the ActorCrashRequested directive.
+	tc.fakeAtelet.Reset()
+	tc.fakeAtelet.FailRestore = ateerrors.NewGRPCError(
+		context.Background(),
+		codes.NotFound,
+		ateerrors.ReasonTerminalFileSystemError,
+		ateerrors.ActorCrashedMetadata(),
+		errors.New("local checkpoint files missing on node: directory not found"),
+	)
+
+	// Call ResumeActor; should fail with DataLoss because actor crashed
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	if err == nil {
+		t.Fatal("expected ResumeActor to fail due to missing local snapshot, but it succeeded")
+	}
+	if status.Code(err) != codes.DataLoss {
+		t.Errorf("ResumeActor err code = %v, want DataLoss", status.Code(err))
+	}
+
+	// Assert actor transitioned to ACTOR_STATE_CRASHED
+	getResp, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("actor state after failed restore = %v, want ACTOR_STATE_CRASHED", getResp.GetStatus().GetState())
+	}
+
+	// Worker assignment must be released so the worker is not leaked
+	if getResp.GetStatus().GetWorkerAssignment() != nil && getResp.GetStatus().GetWorkerAssignment().GetWorkerPod() != "" {
+		t.Errorf("worker assignment = %v, want worker released", getResp.GetStatus().GetWorkerAssignment())
+	}
+
+	// Subsequent ResumeActor call on CRASHED actor must be rejected
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: name},
+	})
+	assertGrpcErrorRegex(t, err, codes.FailedPrecondition, "ACTOR_STATE_CRASHED")
 }
 
 // Pause stamps the ref identity before resolving the Actor record, so a failed

--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -1286,6 +1286,107 @@ func TestDeleteActor_MultipleVolumeDeletionFailures(t *testing.T) {
 	}
 }
 
+// retryDeleteVolumePlugin simulates a CSI control-plane plugin that fails DeleteVolume
+// until failDelete is cleared, recording all deleted volume IDs for assertions.
+type retryDeleteVolumePlugin struct {
+	volume.VolumePluginControlPlane
+	mu         sync.Mutex
+	failDelete bool
+	deletedIDs []string
+}
+
+func (r *retryDeleteVolumePlugin) DeleteVolume(ctx context.Context, volumeID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deletedIDs = append(r.deletedIDs, volumeID)
+	if r.failDelete {
+		return fmt.Errorf("simulated temporary delete error for %s", volumeID)
+	}
+	return nil
+}
+
+// TestDeleteActor_VolumeDeletionFailure_RetrySuccess tests that when volume deletion fails
+// during DeleteActor, the actor transitions to ACTOR_STATE_DELETING and its volumes to
+// ExternalVolume_STATUS_DELETING, and a subsequent retry of DeleteActor cleanly finalizes deletion.
+//
+// Workflow:
+// 1. Creates a suspended actor with a provisioned external volume.
+// 2. Calls DeleteActor, which fails because the CSI plugin returns an error on DeleteVolume.
+// 3. Verifies that the actor is persisted in ACTOR_STATE_DELETING and the volume is marked STATUS_DELETING.
+// 4. Clears the plugin error to simulate backend recovery.
+// 5. Retries DeleteActor, which re-attempts volume deletion and cleans up the actor from the store.
+// 6. Confirms GetActor returns NotFound.
+func TestDeleteActor_VolumeDeletionFailure_RetrySuccess(t *testing.T) {
+	ns := namespaceForTest("ns-delete-vol-retry")
+	plugin := &retryDeleteVolumePlugin{failDelete: true}
+	tc := setupTestWithVolumePlugins(t, ns, map[string]volume.VolumePluginControlPlane{
+		"substrate.io/mock": plugin,
+	})
+	defer tc.cleanup()
+	createTemplate(t, tc, ns)
+
+	// 1. Create suspended actor with a provisioned external volume.
+	actor := &ateapipb.Actor{
+		Metadata: &ateapipb.ResourceMetadata{
+			Atespace: testAtespace,
+			Name:     "delete-retry-actor",
+		},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		Status: &ateapipb.ActorStatus{
+			State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
+			ActorVolumes: []*ateapipb.ExternalVolume{
+				{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", Status: ateapipb.ExternalVolume_STATUS_CREATED, VolumeType: "substrate.io/mock"},
+			},
+		},
+	}
+	if _, err := tc.persistence.CreateActor(context.Background(), actor); err != nil {
+		t.Fatalf("CreateActor: %v", err)
+	}
+
+	// 2. First DeleteActor call should fail due to DeleteVolume error.
+	_, err := tc.service.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "delete-retry-actor"},
+	})
+	if err == nil {
+		t.Fatalf("expected DeleteActor to fail, but got nil")
+	}
+
+	// 3. Verify actor is persisted in ACTOR_STATE_DELETING with volume in ExternalVolume_STATUS_DELETING.
+	getResp, err := tc.service.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "delete-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after failed delete: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_DELETING {
+		t.Errorf("actor state = %v, want ACTOR_STATE_DELETING", getResp.GetStatus().GetState())
+	}
+	if len(getResp.GetStatus().GetActorVolumes()) != 1 || getResp.GetStatus().GetActorVolumes()[0].GetStatus() != ateapipb.ExternalVolume_STATUS_DELETING {
+		t.Errorf("actor volume status = %v, want STATUS_DELETING", getResp.GetStatus().GetActorVolumes())
+	}
+
+	// 4. Recover the CSI plugin to simulate backend recovery.
+	plugin.mu.Lock()
+	plugin.failDelete = false
+	plugin.mu.Unlock()
+
+	// 5. Second DeleteActor call (retry) re-attempts deletion and should succeed.
+	_, err = tc.service.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "delete-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("expected retry DeleteActor to succeed, got: %v", err)
+	}
+
+	// 6. Verify actor is removed from store.
+	_, err = tc.service.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "delete-retry-actor"},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("GetActor after successful delete retry = %v, want NotFound", err)
+	}
+}
+
 func TestCreateActor_AtespaceNotFound(t *testing.T) {
 	ns := namespaceForTest("ns-create-actor-no-atespace")
 	tc := setupTest(t, ns)
@@ -1979,6 +2080,666 @@ func TestResumeActor_VolumeAttachFailure_DeleteActor(t *testing.T) {
 	})
 	if status.Code(err) != codes.NotFound {
 		t.Errorf("GetActor after DeleteActor err = %v, want NotFound", err)
+	}
+}
+
+// multiVolAttachPlugin simulates a CSI control-plane plugin that selectively fails
+// volume attachment for a specified volume up to a configured number of attempts.
+type multiVolAttachPlugin struct {
+	volume.VolumePluginControlPlane
+	mu             sync.Mutex
+	attachAttempts map[string]int
+	failVol        string
+	failUntil      int
+	attachedNodes  map[string][]string
+	detachedNodes  map[string][]string
+	deleted        []string
+}
+
+func newMultiVolAttachPlugin(failVol string, failUntil int) *multiVolAttachPlugin {
+	return &multiVolAttachPlugin{
+		attachAttempts: make(map[string]int),
+		failVol:        failVol,
+		failUntil:      failUntil,
+		attachedNodes:  make(map[string][]string),
+		detachedNodes:  make(map[string][]string),
+	}
+}
+
+func (m *multiVolAttachPlugin) CreateVolume(ctx context.Context, name, capacity, driverName string, parameters map[string]string) (string, map[string]string, error) {
+	return "storage-" + name, parameters, nil
+}
+
+func (m *multiVolAttachPlugin) AttachVolume(ctx context.Context, volumeID, node string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.attachAttempts[volumeID]++
+	if strings.Contains(volumeID, m.failVol) && m.attachAttempts[volumeID] <= m.failUntil {
+		return fmt.Errorf("simulated volume attach failure for %s on attempt %d", volumeID, m.attachAttempts[volumeID])
+	}
+	m.attachedNodes[volumeID] = append(m.attachedNodes[volumeID], node)
+	return nil
+}
+
+func (m *multiVolAttachPlugin) DetachVolume(ctx context.Context, volumeID, node string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.detachedNodes[volumeID] = append(m.detachedNodes[volumeID], node)
+	return nil
+}
+
+func (m *multiVolAttachPlugin) DeleteVolume(ctx context.Context, volumeID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deleted = append(m.deleted, volumeID)
+	return nil
+}
+
+// TestResumeActor_MultiVolumePartialAttachFailure_Retry tests scenario B:
+// when an actor has multiple external volumes and one fails to attach during ResumeActor:
+// 1. ResumeActor fails, leaving the actor in ACTOR_STATE_RESUMING.
+// 2. The successfully attached volume remains attached; the failing volume is not attached.
+// 3. The worker assignment remains held by the actor.
+// 4. A subsequent retry of ResumeActor re-attempts attachment, succeeds, and transitions the actor to ACTOR_STATE_RUNNING.
+//
+// Workflow:
+// 1. Creates a template with two external volumes (vol1, vol2) and creates a mock worker pod on node1.
+// 2. Creates an actor referencing the template.
+// 3. Calls ResumeActor; plugin is configured to fail vol2 on attempt 1.
+// 4. Verifies ResumeActor returns an error, actor is in ACTOR_STATE_RESUMING, worker assignment is held, and vol1 is attached while vol2 is not.
+// 5. Calls ResumeActor a second time (retry).
+// 6. Verifies ResumeActor succeeds and actor transitions to ACTOR_STATE_RUNNING.
+// 7. Cleans up by suspending and deleting the actor.
+func TestResumeActor_MultiVolumePartialAttachFailure_Retry(t *testing.T) {
+	ns := namespaceForTest("ns-resume-multivol-attach-retry")
+	plugin := newMultiVolAttachPlugin("vol2", 1)
+	tc := setupTestWithVolumePlugins(t, ns, map[string]volume.VolumePluginControlPlane{
+		"substrate.io/mock": plugin,
+	})
+	defer tc.cleanup()
+
+	// 1. Create a template with two external volumes and a worker pod.
+	volumes := []*ateapipb.Volume{
+		{
+			Name: "vol1",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
+			},
+		},
+		{
+			Name: "vol2",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
+			},
+		},
+	}
+	mounts := []*ateapipb.VolumeMount{
+		{Name: "vol1", MountPath: "/mnt/vol1"},
+		{Name: "vol2", MountPath: "/mnt/vol2"},
+	}
+	createTemplateWithVolumes(t, tc, ns, volumes, mounts)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	// 2. Create the actor.
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "multi-attach-actor"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	// 3. Attempt 1: vol1 attaches, vol2 fails attach.
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "multi-attach-actor"},
+	})
+	if err == nil {
+		t.Fatalf("expected ResumeActor to fail due to partial attach failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "simulated volume attach failure for") {
+		t.Errorf("expected error containing simulated attach failure, got: %v", err)
+	}
+
+	// 4. Verify actor state is ACTOR_STATE_RESUMING, worker assignment is held, and partial attachment state.
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "multi-attach-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after failed attach: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_RESUMING {
+		t.Errorf("actor state = %v, want ACTOR_STATE_RESUMING", getResp.GetStatus().GetState())
+	}
+	if getResp.GetStatus().GetWorkerAssignment() == nil || getResp.GetStatus().GetWorkerAssignment().GetWorkerPod() != "worker-1" {
+		t.Errorf("worker assignment = %v, want worker-1", getResp.GetStatus().GetWorkerAssignment())
+	}
+
+	// Verify vol1 was attached, vol2 was not attached on attempt 1.
+	actorUID := getResp.GetMetadata().GetUid()
+	vol1ID := "storage-substrate-" + actorUID + "-vol1"
+	vol2ID := "storage-substrate-" + actorUID + "-vol2"
+	plugin.mu.Lock()
+	if len(plugin.attachedNodes[vol1ID]) != 1 || plugin.attachedNodes[vol1ID][0] != "node1" {
+		t.Errorf("vol1 attached nodes = %v, want [node1]", plugin.attachedNodes[vol1ID])
+	}
+	if len(plugin.attachedNodes[vol2ID]) != 0 {
+		t.Errorf("vol2 attached nodes = %v, want empty on attempt 1", plugin.attachedNodes[vol2ID])
+	}
+	plugin.mu.Unlock()
+
+	// 5. Attempt 2 (retry): re-attempts attach, both succeed, actor reaches RUNNING.
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "multi-attach-actor"},
+	})
+	if err != nil {
+		t.Fatalf("expected second ResumeActor to succeed, got: %v", err)
+	}
+
+	// 6. Verify actor state is RUNNING.
+	getResp, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "multi-attach-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after second resume: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_RUNNING {
+		t.Errorf("actor state after retry = %v, want ACTOR_STATE_RUNNING", getResp.GetStatus().GetState())
+	}
+
+	// 7. Clean up by suspending and deleting.
+	_, err = tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "multi-attach-actor"},
+	})
+	if err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "multi-attach-actor"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteActor failed: %v", err)
+	}
+}
+
+// detachFailVolumePlugin simulates a CSI control-plane plugin that fails DetachVolume
+// for a configured number of attempts, tracking attached and detached nodes.
+type detachFailVolumePlugin struct {
+	volume.VolumePluginControlPlane
+	mu             sync.Mutex
+	detachAttempts int
+	failUntil      int
+	attachedNodes  []string
+	detachedNodes  []string
+	deleted        []string
+}
+
+func (d *detachFailVolumePlugin) CreateVolume(ctx context.Context, name, capacity, driverName string, parameters map[string]string) (string, map[string]string, error) {
+	return "storage-" + name, parameters, nil
+}
+
+func (d *detachFailVolumePlugin) AttachVolume(ctx context.Context, volumeID, node string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.attachedNodes = append(d.attachedNodes, node)
+	return nil
+}
+
+func (d *detachFailVolumePlugin) DetachVolume(ctx context.Context, volumeID, node string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.detachAttempts++
+	if d.detachAttempts <= d.failUntil {
+		return fmt.Errorf("simulated volume detach failure on attempt %d", d.detachAttempts)
+	}
+	d.detachedNodes = append(d.detachedNodes, node)
+	return nil
+}
+
+func (d *detachFailVolumePlugin) DeleteVolume(ctx context.Context, volumeID string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.deleted = append(d.deleted, volumeID)
+	return nil
+}
+
+// TestSuspendActor_VolumeDetachFailure_RetrySuccess tests scenario C:
+// when volume detachment fails during SuspendActor:
+// 1. SuspendActor fails, leaving the actor in ACTOR_STATE_SUSPENDING.
+// 2. The worker assignment is preserved (worker is not released).
+// 3. A subsequent retry of SuspendActor succeeds, detaches the volume, releases the worker, and transitions the actor to ACTOR_STATE_SUSPENDED.
+//
+// Workflow:
+// 1. Creates a template with an external volume and creates a mock worker pod on node1.
+// 2. Creates and resumes an actor to ACTOR_STATE_RUNNING (attaching the volume).
+// 3. Calls SuspendActor; plugin is configured to fail DetachVolume on attempt 1.
+// 4. Verifies SuspendActor returns an error, actor state is ACTOR_STATE_SUSPENDING, and worker assignment is preserved.
+// 5. Calls SuspendActor a second time (retry); detachment succeeds.
+// 6. Verifies actor transitions to ACTOR_STATE_SUSPENDED and worker assignment is cleared.
+// 7. Cleans up by deleting the actor.
+func TestSuspendActor_VolumeDetachFailure_RetrySuccess(t *testing.T) {
+	ns := namespaceForTest("ns-suspend-vol-detach-retry")
+	plugin := &detachFailVolumePlugin{failUntil: 1}
+	tc := setupTestWithVolumePlugins(t, ns, map[string]volume.VolumePluginControlPlane{
+		"substrate.io/mock": plugin,
+	})
+	defer tc.cleanup()
+
+	// 1. Create template with external volume and a mock worker pod.
+	volumes := []*ateapipb.Volume{
+		{
+			Name: "vol1",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
+			},
+		},
+	}
+	mounts := []*ateapipb.VolumeMount{
+		{Name: "vol1", MountPath: "/mnt/vol1"},
+	}
+	createTemplateWithVolumes(t, tc, ns, volumes, mounts)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	// 2. Create and resume actor to ACTOR_STATE_RUNNING.
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "suspend-detach-retry-actor"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-detach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+
+	// 3. Attempt 1: SuspendActor fails on DetachVolume.
+	_, err = tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-detach-retry-actor"},
+	})
+	if err == nil {
+		t.Fatalf("expected first SuspendActor to fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "simulated volume detach failure on attempt 1") {
+		t.Errorf("expected error containing simulated detach failure, got: %v", err)
+	}
+
+	// 4. Verify actor state after failed detach: left in ACTOR_STATE_SUSPENDING, worker assignment preserved.
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-detach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after failed detach: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_SUSPENDING {
+		t.Errorf("actor state = %v, want ACTOR_STATE_SUSPENDING", getResp.GetStatus().GetState())
+	}
+	if getResp.GetStatus().GetWorkerAssignment() == nil || getResp.GetStatus().GetWorkerAssignment().GetWorkerPod() != "worker-1" {
+		t.Errorf("worker assignment = %v, want worker-1", getResp.GetStatus().GetWorkerAssignment())
+	}
+
+	// 5. Attempt 2 (retry): SuspendActor retry succeeds, volume is detached.
+	_, err = tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-detach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("expected retry SuspendActor to succeed, got: %v", err)
+	}
+
+	// 6. Verify actor state transitions to ACTOR_STATE_SUSPENDED and worker is released.
+	getResp, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-detach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after successful suspend retry: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_SUSPENDED {
+		t.Errorf("actor state = %v, want ACTOR_STATE_SUSPENDED", getResp.GetStatus().GetState())
+	}
+	if getResp.GetStatus().GetWorkerAssignment() != nil && getResp.GetStatus().GetWorkerAssignment().GetWorkerPod() != "" {
+		t.Errorf("worker assignment = %v, want worker released", getResp.GetStatus().GetWorkerAssignment())
+	}
+
+	// 7. Clean up by deleting actor.
+	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-detach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteActor failed: %v", err)
+	}
+}
+
+// TestSuspendActor_VolumeDetachFailure_DeleteActorAnyState tests scenario C:
+// when volume detachment fails during SuspendActor and leaves the actor in ACTOR_STATE_SUSPENDING:
+// 1. Standard DeleteActor (without AnyState) fails with FailedPrecondition because SUSPENDING is not deletable.
+// 2. DeleteActor with AnyState=true succeeds, tearing down the actor and its volumes.
+//
+// Workflow:
+// 1. Creates a template with an external volume and creates a mock worker pod on node1.
+// 2. Creates and resumes an actor to ACTOR_STATE_RUNNING.
+// 3. Calls SuspendActor, which fails due to simulated volume detachment failure, leaving the actor in ACTOR_STATE_SUSPENDING.
+// 4. Calls DeleteActor without AnyState and verifies it is rejected with FailedPrecondition ("is not in a deletable state").
+// 5. Resets the plugin to allow detachment, then calls DeleteActor with AnyState=true.
+// 6. Verifies the actor is deleted and GetActor returns NotFound.
+func TestSuspendActor_VolumeDetachFailure_DeleteActorAnyState(t *testing.T) {
+	ns := namespaceForTest("ns-suspend-vol-detach-del")
+	plugin := &detachFailVolumePlugin{failUntil: 100}
+	tc := setupTestWithVolumePlugins(t, ns, map[string]volume.VolumePluginControlPlane{
+		"substrate.io/mock": plugin,
+	})
+	defer tc.cleanup()
+
+	// 1. Create template with external volume and a mock worker pod.
+	volumes := []*ateapipb.Volume{
+		{
+			Name: "vol1",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
+			},
+		},
+	}
+	mounts := []*ateapipb.VolumeMount{
+		{Name: "vol1", MountPath: "/mnt/vol1"},
+	}
+	createTemplateWithVolumes(t, tc, ns, volumes, mounts)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	// 2. Create and resume actor to ACTOR_STATE_RUNNING.
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "suspend-del-actor"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-del-actor"},
+	}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+
+	// 3. Attempt SuspendActor; fails on volume detachment, leaving actor in ACTOR_STATE_SUSPENDING.
+	_, err = tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-del-actor"},
+	})
+	if err == nil {
+		t.Fatalf("expected SuspendActor to fail, got nil")
+	}
+
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-del-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_SUSPENDING {
+		t.Fatalf("actor state = %v, want ACTOR_STATE_SUSPENDING", getResp.GetStatus().GetState())
+	}
+
+	// 4. DeleteActor without AnyState fails with FailedPrecondition.
+	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-del-actor"},
+	})
+	assertGrpcErrorRegex(t, err, codes.FailedPrecondition, "is not in a deletable state")
+
+	// 5. Allow detach to succeed and call DeleteActor with AnyState=true.
+	plugin.mu.Lock()
+	plugin.failUntil = 0
+	plugin.mu.Unlock()
+
+	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor:    &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-del-actor"},
+		AnyState: true,
+	})
+	if err != nil {
+		t.Fatalf("DeleteActor with AnyState failed: %v", err)
+	}
+
+	// 6. Verify actor is NotFound.
+	_, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "suspend-del-actor"},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("GetActor after delete err = %v, want NotFound", err)
+	}
+}
+
+// TestPauseActor_VolumeLifecycle_DetachAndResumeAttach tests scenario D:
+// external volume lifecycle across PauseActor and ResumeActor:
+// 1. When an actor is resumed to RUNNING, external volumes are attached to the worker node.
+// 2. When the actor is paused, volumes are detached from the worker node and the actor transitions to ACTOR_STATE_PAUSED.
+// 3. When the actor is resumed from PAUSED, volumes are re-attached to the worker node and the actor transitions to ACTOR_STATE_RUNNING.
+//
+// Workflow:
+// 1. Creates a template with an external volume and creates a mock worker pod on node1.
+// 2. Creates and resumes an actor to ACTOR_STATE_RUNNING; verifies volume is attached to node1.
+// 3. Calls PauseActor; verifies volume is detached from node1 and actor transitions to ACTOR_STATE_PAUSED.
+// 4. Calls ResumeActor from PAUSED; verifies volume is re-attached to node1 and actor transitions to ACTOR_STATE_RUNNING.
+// 5. Cleans up by suspending and deleting the actor.
+func TestPauseActor_VolumeLifecycle_DetachAndResumeAttach(t *testing.T) {
+	ns := namespaceForTest("ns-pause-vol-lifecycle")
+	plugin := &attachFailVolumePlugin{}
+	tc := setupTestWithVolumePlugins(t, ns, map[string]volume.VolumePluginControlPlane{
+		"substrate.io/mock": plugin,
+	})
+	defer tc.cleanup()
+
+	// 1. Create template with external volume and a mock worker pod.
+	volumes := []*ateapipb.Volume{
+		{
+			Name: "vol1",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
+			},
+		},
+	}
+	mounts := []*ateapipb.VolumeMount{
+		{Name: "vol1", MountPath: "/mnt/vol1"},
+	}
+	createTemplateWithVolumes(t, tc, ns, volumes, mounts)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	// 2. Create actor and resume to RUNNING; volume is attached to node1.
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "pause-vol-actor"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-vol-actor"},
+	})
+	if err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+	plugin.mu.Lock()
+	if diff := cmp.Diff([]string{"node1"}, plugin.attachedNodes); diff != "" {
+		t.Errorf("attached nodes after resume mismatch (-want +got):\n%s", diff)
+	}
+	plugin.mu.Unlock()
+
+	// 3. PauseActor: volume is detached from node1 and actor transitions to ACTOR_STATE_PAUSED.
+	_, err = tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-vol-actor"},
+	})
+	if err != nil {
+		t.Fatalf("PauseActor failed: %v", err)
+	}
+
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-vol-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_PAUSED {
+		t.Errorf("actor state = %v, want ACTOR_STATE_PAUSED", getResp.GetStatus().GetState())
+	}
+	plugin.mu.Lock()
+	if diff := cmp.Diff([]string{"node1"}, plugin.detachedNodes); diff != "" {
+		t.Errorf("detached nodes after pause mismatch (-want +got):\n%s", diff)
+	}
+	plugin.mu.Unlock()
+
+	// 4. ResumeActor from PAUSED: volume is re-attached to node1 and actor transitions to ACTOR_STATE_RUNNING.
+	_, err = tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-vol-actor"},
+	})
+	if err != nil {
+		t.Fatalf("ResumeActor from PAUSED failed: %v", err)
+	}
+
+	getResp, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-vol-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after second resume: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_RUNNING {
+		t.Errorf("actor state after retry = %v, want ACTOR_STATE_RUNNING", getResp.GetStatus().GetState())
+	}
+	plugin.mu.Lock()
+	// Should have attached twice: first resume + resume from pause
+	if diff := cmp.Diff([]string{"node1", "node1"}, plugin.attachedNodes); diff != "" {
+		t.Errorf("attached nodes after resume from pause mismatch (-want +got):\n%s", diff)
+	}
+	plugin.mu.Unlock()
+
+	// 5. Clean up by suspending and deleting the actor.
+	_, err = tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-vol-actor"},
+	})
+	if err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-vol-actor"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteActor failed: %v", err)
+	}
+}
+
+// TestPauseActor_VolumeDetachFailure_RetrySuccess tests scenario D:
+// when volume detachment fails during PauseActor:
+// 1. PauseActor fails, leaving the actor in ACTOR_STATE_PAUSING.
+// 2. A subsequent retry of PauseActor re-attempts volume detachment and succeeds, transitioning the actor to ACTOR_STATE_PAUSED.
+//
+// Workflow:
+// 1. Creates a template with an external volume and creates a mock worker pod on node1.
+// 2. Creates and resumes an actor to ACTOR_STATE_RUNNING.
+// 3. Calls PauseActor; plugin is configured to fail DetachVolume on attempt 1.
+// 4. Verifies PauseActor returns an error and actor state is left in ACTOR_STATE_PAUSING.
+// 5. Calls PauseActor a second time (retry); detachment succeeds.
+// 6. Verifies actor state transitions to ACTOR_STATE_PAUSED.
+// 7. Cleans up by deleting the actor with AnyState=true.
+func TestPauseActor_VolumeDetachFailure_RetrySuccess(t *testing.T) {
+	ns := namespaceForTest("ns-pause-vol-detach-retry")
+	plugin := &detachFailVolumePlugin{failUntil: 1}
+	tc := setupTestWithVolumePlugins(t, ns, map[string]volume.VolumePluginControlPlane{
+		"substrate.io/mock": plugin,
+	})
+	defer tc.cleanup()
+
+	// 1. Create template with external volume and a mock worker pod.
+	volumes := []*ateapipb.Volume{
+		{
+			Name: "vol1",
+			ExternalVolumeTemplate: &ateapipb.ExternalVolumeTemplate{
+				StorageClassName: "standard",
+				Capacity:         "10Gi",
+			},
+		},
+	}
+	mounts := []*ateapipb.VolumeMount{
+		{Name: "vol1", MountPath: "/mnt/vol1"},
+	}
+	createTemplateWithVolumes(t, tc, ns, volumes, mounts)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	// 2. Create and resume actor to ACTOR_STATE_RUNNING.
+	_, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{
+		Actor: &ateapipb.Actor{
+			Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: "pause-detach-retry-actor"},
+			ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-detach-retry-actor"},
+	}); err != nil {
+		t.Fatalf("ResumeActor failed: %v", err)
+	}
+
+	// 3. Attempt 1: PauseActor fails on DetachVolume.
+	_, err = tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-detach-retry-actor"},
+	})
+	if err == nil {
+		t.Fatalf("expected first PauseActor to fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "simulated volume detach failure on attempt 1") {
+		t.Errorf("expected error containing simulated detach failure, got: %v", err)
+	}
+
+	// 4. Verify actor state is ACTOR_STATE_PAUSING.
+	getResp, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-detach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after failed pause: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_PAUSING {
+		t.Errorf("actor state = %v, want ACTOR_STATE_PAUSING", getResp.GetStatus().GetState())
+	}
+
+	// 5. Attempt 2 (retry): PauseActor retry succeeds, detaching volume.
+	_, err = tc.client.PauseActor(context.Background(), &ateapipb.PauseActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-detach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("expected retry PauseActor to succeed, got: %v", err)
+	}
+
+	// 6. Verify actor state transitions to ACTOR_STATE_PAUSED.
+	getResp, err = tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-detach-retry-actor"},
+	})
+	if err != nil {
+		t.Fatalf("GetActor after successful pause retry: %v", err)
+	}
+	if getResp.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_PAUSED {
+		t.Errorf("actor state = %v, want ACTOR_STATE_PAUSED", getResp.GetStatus().GetState())
+	}
+
+	// 7. Clean up by deleting the actor with AnyState=true.
+	_, err = tc.client.DeleteActor(context.Background(), &ateapipb.DeleteActorRequest{
+		Actor:    &ateapipb.ObjectRef{Atespace: testAtespace, Name: "pause-detach-retry-actor"},
+		AnyState: true,
+	})
+	if err != nil {
+		t.Fatalf("DeleteActor failed: %v", err)
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/functionaltest/main_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/main_test.go
@@ -127,6 +127,10 @@ type FakeAteletServer struct {
 	UploadRequest *ateletpb.UploadPausedCheckpointRequest
 	FailUpload    error
 
+	TerminateCalled  bool
+	TerminateRequest *ateletpb.TerminateRequest
+	FailTerminate    error
+
 	// objectStore, when set, receives the objects a checkpoint or an upload
 	// writes, so the control plane's copy and release steps have real external
 	// snapshots to act on. setupTest points it at the test's own store.
@@ -173,6 +177,10 @@ func (f *FakeAteletServer) Reset() {
 	f.UploadCalled = false
 	f.UploadRequest = nil
 	f.FailUpload = nil
+
+	f.TerminateCalled = false
+	f.TerminateRequest = nil
+	f.FailTerminate = nil
 
 	f.objectStore = nil
 }
@@ -241,4 +249,16 @@ func (f *FakeAteletServer) lastRestoreRequest() *ateletpb.RestoreRequest {
 		return nil
 	}
 	return proto.Clone(f.RestoreRequest).(*ateletpb.RestoreRequest)
+}
+
+func (f *FakeAteletServer) Terminate(ctx context.Context, req *ateletpb.TerminateRequest) (*ateletpb.TerminateResponse, error) {
+	f.Lock.Lock()
+	defer f.Lock.Unlock()
+
+	f.TerminateCalled = true
+	f.TerminateRequest = proto.Clone(req).(*ateletpb.TerminateRequest)
+	if f.FailTerminate != nil {
+		return nil, f.FailTerminate
+	}
+	return &ateletpb.TerminateResponse{}, nil
 }

--- a/cmd/ateapi/internal/controlapi/volumes_test.go
+++ b/cmd/ateapi/internal/controlapi/volumes_test.go
@@ -16,12 +16,17 @@ package controlapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
 	"github.com/agent-substrate/substrate/internal/volume"
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	storagev1 "k8s.io/api/storage/v1"
@@ -146,11 +151,12 @@ func TestCreateActorVolumes(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		tmpl         *ateapipb.ActorTemplate
-		inputVolumes []*ateapipb.ExternalVolume
-		wantErr      bool
-		wantRes      []*ateapipb.ExternalVolume
+		name           string
+		tmpl           *ateapipb.ActorTemplate
+		inputVolumes   []*ateapipb.ExternalVolume
+		storageClasses map[string]*storagev1.StorageClass
+		wantErr        bool
+		wantRes        []*ateapipb.ExternalVolume
 	}{
 		{
 			name: "partial failure returns error and preserves succeeded, failed, and remaining volumes",
@@ -241,6 +247,40 @@ func TestCreateActorVolumes(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "storage class parameters are propagated to volume context",
+			tmpl: standardTmpl,
+			inputVolumes: []*ateapipb.ExternalVolume{
+				{
+					VolumeName: "data-vol",
+					VolumeType: "mock-standard",
+					Status:     ateapipb.ExternalVolume_STATUS_PENDING,
+				},
+			},
+			storageClasses: map[string]*storagev1.StorageClass{
+				"standard": {
+					ObjectMeta:  metav1.ObjectMeta{Name: "standard"},
+					Provisioner: "mock-standard",
+					Parameters: map[string]string{
+						"type":                      "pd-ssd",
+						"csi.storage.k8s.io/fstype": "ext4",
+					},
+				},
+			},
+			wantErr: false,
+			wantRes: []*ateapipb.ExternalVolume{
+				{
+					VolumeName:      "data-vol",
+					StorageVolumeId: "mock-vol-substrate-actor-uid-123-data-vol",
+					VolumeType:      "mock-standard",
+					Status:          ateapipb.ExternalVolume_STATUS_CREATED,
+					VolumeContext: map[string]string{
+						"type":                      "pd-ssd",
+						"csi.storage.k8s.io/fstype": "ext4",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -252,8 +292,9 @@ func TestCreateActorVolumes(t *testing.T) {
 					"mock-fast":     plugin,
 				},
 			}
-			scLister := &fakeStorageClassLister{
-				storageClasses: map[string]*storagev1.StorageClass{
+			scs := tt.storageClasses
+			if scs == nil {
+				scs = map[string]*storagev1.StorageClass{
 					"standard": {
 						ObjectMeta:  metav1.ObjectMeta{Name: "standard"},
 						Provisioner: "mock-standard",
@@ -262,8 +303,9 @@ func TestCreateActorVolumes(t *testing.T) {
 						ObjectMeta:  metav1.ObjectMeta{Name: "fast"},
 						Provisioner: "mock-fast",
 					},
-				},
+				}
 			}
+			scLister := &fakeStorageClassLister{storageClasses: scs}
 			res, err := createActorVolumes(ctx, registry, scLister, "actor-uid-123", tt.tmpl, tt.inputVolumes)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createActorVolumes() error = %v, wantErr %v", err, tt.wantErr)
@@ -345,4 +387,374 @@ func (m *mockPluginRegistry) GetPlugin(ctx context.Context, name string) (volume
 		return nil, fmt.Errorf("plugin %q not found in mock registry", name)
 	}
 	return p, nil
+}
+
+type mockDetachStore struct {
+	workers map[string]*ateapipb.Worker
+	err     error
+}
+
+func (m *mockDetachStore) GetWorker(ctx context.Context, name string) (*ateapipb.Worker, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.workers == nil {
+		return nil, store.ErrNotFound
+	}
+	w, ok := m.workers[name]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return w, nil
+}
+
+type detachCall struct {
+	VolumeID string
+	Node     string
+}
+
+type mockDetachVolumePlugin struct {
+	volume.VolumePluginControlPlane
+	detachCalls []detachCall
+	detachErrs  map[string]error
+}
+
+func (m *mockDetachVolumePlugin) DetachVolume(ctx context.Context, volumeID, node string) error {
+	m.detachCalls = append(m.detachCalls, detachCall{VolumeID: volumeID, Node: node})
+	if m.detachErrs != nil {
+		if err, ok := m.detachErrs[volumeID]; ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestDetachActorVolumes(t *testing.T) {
+	ctx := context.Background()
+
+	baseWorker := &ateapipb.Worker{
+		Metadata: &ateapipb.ResourceMetadata{Name: "worker-1"},
+		NodeName: "node-1",
+	}
+
+	tests := []struct {
+		name            string
+		actor           *ateapipb.Actor
+		template        *ateapipb.ActorTemplate
+		store           *mockDetachStore
+		plugin          *mockDetachVolumePlugin
+		pluginRegistry  *mockPluginRegistry
+		wantDetachCalls []detachCall
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name: "success with multiple mounted volumes",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "worker-1"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", VolumeType: "mock"},
+						{VolumeName: "vol2", StorageVolumeId: "storage-vol-2", VolumeType: "mock"},
+					},
+				},
+			},
+			template: &ateapipb.ActorTemplate{
+				Volumes: []*ateapipb.Volume{
+					{Name: "vol1"},
+					{Name: "vol2"},
+				},
+				Containers: []*ateapipb.Container{
+					{
+						VolumeMounts: []*ateapipb.VolumeMount{
+							{Name: "vol1"},
+							{Name: "vol2"},
+						},
+					},
+				},
+			},
+			store: &mockDetachStore{
+				workers: map[string]*ateapipb.Worker{"worker-1": baseWorker},
+			},
+			wantDetachCalls: []detachCall{
+				{VolumeID: "storage-vol-1", Node: "node-1"},
+				{VolumeID: "storage-vol-2", Node: "node-1"},
+			},
+		},
+		{
+			name: "skips unmounted volume in template",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "worker-1"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "mounted-vol", StorageVolumeId: "storage-vol-mounted", VolumeType: "mock"},
+						{VolumeName: "unmounted-vol", StorageVolumeId: "storage-vol-unmounted", VolumeType: "mock"},
+					},
+				},
+			},
+			template: &ateapipb.ActorTemplate{
+				Volumes: []*ateapipb.Volume{
+					{Name: "mounted-vol"},
+					{Name: "unmounted-vol"},
+				},
+				Containers: []*ateapipb.Container{
+					{
+						VolumeMounts: []*ateapipb.VolumeMount{
+							{Name: "mounted-vol"},
+						},
+					},
+				},
+			},
+			store: &mockDetachStore{
+				workers: map[string]*ateapipb.Worker{"worker-1": baseWorker},
+			},
+			wantDetachCalls: []detachCall{
+				{VolumeID: "storage-vol-mounted", Node: "node-1"},
+			},
+		},
+		{
+			name: "skips volume with empty StorageVolumeId",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "worker-1"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "", VolumeType: "mock"},
+						{VolumeName: "vol2", StorageVolumeId: "storage-vol-2", VolumeType: "mock"},
+					},
+				},
+			},
+			template: &ateapipb.ActorTemplate{
+				Volumes: []*ateapipb.Volume{
+					{Name: "vol1"},
+					{Name: "vol2"},
+				},
+				Containers: []*ateapipb.Container{
+					{
+						VolumeMounts: []*ateapipb.VolumeMount{
+							{Name: "vol1"},
+							{Name: "vol2"},
+						},
+					},
+				},
+			},
+			store: &mockDetachStore{
+				workers: map[string]*ateapipb.Worker{"worker-1": baseWorker},
+			},
+			wantDetachCalls: []detachCall{
+				{VolumeID: "storage-vol-2", Node: "node-1"},
+			},
+		},
+		{
+			name: "nil template falls back to detaching all actor volumes",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "worker-1"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", VolumeType: "mock"},
+						{VolumeName: "vol2", StorageVolumeId: "storage-vol-2", VolumeType: "mock"},
+					},
+				},
+			},
+			template: nil,
+			store: &mockDetachStore{
+				workers: map[string]*ateapipb.Worker{"worker-1": baseWorker},
+			},
+			wantDetachCalls: []detachCall{
+				{VolumeID: "storage-vol-1", Node: "node-1"},
+				{VolumeID: "storage-vol-2", Node: "node-1"},
+			},
+		},
+		{
+			name: "codes.NotFound from plugin is treated as already detached",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "worker-1"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", VolumeType: "mock"},
+					},
+				},
+			},
+			plugin: &mockDetachVolumePlugin{
+				detachErrs: map[string]error{
+					"storage-vol-1": status.Error(codes.NotFound, "volume not found"),
+				},
+			},
+			store: &mockDetachStore{
+				workers: map[string]*ateapipb.Worker{"worker-1": baseWorker},
+			},
+			wantDetachCalls: []detachCall{
+				{VolumeID: "storage-vol-1", Node: "node-1"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "partial failure attempts all volumes and joins errors",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "worker-1"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", VolumeType: "mock"},
+						{VolumeName: "vol2", StorageVolumeId: "storage-vol-2", VolumeType: "mock"},
+					},
+				},
+			},
+			plugin: &mockDetachVolumePlugin{
+				detachErrs: map[string]error{
+					"storage-vol-1": status.Error(codes.Internal, "disk detach failed"),
+				},
+			},
+			store: &mockDetachStore{
+				workers: map[string]*ateapipb.Worker{"worker-1": baseWorker},
+			},
+			wantDetachCalls: []detachCall{
+				{VolumeID: "storage-vol-1", Node: "node-1"},
+				{VolumeID: "storage-vol-2", Node: "node-1"},
+			},
+			wantErr:         true,
+			wantErrContains: "failed to detach volume \"storage-vol-1\"",
+		},
+		{
+			name: "unknown plugin returns error",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "worker-1"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", VolumeType: "unknown-plugin"},
+					},
+				},
+			},
+			store: &mockDetachStore{
+				workers: map[string]*ateapipb.Worker{"worker-1": baseWorker},
+			},
+			wantErr:         true,
+			wantErrContains: "failed to get volume plugin for \"unknown-plugin\"",
+		},
+		{
+			name: "no worker assignment skips detach",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: nil,
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", VolumeType: "mock"},
+					},
+				},
+			},
+			store:           &mockDetachStore{},
+			wantDetachCalls: nil,
+			wantErr:         false,
+		},
+		{
+			name: "worker not found in store skips detach",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "nonexistent-worker"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", VolumeType: "mock"},
+					},
+				},
+			},
+			store:           &mockDetachStore{workers: map[string]*ateapipb.Worker{}},
+			wantDetachCalls: nil,
+			wantErr:         false,
+		},
+		{
+			name: "worker has empty node name skips detach",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "worker-1"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", VolumeType: "mock"},
+					},
+				},
+			},
+			store: &mockDetachStore{
+				workers: map[string]*ateapipb.Worker{
+					"worker-1": {
+						Metadata: &ateapipb.ResourceMetadata{Name: "worker-1"},
+						NodeName: "",
+					},
+				},
+			},
+			wantDetachCalls: nil,
+			wantErr:         false,
+		},
+		{
+			name: "store internal error returns error",
+			actor: &ateapipb.Actor{
+				Metadata: &ateapipb.ResourceMetadata{Name: "actor-1", Atespace: "default"},
+				Status: &ateapipb.ActorStatus{
+					WorkerAssignment: &ateapipb.WorkerAssignment{
+						Worker: &ateapipb.ObjectRef{Name: "worker-1"},
+					},
+					ActorVolumes: []*ateapipb.ExternalVolume{
+						{VolumeName: "vol1", StorageVolumeId: "storage-vol-1", VolumeType: "mock"},
+					},
+				},
+			},
+			store: &mockDetachStore{
+				err: errors.New("db connection failure"),
+			},
+			wantDetachCalls: nil,
+			wantErr:         true,
+			wantErrContains: "failed to get worker: db connection failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := tt.plugin
+			if plugin == nil {
+				plugin = &mockDetachVolumePlugin{}
+			}
+			registry := tt.pluginRegistry
+			if registry == nil {
+				registry = &mockPluginRegistry{
+					plugins: map[string]volume.VolumePluginControlPlane{
+						"mock": plugin,
+					},
+				}
+			}
+
+			err := detachActorVolumes(ctx, tt.store, registry, tt.actor, tt.template, "test")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("detachActorVolumes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErrContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("detachActorVolumes() error = %v, want error containing %q", err, tt.wantErrContains)
+				}
+			}
+			if diff := cmp.Diff(tt.wantDetachCalls, plugin.detachCalls); diff != "" {
+				t.Errorf("detachCalls mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/cmd/ateapi/internal/controlapi/workflow_delete_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_delete_test.go
@@ -16,6 +16,7 @@ package controlapi
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/agent-substrate/substrate/cmd/ateapi/internal/store"
@@ -326,6 +327,53 @@ func TestEnsureExternalSnapshotsReleased_CollectsStrandedSnapshots(t *testing.T)
 	// Deletion should not release snapshots from other actors
 	if len(objects.Snapshot(t, otherActorsSnapshot)) == 0 {
 		t.Errorf("another actor's external snapshot %v was released", otherActorsSnapshot)
+	}
+}
+
+// TestEnsureExternalSnapshotsReleased_DeletePrefixFailure verifies that if
+// objectstore.DeletePrefix fails with a transient error during actor deletion,
+// ensureExternalSnapshotsReleased returns that error, preserves the un-deleted
+// objects, and cleanly completes the deletion on a subsequent retry.
+func TestEnsureExternalSnapshotsReleased_DeletePrefixFailure(t *testing.T) {
+	ctx := context.Background()
+	persistence := newTestPersistence(t)
+	template := seedSubstrateTemplate(t, ctx, persistence, "sub-tmpl")
+	w, objects := newFinalizeWorkflow(persistence)
+
+	actor := storetest.MustCreateActor(t, ctx, persistence, &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "actor-1"},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "sub-tmpl"},
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_DELETING},
+	})
+
+	current := mustActorSnapshotURI(t, template, actor, "current")
+	objects.PutSnapshot(t, current, "manifest.json", "memory.zst")
+	actor = mustUpdateActorStatus(t, ctx, persistence, actor, func(s *ateapipb.ActorStatus) {
+		s.ExternalSnapshot = &ateapipb.ExternalSnapshot{SnapshotUri: current.String()}
+	})
+
+	errTransient := errors.New("simulated transient delete failure")
+	objects.OnDelete = func(bucket, object string) error {
+		return errTransient
+	}
+
+	err := w.ensureExternalSnapshotsReleased(ctx, actor, template)
+	if !errors.Is(err, errTransient) {
+		t.Fatalf("ensureExternalSnapshotsReleased error = %v, want error wrapping %v", err, errTransient)
+	}
+
+	// Objects should not have been deleted
+	if len(objects.Snapshot(t, current)) == 0 {
+		t.Fatal("objects were unexpectedly deleted despite OnDelete failure")
+	}
+
+	// Retry without failure: should successfully clean up the snapshot objects
+	objects.OnDelete = nil
+	if err := w.ensureExternalSnapshotsReleased(ctx, actor, template); err != nil {
+		t.Fatalf("ensureExternalSnapshotsReleased on retry failed: %v", err)
+	}
+	if remaining := objects.Snapshot(t, current); len(remaining) != 0 {
+		t.Errorf("external snapshot objects remain after retry: %v", remaining)
 	}
 }
 

--- a/cmd/atelet/volumes.go
+++ b/cmd/atelet/volumes.go
@@ -29,13 +29,17 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// volumeHostPath resolves an actor UID and volume name to its mount path on the host.
+// A variable so tests can direct mounts into a temporary directory.
+var volumeHostPath = ateompath.VolumeHostPath
+
 func (s *AteomHerder) mountExternalVolumes(ctx context.Context, actorUID string, volumes []*ateletpb.Volume) error {
 	for _, vol := range volumes {
 		ext := vol.GetExternal()
 		if ext == nil {
 			continue
 		}
-		hostPath := ateompath.VolumeHostPath(actorUID, vol.GetName())
+		hostPath := volumeHostPath(actorUID, vol.GetName())
 		if err := os.MkdirAll(hostPath, 0o750); err != nil {
 			return fmt.Errorf("failed to create mount point %q: %w", hostPath, err)
 		}
@@ -58,7 +62,7 @@ func (s *AteomHerder) unmountExternalVolumes(ctx context.Context, actorUID strin
 		if ext == nil {
 			continue
 		}
-		hostPath := ateompath.VolumeHostPath(actorUID, vol.GetName())
+		hostPath := volumeHostPath(actorUID, vol.GetName())
 		slog.InfoContext(ctx, "Unmounting volume", slog.String("volume_id", ext.GetStorageVolumeId()), slog.String("host_path", hostPath), slog.String("volume_type", ext.GetVolumeType()))
 		// TODO: Standardize volume plugin lookup and error handling across control plane
 		// and worker plane (e.g. via a shared helper).

--- a/cmd/atelet/volumes_test.go
+++ b/cmd/atelet/volumes_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agent-substrate/substrate/internal/ateompath"
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/volume"
 	"github.com/google/go-cmp/cmp"
@@ -35,10 +36,12 @@ type mountCall struct {
 }
 
 type fakeWorkerPlugin struct {
-	mountErr   error
-	unmountErr error
-	unmounted  []string
-	mountCalls []mountCall
+	mountErr    error
+	mountErrs   map[string]error
+	unmountErr  error
+	unmountErrs map[string]error
+	unmounted   []string
+	mountCalls  []mountCall
 }
 
 func (f *fakeWorkerPlugin) MountVolume(ctx context.Context, volumeID string, targetPath string, attributes map[string]string) error {
@@ -47,11 +50,21 @@ func (f *fakeWorkerPlugin) MountVolume(ctx context.Context, volumeID string, tar
 		targetPath: targetPath,
 		attributes: attributes,
 	})
+	if f.mountErrs != nil {
+		if err, ok := f.mountErrs[volumeID]; ok {
+			return err
+		}
+	}
 	return f.mountErr
 }
 
 func (f *fakeWorkerPlugin) UnmountVolume(ctx context.Context, volumeID string, targetPath string) error {
 	f.unmounted = append(f.unmounted, volumeID)
+	if f.unmountErrs != nil {
+		if err, ok := f.unmountErrs[volumeID]; ok {
+			return err
+		}
+	}
 	return f.unmountErr
 }
 
@@ -332,6 +345,228 @@ func TestMountExternalVolumes(t *testing.T) {
 		}
 		if len(fake.mountCalls) != 1 {
 			t.Errorf("mountCalls count = %d, want 1 (stopped after first failure)", len(fake.mountCalls))
+		}
+	})
+
+	t.Run("multi-volume partial failure does not roll back already mounted volume", func(t *testing.T) {
+		tempDir := t.TempDir()
+		origVolumeHostPath := volumeHostPath
+		volumeHostPath = func(uid, name string) string {
+			return filepath.Join(tempDir, uid, name)
+		}
+		t.Cleanup(func() { volumeHostPath = origVolumeHostPath })
+
+		expectedPath1 := filepath.Join(tempDir, actorUID, "vol-1")
+		expectedPath2 := filepath.Join(tempDir, actorUID, "vol-2")
+
+		fake := &fakeWorkerPlugin{
+			mountErrs: map[string]error{
+				"mock-vol-2": errors.New("simulated mount error on vol-2"),
+			},
+		}
+		s := &AteomHerder{
+			volumePlugins: map[string]volume.VolumePluginWorkerPlane{
+				"mock-driver": fake,
+			},
+		}
+
+		err := s.mountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1, extVol2})
+		if err == nil {
+			t.Fatal("expected mountExternalVolumes to fail when vol-2 fails, got nil")
+		}
+		if !strings.Contains(err.Error(), "simulated mount error on vol-2") {
+			t.Errorf("error = %v, want error to contain %q", err, "simulated mount error on vol-2")
+		}
+
+		// Both volumes had MountVolume called: vol-1 succeeded, vol-2 failed.
+		if len(fake.mountCalls) != 2 {
+			t.Fatalf("mountCalls count = %d, want 2", len(fake.mountCalls))
+		}
+		if fake.mountCalls[0].volumeID != "mock-vol-1" || fake.mountCalls[1].volumeID != "mock-vol-2" {
+			t.Errorf("mountCalls = %v, want calls for mock-vol-1 followed by mock-vol-2", fake.mountCalls)
+		}
+
+		// Verify vol-1 was not rolled back or unmounted when vol-2 failed.
+		if len(fake.unmounted) != 0 {
+			t.Errorf("unmounted count = %d, want 0 (vol-1 was not rolled back)", len(fake.unmounted))
+		}
+
+		// Verify host mount directory for vol-1 exists and remains on disk.
+		if _, err := os.Stat(expectedPath1); err != nil {
+			t.Errorf("stat vol-1 mount path %q: %v", expectedPath1, err)
+		}
+
+		// Verify host mount directory for vol-2 was also created prior to MountVolume call.
+		if _, err := os.Stat(expectedPath2); err != nil {
+			t.Errorf("stat vol-2 mount path %q: %v", expectedPath2, err)
+		}
+	})
+}
+
+func TestVolumeHostDirectoryCleanup(t *testing.T) {
+	ctx := context.Background()
+	actorUID := "test-actor-cleanup"
+
+	extVol1 := &ateletpb.Volume{
+		Name: "vol-1",
+		Source: &ateletpb.Volume_External{
+			External: &ateletpb.ExternalVolumeSource{
+				StorageVolumeId: "mock-vol-1",
+				VolumeType:      "mock-driver",
+			},
+		},
+	}
+	extVol2 := &ateletpb.Volume{
+		Name: "vol-2",
+		Source: &ateletpb.Volume_External{
+			External: &ateletpb.ExternalVolumeSource{
+				StorageVolumeId: "mock-vol-2",
+				VolumeType:      "mock-driver",
+			},
+		},
+	}
+
+	t.Run("unmountExternalVolumes preserves host mount directories", func(t *testing.T) {
+		tempDir := t.TempDir()
+		origVolumeHostPath := volumeHostPath
+		volumeHostPath = func(uid, name string) string {
+			return filepath.Join(tempDir, uid, name)
+		}
+		t.Cleanup(func() { volumeHostPath = origVolumeHostPath })
+
+		fake := &fakeWorkerPlugin{}
+		s := &AteomHerder{
+			volumePlugins: map[string]volume.VolumePluginWorkerPlane{
+				"mock-driver": fake,
+			},
+		}
+
+		if err := s.mountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1, extVol2}); err != nil {
+			t.Fatalf("mountExternalVolumes failed: %v", err)
+		}
+
+		path1 := volumeHostPath(actorUID, "vol-1")
+		path2 := volumeHostPath(actorUID, "vol-2")
+		for _, p := range []string{path1, path2} {
+			if _, err := os.Stat(p); err != nil {
+				t.Fatalf("expected mount path %q to exist before unmount: %v", p, err)
+			}
+		}
+
+		if err := s.unmountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1, extVol2}); err != nil {
+			t.Fatalf("unmountExternalVolumes failed: %v", err)
+		}
+
+		// unmountExternalVolumes unmounts the CSI volumes, but preserves the host directories.
+		for _, p := range []string{path1, path2} {
+			if _, err := os.Stat(p); err != nil {
+				t.Errorf("mount path %q was unexpectedly deleted by unmountExternalVolumes: %v", p, err)
+			}
+		}
+	})
+
+	t.Run("resetActorDirs removes empty unmounted volume host directories", func(t *testing.T) {
+		origActorsDir := ateompath.ActorsDir
+		tempDir := t.TempDir()
+		ateompath.ActorsDir = filepath.Join(tempDir, "actors")
+		t.Cleanup(func() { ateompath.ActorsDir = origActorsDir })
+
+		fake := &fakeWorkerPlugin{}
+		s := &AteomHerder{
+			volumePlugins: map[string]volume.VolumePluginWorkerPlane{
+				"mock-driver": fake,
+			},
+		}
+
+		// Mount and then unmount external volumes.
+		if err := s.mountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1, extVol2}); err != nil {
+			t.Fatalf("mountExternalVolumes failed: %v", err)
+		}
+		if err := s.unmountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1, extVol2}); err != nil {
+			t.Fatalf("unmountExternalVolumes failed: %v", err)
+		}
+
+		path1 := ateompath.VolumeHostPath(actorUID, "vol-1")
+		path2 := ateompath.VolumeHostPath(actorUID, "vol-2")
+		for _, p := range []string{path1, path2} {
+			if _, err := os.Stat(p); err != nil {
+				t.Fatalf("expected mount path %q to exist before reset: %v", p, err)
+			}
+		}
+
+		// resetActorDirs cleans up empty volume directories left after unmount.
+		if err := resetActorDirs(actorUID); err != nil {
+			t.Fatalf("resetActorDirs failed: %v", err)
+		}
+
+		for _, p := range []string{path1, path2} {
+			if _, err := os.Stat(p); !os.IsNotExist(err) {
+				t.Errorf("expected mount path %q to be deleted by resetActorDirs, stat err = %v", p, err)
+			}
+		}
+
+		// The parent volumes directory is preserved and empty.
+		volumesDir := ateompath.VolumesDir(actorUID)
+		entries, err := os.ReadDir(volumesDir)
+		if err != nil {
+			t.Fatalf("ReadDir(%q) failed: %v", volumesDir, err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("expected volumes dir to be empty, found %d entries", len(entries))
+		}
+	})
+
+	t.Run("resetActorDirs preserves non-empty volume directories and returns error", func(t *testing.T) {
+		origActorsDir := ateompath.ActorsDir
+		tempDir := t.TempDir()
+		ateompath.ActorsDir = filepath.Join(tempDir, "actors")
+		t.Cleanup(func() { ateompath.ActorsDir = origActorsDir })
+
+		fake := &fakeWorkerPlugin{}
+		s := &AteomHerder{
+			volumePlugins: map[string]volume.VolumePluginWorkerPlane{
+				"mock-driver": fake,
+			},
+		}
+
+		if err := s.mountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1}); err != nil {
+			t.Fatalf("mountExternalVolumes failed: %v", err)
+		}
+
+		// Simulate lingering content in the volume mount point (e.g. unmount failed or data present).
+		path1 := ateompath.VolumeHostPath(actorUID, "vol-1")
+		filePath := filepath.Join(path1, "lingering.txt")
+		if err := os.WriteFile(filePath, []byte("volume data"), 0o600); err != nil {
+			t.Fatalf("writing test file: %v", err)
+		}
+
+		err := resetActorDirs(actorUID)
+		if err == nil {
+			t.Fatal("expected resetActorDirs to fail on non-empty volume dir, got nil")
+		}
+		if !strings.Contains(err.Error(), "while removing volume dir") {
+			t.Errorf("error = %v, want error containing 'while removing volume dir'", err)
+		}
+
+		// Verify data is preserved and not deleted.
+		if _, err := os.Stat(filePath); err != nil {
+			t.Errorf("stat %q: %v (data was unexpectedly deleted)", filePath, err)
+		}
+	})
+
+	t.Run("resetActorDirs succeeds cleanly when volumes directory does not exist", func(t *testing.T) {
+		origActorsDir := ateompath.ActorsDir
+		tempDir := t.TempDir()
+		ateompath.ActorsDir = filepath.Join(tempDir, "actors")
+		t.Cleanup(func() { ateompath.ActorsDir = origActorsDir })
+
+		if err := resetActorDirs(actorUID); err != nil {
+			t.Fatalf("resetActorDirs failed when volumes dir does not exist: %v", err)
+		}
+
+		volumesDir := ateompath.VolumesDir(actorUID)
+		if info, err := os.Stat(volumesDir); err != nil || !info.IsDir() {
+			t.Errorf("expected volumes dir %q to be created, stat err = %v", volumesDir, err)
 		}
 	})
 }

--- a/cmd/atelet/volumes_test.go
+++ b/cmd/atelet/volumes_test.go
@@ -18,19 +18,35 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/agent-substrate/substrate/internal/proto/ateletpb"
 	"github.com/agent-substrate/substrate/internal/volume"
+	"github.com/google/go-cmp/cmp"
 )
+
+type mountCall struct {
+	volumeID   string
+	targetPath string
+	attributes map[string]string
+}
 
 type fakeWorkerPlugin struct {
 	mountErr   error
 	unmountErr error
 	unmounted  []string
+	mountCalls []mountCall
 }
 
 func (f *fakeWorkerPlugin) MountVolume(ctx context.Context, volumeID string, targetPath string, attributes map[string]string) error {
+	f.mountCalls = append(f.mountCalls, mountCall{
+		volumeID:   volumeID,
+		targetPath: targetPath,
+		attributes: attributes,
+	})
 	return f.mountErr
 }
 
@@ -123,6 +139,199 @@ func TestUnmountExternalVolumes(t *testing.T) {
 		// Both volumes should have attempt made
 		if len(fake.unmounted) != 2 {
 			t.Errorf("attempted unmount count = %d, want 2", len(fake.unmounted))
+		}
+	})
+}
+
+func TestMountExternalVolumes(t *testing.T) {
+	ctx := context.Background()
+	actorUID := "test-actor-456"
+
+	extVol1 := &ateletpb.Volume{
+		Name: "vol-1",
+		Source: &ateletpb.Volume_External{
+			External: &ateletpb.ExternalVolumeSource{
+				StorageVolumeId: "mock-vol-1",
+				VolumeType:      "mock-driver",
+				VolumeContext:   map[string]string{"key": "val1"},
+			},
+		},
+	}
+	extVol2 := &ateletpb.Volume{
+		Name: "vol-2",
+		Source: &ateletpb.Volume_External{
+			External: &ateletpb.ExternalVolumeSource{
+				StorageVolumeId: "mock-vol-2",
+				VolumeType:      "mock-driver",
+				VolumeContext:   map[string]string{"key": "val2"},
+			},
+		},
+	}
+	durableVol := &ateletpb.Volume{
+		Name: "durable-1",
+		Source: &ateletpb.Volume_DurableDir{
+			DurableDir: &ateletpb.DurableDirVolume{},
+		},
+	}
+
+	t.Run("success mounts external volumes and creates mount directory", func(t *testing.T) {
+		tempDir := t.TempDir()
+		origVolumeHostPath := volumeHostPath
+		volumeHostPath = func(uid, name string) string {
+			return filepath.Join(tempDir, uid, name)
+		}
+		t.Cleanup(func() { volumeHostPath = origVolumeHostPath })
+
+		fake := &fakeWorkerPlugin{}
+		s := &AteomHerder{
+			volumePlugins: map[string]volume.VolumePluginWorkerPlane{
+				"mock-driver": fake,
+			},
+		}
+
+		err := s.mountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1, durableVol, extVol2})
+		if err != nil {
+			t.Fatalf("mountExternalVolumes failed unexpectedly: %v", err)
+		}
+
+		if len(fake.mountCalls) != 2 {
+			t.Fatalf("mountCalls count = %d, want 2", len(fake.mountCalls))
+		}
+
+		expectedPath1 := filepath.Join(tempDir, actorUID, "vol-1")
+		expectedPath2 := filepath.Join(tempDir, actorUID, "vol-2")
+
+		for _, path := range []string{expectedPath1, expectedPath2} {
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat mount path %q: %v", path, err)
+			}
+			if !info.IsDir() {
+				t.Errorf("%q is not a directory", path)
+			}
+			if perm := info.Mode().Perm(); perm != 0o750 {
+				t.Errorf("perm for %q = %o, want 750", path, perm)
+			}
+		}
+
+		wantCalls := []mountCall{
+			{volumeID: "mock-vol-1", targetPath: expectedPath1, attributes: map[string]string{"key": "val1"}},
+			{volumeID: "mock-vol-2", targetPath: expectedPath2, attributes: map[string]string{"key": "val2"}},
+		}
+		if diff := cmp.Diff(wantCalls, fake.mountCalls, cmp.AllowUnexported(mountCall{})); diff != "" {
+			t.Errorf("mountCalls mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("target directory already exists is handled cleanly", func(t *testing.T) {
+		tempDir := t.TempDir()
+		origVolumeHostPath := volumeHostPath
+		volumeHostPath = func(uid, name string) string {
+			return filepath.Join(tempDir, uid, name)
+		}
+		t.Cleanup(func() { volumeHostPath = origVolumeHostPath })
+
+		expectedPath := filepath.Join(tempDir, actorUID, "vol-1")
+		if err := os.MkdirAll(expectedPath, 0o750); err != nil {
+			t.Fatalf("pre-creating mount point: %v", err)
+		}
+
+		fake := &fakeWorkerPlugin{}
+		s := &AteomHerder{
+			volumePlugins: map[string]volume.VolumePluginWorkerPlane{
+				"mock-driver": fake,
+			},
+		}
+
+		err := s.mountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1})
+		if err != nil {
+			t.Fatalf("mountExternalVolumes with existing directory failed: %v", err)
+		}
+		if len(fake.mountCalls) != 1 || fake.mountCalls[0].targetPath != expectedPath {
+			t.Errorf("mountCalls = %v, want 1 call for %q", fake.mountCalls, expectedPath)
+		}
+	})
+
+	t.Run("plugin lookup failure returns error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		origVolumeHostPath := volumeHostPath
+		volumeHostPath = func(uid, name string) string {
+			return filepath.Join(tempDir, uid, name)
+		}
+		t.Cleanup(func() { volumeHostPath = origVolumeHostPath })
+
+		unknownVol := &ateletpb.Volume{
+			Name: "vol-unknown",
+			Source: &ateletpb.Volume_External{
+				External: &ateletpb.ExternalVolumeSource{
+					StorageVolumeId: "mock-vol-unknown",
+					VolumeType:      "unknown-driver",
+				},
+			},
+		}
+
+		s := &AteomHerder{
+			volumePlugins: map[string]volume.VolumePluginWorkerPlane{},
+		}
+
+		err := s.mountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{unknownVol})
+		if err == nil {
+			t.Fatal("expected mountExternalVolumes to fail with unknown plugin, got nil")
+		}
+		if !strings.Contains(err.Error(), "unknown-driver") {
+			t.Errorf("error = %v, want to contain driver name %q", err, "unknown-driver")
+		}
+	})
+
+	t.Run("plugin mount failure returns error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		origVolumeHostPath := volumeHostPath
+		volumeHostPath = func(uid, name string) string {
+			return filepath.Join(tempDir, uid, name)
+		}
+		t.Cleanup(func() { volumeHostPath = origVolumeHostPath })
+
+		fake := &fakeWorkerPlugin{
+			mountErr: errors.New("mount operation failed: device or resource busy"),
+		}
+		s := &AteomHerder{
+			volumePlugins: map[string]volume.VolumePluginWorkerPlane{
+				"mock-driver": fake,
+			},
+		}
+
+		err := s.mountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1})
+		if err == nil {
+			t.Fatal("expected mountExternalVolumes to fail, got nil")
+		}
+		if !strings.Contains(err.Error(), "device or resource busy") {
+			t.Errorf("error = %v, want to contain underlying mount error", err)
+		}
+	})
+
+	t.Run("multi-volume partial failure aborts on first failure", func(t *testing.T) {
+		tempDir := t.TempDir()
+		origVolumeHostPath := volumeHostPath
+		volumeHostPath = func(uid, name string) string {
+			return filepath.Join(tempDir, uid, name)
+		}
+		t.Cleanup(func() { volumeHostPath = origVolumeHostPath })
+
+		fake := &fakeWorkerPlugin{
+			mountErr: errors.New("cannot mount volume"),
+		}
+		s := &AteomHerder{
+			volumePlugins: map[string]volume.VolumePluginWorkerPlane{
+				"mock-driver": fake,
+			},
+		}
+
+		err := s.mountExternalVolumes(ctx, actorUID, []*ateletpb.Volume{extVol1, extVol2})
+		if err == nil {
+			t.Fatal("expected mountExternalVolumes to fail, got nil")
+		}
+		if len(fake.mountCalls) != 1 {
+			t.Errorf("mountCalls count = %d, want 1 (stopped after first failure)", len(fake.mountCalls))
 		}
 	})
 }

--- a/internal/e2e/suites/demo/demo_test.go
+++ b/internal/e2e/suites/demo/demo_test.go
@@ -488,6 +488,92 @@ func TestDeleteActorAnyStateWithExternalVolume(t *testing.T) {
 	}
 }
 
+func TestExternalVolume_NodeMigration(t *testing.T) {
+	if e2e.IsMicroVM() {
+		t.Skip("Skipping TestExternalVolume_NodeMigration for microVM environment")
+	}
+
+	ctx := context.Background()
+	clients := e2e.GetClients()
+	nsObj := e2e.CreateNamespace(t)
+
+	at, err := createActorTemplateWithExternalVolume(ctx, t, clients, nsObj, ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA, ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA, ateapipb.ResumeSource_RESUME_SOURCE_COLD_BOOT)
+	if err != nil {
+		t.Fatalf("failed to initialize ActorTemplate: %v", err)
+	}
+
+	actorName := "extvol-migration-" + nsObj.Name
+
+	t.Logf("Creating Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.CreateActor(ctx, &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: demoAtespace, Name: actorName},
+		ActorTemplate: e2e.TemplateRef(at),
+	}}); err != nil {
+		t.Fatalf("failed to create Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
+
+	t.Logf("Resuming Actor %q...", actorName)
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); err != nil {
+		t.Fatalf("failed to resume Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_RUNNING)
+
+	resp, err := callActor(t, resources.ActorRef{Atespace: demoAtespace, Name: actorName})
+	if err != nil {
+		t.Fatalf("failed to call actor on initial worker: %v", err)
+	}
+	validateCounterResponse(t, resp, "initial run", 1, 1)
+
+	actor, err := clients.SubstrateAPI.GetActor(ctx, &ateapipb.GetActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	})
+	if err != nil {
+		t.Fatalf("failed to get actor: %v", err)
+	}
+	initialWorkerPod := actor.GetStatus().GetWorkerAssignment().GetWorkerPod()
+	initialWorkerNS := actor.GetStatus().GetWorkerAssignment().GetWorkerNamespace()
+
+	t.Logf("Suspending Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.SuspendActor(ctx, &ateapipb.SuspendActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); err != nil {
+		t.Fatalf("failed to suspend Actor: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_SUSPENDED)
+
+	// Delete initial worker pod to force migration onto another worker upon resume
+	if initialWorkerPod != "" && initialWorkerNS != "" {
+		t.Logf("Evicting initial worker pod %s/%s to force migration...", initialWorkerNS, initialWorkerPod)
+		_ = clients.K8s.CoreV1().Pods(initialWorkerNS).Delete(ctx, initialWorkerPod, metav1.DeleteOptions{})
+	}
+
+	t.Logf("Resuming Actor %q after worker pod eviction...", actorName)
+	if _, err := e2e.ResumeActorAwaitCapacity(t, ctx, clients, &ateapipb.ResumeActorRequest{
+		Actor: &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+	}); err != nil {
+		t.Fatalf("failed to resume Actor after migration: %v", err)
+	}
+	waitForActorState(ctx, t, clients, actorName, ateapipb.ActorState_ACTOR_STATE_RUNNING)
+
+	resp, err = callActor(t, resources.ActorRef{Atespace: demoAtespace, Name: actorName})
+	if err != nil {
+		t.Fatalf("failed to call actor after migration: %v", err)
+	}
+	validateCounterResponse(t, resp, "after migration", 1, 2)
+
+	// Clean up by deleting the actor
+	t.Logf("Deleting Actor %q...", actorName)
+	if _, err := clients.SubstrateAPI.DeleteActor(ctx, &ateapipb.DeleteActorRequest{
+		Actor:    &ateapipb.ObjectRef{Atespace: demoAtespace, Name: actorName},
+		AnyState: true,
+	}); err != nil {
+		t.Fatalf("failed to delete Actor: %v", err)
+	}
+}
+
 // Verify that file and memory counters behavior after pause and suspend, for different snapshot scopes.
 // Test case:
 //  1. Create actor.


### PR DESCRIPTION
Fixes #<issue_number_goes_here>
NA

This PR enhances the tests to validate volume lifecycle during state transition failures

 • **TestDeleteActor_VolumeDeletionFailure_RetrySuccess**- Verifies that when volume deletion fails during DeleteActor, the actor transitions to ACTOR_STATE_DELETING and its volumes to STATUS_DELETING. A     
  subsequent retry successfully finalizes volume deletion and deletes the actor from the store.                                                                                                               
  • **TestResumeActor_VolumeAttachFailureAndRetry** - Verifies that when volume attachment fails during ResumeActor, the actor remains in ACTOR_STATE_RESUMING with worker assignment and provisioned volumes     
  intact. Retrying ResumeActor re-attempts volume attachment and successfully transitions the actor to ACTOR_STATE_RUNNING.                                                                                   
  • **TestResumeActor_VolumeAttachFailure_DeleteActor** - Verifies that an actor stuck in ACTOR_STATE_RESUMING after an attach failure rejects standard DeleteActor requests, but calling DeleteActor with        
  AnyState=true successfully cleans up worker assignments and provisioned volumes.                                                                                                                            
  • **TestResumeActor_MultiVolumePartialAttachFailure_Retry** - Verifies that when attaching multiple volumes during ResumeActor and one volume fails, previously attached volumes remain attached and the actor  
  stays in ACTOR_STATE_RESUMING. A subsequent retry attaches only the remaining unattached volumes and transitions the actor to ACTOR_STATE_RUNNING.                                                          
  • **TestSuspendActor_VolumeDetachFailure_RetrySuccess** - Verifies that volume detach failures during SuspendActor leave the actor in ACTOR_STATE_SUSPENDING with its worker assignment held. A subsequent retry
  succeeds in detaching the volume, releasing the worker, and transitioning the actor to ACTOR_STATE_SUSPENDED.                                                                                               
  • **TestSuspendActor_VolumeDetachFailure_DeleteActorAnyState** - Verifies that an actor stuck in ACTOR_STATE_SUSPENDING due to a volume detach failure rejects standard deletion, but cleanly detaches volumes  
  and deletes the actor when called with AnyState=true.                                                                                                                                                       
  • **TestPauseActor_VolumeLifecycle_DetachAndResumeAttach** - Validates the volume lifecycle across pause and unpause, confirming external volumes are detached when transitioning from RUNNING to PAUSED and re-
  attached when resumed back to RUNNING.                                                                                                                                                                      
  • **TestPauseActor_VolumeDetachFailure_RetrySuccess** - Verifies that volume detachment failure during PauseActor leaves the actor in ACTOR_STATE_PAUSING. A retry of PauseActor re-attempts volume detachment, 
  succeeds, and advances the actor state to ACTOR_STATE_PAUSED.                                                                                                                                               
  • **TestResumeActor_PausedLocalSnapshotMissing_Crashes** - Verifies that if local snapshot files on the worker are missing when resuming a PAUSED actor, the control plane marks the actor ACTOR_STATE_CRASHED  
  and frees the assigned worker pod.                                                                                                                                                                          
  • **TestDetachActorVolumes** - Tests control plane volume detachment logic across multiple scenarios, including container mount filtering, partial detach errors, unassigned workers, and idempotent not-found  
  responses from plugins.                                                                                                                                                                                     
  • **TestCreateActorVolumes (Storage class parameters case)** - Verifies that parameters configured on a StorageClass (such as disk and filesystem types) are correctly propagated into the volume context of    
  newly created external volumes.                                                                                                                                                                             
  • **TestEnsureExternalSnapshotsReleased_DeletePrefixFailure** - Verifies that transient object store errors during actor deletion preserve un-deleted snapshot objects and return an error, which cleanly       
  completes deletion on a retry.                                                                                                                                                                              
  • **TestMountExternalVolumes** - Tests worker-side volume mounting, verifying host mount directory creation, handling pre-existing paths, plugin errors, and ensuring that partial failures during multi-volume 
  mounts do not unmount already mounted volumes.                                                                                                                                                              
  • **TestVolumeHostDirectoryCleanup** - Verifies worker-side host directory management, ensuring volume unmounting preserves mount directories while directory reset removes empty directories and prevents data 
  loss on non-empty ones.                                                                                                                                                                                     
  • **TestExternalVolume_NodeMigration** - Verifies cross-node actor migration with external volumes by suspending an actor, evicting its worker pod, and resuming it on a new worker node while ensuring         
  application state is preserved

- [ x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
