### PR TITLE
Stop the resume and suspend finalizers overwriting a concurrent crash

### DIFF
--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_test.go
@@ -2128,6 +2128,52 @@ func TestResumeActor_ErrorStillStampsRefSpanIdentity(t *testing.T) {
 	assertSpanStr(t, attrs, ateattr.ActorNameKey, "missing")
 }
 
+// TestResumeActor_WorkerDeletedDuringRestore verifies a worker going away
+// mid-restore leaves the actor CRASHED rather than RUNNING. Finalizing the
+// resume over the crash would record a worker assignment that no longer
+// exists, and the actor would never be rescheduled: a resume of a RUNNING
+// actor short-circuits, so every routed request would fail on an empty
+// worker IP.
+func TestResumeActor_WorkerDeletedDuringRestore(t *testing.T) {
+	ns := namespaceForTest("ns-resume-worker-gone")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	const name = "id1"
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}
+	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	// The pod's node reboots while the guest is being restored onto it, and the
+	// worker is deregistered before the workflow gets to commit RUNNING.
+	var deregisterErr error
+	tc.fakeAtelet.OnRestore = func() { deregisterErr = deregisterWorker(tc, ns, "worker-1") }
+
+	_, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: actorRef})
+	if deregisterErr != nil {
+		t.Fatalf("deregistering the worker mid-restore: %v", deregisterErr)
+	}
+	assertGrpcErrorRegex(t, err, codes.FailedPrecondition, "FinalizeRunning prerequisite not met")
+
+	got, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: actorRef})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if got.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("state = %v, want CRASHED", got.GetStatus().GetState())
+	}
+	if assignment := got.GetStatus().GetWorkerAssignment(); assignment != nil {
+		t.Errorf("worker assignment = %v, want none: the worker it named is gone", assignment)
+	}
+}
+
 // TestSuspendActor tests the full workflow of suspending a running actor.
 // Workflow:
 // 1. Creates a mock ActorTemplate.
@@ -3046,6 +3092,68 @@ func TestSuspendActor_DanglingWorker(t *testing.T) {
 	}
 	if getResp.GetStatus().GetWorkerAssignment() != nil {
 		t.Errorf("expected worker_assignment to be cleared, got %v", getResp.GetStatus().GetWorkerAssignment())
+	}
+}
+
+// TestSuspendActor_WorkerDeletedDuringCheckpoint verifies a worker going away
+// mid-checkpoint leaves the actor CRASHED, still recording the snapshot it
+// last suspended to, rather than SUSPENDED on a checkpoint whose node is gone.
+func TestSuspendActor_WorkerDeletedDuringCheckpoint(t *testing.T) {
+	ns := namespaceForTest("ns-suspend-worker-gone")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	createTemplate(t, tc, ns)
+	createWorkerPod(t, tc, ns, "worker-1", "node1", "pool1")
+
+	const name = "id1"
+	actorRef := &ateapipb.ObjectRef{Atespace: testAtespace, Name: name}
+	if _, err := tc.client.CreateActor(context.Background(), &ateapipb.CreateActorRequest{Actor: &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: testAtespace, Name: name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: testAtespace, Name: "tmpl1"},
+	}}); err != nil {
+		t.Fatalf("CreateActor failed: %v", err)
+	}
+
+	// A first clean round trip, to give the actor an external snapshot the
+	// interrupted suspend below would otherwise replace and collect.
+	resume := func() {
+		t.Helper()
+		if _, err := tc.client.ResumeActor(context.Background(), &ateapipb.ResumeActorRequest{Actor: actorRef}); err != nil {
+			t.Fatalf("ResumeActor failed: %v", err)
+		}
+	}
+	resume()
+	suspended, err := tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{Actor: actorRef})
+	if err != nil {
+		t.Fatalf("SuspendActor failed: %v", err)
+	}
+	lastGoodSnapshot := suspended.GetActor().GetStatus().GetExternalSnapshot().GetSnapshotUri()
+	if lastGoodSnapshot == "" {
+		t.Fatalf("first suspend wrote no external snapshot: %v", suspended)
+	}
+	resume()
+
+	// The pod's node reboots while the guest is being checkpointed onto it, and
+	// the worker is deregistered before the workflow gets to commit SUSPENDED.
+	var deregisterErr error
+	tc.fakeAtelet.OnCheckpoint = func() { deregisterErr = deregisterWorker(tc, ns, "worker-1") }
+
+	_, err = tc.client.SuspendActor(context.Background(), &ateapipb.SuspendActorRequest{Actor: actorRef})
+	if deregisterErr != nil {
+		t.Fatalf("deregistering the worker mid-checkpoint: %v", deregisterErr)
+	}
+	assertGrpcErrorRegex(t, err, codes.FailedPrecondition, "FinalizeSuspended prerequisite not met")
+
+	got, err := tc.client.GetActor(context.Background(), &ateapipb.GetActorRequest{Actor: actorRef})
+	if err != nil {
+		t.Fatalf("GetActor failed: %v", err)
+	}
+	if got.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("state = %v, want CRASHED", got.GetStatus().GetState())
+	}
+	if uri := got.GetStatus().GetExternalSnapshot().GetSnapshotUri(); uri != lastGoodSnapshot {
+		t.Errorf("external snapshot = %q, want the last one the actor suspended to, %q", uri, lastGoodSnapshot)
 	}
 }
 

--- a/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/common_test.go
@@ -714,6 +714,30 @@ func setupAteletOnNode(t *testing.T, tc *testContext, name, nodeName string) {
 	}
 }
 
+// deregisterWorker drops the Worker record for the named pod, as the syncer
+// would once it saw the pod go. The Worker is named after the pod UID, but the
+// caller only has the pod name, so it is found by the pod fields it carries.
+//
+// It reports errors instead of failing the test, so it is safe to call from a
+// FakeAteletServer hook, which runs on a server goroutine.
+func deregisterWorker(tc *testContext, ns string, pod string) error {
+	resp, err := tc.client.ListWorkers(context.Background(), &ateapipb.ListWorkersRequest{})
+	if err != nil {
+		return fmt.Errorf("listing workers: %w", err)
+	}
+	for _, w := range resp.GetWorkers() {
+		if w.GetWorkerNamespace() != ns || w.GetWorkerPod() != pod {
+			continue
+		}
+		if _, err := tc.client.DeleteWorker(context.Background(), &ateapipb.DeleteWorkerRequest{
+			Worker: &ateapipb.ObjectRef{Name: w.GetMetadata().GetName()},
+		}); err != nil {
+			return fmt.Errorf("deregistering worker %s: %w", w.GetMetadata().GetName(), err)
+		}
+	}
+	return nil
+}
+
 func deleteWorkerPod(t *testing.T, tc *testContext, ns string, name string) {
 	t.Helper()
 	err := tc.k8sClient.CoreV1().Pods(ns).Delete(context.Background(), name, metav1.DeleteOptions{
@@ -723,22 +747,8 @@ func deleteWorkerPod(t *testing.T, tc *testContext, ns string, name string) {
 		t.Fatalf("failed to delete worker pod %s: %v", name, err)
 	}
 
-	// Deregister the Worker, as the syncer would once it saw the pod go. The
-	// Worker is named after the pod UID, but the caller only has the pod name,
-	// so it is found by the pod fields it carries.
-	resp, err := tc.client.ListWorkers(context.Background(), &ateapipb.ListWorkersRequest{})
-	if err != nil {
-		t.Fatalf("failed to list workers: %v", err)
-	}
-	for _, w := range resp.GetWorkers() {
-		if w.GetWorkerNamespace() != ns || w.GetWorkerPod() != name {
-			continue
-		}
-		if _, err := tc.client.DeleteWorker(context.Background(), &ateapipb.DeleteWorkerRequest{
-			Worker: &ateapipb.ObjectRef{Name: w.GetMetadata().GetName()},
-		}); err != nil {
-			t.Fatalf("failed to deregister worker %s: %v", w.GetMetadata().GetName(), err)
-		}
+	if err := deregisterWorker(tc, ns, name); err != nil {
+		t.Fatal(err)
 	}
 
 	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/cmd/ateapi/internal/controlapi/functionaltest/main_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/main_test.go
@@ -117,11 +117,17 @@ type FakeAteletServer struct {
 
 	CheckpointCalled  bool
 	CheckpointRequest *ateletpb.CheckpointRequest
+	// OnCheckpoint runs while the checkpoint is in flight, which is where a
+	// test drives whatever it wants racing the suspend workflow. It runs
+	// without Lock held, so a hook may call back into the control plane.
+	OnCheckpoint func()
 
 	RestoreCalled  bool
 	RestoreRequest *ateletpb.RestoreRequest
 	FailRestore    error
 	RestoreDelay   time.Duration
+	// OnRestore is the resume-side counterpart of OnCheckpoint.
+	OnRestore func()
 
 	UploadCalled  bool
 	UploadRequest *ateletpb.UploadPausedCheckpointRequest
@@ -164,11 +170,13 @@ func (f *FakeAteletServer) Reset() {
 
 	f.CheckpointCalled = false
 	f.CheckpointRequest = nil
+	f.OnCheckpoint = nil
 
 	f.RestoreCalled = false
 	f.RestoreRequest = nil
 	f.FailRestore = nil
 	f.RestoreDelay = 0
+	f.OnRestore = nil
 
 	f.UploadCalled = false
 	f.UploadRequest = nil
@@ -207,28 +215,36 @@ func (f *FakeAteletServer) Run(ctx context.Context, req *ateletpb.RunRequest) (*
 
 func (f *FakeAteletServer) Checkpoint(ctx context.Context, req *ateletpb.CheckpointRequest) (*ateletpb.CheckpointResponse, error) {
 	f.Lock.Lock()
-	defer f.Lock.Unlock()
-
 	f.CheckpointCalled = true
 	f.CheckpointRequest = proto.Clone(req).(*ateletpb.CheckpointRequest)
+	err := f.writeSnapshot(req.GetExternalConfig().GetSnapshotUri())
+	onCheckpoint := f.OnCheckpoint
+	f.Lock.Unlock()
 
-	if err := f.writeSnapshot(req.GetExternalConfig().GetSnapshotUri()); err != nil {
+	if err != nil {
 		return nil, err
+	}
+	if onCheckpoint != nil {
+		onCheckpoint()
 	}
 	return &ateletpb.CheckpointResponse{}, nil
 }
 
 func (f *FakeAteletServer) Restore(ctx context.Context, req *ateletpb.RestoreRequest) (*ateletpb.RestoreResponse, error) {
 	f.Lock.Lock()
-	defer f.Lock.Unlock()
-
 	f.RestoreCalled = true
 	f.RestoreRequest = proto.Clone(req).(*ateletpb.RestoreRequest)
-	if f.RestoreDelay > 0 {
-		time.Sleep(f.RestoreDelay)
+	delay, failRestore, onRestore := f.RestoreDelay, f.FailRestore, f.OnRestore
+	f.Lock.Unlock()
+
+	if onRestore != nil {
+		onRestore()
 	}
-	if f.FailRestore != nil {
-		return nil, f.FailRestore
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	if failRestore != nil {
+		return nil, failRestore
 	}
 	return &ateletpb.RestoreResponse{}, nil
 }

--- a/cmd/ateapi/internal/controlapi/workflow_resume.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume.go
@@ -789,6 +789,13 @@ func (w *ActorWorkflow) egressGateway() *ateletpb.EgressGateway {
 
 // finalizeRunning re-reads the actor for a fresh version and commits RUNNING,
 // recording the template the sprint booted with.
+//
+// The actor must still be RESUMING: a worker deletion racing the restore
+// crashes it and clears its assignment, and committing RUNNING over that would
+// leave a running actor with no worker — unroutable, and never rescheduled
+// because a resume of a RUNNING actor short-circuits. The fresh read the step
+// needs for its version is also what makes the version guard blind to that
+// crash, so the requirement rides down into the update.
 func (w *ActorWorkflow) finalizeRunning(ctx context.Context, actorRef resources.ActorRef, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "FinalizeRunning")
 	defer func() { err = done(err) }()
@@ -798,13 +805,22 @@ func (w *ActorWorkflow) finalizeRunning(ctx context.Context, actorRef resources.
 		return nil, err
 	}
 
-	storedActor, err := w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(latestActor), func(toUpdate *ateapipb.Actor) error {
-		toUpdate.Status.State = ateapipb.ActorState_ACTOR_STATE_RUNNING
-		// Recorded at sprint start so the next resume can detect a repointed
-		// template by UID; the snapshot it restores was taken under this one.
-		toUpdate.Status.CurrentActorTemplateUid = actorTemplate.GetMetadata().GetUid()
-		return nil
-	})
+	storedActor, err := w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(latestActor),
+		func(toUpdate *ateapipb.Actor) error {
+			// Inside the mutation, not against latestActor: UpdateActor passes the
+			// record the write would land on, and abandons the write when this
+			// returns an error.
+			if got := toUpdate.GetStatus().GetState(); got != ateapipb.ActorState_ACTOR_STATE_RESUMING {
+				return status.Errorf(codes.FailedPrecondition,
+					"FinalizeRunning prerequisite not met for Actor: %s (got: %v, want %s)",
+					actorRef, got, ateapipb.ActorState_ACTOR_STATE_RESUMING)
+			}
+			toUpdate.Status.State = ateapipb.ActorState_ACTOR_STATE_RUNNING
+			// Recorded at sprint start so the next resume can detect a repointed
+			// template by UID; the snapshot it restores was taken under this one.
+			toUpdate.Status.CurrentActorTemplateUid = actorTemplate.GetMetadata().GetUid()
+			return nil
+		})
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent update conflict, please retry")

--- a/cmd/ateapi/internal/controlapi/workflow_resume_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_resume_test.go
@@ -123,6 +123,47 @@ func TestFinalizeRunning_RecordsSprintTemplate(t *testing.T) {
 	}
 }
 
+// TestFinalizeRunning_PreservesConcurrentCrash verifies a worker deletion that
+// crashes the actor mid-restore is not overwritten with RUNNING. The step
+// re-reads the actor for a fresh version, so it would arm its own precondition
+// from the crashed record and commit straight over it; the result would be a
+// RUNNING actor with no worker, unroutable and never rescheduled because a
+// resume of a RUNNING actor short-circuits.
+func TestFinalizeRunning_PreservesConcurrentCrash(t *testing.T) {
+	ctx := context.Background()
+	persistence := newTestPersistence(t)
+	actorRef := resources.ActorRef{Atespace: "team-a", Name: "id1"}
+	storetest.MustCreateActor(t, ctx, persistence, &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: actorRef.Atespace, Name: actorRef.Name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "tmpl-1"},
+		Status: &ateapipb.ActorStatus{
+			// The state releaseBoundActor leaves behind: crashed, with the
+			// assignment cleared.
+			State:                   ateapipb.ActorState_ACTOR_STATE_CRASHED,
+			CurrentActorTemplateUid: "tmpl-uid-1",
+		},
+	})
+	w := &ActorWorkflow{store: persistence}
+
+	_, err := w.finalizeRunning(ctx, actorRef, &ateapipb.ActorTemplate{
+		Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "tmpl-1", Uid: "tmpl-uid-2"},
+	})
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Fatalf("finalizeRunning error = %v (code %v), want FailedPrecondition", err, got)
+	}
+
+	stored, err := persistence.GetActor(ctx, actorRef)
+	if err != nil {
+		t.Fatalf("GetActor: %v", err)
+	}
+	if stored.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("state = %v, want CRASHED preserved", stored.GetStatus().GetState())
+	}
+	if uid := stored.GetStatus().GetCurrentActorTemplateUid(); uid != "tmpl-uid-1" {
+		t.Errorf("CurrentActorTemplateUid = %q, want the crashed record's %q", uid, "tmpl-uid-1")
+	}
+}
+
 // bindErrorStore fails every claim, standing in for a worker that moved or
 // vanished between the pick and the write.
 type bindErrorStore struct {

--- a/cmd/ateapi/internal/controlapi/workflow_suspend.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend.go
@@ -344,9 +344,13 @@ func (w *ActorWorkflow) ensureVolumesDetached(ctx context.Context, actor *ateapi
 // ensureSuspendedFinalized releases the actor's worker (only when it is still
 // owned by this actor), records the in-progress snapshot as the actor's
 // external snapshot, and commits SUSPENDED with the assignment cleared in a
-// single update. It re-reads the actor first so an out-of-band transition
-// (e.g. the syncer crashing the actor after its worker died) is not
-// overwritten: with no assignment left there is nothing to finalize.
+// single update.
+//
+// The actor must still be SUSPENDING: a worker deletion racing the checkpoint
+// crashes it out of band, and finalizing over that would publish an external
+// snapshot on a CRASHED actor. The re-read below is for a fresh version, so it
+// hands the version guard the crashed record itself; the requirement rides
+// down into the commit instead.
 func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef resources.ActorRef, actorTemplate *ateapipb.ActorTemplate) (_ *ateapipb.Actor, err error) {
 	ctx, done := stepSpan(ctx, "FinalizeSuspended")
 	defer func() { err = done(err) }()
@@ -356,14 +360,13 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 	// that stalls and then fails still reports where the time went; steps not
 	// reached (or skipped) log zero.
 	start := time.Now()
-	var dGetActor, dReleaseWorker, dRefetchActor, dReleaseSnapshot, dUpdateActor time.Duration
+	var dGetActor, dReleaseWorker, dReleaseSnapshot, dUpdateActor time.Duration
 	defer func() {
 		slog.InfoContext(ctx, "FinalizeSuspended store call durations",
 			slog.Any("actor", actorRef),
 			slog.Duration("total", time.Since(start)),
 			slog.Duration("get_actor", dGetActor),
 			slog.Duration("release_worker", dReleaseWorker),
-			slog.Duration("refetch_actor", dRefetchActor),
 			slog.Duration("release_snapshot", dReleaseSnapshot),
 			slog.Duration("update_actor", dUpdateActor))
 	}()
@@ -374,20 +377,12 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 	if err != nil {
 		return nil, err
 	}
-
-	// 1. Free the worker (if it hasn't been freed yet)
+	// 1. Free the worker (if it hasn't been freed yet). Releasing touches only
+	// the assignment, never the Actor row, so latestActor stays current.
 	if latestActor.GetStatus().GetWorkerAssignment() != nil {
 		t = time.Now()
 		_, _, err := releaseWorker(ctx, w.store, latestActor)
 		dReleaseWorker = time.Since(t)
-		if err != nil {
-			return nil, err
-		}
-
-		// Re-fetch the actor now that the worker is freed.
-		t = time.Now()
-		latestActor, err = w.store.GetActor(ctx, actorRef)
-		dRefetchActor = time.Since(t)
 		if err != nil {
 			return nil, err
 		}
@@ -422,19 +417,28 @@ func (w *ActorWorkflow) ensureSuspendedFinalized(ctx context.Context, actorRef r
 
 	// 4. Commit the actor.
 	t = time.Now()
-	storedActor, err := w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(latestActor), func(toUpdate *ateapipb.Actor) error {
-		toUpdate.Status.State = ateapipb.ActorState_ACTOR_STATE_SUSPENDED
-		if snapshotName != "" {
-			// The recorded URI is under the actor's own prefix, so the actor now
-			// owns its external snapshot rather than borrowing the tag's it may
-			// have been created from.
-			toUpdate.Status.ExternalSnapshot = proto.CloneOf(externalSnapshot)
-			toUpdate.Status.InProgressSnapshotName = ""
-		}
-		toUpdate.Status.WorkerAssignment = nil
-		toUpdate.Status.LocalSnapshotInfo = nil
-		return nil
-	})
+	storedActor, err := w.store.UpdateActor(ctx, actorRef, store.PreconditionFrom(latestActor),
+		func(toUpdate *ateapipb.Actor) error {
+			// Inside the mutation, not against latestActor: UpdateActor passes the
+			// record the write would land on, and abandons the write when this
+			// returns an error.
+			if got := toUpdate.GetStatus().GetState(); got != ateapipb.ActorState_ACTOR_STATE_SUSPENDING {
+				return status.Errorf(codes.FailedPrecondition,
+					"FinalizeSuspended prerequisite not met for Actor: %s (got: %v, want %s)",
+					actorRef, got, ateapipb.ActorState_ACTOR_STATE_SUSPENDING)
+			}
+			toUpdate.Status.State = ateapipb.ActorState_ACTOR_STATE_SUSPENDED
+			if snapshotName != "" {
+				// The recorded URI is under the actor's own prefix, so the actor now
+				// owns its external snapshot rather than borrowing the tag's it may
+				// have been created from.
+				toUpdate.Status.ExternalSnapshot = proto.CloneOf(externalSnapshot)
+				toUpdate.Status.InProgressSnapshotName = ""
+			}
+			toUpdate.Status.WorkerAssignment = nil
+			toUpdate.Status.LocalSnapshotInfo = nil
+			return nil
+		})
 	dUpdateActor = time.Since(t)
 	if err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {

--- a/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
+++ b/cmd/ateapi/internal/controlapi/workflow_suspend_test.go
@@ -398,6 +398,60 @@ func TestEnsureSuspendedFinalized_ReleasesReplacedSnapshot(t *testing.T) {
 	}
 }
 
+// TestEnsureSuspendedFinalized_PreservesConcurrentCrash verifies a worker
+// deletion that crashes the actor mid-checkpoint is not finalized over. The
+// step re-reads the actor for a fresh version, so it would arm its own
+// precondition from the crashed record, and committing would publish an
+// external snapshot on a CRASHED actor.
+//
+// Only the actor record is asserted on. The step collects the snapshot it
+// replaces before the commit it turns out not to reach, so the replaced
+// objects are gone by the time this returns; putting the collection after the
+// commit is a separate change.
+func TestEnsureSuspendedFinalized_PreservesConcurrentCrash(t *testing.T) {
+	ctx := context.Background()
+	persistence := newTestPersistence(t)
+	template := seedSubstrateTemplate(t, ctx, persistence, "sub-tmpl")
+	w, objects := newFinalizeWorkflow(persistence)
+
+	const snapshotName = "2026-01-01t00-00-00z-new"
+	actorRef := resources.ActorRef{Atespace: "team-a", Name: "actor-1"}
+	actor := storetest.MustCreateActor(t, ctx, persistence, &ateapipb.Actor{
+		Metadata:      &ateapipb.ResourceMetadata{Atespace: actorRef.Atespace, Name: actorRef.Name},
+		ActorTemplate: &ateapipb.ObjectRef{Atespace: "team-a", Name: "sub-tmpl"},
+		Status:        &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDING},
+	})
+
+	previous := mustActorSnapshotURI(t, template, actor, "old")
+	fresh := mustActorSnapshotURI(t, template, actor, snapshotName)
+	objects.PutSnapshot(t, previous, "manifest.json")
+	objects.PutSnapshot(t, fresh, "manifest.json")
+
+	// The state releaseBoundActor leaves behind: crashed, assignment cleared,
+	// with the in-progress checkpoint kept for debugging.
+	mustUpdateActorStatus(t, ctx, persistence, actor, func(s *ateapipb.ActorStatus) {
+		s.State = ateapipb.ActorState_ACTOR_STATE_CRASHED
+		s.InProgressSnapshotName = snapshotName
+		s.ExternalSnapshot = &ateapipb.ExternalSnapshot{SnapshotUri: previous.String()}
+	})
+
+	_, err := w.ensureSuspendedFinalized(ctx, actorRef, template)
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Fatalf("ensureSuspendedFinalized error = %v (code %v), want FailedPrecondition", err, got)
+	}
+
+	stored, err := persistence.GetActor(ctx, actorRef)
+	if err != nil {
+		t.Fatalf("GetActor: %v", err)
+	}
+	if stored.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_CRASHED {
+		t.Errorf("state = %v, want CRASHED preserved", stored.GetStatus().GetState())
+	}
+	if got := stored.GetStatus().GetExternalSnapshot().GetSnapshotUri(); got != previous.String() {
+		t.Errorf("external snapshot = %q, want the one the actor last suspended to, %q", got, previous)
+	}
+}
+
 // errObjectStore stands in for object storage being unreachable.
 var errObjectStore = errors.New("object storage is unavailable")
 


### PR DESCRIPTION
Both finalizers re-read the Actor immediately before committing, so their optimistic precondition is built from the record they just read and cannot tell a concurrent transition from the state they expected. A worker deletion that crashes the Actor mid-restore or mid-checkpoint was therefore overwritten with RUNNING or SUSPENDED, leaving an Actor whose recorded state no sandbox backs and which is never rescheduled. Check the required state inside the mutation instead, where UpdateActor supplies the record the write would land on.

Fixes #1443

- [ x ] Tests pass
- [ x ] Appropriate changes to documentation are included in the PR
