### PR TITLE
benchmarking: expand cAdvisor scrape allowlist for kernel PSI, networ…

### DIFF
--- a/benchmarking/monitoring.yaml
+++ b/benchmarking/monitoring.yaml
@@ -155,18 +155,29 @@ data:
             target_label: __metrics_path__
             replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
         metric_relabel_configs:
+          # cAdvisor reports host-level root cgroup metrics (such as Linux kernel
+          # PSI pressure stall information) with id="/" and an empty container
+          # label. Relabel id="/" to container="node" before dropping empty
+          # container labels so host-level pressure and utilization are kept.
+          - source_labels: [id]
+            regex: ^/$
+            target_label: container
+            replacement: node
           # cAdvisor sends a very large number of metrics. Keep only the
-          # metrics that the benchmarks read.
+          # metrics that the benchmarks read: kernel pressure stall (PSI),
+          # container network bandwidth, disk I/O, memory RSS/working-set,
+          # CPU utilization, and CFS throttling.
           - source_labels: [__name__]
             action: keep
-            regex: container_(memory_working_set_bytes|cpu_usage_seconds_total|spec_memory_limit_bytes)
-          # Drop the series that have an empty container label, not the label
-          # itself. cAdvisor gives a rollup for the whole pod cgroup next to
-          # the series for each container. Keeping both counts the memory of
-          # each pod two times.
-          - source_labels: [container]
+            regex: container_((.*pressure.*)|network_(receive|transmit)_bytes_total|fs_(reads|writes)_bytes_total|memory_rss|memory_working_set_bytes|cpu_usage_seconds_total|cpu_cfs_.*|spec_memory_limit_bytes)
+          # Drop the series that have an empty container label only for cumulative
+          # memory working set and CPU usage. cAdvisor gives a rollup for the whole
+          # pod cgroup next to the series for each container; keeping both counts
+          # the memory/CPU of each pod two times. Dropping empty container on other
+          # metrics (such as network or PSI) would drop valid pod/node stats.
+          - source_labels: [__name__, container]
             action: drop
-            regex: ""
+            regex: container_(memory_working_set_bytes|cpu_usage_seconds_total);$
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Fixes #1588

### What this PR does
This PR updates the Prometheus cAdvisor scrape configuration in `benchmarking/monitoring.yaml` to retain Linux kernel Pressure Stall Information (PSI), network bandwidth, disk I/O throughput, and host-level node resource utilization.

### Problem
Currently, `monitoring.yaml` restricts cAdvisor scrapes to only:
`container_(memory_working_set_bytes|cpu_usage_seconds_total|spec_memory_limit_bytes)`
and unconditionally drops series with `container=""`.

Because cAdvisor reports the host root cgroup (`id="/"`) with an empty container label, this configuration strips:
1. All host-level kernel PSI stalls (`cpu.pressure`, `io.pressure`, `memory.pressure`).
2. Host system daemon resource overhead (`containerd`, `kubelet`, virtualization runtime).
3. Container network bandwidth (`container_network_*`) and disk I/O (`container_fs_*`).

Under high-density multi-tenant agent benchmarks, diagnosing whether tail latency spikes stem from CPU scheduling contention, disk storage bottlenecks, or memory pressure is difficult without kernel PSI.

### Proposed Changes
In `benchmarking/monitoring.yaml`:
1. **Relabel Host Root cgroup**: Relabel `id="/"` to `container="node"` before dropping empty container labels, preserving host-level node rollups.
2. **Expand Allowlist Regex**: Keep `container_pressure_*` (Linux PSI), `container_network_*`, `container_fs_*`, `container_cpu_cfs_*`, and `container_memory_rss`.
3. **Prevent Pod Double-Counting**: Drop empty container labels selectively *only* for cumulative memory working set and CPU usage to prevent 2x double-counting between pod slices and container scopes.

### How this was tested
Tested on a benchmark cluster running the `glutton` user workload:
- Verified that `container_pressure_*` metrics (CPU, memory, and I/O) are actively collected and queryable in Prometheus.
- Verified that host-level root cgroup metrics appear under `container="node"`.
- Verified that container network and filesystem I/O metrics are retained, while pod-level duplicate CPU and memory working-set series are dropped as intended.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
