### PR TITLE
Print single-resource output as a bare object, not a list.

### DIFF
--- a/benchmarking/workloads/deploy.sh
+++ b/benchmarking/workloads/deploy.sh
@@ -149,11 +149,11 @@ wait_actortemplate_ready() {
 
   while ((SECONDS < deadline)); do
     if json=$(run_kubectl_ate get actor-template "${template}" -a "${atespace}" -o json 2>/dev/null); then
-      snapshot=$(jq -r '.actorTemplates[0].status.goldenSnapshotStatus.goldenSnapshot.snapshotUri // empty' <<<"${json}")
+      snapshot=$(jq -r '.status.goldenSnapshotStatus.goldenSnapshot.snapshotUri // empty' <<<"${json}")
       if [[ -n "${snapshot}" ]]; then
         return 0
       fi
-      error_message=$(jq -r '.actorTemplates[0].status.goldenSnapshotStatus.errorMessage // empty' <<<"${json}")
+      error_message=$(jq -r '.status.goldenSnapshotStatus.errorMessage // empty' <<<"${json}")
       if [[ -n "${error_message}" ]]; then
         echo "actor template ${atespace}/${template} failed: ${error_message}" >&2
         return 1

--- a/cmd/kubectl-ate/internal/cmd/create_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/create_actor.go
@@ -49,7 +49,7 @@ var createActorCmd = &cobra.Command{
 			return fmt.Errorf("failed to create actor: %w", err)
 		}
 
-		return printer.PrintActor(resp, outputFmt)
+		return printer.PrintActorTo(cmd.OutOrStdout(), resp, outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/create_actor_template.go
+++ b/cmd/kubectl-ate/internal/cmd/create_actor_template.go
@@ -63,7 +63,7 @@ Actor templates are immutable: there is no update; delete and recreate to change
 		if err != nil {
 			return fmt.Errorf("failed to create actor template: %w", err)
 		}
-		return printer.PrintActorTemplate(resp, outputFmt)
+		return printer.PrintActorTemplateTo(cmd.OutOrStdout(), resp, outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/create_atespace.go
+++ b/cmd/kubectl-ate/internal/cmd/create_atespace.go
@@ -46,7 +46,7 @@ var createAtespaceCmd = &cobra.Command{
 			return fmt.Errorf("failed to create atespace: %w", err)
 		}
 
-		return printer.PrintAtespace(resp, outputFmt)
+		return printer.PrintAtespaceTo(cmd.OutOrStdout(), resp, outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/get_actor_templates.go
+++ b/cmd/kubectl-ate/internal/cmd/get_actor_templates.go
@@ -62,7 +62,10 @@ var getActorTemplatesCmd = &cobra.Command{
 				}
 				templates = append(templates, resp)
 			}
-			return printer.PrintActorTemplates(templates, outputFmt)
+			if len(templates) == 1 {
+				return printer.PrintActorTemplateTo(cmd.OutOrStdout(), templates[0], outputFmt)
+			}
+			return printer.PrintActorTemplatesTo(cmd.OutOrStdout(), templates, outputFmt)
 		}
 
 		// Listing requires exactly one of --atespace (one atespace) or -A (all
@@ -93,7 +96,7 @@ var getActorTemplatesCmd = &cobra.Command{
 			}
 		}
 
-		return printer.PrintActorTemplates(allTemplates, outputFmt)
+		return printer.PrintActorTemplatesTo(cmd.OutOrStdout(), allTemplates, outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/get_actors.go
+++ b/cmd/kubectl-ate/internal/cmd/get_actors.go
@@ -63,7 +63,10 @@ var getActorsCmd = &cobra.Command{
 				}
 				actors = append(actors, resp)
 			}
-			return printer.PrintActors(actors, outputFmt)
+			if len(actors) == 1 {
+				return printer.PrintActorTo(cmd.OutOrStdout(), actors[0], outputFmt)
+			}
+			return printer.PrintActorsTo(cmd.OutOrStdout(), actors, outputFmt)
 		}
 
 		// Listing requires exactly one of --atespace (one atespace) or -A (all
@@ -96,7 +99,7 @@ var getActorsCmd = &cobra.Command{
 			}
 		}
 
-		return printer.PrintActors(allActors, outputFmt)
+		return printer.PrintActorsTo(cmd.OutOrStdout(), allActors, outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/get_atespaces.go
+++ b/cmd/kubectl-ate/internal/cmd/get_atespaces.go
@@ -44,7 +44,10 @@ var getAtespacesCmd = &cobra.Command{
 				}
 				atespaces = append(atespaces, resp)
 			}
-			return printer.PrintAtespaces(atespaces, outputFmt)
+			if len(atespaces) == 1 {
+				return printer.PrintAtespaceTo(cmd.OutOrStdout(), atespaces[0], outputFmt)
+			}
+			return printer.PrintAtespacesTo(cmd.OutOrStdout(), atespaces, outputFmt)
 		}
 
 		var allAtespaces []*ateapipb.Atespace
@@ -64,7 +67,7 @@ var getAtespacesCmd = &cobra.Command{
 				break
 			}
 		}
-		return printer.PrintAtespaces(allAtespaces, outputFmt)
+		return printer.PrintAtespacesTo(cmd.OutOrStdout(), allAtespaces, outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/get_workers.go
+++ b/cmd/kubectl-ate/internal/cmd/get_workers.go
@@ -74,6 +74,9 @@ func (r *GetWorkersRunner) Run(ctx context.Context) error {
 			}
 			workers = append(workers, worker)
 		}
+		if len(workers) == 1 {
+			return printer.PrintWorkerTo(r.out, workers[0], r.outputFmt)
+		}
 		return printer.PrintWorkersTo(r.out, workers, r.outputFmt)
 	}
 

--- a/cmd/kubectl-ate/internal/cmd/get_workers_test.go
+++ b/cmd/kubectl-ate/internal/cmd/get_workers_test.go
@@ -205,6 +205,33 @@ func TestGetWorkersRunner_GetByName(t *testing.T) {
 	}
 }
 
+func TestGetWorkersRunner_GetByName_Single(t *testing.T) {
+	getter := &mockWorkerGetter{workers: map[string]*ateapipb.Worker{
+		"worker-1": {Metadata: &ateapipb.ResourceMetadata{Name: "worker-1"}},
+	}}
+
+	var buf bytes.Buffer
+	runner := &GetWorkersRunner{
+		workerGetter: getter,
+		names:        []string{"worker-1"},
+		outputFmt:    "json",
+		out:          &buf,
+	}
+	if err := runner.Run(context.Background()); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	expected := `{
+  "metadata": {
+    "name": "worker-1"
+  }
+}
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestGetWorkersRunner_GetByName_Error(t *testing.T) {
 	runner := &GetWorkersRunner{
 		workerGetter: &mockWorkerGetter{err: errors.New("rpc failed")},

--- a/cmd/kubectl-ate/internal/cmd/pause_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/pause_actor.go
@@ -46,7 +46,7 @@ var pauseActorCmd = &cobra.Command{
 			return fmt.Errorf("failed to pause actor: %w", err)
 		}
 
-		return printer.PrintActor(resp.GetActor(), outputFmt)
+		return printer.PrintActorTo(cmd.OutOrStdout(), resp.GetActor(), outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/resume_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/resume_actor.go
@@ -48,7 +48,7 @@ var resumeActorCmd = &cobra.Command{
 			return fmt.Errorf("failed to resume actor: %w", err)
 		}
 
-		return printer.PrintActor(resp.GetActor(), outputFmt)
+		return printer.PrintActorTo(cmd.OutOrStdout(), resp.GetActor(), outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/suspend_actor.go
+++ b/cmd/kubectl-ate/internal/cmd/suspend_actor.go
@@ -46,7 +46,7 @@ var suspendActorCmd = &cobra.Command{
 			return fmt.Errorf("failed to suspend actor: %w", err)
 		}
 
-		return printer.PrintActor(resp.GetActor(), outputFmt)
+		return printer.PrintActorTo(cmd.OutOrStdout(), resp.GetActor(), outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/tag.go
+++ b/cmd/kubectl-ate/internal/cmd/tag.go
@@ -61,8 +61,8 @@ var getTagsCmd = &cobra.Command{
 		}
 		defer client.Close()
 
-		var tags []*ateapipb.Tag
 		if len(args) > 0 {
+			tags := make([]*ateapipb.Tag, 0, len(args))
 			for _, name := range args {
 				tag, err := client.GetTag(ctx, &ateapipb.GetTagRequest{
 					Tag: &ateapipb.ObjectRef{Atespace: tagAtespaceFlag, Name: name},
@@ -72,21 +72,26 @@ var getTagsCmd = &cobra.Command{
 				}
 				tags = append(tags, tag)
 			}
-		} else {
-			pageToken := ""
-			for {
-				resp, err := client.ListTags(ctx, &ateapipb.ListTagsRequest{Atespace: tagAtespaceFlag, PageSize: 1000, PageToken: pageToken})
-				if err != nil {
-					return fmt.Errorf("failed to list tags: %w", err)
-				}
-				tags = append(tags, resp.GetTags()...)
-				pageToken = resp.GetNextPageToken()
-				if pageToken == "" {
-					break
-				}
+			if len(tags) == 1 {
+				return printer.PrintTagTo(cmd.OutOrStdout(), tags[0], outputFmt)
+			}
+			return printer.PrintTagsTo(cmd.OutOrStdout(), tags, outputFmt)
+		}
+
+		var tags []*ateapipb.Tag
+		pageToken := ""
+		for {
+			resp, err := client.ListTags(ctx, &ateapipb.ListTagsRequest{Atespace: tagAtespaceFlag, PageSize: 1000, PageToken: pageToken})
+			if err != nil {
+				return fmt.Errorf("failed to list tags: %w", err)
+			}
+			tags = append(tags, resp.GetTags()...)
+			pageToken = resp.GetNextPageToken()
+			if pageToken == "" {
+				break
 			}
 		}
-		return printer.PrintTags(tags, outputFmt)
+		return printer.PrintTagsTo(cmd.OutOrStdout(), tags, outputFmt)
 	},
 }
 
@@ -120,7 +125,7 @@ var createTagCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create tag: %w", err)
 		}
-		return printer.PrintTag(tag, outputFmt)
+		return printer.PrintTagTo(cmd.OutOrStdout(), tag, outputFmt)
 	},
 }
 
@@ -146,7 +151,7 @@ var updateTagCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return printer.PrintTag(resp, outputFmt)
+		return printer.PrintTagTo(cmd.OutOrStdout(), resp, outputFmt)
 	},
 }
 

--- a/cmd/kubectl-ate/internal/cmd/top_workers.go
+++ b/cmd/kubectl-ate/internal/cmd/top_workers.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/agent-substrate/substrate/cmd/kubectl-ate/internal/printer"
 	"github.com/agent-substrate/substrate/internal/ateclient"
@@ -136,12 +135,7 @@ func (r *TopWorkersRunner) Run(ctx context.Context) error {
 		})
 	}
 
-	outWriter := r.out
-	if outWriter == nil {
-		outWriter = os.Stdout
-	}
-
-	return printer.PrintWorkerTopTo(outWriter, items, r.outputFmt)
+	return printer.PrintWorkerTopTo(r.out, items, r.outputFmt)
 }
 
 func extractContainerUsage(pm metricsv1beta1.PodMetrics) (string, string) {
@@ -197,7 +191,7 @@ func runTopWorkers(cmd *cobra.Command, args []string) error {
 		selector:         topWorkerSelectorFlag,
 		sandboxClass:     topWorkerClassFlag,
 		outputFmt:        outputFmt,
-		out:              os.Stdout,
+		out:              cmd.OutOrStdout(),
 	}
 
 	return runner.Run(ctx)

--- a/cmd/kubectl-ate/internal/printer/printer.go
+++ b/cmd/kubectl-ate/internal/printer/printer.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"text/tabwriter"
 	"time"
@@ -41,11 +40,6 @@ var TimeNow = time.Now
 // (e.g. "5m", "3h", "2d").
 func formatAge(ts *timestamppb.Timestamp) string {
 	return duration.HumanDuration(TimeNow().Sub(ts.AsTime()))
-}
-
-// PrintActors prints a slice of actors to stdout in the requested format.
-func PrintActors(actors []*ateapipb.Actor, format string) error {
-	return PrintActorsTo(os.Stdout, actors, format)
 }
 
 func sortActors(actors []*ateapipb.Actor) {
@@ -96,11 +90,6 @@ func PrintActorsTo(out io.Writer, actors []*ateapipb.Actor, format string) error
 	default:
 		return fmt.Errorf("unsupported format %q", format)
 	}
-}
-
-// PrintWorkers prints a slice of workers to stdout in the requested format.
-func PrintWorkers(workers []*ateapipb.Worker, format string) error {
-	return PrintWorkersTo(os.Stdout, workers, format)
 }
 
 // WorkerOccupancy is how full a Worker is, as a count against its limit. A
@@ -184,6 +173,15 @@ func PrintWorkersTo(out io.Writer, workers []*ateapipb.Worker, format string) er
 	}
 }
 
+// PrintWorkerTo prints a single worker to the provided writer.
+func PrintWorkerTo(out io.Writer, worker *ateapipb.Worker, format string) error {
+	if format == "json" || format == "yaml" {
+		return printProto(out, worker, format)
+	}
+	// table has no singular/plural distinction, so reuse the list renderer.
+	return PrintWorkersTo(out, []*ateapipb.Worker{worker}, format)
+}
+
 // WorkerTopItem represents real-time hardware resource utilization for a worker pod.
 type WorkerTopItem struct {
 	Pod       string `json:"pod" yaml:"pod"`
@@ -210,11 +208,6 @@ func sortWorkerTopItems(items []*WorkerTopItem) {
 		}
 		return cmp.Compare(a.Pod, b.Pod)
 	})
-}
-
-// PrintWorkerTop prints a slice of worker top items to stdout in the requested format.
-func PrintWorkerTop(items []*WorkerTopItem, format string) error {
-	return PrintWorkerTopTo(os.Stdout, items, format)
 }
 
 // PrintWorkerTopTo prints a slice of worker top items to the provided writer.
@@ -272,15 +265,13 @@ func PrintWorkerTopYAML(out io.Writer, items []*WorkerTopItem) error {
 	return err
 }
 
-// PrintActor prints a single actor in the requested format.
-func PrintActor(actor *ateapipb.Actor, format string) error {
-	return PrintActors([]*ateapipb.Actor{actor}, format)
-}
-
-// PrintActorTemplates prints a slice of actor templates to stdout in the
-// requested format.
-func PrintActorTemplates(templates []*ateapipb.ActorTemplate, format string) error {
-	return PrintActorTemplatesTo(os.Stdout, templates, format)
+// PrintActorTo prints a single actor to the provided writer.
+func PrintActorTo(out io.Writer, actor *ateapipb.Actor, format string) error {
+	if format == "json" || format == "yaml" {
+		return printProto(out, actor, format)
+	}
+	// table has no singular/plural distinction, so reuse the list renderer.
+	return PrintActorsTo(out, []*ateapipb.Actor{actor}, format)
 }
 
 func sortActorTemplates(templates []*ateapipb.ActorTemplate) {
@@ -320,15 +311,13 @@ func PrintActorTemplatesTo(out io.Writer, templates []*ateapipb.ActorTemplate, f
 	}
 }
 
-// PrintActorTemplate prints a single actor template in the requested format.
-func PrintActorTemplate(template *ateapipb.ActorTemplate, format string) error {
-	return PrintActorTemplates([]*ateapipb.ActorTemplate{template}, format)
-}
-
-// PrintTags prints tags to stdout in the requested
-// format.
-func PrintTags(tags []*ateapipb.Tag, format string) error {
-	return PrintTagsTo(os.Stdout, tags, format)
+// PrintActorTemplateTo prints a single actor template to the provided writer.
+func PrintActorTemplateTo(out io.Writer, template *ateapipb.ActorTemplate, format string) error {
+	if format == "json" || format == "yaml" {
+		return printProto(out, template, format)
+	}
+	// table has no singular/plural distinction, so reuse the list renderer.
+	return PrintActorTemplatesTo(out, []*ateapipb.ActorTemplate{template}, format)
 }
 
 // PrintTagsTo prints a slice of tags to the
@@ -375,17 +364,13 @@ func tagState(tag *ateapipb.Tag) string {
 	return "Ready"
 }
 
-// PrintTag prints a single tag to stdout.
-func PrintTag(tag *ateapipb.Tag, format string) error {
+// PrintTagTo prints a single tag to the provided writer.
+func PrintTagTo(out io.Writer, tag *ateapipb.Tag, format string) error {
 	if format == "json" || format == "yaml" {
-		return printProto(os.Stdout, tag, format)
+		return printProto(out, tag, format)
 	}
-	return PrintTags([]*ateapipb.Tag{tag}, format)
-}
-
-// PrintAtespaces prints a slice of atespaces to stdout in the requested format.
-func PrintAtespaces(atespaces []*ateapipb.Atespace, format string) error {
-	return PrintAtespacesTo(os.Stdout, atespaces, format)
+	// table has no singular/plural distinction, so reuse the list renderer.
+	return PrintTagsTo(out, []*ateapipb.Tag{tag}, format)
 }
 
 func sortAtespaces(atespaces []*ateapipb.Atespace) {
@@ -412,9 +397,13 @@ func PrintAtespacesTo(out io.Writer, atespaces []*ateapipb.Atespace, format stri
 	}
 }
 
-// PrintAtespace prints a single atespace in the requested format.
-func PrintAtespace(atespace *ateapipb.Atespace, format string) error {
-	return PrintAtespaces([]*ateapipb.Atespace{atespace}, format)
+// PrintAtespaceTo prints a single atespace to the provided writer.
+func PrintAtespaceTo(out io.Writer, atespace *ateapipb.Atespace, format string) error {
+	if format == "json" || format == "yaml" {
+		return printProto(out, atespace, format)
+	}
+	// table has no singular/plural distinction, so reuse the list renderer.
+	return PrintAtespacesTo(out, []*ateapipb.Atespace{atespace}, format)
 }
 
 func printProto(out io.Writer, msg proto.Message, format string) error {

--- a/cmd/kubectl-ate/internal/printer/printer_test.go
+++ b/cmd/kubectl-ate/internal/printer/printer_test.go
@@ -233,6 +233,43 @@ func TestPrintActorsTo_Invalid(t *testing.T) {
 	}
 }
 
+func TestPrintActorTo_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	actor := &ateapipb.Actor{Metadata: &ateapipb.ResourceMetadata{Name: "id-1", Version: 2}}
+
+	if err := PrintActorTo(&buf, actor, "json"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `{
+  "metadata": {
+    "name": "id-1",
+    "version": "2"
+  }
+}
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintActorTo_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	actor := &ateapipb.Actor{Metadata: &ateapipb.ResourceMetadata{Name: "id-1", Version: 2}}
+
+	if err := PrintActorTo(&buf, actor, "yaml"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `metadata:
+  name: id-1
+  version: "2"
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestPrintWorkersTo_Table(t *testing.T) {
 	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 	pinNow(t, now)
@@ -346,6 +383,41 @@ func TestPrintWorkersTo_Invalid(t *testing.T) {
 	err := PrintWorkersTo(&buf, nil, "xml")
 	if err == nil {
 		t.Errorf("expected error for invalid format, got nil")
+	}
+}
+
+func TestPrintWorkerTo_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	worker := &ateapipb.Worker{Metadata: &ateapipb.ResourceMetadata{Name: "worker-1"}}
+
+	if err := PrintWorkerTo(&buf, worker, "json"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `{
+  "metadata": {
+    "name": "worker-1"
+  }
+}
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintWorkerTo_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	worker := &ateapipb.Worker{Metadata: &ateapipb.ResourceMetadata{Name: "worker-1"}}
+
+	if err := PrintWorkerTo(&buf, worker, "yaml"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `metadata:
+  name: worker-1
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -474,6 +546,45 @@ func TestPrintActorTemplatesTo_Invalid(t *testing.T) {
 	}
 }
 
+func TestPrintActorTemplateTo_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	template := &ateapipb.ActorTemplate{Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "counter", Version: 1}}
+
+	if err := PrintActorTemplateTo(&buf, template, "json"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `{
+  "metadata": {
+    "atespace": "team-a",
+    "name": "counter",
+    "version": "1"
+  }
+}
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintActorTemplateTo_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	template := &ateapipb.ActorTemplate{Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "counter", Version: 1}}
+
+	if err := PrintActorTemplateTo(&buf, template, "yaml"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `metadata:
+  atespace: team-a
+  name: counter
+  version: "1"
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestPrintTagsTo_Table(t *testing.T) {
 	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 	pinNow(t, now)
@@ -536,6 +647,43 @@ func TestPrintTagsTo_Invalid(t *testing.T) {
 	var buf bytes.Buffer
 	if err := PrintTagsTo(&buf, nil, "xml"); err == nil {
 		t.Errorf("expected error for invalid format, got nil")
+	}
+}
+
+func TestPrintTagTo_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	tag := &ateapipb.Tag{Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "v1"}}
+
+	if err := PrintTagTo(&buf, tag, "json"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `{
+  "metadata": {
+    "atespace": "team-a",
+    "name": "v1"
+  }
+}
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintTagTo_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	tag := &ateapipb.Tag{Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: "v1"}}
+
+	if err := PrintTagTo(&buf, tag, "yaml"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `metadata:
+  atespace: team-a
+  name: v1
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -637,6 +785,41 @@ func TestPrintAtespacesTo_Invalid(t *testing.T) {
 	var buf bytes.Buffer
 	if err := PrintAtespacesTo(&buf, nil, "xml"); err == nil {
 		t.Errorf("expected error for invalid format, got nil")
+	}
+}
+
+func TestPrintAtespaceTo_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	atespace := &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: "team-a"}}
+
+	if err := PrintAtespaceTo(&buf, atespace, "json"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `{
+  "metadata": {
+    "name": "team-a"
+  }
+}
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintAtespaceTo_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	atespace := &ateapipb.Atespace{Metadata: &ateapipb.ResourceMetadata{Name: "team-a"}}
+
+	if err := PrintAtespaceTo(&buf, atespace, "yaml"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `metadata:
+  name: team-a
+`
+	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+		t.Errorf("output mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/hack/install-ate.sh
+++ b/hack/install-ate.sh
@@ -1104,7 +1104,7 @@ get_actor_state() {
   if ! json=$(run_kubectl_ate get actor "${actor_name}" -a "${atespace}" -o json 2>/dev/null); then
     return 1
   fi
-  jq -r '.actors[0].status.state // empty' <<<"${json}"
+  jq -r '.status.state // empty' <<<"${json}"
 }
 
 # prepare_actor_for_delete suspends (or resumes then suspends) until DeleteActor
@@ -1204,11 +1204,11 @@ wait_actortemplate_ready() {
 
   while ((SECONDS < deadline)); do
     if json=$(run_kubectl_ate get actor-template "${template}" -a "${atespace}" -o json 2>/dev/null); then
-      snapshot=$(jq -r '.actorTemplates[0].status.goldenSnapshotStatus.goldenSnapshot.snapshotUri // empty' <<<"${json}")
+      snapshot=$(jq -r '.status.goldenSnapshotStatus.goldenSnapshot.snapshotUri // empty' <<<"${json}")
       if [[ -n "${snapshot}" ]]; then
         return 0
       fi
-      error_message=$(jq -r '.actorTemplates[0].status.goldenSnapshotStatus.errorMessage // empty' <<<"${json}")
+      error_message=$(jq -r '.status.goldenSnapshotStatus.errorMessage // empty' <<<"${json}")
       if [[ -n "${error_message}" ]]; then
         echo "actor template ${atespace}/${template} failed: ${error_message}" >&2
         return 1


### PR DESCRIPTION
Affects get <name>, create, resume, pause, and suspend for actors, actor templates, atespaces, tags, and workers: JSON/YAML no longer wraps a single resource in a List, matching kubectl's convention. Listing (no name, or multiple names) still returns a List.

Also plumb the writer through cmd.OutOrStdout() instead of hardcoding os.Stdout to honor Cobra's writer.
