### PR TITLE
Fix ListActorTemplates pagination error mapping

### DIFF
--- a/cmd/ateapi/internal/controlapi/actor_template.go
+++ b/cmd/ateapi/internal/controlapi/actor_template.go
@@ -128,7 +128,7 @@ func (s *RPCService) ListActorTemplates(ctx context.Context, req *ateapipb.ListA
 
 	page, err := s.impl.ListActorTemplates(ctx, req.GetAtespace(), store.ListOptions{PageSize: effectivePageSize(req.GetPageSize()), PageToken: req.GetPageToken()})
 	if err != nil {
-		return nil, fmt.Errorf("while listing actor templates in db: %w", err)
+		return nil, mapListError(fmt.Errorf("while listing actor templates in db: %w", err))
 	}
 	return &ateapipb.ListActorTemplatesResponse{
 		ActorTemplates: page.Items,

--- a/cmd/ateapi/internal/controlapi/functionaltest/actor_template_test.go
+++ b/cmd/ateapi/internal/controlapi/functionaltest/actor_template_test.go
@@ -133,3 +133,13 @@ func TestActorTemplateCRUD(t *testing.T) {
 	})
 	assertGrpcErrorRegex(t, err, codes.InvalidArgument, `sandbox_config\.config_name`)
 }
+
+func TestListActorTemplates_InvalidPageToken(t *testing.T) {
+	ns := namespaceForTest("ns-template-invalid-token")
+	tc := setupTest(t, ns)
+	defer tc.cleanup()
+
+	_, err := tc.client.ListActorTemplates(context.Background(),
+		&ateapipb.ListActorTemplatesRequest{PageToken: "%%%"})
+	assertGrpcError(t, err, codes.InvalidArgument, "invalid page_token")
+}


### PR DESCRIPTION
Fixes #1432

Map known store pagination errors in `ListActorTemplates` through `mapListError`, matching the other list RPC handlers. Invalid page tokens now return gRPC `InvalidArgument` with `invalid page_token`.

- [x] Tests pass: ran `make verify`
- [x] Appropriate changes to documentation are included in the PR: single line change