### PR TITLE
Enhancements to setup-gcp

### DIFF
--- a/hack/ate-dev-env.sh.example
+++ b/hack/ate-dev-env.sh.example
@@ -35,6 +35,9 @@ export CLUSTER_VERSION=1.36.3-gke.1767000
 export NODE_POOL_NAME=gvisor-pool
 export NODE_POOL_VERSION=1.36.3-gke.1767000
 export GVISOR_NODE_MACHINE_TYPE=c3-standard-4
+# Boot disk customizations (optional; defaults to GKE's default boot disk)
+# export BOOT_DISK_SIZE_GB=500
+# export BOOT_DISK_TYPE=hyperdisk-balanced
 
 # Set this if you are using an existing cluster with a different context name.
 export KUBECTL_CONTEXT=

--- a/tools/setup-gcp/README.md
+++ b/tools/setup-gcp/README.md
@@ -131,7 +131,7 @@ go run ./tools/setup-gcp create cluster [flags]
 | Flag | Description | Default Env Var | Fallback Default |
 | :--- | :--- | :--- | :--- |
 | `--name` | Name of the GKE cluster. | `CLUSTER_NAME` | `substrate-poc` |
-| `--location` | Zone or region for the cluster. | `CLUSTER_LOCATION` | `us-west1-c` |
+| `--location` | Zone or region for the cluster (must be compatible with `--region`). | `CLUSTER_LOCATION` | `us-west1-c` |
 | `--version` | Kubernetes version. | `CLUSTER_VERSION` | None |
 | `--network` | VPC network name. | `NETWORK` | `default` |
 | `--subnetwork` | VPC subnetwork name. | `SUBNETWORK` | `default` |
@@ -259,7 +259,7 @@ go run ./tools/setup-gcp bootstrap [flags]
 | Flag | Description | Default Env Var | Fallback Default |
 | :--- | :--- | :--- | :--- |
 | `--cluster-name` | Name of the GKE cluster. | `CLUSTER_NAME` | `substrate-poc` |
-| `--cluster-location`| Zone or region for the cluster. | `CLUSTER_LOCATION` | `us-west1-c` |
+| `--cluster-location`| Zone or region for the cluster (must be compatible with `--region`). | `CLUSTER_LOCATION` | `us-west1-c` |
 | `--cluster-version` | Kubernetes version. | `CLUSTER_VERSION` | None |
 | `--network` | VPC network name. | `NETWORK` | `default` |
 | `--subnetwork` | VPC subnetwork name. | `SUBNETWORK` | `default` |

--- a/tools/setup-gcp/README.md
+++ b/tools/setup-gcp/README.md
@@ -136,6 +136,8 @@ go run ./tools/setup-gcp create cluster [flags]
 | `--network` | VPC network name. | `NETWORK` | `default` |
 | `--subnetwork` | VPC subnetwork name. | `SUBNETWORK` | `default` |
 | `--machine-type` | Machine type for the gVisor node pool. | `GVISOR_NODE_MACHINE_TYPE` | `c3-standard-4` |
+| `--boot-disk-size` | Boot disk size in GB for the node pool (0 = GKE default). | `BOOT_DISK_SIZE_GB` | None |
+| `--boot-disk-type` | Boot disk type for the node pool (empty = GKE default). | `BOOT_DISK_TYPE` | None |
 
 **Node version labels:** pool labels are the birth default for every node GKE
 creates later (autoscaling, auto-repair, node upgrades), and `setup-gcp` does
@@ -262,6 +264,8 @@ go run ./tools/setup-gcp bootstrap [flags]
 | `--network` | VPC network name. | `NETWORK` | `default` |
 | `--subnetwork` | VPC subnetwork name. | `SUBNETWORK` | `default` |
 | `--machine-type` | Machine type for the gVisor node pool. | `GVISOR_NODE_MACHINE_TYPE` | `c3-standard-4` |
+| `--boot-disk-size` | Boot disk size in GB for the node pool (0 = GKE default). | `BOOT_DISK_SIZE_GB` | None |
+| `--boot-disk-type` | Boot disk type for the node pool (empty = GKE default). | `BOOT_DISK_TYPE` | None |
 | `--bucket-name` | Name of the GCS bucket for snapshots. | `BUCKET_NAME` | None (Required*) |
 | `--dashboard-dir` | Directory containing dashboard JSON files. | `DASHBOARD_DIR` | `tools/setup-gcp/dashboards` |
 

--- a/tools/setup-gcp/README.md
+++ b/tools/setup-gcp/README.md
@@ -45,8 +45,8 @@ These flags can be passed to the root command and apply to all subcommands:
 
 | Flag | Description | Default Env Var | Fallback Default |
 | :--- | :--- | :--- | :--- |
-| `--project-id` | GCP Project ID. | `PROJECT_ID` | None |
-| `--project-number` | GCP Project Number (required for IAM). | `PROJECT_NUMBER` | None |
+| `--project-id` | GCP Project ID. | `PROJECT_ID` | None (Required) |
+| `--project-number` | GCP Project Number (optional, resolved from `--project-id` if needed). | `PROJECT_NUMBER` | None |
 | `--region` | GCP Region for regional resources. | `GCE_REGION` | `us-west1` |
 
 ## Subcommands

--- a/tools/setup-gcp/cmd/bootstrap.go
+++ b/tools/setup-gcp/cmd/bootstrap.go
@@ -91,6 +91,8 @@ func init() {
 	bootstrapCmd.Flags().StringVar(&cfg.Network, "network", getEnv("NETWORK", "default"), "VPC network name [env: NETWORK]")
 	bootstrapCmd.Flags().StringVar(&cfg.Subnetwork, "subnetwork", getEnv("SUBNETWORK", "default"), "VPC subnetwork name [env: SUBNETWORK]")
 	bootstrapCmd.Flags().StringVar(&cfg.MachineType, "machine-type", getEnv("GVISOR_NODE_MACHINE_TYPE", "c3-standard-4"), "Machine type for the gVisor node pool [env: GVISOR_NODE_MACHINE_TYPE]")
+	bootstrapCmd.Flags().Int32Var(&cfg.BootDiskSizeGB, "boot-disk-size", getEnv("BOOT_DISK_SIZE_GB", int32(0)), "Boot disk size in GB for the node pool; 0 = GKE default (100 GB) [env: BOOT_DISK_SIZE_GB]")
+	bootstrapCmd.Flags().StringVar(&cfg.BootDiskType, "boot-disk-type", getEnv("BOOT_DISK_TYPE", ""), "Boot disk type for the node pool; empty = GKE default [env: BOOT_DISK_TYPE]")
 	bootstrapCmd.Flags().StringVar(&cfg.BucketName, "bucket-name", getEnv("BUCKET_NAME", ""), "Name of the GCS bucket for snapshots [env: BUCKET_NAME]")
 	bootstrapCmd.Flags().StringVar(&cfg.DashboardDir, "dashboard-dir", getEnv("DASHBOARD_DIR", "tools/setup-gcp/dashboards"), "Directory containing dashboard JSON files [env: DASHBOARD_DIR]")
 }

--- a/tools/setup-gcp/cmd/bootstrap.go
+++ b/tools/setup-gcp/cmd/bootstrap.go
@@ -26,17 +26,13 @@ var bootstrapCmd = &cobra.Command{
 	Short: "Fully bootstrap the GCP environment",
 	Long:  `Runs all setup steps in order: enable APIs, create cluster, create bucket, grant IAM permissions, and create dashboards.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if cfg.ProjectID == "" {
-			return errors.New("--project-id is required")
-		}
-		if cfg.ProjectNumber == "" {
-			return errors.New("--project-number is required")
+		ctx := cmd.Context()
+		if err := resolveProjectID(ctx, &cfg); err != nil {
+			return err
 		}
 		if cfg.BucketName == "" {
 			return errors.New("--bucket-name is required")
 		}
-
-		ctx := cmd.Context()
 
 		slog.Info("Starting full bootstrap...")
 

--- a/tools/setup-gcp/cmd/bucket.go
+++ b/tools/setup-gcp/cmd/bucket.go
@@ -29,6 +29,10 @@ import (
 )
 
 func createSnapshotBucket(ctx context.Context, cfg *Config) error {
+	if err := resolveProject(ctx, cfg); err != nil {
+		return err
+	}
+
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return err
@@ -149,15 +153,19 @@ func hasUnconditionalBinding(policy *iam.Policy, role, member string) bool {
 	return false
 }
 
+func validateBucketFlags(ctx context.Context, cfg *Config) error {
+	if cfg.BucketName == "" {
+		return errors.New("--name is required")
+	}
+	return resolveProject(ctx, cfg)
+}
+
 var bucketCmd = &cobra.Command{
 	Use:   "bucket",
 	Short: "Create GCS bucket",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if cfg.ProjectID == "" {
-			return errors.New("--project-id is required")
-		}
-		if cfg.BucketName == "" {
-			return errors.New("--name is required")
+		if err := validateBucketFlags(cmd.Context(), &cfg); err != nil {
+			return err
 		}
 		return createSnapshotBucket(cmd.Context(), &cfg)
 	},

--- a/tools/setup-gcp/cmd/bucket_test.go
+++ b/tools/setup-gcp/cmd/bucket_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+)
+
+func TestValidateBucketFlags(t *testing.T) {
+	origGetProject := getProjectFn
+	defer func() { getProjectFn = origGetProject }()
+
+	getProjectFn = func(ctx context.Context, name string) (*resourcemanagerpb.Project, error) {
+		return &resourcemanagerpb.Project{
+			Name:      "projects/123456",
+			ProjectId: "test-project",
+		}, nil
+	}
+
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "missing bucket name",
+			cfg:  Config{ProjectID: "test-project"},
+			want: "--name is required",
+		},
+		{
+			name: "missing project id",
+			cfg:  Config{BucketName: "test-bucket"},
+			want: "--project-id is required",
+		},
+		{
+			name: "missing project id when only project number provided",
+			cfg:  Config{BucketName: "test-bucket", ProjectNumber: "123456"},
+			want: "--project-id is required",
+		},
+		{
+			name: "all required flags present with both id and number",
+			cfg:  Config{ProjectID: "test-project", ProjectNumber: "123456", BucketName: "test-bucket"},
+		},
+		{
+			name: "all required flags present with only project id",
+			cfg:  Config{ProjectID: "test-project", BucketName: "test-bucket"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgCopy := tt.cfg
+			err := validateBucketFlags(t.Context(), &cfgCopy)
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("validateBucketFlags() = %v; want nil", err)
+				}
+				if cfgCopy.ProjectNumber != "123456" {
+					t.Errorf("cfgCopy.ProjectNumber = %q; want %q", cfgCopy.ProjectNumber, "123456")
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateBucketFlags() = nil; want %q", tt.want)
+			}
+			if err.Error() != tt.want {
+				t.Errorf("validateBucketFlags() = %q; want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}

--- a/tools/setup-gcp/cmd/cloudsql.go
+++ b/tools/setup-gcp/cmd/cloudsql.go
@@ -419,14 +419,14 @@ var cloudsqlCmd = &cobra.Command{
 	Use:   "cloudsql",
 	Short: "Create a Cloud SQL PostgreSQL instance for the ateapi store, with IAM database authentication",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if cfg.ProjectID == "" {
-			return errors.New("--project-id is required")
+		ctx := cmd.Context()
+		if err := resolveProjectID(ctx, &cfg); err != nil {
+			return err
 		}
 		// Require explicit region to prevent silent cross-region latency and egress costs.
 		if !cmd.Flags().Changed("region") && os.Getenv("GCE_REGION") == "" {
 			return errors.New("--region is required (or set GCE_REGION): the instance must be in the cluster's region")
 		}
-		ctx := cmd.Context()
 		if err := enableCloudSQLAPIs(ctx, &cfg); err != nil {
 			return err
 		}

--- a/tools/setup-gcp/cmd/cluster.go
+++ b/tools/setup-gcp/cmd/cluster.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -333,10 +332,11 @@ var clusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Short: "Create GKE cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if cfg.ProjectID == "" {
-			return errors.New("--project-id is required")
+		ctx := cmd.Context()
+		if err := resolveProjectID(ctx, &cfg); err != nil {
+			return err
 		}
-		return createClusterIdempotent(cmd.Context(), &cfg)
+		return createClusterIdempotent(ctx, &cfg)
 	},
 }
 

--- a/tools/setup-gcp/cmd/cluster.go
+++ b/tools/setup-gcp/cmd/cluster.go
@@ -58,6 +58,15 @@ func buildCreateClusterRequest(parent string, cfg *Config) *containerpb.CreateCl
 			DatapathProvider: containerpb.DatapathProvider_ADVANCED_DATAPATH,
 		}
 	}
+	nodeConfig := &containerpb.NodeConfig{
+		MachineType: cfg.MachineType,
+	}
+	if cfg.BootDiskSizeGB > 0 {
+		nodeConfig.DiskSizeGb = cfg.BootDiskSizeGB
+	}
+	if cfg.BootDiskType != "" {
+		nodeConfig.DiskType = cfg.BootDiskType
+	}
 	return &containerpb.CreateClusterRequest{
 		Parent: parent,
 		Cluster: &containerpb.Cluster{
@@ -67,9 +76,7 @@ func buildCreateClusterRequest(parent string, cfg *Config) *containerpb.CreateCl
 				{
 					Name:             "substrate-node-pool",
 					InitialNodeCount: 2,
-					Config: &containerpb.NodeConfig{
-						MachineType: cfg.MachineType,
-					},
+					Config:           nodeConfig,
 				},
 			},
 			EnableK8SBetaApis: &containerpb.K8SBetaAPIConfig{
@@ -106,6 +113,9 @@ func createClusterInternal(ctx context.Context, cfg *Config, client *container.C
 }
 
 func createClusterIdempotent(ctx context.Context, cfg *Config) error {
+	if err := validateBootDisk(cfg); err != nil {
+		return err
+	}
 	client, err := container.NewClusterManagerClient(ctx)
 	if err != nil {
 		return err
@@ -312,6 +322,13 @@ func containsAll(clusterAPIs []string, requiredAPIs []string) bool {
 	return true
 }
 
+// validateBootDisk ensures BootDiskSizeGB is non-negative.
+func validateBootDisk(cfg *Config) error {
+	if cfg.BootDiskSizeGB < 0 {
+		return fmt.Errorf("boot disk size %d is invalid: must be greater than or equal to 0", cfg.BootDiskSizeGB)
+	}
+	return nil
+}
 var clusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Short: "Create GKE cluster",
@@ -332,4 +349,6 @@ func init() {
 	clusterCmd.Flags().StringVar(&cfg.Subnetwork, "subnetwork", getEnv("SUBNETWORK", "default"), "VPC subnetwork name [env: SUBNETWORK]")
 	clusterCmd.Flags().StringVar(&cfg.MachineType, "machine-type", getEnv("GVISOR_NODE_MACHINE_TYPE", "c3-standard-4"), "Machine type for the gVisor node pool [env: GVISOR_NODE_MACHINE_TYPE]")
 	clusterCmd.Flags().BoolVar(&cfg.EnableDataplaneV2, "enable-dataplane-v2", getEnv("ENABLE_DATAPLANE_V2", true), "Enable Dataplane V2 [env: ENABLE_DATAPLANE_V2]")
+	clusterCmd.Flags().Int32Var(&cfg.BootDiskSizeGB, "boot-disk-size", getEnv("BOOT_DISK_SIZE_GB", int32(0)), "Boot disk size in GB for the node pool; 0 = GKE default (100 GB) [env: BOOT_DISK_SIZE_GB]")
+	clusterCmd.Flags().StringVar(&cfg.BootDiskType, "boot-disk-type", getEnv("BOOT_DISK_TYPE", ""), "Boot disk type for the node pool; empty = GKE default [env: BOOT_DISK_TYPE]")
 }

--- a/tools/setup-gcp/cmd/cluster.go
+++ b/tools/setup-gcp/cmd/cluster.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -112,6 +113,9 @@ func createClusterInternal(ctx context.Context, cfg *Config, client *container.C
 }
 
 func createClusterIdempotent(ctx context.Context, cfg *Config) error {
+	if err := validateClusterLocation(cfg); err != nil {
+		return err
+	}
 	if err := validateBootDisk(cfg); err != nil {
 		return err
 	}
@@ -328,6 +332,26 @@ func validateBootDisk(cfg *Config) error {
 	}
 	return nil
 }
+
+// validateClusterLocation ensures ClusterLocation is set and compatible with Region.
+func validateClusterLocation(cfg *Config) error {
+	cfg.Region = strings.TrimSpace(cfg.Region)
+	if cfg.Region == "" {
+		return errors.New("--region is required")
+	}
+
+	cfg.ClusterLocation = strings.TrimSpace(cfg.ClusterLocation)
+	if cfg.ClusterLocation == "" {
+		return errors.New("--cluster-location is required")
+	}
+
+	if cfg.ClusterLocation != cfg.Region && !strings.HasPrefix(cfg.ClusterLocation, cfg.Region+"-") {
+		return fmt.Errorf("cluster location %q is not compatible with region %q: cluster location must be the region itself (for regional clusters) or a zone within that region (e.g. %s-c)", cfg.ClusterLocation, cfg.Region, cfg.Region)
+	}
+
+	return nil
+}
+
 var clusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Short: "Create GKE cluster",

--- a/tools/setup-gcp/cmd/cluster_test.go
+++ b/tools/setup-gcp/cmd/cluster_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/container/apiv1/containerpb"
@@ -195,6 +196,71 @@ func TestValidateBootDisk(t *testing.T) {
 				}
 				if err.Error() != tt.wantErr {
 					t.Errorf("got error %q, want %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateClusterLocation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "compatible default us-west1 and us-west1-c",
+			cfg:  Config{Region: "us-west1", ClusterLocation: "us-west1-c"},
+		},
+		{
+			name: "compatible zone in region",
+			cfg:  Config{Region: "us-central1", ClusterLocation: "us-central1-a"},
+		},
+		{
+			name: "compatible regional cluster location",
+			cfg:  Config{Region: "us-central1", ClusterLocation: "us-central1"},
+		},
+		{
+			name:    "incompatible zone and region",
+			cfg:     Config{Region: "us-central1", ClusterLocation: "us-west1-c"},
+			wantErr: `cluster location "us-west1-c" is not compatible with region "us-central1"`,
+		},
+		{
+			name:    "incompatible regions",
+			cfg:     Config{Region: "us-central1", ClusterLocation: "us-west1"},
+			wantErr: `cluster location "us-west1" is not compatible with region "us-central1"`,
+		},
+		{
+			name:    "similar prefix but different region number",
+			cfg:     Config{Region: "us-central1", ClusterLocation: "us-central2-c"},
+			wantErr: `cluster location "us-central2-c" is not compatible with region "us-central1"`,
+		},
+		{
+			name:    "missing region",
+			cfg:     Config{Region: "", ClusterLocation: "us-central1-c"},
+			wantErr: "--region is required",
+		},
+		{
+			name:    "missing cluster location",
+			cfg:     Config{Region: "us-central1", ClusterLocation: ""},
+			wantErr: "--cluster-location is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgCopy := tt.cfg
+			err := validateClusterLocation(&cfgCopy)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("got error %q, want containing %q", err.Error(), tt.wantErr)
 				}
 				return
 			}

--- a/tools/setup-gcp/cmd/cluster_test.go
+++ b/tools/setup-gcp/cmd/cluster_test.go
@@ -49,6 +49,65 @@ func TestBuildCreateClusterRequest_FilestoreDisabled(t *testing.T) {
 	}
 }
 
+func TestBuildCreateClusterRequest_NodeConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		cfg          *Config
+		wantDiskSize int32
+		wantDiskType string
+	}{
+		{
+			name: "custom disk size and type",
+			cfg: &Config{
+				ProjectID:       "test-project",
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-west1-c",
+				MachineType:     "c3-standard-8",
+				BootDiskSizeGB:  500,
+				BootDiskType:    "hyperdisk-balanced",
+			},
+			wantDiskSize: 500,
+			wantDiskType: "hyperdisk-balanced",
+		},
+		{
+			name: "unset disk size and type",
+			cfg: &Config{
+				ProjectID:       "test-project",
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-west1-c",
+				MachineType:     "c3-standard-4",
+			},
+			wantDiskSize: 0,
+			wantDiskType: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := "projects/test-project/locations/us-west1-c"
+			req := buildCreateClusterRequest(parent, tt.cfg)
+			if req.Cluster == nil || len(req.Cluster.NodePools) == 0 {
+				t.Fatal("expected non-empty node pools in request")
+			}
+
+			nodeConfig := req.Cluster.NodePools[0].Config
+			if nodeConfig == nil {
+				t.Fatal("expected non-nil node config")
+			}
+
+			if nodeConfig.MachineType != tt.cfg.MachineType {
+				t.Errorf("MachineType = %q, want %q", nodeConfig.MachineType, tt.cfg.MachineType)
+			}
+			if nodeConfig.DiskSizeGb != tt.wantDiskSize {
+				t.Errorf("DiskSizeGb = %d, want %d", nodeConfig.DiskSizeGb, tt.wantDiskSize)
+			}
+			if nodeConfig.DiskType != tt.wantDiskType {
+				t.Errorf("DiskType = %q, want %q", nodeConfig.DiskType, tt.wantDiskType)
+			}
+		})
+	}
+}
+
 func TestFilestoreCsiDriverEnabled(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -100,6 +159,47 @@ func TestFilestoreCsiDriverEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := filestoreCsiDriverEnabled(tt.cluster); got != tt.want {
 				t.Errorf("filestoreCsiDriverEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateBootDisk(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "valid positive boot disk size",
+			cfg:  Config{BootDiskSizeGB: 500},
+		},
+		{
+			name: "zero boot disk size (unset/default)",
+			cfg:  Config{BootDiskSizeGB: 0},
+		},
+		{
+			name:    "negative boot disk size",
+			cfg:     Config{BootDiskSizeGB: -1},
+			wantErr: "boot disk size -1 is invalid: must be greater than or equal to 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgCopy := tt.cfg
+			err := validateBootDisk(&cfgCopy)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Errorf("got error %q, want %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/tools/setup-gcp/cmd/common.go
+++ b/tools/setup-gcp/cmd/common.go
@@ -35,6 +35,8 @@ type Config struct {
 	NodePoolName    string
 	NodePoolVersion string
 	MachineType     string
+	BootDiskSizeGB  int32
+	BootDiskType    string
 
 	BucketName string
 
@@ -48,7 +50,7 @@ type Config struct {
 }
 
 type getEnvType interface {
-	string | bool | int64
+	string | bool | int64 | int32
 }
 
 // getEnv retrieves an environment variable by key and parses it into the specified type.
@@ -69,6 +71,10 @@ func getEnv[T getEnvType](key string, fallback T) T {
 		ret, err = strconv.ParseBool(val)
 	case int64:
 		ret, err = strconv.ParseInt(val, 10, 64)
+	case int32:
+		var v int64
+		v, err = strconv.ParseInt(val, 10, 32)
+		ret = int32(v)
 	}
 
 	if err == nil {

--- a/tools/setup-gcp/cmd/common_test.go
+++ b/tools/setup-gcp/cmd/common_test.go
@@ -87,3 +87,34 @@ func TestGetEnv_Bool(t *testing.T) {
 		t.Errorf("getEnv(%q, false) with invalid env = %t; want false", key, got)
 	}
 }
+
+func TestGetEnv_Int32(t *testing.T) {
+	const key = "TEST_ENV_INT32_VAR"
+
+	// Ensure clean environment
+	os.Unsetenv(key)
+	defer os.Unsetenv(key)
+
+	// Test fallback when environment variable is not set
+	if got := getEnv(key, int32(500)); got != int32(500) {
+		t.Errorf("getEnv(%q, %d) = %d; want %d", key, 500, got, 500)
+	}
+
+	// Test when environment variable is set
+	os.Setenv(key, "250")
+	if got := getEnv(key, int32(500)); got != int32(250) {
+		t.Errorf("getEnv(%q, %d) = %d; want %d", key, 500, got, 250)
+	}
+
+	// Test when environment variable is invalid int32 string
+	os.Setenv(key, "invalid")
+	if got := getEnv(key, int32(500)); got != int32(500) {
+		t.Errorf("getEnv(%q, %d) with invalid env = %d; want %d", key, 500, got, 500)
+	}
+
+	// Test when environment variable exceeds int32 range
+	os.Setenv(key, "5000000000")
+	if got := getEnv(key, int32(500)); got != int32(500) {
+		t.Errorf("getEnv(%q, %d) with out-of-range env = %d; want %d", key, 500, got, 500)
+	}
+}

--- a/tools/setup-gcp/cmd/dashboards.go
+++ b/tools/setup-gcp/cmd/dashboards.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -105,10 +104,11 @@ var dashboardsCmd = &cobra.Command{
 	Use:   "dashboards",
 	Short: "Create Cloud Monitoring dashboards",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if cfg.ProjectID == "" {
-			return errors.New("--project-id is required")
+		ctx := cmd.Context()
+		if err := resolveProjectID(ctx, &cfg); err != nil {
+			return err
 		}
-		return createMonitoringDashboards(cmd.Context(), &cfg)
+		return createMonitoringDashboards(ctx, &cfg)
 	},
 }
 

--- a/tools/setup-gcp/cmd/enable.go
+++ b/tools/setup-gcp/cmd/enable.go
@@ -15,8 +15,6 @@
 package cmd
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 )
 
@@ -32,10 +30,11 @@ var enableApisCmd = &cobra.Command{
 	Use:   "apis",
 	Short: "Enable required GCP APIs",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if cfg.ProjectID == "" {
-			return errors.New("--project-id is required")
+		ctx := cmd.Context()
+		if err := resolveProjectID(ctx, &cfg); err != nil {
+			return err
 		}
-		return enableRequiredAPIs(cmd.Context(), &cfg)
+		return enableRequiredAPIs(ctx, &cfg)
 	},
 }
 

--- a/tools/setup-gcp/cmd/iam.go
+++ b/tools/setup-gcp/cmd/iam.go
@@ -136,12 +136,9 @@ func grantAteletPermissions(ctx context.Context, cfg *Config) error {
 // grants run. Each grant is a separate SetIamPolicy call, so a flag validated
 // partway through the sequence reports a usage error only after the earlier
 // grants have already been written to the project.
-func validateIamFlags(cfg *Config, bucketBindings bool) error {
-	if cfg.ProjectID == "" {
-		return errors.New("--project-id is required")
-	}
-	if cfg.ProjectNumber == "" {
-		return errors.New("--project-number is required")
+func validateIamFlags(ctx context.Context, cfg *Config, bucketBindings bool) error {
+	if err := resolveProject(ctx, cfg); err != nil {
+		return err
 	}
 	if bucketBindings && cfg.BucketName == "" {
 		return errors.New("--bucket is required for bucket bindings")
@@ -157,7 +154,7 @@ var iamCmd = &cobra.Command{
 		atelet, _ := cmd.Flags().GetBool("atelet")
 		bucketBindings, _ := cmd.Flags().GetBool("bucket-bindings")
 
-		if err := validateIamFlags(&cfg, bucketBindings); err != nil {
+		if err := validateIamFlags(cmd.Context(), &cfg, bucketBindings); err != nil {
 			return err
 		}
 

--- a/tools/setup-gcp/cmd/iam_test.go
+++ b/tools/setup-gcp/cmd/iam_test.go
@@ -14,9 +14,24 @@
 
 package cmd
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+)
 
 func TestValidateIamFlags(t *testing.T) {
+	origGetProject := getProjectFn
+	defer func() { getProjectFn = origGetProject }()
+
+	getProjectFn = func(ctx context.Context, name string) (*resourcemanagerpb.Project, error) {
+		return &resourcemanagerpb.Project{
+			Name:      "projects/123",
+			ProjectId: "test-project",
+		}, nil
+	}
+
 	tests := []struct {
 		name           string
 		cfg            Config
@@ -30,10 +45,16 @@ func TestValidateIamFlags(t *testing.T) {
 			want:           "--project-id is required",
 		},
 		{
-			name:           "missing project number",
+			name:           "missing project id when only project number provided",
+			cfg:            Config{ProjectNumber: "123"},
+			bucketBindings: true,
+			want:           "--project-id is required",
+		},
+		{
+			name:           "only project id provided, bucket missing",
 			cfg:            Config{ProjectID: "test-project"},
 			bucketBindings: true,
-			want:           "--project-number is required",
+			want:           "--bucket is required for bucket bindings",
 		},
 		{
 			name:           "missing bucket while bucket bindings are requested",
@@ -47,15 +68,21 @@ func TestValidateIamFlags(t *testing.T) {
 			bucketBindings: false,
 		},
 		{
-			name:           "all required flags present",
+			name:           "all required flags present with both id and number",
 			cfg:            Config{ProjectID: "test-project", ProjectNumber: "123", BucketName: "test-bucket"},
+			bucketBindings: true,
+		},
+		{
+			name:           "all required flags present with only project id",
+			cfg:            Config{ProjectID: "test-project", BucketName: "test-bucket"},
 			bucketBindings: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateIamFlags(&tt.cfg, tt.bucketBindings)
+			cfgCopy := tt.cfg
+			err := validateIamFlags(t.Context(), &cfgCopy, tt.bucketBindings)
 			if tt.want == "" {
 				if err != nil {
 					t.Fatalf("validateIamFlags() = %v; want nil", err)

--- a/tools/setup-gcp/cmd/project.go
+++ b/tools/setup-gcp/cmd/project.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+)
+
+// getProjectFn fetches a GCP project by resource name (e.g. "projects/<id>" or "projects/<number>").
+// Swappable in tests.
+var getProjectFn = func(ctx context.Context, name string) (*resourcemanagerpb.Project, error) {
+	client, err := resourcemanager.NewProjectsClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create resourcemanager client: %w", err)
+	}
+	defer client.Close()
+	return client.GetProject(ctx, &resourcemanagerpb.GetProjectRequest{Name: name})
+}
+
+// resolveProjectID ensures ProjectID is provided on cfg.
+func resolveProjectID(ctx context.Context, cfg *Config) error {
+	cfg.ProjectID = strings.TrimPrefix(cfg.ProjectID, "projects/")
+	cfg.ProjectNumber = strings.TrimPrefix(cfg.ProjectNumber, "projects/")
+
+	if cfg.ProjectID == "" {
+		return errors.New("--project-id is required")
+	}
+	return nil
+}
+
+// resolveProject ensures both ProjectID and ProjectNumber are populated on cfg.
+// ProjectID is required. If ProjectNumber is missing, it is resolved using the
+// Google Cloud Resource Manager API.
+func resolveProject(ctx context.Context, cfg *Config) error {
+	if err := resolveProjectID(ctx, cfg); err != nil {
+		return err
+	}
+
+	if cfg.ProjectNumber != "" {
+		return nil
+	}
+
+	name := fmt.Sprintf("projects/%s", cfg.ProjectID)
+	project, err := getProjectFn(ctx, name)
+	if err != nil {
+		return fmt.Errorf("resolve project info for %s: %w", name, err)
+	}
+
+	cfg.ProjectNumber = strings.TrimPrefix(project.GetName(), "projects/")
+	slog.Info("Resolved GCP project number", slog.String("project_id", cfg.ProjectID), slog.String("project_number", cfg.ProjectNumber))
+	return nil
+}

--- a/tools/setup-gcp/cmd/project_test.go
+++ b/tools/setup-gcp/cmd/project_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+)
+
+func TestResolveProject(t *testing.T) {
+	origGetProject := getProjectFn
+	defer func() { getProjectFn = origGetProject }()
+
+	tests := []struct {
+		name          string
+		cfg           Config
+		mockProject   *resourcemanagerpb.Project
+		mockErr       error
+		wantProjectID string
+		wantProjectNr string
+		wantErr       string
+		wantCalled    bool
+		wantName      string
+	}{
+		{
+			name:    "missing project ID",
+			cfg:     Config{},
+			wantErr: "--project-id is required",
+		},
+		{
+			name: "only project number provided",
+			cfg: Config{
+				ProjectNumber: "987654",
+			},
+			wantErr: "--project-id is required",
+		},
+		{
+			name: "both provided",
+			cfg: Config{
+				ProjectID:     "my-proj",
+				ProjectNumber: "123456",
+			},
+			wantProjectID: "my-proj",
+			wantProjectNr: "123456",
+			wantCalled:    false,
+		},
+		{
+			name: "only project ID provided resolves project number",
+			cfg: Config{
+				ProjectID: "my-proj",
+			},
+			mockProject: &resourcemanagerpb.Project{
+				Name:      "projects/987654",
+				ProjectId: "my-proj",
+			},
+			wantProjectID: "my-proj",
+			wantProjectNr: "987654",
+			wantCalled:    true,
+			wantName:      "projects/my-proj",
+		},
+		{
+			name: "projects prefix trimmed",
+			cfg: Config{
+				ProjectID: "projects/my-proj",
+			},
+			mockProject: &resourcemanagerpb.Project{
+				Name:      "projects/987654",
+				ProjectId: "my-proj",
+			},
+			wantProjectID: "my-proj",
+			wantProjectNr: "987654",
+			wantCalled:    true,
+			wantName:      "projects/my-proj",
+		},
+		{
+			name: "resolution API error",
+			cfg: Config{
+				ProjectID: "nonexistent-proj",
+			},
+			mockErr:    errors.New("project not found"),
+			wantErr:    "resolve project info for projects/nonexistent-proj: project not found",
+			wantCalled: true,
+			wantName:   "projects/nonexistent-proj",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			var calledName string
+			getProjectFn = func(ctx context.Context, name string) (*resourcemanagerpb.Project, error) {
+				called = true
+				calledName = name
+				if tt.mockErr != nil {
+					return nil, tt.mockErr
+				}
+				return tt.mockProject, nil
+			}
+
+			cfgCopy := tt.cfg
+			err := resolveProject(t.Context(), &cfgCopy)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("got error %q, want containing %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if called != tt.wantCalled {
+				t.Errorf("getProjectFn called = %v; want %v", called, tt.wantCalled)
+			}
+			if tt.wantCalled && calledName != tt.wantName {
+				t.Errorf("getProjectFn called with name = %q; want %q", calledName, tt.wantName)
+			}
+			if cfgCopy.ProjectID != tt.wantProjectID {
+				t.Errorf("cfg.ProjectID = %q; want %q", cfgCopy.ProjectID, tt.wantProjectID)
+			}
+			if cfgCopy.ProjectNumber != tt.wantProjectNr {
+				t.Errorf("cfg.ProjectNumber = %q; want %q", cfgCopy.ProjectNumber, tt.wantProjectNr)
+			}
+		})
+	}
+}
+
+func TestResolveProjectID(t *testing.T) {
+	origGetProject := getProjectFn
+	defer func() { getProjectFn = origGetProject }()
+
+	tests := []struct {
+		name          string
+		cfg           Config
+		mockProject   *resourcemanagerpb.Project
+		mockErr       error
+		wantProjectID string
+		wantProjectNr string
+		wantErr       string
+		wantCalled    bool
+		wantName      string
+	}{
+		{
+			name:    "missing project ID",
+			cfg:     Config{},
+			wantErr: "--project-id is required",
+		},
+		{
+			name: "only project number provided",
+			cfg: Config{
+				ProjectNumber: "987654",
+			},
+			wantErr: "--project-id is required",
+		},
+		{
+			name: "both provided",
+			cfg: Config{
+				ProjectID:     "my-proj",
+				ProjectNumber: "123456",
+			},
+			wantProjectID: "my-proj",
+			wantProjectNr: "123456",
+			wantCalled:    false,
+		},
+		{
+			name: "only project ID provided skips API call",
+			cfg: Config{
+				ProjectID: "my-proj",
+			},
+			wantProjectID: "my-proj",
+			wantCalled:    false,
+		},
+		{
+			name: "projects prefix trimmed with only project ID",
+			cfg: Config{
+				ProjectID: "projects/my-proj",
+			},
+			wantProjectID: "my-proj",
+			wantCalled:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			var calledName string
+			getProjectFn = func(ctx context.Context, name string) (*resourcemanagerpb.Project, error) {
+				called = true
+				calledName = name
+				if tt.mockErr != nil {
+					return nil, tt.mockErr
+				}
+				return tt.mockProject, nil
+			}
+
+			cfgCopy := tt.cfg
+			err := resolveProjectID(t.Context(), &cfgCopy)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("got error %q, want containing %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if called != tt.wantCalled {
+				t.Errorf("getProjectFn called = %v; want %v", called, tt.wantCalled)
+			}
+			if tt.wantCalled && calledName != tt.wantName {
+				t.Errorf("getProjectFn called with name = %q; want %q", calledName, tt.wantName)
+			}
+			if cfgCopy.ProjectID != tt.wantProjectID {
+				t.Errorf("cfg.ProjectID = %q; want %q", cfgCopy.ProjectID, tt.wantProjectID)
+			}
+			if cfgCopy.ProjectNumber != tt.wantProjectNr {
+				t.Errorf("cfg.ProjectNumber = %q; want %q", cfgCopy.ProjectNumber, tt.wantProjectNr)
+			}
+		})
+	}
+}

--- a/tools/setup-gcp/cmd/root.go
+++ b/tools/setup-gcp/cmd/root.go
@@ -35,6 +35,6 @@ func Execute() error {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfg.ProjectID, "project-id", getEnv("PROJECT_ID", ""), "GCP Project ID [env: PROJECT_ID]")
-	rootCmd.PersistentFlags().StringVar(&cfg.ProjectNumber, "project-number", getEnv("PROJECT_NUMBER", ""), "GCP Project Number [env: PROJECT_NUMBER]")
+	rootCmd.PersistentFlags().StringVar(&cfg.ProjectNumber, "project-number", getEnv("PROJECT_NUMBER", ""), "GCP Project Number (optional, resolved from --project-id if needed) [env: PROJECT_NUMBER]")
 	rootCmd.PersistentFlags().StringVar(&cfg.Region, "region", getEnv("GCE_REGION", "us-west1"), "GCP Region [env: GCE_REGION]")
 }


### PR DESCRIPTION
Multiple enhancements to setup-gcp

- Add boot disk customizations. Since snapshots are written to boot disk, being able to increase the size will mitigate IO throttling.
- Require only one of project-id or project-number to be specified
- Verify region and cluster-location are compatible

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
