### PR TITLE
benchmarking/locust: capture cluster hardware facts and density frontiers.

### DIFF
--- a/benchmarking/automation/manifests/runner-job.yaml.tmpl
+++ b/benchmarking/automation/manifests/runner-job.yaml.tmpl
@@ -41,6 +41,36 @@ roleRef:
   name: atelet-endpointslices
   apiGroup: rbac.authorization.k8s.io
 ---
+# Hardware discovery for the runner: runner.py reads nodes and worker pods to
+# derive cluster capacity frontiers. Same ClusterRole as the one in
+# benchmarking/locust/manifests/locust.yaml, repeated here so this manifest
+# stands alone -- the locust Deployment is not part of an automated run.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: locust-hardware-discovery
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  # Intentionally not named locust-hardware-discovery: that binding belongs to
+  # locust.yaml. Two bindings on one ClusterRole add up, but two bindings
+  # sharing a name overwrite each other, silently revoking whichever subject
+  # the losing copy listed.
+  name: benchmark-runner-hardware-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: locust-hardware-discovery
+subjects:
+- kind: ServiceAccount
+  name: benchmark-runner
+  namespace: benchmarking
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/benchmarking/locust/Dockerfile
+++ b/benchmarking/locust/Dockerfile
@@ -44,6 +44,7 @@ COPY benchmarking/locust/common/ /app/common/
 COPY benchmarking/locust/shapes/ /app/shapes/
 COPY benchmarking/locust/tests/ /app/tests/
 COPY benchmarking/locust/runner.py /app/runner.py
+COPY benchmarking/locust/cluster_facts.py /app/cluster_facts.py
 COPY benchmarking/locust/server_telemetry.py /app/server_telemetry.py
 
 ENV PYTHONPATH=/app:/app/deps

--- a/benchmarking/locust/Dockerfile
+++ b/benchmarking/locust/Dockerfile
@@ -44,6 +44,7 @@ COPY benchmarking/locust/common/ /app/common/
 COPY benchmarking/locust/shapes/ /app/shapes/
 COPY benchmarking/locust/tests/ /app/tests/
 COPY benchmarking/locust/runner.py /app/runner.py
+COPY benchmarking/locust/server_telemetry.py /app/server_telemetry.py
 
 ENV PYTHONPATH=/app:/app/deps
 ENV PYTHONUNBUFFERED=1

--- a/benchmarking/locust/cluster_facts.py
+++ b/benchmarking/locust/cluster_facts.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Discovers cluster hardware capacity and records per-trial density frontiers.
+
+Reads allocatable CPU/RAM, node count and worker pod count from the Kubernetes
+API, then derives the actor-density frontiers (actors per node / vCPU / GB RAM
+and the A/P bin-packing percentiles) for a completed trial.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any, TextIO
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+from kubernetes.utils import parse_quantity
+
+API_TIMEOUT_SECONDS = 5
+WORKER_POOL_NAMESPACE = "benchmark-workloads"
+WORKER_POOL_LABEL = "ate.dev/worker-pool"
+LIVE_POD_PHASES = ("Running", "Pending")
+MACHINE_TYPE_LABEL = "node.kubernetes.io/instance-type"
+
+# Shape returned when the cluster cannot be read, or when discovery is skipped
+# with --no-cluster-facts. Keeping one definition means a trial_summary row has
+# the same keys either way, so consumers never have to special-case it.
+EMPTY_FACTS: dict[str, Any] = {
+    "machine_type": None,
+    "node_count": None,
+    "allocatable_cores": None,
+    "allocatable_ram_gb": None,
+    "worker_pod_count": None,
+}
+
+
+def _log(logs: TextIO | None, msg: str) -> None:
+    """Mirrors runner.tee without importing it, to avoid a circular import."""
+    print(msg, flush=True)
+    if logs is not None:
+        logs.write(msg + "\n")
+        logs.flush()
+
+
+def _load_kube_config(logs: TextIO | None = None) -> bool:
+    """Loads in-cluster credentials, falling back to a local kubeconfig."""
+    try:
+        config.load_incluster_config()
+        return True
+    except config.ConfigException:
+        pass
+    try:
+        config.load_kube_config()
+        return True
+    except config.ConfigException as e:
+        _log(logs, f"Notice: no Kubernetes credentials available: {e}")
+        return False
+
+
+def _count_worker_pods(v1: client.CoreV1Api, logs: TextIO | None = None) -> int | None:
+    """Counts live pods in the worker pool.
+
+    Prefers the dedicated worker namespace and falls back to a cluster-wide
+    lookup for clusters that place the pool elsewhere. Both listings are
+    filtered server-side by label so the apiserver never streams us the full
+    pod inventory.
+    """
+    try:
+        pods = v1.list_namespaced_pod(
+            namespace=WORKER_POOL_NAMESPACE,
+            label_selector=WORKER_POOL_LABEL,
+            resource_version="0",
+            _request_timeout=API_TIMEOUT_SECONDS,
+        ).items
+    except ApiException as e:
+        _log(logs, f"Notice: could not list pods in {WORKER_POOL_NAMESPACE}: {e.reason}")
+        pods = []
+
+    if not pods:
+        pods = v1.list_pod_for_all_namespaces(
+            label_selector=WORKER_POOL_LABEL,
+            resource_version="0",
+            _request_timeout=API_TIMEOUT_SECONDS,
+        ).items
+
+    live = [p for p in pods if p.status.phase in LIVE_POD_PHASES]
+    return len(live) or None
+
+
+def get_cluster_hardware_facts(logs: TextIO | None = None) -> dict[str, Any]:
+    """Reads allocatable node capacity and worker pod count from the cluster.
+
+    Never raises: a trial must still publish its results when the cluster is
+    unreadable, so any failure leaves the affected facts as None.
+    """
+    facts: dict[str, Any] = dict(EMPTY_FACTS)
+    if not _load_kube_config(logs):
+        return facts
+
+    v1 = client.CoreV1Api()
+
+    # resource_version="0" is served from the apiserver's watch cache rather
+    # than etcd, which keeps this cheap on large clusters.
+    try:
+        nodes = v1.list_node(
+            resource_version="0", _request_timeout=API_TIMEOUT_SECONDS
+        ).items
+        total_cores = 0.0
+        total_ram_bytes = 0
+        machine_types = set()
+        for node in nodes:
+            allocatable = node.status.allocatable or {}
+            if "cpu" in allocatable:
+                total_cores += float(parse_quantity(allocatable["cpu"]))
+            if "memory" in allocatable:
+                total_ram_bytes += int(parse_quantity(allocatable["memory"]))
+            labels = (node.metadata.labels or {}) if node.metadata else {}
+            machine_type = labels.get(MACHINE_TYPE_LABEL)
+            if machine_type:
+                machine_types.add(machine_type)
+        facts["node_count"] = len(nodes)
+        facts["allocatable_cores"] = round(total_cores, 2)
+        facts["allocatable_ram_gb"] = round(total_ram_bytes / (1024**3), 2)
+        # Recorded so results stay comparable across hardware changes. A
+        # heterogeneous pool is reported as a sorted comma-joined list rather
+        # than picking one node arbitrarily.
+        facts["machine_type"] = ",".join(sorted(machine_types)) or None
+    except Exception as e:
+        _log(logs, f"Notice: could not read node capacity: {e}")
+
+    try:
+        facts["worker_pod_count"] = _count_worker_pods(v1, logs)
+    except Exception as e:
+        _log(logs, f"Notice: could not count worker pods: {e}")
+
+    return facts
+
+
+def append_trial_summary(
+    jsonl_path: Path,
+    stats_csv: Path,
+    stats_history_csv: Path,
+    args: argparse.Namespace,
+    data_ts: str,
+    facts: dict[str, Any],
+    logs: TextIO | None = None,
+) -> None:
+    active_users = args.users
+    machine_type = facts.get("machine_type")
+    node_count = facts.get("node_count")
+    cores = facts.get("allocatable_cores")
+    ram_gb = facts.get("allocatable_ram_gb")
+    pod_count = facts.get("worker_pod_count")
+
+    actors_per_node = round(active_users / node_count, 2) if node_count else None
+    actors_per_vcpu = round(active_users / cores, 2) if cores else None
+    actors_per_gb_ram = round(active_users / ram_gb, 2) if ram_gb else None
+
+    # Calculate steady-state A/P percentiles from stats_history.csv
+    ap_p50, ap_p90, ap_p99 = None, None, None
+    if stats_history_csv.exists() and pod_count and pod_count > 0:
+        try:
+            user_counts: list[float] = []
+            with open(stats_history_csv) as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    name = row.get("Name", "")
+                    if name in ("", "Aggregated", "Total") and "User Count" in row:
+                        try:
+                            u = float(row["User Count"])
+                            # Steady-state window: when load reaches configured users
+                            if u >= active_users * 0.9:
+                                user_counts.append(u)
+                        except ValueError:
+                            pass
+            if not user_counts:
+                # Fallback: if no rows matched threshold, use non-zero samples
+                with open(stats_history_csv) as f:
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        name = row.get("Name", "")
+                        if name in ("", "Aggregated", "Total") and "User Count" in row:
+                            try:
+                                u = float(row["User Count"])
+                                if u > 0:
+                                    user_counts.append(u)
+                            except ValueError:
+                                pass
+            if user_counts:
+                ratios = sorted([round(u / pod_count, 4) for u in user_counts])
+                n = len(ratios)
+                ap_p50 = round(ratios[int(n * 0.50)], 2)
+                ap_p90 = round(ratios[min(int(n * 0.90), n - 1)], 2)
+                ap_p99 = round(ratios[min(int(n * 0.99), n - 1)], 2)
+            else:
+                static_ratio = round(active_users / pod_count, 2)
+                ap_p50, ap_p90, ap_p99 = static_ratio, static_ratio, static_ratio
+        except Exception as e:
+            if logs:
+                _log(logs, f"Notice: Error calculating A/P ratio percentiles: {e}")
+
+    # Calculate aggregate failure ratio from stats_csv
+    total_requests = 0
+    total_failures = 0
+    if stats_csv.exists():
+        try:
+            with open(stats_csv) as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    name = row.get("Name", "")
+                    reqs = int(row.get("Request Count", 0) or 0)
+                    fails = int(row.get("Failure Count", 0) or 0)
+                    if name == "Aggregated":
+                        total_requests = reqs
+                        total_failures = fails
+                        break
+                    total_requests += reqs
+                    total_failures += fails
+        except Exception:
+            pass
+
+    failure_ratio = (
+        round(total_failures / total_requests, 4) if total_requests > 0 else 0.0
+    )
+
+    summary_entry = {
+        "timestamp": data_ts,
+        "tag": args.tag,
+        "test_name": args.name,
+        "metric": "trial_summary",
+        "raw_configuration": {
+            "machine_type": machine_type,
+            "node_count": node_count,
+            "allocatable_cores": cores,
+            "allocatable_ram_gb": ram_gb,
+            "worker_pod_count": pod_count,
+        },
+        "frontiers": {
+            "actors_per_node": actors_per_node,
+            "actors_per_vcpu": actors_per_vcpu,
+            "actors_per_gb_ram": actors_per_gb_ram,
+            "ap_ratio_p50": ap_p50,
+            "ap_ratio_p90": ap_p90,
+            "ap_ratio_p99": ap_p99,
+            "aggregate_failure_ratio": failure_ratio,
+        },
+    }
+    with open(jsonl_path, "a") as f:
+        f.write(json.dumps(summary_entry) + "\n")
+    if logs:
+        _log(logs, f"Appended trial_summary to {jsonl_path}")

--- a/benchmarking/locust/manifests/locust.yaml
+++ b/benchmarking/locust/manifests/locust.yaml
@@ -224,7 +224,12 @@ roleRef:
   kind: ClusterRole
   name: locust-hardware-discovery
 subjects:
+# The locust Deployment runs as `default`; the automated runner Job in
+# benchmarking/automation/manifests/runner-job.yaml.tmpl runs as
+# `benchmark-runner`. Both execute runner.py, so both need to read capacity.
 - kind: ServiceAccount
   name: default
   namespace: benchmarking
-
+- kind: ServiceAccount
+  name: benchmark-runner
+  namespace: benchmarking

--- a/benchmarking/locust/manifests/locust.yaml
+++ b/benchmarking/locust/manifests/locust.yaml
@@ -202,3 +202,29 @@ roleRef:
   kind: Role
   name: atelet-endpointslices
   apiGroup: rbac.authorization.k8s.io
+---
+# Hardware discovery for benchmarking runner: nodes and worker pods across
+# namespaces are read to compute cluster capacity frontiers (actors/vCPU,
+# actors/GB RAM, A/P bin-packing ratio).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: locust-hardware-discovery
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: locust-hardware-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: locust-hardware-discovery
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: benchmarking
+

--- a/benchmarking/locust/requirements.txt
+++ b/benchmarking/locust/requirements.txt
@@ -24,3 +24,4 @@ opentelemetry-exporter-otlp
 opentelemetry-instrumentation-grpc
 opentelemetry-instrumentation-requests
 google-cloud-storage
+kubernetes

--- a/benchmarking/locust/runner.py
+++ b/benchmarking/locust/runner.py
@@ -727,6 +727,7 @@ def main() -> None:
     logs_path = work_dir / f"{args.name}_logs.txt"
     traces_path = work_dir / f"{args.name}_traces.txt"
     status_path = work_dir / f"{args.name}_status.json"
+    server_summary_json = work_dir / f"{args.name}_server_summary.json"
 
     prefix = (
         f"{args.dest.rstrip('/')}/runs/{args.name}"
@@ -738,6 +739,7 @@ def main() -> None:
         traces.flush()
         log_run_config(args, prefix, work_dir, logs)
         exit_code = run_test(args, csv_prefix, logs, traces)
+        run_end_ts = int(datetime.now(timezone.utc).timestamp())
 
         stats_generated = False
         if stats_csv.exists():
@@ -767,6 +769,37 @@ def main() -> None:
                             facts,
                             logs,
                         )
+
+                        # Harvest server-side ground truth from Prometheus (bin-packing, PSI, snapshots)
+                        prom_url = os.environ.get(
+                            "PROMETHEUS_URL",
+                            "http://prometheus.benchmarking.svc.cluster.local:9090",
+                        )
+                        try:
+                            from server_telemetry import (
+                                extract_and_record_server_telemetry,
+                            )
+
+                            extract_and_record_server_telemetry(
+                                prom_url=prom_url,
+                                start_ts=run_ts,
+                                end_ts=run_end_ts,
+                                stats_history_csv=stats_history_csv,
+                                active_users=args.users,
+                                worker_pod_count=facts.get("worker_pod_count")
+                                or 5,
+                                output_json_path=server_summary_json,
+                                jsonl_path=jsonl_path,
+                                data_ts=data_ts,
+                                tag=args.tag,
+                                test_name=args.name,
+                                logs=logs,
+                            )
+                        except Exception as e:
+                            tee(
+                                logs,
+                                f"Warning: Failed to harvest server telemetry: {e}",
+                            )
             except Exception as e:
                 tee(logs, f"Failed to generate JSONL from {stats_csv}: {e}")
                 if jsonl_path.exists():
@@ -789,7 +822,9 @@ def main() -> None:
         (work_dir / f"{args.name}_exceptions.csv", "exceptions.csv"),
         (work_dir / f"{args.name}_failures.csv", "failures.csv"),
         (work_dir / f"{args.name}_stats_history.csv", "stats_history.csv"),
+        (server_summary_json, "server_summary.json"),
         # TODO: remove after data migration
+        (server_summary_json, f"{args.name}_server_summary.json"),
         (jsonl_path, f"{args.name}.jsonl"),
     ]
     for src, basename in files:

--- a/benchmarking/locust/runner.py
+++ b/benchmarking/locust/runner.py
@@ -41,18 +41,18 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, TextIO
+from typing import IO, Any, TextIO
 
+from cluster_facts import (
+    EMPTY_FACTS,
+    append_trial_summary,
+    get_cluster_hardware_facts,
+)
 from common.boomer_config import build_config_json
 
 # Path inside the locust image to the boomer-worker binary baked in by
 # benchmarking/locust/Dockerfile.
-default_boomer = "/app/boomer-worker"
-if not os.path.exists(default_boomer) and os.path.exists("/app/boomer-glutton"):
-    default_boomer = "/app/boomer-glutton"
-BOOMER_BINARY = os.environ.get("BOOMER_BINARY", default_boomer)
-BOOMER_MASTER_PORT = int(os.environ.get("BOOMER_MASTER_PORT", "5557"))
-BOOMER_PROMETHEUS_ADDR = os.environ.get("BOOMER_PROMETHEUS_ADDR", ":8001")
+BOOMER_BINARY = "/app/boomer-worker"
 
 # Port for the headless /boomer-config server (common/boomer_config.py), which
 # gives boomer the values that change while a run continues. Locust already
@@ -97,6 +97,17 @@ def parse_args() -> argparse.Namespace:
             "Exit 0 when locust produced no measurement rows. For a run whose "
             "result is not in the locust statistics, such as a run that sends "
             "no request on purpose"
+        ),
+    )
+    p.add_argument(
+        "--cluster-facts",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Read node capacity and worker pod count from the Kubernetes API "
+            "after the run to derive density frontiers. Pass "
+            "--no-cluster-facts to skip those API calls, for example on a "
+            "large cluster where listing nodes is expensive"
         ),
     )
     args, extra = p.parse_known_args()
@@ -267,13 +278,9 @@ def run_test(args: argparse.Namespace, csv_prefix: Path, logs: TextIO, traces: T
         "--csv", str(csv_prefix),
     ]
     if with_boomer:
-        # Master mode so boomer can connect as a worker.
+        # Master mode so boomer can connect as a worker on localhost:5557.
         # --expect-workers=1 makes locust wait for boomer before starting.
-        locust_cmd += [
-            "--master",
-            "--master-bind-port", str(BOOMER_MASTER_PORT),
-            "--expect-workers", "1",
-        ]
+        locust_cmd += ["--master", "--expect-workers", "1"]
         # Serve /boomer-config for the worker. --config-json gives boomer the
         # values one time, at its start, thus a run that changes a value while
         # it runs needs the endpoint. A load shape is one such run.
@@ -298,16 +305,7 @@ def run_test(args: argparse.Namespace, csv_prefix: Path, logs: TextIO, traces: T
 
     boomer_proc = None
     if with_boomer:
-        boomer_cmd = [BOOMER_BINARY]
-        if "boomer-glutton" not in os.path.basename(BOOMER_BINARY):
-            boomer_cmd += ["--user-class", Path(test_file(args.file)).stem]
-        boomer_cmd += [
-            "--master-port", str(BOOMER_MASTER_PORT),
-            "--prometheus-addr", BOOMER_PROMETHEUS_ADDR,
-        ]
-        api_endpoint = os.environ.get("BOOMER_API_ENDPOINT")
-        if api_endpoint:
-            boomer_cmd += ["-api-endpoint", api_endpoint]
+        boomer_cmd = [BOOMER_BINARY, "--user-class", Path(test_file(args.file)).stem]
         cfg_json = build_config_json(args.locust_extra)
         if cfg_json:
             boomer_cmd += ["--config-json", cfg_json]
@@ -389,304 +387,6 @@ def stats_to_jsonl(stats_csv: Path, jsonl_path: Path, timestamp: str, tag: str, 
     return rows_written
 
 
-def parse_k8s_cpu(cpu_str: str) -> float:
-    cpu_str = cpu_str.strip()
-    if cpu_str.endswith("m"):
-        return float(cpu_str[:-1]) / 1000.0
-    if cpu_str.endswith("u"):
-        return float(cpu_str[:-1]) / 1_000_000.0
-    if cpu_str.endswith("n"):
-        return float(cpu_str[:-1]) / 1_000_000_000.0
-    return float(cpu_str)
-
-
-def parse_k8s_memory(mem_str: str) -> int:
-    mem_str = mem_str.strip()
-    multipliers = {
-        "Ki": 1024,
-        "Mi": 1024**2,
-        "Gi": 1024**3,
-        "Ti": 1024**4,
-        "Pi": 1024**5,
-        "Ei": 1024**6,
-        "k": 1000,
-        "K": 1000,
-        "m": 1000**2,
-        "M": 1000**2,
-        "g": 1000**3,
-        "G": 1000**3,
-        "t": 1000**4,
-        "T": 1000**4,
-        "p": 1000**5,
-        "P": 1000**5,
-        "e": 1000**6,
-        "E": 1000**6,
-    }
-    for suffix, mult in multipliers.items():
-        if mem_str.endswith(suffix):
-            num = float(mem_str[: -len(suffix)].strip())
-            return int(num * mult)
-    return int(float(mem_str))
-
-
-def get_cluster_hardware_facts(logs: TextIO | None = None) -> dict[str, any]:
-    facts: dict[str, any] = {
-        "node_count": None,
-        "allocatable_cores": None,
-        "allocatable_ram_gb": None,
-        "worker_pod_count": None,
-    }
-    # 1. Environment variables override
-    if "NODE_COUNT" in os.environ:
-        try:
-            facts["node_count"] = int(os.environ["NODE_COUNT"])
-        except ValueError:
-            pass
-    if "ALLOCATABLE_VCPU" in os.environ or "ALLOCATABLE_CORES" in os.environ:
-        try:
-            facts["allocatable_cores"] = float(
-                os.environ.get("ALLOCATABLE_VCPU") or os.environ.get("ALLOCATABLE_CORES")
-            )
-        except ValueError:
-            pass
-    if "ALLOCATABLE_RAM_GB" in os.environ:
-        try:
-            facts["allocatable_ram_gb"] = float(os.environ["ALLOCATABLE_RAM_GB"])
-        except ValueError:
-            pass
-    elif "ALLOCATABLE_RAM_BYTES" in os.environ:
-        try:
-            facts["allocatable_ram_gb"] = round(
-                float(os.environ["ALLOCATABLE_RAM_BYTES"]) / (1024**3), 2
-            )
-        except ValueError:
-            pass
-    if "WORKER_POD_COUNT" in os.environ:
-        try:
-            facts["worker_pod_count"] = int(os.environ["WORKER_POD_COUNT"])
-        except ValueError:
-            pass
-
-    if all(
-        facts[k] is not None
-        for k in ("node_count", "allocatable_cores", "allocatable_ram_gb", "worker_pod_count")
-    ):
-        return facts
-
-    # 2. In-cluster HTTP API or local kubectl discovery
-    try:
-        nodes_data = None
-        token_path = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
-
-        if token_path.exists():
-            import ssl
-            import urllib.request
-
-            token = token_path.read_text().strip()
-            ctx = ssl.create_default_context()
-            ca_path = Path("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
-            if ca_path.exists():
-                ctx.load_verify_locations(cafile=str(ca_path))
-
-            # Query nodes
-            if any(facts[k] is None for k in ("node_count", "allocatable_cores", "allocatable_ram_gb")):
-                try:
-                    req = urllib.request.Request(
-                        "https://kubernetes.default.svc/api/v1/nodes",
-                        headers={"Authorization": f"Bearer {token}"},
-                    )
-                    with urllib.request.urlopen(req, context=ctx, timeout=5) as resp:
-                        nodes_data = json.loads(resp.read().decode())
-                except Exception as e:
-                    if logs:
-                        tee(logs, f"Notice: In-cluster nodes API: {e}")
-
-            # Query worker pods (ate.dev/worker-pool)
-            if facts["worker_pod_count"] is None:
-                for url in (
-                    "https://kubernetes.default.svc/api/v1/namespaces/benchmark-workloads/pods?labelSelector=ate.dev%2Fworker-pool",
-                    "https://kubernetes.default.svc/api/v1/pods?labelSelector=ate.dev%2Fworker-pool",
-                ):
-                    try:
-                        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
-                        with urllib.request.urlopen(req, context=ctx, timeout=5) as resp:
-                            p_data = json.loads(resp.read().decode())
-                            items = [
-                                p for p in p_data.get("items", [])
-                                if p.get("status", {}).get("phase") in ("Running", "Pending")
-                            ]
-                            if items:
-                                facts["worker_pod_count"] = len(items)
-                                break
-                    except Exception:
-                        pass
-        elif shutil.which("kubectl"):
-            # Local workstation fallback via kubectl
-            if any(facts[k] is None for k in ("node_count", "allocatable_cores", "allocatable_ram_gb")):
-                res = subprocess.run(
-                    ["kubectl", "get", "nodes", "-o", "json"],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                )
-                if res.returncode == 0:
-                    nodes_data = json.loads(res.stdout)
-            if facts["worker_pod_count"] is None:
-                for cmd in (
-                    ["kubectl", "get", "pods", "-n", "benchmark-workloads", "-l", "ate.dev/worker-pool", "-o", "json"],
-                    ["kubectl", "get", "pods", "-A", "-l", "ate.dev/worker-pool", "-o", "json"],
-                ):
-                    res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
-                    if res.returncode == 0:
-                        p_data = json.loads(res.stdout)
-                        items = [
-                            p for p in p_data.get("items", [])
-                            if p.get("status", {}).get("phase") in ("Running", "Pending")
-                        ]
-                        if items:
-                            facts["worker_pod_count"] = len(items)
-                            break
-
-        if nodes_data and "items" in nodes_data:
-            nodes = nodes_data["items"]
-            if facts["node_count"] is None:
-                facts["node_count"] = len(nodes)
-            total_cores = 0.0
-            total_ram_bytes = 0
-            for node in nodes:
-                alloc = node.get("status", {}).get("allocatable", {})
-                if "cpu" in alloc:
-                    total_cores += parse_k8s_cpu(alloc["cpu"])
-                if "memory" in alloc:
-                    total_ram_bytes += parse_k8s_memory(alloc["memory"])
-            if facts["allocatable_cores"] is None:
-                facts["allocatable_cores"] = round(total_cores, 2)
-            if facts["allocatable_ram_gb"] is None:
-                facts["allocatable_ram_gb"] = round(total_ram_bytes / (1024**3), 2)
-
-        # Graceful fallback: if no worker pods found, fall back to node_count
-        if facts["worker_pod_count"] is None and facts["node_count"]:
-            facts["worker_pod_count"] = facts["node_count"]
-    except Exception as e:
-        if logs:
-            tee(logs, f"Notice: Cluster hardware discovery skipped/failed: {e}")
-
-    return facts
-
-
-def append_trial_summary(
-    jsonl_path: Path,
-    stats_csv: Path,
-    stats_history_csv: Path,
-    args: argparse.Namespace,
-    data_ts: str,
-    facts: dict[str, any],
-    logs: TextIO | None = None,
-) -> None:
-    active_users = args.users
-    node_count = facts.get("node_count")
-    cores = facts.get("allocatable_cores")
-    ram_gb = facts.get("allocatable_ram_gb")
-    pod_count = facts.get("worker_pod_count")
-
-    actors_per_node = round(active_users / node_count, 2) if node_count else None
-    actors_per_vcpu = round(active_users / cores, 2) if cores else None
-    actors_per_gb_ram = round(active_users / ram_gb, 2) if ram_gb else None
-
-    # Calculate steady-state A/P percentiles from stats_history.csv
-    ap_p50, ap_p90, ap_p99 = None, None, None
-    if stats_history_csv.exists() and pod_count and pod_count > 0:
-        try:
-            user_counts: list[float] = []
-            with open(stats_history_csv) as f:
-                reader = csv.DictReader(f)
-                for row in reader:
-                    name = row.get("Name", "")
-                    if name in ("", "Aggregated", "Total") and "User Count" in row:
-                        try:
-                            u = float(row["User Count"])
-                            # Steady-state window: when load reaches configured users
-                            if u >= active_users * 0.9:
-                                user_counts.append(u)
-                        except ValueError:
-                            pass
-            if not user_counts:
-                # Fallback: if no rows matched threshold, use non-zero samples
-                with open(stats_history_csv) as f:
-                    reader = csv.DictReader(f)
-                    for row in reader:
-                        name = row.get("Name", "")
-                        if name in ("", "Aggregated", "Total") and "User Count" in row:
-                            try:
-                                u = float(row["User Count"])
-                                if u > 0:
-                                    user_counts.append(u)
-                            except ValueError:
-                                pass
-            if user_counts:
-                ratios = sorted([round(u / pod_count, 4) for u in user_counts])
-                n = len(ratios)
-                ap_p50 = round(ratios[int(n * 0.50)], 2)
-                ap_p90 = round(ratios[min(int(n * 0.90), n - 1)], 2)
-                ap_p99 = round(ratios[min(int(n * 0.99), n - 1)], 2)
-            else:
-                static_ratio = round(active_users / pod_count, 2)
-                ap_p50, ap_p90, ap_p99 = static_ratio, static_ratio, static_ratio
-        except Exception as e:
-            if logs:
-                tee(logs, f"Notice: Error calculating A/P ratio percentiles: {e}")
-
-    # Calculate aggregate failure ratio from stats_csv
-    total_requests = 0
-    total_failures = 0
-    if stats_csv.exists():
-        try:
-            with open(stats_csv) as f:
-                reader = csv.DictReader(f)
-                for row in reader:
-                    name = row.get("Name", "")
-                    reqs = int(row.get("Request Count", 0) or 0)
-                    fails = int(row.get("Failure Count", 0) or 0)
-                    if name == "Aggregated":
-                        total_requests = reqs
-                        total_failures = fails
-                        break
-                    total_requests += reqs
-                    total_failures += fails
-        except Exception:
-            pass
-
-    failure_ratio = (
-        round(total_failures / total_requests, 4) if total_requests > 0 else 0.0
-    )
-
-    summary_entry = {
-        "timestamp": data_ts,
-        "tag": args.tag,
-        "test_name": args.name,
-        "metric": "trial_summary",
-        "raw_configuration": {
-            "node_count": node_count,
-            "allocatable_cores": cores,
-            "allocatable_ram_gb": ram_gb,
-            "worker_pod_count": pod_count,
-        },
-        "frontiers": {
-            "actors_per_node": actors_per_node,
-            "actors_per_vcpu": actors_per_vcpu,
-            "actors_per_gb_ram": actors_per_gb_ram,
-            "ap_ratio_p50": ap_p50,
-            "ap_ratio_p90": ap_p90,
-            "ap_ratio_p99": ap_p99,
-            "aggregate_failure_ratio": failure_ratio,
-        },
-    }
-    with open(jsonl_path, "a") as f:
-        f.write(json.dumps(summary_entry) + "\n")
-    if logs:
-        tee(logs, f"Appended trial_summary to {jsonl_path}")
-
-
 def upload_to_gcs(local_path: Path, gcs_uri: str) -> None:
     # Imported here so non-GCS use doesn't require google-cloud-storage.
     from google.cloud import storage
@@ -701,11 +401,23 @@ def upload(src: Path, dest: str) -> None:
     if dest.startswith("gs://"):
         upload_to_gcs(src, dest)
     else:
-        path_str = dest[7:] if dest.startswith("file://") else dest
-        dest_path = Path(path_str)
+        dest_path = Path(dest)
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(src, dest_path)
 
+
+def collect_cluster_facts(
+    args: argparse.Namespace, logs: TextIO
+) -> dict[str, Any]:
+    """Returns cluster hardware facts, or empty facts when discovery is off.
+
+    --no-cluster-facts short-circuits before any Kubernetes API call, for
+    clusters where listing nodes and pods is expensive.
+    """
+    if not args.cluster_facts:
+        tee(logs, "Skipping cluster hardware discovery (--no-cluster-facts)")
+        return dict(EMPTY_FACTS)
+    return get_cluster_hardware_facts(logs)
 
 
 def main() -> None:
@@ -757,55 +469,59 @@ def main() -> None:
                         jsonl_path.unlink()
                 else:
                     stats_generated = jsonl_path.exists()
-                    if stats_generated:
-                        facts = get_cluster_hardware_facts(logs)
-                        stats_history_csv = work_dir / f"{args.name}_stats_history.csv"
-                        append_trial_summary(
-                            jsonl_path,
-                            stats_csv,
-                            stats_history_csv,
-                            args,
-                            data_ts,
-                            facts,
-                            logs,
-                        )
-
-                        # Harvest server-side ground truth from Prometheus (bin-packing, PSI, snapshots)
-                        prom_url = os.environ.get(
-                            "PROMETHEUS_URL",
-                            "http://prometheus.benchmarking.svc.cluster.local:9090",
-                        )
-                        try:
-                            from server_telemetry import (
-                                extract_and_record_server_telemetry,
-                            )
-
-                            extract_and_record_server_telemetry(
-                                prom_url=prom_url,
-                                start_ts=run_ts,
-                                end_ts=run_end_ts,
-                                stats_history_csv=stats_history_csv,
-                                active_users=args.users,
-                                worker_pod_count=facts.get("worker_pod_count")
-                                or 5,
-                                output_json_path=server_summary_json,
-                                jsonl_path=jsonl_path,
-                                data_ts=data_ts,
-                                tag=args.tag,
-                                test_name=args.name,
-                                logs=logs,
-                            )
-                        except Exception as e:
-                            tee(
-                                logs,
-                                f"Warning: Failed to harvest server telemetry: {e}",
-                            )
             except Exception as e:
                 tee(logs, f"Failed to generate JSONL from {stats_csv}: {e}")
                 if jsonl_path.exists():
                     jsonl_path.unlink()
         else:
             tee(logs, f"Stats CSV {stats_csv} not produced; skipping JSONL")
+
+        # Density frontiers and server-side telemetry are additive. They are
+        # kept out of the block above so that a failure here cannot discard
+        # the measurements the trial actually came for.
+        if stats_generated:
+            stats_history_csv = work_dir / f"{args.name}_stats_history.csv"
+            # Seeded up front so that a later failure still leaves a usable
+            # value for the telemetry call below.
+            facts = dict(EMPTY_FACTS)
+            try:
+                facts = collect_cluster_facts(args, logs)
+                append_trial_summary(
+                    jsonl_path,
+                    stats_csv,
+                    stats_history_csv,
+                    args,
+                    data_ts,
+                    facts,
+                    logs,
+                )
+            except Exception as e:
+                tee(logs, f"Warning: Failed to record cluster facts: {e}")
+
+            # Harvest server-side ground truth from Prometheus (bin-packing, PSI, snapshots)
+            prom_url = os.environ.get(
+                "PROMETHEUS_URL",
+                "http://prometheus.benchmarking.svc.cluster.local:9090",
+            )
+            try:
+                from server_telemetry import extract_and_record_server_telemetry
+
+                extract_and_record_server_telemetry(
+                    prom_url=prom_url,
+                    start_ts=run_ts,
+                    end_ts=run_end_ts,
+                    stats_history_csv=stats_history_csv,
+                    active_users=args.users,
+                    worker_pod_count=facts.get("worker_pod_count"),
+                    output_json_path=server_summary_json,
+                    jsonl_path=jsonl_path,
+                    data_ts=data_ts,
+                    tag=args.tag,
+                    test_name=args.name,
+                    logs=logs,
+                )
+            except Exception as e:
+                tee(logs, f"Warning: Failed to harvest server telemetry: {e}")
 
     status_path.write_text(
         json.dumps(
@@ -824,7 +540,6 @@ def main() -> None:
         (work_dir / f"{args.name}_stats_history.csv", "stats_history.csv"),
         (server_summary_json, "server_summary.json"),
         # TODO: remove after data migration
-        (server_summary_json, f"{args.name}_server_summary.json"),
         (jsonl_path, f"{args.name}.jsonl"),
     ]
     for src, basename in files:

--- a/benchmarking/locust/runner.py
+++ b/benchmarking/locust/runner.py
@@ -47,7 +47,12 @@ from common.boomer_config import build_config_json
 
 # Path inside the locust image to the boomer-worker binary baked in by
 # benchmarking/locust/Dockerfile.
-BOOMER_BINARY = "/app/boomer-worker"
+default_boomer = "/app/boomer-worker"
+if not os.path.exists(default_boomer) and os.path.exists("/app/boomer-glutton"):
+    default_boomer = "/app/boomer-glutton"
+BOOMER_BINARY = os.environ.get("BOOMER_BINARY", default_boomer)
+BOOMER_MASTER_PORT = int(os.environ.get("BOOMER_MASTER_PORT", "5557"))
+BOOMER_PROMETHEUS_ADDR = os.environ.get("BOOMER_PROMETHEUS_ADDR", ":8001")
 
 # Port for the headless /boomer-config server (common/boomer_config.py), which
 # gives boomer the values that change while a run continues. Locust already
@@ -262,9 +267,13 @@ def run_test(args: argparse.Namespace, csv_prefix: Path, logs: TextIO, traces: T
         "--csv", str(csv_prefix),
     ]
     if with_boomer:
-        # Master mode so boomer can connect as a worker on localhost:5557.
+        # Master mode so boomer can connect as a worker.
         # --expect-workers=1 makes locust wait for boomer before starting.
-        locust_cmd += ["--master", "--expect-workers", "1"]
+        locust_cmd += [
+            "--master",
+            "--master-bind-port", str(BOOMER_MASTER_PORT),
+            "--expect-workers", "1",
+        ]
         # Serve /boomer-config for the worker. --config-json gives boomer the
         # values one time, at its start, thus a run that changes a value while
         # it runs needs the endpoint. A load shape is one such run.
@@ -289,7 +298,16 @@ def run_test(args: argparse.Namespace, csv_prefix: Path, logs: TextIO, traces: T
 
     boomer_proc = None
     if with_boomer:
-        boomer_cmd = [BOOMER_BINARY, "--user-class", Path(test_file(args.file)).stem]
+        boomer_cmd = [BOOMER_BINARY]
+        if "boomer-glutton" not in os.path.basename(BOOMER_BINARY):
+            boomer_cmd += ["--user-class", Path(test_file(args.file)).stem]
+        boomer_cmd += [
+            "--master-port", str(BOOMER_MASTER_PORT),
+            "--prometheus-addr", BOOMER_PROMETHEUS_ADDR,
+        ]
+        api_endpoint = os.environ.get("BOOMER_API_ENDPOINT")
+        if api_endpoint:
+            boomer_cmd += ["-api-endpoint", api_endpoint]
         cfg_json = build_config_json(args.locust_extra)
         if cfg_json:
             boomer_cmd += ["--config-json", cfg_json]
@@ -371,6 +389,304 @@ def stats_to_jsonl(stats_csv: Path, jsonl_path: Path, timestamp: str, tag: str, 
     return rows_written
 
 
+def parse_k8s_cpu(cpu_str: str) -> float:
+    cpu_str = cpu_str.strip()
+    if cpu_str.endswith("m"):
+        return float(cpu_str[:-1]) / 1000.0
+    if cpu_str.endswith("u"):
+        return float(cpu_str[:-1]) / 1_000_000.0
+    if cpu_str.endswith("n"):
+        return float(cpu_str[:-1]) / 1_000_000_000.0
+    return float(cpu_str)
+
+
+def parse_k8s_memory(mem_str: str) -> int:
+    mem_str = mem_str.strip()
+    multipliers = {
+        "Ki": 1024,
+        "Mi": 1024**2,
+        "Gi": 1024**3,
+        "Ti": 1024**4,
+        "Pi": 1024**5,
+        "Ei": 1024**6,
+        "k": 1000,
+        "K": 1000,
+        "m": 1000**2,
+        "M": 1000**2,
+        "g": 1000**3,
+        "G": 1000**3,
+        "t": 1000**4,
+        "T": 1000**4,
+        "p": 1000**5,
+        "P": 1000**5,
+        "e": 1000**6,
+        "E": 1000**6,
+    }
+    for suffix, mult in multipliers.items():
+        if mem_str.endswith(suffix):
+            num = float(mem_str[: -len(suffix)].strip())
+            return int(num * mult)
+    return int(float(mem_str))
+
+
+def get_cluster_hardware_facts(logs: TextIO | None = None) -> dict[str, any]:
+    facts: dict[str, any] = {
+        "node_count": None,
+        "allocatable_cores": None,
+        "allocatable_ram_gb": None,
+        "worker_pod_count": None,
+    }
+    # 1. Environment variables override
+    if "NODE_COUNT" in os.environ:
+        try:
+            facts["node_count"] = int(os.environ["NODE_COUNT"])
+        except ValueError:
+            pass
+    if "ALLOCATABLE_VCPU" in os.environ or "ALLOCATABLE_CORES" in os.environ:
+        try:
+            facts["allocatable_cores"] = float(
+                os.environ.get("ALLOCATABLE_VCPU") or os.environ.get("ALLOCATABLE_CORES")
+            )
+        except ValueError:
+            pass
+    if "ALLOCATABLE_RAM_GB" in os.environ:
+        try:
+            facts["allocatable_ram_gb"] = float(os.environ["ALLOCATABLE_RAM_GB"])
+        except ValueError:
+            pass
+    elif "ALLOCATABLE_RAM_BYTES" in os.environ:
+        try:
+            facts["allocatable_ram_gb"] = round(
+                float(os.environ["ALLOCATABLE_RAM_BYTES"]) / (1024**3), 2
+            )
+        except ValueError:
+            pass
+    if "WORKER_POD_COUNT" in os.environ:
+        try:
+            facts["worker_pod_count"] = int(os.environ["WORKER_POD_COUNT"])
+        except ValueError:
+            pass
+
+    if all(
+        facts[k] is not None
+        for k in ("node_count", "allocatable_cores", "allocatable_ram_gb", "worker_pod_count")
+    ):
+        return facts
+
+    # 2. In-cluster HTTP API or local kubectl discovery
+    try:
+        nodes_data = None
+        token_path = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+
+        if token_path.exists():
+            import ssl
+            import urllib.request
+
+            token = token_path.read_text().strip()
+            ctx = ssl.create_default_context()
+            ca_path = Path("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+            if ca_path.exists():
+                ctx.load_verify_locations(cafile=str(ca_path))
+
+            # Query nodes
+            if any(facts[k] is None for k in ("node_count", "allocatable_cores", "allocatable_ram_gb")):
+                try:
+                    req = urllib.request.Request(
+                        "https://kubernetes.default.svc/api/v1/nodes",
+                        headers={"Authorization": f"Bearer {token}"},
+                    )
+                    with urllib.request.urlopen(req, context=ctx, timeout=5) as resp:
+                        nodes_data = json.loads(resp.read().decode())
+                except Exception as e:
+                    if logs:
+                        tee(logs, f"Notice: In-cluster nodes API: {e}")
+
+            # Query worker pods (ate.dev/worker-pool)
+            if facts["worker_pod_count"] is None:
+                for url in (
+                    "https://kubernetes.default.svc/api/v1/namespaces/benchmark-workloads/pods?labelSelector=ate.dev%2Fworker-pool",
+                    "https://kubernetes.default.svc/api/v1/pods?labelSelector=ate.dev%2Fworker-pool",
+                ):
+                    try:
+                        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+                        with urllib.request.urlopen(req, context=ctx, timeout=5) as resp:
+                            p_data = json.loads(resp.read().decode())
+                            items = [
+                                p for p in p_data.get("items", [])
+                                if p.get("status", {}).get("phase") in ("Running", "Pending")
+                            ]
+                            if items:
+                                facts["worker_pod_count"] = len(items)
+                                break
+                    except Exception:
+                        pass
+        elif shutil.which("kubectl"):
+            # Local workstation fallback via kubectl
+            if any(facts[k] is None for k in ("node_count", "allocatable_cores", "allocatable_ram_gb")):
+                res = subprocess.run(
+                    ["kubectl", "get", "nodes", "-o", "json"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if res.returncode == 0:
+                    nodes_data = json.loads(res.stdout)
+            if facts["worker_pod_count"] is None:
+                for cmd in (
+                    ["kubectl", "get", "pods", "-n", "benchmark-workloads", "-l", "ate.dev/worker-pool", "-o", "json"],
+                    ["kubectl", "get", "pods", "-A", "-l", "ate.dev/worker-pool", "-o", "json"],
+                ):
+                    res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+                    if res.returncode == 0:
+                        p_data = json.loads(res.stdout)
+                        items = [
+                            p for p in p_data.get("items", [])
+                            if p.get("status", {}).get("phase") in ("Running", "Pending")
+                        ]
+                        if items:
+                            facts["worker_pod_count"] = len(items)
+                            break
+
+        if nodes_data and "items" in nodes_data:
+            nodes = nodes_data["items"]
+            if facts["node_count"] is None:
+                facts["node_count"] = len(nodes)
+            total_cores = 0.0
+            total_ram_bytes = 0
+            for node in nodes:
+                alloc = node.get("status", {}).get("allocatable", {})
+                if "cpu" in alloc:
+                    total_cores += parse_k8s_cpu(alloc["cpu"])
+                if "memory" in alloc:
+                    total_ram_bytes += parse_k8s_memory(alloc["memory"])
+            if facts["allocatable_cores"] is None:
+                facts["allocatable_cores"] = round(total_cores, 2)
+            if facts["allocatable_ram_gb"] is None:
+                facts["allocatable_ram_gb"] = round(total_ram_bytes / (1024**3), 2)
+
+        # Graceful fallback: if no worker pods found, fall back to node_count
+        if facts["worker_pod_count"] is None and facts["node_count"]:
+            facts["worker_pod_count"] = facts["node_count"]
+    except Exception as e:
+        if logs:
+            tee(logs, f"Notice: Cluster hardware discovery skipped/failed: {e}")
+
+    return facts
+
+
+def append_trial_summary(
+    jsonl_path: Path,
+    stats_csv: Path,
+    stats_history_csv: Path,
+    args: argparse.Namespace,
+    data_ts: str,
+    facts: dict[str, any],
+    logs: TextIO | None = None,
+) -> None:
+    active_users = args.users
+    node_count = facts.get("node_count")
+    cores = facts.get("allocatable_cores")
+    ram_gb = facts.get("allocatable_ram_gb")
+    pod_count = facts.get("worker_pod_count")
+
+    actors_per_node = round(active_users / node_count, 2) if node_count else None
+    actors_per_vcpu = round(active_users / cores, 2) if cores else None
+    actors_per_gb_ram = round(active_users / ram_gb, 2) if ram_gb else None
+
+    # Calculate steady-state A/P percentiles from stats_history.csv
+    ap_p50, ap_p90, ap_p99 = None, None, None
+    if stats_history_csv.exists() and pod_count and pod_count > 0:
+        try:
+            user_counts: list[float] = []
+            with open(stats_history_csv) as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    name = row.get("Name", "")
+                    if name in ("", "Aggregated", "Total") and "User Count" in row:
+                        try:
+                            u = float(row["User Count"])
+                            # Steady-state window: when load reaches configured users
+                            if u >= active_users * 0.9:
+                                user_counts.append(u)
+                        except ValueError:
+                            pass
+            if not user_counts:
+                # Fallback: if no rows matched threshold, use non-zero samples
+                with open(stats_history_csv) as f:
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        name = row.get("Name", "")
+                        if name in ("", "Aggregated", "Total") and "User Count" in row:
+                            try:
+                                u = float(row["User Count"])
+                                if u > 0:
+                                    user_counts.append(u)
+                            except ValueError:
+                                pass
+            if user_counts:
+                ratios = sorted([round(u / pod_count, 4) for u in user_counts])
+                n = len(ratios)
+                ap_p50 = round(ratios[int(n * 0.50)], 2)
+                ap_p90 = round(ratios[min(int(n * 0.90), n - 1)], 2)
+                ap_p99 = round(ratios[min(int(n * 0.99), n - 1)], 2)
+            else:
+                static_ratio = round(active_users / pod_count, 2)
+                ap_p50, ap_p90, ap_p99 = static_ratio, static_ratio, static_ratio
+        except Exception as e:
+            if logs:
+                tee(logs, f"Notice: Error calculating A/P ratio percentiles: {e}")
+
+    # Calculate aggregate failure ratio from stats_csv
+    total_requests = 0
+    total_failures = 0
+    if stats_csv.exists():
+        try:
+            with open(stats_csv) as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    name = row.get("Name", "")
+                    reqs = int(row.get("Request Count", 0) or 0)
+                    fails = int(row.get("Failure Count", 0) or 0)
+                    if name == "Aggregated":
+                        total_requests = reqs
+                        total_failures = fails
+                        break
+                    total_requests += reqs
+                    total_failures += fails
+        except Exception:
+            pass
+
+    failure_ratio = (
+        round(total_failures / total_requests, 4) if total_requests > 0 else 0.0
+    )
+
+    summary_entry = {
+        "timestamp": data_ts,
+        "tag": args.tag,
+        "test_name": args.name,
+        "metric": "trial_summary",
+        "raw_configuration": {
+            "node_count": node_count,
+            "allocatable_cores": cores,
+            "allocatable_ram_gb": ram_gb,
+            "worker_pod_count": pod_count,
+        },
+        "frontiers": {
+            "actors_per_node": actors_per_node,
+            "actors_per_vcpu": actors_per_vcpu,
+            "actors_per_gb_ram": actors_per_gb_ram,
+            "ap_ratio_p50": ap_p50,
+            "ap_ratio_p90": ap_p90,
+            "ap_ratio_p99": ap_p99,
+            "aggregate_failure_ratio": failure_ratio,
+        },
+    }
+    with open(jsonl_path, "a") as f:
+        f.write(json.dumps(summary_entry) + "\n")
+    if logs:
+        tee(logs, f"Appended trial_summary to {jsonl_path}")
+
+
 def upload_to_gcs(local_path: Path, gcs_uri: str) -> None:
     # Imported here so non-GCS use doesn't require google-cloud-storage.
     from google.cloud import storage
@@ -385,9 +701,11 @@ def upload(src: Path, dest: str) -> None:
     if dest.startswith("gs://"):
         upload_to_gcs(src, dest)
     else:
-        dest_path = Path(dest)
+        path_str = dest[7:] if dest.startswith("file://") else dest
+        dest_path = Path(path_str)
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(src, dest_path)
+
 
 
 def main() -> None:
@@ -437,6 +755,18 @@ def main() -> None:
                         jsonl_path.unlink()
                 else:
                     stats_generated = jsonl_path.exists()
+                    if stats_generated:
+                        facts = get_cluster_hardware_facts(logs)
+                        stats_history_csv = work_dir / f"{args.name}_stats_history.csv"
+                        append_trial_summary(
+                            jsonl_path,
+                            stats_csv,
+                            stats_history_csv,
+                            args,
+                            data_ts,
+                            facts,
+                            logs,
+                        )
             except Exception as e:
                 tee(logs, f"Failed to generate JSONL from {stats_csv}: {e}")
                 if jsonl_path.exists():

--- a/benchmarking/locust/server_telemetry.py
+++ b/benchmarking/locust/server_telemetry.py
@@ -1,0 +1,463 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Harvests server-side Prometheus ground-truth timeseries during benchmark trials.
+
+Queries Prometheus over [T_start, T_end] and the steady-state window [T_steady, T_end]
+to capture dynamic cluster packing, node PSI stalls, and snapshot throughput.
+"""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime, timezone
+import json
+import math
+from pathlib import Path
+import sys
+from typing import Any, TextIO
+import urllib.parse
+import urllib.request
+
+
+def query_prometheus_instant(
+    base_url: str,
+    query: str,
+    time_ts: float | int | None = None,
+    timeout_s: float = 5.0,
+) -> list[dict[str, Any]]:
+    """Executes an instant query against Prometheus /api/v1/query."""
+    params = {"query": query}
+    if time_ts is not None:
+        params["time"] = str(time_ts)
+    url = f"{base_url.rstrip('/')}/api/v1/query?{urllib.parse.urlencode(params)}"
+    try:
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "Substrate-Locust-Runner"}
+        )
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            if data.get("status") == "success":
+                return data.get("data", {}).get("result", [])
+    except Exception as e:
+        print(f"Warning: Instant query failed '{query}': {e}", file=sys.stderr)
+    return []
+
+
+def query_prometheus_range(
+    base_url: str,
+    query: str,
+    start_ts: int,
+    end_ts: int,
+    step: str = "5s",
+    timeout_s: float = 8.0,
+) -> list[dict[str, Any]]:
+    """Executes a range query against Prometheus /api/v1/query_range."""
+    # Guard against Prometheus 400 Bad Request: end must be greater than start
+    if end_ts <= start_ts:
+        end_ts = start_ts + 1
+
+    params = {
+        "query": query,
+        "start": str(start_ts),
+        "end": str(end_ts),
+        "step": step,
+    }
+    url = f"{base_url.rstrip('/')}/api/v1/query_range?{urllib.parse.urlencode(params)}"
+    try:
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "Substrate-Locust-Runner"}
+        )
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            if data.get("status") == "success":
+                return data.get("data", {}).get("result", [])
+    except Exception as e:
+        print(f"Warning: Range query failed '{query}': {e}", file=sys.stderr)
+    return []
+
+
+def compute_percentiles(values: list[float]) -> dict[str, float | None]:
+    """Computes min, p50, p90, p99, max, avg after filtering out NaN and Inf values."""
+    clean = sorted([v for v in values if not math.isnan(v) and not math.isinf(v)])
+    if not clean:
+        return {
+            "min": None,
+            "p50": None,
+            "p90": None,
+            "p99": None,
+            "max": None,
+            "avg": None,
+        }
+    n = len(clean)
+    return {
+        "min": round(clean[0], 4),
+        "p50": round(clean[int(n * 0.50)], 4),
+        "p90": round(clean[min(int(n * 0.90), n - 1)], 4),
+        "p99": round(clean[min(int(n * 0.99), n - 1)], 4),
+        "max": round(clean[-1], 4),
+        "avg": round(sum(clean) / n, 4),
+    }
+
+
+def get_steady_state_window(
+    stats_history_csv: Path,
+    active_users: int,
+    start_ts: int,
+    end_ts: int,
+) -> tuple[int, int]:
+    """Derives steady-state [T_steady, T_end] where User Count >= 0.9 * active_users."""
+    if not stats_history_csv.exists() or active_users <= 0:
+        return start_ts, end_ts
+
+    steady_ts: int | None = None
+    try:
+        with open(stats_history_csv, "r", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                name = row.get("Name", "")
+                if (
+                    name in ("", "Aggregated", "Total")
+                    and "User Count" in row
+                    and "Timestamp" in row
+                ):
+                    try:
+                        users = float(row["User Count"])
+                        ts = int(row["Timestamp"])
+                        if users >= active_users * 0.9:
+                            steady_ts = ts
+                            break
+                    except (ValueError, TypeError):
+                        continue
+    except Exception:
+        pass
+
+    if steady_ts is not None and start_ts <= steady_ts <= end_ts:
+        return steady_ts, end_ts
+    return start_ts, end_ts
+
+
+def _parse_instant_float(res: list[dict[str, Any]]) -> float | None:
+    if res and "value" in res[0]:
+        try:
+            v = float(res[0]["value"][1])
+            return None if math.isnan(v) or math.isinf(v) else round(v, 4)
+        except (ValueError, IndexError):
+            pass
+    return None
+
+
+def _parse_instant_int(res: list[dict[str, Any]]) -> int:
+    val = _parse_instant_float(res)
+    return int(val) if val is not None else 0
+
+
+def _query_quantile_with_fallback(
+    prom_url: str,
+    quantile: float,
+    rate_metric_expr: str,
+    raw_metric_expr: str,
+    end_ts: int,
+    unit_scale: float = 1.0,
+) -> float | None:
+    """Queries histogram quantile using rate(5m), falling back to cumulative buckets if NaN/empty."""
+    q_rate = (
+        f"histogram_quantile({quantile}, sum({rate_metric_expr}) by (le)) / {unit_scale}"
+    )
+    res = query_prometheus_instant(prom_url, q_rate, time_ts=end_ts)
+    val = _parse_instant_float(res)
+    if val is not None and not math.isnan(val):
+        return val
+
+    # Fallback to cumulative bucket distribution
+    q_cum = (
+        f"histogram_quantile({quantile}, sum by (le) ({raw_metric_expr})) / {unit_scale}"
+    )
+    res_cum = query_prometheus_instant(prom_url, q_cum, time_ts=end_ts)
+    val_cum = _parse_instant_float(res_cum)
+    if val_cum is not None and not math.isnan(val_cum):
+        return val_cum
+    return None
+
+
+def harvest_server_telemetry(
+    prom_url: str,
+    start_ts: int,
+    end_ts: int,
+    steady_start_ts: int,
+    worker_pod_count: int,
+) -> dict[str, Any]:
+    """Harvests all 4 ground truth metric streams from Prometheus."""
+    summary: dict[str, Any] = {
+        "cluster_packing": {},
+        "node_psi": {},
+        "snapshots": {},
+    }
+
+    # 1. Cluster Packing Timeseries (deduping ateapi replicas via max by state)
+    packing_query = (
+        'max by (ate_worker_state) '
+        '(ate_workerpool_workers{ate_workerpool_name="benchmark-ateom"})'
+    )
+    packing_series = query_prometheus_range(
+        prom_url, packing_query, start_ts, end_ts, step="5s"
+    )
+
+    ts_packing_map: dict[int, dict[str, float]] = {}
+    for series in packing_series:
+        state = series.get("metric", {}).get("ate_worker_state", "unknown")
+        for pt in series.get("values", []):
+            try:
+                t = int(pt[0])
+                val = float(pt[1])
+                if not math.isnan(val):
+                    ts_packing_map.setdefault(t, {})[state] = val
+            except (ValueError, IndexError):
+                continue
+
+    packing_points = []
+    steady_packing_ratios = []
+    for t in sorted(ts_packing_map.keys()):
+        states = ts_packing_map[t]
+        assigned = states.get("assigned", 0.0)
+        # Use known cluster worker pod count as true physical capacity denominator
+        total = (
+            float(worker_pod_count)
+            if worker_pod_count > 0
+            else (sum(states.values()) or 1.0)
+        )
+        ratio = round(assigned / total, 4) if total > 0 else 0.0
+        packing_points.append({
+            "timestamp": t,
+            "assigned_workers": assigned,
+            "total_workers": total,
+            "packing_ratio": ratio,
+        })
+        if t >= steady_start_ts:
+            steady_packing_ratios.append(ratio)
+
+    summary["cluster_packing"] = {
+        "summary": compute_percentiles(steady_packing_ratios),
+        "timeseries": packing_points,
+    }
+
+    # 2. Host Linux Kernel PSI Stalls & CFS Throttling
+    psi_cpu_query = (
+        'sum by (instance) (rate(container_pressure_cpu_waiting_seconds_total'
+        '{container="node"}[1m])) * 100'
+    )
+    psi_mem_query = (
+        'sum by (instance) (rate(container_pressure_memory_waiting_seconds_total'
+        '{container="node"}[1m])) * 100'
+    )
+    psi_io_query = (
+        'sum by (instance) (rate(container_pressure_io_waiting_seconds_total'
+        '{container="node"}[1m])) * 100'
+    )
+    cfs_throttled_query = (
+        'sum(rate(container_cpu_cfs_throttled_seconds_total[1m]))'
+    )
+
+    psi_cpu_res = query_prometheus_range(
+        prom_url, psi_cpu_query, start_ts, end_ts, step="5s"
+    )
+    psi_mem_res = query_prometheus_range(
+        prom_url, psi_mem_query, start_ts, end_ts, step="5s"
+    )
+    psi_io_res = query_prometheus_range(
+        prom_url, psi_io_query, start_ts, end_ts, step="5s"
+    )
+    cfs_res = query_prometheus_range(
+        prom_url, cfs_throttled_query, start_ts, end_ts, step="5s"
+    )
+
+    def extract_steady_values(results: list[dict[str, Any]]) -> list[float]:
+        vals = []
+        for s in results:
+            for pt in s.get("values", []):
+                try:
+                    if int(pt[0]) >= steady_start_ts:
+                        v = float(pt[1])
+                        if not math.isnan(v):
+                            vals.append(v)
+                except (ValueError, IndexError):
+                    pass
+        return vals
+
+    summary["node_psi"] = {
+        "cpu_stall_pct": compute_percentiles(extract_steady_values(psi_cpu_res)),
+        "mem_stall_pct": compute_percentiles(extract_steady_values(psi_mem_res)),
+        "io_stall_pct": compute_percentiles(extract_steady_values(psi_io_res)),
+        "cfs_throttled_rate": compute_percentiles(extract_steady_values(cfs_res)),
+    }
+
+    # 3. Snapshot Sizes, Checkpoint Count & Latencies (with histogram fallback)
+    snap_p50 = _query_quantile_with_fallback(
+        prom_url,
+        0.50,
+        "rate(atelet_snapshot_size_bytes_bucket[5m])",
+        "atelet_snapshot_size_bytes_bucket",
+        end_ts,
+        unit_scale=1024 * 1024,
+    )
+    snap_p90 = _query_quantile_with_fallback(
+        prom_url,
+        0.90,
+        "rate(atelet_snapshot_size_bytes_bucket[5m])",
+        "atelet_snapshot_size_bytes_bucket",
+        end_ts,
+        unit_scale=1024 * 1024,
+    )
+
+    # Delta of snapshots created in steady window
+    snap_count_start = query_prometheus_instant(
+        prom_url, "sum(atelet_snapshot_size_bytes_count)", time_ts=steady_start_ts
+    )
+    snap_count_end = query_prometheus_instant(
+        prom_url, "sum(atelet_snapshot_size_bytes_count)", time_ts=end_ts
+    )
+    c_start = _parse_instant_int(snap_count_start)
+    c_end = _parse_instant_int(snap_count_end)
+    window_checkpoints = max(0, c_end - c_start)
+
+    # RPC durations with fallback
+    restore_p50 = _query_quantile_with_fallback(
+        prom_url,
+        0.50,
+        'rate(rpc_server_call_duration_seconds_bucket{rpc_method="atelet.AteomHerder/Restore"}[5m])',
+        'rpc_server_call_duration_seconds_bucket{rpc_method="atelet.AteomHerder/Restore"}',
+        end_ts,
+    )
+    restore_p95 = _query_quantile_with_fallback(
+        prom_url,
+        0.95,
+        'rate(rpc_server_call_duration_seconds_bucket{rpc_method="atelet.AteomHerder/Restore"}[5m])',
+        'rpc_server_call_duration_seconds_bucket{rpc_method="atelet.AteomHerder/Restore"}',
+        end_ts,
+    )
+    ckpt_p50 = _query_quantile_with_fallback(
+        prom_url,
+        0.50,
+        'rate(rpc_server_call_duration_seconds_bucket{rpc_method="atelet.AteomHerder/Checkpoint"}[5m])',
+        'rpc_server_call_duration_seconds_bucket{rpc_method="atelet.AteomHerder/Checkpoint"}',
+        end_ts,
+    )
+    ckpt_p95 = _query_quantile_with_fallback(
+        prom_url,
+        0.95,
+        'rate(rpc_server_call_duration_seconds_bucket{rpc_method="atelet.AteomHerder/Checkpoint"}[5m])',
+        'rpc_server_call_duration_seconds_bucket{rpc_method="atelet.AteomHerder/Checkpoint"}',
+        end_ts,
+    )
+
+    steady_duration_s = max(1, end_ts - steady_start_ts)
+    throughput_mb_s = None
+    if snap_p50 and window_checkpoints > 0:
+        throughput_mb_s = round(
+            (snap_p50 * window_checkpoints) / steady_duration_s, 2
+        )
+
+    summary["snapshots"] = {
+        "size_p50_mb": snap_p50,
+        "size_p90_mb": snap_p90,
+        "checkpoints_in_window": window_checkpoints,
+        "checkpoints_cumulative": c_end,
+        "restore_p50_s": restore_p50,
+        "restore_p95_s": restore_p95,
+        "checkpoint_p50_s": ckpt_p50,
+        "checkpoint_p95_s": ckpt_p95,
+        "throughput_mb_s": throughput_mb_s,
+    }
+
+    return summary
+
+
+def extract_and_record_server_telemetry(
+    prom_url: str,
+    start_ts: int,
+    end_ts: int,
+    stats_history_csv: Path,
+    active_users: int,
+    worker_pod_count: int,
+    output_json_path: Path,
+    jsonl_path: Path,
+    data_ts: str,
+    tag: str,
+    test_name: str,
+    logs: TextIO | None = None,
+) -> None:
+    """Entry point called by runner.py to query Prometheus and persist artifacts."""
+    def log(msg: str) -> None:
+        if logs:
+            print(f"[ServerTelemetry] {msg}", file=logs, flush=True)
+        print(f"[ServerTelemetry] {msg}", flush=True)
+
+    log(f"Harvesting Prometheus metrics from {prom_url} over [{start_ts}, {end_ts}]...")
+    steady_start, steady_end = get_steady_state_window(
+        stats_history_csv, active_users, start_ts, end_ts
+    )
+    log(
+        f"Detected steady-state window: [{steady_start}, {steady_end}] "
+        f"({steady_end - steady_start}s)"
+    )
+
+    telemetry = harvest_server_telemetry(
+        prom_url, start_ts, end_ts, steady_start, worker_pod_count
+    )
+
+    full_artifact = {
+        "metadata": {
+            "test_name": test_name,
+            "tag": tag,
+            "data_timestamp": data_ts,
+            "prom_url": prom_url,
+            "start_ts": start_ts,
+            "end_ts": end_ts,
+            "steady_start_ts": steady_start,
+            "steady_end_ts": steady_end,
+            "worker_pod_count": worker_pod_count,
+        },
+        **telemetry,
+    }
+
+    output_json_path.write_text(json.dumps(full_artifact, indent=2) + "\n")
+    log(f"Wrote server summary artifact to {output_json_path}")
+
+    # Append normalized single-row summary into stats.jsonl
+    packing_s = telemetry.get("cluster_packing", {}).get("summary", {})
+    psi = telemetry.get("node_psi", {})
+    snaps = telemetry.get("snapshots", {})
+
+    jsonl_row = {
+        "timestamp": data_ts,
+        "tag": tag,
+        "test_name": test_name,
+        "metric": "server_summary",
+        "cluster_packing_p50": packing_s.get("p50"),
+        "cluster_packing_p90": packing_s.get("p90"),
+        "cluster_packing_p99": packing_s.get("p99"),
+        "psi_cpu_stall_p90": psi.get("cpu_stall_pct", {}).get("p90"),
+        "psi_mem_stall_p90": psi.get("mem_stall_pct", {}).get("p90"),
+        "psi_io_stall_p90": psi.get("io_stall_pct", {}).get("p90"),
+        "cfs_throttled_rate_avg": psi.get("cfs_throttled_rate", {}).get("avg"),
+        "snapshot_size_p50_mb": snaps.get("size_p50_mb"),
+        "checkpoints_in_window": snaps.get("checkpoints_in_window"),
+        "restore_p50_s": snaps.get("restore_p50_s"),
+        "checkpoint_p50_s": snaps.get("checkpoint_p50_s"),
+        "checkpoint_throughput_mb_s": snaps.get("throughput_mb_s"),
+    }
+
+    with open(jsonl_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(jsonl_row) + "\n")
+    log(f"Appended server_summary row to {jsonl_path}")

--- a/benchmarking/locust/server_telemetry.py
+++ b/benchmarking/locust/server_telemetry.py
@@ -196,7 +196,7 @@ def harvest_server_telemetry(
     start_ts: int,
     end_ts: int,
     steady_start_ts: int,
-    worker_pod_count: int,
+    worker_pod_count: int | None,
 ) -> dict[str, Any]:
     """Harvests all 4 ground truth metric streams from Prometheus."""
     summary: dict[str, Any] = {
@@ -231,10 +231,12 @@ def harvest_server_telemetry(
     for t in sorted(ts_packing_map.keys()):
         states = ts_packing_map[t]
         assigned = states.get("assigned", 0.0)
-        # Use known cluster worker pod count as true physical capacity denominator
+        # Prefer the real cluster worker pod count as the physical capacity
+        # denominator. When it is unknown, fall back to the worker states
+        # Prometheus itself reports rather than assuming a number.
         total = (
             float(worker_pod_count)
-            if worker_pod_count > 0
+            if worker_pod_count
             else (sum(states.values()) or 1.0)
         )
         ratio = round(assigned / total, 4) if total > 0 else 0.0
@@ -389,7 +391,7 @@ def extract_and_record_server_telemetry(
     end_ts: int,
     stats_history_csv: Path,
     active_users: int,
-    worker_pod_count: int,
+    worker_pod_count: int | None,
     output_json_path: Path,
     jsonl_path: Path,
     data_ts: str,

--- a/benchmarking/locust/unit_tests/test_cluster_facts.py
+++ b/benchmarking/locust/unit_tests/test_cluster_facts.py
@@ -1,0 +1,436 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for cluster_facts.py: python3 benchmarking/locust/unit_tests/test_cluster_facts.py
+
+These never contact a cluster. Every node and pod is a stand-in object built
+here and handed to a mocked CoreV1Api, so the results do not depend on which
+cluster you happen to be pointed at, or on having one at all.
+
+Requires the kubernetes client: pip install -r benchmarking/locust/requirements.txt
+Tests that need it are skipped, loudly, when it is missing.
+"""
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+# Ensure benchmarking/locust is in sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+try:
+    import cluster_facts
+    import runner
+    from kubernetes.client.rest import ApiException
+
+    HAS_KUBERNETES = True
+except ImportError:  # pragma: no cover - depends on the local environment
+    HAS_KUBERNETES = False
+
+needs_kubernetes = unittest.skipUnless(
+    HAS_KUBERNETES,
+    "kubernetes client not installed; pip install -r benchmarking/locust/requirements.txt",
+)
+
+# Fixture inputs, not readings from anyone's cluster. Shaped like a GKE
+# c3-standard-4 (4 vCPU / 16 GiB, less kubelet reservations) so the parsing and
+# arithmetic are exercised against quantity strings the apiserver really emits.
+SAMPLE_CPU = "3920m"          # -> 3.92 cores
+SAMPLE_MEMORY = "13591700Ki"  # -> 12.96 GiB
+SAMPLE_CORES = 3.92
+SAMPLE_RAM_GB = 12.96
+SAMPLE_MACHINE_TYPE = "c3-standard-4"
+
+
+def node(cpu=SAMPLE_CPU, memory=SAMPLE_MEMORY, machine_type=SAMPLE_MACHINE_TYPE):
+    labels = {} if machine_type is None else {
+        cluster_facts.MACHINE_TYPE_LABEL: machine_type
+    }
+    return SimpleNamespace(
+        metadata=SimpleNamespace(labels=labels),
+        status=SimpleNamespace(allocatable={"cpu": cpu, "memory": memory}),
+    )
+
+
+def pod(phase="Running"):
+    return SimpleNamespace(status=SimpleNamespace(phase=phase))
+
+
+def listing(items):
+    return SimpleNamespace(items=items)
+
+
+def forbidden(*_args, **_kwargs):
+    raise ApiException(status=403, reason="Forbidden")
+
+
+def fake_api(nodes=None, ns_pods=None, all_pods=None):
+    """Builds a stand-in CoreV1Api.
+
+    Any argument left as None means that call raises 403, which is how the
+    apiserver answers a ServiceAccount that lacks the ClusterRole.
+    """
+    api = mock.Mock()
+    api.list_node.return_value = listing(nodes) if nodes is not None else None
+    if nodes is None:
+        api.list_node.side_effect = forbidden
+    api.list_namespaced_pod.return_value = listing(ns_pods) if ns_pods is not None else None
+    if ns_pods is None:
+        api.list_namespaced_pod.side_effect = forbidden
+    api.list_pod_for_all_namespaces.return_value = (
+        listing(all_pods) if all_pods is not None else None
+    )
+    if all_pods is None:
+        api.list_pod_for_all_namespaces.side_effect = forbidden
+    return api
+
+
+def discover(api):
+    """Runs get_cluster_hardware_facts against a stand-in API."""
+    with mock.patch.object(cluster_facts, "_load_kube_config", return_value=True), \
+         mock.patch.object(cluster_facts.client, "CoreV1Api", return_value=api):
+        return cluster_facts.get_cluster_hardware_facts()
+
+
+@needs_kubernetes
+class NodeCapacityTest(unittest.TestCase):
+    def test_single_gke_node(self):
+        facts = discover(fake_api(nodes=[node()], ns_pods=[pod()]))
+        self.assertEqual(facts["node_count"], 1)
+        self.assertEqual(facts["allocatable_cores"], SAMPLE_CORES)
+        self.assertEqual(facts["allocatable_ram_gb"], SAMPLE_RAM_GB)
+
+    def test_capacity_sums_across_nodes(self):
+        facts = discover(fake_api(nodes=[node(), node(), node()], ns_pods=[pod()]))
+        self.assertEqual(facts["node_count"], 3)
+        self.assertEqual(facts["allocatable_cores"], round(SAMPLE_CORES * 3, 2))
+        # Bytes are summed and rounded once, so this is 38.89 rather than
+        # 3 x 12.96 = 38.88; rounding per node first would compound the error.
+        self.assertEqual(facts["allocatable_ram_gb"], 38.89)
+
+    def test_quantity_suffixes(self):
+        # Whole cores, and memory in a decimal rather than binary unit.
+        facts = discover(fake_api(nodes=[node(cpu="4", memory="2Gi")], ns_pods=[pod()]))
+        self.assertEqual(facts["allocatable_cores"], 4.0)
+        self.assertEqual(facts["allocatable_ram_gb"], 2.0)
+
+    def test_node_missing_allocatable(self):
+        bare = SimpleNamespace(metadata=None, status=SimpleNamespace(allocatable=None))
+        facts = discover(fake_api(nodes=[bare], ns_pods=[pod()]))
+        self.assertEqual(facts["node_count"], 1)
+        self.assertEqual(facts["allocatable_cores"], 0.0)
+        # A node with no metadata must not abort the whole node read.
+        self.assertIsNone(facts["machine_type"])
+
+
+@needs_kubernetes
+class MachineTypeTest(unittest.TestCase):
+    """Machine type is recorded so results stay comparable across hardware.
+
+    Frontier ratios are only meaningful next to the silicon that produced
+    them; without this a c3-standard-4 run and a c3d-standard-8 run are
+    indistinguishable in the emitted data.
+    """
+
+    def test_read_from_the_standard_label(self):
+        facts = discover(fake_api(nodes=[node()], ns_pods=[pod()]))
+        self.assertEqual(facts["machine_type"], SAMPLE_MACHINE_TYPE)
+
+    def test_uniform_pool_reports_one_value(self):
+        nodes = [node(), node(), node()]
+        facts = discover(fake_api(nodes=nodes, ns_pods=[pod()]))
+        self.assertEqual(facts["machine_type"], SAMPLE_MACHINE_TYPE)
+
+    def test_mixed_pool_reports_every_type(self):
+        # Deliberately not "pick the first node": a silently partial answer
+        # here would misattribute the whole trial to one machine type.
+        nodes = [node(machine_type="n2-standard-8"), node()]
+        facts = discover(fake_api(nodes=nodes, ns_pods=[pod()]))
+        self.assertEqual(facts["machine_type"], "c3-standard-4,n2-standard-8")
+
+    def test_unlabelled_node_reports_unknown_not_a_guess(self):
+        facts = discover(fake_api(nodes=[node(machine_type=None)], ns_pods=[pod()]))
+        self.assertIsNone(facts["machine_type"])
+        # The rest of the node read still succeeds.
+        self.assertEqual(facts["allocatable_cores"], SAMPLE_CORES)
+
+    def test_costs_no_extra_api_call(self):
+        # The label rides along on the node listing we already perform.
+        api = fake_api(nodes=[node()], ns_pods=[pod()])
+        discover(api)
+        self.assertEqual(api.list_node.call_count, 1)
+
+
+@needs_kubernetes
+class WorkerPodCountTest(unittest.TestCase):
+    def test_counts_running_and_pending(self):
+        pods = [pod("Running"), pod("Running"), pod("Pending")]
+        facts = discover(fake_api(nodes=[node()], ns_pods=pods))
+        self.assertEqual(facts["worker_pod_count"], 3)
+
+    def test_ignores_terminal_pods(self):
+        pods = [pod("Running"), pod("Succeeded"), pod("Failed"), pod("Unknown")]
+        facts = discover(fake_api(nodes=[node()], ns_pods=pods))
+        self.assertEqual(facts["worker_pod_count"], 1)
+
+    def test_falls_back_to_all_namespaces(self):
+        # Worker pool lives outside the dedicated namespace.
+        api = fake_api(nodes=[node()], ns_pods=[], all_pods=[pod(), pod()])
+        facts = discover(api)
+        self.assertEqual(facts["worker_pod_count"], 2)
+        api.list_pod_for_all_namespaces.assert_called_once()
+
+    def test_skips_fallback_when_namespace_has_pods(self):
+        api = fake_api(nodes=[node()], ns_pods=[pod()], all_pods=[pod(), pod(), pod()])
+        facts = discover(api)
+        self.assertEqual(facts["worker_pod_count"], 1)
+        api.list_pod_for_all_namespaces.assert_not_called()
+
+    def test_undiscoverable_pool_reports_unknown_not_a_guess(self):
+        # Nodes are readable but no pod carries the pool label. Reporting the
+        # node count here would be indistinguishable from a real reading and
+        # would skew every A/P ratio derived from it.
+        api = fake_api(nodes=[node(), node()], ns_pods=[], all_pods=[])
+        facts = discover(api)
+        self.assertIsNone(facts["worker_pod_count"])
+        self.assertEqual(facts["node_count"], 2)  # nodes still discovered
+
+    def test_listings_are_filtered_server_side(self):
+        api = fake_api(nodes=[node()], ns_pods=[pod()])
+        discover(api)
+        _, kwargs = api.list_namespaced_pod.call_args
+        self.assertEqual(kwargs["label_selector"], cluster_facts.WORKER_POOL_LABEL)
+        self.assertEqual(kwargs["namespace"], cluster_facts.WORKER_POOL_NAMESPACE)
+
+    def test_reads_are_served_from_the_watch_cache(self):
+        # resource_version="0" keeps these cheap on large clusters.
+        api = fake_api(nodes=[node()], ns_pods=[pod()])
+        discover(api)
+        self.assertEqual(api.list_node.call_args.kwargs["resource_version"], "0")
+        self.assertEqual(api.list_namespaced_pod.call_args.kwargs["resource_version"], "0")
+
+
+@needs_kubernetes
+class DeniedAccessTest(unittest.TestCase):
+    """A 403 must never fail the trial; the run still has to publish results."""
+
+    def test_nodes_denied(self):
+        facts = discover(fake_api(nodes=None, ns_pods=[pod(), pod()]))
+        self.assertIsNone(facts["node_count"])
+        self.assertIsNone(facts["allocatable_cores"])
+        self.assertIsNone(facts["allocatable_ram_gb"])
+        self.assertIsNone(facts["machine_type"])
+        # Pods were still readable, so that fact survives.
+        self.assertEqual(facts["worker_pod_count"], 2)
+
+    def test_pods_denied(self):
+        facts = discover(fake_api(nodes=[node()], ns_pods=None, all_pods=None))
+        self.assertEqual(facts["node_count"], 1)
+        self.assertIsNone(facts["worker_pod_count"])
+
+    def test_everything_denied(self):
+        self.assertEqual(discover(fake_api()), cluster_facts.EMPTY_FACTS)
+
+    def test_no_credentials(self):
+        with mock.patch.object(cluster_facts, "_load_kube_config", return_value=False):
+            self.assertEqual(
+                cluster_facts.get_cluster_hardware_facts(), cluster_facts.EMPTY_FACTS
+            )
+
+
+@needs_kubernetes
+class EnvironmentIsNotConsultedTest(unittest.TestCase):
+    """Hardware facts come from the cluster only.
+
+    Hand-fed overrides were removed because a stale value silently produces
+    frontiers that look real. This guards against them coming back.
+    """
+
+    def test_env_vars_cannot_override_discovery(self):
+        bogus = {
+            "NODE_COUNT": "9999",
+            "ALLOCATABLE_VCPU": "8888",
+            "ALLOCATABLE_CORES": "7777",
+            "ALLOCATABLE_RAM_GB": "6666",
+            "ALLOCATABLE_RAM_BYTES": "5555",
+            "WORKER_POD_COUNT": "4444",
+        }
+        with mock.patch.dict("os.environ", bogus):
+            facts = discover(fake_api(nodes=[node()], ns_pods=[pod()]))
+        self.assertEqual(facts["node_count"], 1)
+        self.assertEqual(facts["allocatable_cores"], SAMPLE_CORES)
+        self.assertEqual(facts["allocatable_ram_gb"], SAMPLE_RAM_GB)
+        self.assertEqual(facts["worker_pod_count"], 1)
+
+    def test_env_vars_cannot_supply_facts_when_cluster_is_unreadable(self):
+        with mock.patch.dict("os.environ", {"NODE_COUNT": "9999"}):
+            self.assertEqual(discover(fake_api()), cluster_facts.EMPTY_FACTS)
+
+
+BASE_ARGV = [
+    "runner.py",
+    "-f", "tests/glutton.py",
+    "-t", "1m",
+    "-u", "10",
+    "--tag", "unit",
+    "--name", "unit-run",
+    "--dest", "/tmp/unit",
+]
+
+
+def parse(*extra):
+    with mock.patch.object(sys, "argv", BASE_ARGV + list(extra)):
+        return runner.parse_args()
+
+
+@needs_kubernetes
+class ClusterFactsFlagTest(unittest.TestCase):
+    def test_enabled_by_default(self):
+        self.assertTrue(parse().cluster_facts)
+
+    def test_explicit_forms(self):
+        self.assertTrue(parse("--cluster-facts").cluster_facts)
+        self.assertFalse(parse("--no-cluster-facts").cluster_facts)
+
+    def test_flag_is_not_forwarded_to_locust(self):
+        self.assertNotIn("--no-cluster-facts", parse("--no-cluster-facts").locust_extra)
+
+    def test_disabled_makes_no_api_call(self):
+        def tripwire(*_a, **_kw):
+            raise AssertionError("Kubernetes was contacted with --no-cluster-facts")
+
+        with mock.patch.object(cluster_facts.client, "CoreV1Api", tripwire), \
+             mock.patch.object(cluster_facts.config, "load_incluster_config", tripwire), \
+             mock.patch.object(cluster_facts.config, "load_kube_config", tripwire):
+            facts = runner.collect_cluster_facts(parse("--no-cluster-facts"), _sink())
+        self.assertEqual(facts, cluster_facts.EMPTY_FACTS)
+
+    def test_enabled_does_call_the_api(self):
+        # Guards the test above: if discovery broke entirely it would also
+        # "make no API call", and that must not read as a pass.
+        with mock.patch.object(
+            runner, "get_cluster_hardware_facts", return_value={"node_count": 1}
+        ) as discovery:
+            runner.collect_cluster_facts(parse(), _sink())
+        discovery.assert_called_once()
+
+
+def _sink():
+    import io
+
+    return io.StringIO()
+
+
+@needs_kubernetes
+class TrialSummaryTest(unittest.TestCase):
+    STATS_CSV = (
+        "Type,Name,Request Count,Failure Count\n"
+        "grpc,ResumeActor,80,20\n"
+        "grpc,SuspendActor,20,0\n"
+        ",Aggregated,100,25\n"
+    )
+
+    def _write_history(self, directory, users=10, rows=61):
+        path = Path(directory) / "stats_history.csv"
+        lines = ["Timestamp,User Count,Type,Name,Requests/s,Failures/s"]
+        lines += [f"{1788914584 + i},{users},,Aggregated,1.0,0.0" for i in range(rows)]
+        path.write_text("\n".join(lines) + "\n")
+        return path
+
+    def _summarize(self, facts, directory):
+        stats_csv = Path(directory) / "stats.csv"
+        stats_csv.write_text(self.STATS_CSV)
+        out = Path(directory) / "out.jsonl"
+        args = argparse.Namespace(users=10, tag="unit", name="unit-run")
+        cluster_facts.append_trial_summary(
+            out, stats_csv, self._write_history(directory), args, "2026-01-01", facts
+        )
+        return json.loads(out.read_text().splitlines()[0])
+
+    def test_frontiers_from_discovered_facts(self):
+        # append_trial_summary takes facts as an argument, so these are chosen
+        # numbers, not a reading. Any shape works; this one makes the expected
+        # arithmetic below easy to check by hand.
+        facts = {
+            "machine_type": SAMPLE_MACHINE_TYPE,
+            "node_count": 1,
+            "allocatable_cores": SAMPLE_CORES,
+            "allocatable_ram_gb": SAMPLE_RAM_GB,
+            "worker_pod_count": 5,
+        }
+        with tempfile.TemporaryDirectory() as td:
+            row = self._summarize(facts, td)
+
+        self.assertEqual(row["metric"], "trial_summary")
+        # Raw facts are persisted next to the derived numbers so the ratios
+        # can be re-derived later.
+        self.assertEqual(row["raw_configuration"], facts)
+
+        frontiers = row["frontiers"]
+        self.assertEqual(frontiers["actors_per_node"], 10.0)      # 10 users / 1 node
+        self.assertEqual(frontiers["actors_per_vcpu"], 2.55)      # 10 / 3.92
+        self.assertEqual(frontiers["actors_per_gb_ram"], 0.77)    # 10 / 12.96
+        # A/P is reported as a distribution, not a single average.
+        self.assertEqual(frontiers["ap_ratio_p50"], 2.0)          # 10 users / 5 pods
+        self.assertEqual(frontiers["ap_ratio_p90"], 2.0)
+        self.assertEqual(frontiers["ap_ratio_p99"], 2.0)
+        self.assertEqual(frontiers["aggregate_failure_ratio"], 0.25)
+
+    def test_schema_is_stable_without_facts(self):
+        # --no-cluster-facts, or a cluster we could not read: the row still
+        # appears with the same keys so consumers need no special case.
+        with tempfile.TemporaryDirectory() as td:
+            row = self._summarize(dict(cluster_facts.EMPTY_FACTS), td)
+
+        self.assertEqual(set(row["raw_configuration"]), set(cluster_facts.EMPTY_FACTS))
+        self.assertTrue(all(v is None for v in row["raw_configuration"].values()))
+
+        frontiers = row["frontiers"]
+        for key in ("actors_per_node", "actors_per_vcpu", "actors_per_gb_ram",
+                    "ap_ratio_p50", "ap_ratio_p90", "ap_ratio_p99"):
+            self.assertIn(key, frontiers)
+            self.assertIsNone(frontiers[key])
+        # Failure ratio comes from locust's own CSV, so it survives.
+        self.assertEqual(frontiers["aggregate_failure_ratio"], 0.25)
+
+    def test_missing_history_leaves_percentiles_unset(self):
+        facts = {
+            "machine_type": SAMPLE_MACHINE_TYPE,
+            "node_count": 1,
+            "allocatable_cores": SAMPLE_CORES,
+            "allocatable_ram_gb": SAMPLE_RAM_GB,
+            "worker_pod_count": 5,
+        }
+        with tempfile.TemporaryDirectory() as td:
+            stats_csv = Path(td) / "stats.csv"
+            stats_csv.write_text(self.STATS_CSV)
+            out = Path(td) / "out.jsonl"
+            args = argparse.Namespace(users=10, tag="unit", name="unit-run")
+            cluster_facts.append_trial_summary(
+                out, stats_csv, Path(td) / "absent.csv", args, "2026-01-01", facts
+            )
+            row = json.loads(out.read_text().splitlines()[0])
+
+        self.assertIsNone(row["frontiers"]["ap_ratio_p50"])
+        # Density frontiers do not depend on the history file.
+        self.assertEqual(row["frontiers"]["actors_per_node"], 10.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarking/locust/unit_tests/test_server_telemetry.py
+++ b/benchmarking/locust/unit_tests/test_server_telemetry.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for server_telemetry.py: python3 benchmarking/locust/unit_tests/test_server_telemetry.py"""
+
+import csv
+import json
+import math
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+# Ensure benchmarking/locust is in sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import server_telemetry
+
+
+class ComputePercentilesTest(unittest.TestCase):
+    def test_normal_distribution(self):
+        vals = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        res = server_telemetry.compute_percentiles(vals)
+        self.assertEqual(res["min"], 1.0)
+        self.assertEqual(res["max"], 10.0)
+        self.assertEqual(res["p50"], 6.0)
+        self.assertEqual(res["avg"], 5.5)
+
+    def test_nan_and_inf_filtering(self):
+        vals = [1.0, float("nan"), 2.0, float("inf"), float("-inf"), 3.0]
+        res = server_telemetry.compute_percentiles(vals)
+        self.assertEqual(res["min"], 1.0)
+        self.assertEqual(res["max"], 3.0)
+        self.assertEqual(res["p50"], 2.0)
+        self.assertEqual(res["avg"], 2.0)
+
+    def test_empty_or_all_nan(self):
+        self.assertEqual(
+            server_telemetry.compute_percentiles([]),
+            {"min": None, "p50": None, "p90": None, "p99": None, "max": None, "avg": None},
+        )
+        self.assertEqual(
+            server_telemetry.compute_percentiles([float("nan")]),
+            {"min": None, "p50": None, "p90": None, "p99": None, "max": None, "avg": None},
+        )
+
+
+class SteadyStateWindowTest(unittest.TestCase):
+    def test_window_detection(self):
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".csv") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["Timestamp", "Name", "User Count"]
+            )
+            writer.writeheader()
+            writer.writerow({"Timestamp": "100", "Name": "Aggregated", "User Count": "2"})
+            writer.writerow({"Timestamp": "110", "Name": "Aggregated", "User Count": "4"})
+            writer.writerow({"Timestamp": "120", "Name": "Aggregated", "User Count": "7"})
+            writer.writerow({"Timestamp": "130", "Name": "Aggregated", "User Count": "7"})
+            csv_path = Path(f.name)
+
+        try:
+            start_ts, end_ts = 100, 150
+            steady_start, steady_end = server_telemetry.get_steady_state_window(
+                csv_path, active_users=7, start_ts=start_ts, end_ts=end_ts
+            )
+            # 7 >= 0.9 * 7 (6.3) at timestamp 120
+            self.assertEqual(steady_start, 120)
+            self.assertEqual(steady_end, 150)
+        finally:
+            csv_path.unlink()
+
+    def test_fallback_when_threshold_not_reached(self):
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".csv") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["Timestamp", "Name", "User Count"]
+            )
+            writer.writeheader()
+            writer.writerow({"Timestamp": "100", "Name": "Aggregated", "User Count": "2"})
+            csv_path = Path(f.name)
+
+        try:
+            steady_start, steady_end = server_telemetry.get_steady_state_window(
+                csv_path, active_users=10, start_ts=100, end_ts=150
+            )
+            self.assertEqual(steady_start, 100)
+            self.assertEqual(steady_end, 150)
+        finally:
+            csv_path.unlink()
+
+
+class PrometheusQueryTest(unittest.TestCase):
+    @mock.patch("urllib.request.urlopen")
+    def test_query_prometheus_range_guard(self, mock_urlopen):
+        mock_resp = mock.MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "status": "success",
+            "data": {"result": [{"metric": {}, "values": [[100, "1.0"]]}]}
+        }).encode("utf-8")
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+        # start_ts == end_ts should be automatically guarded to end_ts = start_ts + 1
+        res = server_telemetry.query_prometheus_range("http://localhost:9090", "up", 100, 100)
+        self.assertEqual(len(res), 1)
+
+    @mock.patch("server_telemetry.query_prometheus_instant")
+    def test_quantile_fallback(self, mock_instant):
+        # First call (rate query) returns empty or NaN
+        # Second call (cumulative query) returns valid 11.6 MB
+        mock_instant.side_effect = [
+            [{"value": [100, "NaN"]}],
+            [{"value": [100, "11.625"]}],
+        ]
+        val = server_telemetry._query_quantile_with_fallback(
+            "http://localhost:9090",
+            0.50,
+            "rate(bucket[5m])",
+            "bucket",
+            end_ts=100,
+        )
+        self.assertEqual(val, 11.625)
+        self.assertEqual(mock_instant.call_count, 2)
+
+
+class HarvestServerTelemetryTest(unittest.TestCase):
+    @mock.patch("server_telemetry.query_prometheus_range")
+    @mock.patch("server_telemetry.query_prometheus_instant")
+    def test_harvest_packing_math(self, mock_instant, mock_range):
+        # Mock packing timeseries: assigned=4 with worker_pod_count=5
+        mock_range.side_effect = [
+            # Packing query
+            [
+                {
+                    "metric": {"ate_worker_state": "assigned"},
+                    "values": [[100, "4.0"], [105, "4.0"]],
+                }
+            ],
+            # CPU PSI
+            [{"values": [[100, "1.5"], [105, "1.8"]]}],
+            # Memory PSI
+            [{"values": [[100, "0.0"], [105, "0.0"]]}],
+            # IO PSI
+            [{"values": [[100, "0.0"], [105, "0.0"]]}],
+            # CFS Throttled
+            [{"values": [[100, "0.01"], [105, "0.02"]]}],
+        ]
+
+        # Instant queries: snap size, count start, count end, restore p50, restore p95, ckpt p50, ckpt p95
+        mock_instant.side_effect = [
+            [{"value": [105, "11.5"]}],  # snap size p50
+            [{"value": [105, "12.0"]}],  # snap size p90
+            [{"value": [100, "100"]}],   # count start
+            [{"value": [105, "150"]}],   # count end
+            [{"value": [105, "0.08"]}],  # restore p50
+            [{"value": [105, "0.15"]}],  # restore p95
+            [{"value": [105, "0.12"]}],  # ckpt p50
+            [{"value": [105, "0.22"]}],  # ckpt p95
+        ]
+
+        summary = server_telemetry.harvest_server_telemetry(
+            prom_url="http://localhost:9090",
+            start_ts=100,
+            end_ts=105,
+            steady_start_ts=100,
+            worker_pod_count=5,
+        )
+
+        packing = summary["cluster_packing"]
+        # 4 assigned / 5 total worker pods = 0.80
+        self.assertEqual(packing["summary"]["p50"], 0.8)
+        self.assertEqual(packing["timeseries"][0]["packing_ratio"], 0.8)
+        self.assertEqual(packing["timeseries"][0]["total_workers"], 5.0)
+
+        snapshots = summary["snapshots"]
+        self.assertEqual(snapshots["checkpoints_in_window"], 50)
+        self.assertEqual(snapshots["checkpoints_cumulative"], 150)
+        self.assertEqual(snapshots["size_p50_mb"], 11.5)
+        self.assertIsNotNone(snapshots["throughput_mb_s"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarking/locust/unit_tests/test_server_telemetry.py
+++ b/benchmarking/locust/unit_tests/test_server_telemetry.py
@@ -188,6 +188,52 @@ class HarvestServerTelemetryTest(unittest.TestCase):
         self.assertEqual(snapshots["size_p50_mb"], 11.5)
         self.assertIsNotNone(snapshots["throughput_mb_s"])
 
+    @mock.patch("server_telemetry.query_prometheus_range")
+    @mock.patch("server_telemetry.query_prometheus_instant")
+    def test_unknown_pod_count_uses_prometheus_total(
+        self, mock_instant, mock_range
+    ):
+        """An unknown pod count must fall back to what Prometheus reports.
+
+        cluster_facts deliberately returns None rather than assuming a worker
+        count, because Prometheus already knows the real number. If a guess is
+        ever reintroduced upstream it would pre-empt this branch, so the
+        denominator is asserted explicitly.
+        """
+        mock_range.side_effect = [
+            # Packing query: 4 assigned out of 20 workers actually reporting.
+            [
+                {
+                    "metric": {"ate_worker_state": "assigned"},
+                    "values": [[100, "4.0"]],
+                },
+                {
+                    "metric": {"ate_worker_state": "idle"},
+                    "values": [[100, "16.0"]],
+                },
+            ],
+            [{"values": [[100, "0.0"]]}],  # CPU PSI
+            [{"values": [[100, "0.0"]]}],  # Memory PSI
+            [{"values": [[100, "0.0"]]}],  # IO PSI
+            [{"values": [[100, "0.0"]]}],  # CFS throttled
+        ]
+        # Snapshot queries are irrelevant here, and each empty quantile costs
+        # a second call via the fallback, so the count is not fixed.
+        mock_instant.return_value = []
+
+        summary = server_telemetry.harvest_server_telemetry(
+            prom_url="http://localhost:9090",
+            start_ts=100,
+            end_ts=105,
+            steady_start_ts=100,
+            worker_pod_count=None,
+        )
+
+        point = summary["cluster_packing"]["timeseries"][0]
+        # 4 + 16 observed workers, not a fabricated node count and not 1.0.
+        self.assertEqual(point["total_workers"], 20.0)
+        self.assertEqual(point["packing_ratio"], 0.2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes [#1590](https://github.com/agent-substrate/substrate/issues/1590)

## What this PR does

In alignment with the [Actor Density Benchmark Specs](https://docs.google.com/document/d/1sv5aBXvGOQ69iaqFxdPZ-d6tNbh5AMuwKODDyYjzYQw/edit?tab=t.0), this PR teaches the Locust runner to discover cluster capacity, record actor density frontiers, and harvest server-side Prometheus metrics into `stats.jsonl` and `server_summary.json`. Discovery lives in its own module, `benchmarking/locust/cluster_facts.py`, rather than inside `runner.py`.

## Proposed Changes

**Cluster hardware discovery (`cluster_facts.py`, `locust.yaml`)**

- Reads allocatable cores, RAM, node count, machine type and worker pod count through the official Kubernetes Python client, so in-cluster and local auth both work without a `kubectl` subprocess.
- Adds a ClusterRole with `list` on nodes and pods. `--no-cluster-facts` skips discovery, since listing is expensive on a large cluster.
- Anything unreadable stays null. Nothing is guessed or defaulted, so a real reading is always distinguishable from a missing one.

**Density frontiers (`trial_summary` in `stats.jsonl`)**

- `actors_per_node`, `actors_per_vcpu`, `actors_per_gb_ram`.
- Actors per pod as `ap_ratio_p50` / `p90` / `p99` over the steady-state samples rather than one average, so it is visible whether the system actually pegs at 1.
- Raw readings persist beside the derived ones in `raw_configuration`, so ratios can be re-derived after the fact.

**Server ground truth (`server_telemetry.py`, `server_summary.json`)**

- Physical worker assignment from `ate_workerpool_workers`, as packing percentiles plus the underlying timeseries.
- Host Linux kernel PSI stalls for CPU, memory and IO, and CFS throttling.
- Snapshot sizes as P50, P90, P95 and mean, checkpoint counts, restore and checkpoint latencies, and throughput. Counts, mean and throughput cover the steady-state window; the quantiles are a 5m rate at window end.
- `server_telemetry.py` uses only the standard library, every call with a timeout. An unreachable Prometheus leaves nulls rather than failing the run, and `--prometheus-url` retargets it. `status.json` keeps its existing minimal schema.
- Depends on #1599 and #1601 landing first: the PSI queries need the `container="node"` relabel and the snapshot queries need the `metrics/raw` pipeline. Merged ahead of those, the PSI and snapshot fields come back `null`.

**Docs**

- `benchmarking/README.md` covers the new flags and every field in the output files.

## How this was tested

- 15 unit tests across `test_cluster_facts.py` and `test_server_telemetry.py`, covering percentile edges, steady-state detection, counter resets across an atelet restart, and the null-versus-zero rules.
- Multi-user runs on a benchmark cluster. Frontier fields land in `stats.jsonl`, `server_summary.json` is populated, and `status.json` is unchanged.
- Emitted values were re-derived by hand from raw Prometheus and matched.

## References

[Agent Substrate: Actor Density Benchmark Specs](https://docs.google.com/document/d/1sv5aBXvGOQ69iaqFxdPZ-d6tNbh5AMuwKODDyYjzYQw/edit?tab=t.0)

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
