### PR TITLE
benchmarking: expose raw atelet and ate metrics via Prometheus export…

### DIFF
--- a/benchmarking/telemetry/meter.yaml
+++ b/benchmarking/telemetry/meter.yaml
@@ -144,6 +144,13 @@ data:
           receivers: [count]
           processors: [deltatocumulative]
           exporters: [prometheus]
+
+        # Forward raw OTLP metrics directly to the Prometheus exporter on :8889.
+        # (monitoring.yaml auto-scrapes telemetry-meter:8889 via pod annotations).
+        metrics/raw:
+          receivers: [otlp]
+          processors: [memory_limiter]
+          exporters: [prometheus]
       telemetry:
         metrics:
           level: detailed


### PR DESCRIPTION
Fixes #1589

### What this PR does
This PR routes incoming raw OTLP metrics from `atelet` and `ateapi` to the Prometheus pull exporter on port 8889 in `benchmarking/telemetry/meter.yaml`.

### Problem
Currently, `telemetry-meter` only routes aggregated count metrics (`substrate_spans` and `substrate_datapoints`) to the Prometheus exporter on port 8889. Raw OTLP metrics (including snapshot sizes, restore durations, and worker pool states) are only forwarded upstream to managed cloud collectors.

In local or standalone benchmarking environments where cloud monitoring backends are not configured, in-cluster Prometheus cannot scrape these raw histograms and gauges.

### Proposed Changes
In `benchmarking/telemetry/meter.yaml`:
- Add a `metrics/raw` pipeline under `service.pipelines` routing incoming `otlp` metrics through the `memory_limiter` processor to the `prometheus` exporter on port 8889.
- Leaves existing forwarding and counting pipelines intact.

### How this was tested
- Deployed on a benchmark cluster and ran the `glutton` user workload.
- Verified that `telemetry-meter:8889` exposes `atelet_snapshot_size_bytes` and `ate_workerpool_workers`.
- Verified that in-cluster Prometheus scrapes these metrics via the default pod annotations without error.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
